### PR TITLE
Typo in yearmonth.md

### DIFF
--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -1,6 +1,6 @@
 # `Temporal.YearMonth`
 
-A representatio nof a calendar date.
+A representation of a calendar date.
 
 ## new Temporal.YearMonth(year: number, month: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
 


### PR DESCRIPTION
A space ended up in the wrong position.