### PR TITLE
Correct generated doc links

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build:javascript": "rollup -c rollup.config.ejs",
-    "build:html": "for FILE in `ls *.md`; do marked -o `echo $FILE | sed -e 's/.md/.html/'` $FILE; done && cp README.html index.html"
+    "build:html": "for FILE in `ls *.md`; do cat $FILE | sed 's/.md)/.html)/' | marked -o `echo $FILE | sed -e 's/.md/.html/'`; done && cp README.html index.html"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The links in the generated HTML now point to .html siblings instead of .md siblings.