### PR TITLE
Remove setup() function from polyfill

### DIFF
--- a/docs/setup.ejs
+++ b/docs/setup.ejs
@@ -1,4 +1,3 @@
 import { Temporal, Intl } from '../polyfill';
-globalThis.Temporal = {};
-Object.assign(globalThis.Temporal, Temporal);
+globalThis.Temporal = { ...Temporal };
 Object.assign(globalThis.Intl, Intl);

--- a/docs/setup.ejs
+++ b/docs/setup.ejs
@@ -1,2 +1,4 @@
-import { setup } from '../polyfill';
-setup();
+import { Temporal, Intl } from '../polyfill';
+globalThis.Temporal = {};
+Object.assign(globalThis.Temporal, Temporal);
+Object.assign(globalThis.Intl, Intl);

--- a/polyfill/lib/index.mjs
+++ b/polyfill/lib/index.mjs
@@ -2,14 +2,3 @@ import * as Temporal from './temporal.mjs';
 import * as Intl from './intl.mjs';
 
 export { Temporal, Intl };
-export function setup(global = globalThis) {
-  global.Temporal = {};
-  copy(global.Temporal, Temporal);
-  copy(global.Intl, Intl);
-
-  function copy(target, source) {
-    for (const prop of Object.getOwnPropertyNames(source)) {
-      target[prop] = source[prop];
-    }
-  }
-}

--- a/polyfill/lib/initialise.js
+++ b/polyfill/lib/initialise.js
@@ -1,5 +1,9 @@
 import('./index.mjs')
-  .then(({ setup }) => setup(globalThis))
+  .then(({ Temporal, Intl }) => {
+    globalThis.Temporal = {};
+    Object.assign(globalThis.Temporal, Temporal);
+    Object.assign(globalThis.Intl, Intl);
+  })
   .catch((err) => {
     console.error(err);
     process.exit(1);

--- a/polyfill/lib/initialise.js
+++ b/polyfill/lib/initialise.js
@@ -1,7 +1,6 @@
 import('./index.mjs')
   .then(({ Temporal, Intl }) => {
-    globalThis.Temporal = {};
-    Object.assign(globalThis.Temporal, Temporal);
+    globalThis.Temporal = { ...Temporal };
     Object.assign(globalThis.Intl, Intl);
   })
   .catch((err) => {


### PR DESCRIPTION
The rationale for this is that client code might come to depend on the
shipped API working like the polyfill.

We do use the setup function twice internally, to initialize the docs
playground and the node interpreter playground. In these cases, instead
import the Temporal and Intl objects from the polyfill and copy them to
the global object manually.

Closes: #306