### PR TITLE
Remove test duplication from polyfill/tests/duration.mjs.

### DIFF
--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -12,22 +12,15 @@ import { Duration } from 'tc39-temporal';
 describe('Duration', () => {
   describe('Construction', () => {
     describe('Disambiguation', () => {
-      it('reject', () => throws(() => new Duration(-1, -1, -1, -1, -1, -1, -1, -1, -1, 'reject'), RangeError));
-      it('constrain', () =>
+      it('negative values throw when "reject"', () =>
+        throws(() => new Duration(-1, -1, -1, -1, -1, -1, -1, -1, -1, 'reject'), RangeError));
+      it('negative values invert when "constrain"', () =>
         equal(`${new Duration(-1, -1, -1, -1, -1, -1, -1, -1, -1, 'constrain')}`, 'P1Y1M1DT1H1M1.001001001S'));
-      it('balance', () => equal(`${new Duration(0, 0, 0, 0, 0, 0, 0, 0, 1000, 'balance')}`, 'PT0.000001S'));
+      it('excessive values balance when "balance"', () =>
+        equal(`${new Duration(0, 0, 0, 0, 0, 0, 0, 0, 1000, 'balance')}`, 'PT0.000001S'));
       it('throw when bad disambiguation', () =>
         throws(() => new Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 'xyz'), TypeError));
     });
-  });
-  describe('basic', () => {
-    it('negative values throw when "reject"', () =>
-      throws(() => new Duration(-1, -1, -1, -1, -1, -1, -1, -1, -1, 'reject'), RangeError));
-    it('negative values invert when "constrain"', () =>
-      equal(`${new Duration(-1, -1, -1, -1, -1, -1, -1, -1, -1, 'constrain')}`, 'P1Y1M1DT1H1M1.001001001S'));
-    it('excessive values balance when "balance"', () =>
-      equal(`${new Duration(0, 0, 0, 0, 0, 0, 0, 0, 1000, 'balance')}`, 'PT0.000001S'));
-    it('throw when bad disambiguation', () => throws(() => new Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 'xyz'), TypeError));
   });
   describe('from()', () => {
     it(`Duration.from(P5Y) == P5Y`, () => {


### PR DESCRIPTION
Two blocks of duration tests were identical except one had better error messaging. I removed the duplicated set and kept the more descriptive messaging.