### PR TITLE
Changes to keep aligned with discussion

### DIFF
--- a/polyfill/lib/civildate.mjs
+++ b/polyfill/lib/civildate.mjs
@@ -13,6 +13,7 @@ export class CivilDate {
     const { year, month, day } = plus({}, { years, months, days });
     this[DATA] = { year, month, day };
   }
+  get [Symbol.toStringTag] () { return 'CivilDate'; }
 
   get year() { return this[DATA].year; }
   get month() { return this[DATA].month; }

--- a/polyfill/lib/civildate.mjs
+++ b/polyfill/lib/civildate.mjs
@@ -13,7 +13,6 @@ export class CivilDate {
     const { year, month, day } = plus({}, { years, months, days });
     this[DATA] = { year, month, day };
   }
-  get [Symbol.toStringTag] () { return 'CivilDate'; }
 
   get year() { return this[DATA].year; }
   get month() { return this[DATA].month; }
@@ -59,3 +58,4 @@ export class CivilDate {
     return CivilDateTime.fromMilliseconds(millis, zone).toCivilDate();
   }
 };
+CivilDate.prototype[Symbol.toStringTag] = 'CivilDate';

--- a/polyfill/lib/civildate.mjs
+++ b/polyfill/lib/civildate.mjs
@@ -33,6 +33,7 @@ export class CivilDate {
     const { year, month, day } = this;
     return `${spad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`;
   }
+  toJSON() { return this.toString(); }
 
   static fromString(string) {
     const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(string);

--- a/polyfill/lib/civildate.mjs
+++ b/polyfill/lib/civildate.mjs
@@ -25,7 +25,7 @@ export class CivilDate {
   with({ year = this.year, month = this.month , day = this.day } = {}) {
     return new CivilDate(year, month, day);
   }
-  withTime(time = CivilDateTime.now().toCivilTime()) {
+  withTime(time) {
     return new CivilDateTime.from(this, time);
   }
   toString() {

--- a/polyfill/lib/civildate.mjs
+++ b/polyfill/lib/civildate.mjs
@@ -3,7 +3,7 @@
 ** This code is governed by the license found in the LICENSE file.
 */
 
-import { plus, pad, spad  } from './util.mjs';
+import { plus, pad, spad, dayOfWeek, dayOfYear, weekOfYear  } from './util.mjs';
 import { CivilDateTime } from './civildatetime.mjs';
 
 const DATA = Symbol('data');
@@ -19,6 +19,10 @@ export class CivilDate {
   get month() { return this[DATA].month; }
   get day() { return this[DATA].day; }
 
+  get dayOfWeek() { return dayOfWeek(this.year, this.month, this.day); }
+  get dayOfYear() { return dayOfYear(this.year, this.month, this.day); }
+  get weekOfYear() { return weekOfYear(this.year, this.month, this.day); }
+
   plus(data) {
     const { year, month, day } = plus(this, data);
     return new CivilDate(year, month, day);
@@ -29,11 +33,20 @@ export class CivilDate {
   withTime(time) {
     return new CivilDateTime.from(this, time);
   }
-  toString() {
+  toString() { return this.toDateString(); }
+  toJSON() { return this.toString(); }
+  toDateString() {
     const { year, month, day } = this;
     return `${spad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`;
   }
-  toJSON() { return this.toString(); }
+  toWeekDateString() {
+    const { year, weekOfYear, dayOfWeek } = this;
+    return `${spad(year, 4)}-W${pad(weekOfYear, 2)}-${pad(dayOfWeek, 2)}`;
+  }
+  toOrdinalDateString() {
+    const { year, dayOfYear } = this;
+    return `${spad(year, 4)}-${pad(dayOfYear, 3)}`;
+  }
 
   static fromString(string) {
     const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(string);

--- a/polyfill/lib/civildatetime.mjs
+++ b/polyfill/lib/civildatetime.mjs
@@ -16,6 +16,7 @@ export class CivilDateTime {
   constructor(years, months, days, hours, minutes, seconds = 0, milliseconds = 0, nanoseconds = 0) {
     this[DATA] = plus({}, { years, months, days, hours, minutes, seconds, milliseconds, nanoseconds });
   }
+  get [Symbol.toStringTag] () { return 'CivilDateTime'; }
 
   get year() { return this[DATA].year; }
   get month() { return this[DATA].month; }

--- a/polyfill/lib/civildatetime.mjs
+++ b/polyfill/lib/civildatetime.mjs
@@ -3,7 +3,7 @@
 ** This code is governed by the license found in the LICENSE file.
 */
 
-import { plus, pad, spad  } from './util.mjs';
+import { plus, pad, spad, dayOfWeek, dayOfYear, weekOfYear  } from './util.mjs';
 import { toEpoch } from './epoch.mjs';
 import { CivilDate } from './civildate.mjs';
 import { CivilTime } from './civiltime.mjs';
@@ -27,6 +27,10 @@ export class CivilDateTime {
   get millisecond() { return this[DATA].millisecond; }
   get nanosecond() { return this[DATA].nanosecond; }
 
+  get dayOfWeek() { return dayOfWeek(this.year, this.month, this.day); }
+  get dayOfYear() { return dayOfYear(this.year, this.month, this.day); }
+  get weekOfYear() { return weekOfYear(this.year, this.month, this.day); }
+
   plus(data) {
     const { year, month, day, hour, minute, second, millisecond, nanosecond } = plus(this, data);
     return new CivilDateTime(year, month, day, hour, minute, second, millisecond, nanosecond);
@@ -49,11 +53,20 @@ export class CivilDateTime {
     instant[VALUE] = { milliseconds, nanoseconds };
     return new ZonedInstant(instant, zone);
   }
-  toString() {
+  toString() { return this.toDateTimeString(); }
+  toJSON() { return this.toString(); }
+  toDateTimeString() {
     const { year, month, day, hour, minute, second, millisecond, nanosecond } = this;
     return `${spad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}T${pad(hour, 2)}:${pad(minute, 2)}:${pad(second, 2)}.${pad(millisecond,3)}${pad(nanosecond, 6)}`;
   }
-  toJSON() { return this.toString(); }
+  toWeekDateTimeString() {
+    const { year, weekOfYear, dayOfWeek, hour, minute, second, millisecond, nanosecond } = this;
+    return `${spad(year, 4)}-W${pad(weekOfYear, 2)}-${pad(dayOfWeek, 2)}T${pad(hour, 2)}:${pad(minute, 2)}:${pad(second, 2)}.${pad(millisecond,3)}${pad(nanosecond, 6)}`;
+  }
+  toOrdinalDateTimeString() {
+    const { year, dayOfYear, hour, minute, second, millisecond, nanosecond } = this;
+    return `${spad(year, 4)}-${pad(dayOfYear, 3)}T${pad(hour, 2)}:${pad(minute, 2)}:${pad(second, 2)}.${pad(millisecond,3)}${pad(nanosecond, 6)}`;
+  }
 
   static fromString(string) {
     const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{3})(\d{6})$/.exec(string);

--- a/polyfill/lib/civildatetime.mjs
+++ b/polyfill/lib/civildatetime.mjs
@@ -16,7 +16,6 @@ export class CivilDateTime {
   constructor(years, months, days, hours, minutes, seconds = 0, milliseconds = 0, nanoseconds = 0) {
     this[DATA] = plus({}, { years, months, days, hours, minutes, seconds, milliseconds, nanoseconds });
   }
-  get [Symbol.toStringTag] () { return 'CivilDateTime'; }
 
   get year() { return this[DATA].year; }
   get month() { return this[DATA].month; }
@@ -85,3 +84,4 @@ export class CivilDateTime {
     return ZonedInstant.fromMilliseconds(date, zone).toCivilDateTime();
   }
 };
+CivilDateTime.prototype[Symbol.toStringTag] = 'CivilDateTime';

--- a/polyfill/lib/civildatetime.mjs
+++ b/polyfill/lib/civildatetime.mjs
@@ -53,6 +53,7 @@ export class CivilDateTime {
     const { year, month, day, hour, minute, second, millisecond, nanosecond } = this;
     return `${spad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}T${pad(hour, 2)}:${pad(minute, 2)}:${pad(second, 2)}.${pad(millisecond,3)}${pad(nanosecond, 6)}`;
   }
+  toJSON() { return this.toString(); }
 
   static fromString(string) {
     const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{3})(\d{6})$/.exec(string);

--- a/polyfill/lib/civiltime.mjs
+++ b/polyfill/lib/civiltime.mjs
@@ -42,6 +42,7 @@ export class CivilTime {
     const { hour, minute, second, millisecond, nanosecond } = this;
     return `${pad(hour, 2)}:${pad(minute, 2)}:${pad(second, 2)}.${pad(millisecond, 3)}${pad(nanosecond, 6)}`;
   }
+  toJSON() { return this.toString(); }
 
   static fromString(string) {
     const match = /^(\d{2}):(\d{2}):(\d{2})\.(\d{3})(\d{6})$/.exec(string);

--- a/polyfill/lib/civiltime.mjs
+++ b/polyfill/lib/civiltime.mjs
@@ -14,6 +14,7 @@ export class CivilTime {
     const { hour, minute, second, millisecond, nanosecond } = plus({}, { hours, minutes, seconds, milliseconds, nanoseconds });
     this[DATA] = { hour, minute, second, millisecond, nanosecond };
   }
+  get [Symbol.toStringTag] () { return 'CivilTime'; }
 
   get hour() { return this[DATA].hour; }
   get minute() { return this[DATA].minute; }

--- a/polyfill/lib/civiltime.mjs
+++ b/polyfill/lib/civiltime.mjs
@@ -14,7 +14,6 @@ export class CivilTime {
     const { hour, minute, second, millisecond, nanosecond } = plus({}, { hours, minutes, seconds, milliseconds, nanoseconds });
     this[DATA] = { hour, minute, second, millisecond, nanosecond };
   }
-  get [Symbol.toStringTag] () { return 'CivilTime'; }
 
   get hour() { return this[DATA].hour; }
   get minute() { return this[DATA].minute; }
@@ -54,4 +53,5 @@ export class CivilTime {
   static fromMilliseconds(milliseconds, zone) {
     return CivilDateTime.fromMilliseconds(milliseconds, zone).toCivilTime();
   }
-}
+};
+CivilTime.prototype[Symbol.toStringTag] = 'CivilTime';

--- a/polyfill/lib/civiltime.mjs
+++ b/polyfill/lib/civiltime.mjs
@@ -34,7 +34,7 @@ export class CivilTime {
   with({ hour = this.hour, minute = this.minute, second = this.second, millisecond = this.millisecond, nanosecond = this.nanosecond } = {}) {
     return new CivilTime(hour, minute, second, millisecond, nanosecond);
   }
-  withDate(date = CivilDateTime.now().toCivilDate()) {
+  withDate(date) {
     return new CivilDateTime.from(date, this);
   }
   toString() {

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -16,7 +16,6 @@ export class Instant {
     const nanoseconds = Number(nanos % BigInt(1e6));
     this[VALUE] = { milliseconds, nanoseconds };
   }
-  get [Symbol.toStringTag] () { return 'Instant'; }
 
   get milliseconds() { return this[VALUE].milliseconds; }
   get nanoseconds() { return this[VALUE].nanoseconds; }
@@ -69,6 +68,7 @@ export class Instant {
     return object;
   }
 }
+Instant.prototype[Symbol.toStringTag] = 'Instant';
 
 function toParts(value) {
   const millis = value.milliseconds;

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -16,6 +16,7 @@ export class Instant {
     const nanoseconds = Number(nanos % BigInt(1e6));
     this[VALUE] = { milliseconds, nanoseconds };
   }
+  get [Symbol.toStringTag] () { return 'Instant'; }
 
   get milliseconds() { return this[VALUE].milliseconds; }
   get nanoseconds() { return this[VALUE].nanoseconds; }

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -19,6 +19,7 @@ export class Instant {
 
   get milliseconds() { return this[VALUE].milliseconds; }
   get nanoseconds() { return this[VALUE].nanoseconds; }
+  get value() { return BigInt(this.milliseconds) * BigInt(1e6) + BigInt(this.nanoseconds); }
 
   plus(data) {
     const object = Object.create(Instant.prototype);
@@ -32,9 +33,6 @@ export class Instant {
   }
   withZone(zone) {
     return new ZonedInstant(this, zone);
-  }
-  valueOf() {
-    return BigInt(this[VALUE].milliseconds) * BigInt(1e6) + BigInt(this[VALUE].nanoseconds);
   }
   format(locale, options) {
     return this.withZone().format(locale, options);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -43,6 +43,7 @@ export class Instant {
     const nanosecond = this.nanoseconds;
     return `${spad(year,4)}-${pad(month,2)}-${pad(day,2)}T${pad(hour,2)}:${pad(minute,2)}:${pad(second,2)}.${pad(millisecond,3)}${pad(nanosecond,6)}Z`;
   }
+  toJSON() { return this.toString(); }
 
   static fromString(string) {
     const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{3})(\d{6})Z$/.exec(string);

--- a/polyfill/lib/util.mjs
+++ b/polyfill/lib/util.mjs
@@ -55,6 +55,46 @@ export function num(number = 0) {
   return +number;
 };
 
+export function dayOfWeek(year, month, day) {
+    const m = month + ((month < 3) ? 10 : -2);
+    const Y = year - ((month < 3) ? 1 : 0);
+
+    const c = Math.floor(Y / 100);
+    const y = Y - (c * 100);
+    const d = day;
+
+    const pD = d;
+    const pM = Math.floor((2.6 * m) - 0.2);
+    const pY = y + Math.floor(y / 4);
+    const pC = Math.floor(c / 4) - (2 * c);
+
+    const dow = (pD + pM + pY + pC) % 7;
+
+    return dow + ((dow < 0) ? 7 : 0);
+};
+
+export function isLeapYear(year) {
+    return (((year % 4) === 0) && !((year % 100) === 0)) || ((year % 400) === 0);
+};
+
+export function dayOfYear(year, month, day) {
+    const dm = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ];
+    let days = day;
+    for(let m = 0; m < (month - 1); m++) {
+        days += dm[m];
+    }
+    days += (isLeapYear(year) && (month > 2)) ? 1 : 0;
+    return days;
+};
+
+export function weekOfYear(year, month, day) {
+    const doy = dayOfYear(year, month, day);
+    const dow = dayOfWeek(year, month, day);
+    const doj = dayOfWeek(year, 1, 1);
+
+    return ((doy + 6) / 7) + ((dow < doj) ? 1 : 0);
+};
+
 export function validZone(zone) {
   if (zone === 'UTC') { return 'UTC'; }
   zone = (zone === 'SYSTEM') ? systemTimeZone() : zone;

--- a/polyfill/lib/zonedinstant.mjs
+++ b/polyfill/lib/zonedinstant.mjs
@@ -65,10 +65,6 @@ export class ZonedInstant{
     const civil = new CivilDateTime(match[1], match[2], match[3], match[4], match[5], match[6], match[7], match[8]);
     return civil.withZone(match[9] === 'Z' ? 'UTC' : match[9]);
   }
-
-  static now(zone) {
-    return Instant.now().withZone(zone);
-  }
   static fromMilliseconds(milliseconds, zone) {
     return Instant.fromMilliseconds(milliseconds).withZone(zone);
   }

--- a/polyfill/lib/zonedinstant.mjs
+++ b/polyfill/lib/zonedinstant.mjs
@@ -21,6 +21,7 @@ export class ZonedInstant{
 
   get milliseconds() { return this[INSTANT].milliseconds; }
   get nanoseconds() { return this[INSTANT].nanoseconds; }
+  get value() { return BigInt(this.milliseconds) * BigInt(1e6) + BigInt(this.nanoseconds); }
   get timeZone() { return this[ZONE]; }
 
   toCivilDateTime() {
@@ -39,9 +40,6 @@ export class ZonedInstant{
   }
   toInstant() { return this[INSTANT]; }
 
-  valueOf() {
-    return this.toInstant().valueOf();
-  }
   format(locale = navigator.language, options = {}) {
     const fmt = new Intl.DateTimeFormat(
       locale,

--- a/polyfill/lib/zonedinstant.mjs
+++ b/polyfill/lib/zonedinstant.mjs
@@ -18,6 +18,7 @@ export class ZonedInstant{
     this[INSTANT] = instant;
     this[ZONE] = zone;
   }
+  get [Symbol.toStringTag] () { return 'ZonedInstant'; }
 
   get milliseconds() { return this[INSTANT].milliseconds; }
   get nanoseconds() { return this[INSTANT].nanoseconds; }

--- a/polyfill/lib/zonedinstant.mjs
+++ b/polyfill/lib/zonedinstant.mjs
@@ -55,6 +55,7 @@ export class ZonedInstant{
     const offset = ([ 'UTC', '+00:00', '-00:00' ].indexOf(this[ZONE]) > -1) ? 'Z' : zoneOffset(ts, this[ZONE]);
     return `${spad(year,4)}-${pad(month,2)}-${pad(day,2)}T${pad(hour,2)}:${pad(minute,2)}:${pad(second,2)}.${pad(millisecond,3)}${pad(nanosecond,6)}${offset}`;
   }
+  toJSON() { return this.toString(); }
 
   static fromString(string) {
     const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{3})(\d{6})(Z|[+-]\d{2}:\d{2})$/.exec(string);

--- a/polyfill/lib/zonedinstant.mjs
+++ b/polyfill/lib/zonedinstant.mjs
@@ -18,7 +18,6 @@ export class ZonedInstant{
     this[INSTANT] = instant;
     this[ZONE] = zone;
   }
-  get [Symbol.toStringTag] () { return 'ZonedInstant'; }
 
   get milliseconds() { return this[INSTANT].milliseconds; }
   get nanoseconds() { return this[INSTANT].nanoseconds; }
@@ -69,4 +68,4 @@ export class ZonedInstant{
     return Instant.fromMilliseconds(milliseconds).withZone(zone);
   }
 };
-
+ZonedInstant.prototype[Symbol.toStringTag] = 'ZonedInstant';

--- a/polyfill/test/temporal/Instant/constructor.js
+++ b/polyfill/test/temporal/Instant/constructor.js
@@ -14,4 +14,5 @@ assert.sameValue(typeof instance, 'object');
 assert.sameValue(instance instanceof temporal.Instant, true);
 assert.sameValue(instance.milliseconds, 217178610450);
 assert.sameValue(instance.nanoseconds, 100);
+assert.sameValue(instance.value, 217178610450000100n);
 assert.sameValue(instance.toString(), '1976-11-18T15:23:30.450000100Z');

--- a/polyfill/test/temporal/Instant/fromString.js
+++ b/polyfill/test/temporal/Instant/fromString.js
@@ -12,6 +12,7 @@ const one = temporal.Instant.fromString('1976-11-18T14:23:30.450000100Z');
 assert.sameValue(one instanceof temporal.Instant, true);
 assert.sameValue(one.milliseconds, 217175010450);
 assert.sameValue(one.nanoseconds, 100);
+assert.sameValue(one.value, 217175010450000100n);
 
 
 assert.throws(Error, ()=>{

--- a/polyfill/test/temporal/ZonedInstant/constructor.js
+++ b/polyfill/test/temporal/ZonedInstant/constructor.js
@@ -15,6 +15,7 @@ assert.sameValue(typeof one, 'object');
 assert.sameValue(one instanceof temporal.ZonedInstant, true);
 assert.sameValue(one.milliseconds, 217175010450);
 assert.sameValue(one.nanoseconds, 100);
+assert.sameValue(one.value, 217175010450000100n);
 assert.sameValue(one.toString(), '1976-11-18T15:23:30.450000100+01:00');
 
 const two = new temporal.ZonedInstant(instant, 'America/New_York');
@@ -22,4 +23,5 @@ assert.sameValue(typeof two, 'object');
 assert.sameValue(two instanceof temporal.ZonedInstant, true);
 assert.sameValue(two.milliseconds, 217175010450);
 assert.sameValue(two.nanoseconds, 100);
+assert.sameValue(two.value, 217175010450000100n);
 assert.sameValue(two.toString(), '1976-11-18T09:23:30.450000100-05:00');

--- a/polyfill/test/temporal/ZonedInstant/fromString.js
+++ b/polyfill/test/temporal/ZonedInstant/fromString.js
@@ -12,6 +12,7 @@ const one = temporal.ZonedInstant.fromString('1976-11-18T15:23:30.450000100+01:0
 assert.sameValue(one instanceof temporal.ZonedInstant, true);
 assert.sameValue(one.milliseconds, 217175010450);
 assert.sameValue(one.nanoseconds, 100);
+assert.sameValue(one.value, 217175010450000100n);
 assert.sameValue(one.timeZone, '+01:00');
 
 assert.throws(Error, ()=>{


### PR DESCRIPTION

 * Remove traces of `.now()` as per #73
 * Replacing `.valueOf()` with `.value` in line with #74
 * `.toString()` gives [object Type ISO-String] in line with #74 
 * `.asString()` gives ISO-String

I named the method `.asString()` for now, but that should be name-checked (open for suggestions). I really don't like `toISOString()` because that suggests generi ISO. However the string produced has quite detailed specification in order to clarify `fromString()`. (Maybe I'm just too hestitant, but it just gives me heebe-jeebies)