### PR TITLE
[polyfill] Get rid of extraneous argument

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -130,7 +130,6 @@ export class Duration {
       milliseconds,
       microseconds,
       nanoseconds,
-      'reject'
     );
   }
   static from(...args) {


### PR DESCRIPTION
@pipobscure since `GetIntrinsic('%Temporal.Duration %') returns the `Duration` constructor, this argument is getting ignored anyway, so I didn't understand why it was being passed in the first place...

Is it intentional? Does it need to be included in the spec?