### PR TITLE
Fix Duration constructor docs

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -2,13 +2,9 @@
 
 A representations of a duration of time which can be used in date/time arithmetic.
 
-## new Temporal.Duration(durationLike: object) : Temporal.Duration
+## new Temporal.Duration(years?: number, months?: number, days?: number, hours?: number, minutes?: number, seconds?: number, milliseconds?: number, microseconds?: number, nanoseconds?: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Duration
 
 Creates a new `Duration` object that represents a duration of time.
-
-## new Temporal.Duration(iso: string) : Temporal.Duration
-
-## new Temporal.Duration(years?: number, months?: number, days?: number, hours?: number, minutes?: number, seconds?: number, milliseconds?: number, microseconds?: number, nanoseconds?: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Duration
 
 ## Temporal.Duration.from(thing: string | object) : Temporal.Duration
 

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -92,7 +92,7 @@
       initialize subclass instances with the necessary internal slots.
     </p>
     <emu-clause id="sec-temporal.duration">
-      <h1>Temporal.Duration ( _years_, _months_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _disambiguation_ )</h1>
+      <h1>Temporal.Duration ( [ _years_ [ , _months_ [ , _days_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _milliseconds_ [ , _microseconds_ [ , _nanoseconds_ [ , _disambiguation_ ] ] ] ] ] ] ] ] ] ] )</h1>
       <p>
         When the `Temporal.Duration` function is called, the following steps are taken:
       </p>
@@ -108,7 +108,10 @@
         1. Let _ms_ be ? ToInteger(_milliseconds_).
         1. Let _mis_ be ? ToInteger(_microseconds_).
         1. Let _ns_ be ? ToInteger(_nanoseconds_).
-        1. Let _disambiguation_ be ? ToString(_disambiguation_).
+        1. If _disambiguation_ is not *undefined*, then
+          1. Set _disambiguation_ to ? ToString(_disambiguation_).
+        1. Else
+          1. Set _disambiguation_ to `"constrain"`.
         1. If _disambiguation_ is *"reject"*, then
           1. For each of _y_, _mo_, _d_, _h_, _m_, _s_, _ms_, _mis_, _ns_, if any of the values is negative, throw a *RangeError* exception.
         1. Else if _disambiguation_ is *"constrain"*, then


### PR DESCRIPTION
Corrects the signature of `new Temporal.Duration()` in the reference docs and spec to match the polyfill.

Closes: #276 