### PR TITLE
move from to the top under constructor

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -7,6 +7,10 @@ No timezone or offset information is present. As such `Absolute`s have no concep
 
 Creates a new `Absolute` object that represents an absolute point on the timeline.
 
+## Temporal.Absolute.from(thing: string | object) : Temporal.Absolute
+
+Creates a new `Absolute` object from either an object or IEO-8601 string.
+
 ## absolute.getEpochSeconds() : number
 
 Returns the numeric value of the specified date as the number of seconds since January 1, 1970, 00:00:00 UTC (negative for prior times).
@@ -51,10 +55,6 @@ date.toString(); // 2019-11-18T10:52:01.816Z
 ## absolute.toLocaleString(locale?: string, options: object) : string
 
 Returns a string with a locally sensitive representation of the specified `Absolute` object. Overrides the `Object.prototype.toLocaleString()` method.
-
-## Temporal.Absolute.from(thing: string | object) : Temporal.Absolute
-
-Creates a new `Absolute` object from either an object or IEO-8601 string.
 
 ### String Example
 

--- a/docs/date.md
+++ b/docs/date.md
@@ -6,6 +6,8 @@ A representation of a calendar date.
 
 Creates a new `Date` object that represents a calendar date
 
+## Temporal.Date.from(thing: string | object) : Temporal.Date
+
 ## date.year : number
 
 Returns the year this `Date` represents
@@ -76,8 +78,6 @@ Returns a new [`YearMonth`](./YearMonth) object.
 ## date.getMonthDay() : Temporal.MonthDay
 
 Returns a new [`YearMonth`](./MonthDay) object.
-
-## Temporal.Date.from(thing: string | object) : Temporal.Date
 
 ## Temporal.Date.compare(one: Temporal.Date | object, two: Temporal.Date | object) : number
 

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -2,6 +2,8 @@
 
 ## new Temporal.DateTime(year: number, month: number, day: number, hour: number, minute: number, second: number = 0, milliseconds: number =0, microsecond: number = 0, nanosecond: nunber = 0, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
 
+## Temporal.DateTime.from(thing: string | object) : Temporal.DateTime
+
 ## datetime.year : number
 
 ## datetime.month : number
@@ -51,7 +53,5 @@
 ## datetime.getMonthDay() : Temporal.MonthDay
 
 ## datetime.getTime() : Temporal.Time
-
-## Temporal.DateTime.from(thing: string | object) : Temporal.DateTime
 
 ## Temporal.DateTime.compare(one: Temporal.DateTime | object, two: Temporal.DateTime | object) : number;

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -10,6 +10,8 @@ Creates a new `Duration` object that represents a duration of time.
 
 ## new Temporal.Duration(years?: number, months?: number, days?: number, hours?: number, minutes?: number, seconds?: number, milliseconds?: number, microseconds?: number, nanoseconds?: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Duration
 
+## Temporal.Duration.from(thing: string | object) : Temporal.Duration
+
 ## duration.years : number
 
 ## duration.months : number
@@ -33,5 +35,3 @@ Creates a new `Duration` object that represents a duration of time.
 ## duration.toString() : string
 
 ## duration.toLocaleString(locale?: string, options?: object) : string
-
-## Temporal.Duration.from(thing: string | object) : Temporal.Duration

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -2,6 +2,8 @@
 
 ## new Temporal.MonthDay(month: number, day: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
 
+## Temporal.MonthDay.from(thing: string | object) : Temporal.MonthDay
+
 ## monthDay.month : number
 
 ## monthDay.day : number
@@ -21,7 +23,5 @@
 ## monthDay.toLocaleString(locale?: string, options?: object) : string
 
 ## monthDay.withYear(year: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
-
-## Temporal.MonthDay.from(thing: string | object) : Temporal.MonthDay
 
 ## Temporal.MonthDay.compare(one: Temporal.MonthDay | object, two: Temporal.MonthDay | object) : number

--- a/docs/time.md
+++ b/docs/time.md
@@ -4,6 +4,8 @@ A representation of wall-clock time.
 
 ## new Temporal.Time(hour: number, minute: number, second: number = 0, milliseconds: number =0, microsecond: number = 0, nanosecond: number = 0, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
 
+## Temporal.Time.from(thing: string | object) : Temporal.Time
+
 ## time.hour: number
 
 ## time.minute: number
@@ -29,7 +31,5 @@ A representation of wall-clock time.
 ## time.toLocaleString(locale?:string, options?: object) : string
 
 ## time.withDate(date: Temporal.Date | object) : Temporal.DateTime
-
-## Temporal.Time.from(thing: string | object) : Temporal.Time
 
 ## Temporal.Time.compare(one: Temporal.Time | object, two: Temporal.Time | object) : number;

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -4,6 +4,8 @@ A representatio nof a calendar date.
 
 ## new Temporal.YearMonth(year: number, month: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
 
+## Temporal.YearMonth.from(thing: string | object) : Temporal.YearMonth
+
 ## yearMonth.year : number
 
 ## yearMonth.month : number
@@ -27,7 +29,5 @@ A representatio nof a calendar date.
 ## yearMonth.toLocaleString(locale?: string, options?: object) : string
 
 ## yearMonth.withDay(day: number) : Temporal.Date
-
-## Temporal.YearMonth.from(thing: string | object) : Temporal.YearMonth
 
 ## Temporal.YearMonth.compare(one: Temporal.YearMonth | object, two: Temporal.YearMonth | object) : number


### PR DESCRIPTION
It usually helps to show the constructors (plus other ways of creating this object) near the top.
As most developers will use `from` rather than the `new` constructor the from method should be shown just underneath.