### PR TITLE
Correct optional constructor arguments for CivilTime and CivilDateTime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Represents a position on a 24-hour clock.
 
 ### Constructor
 ```js
-new CivilTime(hour, minute[[[, second], millisecond], nanosecond])
+new CivilTime(hour, minute[, second[, millisecond[, nanosecond]]])
 ```
 
 

--- a/spec/civildatetime.html
+++ b/spec/civildatetime.html
@@ -112,7 +112,7 @@
   </emu-clause>
 
   <emu-clause id=sec-temporal-civildatetime-constructor-alg>
-    <h1>CivilDateTime (year, month, day, hour, minute[[[, second], millisecond], nanosecond])</h1>
+    <h1>CivilDateTime (year, month, day, hour, minute[, second[, millisecond[, nanosecond]]])</h1>
     <p>This description only applies if the CivilDateTime constructor is called with at least five arguments.</p>
     <p>When the CivilDateTime function is called, the following steps are taken:</p>
     <emu-alg>

--- a/spec/civiltime.html
+++ b/spec/civiltime.html
@@ -78,7 +78,7 @@
   </emu-clause>
 
   <emu-clause id=sec-temporal-civiltime-constructor-alg>
-    <h1>CivilTime (hour, minute[[[, second], millisecond], nanosecond])</h1>
+    <h1>CivilTime (hour, minute[, second[, millisecond[, nanosecond]]])</h1>
     <p>This description only applies if the CivilTime constructor is called with at least two arguments.</p>
     <p>When the CivilTime function is called, the following steps are taken:</p>
     <emu-alg>


### PR DESCRIPTION
The previous forms of the constructor optional arguments gave the
nanosecond field the highest priority, with the second field the lowest.
This patch reverses the optional brace nesting to match intended usage.

Fixes #75.