### PR TITLE
[polyfill] unify behavior on numerical types

### DIFF
--- a/polyfill/lib/casts.mjs
+++ b/polyfill/lib/casts.mjs
@@ -189,8 +189,6 @@ export function CastDuration(arg) {
       return Duration.fromString(arg);
     } catch (ex) {}
   }
-  if ('bigint' === typeof arg) return new Duration(0, 0, 0, 0, 0, 0, 0, 0, arg);
-  if (Number.isFinite(+arg)) return new Duration(0, 0, 0, 0, 0, 0, +arg, 0, 0);
   if ('object' === typeof arg) {
     const {
       years = 0,


### PR DESCRIPTION
Unify the behavior of Temporal.Duration.from() on all numerical types
(number and bigint) and providing previously available behavior through
the static Temporal.Duration.fromNanoSeconds() method.

/cc @pipobscure @Ms2ger @littledan 