### PR TITLE
Cleanup ZonedDateTime & OffsetDateTime Spec

### DIFF
--- a/objects.md
+++ b/objects.md
@@ -172,11 +172,6 @@ Creates a new `OffsetDateTime` object by subtracting values to its members. The 
 must be numeric if specified and will be cast to a scaled integer (by calulating the absolute
 value and flooring it).
 
-
-#### OffsetDateTime.prototype.withZone(iana: string) : [ZonedDateTime](#ZonedDateTime)
-
-Creates a new `ZonedDateTime` object representing the same point in time with the passed IANA-Timezone. If the IANA-Timezone is invalid this method throws.
-
 #### OffsetDateTime.prototype.getCivilDateTime() : [CivilDateTime](#CivilDateTime)
 #### OffsetDateTime.prototype.getCivilDate() : [CivilDate](#CivilDate)
 #### OffsetDateTime.prototype.getCivilTime() : [CivilTime](#CivilTime)

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -34,27 +34,20 @@
     <p>`instant.epochNanoseconds` is a getter that returns the nanoseconds BigInt since epoch of the point in time
       represented by the instant object such that `instant.epochNanoseconds === instant.valueOf()` is *true*.</p>
   </emu-clause>
-
   <emu-clause id=sec-temporal-instant.prototype.withZone>
     <h1>Instant.prototype.withZone(_timezone_)</h1>
     <p>When called with an Instant object as a _this_ context it will return a <emu-xref href="#sec-temporal-zoneddatetime">ZonedDateTime</emu-xref>
       object that specifies an instant in time in the given time zone.</p>
-    <p>_timezone_ is a string specifying a time zone. Legal values are IANA geographic time zone names as well as the
-      special values *"SYSTEM"* and *"UTC"*.</p>
-    <ul>
-      <li>*"UTC"* indicates that the time zone should be Coordinated Universal Time.</li>
-      <li>*"SYSTEM"* indicates that the time zone should be local time as provided by the system.</li>
-    </ul>
+    <p>_timezone_ is a string specifying a time zone. Legal values are IANA time zone names.</p>
     <p>Calling this function with a _this_ context that is not an instance of Instant is illegal.</p>
   </emu-clause>
-
-  <emu-clause id=sec-temporal-instant.prototype.valueOf>
-    <h1>Instant.prototype.valueOf()</h1>
-    <p>When called with an Instant object as the _this_ context the result will be a BigInt value with the nanoseconds
-      since epoch the instant represents.</p>
-    <p>Calling this function with anything other than an Instant object as the _this_ context is illegal.</p>
+  <emu-clause id=sec-temporal-instant.prototype.withOffset>
+    <h1>Instant.prototype.withOffset(_offset_)</h1>
+    <p>When called with an Instant object as a _this_ context it will return a <emu-xref href="#sec-temporal-offsetdatetime">OffsetDateTime</emu-xref>
+      object that specifies an instant in time in the given time zone.</p>
+    <p>_offset_ is a string specifying an offset as specified in <emu-xref href="#sec-temporal-offsetdatetime-constructor">OffsetDateTime</emu-xref></p>
+    <p>Calling this function with a _this_ context that is not an instance of Instant is illegal.</p>
   </emu-clause>
-
   <emu-clause id=sec-temporal-instant.prototype.toString>
     <h1>Instant.prototype.toString()</h1>
     <p>When called with an Instant object as a _this_ context it will return an ISO 8601 String value representing the
@@ -75,14 +68,13 @@
     </emu-grammar>
     <p>Calling this function with a _this_ context that is not an instance of Instant is illegal.</p>
   </emu-clause>
+
   <emu-clause id=sec-temporal-instant.fromString>
     <h1>Instant.fromString(_string_)</h1>
     <p>This function will create an Instant object from a String. The _string_ has to strictly conform to the format
-      produced by
-      <emu-xref href="#sec-temporal-instant.prototype.toString" title />. Any _string_ not strictly conforming to that
+      produced by <emu-xref href="#sec-temporal-instant.prototype.toString" title />. Any _string_ not strictly conforming to that
       format will throw an Error.</p>
   </emu-clause>
-  
   <emu-clause id=sec-temporal-instant.fromEpochSeconds>
     <h1>Instant.fromEpochSeconds(_seconds_)</h1>
     <p>

--- a/spec/offsetdatetime.html
+++ b/spec/offsetdatetime.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<meta charset="utf8" />
+
+<emu-clause id="sec-temporal-offsetdatetime">
+    <h1>OffsetDateTime Objects</h1>
+    <p>
+    A `OffsetDateTime` object is an immutable object referencing a point in time
+    where the referenced point in time is specific to a given time zone and is
+    measured with nanoseconds precision.
+    </p>
+
+    <emu-clause id="sec-temporal-offsetdatetime-constructor">
+        <h1>OffsetDateTime Constructor</h1>
+        <h1>new OffsetDateTime(_instant_, _timezone_)</h1>
+        <p>
+        The OffsetDateTime constructor is the %OffsetDateTime% intrinsic object.
+        When called as a constructor, it creates a new OffsetDateTime object.
+        </p>
+        <p>The OffsetDateTime constructor is a single function.</p>
+        <p>The OffsetDateTime constructor is subclassable.</p>
+        <p>The length property of the OffsetDateTime construtor function is 2.</p>
+        <p>
+        When called as a constructor creates a new `OffsetDateTime` object.
+        _instant_ is an instance of `Instant`; _offset_ is a string of:
+        </p>
+        <emu-grammar>
+        Sign: `-` or `+`
+        Hours: `00` through `24`
+        Minutes: `00` through `59`
+        Offset: Sign Hours `:`? Minutes 
+        </emu-grammar>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime-alg">
+        <h1>OffsetDateTime(_instant_, _offset_)</h1>
+        <p>This description only applies if the OffsetDateTime constructor is called with at least 2 arguments.</p>
+        <p>When the OffsetDateTime constructor function is called, the following steps are taken:</p>
+        <emu-alg>
+        1. Let numberOfArgs be the number of arguments passed to this function call.
+        1. Assert: numberOfArgs == 2.
+        1. Assert: offset is valid String
+        1. If NewTarget is not undefined, then
+            1. Let inst be instant.milliseconds.
+            1. Let off be offset.
+            1. Let O be
+            ? OrdinaryCreateFromConstructor(
+                NewTarget,
+                "%OffsetDateTimePrototype%", <<[[InstantValue,TimeZoneValue]]>>).
+            1. Set O.[[InstantValue]] to instant.
+            1. Set O.[[OffsetValue]] to off.
+        Return O.
+        </emu-alg>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime-constructor-prop">
+        <h1>Properties of the OffsetDateTime Constructor</h1>
+        <p>The value of the [[Prototype]] internal slot of the OffsetDateTime constructor is the intrinsic object %FunctionPrototype%.</p>
+        <p>The OffsetDateTime constructor has the following properties:</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime-prototype">
+        <h1>OffsetDateTime Prototype</h1>
+        <p>
+        The initial value of OffsetDateTime.prototype is the intrinsic object
+        %OffsetDateTimePrototype%. This property has the attributes {[[Writable]]:
+        false, [[Enumerable]]: false, [[Configurable]]: false}.
+        </p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.instant">
+        <h1>OffsetDateTime.prototype.instant</h1>
+        <p>`OffsetDateTime.instant` is a getter that returns the underlying instant represented by this `OffsetDateTime`.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.offset">
+        <h1>OffsetDateTime.prototype.offset</h1>
+        <p>`OffsetDateTime.offset` is a getter that returns the String offset of the timezone represented by this `OffsetDateTime` in the format `[+-]HH:MM`.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.year">
+        <h1>OffsetDateTime.prototype.year</h1>
+        <p>`OffsetDateTime.year` is a getter that returns the year represented by this `OffsetDateTime` according to the proleptic gregorian calendar.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.month">
+        <h1>OffsetDateTime.prototype.month</h1>
+        <p>`OffsetDateTime.month` is a getter that returns the month represented by this `OffsetDateTime` according to the proleptic gregorian calendar.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.day">
+        <h1>OffsetDateTime.prototype.day</h1>
+        <p>`OffsetDateTime.day` is a getter that returns the day of the month represented by this `OffsetDateTime` according to the proleptic gregorian calendar.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.hours">
+        <h1>OffsetDateTime.prototype.hours</h1>
+        <p>`OffsetDateTime.hours` is a getter that returns the hours of the day represented by this `OffsetDateTime`.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.minutes">
+        <h1>OffsetDateTime.prototype.minutes</h1>
+        <p>`OffsetDateTime.minutes` is a getter that returns the minutes of the hour represented by this `OffsetDateTime`.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.seconds">
+        <h1>OffsetDateTime.prototype.seconds</h1>
+        <p>`OffsetDateTime.seconds` is a getter that returns the seconds of the minute represented by this `OffsetDateTime`.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.milliseconds">
+        <h1>OffsetDateTime.prototype.milliseconds</h1>
+        <p>`OffsetDateTime.milliseconds` is a getter that returns the milliseconds of the second represented by this `OffsetDateTime`. This value is restricted to the range of `0` to `999` inclusive.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.microseconds">
+        <h1>OffsetDateTime.prototype.microseconds</h1>
+        <p>
+        `OffsetDateTime.microseconds` is a getter that returns the microseconds of the dat represented by this `OffsetDateTime`.
+        This value is restricted to the range of `0` to `999` inclusive.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.nanoseconds">
+        <h1>OffsetDateTime.prototype.nanoseconds</h1>
+        <p>
+        `OffsetDateTime.nanoseconds` is a getter that returns the nanoseconds of the dat represented by this `OffsetDateTime`.
+        This value is restricted to the range of `0` to `999` inclusive.
+        </p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.dayOfWeek">
+        <h1>OffsetDateTime.prototype.dayOfWeek</h1>
+        <p>
+        `OffsetDateTime.dayOfWeek` is a getter that returns the day of the week represented by this `OffsetDateTime` according to the proleptic gregorian calendar.
+        The values are `1` through `7` corresponding to the ISO weekday numbers.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.dayOfYear">
+        <h1>OffsetDateTime.prototype.dayOfYear</h1>
+        <p>
+        `OffsetDateTime.dayOfYear` is a getter that returns the day of the year represented by this `OffsetDateTime` according to the proleptic gregorian calendar.
+        The values are `1` through `365` in a normal year and `1` through `366` in a leapyear.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.weekOfYear">
+        <h1>OffsetDateTime.prototype.weekOfYear</h1>
+        <p>
+        `OffsetDateTime.weekOfYear` is a getter that returns the week of the year represented by this `OffsetDateTime` according to the proleptic gregorian calendar.
+        The values are `1` through `53` and correspond to the ISO week numbers.
+        </p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.with">
+        <h1>
+        OffsetDateTime.prototype.with({ ? _years_, ? _months_, ? _days_, ? _hours_,
+        ? _minutes_, ? _seconds_, ? _milliseconds_, ? _microseconds_, ? _nanoseconds_ })
+        </h1>
+        <p>When called with a OffsetDateTime object as the _this_ context, the result will be a new OffsetDateTime object.</p>
+        <p>
+        The value of the new OffsetDateTime object is the value of the original
+        OffsetDateTime's milliseconds with the specified date parts, excepting any
+        nanoseconds argument, converted to milliseconds and added to the original
+        MillisecondValue.
+        </p>
+        <p>
+        Units will be added in order of size, descending. Calling this function
+        with a _this_ context that is not an instance of OffsetDateTime is illegal.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.plus">
+        <h1>
+        OffsetDateTime.prototype.plus({ ? _years_, ? _months_, ? _days_, ? _hours_,
+        ? _minutes_, ? _seconds_, ? _milliseconds_, ? _microseconds_, ? _nanoseconds_ })
+        </h1>
+        <p>
+        When called with a OffsetDateTime object as the _this_ context, the result
+        will be a new OffsetDateTime object.
+        </p>
+        <p>
+        The value of the new OffsetDateTime object is the value of the original
+        OffsetDateTime with the specified date parts added. Units will be added in
+        order of size, descending.
+        </p>
+        <p>Calling this function with a _this_ context that is not an instance of OffsetDateTime is illegal.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.minus">
+        <h1>OffsetDateTime.prototype.minus(_otherOffsetDateTime_)</h1>
+        <p>
+        When called with a OffsetDateTime object as the _this_ context, the result
+        will be a new <emu-xref href="#sec-temporal-duration" title /> object.
+        </p>
+        <p>The value of the new Duration object is difference between _this_ and the supplied OffsetDateTime.</p>
+        <p>Calling this function with a _this_ context that is not an instance of OffsetDateTime is illegal.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.getcivildate">
+        <h1>OffsetDateTime.prototype.getCivilDate()</h1>
+        <p>
+        The abstract operation getCivilDate returns a new CivilDate Object with the
+        year, month, and day values calculated from the milliseconds and
+        nanoseconds since Epoch
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.getciviltime">
+        <h1>OffsetDateTime.prototype.getCivilTime()</h1>
+    </emu-clause>
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.getcivildatetime">
+        <h1>OffsetDateTime.prototype.getCivilDateTime()</h1>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-offsetdatetime.prototype.tostring">
+        <h1>OffsetDateTime.prototype.toString()</h1>
+        <p>
+        When called with a OffsetDateTime object as a _this_ context it will return
+        an ISO 8601 String value representing the value of the OffsetDateTime
+        object.
+        </p>
+        <p>The format of the String will always be an IsoDateTime of the following form:</p>
+        <emu-grammar>
+        Sign: `-`
+        Year: Sign? Digit Digit Digit Digit
+        Month: `01` through `12`
+        Day: `01` through `31`
+        Hour: `00` through `24`
+        Minute: `00` through `59`
+        Second: `00` through `59`
+        Milliseconds: `000` through `999`
+        Microseconds: `000` through `999`
+        Nanoseconds: `000` through `999`
+        DatePart: Year `-` Month `-` Day
+        SubSeconds: `.` Milliseconds Microseconds Nanoseconds
+        TimePart: Hour `:` Minute `:` Second SubSeconds
+        OffsetDirection: `+` or `-`
+        OffsetHours: `00` to `24`
+        OffsetMinutes: `00` to `59`
+        Offset: OffsetDirection OffsetHours `:` OffsetMinutes
+        IsoDateTime: DatePart `T` TimePart Offset
+        </emu-grammar>
+        <p>Calling this function with a _this_ context that is not an instance of OffsetDateTime is illegal.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-offsetdatetime.fromstring">
+        <h1>OffsetDateTime.fromString(_isostring_)</h1>
+        <p>
+        _isostring_ has to be in the precise format produced by <emu-xref href="#sec-temporal-offsetdatetime.prototype.tostring" title />.
+        However the `SubSeconds` are optional from right to left (when there isn't a `Milliseconds` part the `.` is disallowed).
+        </p>
+        <p>Calling this function with a _this_ context that is not an instance of OffsetDateTime is illegal.</p>
+    </emu-clause>
+</emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -2,312 +2,268 @@
 <meta charset="utf8" />
 
 <emu-clause id="sec-temporal-zoneddatetime">
-  <h1>ZonedDateTime Objects</h1>
-  <p>
-    A `ZonedDateTime` object is an immutable object referencing a point in time
-    where the referenced point in time is specific to a given time zone and is
-    measured with nanoseconds precision.
-  </p>
-
-  <emu-clause id="sec-temporal-zoneddatetime-constructor">
-    <h1>ZonedDateTime Constructor</h1>
+    <h1>ZonedDateTime Objects</h1>
     <p>
-      The ZonedDateTime constructor is the %ZonedDateTime% intrinsic object.
-      When called as a constructor, it creates a new ZonedDateTime object.
-      *instant* is an Instant object and *timeZone* is a String corresponding to
-      an IANA time zone.
+    A `ZonedDateTime` object is an immutable object referencing a point in
+    time where the referenced point in time is specific to a given timezone and
+    is measured with nanoseconds precision.
     </p>
 
-    <p>The ZonedDateTime constructor is a single function.</p>
-    <p>The ZonedDateTime constructor is subclassable.</p>
-    <p>The length property of the ZonedDateTime construtor function is 2.</p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime-constructor">
-    <h1>new ZonedDateTime(_instant_, _timezone_)</h1>
-    <p>
-      When called as a constructor creates a new `ZonedDateTime` object.
-      _instant_ is an instance of `Instant`; _timezone_ is a string of:
-      <ul>
-        <li>An IANA-Timezone name or link</li>
-        <li>An offset in the format `+HH:MM`, `-HH:MM`, `+HHMM`, `-HHMM`</li>
-        <li>The value "UTC"</li>
-        <li>The value "SYSTEM"</li>
-      </ul>
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime-alg">
-    <h1>ZonedDateTime(*instant*, *timeZone*)</h1>
-    <p>
-      This description only applies if the ZonedDateTime constructor is called
-      with at least 2 arguments.
-    </p>
-    <p>
-      When the ZonedDateTime constructor function is called, the following steps
-      are taken:
-    </p>
-    <emu-alg>
-      1. Let numberOfArgs be the number of arguments passed to this function call.
-      1. Assert: numberOfArgs == 2.
-      1. Assert: timeZone is valid String
-      1. If NewTarget is not undefined, then
-        1. Let inst be instant.milliseconds.
-        1. Let tz be timeZone.
-        1. Let O be
-          ? OrdinaryCreateFromConstructor(
-            NewTarget,
-            "%ZonedDateTimePrototype%", <<[[InstantValue,TimeZoneValue]]>>).
-        1. Set O.[[InstantValue]] to instant.
-        1. Set O.[[TimeZoneValue]] to tz.
-      Return O.
-    </emu-alg>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime-constructor-prop">
-    <h1>Properties of the ZonedDateTime Constructor</h1>
-    <p>
-      The value of the [[Prototype]] internal slot of the ZonedDateTime
-      constructor is the intrinsic object %FunctionPrototype%.
-    </p>
-    <p>The ZonedDateTime constructor has the following properties:</p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime-prototype">
-    <h1>ZonedDateTime Prototype</h1>
-    <p>
-      The initial value of ZonedDateTime.prototype is the intrinsic object
-      %ZonedDateTimePrototype%. This property has the attributes {[[Writable]]:
-      false, [[Enumerable]]: false, [[Configurable]]: false}.
-    </p>
-  </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime-constructor">
+        <h1>ZonedDateTime Constructor</h1>
+        <h1>new ZonedDateTime(_instant_, _timezone_)</h1>
+        <p>
+        The ZonedDateTime constructor is the %ZonedDateTime% intrinsic object.
+        When called as a constructor, it creates a new ZonedDateTime object.
+        *instant* is an Instant object and *timeZone* is a String corresponding to an IANA time zone.
+        </p>
+        <p>The ZonedDateTime constructor is a single function.</p>
+        <p>The ZonedDateTime constructor is subclassable.</p>
+        <p>The length property of the ZonedDateTime construtor function is 2.</p>
+        <p>
+        When called as a constructor creates a new `ZonedDateTime` object.
+        _instant_ is an instance of `Instant`; _timezone_ is a string of an
+        IANA-Timezone name or link.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime-alg">
+        <h1>ZonedDateTime(*instant*, *timeZone*)</h1>
+        <p>
+        This description only applies if the ZonedDateTime constructor is called
+        with at least 2 arguments.
+        </p>
+        <p>When the ZonedDateTime constructor function is called, the following steps are taken:</p>
+        <emu-alg>
+        1. Let numberOfArgs be the number of arguments passed to this function call.
+        1. Assert: numberOfArgs == 2.
+        1. Assert: timeZone is valid String
+        1. If NewTarget is not undefined, then
+            1. Let inst be instant.milliseconds.
+            1. Let tz be timeZone.
+            1. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%ZonedDateTimePrototype%", <<[[InstantValue,TimeZoneValue]]>>).
+          1. Set O.[[InstantValue]] to instant.
+          1. Set O.[[TimeZoneValue]] to tz.
+        Return O.
+        </emu-alg>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime-constructor-prop">
+        <h1>Properties of the ZonedDateTime Constructor</h1>
+        <p>
+        The value of the [[Prototype]] internal slot of the ZonedDateTime
+        constructor is the intrinsic object %FunctionPrototype%.
+        </p>
+        <p>The ZonedDateTime constructor has the following properties:</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime-prototype">
+        <h1>ZonedDateTime Prototype</h1>
+        <p>
+        The initial value of ZonedDateTime.prototype is the intrinsic object
+        %ZonedDateTimePrototype%. This property has the attributes {[[Writable]]:
+        false, [[Enumerable]]: false, [[Configurable]]: false}.
+        </p>
+    </emu-clause>
 
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.instant">
-    <h1>ZonedDateTime.prototype.instant</h1>
-    <p>
-      `zonedDateTime.instant` is a getter that returns the underlying instant represented by this `ZonedDateTime`.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.offsetSeconds">
-    <h1>ZonedDateTime.prototype.offsetSeconds</h1>
-    <p>
-      `zonedDateTime.offsetSeconds` is a getter that returns the Number integer offset of the timezone represented by this `ZonedDateTime`.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.offsetString">
-    <h1>ZonedDateTime.prototype.offsetString</h1>
-    <p>
-      `zonedDateTime.offsetString` is a getter that returns the String offset of the timezone represented by this `ZonedDateTime`
-      in the format `[+-]HH:MM`.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.ianaZone">
-    <h1>ZonedDateTime.prototype.ianaZone</h1>
-    <p>
-      `zonedDateTime.ianaZone` is a getter that returns the String IANA name or link of the timezone represented by this `ZonedDateTime`.
-      If the `ZonedDateTime` was created using an offset or "SYSTEM" this value can be `undefined`
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.timeZone">
-    <h1>ZonedDateTime.prototype.timeZone</h1>
-    <p>
-      `zonedDateTime.timeZone` is a getter that returns the String of the timezone represented by this `ZonedDateTime`.
-      If present this equates to `zonedDateTime.ianaZone` otherwise it equates to `zonedDateTime.offsetString`
-    </p>
-  </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.instant">
+        <h1>ZonedDateTime.prototype.instant</h1>
+        <p>`zonedDateTime.instant` is a getter that returns the underlying instant represented by this `ZonedDateTime`.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.offsetSeconds">
+        <h1>ZonedDateTime.prototype.offsetSeconds</h1>
+        <p>`zonedDateTime.offsetSeconds` is a getter that returns the Number integer offset of the timezone represented by this `ZonedDateTime`.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.offsetString">
+        <h1>ZonedDateTime.prototype.offsetString</h1>
+        <p>
+        `zonedDateTime.offsetString` is a getter that returns the String offset of the timezone represented by this `ZonedDateTime`
+        in the format `[+-]HH:MM`.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.ianaZone">
+        <h1>ZonedDateTime.prototype.ianaZone</h1>
+        <p>
+        `zonedDateTime.ianaZone` is a getter that returns the String IANA name or link of the timezone represented by this `ZonedDateTime`.
+        If the `ZonedDateTime` was created using an offset or "SYSTEM" this value can be `undefined`
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.timeZone">
+        <h1>ZonedDateTime.prototype.timeZone</h1>
+        <p>
+        `zonedDateTime.timeZone` is a getter that returns the String of the timezone represented by this `ZonedDateTime`.
+        If present this equates to `zonedDateTime.ianaZone` otherwise it equates to `zonedDateTime.offsetString`
+        </p>
+    </emu-clause>
 
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.year">
-    <h1>ZonedDateTime.prototype.year</h1>
-    <p>
-      `zonedDateTime.year` is a getter that returns the year represented by this `ZonedDateTime` according to the 
-      proleptic gregorian calendar.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.month">
-    <h1>ZonedDateTime.prototype.month</h1>
-    <p>
-      `zonedDateTime.month` is a getter that returns the month represented by this `ZonedDateTime` according to the 
-      proleptic gregorian calendar.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.day">
-    <h1>ZonedDateTime.prototype.day</h1>
-    <p>
-      `zonedDateTime.day` is a getter that returns the day of the month represented by this `ZonedDateTime` according to the 
-      proleptic gregorian calendar.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.hours">
-    <h1>ZonedDateTime.prototype.hours</h1>
-    <p>
-      `zonedDateTime.hours` is a getter that returns the hours of the day represented by this `ZonedDateTime`.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.minutes">
-    <h1>ZonedDateTime.prototype.minutes</h1>
-    <p>
-      `zonedDateTime.minutes` is a getter that returns the minutes of the hour represented by this `ZonedDateTime`.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.seconds">
-    <h1>ZonedDateTime.prototype.seconds</h1>
-    <p>
-      `zonedDateTime.seconds` is a getter that returns the seconds of the minute represented by this `ZonedDateTime`.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.milliseconds">
-    <h1>ZonedDateTime.prototype.milliseconds</h1>
-    <p>
-      `zonedDateTime.milliseconds` is a getter that returns the milliseconds of the second represented by this `ZonedDateTime`.
-      This value is restricted to the range of `0` to `999` inclusive.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.microseconds">
-    <h1>ZonedDateTime.prototype.microseconds</h1>
-    <p>
-      `zonedDateTime.microseconds` is a getter that returns the microseconds of the dat represented by this `ZonedDateTime`.
-      This value is restricted to the range of `0` to `999` inclusive.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.nanoseconds">
-    <h1>ZonedDateTime.prototype.nanoseconds</h1>
-    <p>
-      `zonedDateTime.nanoseconds` is a getter that returns the nanoseconds of the dat represented by this `ZonedDateTime`.
-      This value is restricted to the range of `0` to `999` inclusive.
-    </p>
-  </emu-clause>
-  
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.dayOfWeek">
-    <h1>ZonedDateTime.prototype.dayOfWeek</h1>
-    <p>
-      `zonedDateTime.dayOfWeek` is a getter that returns the day of the week represented by this `ZonedDateTime` according to the 
-      proleptic gregorian calendar. The values are `1` through `7` corresponding to the ISO weekday numbers.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.dayOfYear">
-    <h1>ZonedDateTime.prototype.dayOfYear</h1>
-    <p>
-      `zonedDateTime.dayOfYear` is a getter that returns the day of the year represented by this `ZonedDateTime` according to the 
-      proleptic gregorian calendar. The values are `1` through `365` in a normal year and `1` through `366` in a leapyear.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.weekOfYear">
-    <h1>ZonedDateTime.prototype.weekOfYear</h1>
-    <p>
-      `zonedDateTime.weekOfYear` is a getter that returns the week of the year represented by this `ZonedDateTime` according to the 
-      proleptic gregorian calendar. The values are `1` through `53` and correspond to the ISO week numbers.
-    </p>
-  </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.year">
+        <h1>ZonedDateTime.prototype.year</h1>
+        <p>
+        `zonedDateTime.year` is a getter that returns the year represented by this `ZonedDateTime` according to the 
+        proleptic gregorian calendar.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.month">
+        <h1>ZonedDateTime.prototype.month</h1>
+        <p>
+        `zonedDateTime.month` is a getter that returns the month represented by this `ZonedDateTime` according to the 
+        proleptic gregorian calendar.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.day">
+        <h1>ZonedDateTime.prototype.day</h1>
+        <p>
+        `zonedDateTime.day` is a getter that returns the day of the month represented by this `ZonedDateTime` according to the 
+        proleptic gregorian calendar.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.hours">
+        <h1>ZonedDateTime.prototype.hours</h1>
+        <p>`zonedDateTime.hours` is a getter that returns the hours of the day represented by this `ZonedDateTime`.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.minutes">
+        <h1>ZonedDateTime.prototype.minutes</h1>
+        <p>`zonedDateTime.minutes` is a getter that returns the minutes of the hour represented by this `ZonedDateTime`.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.seconds">
+        <h1>ZonedDateTime.prototype.seconds</h1>
+        <p>`zonedDateTime.seconds` is a getter that returns the seconds of the minute represented by this `ZonedDateTime`.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.milliseconds">
+        <h1>ZonedDateTime.prototype.milliseconds</h1>
+        <p>
+        `zonedDateTime.milliseconds` is a getter that returns the milliseconds of the second represented by this `ZonedDateTime`.
+        This value is restricted to the range of `0` to `999` inclusive.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.microseconds">
+        <h1>ZonedDateTime.prototype.microseconds</h1>
+        <p>
+        `zonedDateTime.microseconds` is a getter that returns the microseconds of the dat represented by this `ZonedDateTime`.
+        This value is restricted to the range of `0` to `999` inclusive.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.nanoseconds">
+        <h1>ZonedDateTime.prototype.nanoseconds</h1>
+        <p>
+        `zonedDateTime.nanoseconds` is a getter that returns the nanoseconds of the dat represented by this `ZonedDateTime`.
+        This value is restricted to the range of `0` to `999` inclusive.
+        </p>
+    </emu-clause>
 
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.valueof">
-    <h1>ZonedDateTime.prototype.valueOf()</h1>
-    <p>
-      When called with a ZonedDateTime object as the _this_ context the result
-      will be a BigInt value with the nanoseconds since epoch the `ZonedDateTime`
-      represents.
-    </p>
-    <p>
-      Calling this function with anything other than a ZonedDateTime object as
-      the _this_ context is illegal.
-    </p>
-  </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.dayOfWeek">
+        <h1>ZonedDateTime.prototype.dayOfWeek</h1>
+        <p>
+        `zonedDateTime.dayOfWeek` is a getter that returns the day of the week represented by this `ZonedDateTime` according to the 
+        proleptic gregorian calendar. The values are `1` through `7` corresponding to the ISO weekday numbers.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.dayOfYear">
+        <h1>ZonedDateTime.prototype.dayOfYear</h1>
+        <p>
+        `zonedDateTime.dayOfYear` is a getter that returns the day of the year represented by this `ZonedDateTime` according to the 
+        proleptic gregorian calendar. The values are `1` through `365` in a normal year and `1` through `366` in a leapyear.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.weekOfYear">
+        <h1>ZonedDateTime.prototype.weekOfYear</h1>
+        <p>
+        `zonedDateTime.weekOfYear` is a getter that returns the week of the year represented by this `ZonedDateTime` according to the 
+        proleptic gregorian calendar. The values are `1` through `53` and correspond to the ISO week numbers.
+        </p>
+    </emu-clause>
 
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.with">
-    <h1>
-      ZonedDateTime.prototype.with({ ? _years_, ? _months_, ? _days_, ? _hours_,
-      ? _minutes_, ? _seconds_, ? _milliseconds_, ? _microseconds_, ? _nanoseconds_ })
-    </h1>
-    <p>
-      >When called with a ZonedDateTime object as the _this_ context, the result
-      will be a new ZonedDateTime object.
-    </p>
-    <p>
-      The value of the new ZonedDateTime object is the value of the original
-      ZonedDateTime's milliseconds with the specified date parts, excepting any
-      nanoseconds argument, converted to milliseconds and added to the original
-      MillisecondValue.
-    </p>
-    <p>
-      Units will be added in order of size, descending. Calling this function
-      with a _this_ context that is not an instance of ZonedDateTime is illegal.
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.plus">
-    <h1>
-      ZonedDateTime.prototype.plus({ ? _years_, ? _months_, ? _days_, ? _hours_,
-      ? _minutes_, ? _seconds_, ? _milliseconds_, ? _microseconds_, ? _nanoseconds_ })
-    </h1>
-    <p>
-      When called with a ZonedDateTime object as the _this_ context, the result
-      will be a new ZonedDateTime object.
-    </p>
-    <p>
-      The value of the new ZonedDateTime object is the value of the original
-      ZonedDateTime with the specified date parts added. Units will be added in
-      order of size, descending.
-    </p>
-    <p>
-      Calling this function with a _this_ context that is not an instance of
-      ZonedDateTime is illegal.
-    </p>
-  </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.with">
+        <h1>
+        ZonedDateTime.prototype.with({ ? _years_, ? _months_, ? _days_, ? _hours_,
+        ? _minutes_, ? _seconds_, ? _milliseconds_, ? _microseconds_, ? _nanoseconds_ })
+        </h1>
+        <p>
+        When called with a ZonedDateTime object as the _this_ context, the result
+        will be a new ZonedDateTime object.
+        </p>
+        <p>
+        Units will be added in order of size, descending.
+        </p>
+        <p>Calling this function with a _this_ context that is not an instance of ZonedDateTime is illegal.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.plus">
+        <h1>
+        OffsetDateTime.prototype.plus({ ? _years_, ? _months_, ? _days_, ? _hours_,
+        ? _minutes_, ? _seconds_, ? _milliseconds_, ? _microseconds_, ? _nanoseconds_ })
+        </h1>
+        <p>
+        When called with a ZonedDateTime object as the _this_ context, the result
+        will be a new ZonedDateTime object.
+        </p>
+        <p>
+        The value of the new ZonedDateTime object is the value of the original
+        ZonedDateTime with the specified date parts added. Units will be added in
+        order of size, descending.
+        </p>
+        <p>Calling this function with a _this_ context that is not an instance of ZonedDateTime is illegal.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.minus">
+        <h1>ZonedDateTime.prototype.minus(_otherZonedDateTime_)</h1>
+        <p>
+        When called with a ZonedDateTime object as the _this_ context, the result
+        will be a new <emu-xref href="#sec-temporal-duration" title /> object.
+        </p>
+        <p>The value of the new Duration object is difference between _this_ and the supplied ZonedDateTime.</p>
+        <p>Calling this function with a _this_ context that is not an instance of OffsetDateTime is illegal.</p>
+    </emu-clause>
 
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.tocivildate">
-    <h1>ZonedDateTime.prototype.toCivilDate()</h1>
-    <p>
-      The abstract operation toCivilDate returns a new CivilDate Object with the
-      year, month, and day values calculated from the milliseconds and
-      nanoseconds since Epoch
-    </p>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.tociviltime">
-    <h1>ZonedDateTime.prototype.toCivilTime()</h1>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.tocivildatetime">
-    <h1>ZonedDateTime.prototype.toCivilDateTime()</h1>
-  </emu-clause>
-  <emu-clause id="sec-temporal-zoneddatetime.prototype.tostring">
-    <h1>ZonedDateTime.prototype.toString()</h1>
-    <p>
-      When called with a ZonedDateTime object as a _this_ context it will return
-      an ISO 8601 String value representing the value of the ZonedDateTime
-      object.
-    </p>
-    <p>
-      The format of the String will always be an IsoDateTime of the following
-      form:
-    </p>
-    <emu-grammar>
-      Sign: `-` Year: Sign? Digit Digit Digit Digit Month: `01` through `12`
-      Day: `01` through `31` Hour: `00` through `24` Minute: `00` through `59`
-      Second: `00` through `59` Nanoseconds: `000000000` through `999999999`
-      IsoDateTime: Year Month Day `T` Hour Minute Second `.` Nanoseconds `Z`
-    </emu-grammar>
-    Calling this function with a _this_ context that is not an instance of
-    ZonedDateTime is illegal.
-  </emu-clause>
-  <emu-clause id=sec-temporal-zoneddatetime.fromEpochSeconds>
-    <h1>ZonedDateTime.fromEpochSeconds(_seconds_, _timezone_)</h1>
-    <p>
-      This function will create a ZonedDateTime object that is equivalent to:
-      `new ZonedDateTime(Instant.fromEpochSeconds(_seconds), _timezone)`.
-    </p>
-  </emu-clause>
-  <emu-clause id=sec-temporal-zoneddatetime.fromEpochMilliseconds>
-    <h1>ZonedDateTime.fromEpochMilliseconds(_milliseconds_, _timezone_)</h1>
-    <p>
-      This function will create a ZonedDateTime object that is equivalent to:
-      `new ZonedDateTime(Instant.fromEpochMilliseconds(_milliseconds), _timezone)`.
-    </p>
-  </emu-clause>
-  <emu-clause id=sec-temporal-zoneddatetime.fromEpochMicroseconds>
-    <h1>ZonedDateTime.fromEpochMicroseconds(_microseconds_, _timezone_)</h1>
-    <p>
-      This function will create a ZonedDateTime object that is equivalent to:
-      `new ZonedDateTime(Instant.fromEpochMicroseconds(_microseconds), _timezone)`.
-    </p>
-  </emu-clause>
-  <emu-clause id=sec-temporal-zoneddatetime.fromEpochNanoseconds>
-    <h1>ZonedDateTime.fromEpochNanoseconds(_nanoseconds_, _timezone_)</h1>
-    <p>
-      This function will create a ZonedDateTime object that is equivalent to:
-      `new ZonedDateTime(Instant.fromEpochNanoseconds(_nanoseconds), _timezone)`.
-    </p>
-  </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.getcivildate">
+        <h1>ZonedDateTime.prototype.getCivilDate()</h1>
+        <p>
+        The abstract operation toCivilDate returns a new CivilDate Object with the
+        year, month, and day values calculated from the milliseconds and
+        nanoseconds since Epoch
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.getciviltime">
+        <h1>ZonedDateTime.prototype.getCivilTime()</h1>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.getcivildatetime">
+        <h1>ZonedDateTime.prototype.getCivilDateTime()</h1>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-zoneddatetime.prototype.tostring">
+        <h1>ZonedDateTime.prototype.toString()</h1>
+        <p>
+        When called with a ZonedDateTime object as a _this_ context it will return
+        an ISO 8601 String value representing the value of the ZonedDateTime
+        object.
+        </p>
+        <p>The format of the String will always be an IsoDateTime of the following form:</p>
+        <emu-grammar>
+        Sign: `-`
+        Year: Sign? Digit Digit Digit Digit
+        Month: `01` through `12`
+        Day: `01` through `31`
+        Hour: `00` through `24`
+        Minute: `00` through `59`
+        Second: `00` through `59`
+        Milliseconds: `000` through `999`
+        Microseconds: `000` through `999`
+        Nanoseconds: `000` through `999`
+        DatePart: Year `-` Month `-` Day
+        SubSeconds: `.` Milliseconds Microseconds Nanoseconds
+        TimePart: Hour `:` Minute `:` Second SubSeconds
+        OffsetDirection: `+` or `-`
+        OffsetHours: `00` to `24`
+        OffsetMinutes: `00` to `59`
+        Offset: OffsetDirection OffsetHours `:` OffsetMinutes
+        TimeZone: IANA timezone (geographic / link) name
+        IsoDateTime: DatePart `T` TimePart Offset `[` TimeZone `]`
+        </emu-grammar>
+        <p>Calling this function with a _this_ context that is not an instance of ZonedDateTime is illegal.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-zoneddatetime.fromstring">
+        <h1>ZonedDateTime.fromString(_isostring_)</h1>
+        <p>
+        _isostring_ has to be in the precise format produced by <emu-xref href="#sec-temporal-zoneddatetime.prototype.tostring" title />.
+        However the `SubSeconds` are optional from right to left (when there isn't a `Milliseconds` part the `.` is disallowed).
+        </p>
+        <p>The offset in the string has to match the timezone at that time and date. Strings where this is not true are illegal.</p>
+        <p>Calling this function with a _this_ context that is not an instance of OffsetDateTime is illegal.</p>
+    </emu-clause>
 </emu-clause>


### PR DESCRIPTION
Basic cleanup of the spec to closer match `objects.md` .

# Changes

## Eliminate `OffsetDateTime.prototype.withZone`

Reason is that it's just as easy to `offsetdatetime.instant.withZone()` which is much more explicit.
