### PR TITLE
[spec] fix all occurances of [[Day]] in BalanceTime

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -115,7 +115,7 @@
           1. For each of _y_, _mo_, _d_, _h_, _m_, _s_, _ms_, _mis_, _ns_, if any of the values is negative, let it be its own absolute value.
         1. Else if _disambiguation_ is *"balance"*, then
           1. Let _bt_ be ? BalanceTime(_h_, _m_, _s_, _ms_, _mis_, _ns_).
-          1. Increment _d_ by _bt_.[[Day]].
+          1. Increment _d_ by _bt_.[[Days]].
           1. Set _h_ to _bt_.[[Hour]].
           1. Set _m_ to _bt_.[[Minute]].
           1. Set _s_ to _bt_.[[Second]].

--- a/spec/time.html
+++ b/spec/time.html
@@ -228,7 +228,7 @@
         1. Let _millisecond_ be _time_.[[Millisecond]] + _duration_.[[Milliseconds]].
         1. Let _microsecond_ be _time_.[[Microsecond]] + _duration_.[[Microseconds]].
         1. Let _nanosecond_ be _time_.[[Nanosecond]] + _duration_.[[Nanoseconds]].
-        1. Let _result_ be ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+        1. Let _result_ be ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. Return ? CreateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
@@ -250,7 +250,7 @@
         1. Let _millisecond_ be _time_.[[Millisecond]] - _duration_.[[Millisecond]].
         1. Let _microsecond_ be _time_.[[Microsecond]] - _duration_.[[Microsecond]].
         1. Let _nanosecond_ be _time_.[[Nanosecond]] - _duration_.[[Nanosecond]].
-        1. Let _result_ be ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+        1. Let _result_ be ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. Return ? CreateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
@@ -322,7 +322,7 @@
         1. Let _millisecond_ be _greater_.[[Millisecond]] - _smaller_.[[Millisecond]].
         1. Let _microsecond_ be _greater_.[[Microsecond]] - _smaller_.[[Microsecond]].
         1. Let _nanosecond_ be _greater_.[[Nanosecond]] - _smaller_.[[Nanosecond]].
-        1. Let _result_ be ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+        1. Let _result_ be ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. Return ? CreateDuration(0, 0, _result_.[[Days]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
@@ -474,7 +474,7 @@
         1. If _disambiguation_ is `"constrain"`, then
           1. <mark>TODO: define.</mark>
         1. If _disambiguation_ is `"balance"`, then
-          1. Return ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+          1. Return ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. If _disambiguation_ is `"reject"`, then
           1. If ! ValidateTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *false*, then
             1. Throw a *RangeError* exception.

--- a/spec/time.html
+++ b/spec/time.html
@@ -228,7 +228,7 @@
         1. Let _millisecond_ be _time_.[[Millisecond]] + _duration_.[[Milliseconds]].
         1. Let _microsecond_ be _time_.[[Microsecond]] + _duration_.[[Microseconds]].
         1. Let _nanosecond_ be _time_.[[Nanosecond]] + _duration_.[[Nanoseconds]].
-        1. Let _result_ be BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+        1. Let _result_ be ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. Return ? CreateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
@@ -250,7 +250,7 @@
         1. Let _millisecond_ be _time_.[[Millisecond]] - _duration_.[[Millisecond]].
         1. Let _microsecond_ be _time_.[[Microsecond]] - _duration_.[[Microsecond]].
         1. Let _nanosecond_ be _time_.[[Nanosecond]] - _duration_.[[Nanosecond]].
-        1. Let _result_ be BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+        1. Let _result_ be ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. Return ? CreateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
@@ -322,8 +322,8 @@
         1. Let _millisecond_ be _greater_.[[Millisecond]] - _smaller_.[[Millisecond]].
         1. Let _microsecond_ be _greater_.[[Microsecond]] - _smaller_.[[Microsecond]].
         1. Let _nanosecond_ be _greater_.[[Nanosecond]] - _smaller_.[[Nanosecond]].
-        1. Let _result_ be BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
-        1. Return ? CreateDuration(0, 0, _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+        1. Let _result_ be ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+        1. Return ? CreateDuration(0, 0, _result_.[[Days]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
 
@@ -474,12 +474,12 @@
         1. If _disambiguation_ is `"constrain"`, then
           1. <mark>TODO: define.</mark>
         1. If _disambiguation_ is `"balance"`, then
-          1. Return BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+          1. Return ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. If _disambiguation_ is `"reject"`, then
           1. If ! ValidateTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *false*, then
             1. Throw a *RangeError* exception.
           1. Return the new Record {
-            [[Day]]: 0,
+            [[Days]]: 0,
             [[Hour]]: _hour_,
             [[Minute]]: _minute_,
             [[Second]]: _second_,
@@ -524,10 +524,10 @@
         1. Set _second_ to NonNegativeModulo(_second_, 60).
         1. Set _hour_ to _hour_ + floor(_minute_ / 60).
         1. Set _minute_ to NonNegativeModulo(_minute_, 60).
-        1. Let _day_ be floor(_hour_ / 24).
+        1. Let _days_ be floor(_hour_ / 24).
         1. Set _hour_ to NonNegativeModulo(_hour_, 24).
         1. Return the new Record {
-          [[Day]]: _day_,
+          [[Days]]: _days_,
           [[Hour]]: _hour_,
           [[Minute]]: _minute_,
           [[Second]]: _second_,


### PR DESCRIPTION
In the spec, BalanceTime was returning an object with a [[Day]] internal
slot, which was neither inline with the polyfill nor the intended
behavior, this PR renames that slot to [[Days]], which better represents
is actual significance (to denote the delta days).

Fixes: https://github.com/tc39/proposal-temporal/issues/234