### PR TITLE
[api] rename inZone to inTimeZone

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -12,7 +12,7 @@ An absolute point in time.
 
 ## absolute.getEpochNanoseconds() : bigint
 
-## absolute.inZone(timeZone: Temporal.TimeZone | string) : Temporal.DateTime
+## absolute.inTimeZone(timeZone: Temporal.TimeZone | string) : Temporal.DateTime
 
 ## absolute.plus(duration: Temporal.Duration | string | object) : Temporal.Absolute
 

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -42,7 +42,7 @@
 
 ## datetime.toLocaleString(locale?:string, options?: object) : string
 
-## datetime.inZone(timeZoneParam = 'UTC', disambiguation = 'earlier') : Temporal.Absolute
+## datetime.inTimeZone(timeZoneParam = 'UTC', disambiguation = 'earlier') : Temporal.Absolute
 
 ## datetime.getDate() : Temporal.Date
 

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -34,7 +34,7 @@ dt.millisecond/* 0 */; dt.microsecond/* 0 */; dt.nanosecond/* 0 */;
 dt.with({ month: 11 }); // 2019-11-07T13:03:30
 dt.plus('P1D'); // 2019-10-08T13:03:30
 dt.minus('P1M'); // 2019-09-07T13:03:30
-dt.inZone('Europe/Vienna'); // 2019-10-07T11:03:30Z
+dt.inTimeZone('Europe/Vienna'); // 2019-10-07T11:03:30Z
 dt.getDate()/* 2019-10-07 */; dt.getTime()/* 13:03:30 */;
 ```
 
@@ -79,8 +79,8 @@ dt.getEpochNanoseconds(); // 1570537307821560338n
 dt.getEpochMicroseconds(); // 1570537307821560n
 dt.getEpochMilliseconds(); // 1570537307821
 dt.getEpochSeconds(); // 1570537307
-dt.inZone('America/New_York'); // 2019-10-08T08:21:47.821560338
-dt.inZone('Europe/Berlin'); // 2019-10-08T14:21:47.821560338
+dt.inTimeZone('America/New_York'); // 2019-10-08T08:21:47.821560338
+dt.inTimeZone('Europe/Berlin'); // 2019-10-08T14:21:47.821560338
 dt.toString('America/New_York'); // 2019-10-08T08:21:47.821560338-04:00[America/New_York]
 ```
 

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -147,7 +147,7 @@ export class Absolute {
     if (!ES.IsAbsolute(this)) throw new TypeError('invalid receiver');
     return new Intl.DateTimeFormat(...args).format(this);
   }
-  inZone(timeZoneParam = 'UTC') {
+  inTimeZone(timeZoneParam = 'UTC') {
     if (!ES.IsAbsolute(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTimeZone(timeZoneParam);
     return timeZone.getDateTimeFor(this);
@@ -210,7 +210,7 @@ export class Absolute {
       microsecond,
       nanosecond
     });
-    const result = datetime.inZone(zone || 'UTC', match[11] ? match[10] : 'earlier');
+    const result = datetime.inTimeZone(zone || 'UTC', match[11] ? match[10] : 'earlier');
     return this === Absolute ? result : new this(result.getEpochNanoseconds());
   }
   static from(...args) {

--- a/polyfill/lib/casts.mjs
+++ b/polyfill/lib/casts.mjs
@@ -48,7 +48,7 @@ export function CastDateTime(arg, aux) {
   if (HasSlot(arg, YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND)) {
     return arg;
   }
-  if (HasSlot(arg, EPOCHNANOSECONDS)) return arg.inZone(aux);
+  if (HasSlot(arg, EPOCHNANOSECONDS)) return arg.inTimeZone(aux);
   if (HasSlot(arg, YEAR, MONTH, DAY) && HasSlot(aux, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND)) {
     return new DateTime(
       GetSlot(arg, YEAR),
@@ -105,7 +105,8 @@ export function CastDateTime(arg, aux) {
       return DateTime.fromString(arg);
     } catch (ex) {}
   }
-  if ('bigint' === typeof arg || 'number' === typeof arg || Number.isFinite(+arg)) return CastAbsolute(arg).inZone(aux);
+  if ('bigint' === typeof arg || 'number' === typeof arg || Number.isFinite(+arg))
+    return CastAbsolute(arg).inTimeZone(aux);
   throw new RangeError(`invalid datetime ${arg}`);
 }
 

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -260,7 +260,7 @@ export class DateTime {
     return new Intl.DateTimeFormat(...args).format(this);
   }
 
-  inZone(timeZoneParam = 'UTC', disambiguation = 'earlier') {
+  inTimeZone(timeZoneParam = 'UTC', disambiguation = 'earlier') {
     if (!ES.IsDateTime(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.CastTimeZone(timeZoneParam);
     return timeZone.getAbsoluteFor(this, disambiguation);

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -38,6 +38,9 @@ describe('Absolute', () => {
       it('Absolute.prototype has getEpochNanoseconds', () => {
         assert('getEpochNanoseconds' in Absolute.prototype);
       });
+      it('Absolute.prototype.inTimeZone is a Function', () => {
+        equal(typeof Absolute.prototype.inTimeZone, 'function');
+      });
       it('Absolute.prototype.toString is a Function', () => {
         equal(typeof Absolute.prototype.toString, 'function');
       });

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -74,8 +74,8 @@ describe('DateTime', () => {
       it('DateTime.prototype.difference is a Function', () => {
         equal(typeof DateTime.prototype.difference, 'function');
       });
-      it('DateTime.prototype.inZone is a Function', () => {
-        equal(typeof DateTime.prototype.inZone, 'function');
+      it('DateTime.prototype.inTimeZone is a Function', () => {
+        equal(typeof DateTime.prototype.inTimeZone, 'function');
       });
       it('DateTime.prototype.getDate is a Function', () => {
         equal(typeof DateTime.prototype.getDate, 'function');


### PR DESCRIPTION
Rename `Absolute.prototype.inZone` and `DateTime.prototype.inZone` to
`Absolute.prototype.inTimeZone` and `DateTime.prototype.inTimeZone`
respectively, since Temporal.TimeZone now exists.

Fixes: https://github.com/tc39/proposal-temporal/issues/235