### PR TITLE
adding getSortedLocalDateTimes

### DIFF
--- a/docs/cookbook/getSortedLocalDateTimes.mjs
+++ b/docs/cookbook/getSortedLocalDateTimes.mjs
@@ -4,20 +4,38 @@ import assert from "assert";
  * corresponding local date and time of day (e.g., for building a conference schedule).
  *
  *
- * @param {Temporal.DateTime[]} dateTimes This is a Date instance
- * @param {boolean} direction ascending or descending order
- * @returns {Temporal.DateTime[]} Temporal.Absolute instance
+ * @param {Temporal.DateTime[]} dateTimes This is a DateTime instance
+ * @param {boolean} direction reverse
+ * @returns {Temporal.DateTime[]} the array from dateTimes, sorted
  */
 function getSortedLocalDateTimes(dateTimes, reverse = false) {
-    let newDateTimes = dateTimes.sort(Temporal.DateTime.compare);
+    let newDateTimes = Array.from(dateTimes).sort(Temporal.DateTime.compare);
 
     return reverse ? newDateTimes.reverse() : newDateTimes;
 }
 
-// Sorting some conferences without timezones
-let a = Temporal.DateTime.from({ year: 2020, day: 15, month: 2, hour: 9 }); // FontFest
-let b = Temporal.DateTime.from({ year: 2020, day: 26, month: 5 }); // React Finland
-let c = Temporal.DateTime.from({ year: 2020, day: 23, month: 2, hour: 9 }); // ReactConf AU
+// Sorting some conferences without timezones for example vue.js Amsterdam 2020
+let a = Temporal.DateTime.from({
+    year: 2020,
+    day: 20,
+    month: 2,
+    hour: 8,
+    minute: 45
+}); // Introduction
+let b = Temporal.DateTime.from({
+    year: 2020,
+    day: 21,
+    month: 2,
+    hour: 13,
+    minute: 10
+}); // Lunch Break
+let c = Temporal.DateTime.from({
+    year: 2020,
+    day: 20,
+    month: 2,
+    hour: 15,
+    minute: 30
+}); // Coffee Break
 const results = getSortedLocalDateTimes([a, b, c]);
 assert.equal(results[0], a);
 assert.equal(results[1], c);

--- a/docs/cookbook/getSortedLocalDateTimes.mjs
+++ b/docs/cookbook/getSortedLocalDateTimes.mjs
@@ -1,3 +1,4 @@
+import assert from "assert";
 /**
  * getSortedLocalDateTimes will sort an array of zoneless Temporal.DateTime instances by the
  * corresponding local date and time of day (e.g., for building a conference schedule).
@@ -13,7 +14,11 @@ function getSortedLocalDateTimes(dateTimes, reverse = false) {
     return reverse ? newDateTimes.reverse() : newDateTimes;
 }
 
-let a = Temporal.DateTime.from({ day: 4, month: 2 });
-let b = Temporal.DateTime.from({ day: 5, month: 2 });
-let c = Temporal.DateTime.from({ day: 6, month: 3 });
-getSortedLocalDateTimes([a, b, c]);
+// Sorting some conferences without timezones
+let a = Temporal.DateTime.from({ year: 2020, day: 15, month: 2, hour: 9 }); // FontFest
+let b = Temporal.DateTime.from({ year: 2020, day: 26, month: 5 }); // React Finland
+let c = Temporal.DateTime.from({ year: 2020, day: 23, month: 2, hour: 9 }); // ReactConf AU
+const results = getSortedLocalDateTimes([a, b, c]);
+assert.equal(results[0], a);
+assert.equal(results[1], c);
+assert.equal(results[2], b);

--- a/docs/cookbook/getSortedLocalDateTimes.mjs
+++ b/docs/cookbook/getSortedLocalDateTimes.mjs
@@ -4,18 +4,16 @@
  *
  *
  * @param {Temporal.DateTime[]} dateTimes This is a Date instance
- * @param {boolean} direction accending or descending order
- * @returns {Temporal.Absolute} Temporal.Absolute instance
+ * @param {boolean} direction ascending or descending order
+ * @returns {Temporal.DateTime[]} Temporal.Absolute instance
  */
 function getSortedLocalDateTimes(dateTimes, reverse = false) {
-    let newDateTimes = dateTimes.sort((a, b) => {
-        return a.compare(b);
-    });
+    let newDateTimes = dateTimes.sort(Temporal.DateTime.compare);
 
     return reverse ? newDateTimes.reverse() : newDateTimes;
 }
 
-let a = new Temporal.DateTime({ day: 4, month: 2 });
-let b = new Temporal.DateTime({ day: 5, month: 2 });
-let c = new Temporal.DateTime({ day: 6, month: 3 });
+let a = Temporal.DateTime.from({ day: 4, month: 2 });
+let b = Temporal.DateTime.from({ day: 5, month: 2 });
+let c = Temporal.DateTime.from({ day: 6, month: 3 });
 getSortedLocalDateTimes([a, b, c]);

--- a/docs/cookbook/getSortedLocalDateTimes.mjs
+++ b/docs/cookbook/getSortedLocalDateTimes.mjs
@@ -1,0 +1,21 @@
+/**
+ * getSortedLocalDateTimes will sort an array of zoneless Temporal.DateTime instances by the
+ * corresponding local date and time of day (e.g., for building a conference schedule).
+ *
+ *
+ * @param {Temporal.DateTime[]} dateTimes This is a Date instance
+ * @param {boolean} direction accending or descending order
+ * @returns {Temporal.Absolute} Temporal.Absolute instance
+ */
+function getSortedLocalDateTimes(dateTimes, reverse = false) {
+    let newDateTimes = dateTimes.sort((a, b) => {
+        return a.compare(b);
+    });
+
+    return reverse ? newDateTimes.reverse() : newDateTimes;
+}
+
+let a = new Temporal.DateTime({ day: 4, month: 2 });
+let b = new Temporal.DateTime({ day: 5, month: 2 });
+let c = new Temporal.DateTime({ day: 6, month: 3 });
+getSortedLocalDateTimes([a, b, c]);


### PR DESCRIPTION
This currently does not work.

```
proposal-temporal/cookbook/getSortedLocalDateTimes.mjs:12
        return a.compare(b);
                 ^

TypeError: a.compare is not a function
```

Does anyone know why? 
According to the code/docs .compare() should exist