### PR TITLE
[polyfill] remove new from fromString methods

### DIFF
--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -45,7 +45,7 @@ export class Absolute {
   }
 
   plus(durationLike = {}) {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     if (GetSlot(duration, YEARS) !== 0) throw new RangeError(`invalid duration field years`);
     if (GetSlot(duration, MONTHS) !== 0) throw new RangeError(`invalid duration field months`);
 
@@ -74,7 +74,7 @@ export class Absolute {
     return result;
   }
   minus(durationLike = {}) {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     if (GetSlot(duration, YEARS) !== 0) throw new RangeError(`invalid duration field years`);
     if (GetSlot(duration, MONTHS) !== 0) throw new RangeError(`invalid duration field months`);
 
@@ -98,7 +98,7 @@ export class Absolute {
     return result;
   }
   difference(other) {
-    other = ES.GetIntrinsic('%Temporal.absolute%')(other);
+    other = ES.GetIntrinsic('%Temporal.Absolute%')(other);
 
     const [one, two] = [this, other].sort(Absoulte.compare);
     const { ms: onems, ns: onens } = GetSlot(one, EPOCHNANOSECONDS);
@@ -111,7 +111,7 @@ export class Absolute {
     return duration;
   }
   toString(timeZoneParam = 'UTC') {
-    let timeZone = ES.GetIntrinsic('%Temporal.timezone%')(timeZoneParam);
+    let timeZone = ES.GetIntrinsic('%Temporal.TimeZone%')(timeZoneParam);
     let dateTime = timeZone.getDateTimeFor(this);
     let year = ES.ISOYearString(dateTime.year);
     let month = ES.ISODateTimePartString(dateTime.month);
@@ -177,7 +177,7 @@ export class Absolute {
     const microsecond = ES.ToInteger(match[8]);
     const nanosecond = ES.ToInteger(match[9]);
     const zone = match[11] || match[10] || 'UTC';
-    const datetime = ES.GetIntrinsic('%Temporal.datetime%', {
+    const datetime = ES.GetIntrinsic('%Temporal.DateTime%', {
       year,
       month,
       day,
@@ -191,11 +191,11 @@ export class Absolute {
     return datetime.inZone(zone || 'UTC', match[11] ? match[10] : 'earlier');
   }
   static from(...args) {
-    return ES.GetIntrinsic('%Temporal.absolute%')(...args);
+    return ES.GetIntrinsic('%Temporal.Absolute%')(...args);
   }
   static compare(one, two) {
-    one = ES.GetIntrinsic('%Temporal.absolute%')(one);
-    two = ES.GetIntrinsic('%Temporal.absolute%')(two);
+    one = ES.GetIntrinsic('%Temporal.Absolute%')(one);
+    two = ES.GetIntrinsic('%Temporal.Absolute%')(two);
     one = GetSlot(one, EPOCHNANOSECONDS);
     two = GetSlot(two, EPOCHNANOSECONDS);
     if (one.ms !== two.ms) return ES.ComparisonResult(two.ms - one.ms);

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -107,7 +107,7 @@ export class Absolute {
     ns = twons - onens;
     ms = twoms - onems;
 
-    const duration = new ES.GetIntrinsic('%Temporal.Duration%')(delta);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(delta);
     return duration;
   }
   toString(timeZoneParam = 'UTC') {

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -57,7 +57,7 @@ export class Date {
     return new Date(year, month, day, disambiguation);
   }
   plus(durationLike = {}, disambiguation = 'constrain') {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     let { year, month, day } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     if (hours || minutes || seconds || milliseconds || microseconds || nanoseconds)
@@ -67,7 +67,7 @@ export class Date {
     return new Date(year, month, day);
   }
   minus(durationLike = {}, disambiguation = 'constrain') {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     let { year, month, day } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     if (hours !== 0 || minutes !== 0 || seconds !== 0 || milliseconds !== 0 || microseconds !== 0 || nanoseconds !== 0)
@@ -77,7 +77,7 @@ export class Date {
     return new Date(year, month, day);
   }
   difference(other, disambiguation = 'constrain') {
-    other = ES.GetIntrinsic('%Temporal.date%')(other);
+    other = ES.GetIntrinsic('%Temporal.Date%')(other);
     const [one, two] = [this, other].sort(DateTime.compare);
     let years = two.year - one.year;
 
@@ -110,7 +110,7 @@ export class Date {
     const year = GetSlot(this, YEAR);
     const month = GetSlot(this, MONTH);
     const day = GetSlot(this, DAY);
-    timeLike = ES.GetIntrinsic('%Temporal.time%')(timeLike);
+    timeLike = ES.GetIntrinsic('%Temporal.Time%')(timeLike);
     const { hour, minute, second, millisecond, microsecond, nanosecond } = timeLike;
     const DateTime = ES.GetIntrinsic('%Temporal.DateTime%');
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, disambiguation);
@@ -124,7 +124,7 @@ export class Date {
     return new MonthDay(GetSlot(this, MONTH), GetSlot(this, DAY));
   }
 
-  static fromString(isoStringParam) {
+  static fromString(isoString) {
     isoString = ES.ToString(isoString);
     const match = STRING.exec(isoString);
     if (!match) throw new RangeError(`invalid date: ${isoString}`);
@@ -134,11 +134,11 @@ export class Date {
     return ES.GetIntrinsic('%Temporal.Date%')(year, month, day, 'reject');
   }
   static from(...args) {
-    return ES.GetIntrinsic('%Temporal.date%')(...args);
+    return ES.GetIntrinsic('%Temporal.Date%')(...args);
   }
   static compare(one, two) {
-    one = ES.GetIntrinsic('%Temporal.date%')(one);
-    two = ES.GetIntrinsic('%Temporal.date%')(two);
+    one = ES.GetIntrinsic('%Temporal.Date%')(one);
+    two = ES.GetIntrinsic('%Temporal.Date%')(two);
     if (one.year !== two.year) return ES.ComparisonResult(one.year - two.year);
     if (one.month !== two.month) return ES.ComparisonResult(one.month - two.month);
     if (one.day !== two.day) return ES.ComparisonResult(one.day - two.day);

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -131,7 +131,7 @@ export class Date {
     const year = ES.ToInteger(match[1]);
     const month = ES.ToInteger(match[2]);
     const day = ES.ToInteger(match[3]);
-    return new ES.GetIntrinsic('%Temporal.Date%')(year, month, day, 'reject');
+    return ES.GetIntrinsic('%Temporal.Date%')(year, month, day, 'reject');
   }
   static from(...args) {
     return ES.GetIntrinsic('%Temporal.date%')(...args);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -138,7 +138,7 @@ export class DateTime {
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, disambiguation);
   }
   plus(durationLike = {}, disambiguation = 'constrain') {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     ({ year, month, day } = ES.AddDate(year, month, day, years, months, days, disambiguation));
@@ -161,7 +161,7 @@ export class DateTime {
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }
   minus(durationLike = {}, disambiguation = 'constrain') {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     ({ year, month, day } = ES.SubtractDate(year, month, day, years, months, days, disambiguation));
@@ -184,7 +184,7 @@ export class DateTime {
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }
   difference(other, disambiguation = 'constrain') {
-    other = ES.GetIntrinsic('%Temporal.datetime%')(other);
+    other = ES.GetIntrinsic('%Temporal.DateTime%')(other);
     const [one, two] = [this, other].sort(DateTime.compare);
     let years = two.year - one.year;
 
@@ -240,7 +240,7 @@ export class DateTime {
   }
 
   inZone(timeZoneParam = 'UTC', disambiguation = 'earlier') {
-    const timeZone = ES.GetIntrinsic('%Temporal.timezone%')(timeZoneParam);
+    const timeZone = ES.GetIntrinsic('%Temporal.TimeZone%')(timeZoneParam);
     return timeZone.getAbsoluteFor(this, disambiguation);
   }
   getDate() {
@@ -294,11 +294,11 @@ export class DateTime {
     );
   }
   static from(...args) {
-    return ES.GetIntrinsic('%Temporal.datetime%')(...args);
+    return ES.GetIntrinsic('%Temporal.DateTime%')(...args);
   }
   static compare(one, two) {
-    one = ES.GetIntrinsic('%Temporal.datetime%')(one);
-    two = ES.GetIntrinsic('%Temporal.datetime%')(two);
+    one = ES.GetIntrinsic('%Temporal.DateTime%')(one);
+    two = ES.GetIntrinsic('%Temporal.DateTime%')(two);
     if (one.year !== two.year) return ES.ComparisonResult(one.year - two.year);
     if (one.month !== two.month) return ES.ComparisonResult(one.month - two.month);
     if (one.day !== two.day) return ES.ComparisonResult(one.day - two.day);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -280,7 +280,7 @@ export class DateTime {
     const millisecond = ES.ToInteger(match[7]);
     const microsecond = ES.ToInteger(match[8]);
     const nanosecond = ES.ToInteger(match[9]);
-    return new ES.GetIntrinsic('%Temporal.DateTime%')(
+    return ES.GetIntrinsic('%Temporal.DateTime%')(
       year,
       month,
       day,

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -121,7 +121,7 @@ export class Duration {
     const milliseconds = ES.ToInteger(match[7]);
     const microseconds = ES.ToInteger(match[8]);
     const nanoseconds = ES.ToInteger(match[9]);
-    return new ES.GetIntrinsic('%Temporal.Duration%')(
+    return ES.GetIntrinsic('%Temporal.Duration%')(
       years,
       months,
       days,

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -135,7 +135,7 @@ export class Duration {
     );
   }
   static from(...args) {
-    return ES.GetIntrinsic('%Temporal.duration%')(...args);
+    return ES.GetIntrinsic('%Temporal.Duration%')(...args);
   }
 }
 Duration.prototype.toJSON = Duration.prototype.toString;

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -99,7 +99,7 @@ export class MonthDay {
     if (!match) throw new RangeError(`invalid monthday: ${isoString}`);
     const month = ES.ToInteger(match[1]);
     const day = ES.ToInteger(match[2]);
-    return new ES.GetIntrinsic('%Temporal.MonthDay%')(month, day, 'reject');
+    return ES.GetIntrinsic('%Temporal.MonthDay%')(month, day, 'reject');
   }
   static from(...args) {
     return ES.GetIntrinsic('%Temporal.monthday%')(...args);

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -37,7 +37,7 @@ export class MonthDay {
     return new MonthDay(month, day, disambiguation);
   }
   plus(durationLike = {}, disambiguation = 'constrain') {
-    const duration = ES.GetIntrinsic('%Temporal.duration')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration')(durationLike);
     let { month, day } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     if (
@@ -55,7 +55,7 @@ export class MonthDay {
     return new MonthDay(month, day);
   }
   minus(durationLike = {}, disambiguation = 'constrain') {
-    const duration = ES.GetIntrinsic('%Temporal.duration')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration')(durationLike);
     let { year, month, day } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     if (hours !== 0 || minutes !== 0 || seconds !== 0 || milliseconds !== 0 || microseconds !== 0 || nanoseconds !== 0)
@@ -65,7 +65,7 @@ export class MonthDay {
     return new MonthDay(month, day);
   }
   difference(other, disambiguation = 'constrain') {
-    other = ES.GetIntrinsic('%Temporal.monthday')(other);
+    other = ES.GetIntrinsic('%Temporal.MonthDay')(other);
     const [one, two] = [this, other].sort(MonthDay.compare);
     let months = two.month - one.month;
     let days = (two.days = one.days);
@@ -102,11 +102,11 @@ export class MonthDay {
     return ES.GetIntrinsic('%Temporal.MonthDay%')(month, day, 'reject');
   }
   static from(...args) {
-    return ES.GetIntrinsic('%Temporal.monthday%')(...args);
+    return ES.GetIntrinsic('%Temporal.MonthDay%')(...args);
   }
   static compare(one, two) {
-    one = ES.GetIntrinsic('%Temporal.monthday')(one);
-    two = ES.GetIntrinsic('%Temporal.monthday')(two);
+    one = ES.GetIntrinsic('%Temporal.MonthDay')(one);
+    two = ES.GetIntrinsic('%Temporal.MonthDay')(two);
     if (one.month !== two.month) return ES.ComparisonResult(one.month - two.month);
     if (one.day !== two.day) return ES.ComparisonResult(one.day - two.day);
     return ES.ComparisonResult(0);

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -86,7 +86,7 @@ export class Time {
     return new Time(hour, minute, second, millisecond, microsecond, nanosecond, disambiguation);
   }
   plus(durationLike) {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     let { hour, minute, second, millisecond, microsecond, nanosecond } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     if (years !== 0 || months !== 0 || days !== 0) throw new RangeError('invalid duration');
@@ -121,7 +121,7 @@ export class Time {
     return new Time(hour, minute, second, millisecond, microsecond, nanosecond);
   }
   minus(durationLike) {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     let { hour, minute, second, millisecond, microsecond, nanosecond } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     if (years !== 0 || months !== 0 || days !== 0) throw new RangeError('invalid duration');
@@ -156,7 +156,7 @@ export class Time {
     return new Time(hour, minute, second, millisecond, microsecond, nanosecond);
   }
   difference(other = {}) {
-    other = ES.GetIntrinsic('%Temporal.time%')(other);
+    other = ES.GetIntrinsic('%Temporal.Time%')(other);
     const [one, two] = [this, other].sort(Time.compare);
     const hours = two.hour - one.hour;
     const minutes = two.minute - one.minute;
@@ -184,7 +184,7 @@ export class Time {
   }
 
   withDate(dateLike = {}, disambiguation = 'constrain') {
-    let { year, month, day } = ES.GetIntrinsic('%Temporal.date%')(dateLike);
+    let { year, month, day } = ES.GetIntrinsic('%Temporal.Date%')(dateLike);
     let { hour, minute, second, millisecond, microsecond, nanosecond } = this;
     const DateTime = ES.GetIntrinsic('%Temporal.DateTime%');
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, disambiguation);
@@ -203,11 +203,11 @@ export class Time {
     return ES.GetIntrinsic('%Temporal.Time%')(hour, minute, second, millisecond, microsecond, nanosecond, 'reject');
   }
   static from(...args) {
-    return ES.GetIntrinsic('%Temporal.time%')(...args);
+    return ES.GetIntrinsic('%Temporal.Time%')(...args);
   }
   static compare(one, two) {
-    one = ES.GetIntrinsic('%Temporal.time%')(one);
-    two = ES.GetIntrinsic('%Temporal.time%')(two);
+    one = ES.GetIntrinsic('%Temporal.Time%')(one);
+    two = ES.GetIntrinsic('%Temporal.Time%')(two);
     if (one.hour !== two.hour) return ES.ComparisonResult(one.hour - two.hour);
     if (one.minute !== two.minute) return ES.ComparisonResult(one.minute - two.minute);
     if (one.second !== two.second) return ES.ComparisonResult(one.second - two.second);

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -200,7 +200,7 @@ export class Time {
     const millisecond = ES.ToInteger(match[4]);
     const microsecond = ES.ToInteger(match[5]);
     const nanosecond = ES.ToInteger(match[6]);
-    return new ES.GetIntrinsic('%Temporal.Time%')(hour, minute, second, millisecond, microsecond, nanosecond, 'reject');
+    return ES.GetIntrinsic('%Temporal.Time%')(hour, minute, second, millisecond, microsecond, nanosecond, 'reject');
   }
   static from(...args) {
     return ES.GetIntrinsic('%Temporal.time%')(...args);

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -13,11 +13,11 @@ export class TimeZone {
     return String(GetSlot(this, IDENTIFIER));
   }
   getOffsetFor(absolute) {
-    absolute = ES.GetIntrinsic('%Temporal.absolute%')(absolute);
+    absolute = ES.GetIntrinsic('%Temporal.Absolute%')(absolute);
     return ES.GetTimeZoneOffsetString(absolute.getEpochMilliseconds(), GetSlot(this, IDENTIFIER));
   }
   getDateTimeFor(absolute) {
-    absolute = ES.GetIntrinsic('%Temporal.absolute%')(absolute);
+    absolute = ES.GetIntrinsic('%Temporal.Absolute%')(absolute);
     const { ms, ns } = GetSlot(absolute, EPOCHNANOSECONDS);
     const {
       year,
@@ -34,7 +34,7 @@ export class TimeZone {
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }
   getAbsoluteFor(dateTime, disambiguation = 'earlier') {
-    dateTime = ES.GetIntrinsic('%Temporal.datetime%')(dateTime);
+    dateTime = ES.GetIntrinsic('%Temporal.DateTime%')(dateTime);
     const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = dateTime;
     const options = ES.GetTimeZoneEpochValue(
@@ -99,7 +99,7 @@ export class TimeZone {
     }
   }
   getTransitions(startingPoint) {
-    startingPoint = ES.GetIntrinsic('%Temporal.absolute%')(startingPoint);
+    startingPoint = ES.GetIntrinsic('%Temporal.Absolute%')(startingPoint);
     let { ms } = GetSlot(startingPoint, EPOCHNANOSECONDS);
     const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');
     return {
@@ -122,7 +122,7 @@ export class TimeZone {
     return new TimeZone(zone);
   }
   static from(...args) {
-    return ES.GetIntrinsic('%Temporal.timezone%')(...args);
+    return ES.GetIntrinsic('%Temporal.TimeZone%')(...args);
   }
 }
 if ('undefined' !== typeof Symbol) {

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -40,7 +40,7 @@ export class YearMonth {
     return new YearMonth(year, month, disambiguation);
   }
   plus(durationLike = {}, disambiguation = 'constrain') {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     let { year, month } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     if ((days, hours || minutes || seconds || milliseconds || microseconds || nanoseconds))
@@ -50,7 +50,7 @@ export class YearMonth {
     return new YearMonth(year, month);
   }
   minus(durationLike = {}, disambiguation = 'constrain') {
-    const duration = ES.GetIntrinsic('%Temporal.duration%')(durationLike);
+    const duration = ES.GetIntrinsic('%Temporal.Duration%')(durationLike);
     let { year, month } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     if (
@@ -68,7 +68,7 @@ export class YearMonth {
     return new YearMonth(year, month);
   }
   difference(other) {
-    other = ES.GetIntrinsic('%Temporal.yearmonth%')(other);
+    other = ES.GetIntrinsic('%Temporal.YearMonth%')(other);
     const [one, two] = [this, other].sort(DateTime.compare);
     let years = two.year - one.year;
     let months = two.month - one.month;
@@ -104,11 +104,11 @@ export class YearMonth {
     return ES.GetIntrinsic('%Temporal.YearMonth%')(year, month, 'reject');
   }
   static from(...args) {
-    return ES.GetIntrinsic('%Temporal.yearmonth%')(...args);
+    return ES.GetIntrinsic('%Temporal.YearMonth%')(...args);
   }
   static compare(one, two) {
-    one = ES.GetIntrinsic('%Temporal.yearmonth%')(one);
-    two = ES.GetIntrinsic('%Temporal.yearmonth%')(two);
+    one = ES.GetIntrinsic('%Temporal.YearMonth%')(one);
+    two = ES.GetIntrinsic('%Temporal.YearMonth%')(two);
     if (one.year !== two.year) return ES.ComparisonResult(one.year - two.year);
     if (one.month !== two.month) return ES.ComparisonResult(one.month - two.month);
     return ES.ComparisonResult(0);

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -101,7 +101,7 @@ export class YearMonth {
     if (!match) throw new RangeError(`invalid yearmonth: ${isoString}`);
     const year = ES.ToInteger(match[1]);
     const month = ES.ToInteger(match[2]);
-    return new ES.GetIntrinsic('%Temporal.YearMonth%')(year, month, 'reject');
+    return ES.GetIntrinsic('%Temporal.YearMonth%')(year, month, 'reject');
   }
   static from(...args) {
     return ES.GetIntrinsic('%Temporal.yearmonth%')(...args);


### PR DESCRIPTION
The fromString methods in different Temporal intrinsics were using the
result of ES.GetIntrinsic as a constructor and calling it with the
`new` keyword even though it's not required.

Fixes: https://github.com/tc39/proposal-temporal/issues/181

/cc @jasonwilliams