### PR TITLE
Remove casting in methods

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -55,7 +55,7 @@ Returns a new `Date` object which is the sum of the current object plus the addi
 
 Returns a new `Date` object which is the sum of the current object minus the additional argument.
 
-## date.difference(other: Temporal.Date | object) : Temporal.Duration
+## date.difference(other: Temporal.Date) : Temporal.Duration
 
 Returns a new `Duration` object which is the difference between the current `Date` object and the argument `Date` value.
 
@@ -67,7 +67,7 @@ Returns an ISO 8601 string representing the current `Date` object
 
 Returns a string with a locally sensitive representation of the specified `Date` object. Overrides the `Object.prototype.toLocaleString()` method.
 
-## date.withTime(time: Temporal.Time | object) : Temporal.DateTime
+## date.withTime(time: Temporal.Time) : Temporal.DateTime
 
 Returns a new [`DateTime`](./DateTime) object using the combination of this `Date` and the `Time` object passed in.
 
@@ -79,7 +79,7 @@ Returns a new [`YearMonth`](./YearMonth) object.
 
 Returns a new [`YearMonth`](./MonthDay) object.
 
-## Temporal.Date.compare(one: Temporal.Date | object, two: Temporal.Date | object) : number
+## Temporal.Date.compare(one: Temporal.Date, two: Temporal.Date) : number
 
 Allows for easier comparison of `Date` objects, returns:
 

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -38,7 +38,7 @@
 
 ## datetime.minus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.DateTime
 
-## datetime.difference(other: Temporal.DateTime | object) : Temporal.Duration
+## datetime.difference(other: Temporal.DateTime) : Temporal.Duration
 
 ## datetime.toString() : string
 
@@ -54,4 +54,4 @@
 
 ## datetime.getTime() : Temporal.Time
 
-## Temporal.DateTime.compare(one: Temporal.DateTime | object, two: Temporal.DateTime | object) : number;
+## Temporal.DateTime.compare(one: Temporal.DateTime, two: Temporal.DateTime) : number;

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -16,7 +16,7 @@
 
 ## monthDay.minus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
 
-## monthDay.difference(other: Temporal.MonthDay | object) : Temporal.Duration
+## monthDay.difference(other: Temporal.MonthDay) : Temporal.Duration
 
 ## monthDay.toString() : string
 
@@ -24,4 +24,4 @@
 
 ## monthDay.withYear(year: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
 
-## Temporal.MonthDay.compare(one: Temporal.MonthDay | object, two: Temporal.MonthDay | object) : number
+## Temporal.MonthDay.compare(one: Temporal.MonthDay, two: Temporal.MonthDay) : number

--- a/docs/time.md
+++ b/docs/time.md
@@ -24,12 +24,12 @@ A representation of wall-clock time.
 
 ## time.minus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
 
-## time.difference(other: Temporal.Time | object) : Temporal.Duration
+## time.difference(other: Temporal.Time) : Temporal.Duration
 
 ## time.toString() : string
 
 ## time.toLocaleString(locale?:string, options?: object) : string
 
-## time.withDate(date: Temporal.Date | object) : Temporal.DateTime
+## time.withDate(date: Temporal.Date) : Temporal.DateTime
 
-## Temporal.Time.compare(one: Temporal.Time | object, two: Temporal.Time | object) : number;
+## Temporal.Time.compare(one: Temporal.Time, two: Temporal.Time) : number;

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -22,7 +22,7 @@ A representation of a calendar date.
 
 ## yearMonth.minus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
 
-## yearMonth.difference(other: Temporal.YearMonth | object) : Temporal.Duration
+## yearMonth.difference(other: Temporal.YearMonth) : Temporal.Duration
 
 ## yearMonth.toString() : string
 
@@ -30,4 +30,4 @@ A representation of a calendar date.
 
 ## yearMonth.withDay(day: number) : Temporal.Date
 
-## Temporal.YearMonth.compare(one: Temporal.YearMonth | object, two: Temporal.YearMonth | object) : number
+## Temporal.YearMonth.compare(one: Temporal.YearMonth, two: Temporal.YearMonth) : number

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -85,7 +85,6 @@ export class Absolute {
   }
   difference(other) {
     if (!ES.IsAbsolute(this)) throw new TypeError('invalid receiver');
-    other = ES.ToAbsolute(other);
 
     const [one, two] = [this, other].sort(Absolute.compare);
     const onens = GetSlot(one, EPOCHNANOSECONDS);
@@ -142,8 +141,6 @@ export class Absolute {
     return this === Absolute ? result : new this(GetSlot(result, EPOCHNANOSECONDS));
   }
   static compare(one, two) {
-    one = ES.ToAbsolute(one);
-    two = ES.ToAbsolute(two);
     one = GetSlot(one, EPOCHNANOSECONDS);
     two = GetSlot(two, EPOCHNANOSECONDS);
     if (bigInt(one).lesser(two)) return -1;

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -101,7 +101,6 @@ export class Date {
   }
   difference(other) {
     if (!ES.IsDate(this)) throw new TypeError('invalid receiver');
-    other = ES.ToDate(other);
     const [smaller, larger] = [this, other].sort(Date.compare);
     const { years, months, days } = ES.DifferenceDate(smaller, larger);
     const Duration = ES.GetIntrinsic('%Temporal.Duration%');
@@ -149,8 +148,7 @@ export class Date {
     );
   }
   static compare(one, two) {
-    one = ES.ToDate(one);
-    two = ES.ToDate(two);
+    if (!ES.IsDate(one) || !ES.IsDate(two)) throw new TypeError('invalid Date object');
     if (one.year !== two.year) return ES.ComparisonResult(one.year - two.year);
     if (one.month !== two.month) return ES.ComparisonResult(one.month - two.month);
     if (one.day !== two.day) return ES.ComparisonResult(one.day - two.day);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -226,7 +226,6 @@ export class DateTime {
   }
   difference(other) {
     if (!ES.IsDateTime(this)) throw new TypeError('invalid receiver');
-    other = ES.ToDateTime(other);
     const [smaller, larger] = [this, other].sort(DateTime.compare);
     const { deltaDays, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(
       smaller,
@@ -310,8 +309,7 @@ export class DateTime {
     );
   }
   static compare(one, two) {
-    one = ES.ToDateTime(one);
-    two = ES.ToDateTime(two);
+    if (!ES.IsDateTime(one) || !ES.IsDateTime(two)) throw new TypeError('invalid DateTime object');
     if (one.year !== two.year) return ES.ComparisonResult(one.year - two.year);
     if (one.month !== two.month) return ES.ComparisonResult(one.month - two.month);
     if (one.day !== two.day) return ES.ComparisonResult(one.day - two.day);

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -101,7 +101,7 @@ export class MonthDay {
     other = ES.ToMonthDay(other);
     const [one, two] = [this, other].sort(MonthDay.compare);
     let months = two.month - one.month;
-    let days = two.days - one.days;
+    let days = two.day - one.day;
     if (days < 0) {
       months -= 1;
       let month = one.month + months;

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -98,7 +98,6 @@ export class MonthDay {
   }
   difference(other) {
     if (!ES.IsMonthDay(this)) throw new TypeError('invalid receiver');
-    other = ES.ToMonthDay(other);
     const [one, two] = [this, other].sort(MonthDay.compare);
     let months = two.month - one.month;
     let days = two.day - one.day;
@@ -138,8 +137,7 @@ export class MonthDay {
     );
   }
   static compare(one, two) {
-    one = ES.ToMonthDay(one);
-    two = ES.ToMonthDay(two);
+    if (!ES.IsMonthDay(one) || !ES.IsMonthDay(two)) throw new TypeError('invalid MonthDay object');
     if (one.month !== two.month) return ES.ComparisonResult(one.month - two.month);
     if (one.day !== two.day) return ES.ComparisonResult(one.day - two.day);
     return ES.ComparisonResult(0);

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -17,12 +17,10 @@ export class TimeZone {
   }
   getOffsetFor(absolute) {
     if (!ES.IsTimeZone(this)) throw new TypeError('invalid receiver');
-    absolute = ES.ToAbsolute(absolute);
     return ES.GetTimeZoneOffsetString(GetSlot(absolute, EPOCHNANOSECONDS), GetSlot(this, IDENTIFIER));
   }
   getDateTimeFor(absolute) {
     if (!ES.IsTimeZone(this)) throw new TypeError('invalid receiver');
-    absolute = ES.ToAbsolute(absolute);
     const ns = GetSlot(absolute, EPOCHNANOSECONDS);
     const {
       year,

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -101,7 +101,7 @@ export class YearMonth {
   difference(other) {
     if (!ES.IsYearMonth(this)) throw new TypeError('invalid receiver');
     other = ES.ToYearMonth(other);
-    const [one, two] = [this, other].sort(DateTime.compare);
+    const [one, two] = [this, other].sort(YearMonth.compare);
     let years = two.year - one.year;
     let months = two.month - one.month;
     if (months < 0) {

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -100,7 +100,6 @@ export class YearMonth {
   }
   difference(other) {
     if (!ES.IsYearMonth(this)) throw new TypeError('invalid receiver');
-    other = ES.ToYearMonth(other);
     const [one, two] = [this, other].sort(YearMonth.compare);
     let years = two.year - one.year;
     let months = two.month - one.month;
@@ -138,8 +137,7 @@ export class YearMonth {
     );
   }
   static compare(one, two) {
-    one = ES.ToYearMonth(one);
-    two = ES.ToYearMonth(two);
+    if (!ES.IsYearMonth(one) || !ES.IsYearMonth(two)) throw new TypeError('invalid YearMonth object');
     if (one.year !== two.year) return ES.ComparisonResult(one.year - two.year);
     if (one.month !== two.month) return ES.ComparisonResult(one.month - two.month);
     return ES.ComparisonResult(0);

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -198,6 +198,14 @@ describe('Absolute', () => {
     it('cross epoch larger/smaller', () => equal(Absolute.compare(abs2, abs1), 1));
     it('epoch smaller/larger', () => equal(Absolute.compare(abs2, abs3), -1));
     it('epoch larger/smaller', () => equal(Absolute.compare(abs3, abs2), 1));
+    it("doesn't cast first argument", () => {
+      throws(() => Absolute.compare(abs1, abs1.toString()), TypeError);
+      throws(() => Absolute.compare(abs1, {}), TypeError);
+    });
+    it("doesn't cast second argument", () => {
+      throws(() => Absolute.compare(abs2.getEpochNanoseconds(), abs2), TypeError);
+      throws(() => Absolute.compare({}, abs2), TypeError);
+    });
   });
   describe('Absolute.difference works', () => {
     const earlier = Absolute.from('1976-11-18T15:23:30.123456789Z');
@@ -207,6 +215,10 @@ describe('Absolute', () => {
       equal(`${later.difference(earlier)}`, `${diff}`));
     it(`(${earlier}).plus(${diff}) == (${later})`, () => equal(`${earlier.plus(diff)}`, `${later}`));
     it(`(${later}).minus(${diff}) == (${earlier})`, () => equal(`${later.minus(diff)}`, `${earlier}`));
+    it("doesn't cast argument", () => {
+      throws(() => earlier.difference(later.toString()), TypeError);
+      throws(() => earlier.difference({}), TypeError);
+    });
   });
 });
 

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -47,6 +47,9 @@ describe('Absolute', () => {
       it('Absolute.prototype.toJSON is a Function', () => {
         equal(typeof Absolute.prototype.toJSON, 'function');
       });
+      it('Absolute.prototype.difference is a Function', () => {
+        equal(typeof Absolute.prototype.difference, 'function');
+      });
     });
     it('Absolute.fromEpochSeconds is a Function', () => {
       equal(typeof Absolute.fromEpochSeconds, 'function');
@@ -62,6 +65,9 @@ describe('Absolute', () => {
     });
     it('Absolute.from is a Function', () => {
       equal(typeof Absolute.from, 'function');
+    });
+    it('Absolute.compare is a Function', () => {
+      equal(typeof Absolute.compare, 'function');
     });
   });
   describe('Construction', () => {
@@ -181,6 +187,26 @@ describe('Absolute', () => {
       it(`(${two}).minus({ days: 20, nanoseconds: 1600 }) = ${one}`, () => equal(`${three}`, `${one}`));
       it(`(${one}).plus( days: 20, nanoseconds: 1600 }) = ${two}`, () => equal(`${four}`, `${two}`));
     });
+  });
+  describe('Absolute.compare works', () => {
+    const abs1 = Absolute.from('1963-02-13T09:36:29.123456789Z');
+    const abs2 = Absolute.from('1976-11-18T15:23:30.123456789Z');
+    const abs3 = Absolute.from('1981-12-15T14:34:31.987654321Z');
+    it('pre epoch equal', () => equal(Absolute.compare(abs1, Absolute.from(abs1)), 0));
+    it('epoch equal', () => equal(Absolute.compare(abs2, Absolute.from(abs2)), 0));
+    it('cross epoch smaller/larger', () => equal(Absolute.compare(abs1, abs2), -1));
+    it('cross epoch larger/smaller', () => equal(Absolute.compare(abs2, abs1), 1));
+    it('epoch smaller/larger', () => equal(Absolute.compare(abs2, abs3), -1));
+    it('epoch larger/smaller', () => equal(Absolute.compare(abs3, abs2), 1));
+  });
+  describe('Absolute.difference works', () => {
+    const earlier = Absolute.from('1976-11-18T15:23:30.123456789Z');
+    const later = Absolute.from('2019-10-29T10:46:38.271986102Z');
+    const diff = earlier.difference(later);
+    it(`(${earlier}).difference(${later}) == (${later}).difference(${earlier})`, () =>
+      equal(`${later.difference(earlier)}`, `${diff}`));
+    it(`(${earlier}).plus(${diff}) == (${later})`, () => equal(`${earlier.plus(diff)}`, `${later}`));
+    it(`(${later}).minus(${diff}) == (${earlier})`, () => equal(`${later.minus(diff)}`, `${earlier}`));
   });
 });
 

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -133,11 +133,15 @@ describe('Date', () => {
     const dt = date.withTime(Temporal.Time.from('11:30:23'));
     it('returns a Temporal.DateTime', () => assert(dt instanceof Temporal.DateTime));
     it('combines the date and time', () => equal(`${dt}`, '1976-11-18T11:30:23'));
+    it("doesn't cast argument", () => {
+      throws(() => dt.withTime({ hours: 11, minutes: 30, seconds: 23 }), TypeError);
+      throws(() => dt.withTime('11:30:23'), TypeError);
+    });
   });
   describe('date.difference() works', () => {
     const date = new Date(1976, 11, 18);
     it('date.difference({ year: 1976, month: 10, day: 5 })', () => {
-      const duration = date.difference({ year: 1976, month: 10, day: 5 });
+      const duration = date.difference(Date.from({ year: 1976, month: 10, day: 5 }));
 
       equal(duration.years, 0);
       equal(duration.months, 1);
@@ -150,7 +154,7 @@ describe('Date', () => {
       equal(duration.nanoseconds, 0);
     });
     it('date.difference({ year: 2019, month: 11, day: 18 })', () => {
-      const duration = date.difference({ year: 2019, month: 11, day: 18 });
+      const duration = date.difference(Date.from({ year: 2019, month: 11, day: 18 }));
       equal(duration.years, 43);
       equal(duration.months, 0);
       equal(duration.days, 0);
@@ -161,6 +165,10 @@ describe('Date', () => {
       equal(duration.microseconds, 0);
       equal(duration.nanoseconds, 0);
     });
+    it("doesn't cast argument", () => {
+      throws(() => date.difference({ year: 2019, month: 11, day: 5 }), TypeError);
+      throws(() => date.difference('2019-11-05'), TypeError);
+    })
   });
   describe('date.plus() works', () => {
     let date = new Date(1976, 11, 18);
@@ -236,6 +244,14 @@ describe('Date', () => {
     it('equal', () => equal(Date.compare(d1, d1), 0));
     it('smaller/larger', () => equal(Date.compare(d1, d2), -1));
     it('larger/smaller', () => equal(Date.compare(d2, d1), 1));
+    it("doesn't cast first argument", () => {
+      throws(() => Date.compare({ year: 1976, month: 11, day: 18 }, d2), TypeError);
+      throws(() => Date.compare('1976-11-18', d2), TypeError);
+    });
+    it("doesn't cast second argument", () => {
+      throws(() => Date.compare(d1, { year: 2019, month: 6, day: 30 }), TypeError);
+      throws(() => Date.compare(d1, '2019-06-30'), TypeError);
+    });
   });
 });
 

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -14,7 +14,8 @@ const { reporter } = Pretty;
 import Assert from 'assert';
 const { ok: assert, equal, throws } = Assert;
 
-import { Date } from 'tc39-temporal';
+import * as Temporal from 'tc39-temporal';
+const { Date } = Temporal;
 
 describe('Date', () => {
   describe('Structure', () => {
@@ -75,6 +76,9 @@ describe('Date', () => {
     it('Date.from is a Function', () => {
       equal(typeof Date.from, 'function');
     });
+    it('Date.compare is a Function', () => {
+      equal(typeof Date.compare, 'function');
+    });
   });
   describe('Construction', () => {
     let date;
@@ -123,6 +127,12 @@ describe('Date', () => {
       const date = original.with({ day: 17 });
       equal(`${date}`, '1976-11-17');
     });
+  });
+  describe('Date.withTime() works', () => {
+    const date = Date.from('1976-11-18');
+    const dt = date.withTime(Temporal.Time.from('11:30:23'));
+    it('returns a Temporal.DateTime', () => assert(dt instanceof Temporal.DateTime));
+    it('combines the date and time', () => equal(`${dt}`, '1976-11-18T11:30:23'));
   });
   describe('date.difference() works', () => {
     const date = new Date(1976, 11, 18);
@@ -219,6 +229,13 @@ describe('Date', () => {
     });
     it('Date.from({ year: 1976, month: 11, day: 18 }) == 1976-11-18', () => equal(`${Date.from({ year: 1976, month: 11, day: 18 })}`, '1976-11-18'));
     it('DateTime.from({}) throws', () => throws(() => Date.from({}), RangeError));
+  });
+  describe('Date.compare works', () => {
+    const d1 = Date.from('1976-11-18');
+    const d2 = Date.from('2019-06-30');
+    it('equal', () => equal(Date.compare(d1, d1), 0));
+    it('smaller/larger', () => equal(Date.compare(d1, d2), -1));
+    it('larger/smaller', () => equal(Date.compare(d2, d1), 1));
   });
 });
 

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -93,6 +93,9 @@ describe('DateTime', () => {
     it('DateTime.from is a Function', () => {
       equal(typeof DateTime.from, 'function');
     });
+    it('DateTime.compare is a Function', () => {
+      equal(typeof DateTime.compare, 'function');
+    });
   });
   describe('Construction', () => {
     describe('new DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789)', () => {
@@ -240,6 +243,13 @@ describe('DateTime', () => {
     it('datetime.with({ month: 5, second: 15 } works', () => {
       equal(`${datetime.with({ month: 5, second: 15 })}`, '1976-05-18T15:23:15.123456789');
     });
+  });
+  describe('DateTime.compare() works', () => {
+    const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
+    const dt2 = DateTime.from('2019-10-29T10:46:38.271986102');
+    it('equal', () => equal(DateTime.compare(dt1, dt1), 0));
+    it('smaller/larger', () => equal(DateTime.compare(dt1, dt2), -1));
+    it('larger/smaller', () => equal(DateTime.compare(dt2, dt1), 1));
   });
   describe('date/time maths', () => {
     const earlier = DateTime.from('1976-11-18T15:23:30.123456789');

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -250,6 +250,14 @@ describe('DateTime', () => {
     it('equal', () => equal(DateTime.compare(dt1, dt1), 0));
     it('smaller/larger', () => equal(DateTime.compare(dt1, dt2), -1));
     it('larger/smaller', () => equal(DateTime.compare(dt2, dt1), 1));
+    it("doesn't cast first argument", () => {
+      throws(() => DateTime.compare({ year: 1976, month: 11, day: 18, hour: 15 }, dt2), TypeError);
+      throws(() => DateTime.compare('1976-11-18T15:23:30.123456789', dt2), TypeError);
+    });
+    it("doesn't cast second argument", () => {
+      throws(() => DateTime.compare(dt1, { year: 2019, month: 10, day: 29, hour: 10 }), TypeError);
+      throws(() => DateTime.compare('2019-10-29T10:46:38.271986102', dt2), TypeError);
+    });
   });
   describe('date/time maths', () => {
     const earlier = DateTime.from('1976-11-18T15:23:30.123456789');
@@ -259,6 +267,13 @@ describe('DateTime', () => {
       equal(`${later.difference(earlier)}`, `${diff}`));
     it(`(${earlier}).plus(${diff}) == (${later})`, () => equal(`${earlier.plus(diff)}`, `${later}`));
     it(`(${later}).minus(${diff}) == (${earlier})`, () => equal(`${later.minus(diff)}`, `${earlier}`));
+  });
+  describe('DateTime.difference()', () => {
+    const dt = DateTime.from('1976-11-18T15:23:30.123456789');
+    it("doesn't cast argument", () => {
+      throws(() => dt.difference({ year: 2019, month: 10, day: 29, hour: 10}), TypeError);
+      throws(() => dt.difference('2019-10-29T10:46:38.271986102'), TypeError);
+    });
   });
   describe('DateTime.from() works', () => {
     it('DateTime.from("1976-11-18 15:23:30")', () => equal(`${DateTime.from('1976-11-18 15:23:30')}`, "1976-11-18T15:23:30"));

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -98,6 +98,14 @@ describe('MonthDay', () => {
     it('equal', () => equal(MonthDay.compare(jan15, jan15), 0));
     it('smaller/larger', () => equal(MonthDay.compare(jan15, feb1), -1));
     it('larger/smaller', () => equal(MonthDay.compare(feb1, jan15), 1));
+    it("doesn't cast first argument", () => {
+      throws(() => MonthDay.compare({ month: 1, day: 15 }, feb1), TypeError);
+      throws(() => MonthDay.compare('01-15', feb1), TypeError);
+    });
+    it("doesn't cast second argument", () => {
+      throws(() => MonthDay.compare(jan15, { month: 2, day: 1 }), TypeError);
+      throws(() => MonthDay.compare(jan15, '02-01'), TypeError);
+    });
   });
   describe('MonthDay.difference() works', () => {
     const jan15 = MonthDay.from('01-15');
@@ -107,6 +115,10 @@ describe('MonthDay', () => {
       equal(`${diff}`, `${feb1.difference(jan15)}`));
     it(`${jan15}.plus(${diff}) == ${feb1}`, () => equal(`${jan15.plus(diff)}`, `${feb1}`));
     it(`${feb1}.minus(${diff}) == ${jan15}`, () => equal(`${feb1.minus(diff)}`, `${jan15}`));
+    it("doesn't cast argument", () => {
+      throws(() => jan15.difference({ month: 2, day: 1 }), TypeError);
+      throws(() => jan15.difference('02-01'), TypeError);
+    });
   });
 });
 

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -75,6 +75,15 @@ describe('MonthDay', () => {
       });
     });
   });
+  describe('MonthDay.difference() works', () => {
+    const jan15 = MonthDay.from('01-15');
+    const feb1 = MonthDay.from('02-01');
+    const diff = jan15.difference(feb1);
+    it(`${jan15}.difference(${feb1}) == ${feb1}.difference(${jan15})`, () =>
+      equal(`${diff}`, `${feb1.difference(jan15)}`));
+    it(`${jan15}.plus(${diff}) == ${feb1}`, () => equal(`${jan15.plus(diff)}`, `${feb1}`));
+    it(`${feb1}.minus(${diff}) == ${jan15}`, () => equal(`${feb1.minus(diff)}`, `${jan15}`));
+  });
 });
 
 import { normalize } from 'path';

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -10,6 +10,23 @@ const { throws, equal } = assert;
 import { MonthDay } from 'tc39-temporal';
 
 describe('MonthDay', () => {
+  describe('Structure', () => {
+    it('MonthDay is a Function', () => {
+      equal(typeof MonthDay, 'function');
+    });
+    it('MonthDay has a prototype', () => {
+      assert(MonthDay.prototype);
+      equal(typeof MonthDay.prototype, 'object');
+    });
+    describe('MonthDay.prototype', () => {
+      it('MonthDay.prototype.difference is a Function', () => {
+        equal(typeof MonthDay.prototype.difference, 'function');
+      });
+    });
+    it('MonthDay.compare is a Function', () => {
+      equal(typeof MonthDay.compare, 'function');
+    });
+  });
   describe('Construction', () => {
     describe('Disambiguation', () => {
       it('reject', () => throws(() => new MonthDay(1, 32, 'reject'), RangeError));
@@ -74,6 +91,13 @@ describe('MonthDay', () => {
         equal(`${april15.plus(duration)}`, '04-15');
       });
     });
+  });
+  describe('MonthDay.compare() works', () => {
+    const jan15 = MonthDay.from('01-15');
+    const feb1 = MonthDay.from('02-01');
+    it('equal', () => equal(MonthDay.compare(jan15, jan15), 0));
+    it('smaller/larger', () => equal(MonthDay.compare(jan15, feb1), -1));
+    it('larger/smaller', () => equal(MonthDay.compare(feb1, jan15), 1));
   });
   describe('MonthDay.difference() works', () => {
     const jan15 = MonthDay.from('01-15');

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -70,6 +70,9 @@ describe('Time', () => {
     it('Time.from is a Function', () => {
       equal(typeof Time.from, 'function');
     });
+    it('Time.compare is a Function', () => {
+      equal(typeof Time.compare, 'function');
+    });
   });
   describe('Construction', () => {
     describe('complete', () => {
@@ -209,6 +212,12 @@ describe('Time', () => {
         equal(`${time.with({ minute: 8, nanosecond: 3 })}`, '15:08:30.123456003');
       });
     });
+  describe('time.withDate() works', () => {
+    const time = Time.from('11:30:23.123456789');
+    const dt = time.withDate(Temporal.Date.from('1976-11-18'));
+    it('returns a Temporal.DateTime', () => assert(dt instanceof Temporal.DateTime));
+    it('combines the date and time', () => equal(`${dt}`, '1976-11-18T11:30:23.123456789'));
+  });
     describe('time.difference() works', () => {
       const time = new Time(15, 23, 30, 123, 456, 789);
       const one = new Time(14, 23, 30, 123, 456, 789);
@@ -221,6 +230,13 @@ describe('Time', () => {
         const duration = time.difference(two);
         equal(`${duration}`, 'PT1H53M');
       });
+    });
+    describe('Time.compare() works', () => {
+      const t1 = Time.from('08:44:15.321');
+      const t2 = Time.from('14:23:30.123');
+      it('equal', () => equal(Time.compare(t1, t1), 0));
+      it('smaller/larger', () => equal(Time.compare(t1, t2), -1));
+      it('larger/smaller', () => equal(Time.compare(t2, t1), 1));
     });
     describe('time.plus() works', () => {
       const time = new Time(15, 23, 30, 123, 456, 789);

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -106,6 +106,19 @@ describe('TimeZone', ()=>{
             throws(() => zone.getAbsoluteFor(dtm, 'reject'), RangeError);
         });
     });
+    describe('Casting', () => {
+        const zone = Temporal.TimeZone.from('+03:30');
+        it("getOffsetFor() doesn't cast its argument", () => {
+            throws(() => zone.getOffsetFor(0n), TypeError);
+            throws(() => zone.getOffsetFor('2019-02-17T01:45Z'), TypeError);
+            throws(() => zone.getOffsetFor({}), TypeError);
+        });
+        it("getDateTimeFor() doesn't cast its argument", () => {
+            throws(() => zone.getDateTimeFor(0n), TypeError);
+            throws(() => zone.getDateTimeFor('2019-02-17T01:45Z'), TypeError);
+            throws(() => zone.getDateTimeFor({}), TypeError);
+        });
+    });
 });
 
 function ArrayFrom(iter, limit = Number.POSITIVE_INFINITY) {

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -55,6 +55,14 @@ describe('YearMonth', () => {
     it('equal', () => equal(YearMonth.compare(nov94, nov94), 0));
     it('smaller/larger', () => equal(YearMonth.compare(nov94, jun13), -1));
     it('larger/smaller', () => equal(YearMonth.compare(jun13, nov94), 1));
+    it("doesn't cast first argument", () => {
+      throws(() => YearMonth.compare({ year: 1994, month: 11 }, jun13), TypeError);
+      throws(() => YearMonth.compare('1994-11', jun13), TypeError);
+    });
+    it("doesn't cast second argument", () => {
+      throws(() => YearMonth.compare(nov94, { year: 2013, month: 6 }), TypeError);
+      throws(() => YearMonth.compare(nov94, '2013-06'), TypeError);
+    });
   });
   describe('YearMonth.difference() works', () => {
     const nov94 = YearMonth.from('1994-11');
@@ -64,6 +72,10 @@ describe('YearMonth', () => {
       equal(`${diff}`, `${jun13.difference(nov94)}`));
     it(`${nov94}.plus(${diff}) == ${jun13}`, () => equal(`${nov94.plus(diff)}`, `${jun13}`));
     it(`${jun13}.minus(${diff}) == ${nov94}`, () => equal(`${jun13.minus(diff)}`, `${nov94}`));
+    it("doesn't cast argument", () => {
+      throws(() => nov94.difference({ year: 2013, month: 6 }), TypeError);
+      throws(() => nov94.difference('2013-06'), TypeError);
+    });
   });
 });
 

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -32,6 +32,15 @@ describe('YearMonth', () => {
       it('YearMonth.from({}) throws', () => throws(() => YearMonth.from({}), RangeError));
     });
   });
+  describe('YearMonth.difference() works', () => {
+    const nov94 = YearMonth.from('1994-11');
+    const jun13 = YearMonth.from('2013-06');
+    const diff = nov94.difference(jun13);
+    it(`${nov94}.difference(${jun13}) == ${jun13}.difference(${nov94})`, () =>
+      equal(`${diff}`, `${jun13.difference(nov94)}`));
+    it(`${nov94}.plus(${diff}) == ${jun13}`, () => equal(`${nov94.plus(diff)}`, `${jun13}`));
+    it(`${jun13}.minus(${diff}) == ${nov94}`, () => equal(`${jun13.minus(diff)}`, `${nov94}`));
+  });
 });
 
 import { normalize } from 'path';

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -10,6 +10,23 @@ const { throws, equal } = assert;
 import { YearMonth } from 'tc39-temporal';
 
 describe('YearMonth', () => {
+  describe('Structure', () => {
+    it('YearMonth is a Function', () => {
+      equal(typeof YearMonth, 'function');
+    });
+    it('YearMonth has a prototype', () => {
+      assert(YearMonth.prototype);
+      equal(typeof YearMonth.prototype, 'object');
+    });
+    describe('YearMonth.prototype', () => {
+      it('YearMonth.prototype.difference is a Function', () => {
+        equal(typeof YearMonth.prototype.difference, 'function');
+      });
+    });
+    it('YearMonth.compare is a Function', () => {
+      equal(typeof YearMonth.compare, 'function');
+    });
+  });
   describe('Construction', () => {
     describe('Disambiguation', () => {
       it('reject', () => throws(() => new YearMonth(2019, 13, 'reject'), RangeError));
@@ -31,6 +48,13 @@ describe('YearMonth', () => {
       });
       it('YearMonth.from({}) throws', () => throws(() => YearMonth.from({}), RangeError));
     });
+  });
+  describe('YearMonth.compare() works', () => {
+    const nov94 = YearMonth.from('1994-11');
+    const jun13 = YearMonth.from('2013-06');
+    it('equal', () => equal(YearMonth.compare(nov94, nov94), 0));
+    it('smaller/larger', () => equal(YearMonth.compare(nov94, jun13), -1));
+    it('larger/smaller', () => equal(YearMonth.compare(jun13, nov94), 1));
   });
   describe('YearMonth.difference() works', () => {
     const nov94 = YearMonth.from('1994-11');

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -113,8 +113,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _one_ be ? ToAbsolute(_one_).
-        1. Let _two_ be ? ToAbsolute(_two_).
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalAbsolute]]).
+        1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalAbsolute]]).
         1. Return ! AbsoluteCompare(_one_, _two_).
       </emu-alg>
     </emu-clause>
@@ -256,7 +256,7 @@
       <emu-alg>
         1. Let _absolute_ be the *this* value.
         1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
-        1. Let _otherAbsolute_ be ? ToAbsolute(_otherAbsolute_).
+        1. Perform ? RequireInternalSlot(_otherAbsolute_, [[InitializedTemporalAbsolute]]).
         1. If ! AbsoluteCompare(_absolute_, _otherAbsolute_) &lt; 0, then
           1. Let _greater_ be _otherAbsolute_.
           1. Let _smaller_ be _absolute_.

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -331,7 +331,7 @@
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-datetime-abstract-ops">
+  <emu-clause id="sec-temporal-absolute-abstract-ops">
     <h1>Abstract operations</h1>
 
     <emu-clause id="sec-temporal-createabsolute" aoid="CreateAbsolute">

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -345,6 +345,13 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-toabsolute" aoid="ToAbsolute">
+      <h1>ToAbsolute ( _arg_ )</h1>
+      <emu-alg>
+        1. <mark>TODO</mark>
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-absolutecompare" aoid="AbsoluteCompare">
       <h1>AbsoluteCompare ( _one_, _two_ )</h1>
       <emu-alg>

--- a/spec/date.html
+++ b/spec/date.html
@@ -67,8 +67,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _one_ be ? ToDate(_one_).
-        1. Let _two_ be ? ToDate(_two_).
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDate]]).
+        1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalDate]]).
         1. If _one_.[[Year]] &gt; _two_.[[Year]], return 1.
         1. If _one_.[[Year]] &lt; _two_.[[Year]], return -1.
         1. If _one_.[[Month]] &gt; _two_.[[Month]], return 1.
@@ -321,7 +321,7 @@
       <emu-alg>
         1. Let _date_ be the *this* value.
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
-        1. Let _otherDate_ be ? ToDate(_otherDate_).
+        1. Perform ? RequireInternalSlot(_otherDate_, [[InitializedTemporalDate]]).
         1. Let _disambiguation_ be ? ToString(_disambiguation_).
         1. Let _greater_ be _date_.
         1. Let _smaller_ be _otherDate_.
@@ -345,7 +345,7 @@
       <emu-alg>
         1. Let _date_ be the *this* value.
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
-        1. Let _time_ be ? ToTime(_time_).
+        1. Perform ? RequireInternalSlot(_time_, [[InitializedTemporalTime]]).
         1. Return ? CreateDateTime(_date_.[[Year]], _date_.[[Month]], _date_.[[Day]],
           _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]],
           _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]]).

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -89,8 +89,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _one_ be ? ToDateTime(_one_).
-        1. Let _two_ be ? ToDateTime(_two_).
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDateTime]]).
+        1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalDateTime]]).
         1. Return ! DateTimeCompare(_one_, _two_).
       </emu-alg>
     </emu-clause>
@@ -420,7 +420,7 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Let _otherDateTime_ be ? ToDateTime(_otherDateTime_).
+        1. Perform ? RequireInternalSlot(_otherDateTime_, [[InitializedTemporalDateTime]]).
         1. If ! DateTimeCompare(_dateTime_, _otherDateTime_) &lt; 0, then
           1. Let _greater_ be _otherDateTime_.
           1. Let _smaller_ be _dateTime_.

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -70,8 +70,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _one_ be ? ToMonthDay(_one_).
-        1. Let _two_ be ? ToMonthDay(_two_).
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalMonthDay]]).
+        1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalMonthDay]]).
         1. Return ! MonthDayCompare(_one_, _two_).
       </emu-alg>
     </emu-clause>
@@ -209,7 +209,7 @@
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
-        1. Let _otherMonthDay_ be ? ToMonthDay(_otherMonthDay_).
+        1. Perform ? RequireInternalSlot(_otherMonthDay_, [[InitializedTemporalMonthDay]]).
         1. If ! MonthDayCompare(_monthDay_, _otherMonthDay_) &lt; 0, then
           1. Let _greater_ be _otherMonthDay_.
           1. Let _smaller_ be _monthDay_.

--- a/spec/time.html
+++ b/spec/time.html
@@ -88,8 +88,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _one_ be ? ToTime(_one_).
-        1. Let _two_ be ? ToTime(_two_).
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalTime]]).
+        1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalTime]]).
         1. Return ! TimeCompare(_one_, _two_).
       </emu-alg>
     </emu-clause>
@@ -288,7 +288,7 @@
       <emu-alg>
         1. Let _time_ be the *this* value.
         1. Perform ? RequireInternalSlot(_time_, [[InitializedTemporalTime]]).
-        1. Let _otherTime_ be ? ToTime(_otherTime_).
+        1. Perform ? RequireInternalSlot(_otherTime_, [[InitializedTemporalTime]]).
         1. If ! TimeCompare(_time_, _otherTime_) &lt; 0, then
           1. Let _greater_ be _otherTime_.
           1. Let _smaller_ be _time_.
@@ -315,7 +315,7 @@
       <emu-alg>
         1. Let _time_ be the *this* value.
         1. Perform ? RequireInternalSlot(_time_, [[InitializedTemporalTime]]).
-        1. Let _date_ be ? ToDate(_date_).
+        1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. If _disambiguation_ is not *undefined*, then
           1. Set _disambiguation_ to ? ToString(_disambiguation_).
         1. Else

--- a/spec/time.html
+++ b/spec/time.html
@@ -368,7 +368,7 @@
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-date-abstract-ops">
+  <emu-clause id="sec-temporal-time-abstract-ops">
     <h1>Abstract operations</h1>
 
     <emu-clause id="sec-temporal-topartialtime" aoid="ToPartialTime">

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -114,7 +114,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. Let _absolute_ be ? ToAbsolute(_absolute_).
+        1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
         1. Return ? GetTimeZoneOffsetString(_absolute_.[[Nanoseconds]], _timeZone_.[[Identifier]]).
       </emu-alg>
     </emu-clause>
@@ -128,7 +128,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. Let _absolute_ be ? ToAbsolute(_absolute_).
+        1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
         1. Return ? GetDateTimeFor(_timeZone_, _absolute_);
       </emu-alg>
     </emu-clause>

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -70,8 +70,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _one_ be ? ToYearMonth(_one_).
-        1. Let _two_ be ? ToYearMonth(_two_).
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalYearMonth]]).
+        1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalYearMonth]]).
         1. Return ! YearMonthCompare(_one_, _two_).
       </emu-alg>
     </emu-clause>
@@ -235,7 +235,7 @@
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
-        1. Let _otherYearMonth_ be ? ToYearMonth(_otherYearMonth_).
+        1. Perform ? RequireInternalSlot(_otherYearMonth_, [[InitializedTemporalYearMonth]]).
         1. If ! YearMonthCompare(_yearMonth_, _otherYearMonth_) &lt; 0, then
           1. Let _greater_ be _otherYearMonth_.
           1. Let _smaller_ be _yearMonth_.


### PR DESCRIPTION
Removes casting from all `compare()` and `difference()` methods, as well as:
- `Date.withTime()`
- `Time.withDate()`
- `TimeZone.getOffsetFor()`
- `TimeZone.getAbsoluteFor()`

Closes: #237 