### PR TITLE
Create a test262-based test suite.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 polyfill/index.js
 polyfill/index.js.map
+polyfill/script.js
+polyfill/test262/
 out/
 .vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ matrix:
   - name: "Polyfill tests"
     script:
     - npm run codecov
+  - name: "test262 tests"
+    script:
+    - npm run test262
   - name: "Specification compilation"
     script:
     - npm run build

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "cd polyfill && npm install && npm test && cd ..",
     "codecov": "cd polyfill && npm install && npm run codecov && cd ..",
+    "test262": "cd polyfill && npm run test262",
     "build:prepare": "mkdirp out && mkdirp out/docs",
     "build:polyfill": "cd polyfill && npm install && npm run build && cd ..",
     "build:javascript": "npm run build:polyfill && cd docs && npm install && npm run build:javascript && cd .. && cp docs/*.js docs/*.js.map out/docs/",

--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+export NODE_PATH=$PWD/node_modules
+npm install
+npm run build-script
+npm install test262-harness
+if [ ! -d "test262" ]; then
+  git clone --depth 1 https://github.com/tc39/test262.git
+else
+  cd ./test262
+  git fetch origin
+  git merge --ff-only origin/master
+  cd ..
+fi
+
+cd test/
+
+test262-harness \
+  -r json \
+  --test262Dir ../test262 \
+  --prelude ../script.js \
+  "./*/**/*.js" \
+  > ../exec.out
+./parseResults.py ../exec.out
+RESULT=$?
+rm ../exec.out
+exit $RESULT

--- a/polyfill/lib/index.mjs
+++ b/polyfill/lib/index.mjs
@@ -1,5 +1,24 @@
 import * as Temporal from './temporal.mjs';
 import * as Intl from './intl.mjs';
 
-globalThis.Temporal = Temporal;
+Object.defineProperty(globalThis, "Temporal", {
+  value: {},
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+copy(globalThis.Temporal, Temporal);
+copy(globalThis.Intl, Intl);
+
+function copy(target, source) {
+  for (const prop of Object.getOwnPropertyNames(source)) {
+    Object.defineProperty(target, prop, {
+      value: source[prop],
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+}
+
 export { Temporal, Intl };

--- a/polyfill/lib/intrinsicclass.mjs
+++ b/polyfill/lib/intrinsicclass.mjs
@@ -1,7 +1,23 @@
 export function MakeIntrinsicClass(Class, name) {
   if ('undefined' !== typeof Symbol) {
-    Class.prototype[Symbol.toStringTag] = name;
-    Class.prototype[Symbol.species] = Class;
+    Object.defineProperty(Class.prototype, Symbol.toStringTag, {
+      value: name,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+    const species = function() { return this };
+    Object.defineProperty(species, "name", {
+      value: "get [Symbol.species]",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+    Object.defineProperty(Class.prototype, Symbol.class, {
+      get: species,
+      enumerable: false,
+      configurable: true,
+    });
   }
   for (let prop of Object.getOwnPropertyNames(Class)) {
     const desc = Object.getOwnPropertyDescriptor(Class, prop);

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "coverage": "c8 report --reporter html",
     "test": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu/icudt64l.dat --loader ./test/resolve.source.mjs ./test/all.mjs",
+    "test262": "./ci_test.sh",
     "codecov": "npm install codecov && NODE_V8_COVERAGE=coverage/tmp npm run test && c8 report --reporter=text-lcov > coverage/tests.lcov && codecov",
     "pretty": "prettier --write lib/*.*(m)js test/*.*(m)js",
     "build": "rollup -c rollup.config.js",
+    "build-script": "rollup -c rollup-script.config.js",
     "prepublishOnly": "npm run build",
     "playground": "npm run build && node --experimental-modules --no-warnings --icu-data-dir ./node_modules/full-icu/ -r ./lib/initialise.js"
   },
@@ -34,7 +36,8 @@
   "dependencies": {
     "big-integer": "^1.6.48",
     "codecov": "^3.6.5",
-    "es-abstract": "^1.17.4"
+    "es-abstract": "^1.17.4",
+    "test262-harness": "^6.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/polyfill/rollup-script.config.js
+++ b/polyfill/rollup-script.config.js
@@ -1,0 +1,16 @@
+import commonjs from "rollup-plugin-commonjs";
+import resolve from "rollup-plugin-node-resolve";
+
+export default {
+  input: "lib/index.mjs",
+  output: {
+    name: "temporal",
+    file: "script.js",
+    format: "iife",
+    lib: ["es6"],
+  },
+  plugins: [
+    commonjs(),
+    resolve({ preferBuiltins: false }),
+  ]
+};

--- a/polyfill/test/Absolute/prototype/builtin.js
+++ b/polyfill/test/Absolute/prototype/builtin.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+
+assert.sameValue(Object.isExtensible(Absolute.prototype), true,
+                 "Built-in objects must be extensible.");
+
+assert.sameValue(Object.getPrototypeOf(Absolute.prototype), Object.prototype,
+                 "Built-in prototype objects must have Object.prototype as their prototype.");

--- a/polyfill/test/Absolute/prototype/difference/branding.js
+++ b/polyfill/test/Absolute/prototype/difference/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const difference = Temporal.Absolute.prototype.difference;
+
+assert.sameValue(typeof difference, "function");
+
+assert.throws(TypeError, () => difference.call(undefined), "undefined");
+assert.throws(TypeError, () => difference.call(null), "null");
+assert.throws(TypeError, () => difference.call(true), "true");
+assert.throws(TypeError, () => difference.call(""), "empty string");
+assert.throws(TypeError, () => difference.call(Symbol()), "symbol");
+assert.throws(TypeError, () => difference.call(1), "1");
+assert.throws(TypeError, () => difference.call({}), "plain object");
+assert.throws(TypeError, () => difference.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => difference.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/difference/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/difference/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.difference,
+  "function",
+  "`typeof Absolute.prototype.difference` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "difference", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/getEpochMicroseconds/branding.js
+++ b/polyfill/test/Absolute/prototype/getEpochMicroseconds/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const getEpochMicroseconds = Temporal.Absolute.prototype.getEpochMicroseconds;
+
+assert.sameValue(typeof getEpochMicroseconds, "function");
+
+assert.throws(TypeError, () => getEpochMicroseconds.call(undefined), "undefined");
+assert.throws(TypeError, () => getEpochMicroseconds.call(null), "null");
+assert.throws(TypeError, () => getEpochMicroseconds.call(true), "true");
+assert.throws(TypeError, () => getEpochMicroseconds.call(""), "empty string");
+assert.throws(TypeError, () => getEpochMicroseconds.call(Symbol()), "symbol");
+assert.throws(TypeError, () => getEpochMicroseconds.call(1), "1");
+assert.throws(TypeError, () => getEpochMicroseconds.call({}), "plain object");
+assert.throws(TypeError, () => getEpochMicroseconds.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => getEpochMicroseconds.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/getEpochMicroseconds/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/getEpochMicroseconds/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.getEpochMicroseconds,
+  "function",
+  "`typeof Absolute.prototype.getEpochMicroseconds` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "getEpochMicroseconds", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/getEpochMilliseconds/branding.js
+++ b/polyfill/test/Absolute/prototype/getEpochMilliseconds/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const getEpochMilliseconds = Temporal.Absolute.prototype.getEpochMilliseconds;
+
+assert.sameValue(typeof getEpochMilliseconds, "function");
+
+assert.throws(TypeError, () => getEpochMilliseconds.call(undefined), "undefined");
+assert.throws(TypeError, () => getEpochMilliseconds.call(null), "null");
+assert.throws(TypeError, () => getEpochMilliseconds.call(true), "true");
+assert.throws(TypeError, () => getEpochMilliseconds.call(""), "empty string");
+assert.throws(TypeError, () => getEpochMilliseconds.call(Symbol()), "symbol");
+assert.throws(TypeError, () => getEpochMilliseconds.call(1), "1");
+assert.throws(TypeError, () => getEpochMilliseconds.call({}), "plain object");
+assert.throws(TypeError, () => getEpochMilliseconds.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => getEpochMilliseconds.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/getEpochMilliseconds/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/getEpochMilliseconds/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.getEpochMilliseconds,
+  "function",
+  "`typeof Absolute.prototype.getEpochMilliseconds` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "getEpochMilliseconds", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/getEpochNanoseconds/branding.js
+++ b/polyfill/test/Absolute/prototype/getEpochNanoseconds/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const getEpochNanoseconds = Temporal.Absolute.prototype.getEpochNanoseconds;
+
+assert.sameValue(typeof getEpochNanoseconds, "function");
+
+assert.throws(TypeError, () => getEpochNanoseconds.call(undefined), "undefined");
+assert.throws(TypeError, () => getEpochNanoseconds.call(null), "null");
+assert.throws(TypeError, () => getEpochNanoseconds.call(true), "true");
+assert.throws(TypeError, () => getEpochNanoseconds.call(""), "empty string");
+assert.throws(TypeError, () => getEpochNanoseconds.call(Symbol()), "symbol");
+assert.throws(TypeError, () => getEpochNanoseconds.call(1), "1");
+assert.throws(TypeError, () => getEpochNanoseconds.call({}), "plain object");
+assert.throws(TypeError, () => getEpochNanoseconds.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => getEpochNanoseconds.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/getEpochNanoseconds/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/getEpochNanoseconds/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.getEpochNanoseconds,
+  "function",
+  "`typeof Absolute.prototype.getEpochNanoseconds` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "getEpochNanoseconds", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/getEpochSeconds/branding.js
+++ b/polyfill/test/Absolute/prototype/getEpochSeconds/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const getEpochSeconds = Temporal.Absolute.prototype.getEpochSeconds;
+
+assert.sameValue(typeof getEpochSeconds, "function");
+
+assert.throws(TypeError, () => getEpochSeconds.call(undefined), "undefined");
+assert.throws(TypeError, () => getEpochSeconds.call(null), "null");
+assert.throws(TypeError, () => getEpochSeconds.call(true), "true");
+assert.throws(TypeError, () => getEpochSeconds.call(""), "empty string");
+assert.throws(TypeError, () => getEpochSeconds.call(Symbol()), "symbol");
+assert.throws(TypeError, () => getEpochSeconds.call(1), "1");
+assert.throws(TypeError, () => getEpochSeconds.call({}), "plain object");
+assert.throws(TypeError, () => getEpochSeconds.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => getEpochSeconds.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/getEpochSeconds/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/getEpochSeconds/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.getEpochSeconds,
+  "function",
+  "`typeof Absolute.prototype.getEpochSeconds` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "getEpochSeconds", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/inTimeZone/branding.js
+++ b/polyfill/test/Absolute/prototype/inTimeZone/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const inTimeZone = Temporal.Absolute.prototype.inTimeZone;
+
+assert.sameValue(typeof inTimeZone, "function");
+
+assert.throws(TypeError, () => inTimeZone.call(undefined), "undefined");
+assert.throws(TypeError, () => inTimeZone.call(null), "null");
+assert.throws(TypeError, () => inTimeZone.call(true), "true");
+assert.throws(TypeError, () => inTimeZone.call(""), "empty string");
+assert.throws(TypeError, () => inTimeZone.call(Symbol()), "symbol");
+assert.throws(TypeError, () => inTimeZone.call(1), "1");
+assert.throws(TypeError, () => inTimeZone.call({}), "plain object");
+assert.throws(TypeError, () => inTimeZone.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => inTimeZone.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/inTimeZone/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/inTimeZone/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.inTimeZone,
+  "function",
+  "`typeof Absolute.prototype.inTimeZone` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "inTimeZone", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/minus/branding.js
+++ b/polyfill/test/Absolute/prototype/minus/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const minus = Temporal.Absolute.prototype.minus;
+
+assert.sameValue(typeof minus, "function");
+
+assert.throws(TypeError, () => minus.call(undefined), "undefined");
+assert.throws(TypeError, () => minus.call(null), "null");
+assert.throws(TypeError, () => minus.call(true), "true");
+assert.throws(TypeError, () => minus.call(""), "empty string");
+assert.throws(TypeError, () => minus.call(Symbol()), "symbol");
+assert.throws(TypeError, () => minus.call(1), "1");
+assert.throws(TypeError, () => minus.call({}), "plain object");
+assert.throws(TypeError, () => minus.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => minus.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/minus/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/minus/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.minus,
+  "function",
+  "`typeof Absolute.prototype.minus` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "minus", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/plus/branding.js
+++ b/polyfill/test/Absolute/prototype/plus/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const plus = Temporal.Absolute.prototype.plus;
+
+assert.sameValue(typeof plus, "function");
+
+assert.throws(TypeError, () => plus.call(undefined), "undefined");
+assert.throws(TypeError, () => plus.call(null), "null");
+assert.throws(TypeError, () => plus.call(true), "true");
+assert.throws(TypeError, () => plus.call(""), "empty string");
+assert.throws(TypeError, () => plus.call(Symbol()), "symbol");
+assert.throws(TypeError, () => plus.call(1), "1");
+assert.throws(TypeError, () => plus.call({}), "plain object");
+assert.throws(TypeError, () => plus.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => plus.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/plus/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/plus/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.plus,
+  "function",
+  "`typeof Absolute.prototype.plus` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "plus", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/prop-desc.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+
+assert.sameValue(typeof Absolute.prototype, "object");
+assert.notSameValue(Absolute.prototype, null);
+
+verifyProperty(Absolute, "prototype", {
+  writable: false,
+  enumerable: false,
+  configurable: false,
+});

--- a/polyfill/test/Absolute/prototype/toJSON/branding.js
+++ b/polyfill/test/Absolute/prototype/toJSON/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const toJSON = Temporal.Absolute.prototype.toJSON;
+
+assert.sameValue(typeof toJSON, "function");
+
+assert.throws(TypeError, () => toJSON.call(undefined), "undefined");
+assert.throws(TypeError, () => toJSON.call(null), "null");
+assert.throws(TypeError, () => toJSON.call(true), "true");
+assert.throws(TypeError, () => toJSON.call(""), "empty string");
+assert.throws(TypeError, () => toJSON.call(Symbol()), "symbol");
+assert.throws(TypeError, () => toJSON.call(1), "1");
+assert.throws(TypeError, () => toJSON.call({}), "plain object");
+assert.throws(TypeError, () => toJSON.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => toJSON.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/toJSON/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/toJSON/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.toJSON,
+  "function",
+  "`typeof Absolute.prototype.toJSON` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "toJSON", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/toLocaleString/branding.js
+++ b/polyfill/test/Absolute/prototype/toLocaleString/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const toLocaleString = Temporal.Absolute.prototype.toLocaleString;
+
+assert.sameValue(typeof toLocaleString, "function");
+
+assert.throws(TypeError, () => toLocaleString.call(undefined), "undefined");
+assert.throws(TypeError, () => toLocaleString.call(null), "null");
+assert.throws(TypeError, () => toLocaleString.call(true), "true");
+assert.throws(TypeError, () => toLocaleString.call(""), "empty string");
+assert.throws(TypeError, () => toLocaleString.call(Symbol()), "symbol");
+assert.throws(TypeError, () => toLocaleString.call(1), "1");
+assert.throws(TypeError, () => toLocaleString.call({}), "plain object");
+assert.throws(TypeError, () => toLocaleString.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => toLocaleString.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/toLocaleString/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/toLocaleString/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.toLocaleString,
+  "function",
+  "`typeof Absolute.prototype.toLocaleString` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "toLocaleString", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/toString/branding.js
+++ b/polyfill/test/Absolute/prototype/toString/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const toString = Temporal.Absolute.prototype.toString;
+
+assert.sameValue(typeof toString, "function");
+
+assert.throws(TypeError, () => toString.call(undefined), "undefined");
+assert.throws(TypeError, () => toString.call(null), "null");
+assert.throws(TypeError, () => toString.call(true), "true");
+assert.throws(TypeError, () => toString.call(""), "empty string");
+assert.throws(TypeError, () => toString.call(Symbol()), "symbol");
+assert.throws(TypeError, () => toString.call(1), "1");
+assert.throws(TypeError, () => toString.call({}), "plain object");
+assert.throws(TypeError, () => toString.call(Temporal.Absolute), "Temporal.Absolute");
+assert.throws(TypeError, () => toString.call(Temporal.Absolute.prototype), "Temporal.Absolute.prototype");

--- a/polyfill/test/Absolute/prototype/toString/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/toString/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+assert.sameValue(
+  typeof Absolute.prototype.toString,
+  "function",
+  "`typeof Absolute.prototype.toString` is `function`"
+);
+
+verifyProperty(Absolute.prototype, "toString", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/toStringTag/prop-desc.js
+++ b/polyfill/test/Absolute/prototype/toStringTag/prop-desc.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const {Absolute} = Temporal;
+verifyProperty(Absolute.prototype, Symbol.toStringTag, {
+  value: "Temporal.Absolute",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/prototype/type.js
+++ b/polyfill/test/Absolute/prototype/type.js
@@ -1,0 +1,7 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const {Absolute} = Temporal;
+
+assert.sameValue(typeof Absolute.prototype, "object");
+assert.notSameValue(Absolute.prototype, null);

--- a/polyfill/test/Temporal/prop-desc.js
+++ b/polyfill/test/Temporal/prop-desc.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(typeof Temporal, "object");
+verifyProperty(this, "Temporal", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -21,36 +21,6 @@ describe('Absolute', () => {
     it('Absolute is a Function', () => {
       equal(typeof Absolute, 'function');
     });
-    it('Absolute has a prototype', () => {
-      assert(Absolute.prototype);
-      equal(typeof Absolute.prototype, 'object');
-    });
-    describe('Absolute.prototype', () => {
-      it('Absolute.prototype has getEpochSeconds', () => {
-        assert('getEpochSeconds' in Absolute.prototype);
-      });
-      it('Absolute.prototype has getEpochMilliseconds', () => {
-        assert('getEpochMilliseconds' in Absolute.prototype);
-      });
-      it('Absolute.prototype has getEpochMicroseconds', () => {
-        assert('getEpochMicroseconds' in Absolute.prototype);
-      });
-      it('Absolute.prototype has getEpochNanoseconds', () => {
-        assert('getEpochNanoseconds' in Absolute.prototype);
-      });
-      it('Absolute.prototype.inTimeZone is a Function', () => {
-        equal(typeof Absolute.prototype.inTimeZone, 'function');
-      });
-      it('Absolute.prototype.toString is a Function', () => {
-        equal(typeof Absolute.prototype.toString, 'function');
-      });
-      it('Absolute.prototype.toJSON is a Function', () => {
-        equal(typeof Absolute.prototype.toJSON, 'function');
-      });
-      it('Absolute.prototype.difference is a Function', () => {
-        equal(typeof Absolute.prototype.difference, 'function');
-      });
-    });
     it('Absolute.fromEpochSeconds is a Function', () => {
       equal(typeof Absolute.fromEpochSeconds, 'function');
     });

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -1,0 +1,2 @@
+# Bad property descriptor.
+Temporal/prop-desc.js

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -1,1 +1,2 @@
-# Empty.
+# Bad property descriptor
+Absolute/prototype/toStringTag/prop-desc.js

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -1,2 +1,1 @@
-# Bad property descriptor.
-Temporal/prop-desc.js
+# Empty.

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -1,2 +1,1 @@
-# Bad property descriptor
-Absolute/prototype/toStringTag/prop-desc.js
+# Empty.

--- a/polyfill/test/parseResults.py
+++ b/polyfill/test/parseResults.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+PREFIXES = [
+    ["FAIL", "PASS"],
+    ["EXPECTED FAIL", "UNEXPECTED PASS"],
+]
+
+
+def parse_expected_failures():
+    expected_failures = set()
+    with open("expected-failures.txt", "r") as fp:
+        for line in fp:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("#"):
+                continue
+            expected_failures.add(line)
+    return expected_failures
+
+
+def main(filename):
+    expected_failures = parse_expected_failures()
+    with open(filename, "r") as fp:
+        results = json.load(fp)
+
+    unexpected_results = []
+    for test in results:
+        expected_failure = test["file"] in expected_failures
+        actual_result = test["result"]["pass"]
+        print("{} {}".format(PREFIXES[expected_failure][actual_result], test["file"]))
+        if actual_result == expected_failure:
+            if not actual_result:
+                print(test["rawResult"]["stderr"])
+                print(test["rawResult"]["stdout"])
+                print(test["result"]["message"])
+            unexpected_results.append(test)
+
+    if unexpected_results:
+        print("{} unexpected results:".format(len(unexpected_results)))
+        for unexpected in unexpected_results:
+            print("- {}".format(unexpected["file"]))
+        return False
+
+    print("All results as expected.")
+    return True
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main(sys.argv[1]) else 1)


### PR DESCRIPTION
We will need to add a comprehensive test suite for Temporal to test262, both to advance the proposal in TC39 and to ensure that the specification, native implementations, and the polyfill are all interoperable. We should start writing tests against the polyfill in a way that will allow us to submit them to test262 without too much effort, to avoid duplicating work and to ensure that no coverage is lost in the conversion. This PR uses test262-harness to run the tests against the polyfill in node.