### PR TITLE
Grammar nit in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A complete polyfill can be found [here](./polyfill). It is being developed as sp
 
 ### `Temporal.Absolute`
 
-An `Temporal.Absolute` represents a fixed point in time along the POSIX timeline. It does this by internally maintaining a slot for "Nanoseconds since the POSIX-Epoch".
+A `Temporal.Absolute` represents a fixed point in time along the POSIX timeline. It does this by internally maintaining a slot for "Nanoseconds since the POSIX-Epoch".
 
 See [Temporal.Absolute Documentation](./docs/absolute.md) for more detailed documentation.
 


### PR DESCRIPTION
s/An/A/ in Temporal.Absolute's description because it was bugging me. Every other class described starts with "A".

Entirely possible "An" is matching against the class name "Absolute" starting with a vowel, which would hold true because all of the ones starting with "A" have classes that start with consonants. Feel free to close this if that's the case. :)