### PR TITLE
Add section headings in reference docs

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -11,7 +11,9 @@ Since `Temporal.Absolute` doesn't contain any information about time zones, a `T
 
 Like Unix time, `Temporal.Absolute` ignores leap seconds.
 
-## new Temporal.Absolute(epochNanoseconds : bigint) : Temporal.Absolute
+## Constructor
+
+### new Temporal.Absolute(epochNanoseconds : bigint) : Temporal.Absolute
 
 **Parameters:**
 - `epochNanoSeconds` (bigint): A number of nanoseconds.
@@ -34,7 +36,9 @@ epoch = new Temporal.Absolute(0n);  // => 1970-01-01T00:00Z
 turnOfTheCentury = new Temporal.Absolute(-2208988800000000000n);  // => 1900-01-01T00:00Z
 ```
 
-## Temporal.Absolute.from(thing: string | Temporal.Absolute) : Temporal.Absolute
+## Static methods
+
+### Temporal.Absolute.from(thing: string | Temporal.Absolute) : Temporal.Absolute
 
 **Parameters:**
 - `thing` (string or `Temporal.Absolute`): The value representing the desired point in time.
@@ -61,7 +65,7 @@ abs === Temporal.Absolute.from(abs);  // => true
 /* WRONG */ abs = Temporal.Absolute.from('2019-03031T02:45+01:00[Europe/Berlin]');  // time skipped in DST transition; throws
 ```
 
-## Temporal.Absolute.fromEpochSeconds(epochSeconds: number) : Temporal.Absolute
+### Temporal.Absolute.fromEpochSeconds(epochSeconds: number) : Temporal.Absolute
 
 **Parameters:**
 - `epochSeconds` (number): A number of seconds.
@@ -82,7 +86,7 @@ epoch = Temporal.Absolute.fromEpochSeconds(0);  // => 1970-01-01T00:00Z
 turnOfTheCentury = Temporal.Absolute.fromEpochSeconds(-2208988800);  // => 1900-01-01T00:00Z
 ```
 
-## Temporal.Absolute.fromEpochMilliseconds(epochMilliseconds: number) : Temporal.Absolute
+### Temporal.Absolute.fromEpochMilliseconds(epochMilliseconds: number) : Temporal.Absolute
 
 **Parameters:**
 - `epochMilliseconds` (number): A number of milliseconds.
@@ -103,7 +107,7 @@ todayMs = Temporal.Absolute.fromEpochMilliseconds(Date.now());
 todayNs = Temporal.now.absolute();
 ```
 
-## Temporal.Absolute.fromEpochMicroseconds(epochMilliseconds : bigint) : Temporal.Absolute
+### Temporal.Absolute.fromEpochMicroseconds(epochMilliseconds : bigint) : Temporal.Absolute
 
 **Parameters:**
 - `epochMicroseconds` (bigint): A number of microseconds.
@@ -112,7 +116,7 @@ todayNs = Temporal.now.absolute();
 
 Same as `Temporal.Absolute.fromEpochSeconds()`, but with microsecond (10<sup>&minus;6</sup> second) precision.
 
-## Temporal.Absolute.fromEpochNanoseconds(epochNanoseconds : bigint) : Temporal.Absolute
+### Temporal.Absolute.fromEpochNanoseconds(epochNanoseconds : bigint) : Temporal.Absolute
 
 **Parameters:**
 - `epochNanoseconds` (bigint): A number of nanoseconds.
@@ -122,7 +126,34 @@ Same as `Temporal.Absolute.fromEpochSeconds()`, but with microsecond (10<sup>&mi
 Same as `Temporal.Absolute.fromEpochSeconds()`, but with nanosecond (10<sup>&minus;9</sup> second) precision.
 Also the same as `new Temporal.Absolute(epochNanoseconds)`.
 
-## absolute.getEpochSeconds() : number
+### Temporal.Absolute.compare(one: Temporal.Absolute, two: Temporal.Absolute) : number
+
+**Parameters:**
+- `one` (`Temporal.Absolute`): First time to compare.
+- `two` (`Temporal.Absolute`): Second time to compare.
+
+**Returns:** &minus;1, 0, or 1.
+
+Compares two `Temporal.Absolute` objects.
+Returns an integer indicating whether `one` comes before or after or is equal to `two`.
+- &minus;1 if `one` comes before `two`;
+- 0 if `one` and `two` represent the same time;
+- 1 if `one` comes after `two`.
+
+This function can be used to sort arrays of `Temporal.Absolute` objects.
+For example:
+```javascript
+one = Temporal.Absolute.fromEpochSeconds(1.0e9);
+two = Temporal.Absolute.fromEpochSeconds(1.1e9);
+three = Temporal.Absolute.fromEpochSeconds(1.2e9);
+sorted = [three, one, two].sort(Temporal.Absolute.compare);
+sorted.join(' ');
+// => 2001-09-09T01:46:40Z 2004-11-09T11:33:20Z 2008-01-10T21:20Z
+```
+
+## Methods
+
+### absolute.getEpochSeconds() : number
 
 **Returns:** an integer number of seconds.
 
@@ -138,7 +169,7 @@ abs = Temporal.Absolute.from('2019-03-30T01:45+01:00');
 abs.getEpochSeconds();  // => 1554000300
 ```
 
-## absolute.getEpochMilliseconds() : number
+### absolute.getEpochMilliseconds() : number
 
 **Returns:** an integer number of milliseconds.
 
@@ -151,13 +182,13 @@ abs = Temporal.Absolute.from('2019-03-30T00:45Z');
 new Date(abs.getEpochMilliseconds());  // => 2019-03-30T00:45:00.000Z
 ```
 
-## absolute.getEpochMicroseconds() : bigint
+### absolute.getEpochMicroseconds() : bigint
 
 **Returns:** a number of microseconds, as a bigint.
 
 Same as `getEpochSeconds()`, but with microsecond (10<sup>&minus;6</sup> second) precision.
 
-## absolute.getEpochNanoseconds() : bigint
+### absolute.getEpochNanoseconds() : bigint
 
 **Returns:** a number of nanoseconds, as a bigint.
 
@@ -165,7 +196,7 @@ Same as `getEpochSeconds()`, but with nanosecond (10<sup>&minus;9</sup> second) 
 
 The value returned from this method is suitable to be passed to `new Temporal.Absolute()`.
 
-## absolute.inTimeZone(timeZone: Temporal.TimeZone | string) : Temporal.DateTime
+### absolute.inTimeZone(timeZone: Temporal.TimeZone | string) : Temporal.DateTime
 
 **Parameters:**
 - `timeZone` (object or string): A `Temporal.TimeZone` object, or a string description of the time zone; either its IANA name or UTC offset.
@@ -192,7 +223,7 @@ tz = new Temporal.TimeZone('America/New_York');
 epoch.inTimeZone(tz);  // => 1969-12-31T19:00
 ```
 
-## absolute.plus(duration: string | object) : Temporal.Absolute
+### absolute.plus(duration: string | object) : Temporal.Absolute
 
 **Parameters:**
 - `duration` (string or object): A `Temporal.Duration` object, a duration-like object, or a string from which to create a `Temporal.Duration`.
@@ -215,7 +246,7 @@ fiveHours = new Temporal.Duration(0, 0, 0, 5);
 Temporal.now.absolute().plus(fiveHours);
 ```
 
-## absolute.minus(duration: string | object) : Temporal.Absolute
+### absolute.minus(duration: string | object) : Temporal.Absolute
 
 **Parameters:**
 - `duration` (string or object): A `Temporal.Duration` object, a duration-like object, or a string from which to create a `Temporal.Duration`.
@@ -238,7 +269,7 @@ oneDay = new Temporal.Duration(0, 0, 1);
 Temporal.now.absolute().minus(oneDay);
 ```
 
-## absolute.difference(other: Temporal.Absolute) : Temporal.Duration
+### absolute.difference(other: Temporal.Absolute) : Temporal.Duration
 
 **Parameters:**
 - `other` (`Temporal.Absolute`): Another time with which to compute the difference.
@@ -257,7 +288,7 @@ endOfMoonMission.difference(startOfMoonMission);  // => P8DT3H18M35S
 missionLength.toLocaleString();  // example output: '8 days 3 hours 18 minutes 35 seconds'
 ```
 
-## absolute.toString(timeZone?: Temporal.TimeZone | string) : string
+### absolute.toString(timeZone?: Temporal.TimeZone | string) : string
 
 **Parameters:**
 - `timeZone` (optional string or `Temporal.TimeZone`): the time zone to express `absolute` in.
@@ -276,7 +307,7 @@ abs.toString(Temporal.TimeZone.from('UTC'));  // => 2019-11-18T10:52:01.816Z
 abs.toString('Asia/Seoul');  // => 2019-11-18T19:52:01.816+09:00[Asia/Seoul]
 ```
 
-## absolute.toLocaleString(locales?: string | array&lt;string&gt;, options?: object) : string
+### absolute.toLocaleString(locales?: string | array&lt;string&gt;, options?: object) : string
 
 **Parameters:**
 - `locales` (optional string or array of strings): A string with a BCP 47 language tag with an optional Unicode extension key, or an array of such strings.
@@ -295,31 +326,6 @@ abs.toLocaleString();  // => example output: 2019-11-18, 3:00:00 a.m.
 abs.toLocaleString('de-DE');  // => example output: 18.11.2019, 03:00:00
 abs.toLocaleString('de-DE', { timeZone: 'Europe/Berlin', weekday: 'long' });  // => Montag, 18.11.2019, 12:00:00
 abs.toLocaleString('en-US-u-nu-fullwide-hc-h12', { timeZone: 'Asia/Kolkata' });  // => １１/１８/２０１９, ４:３０:００ PM
-```
-
-## Temporal.Absolute.compare(one: Temporal.Absolute, two: Temporal.Absolute) : number
-
-**Parameters:**
-- `one` (`Temporal.Absolute`): First time to compare.
-- `two` (`Temporal.Absolute`): Second time to compare.
-
-**Returns:** &minus;1, 0, or 1.
-
-Compares two `Temporal.Absolute` objects.
-Returns an integer indicating whether `one` comes before or after or is equal to `two`.
-- &minus;1 if `one` comes before `two`;
-- 0 if `one` and `two` represent the same time;
-- 1 if `one` comes after `two`.
-
-This function can be used to sort arrays of `Temporal.Absolute` objects.
-For example:
-```javascript
-one = Temporal.Absolute.fromEpochSeconds(1.0e9);
-two = Temporal.Absolute.fromEpochSeconds(1.1e9);
-three = Temporal.Absolute.fromEpochSeconds(1.2e9);
-sorted = [three, one, two].sort(Temporal.Absolute.compare);
-sorted.join(' ');
-// => 2001-09-09T01:46:40Z 2004-11-09T11:33:20Z 2008-01-10T21:20Z
 ```
 
 <script type="application/javascript" src="./prism.js"></script>

--- a/docs/date.md
+++ b/docs/date.md
@@ -2,82 +2,15 @@
 
 A representation of a calendar date.
 
-## new Temporal.Date(year: number, month: number, day: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
+## Constructor
+
+### new Temporal.Date(year: number, month: number, day: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
 
 Creates a new `Date` object that represents a calendar date
 
-## Temporal.Date.from(thing: string | object) : Temporal.Date
+## Static methods
 
-## date.year : number
-
-Returns the year this `Date` represents
-
-## date.month : number
-
-Returns the month this `Date` represents
-
-## date.day : number
-
-Returns the day this `Date` represents
-
-## date.dayOfWeek : number
-
-Returns the day of the week this `Date` represents
-
-```js
-const date = new Temporal.Date(2019, 11, 18); // Monday
-date.dayOfWeek; // 1
-```
-
-## date.weekOfYear : number
-
-Returns the week in a calendar year
-
-## date.daysInMonth : number
-
-Returns the number of days in the month the `Date` Object represents
-
-## date.daysInYear : number
-
-Returns the number of days in the year the `Date` Object represents
-
-## date.leapYear : boolean
-
-Returns a boolean indicating whether the `Date` is in a leap year or not
-
-## date.with(dateLike: object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
-
-## date.plus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
-
-Returns a new `Date` object which is the sum of the current object plus the additional argument.
-
-## date.minus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
-
-Returns a new `Date` object which is the sum of the current object minus the additional argument.
-
-## date.difference(other: Temporal.Date) : Temporal.Duration
-
-Returns a new `Duration` object which is the difference between the current `Date` object and the argument `Date` value.
-
-## date.toString() : string
-
-Returns an ISO 8601 string representing the current `Date` object
-
-## date.toLocaleString(locale?: string, options?: object) : string
-
-Returns a string with a locally sensitive representation of the specified `Date` object. Overrides the `Object.prototype.toLocaleString()` method.
-
-## date.withTime(time: Temporal.Time) : Temporal.DateTime
-
-Returns a new [`DateTime`](./DateTime) object using the combination of this `Date` and the `Time` object passed in.
-
-## date.getYearMonth() : Temporal.YearMonth
-
-Returns a new [`YearMonth`](./YearMonth) object.
-
-## date.getMonthDay() : Temporal.MonthDay
-
-Returns a new [`YearMonth`](./MonthDay) object.
+### Temporal.Date.from(thing: string | object) : Temporal.Date
 
 ## Temporal.Date.compare(one: Temporal.Date, two: Temporal.Date) : number
 
@@ -86,6 +19,81 @@ Allows for easier comparison of `Date` objects, returns:
 - `-1` if the first object represents a lower value than the second
 - `0` if the 2 objects represent the same value
 - `1` if the first object represents a higher value than the second
+
+## Properties
+
+### date.year : number
+
+Returns the year this `Date` represents
+
+### date.month : number
+
+Returns the month this `Date` represents
+
+### date.day : number
+
+Returns the day this `Date` represents
+
+### date.dayOfWeek : number
+
+Returns the day of the week this `Date` represents
+
+```js
+const date = new Temporal.Date(2019, 11, 18); // Monday
+date.dayOfWeek; // 1
+```
+
+### date.weekOfYear : number
+
+Returns the week in a calendar year
+
+### date.daysInMonth : number
+
+Returns the number of days in the month the `Date` Object represents
+
+### date.daysInYear : number
+
+Returns the number of days in the year the `Date` Object represents
+
+### date.leapYear : boolean
+
+Returns a boolean indicating whether the `Date` is in a leap year or not
+
+## Methods
+
+### date.with(dateLike: object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
+
+## date.plus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
+
+Returns a new `Date` object which is the sum of the current object plus the additional argument.
+
+### date.minus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
+
+Returns a new `Date` object which is the sum of the current object minus the additional argument.
+
+### date.difference(other: Temporal.Date) : Temporal.Duration
+
+Returns a new `Duration` object which is the difference between the current `Date` object and the argument `Date` value.
+
+### date.toString() : string
+
+Returns an ISO 8601 string representing the current `Date` object
+
+### date.toLocaleString(locale?: string, options?: object) : string
+
+Returns a string with a locally sensitive representation of the specified `Date` object. Overrides the `Object.prototype.toLocaleString()` method.
+
+### date.withTime(time: Temporal.Time) : Temporal.DateTime
+
+Returns a new [`DateTime`](./DateTime) object using the combination of this `Date` and the `Time` object passed in.
+
+### date.getYearMonth() : Temporal.YearMonth
+
+Returns a new [`YearMonth`](./YearMonth) object.
+
+### date.getMonthDay() : Temporal.MonthDay
+
+Returns a new [`YearMonth`](./MonthDay) object.
 
 <script type="application/javascript" src="./prism.js"></script>
 <link rel="stylesheet" type="text/css" href="./prism.css">

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -1,60 +1,68 @@
 # `Temporal.DateTime`
 
-## new Temporal.DateTime(year: number, month: number, day: number, hour: number, minute: number, second: number = 0, milliseconds: number =0, microsecond: number = 0, nanosecond: nunber = 0, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
+## Constructor
 
-## Temporal.DateTime.from(thing: string | object) : Temporal.DateTime
+### new Temporal.DateTime(year: number, month: number, day: number, hour: number, minute: number, second: number = 0, milliseconds: number =0, microsecond: number = 0, nanosecond: nunber = 0, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
 
-## datetime.year : number
+## Static methods
 
-## datetime.month : number
+### Temporal.DateTime.from(thing: string | object) : Temporal.DateTime
 
-## datetime.day : number
+### Temporal.DateTime.compare(one: Temporal.DateTime, two: Temporal.DateTime) : number;
 
-## datetime.hour: number
+## Properties
 
-## datetime.minute: number
+### datetime.year : number
 
-## datetime.second: number
+### datetime.month : number
 
-## datetime.millisecond: number
+### datetime.day : number
 
-## datetime.microsecond: number
+### datetime.hour: number
 
-## datetime.nanosecond: number
+### datetime.minute: number
 
-## datetime.dayOfWeek : number
+### datetime.second: number
 
-## datetime.weekOfYear : number
+### datetime.millisecond: number
 
-## datetime.daysInMonth : number
+### datetime.microsecond: number
 
-## datetime.daysInYear : number
+### datetime.nanosecond: number
 
-## datetime.leapYear : boolean
+### datetime.dayOfWeek : number
 
-## datetime.with({ year: number, month: number, hour: number, hour: number = this.hour, minute: number = this.minute, ...}, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.DateTime
+### datetime.weekOfYear : number
 
-## datetime.plus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.DateTime
+### datetime.daysInMonth : number
 
-## datetime.minus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.DateTime
+### datetime.daysInYear : number
 
-## datetime.difference(other: Temporal.DateTime) : Temporal.Duration
+### datetime.leapYear : boolean
 
-## datetime.toString() : string
+## Methods
 
-## datetime.toLocaleString(locale?:string, options?: object) : string
+### datetime.with({ year: number, month: number, hour: number, hour: number = this.hour, minute: number = this.minute, ...}, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.DateTime
 
-## datetime.inTimeZone(timeZoneParam = 'UTC', disambiguation = 'earlier') : Temporal.Absolute
+### datetime.plus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.DateTime
 
-## datetime.getDate() : Temporal.Date
+### datetime.minus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.DateTime
 
-## datetime.getYearMonth() : Temporal.YearMonth
+### datetime.difference(other: Temporal.DateTime) : Temporal.Duration
 
-## datetime.getMonthDay() : Temporal.MonthDay
+### datetime.toString() : string
 
-## datetime.getTime() : Temporal.Time
+### datetime.toLocaleString(locale?:string, options?: object) : string
 
-## Temporal.DateTime.compare(one: Temporal.DateTime, two: Temporal.DateTime) : number;
+### datetime.inTimeZone(timeZoneParam = 'UTC', disambiguation = 'earlier') : Temporal.Absolute
+
+### datetime.getDate() : Temporal.Date
+
+### datetime.getYearMonth() : Temporal.YearMonth
+
+### datetime.getMonthDay() : Temporal.MonthDay
+
+### datetime.getTime() : Temporal.Time
 
 <script type="application/javascript" src="./prism.js"></script>
 <link rel="stylesheet" type="text/css" href="./prism.css">

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -2,35 +2,43 @@
 
 A representations of a duration of time which can be used in date/time arithmetic.
 
-## new Temporal.Duration(years?: number, months?: number, days?: number, hours?: number, minutes?: number, seconds?: number, milliseconds?: number, microseconds?: number, nanoseconds?: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Duration
+## Constructor
+
+### new Temporal.Duration(years?: number, months?: number, days?: number, hours?: number, minutes?: number, seconds?: number, milliseconds?: number, microseconds?: number, nanoseconds?: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Duration
 
 Creates a new `Duration` object that represents a duration of time.
 
-## Temporal.Duration.from(thing: string | object) : Temporal.Duration
+## Static methods
 
-## duration.years : number
+### Temporal.Duration.from(thing: string | object) : Temporal.Duration
 
-## duration.months : number
+## Properties
 
-## duration.days : number
+### duration.years : number
 
-## duration.hours : number
+### duration.months : number
 
-## duration.minutes : number
+### duration.days : number
 
-## duration.seconds : number
+### duration.hours : number
 
-## duration.milliseconds : number
+### duration.minutes : number
 
-## duration.microseconds : number
+### duration.seconds : number
 
-## duration.nanoseconds : number
+### duration.milliseconds : number
 
-## duration.years : number
+### duration.microseconds : number
 
-## duration.toString() : string
+### duration.nanoseconds : number
 
-## duration.toLocaleString(locale?: string, options?: object) : string
+### duration.years : number
+
+## Methods
+
+### duration.toString() : string
+
+### duration.toLocaleString(locale?: string, options?: object) : string
 
 <script type="application/javascript" src="./prism.js"></script>
 <link rel="stylesheet" type="text/css" href="./prism.css">

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -1,30 +1,38 @@
 # `Temporal.MonthDay`
 
-## new Temporal.MonthDay(month: number, day: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
+## Constructor
 
-## Temporal.MonthDay.from(thing: string | object) : Temporal.MonthDay
+### new Temporal.MonthDay(month: number, day: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
 
-## monthDay.month : number
+## Static methods
 
-## monthDay.day : number
+### Temporal.MonthDay.from(thing: string | object) : Temporal.MonthDay
 
-## monthDay.daysInMonth : number
+### Temporal.MonthDay.compare(one: Temporal.MonthDay, two: Temporal.MonthDay) : number
 
-## monthDay.with(monthDayLike: object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
+## Properties
 
-## monthDay.plus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
+### monthDay.month : number
 
-## monthDay.minus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
+### monthDay.day : number
 
-## monthDay.difference(other: Temporal.MonthDay) : Temporal.Duration
+### monthDay.daysInMonth : number
 
-## monthDay.toString() : string
+## Methods
 
-## monthDay.toLocaleString(locale?: string, options?: object) : string
+### monthDay.with(monthDayLike: object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
 
-## monthDay.withYear(year: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
+### monthDay.plus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
 
-## Temporal.MonthDay.compare(one: Temporal.MonthDay, two: Temporal.MonthDay) : number
+### monthDay.minus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
+
+### monthDay.difference(other: Temporal.MonthDay) : Temporal.Duration
+
+### monthDay.toString() : string
+
+### monthDay.toLocaleString(locale?: string, options?: object) : string
+
+### monthDay.withYear(year: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
 
 <script type="application/javascript" src="./prism.js"></script>
 <link rel="stylesheet" type="text/css" href="./prism.css">

--- a/docs/time.md
+++ b/docs/time.md
@@ -2,37 +2,45 @@
 
 A representation of wall-clock time.
 
-## new Temporal.Time(hour: number, minute: number, second: number = 0, milliseconds: number =0, microsecond: number = 0, nanosecond: number = 0, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
+## Constructor
 
-## Temporal.Time.from(thing: string | object) : Temporal.Time
+### new Temporal.Time(hour: number, minute: number, second: number = 0, milliseconds: number =0, microsecond: number = 0, nanosecond: number = 0, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
 
-## time.hour: number
+## Static methods
 
-## time.minute: number
+### Temporal.Time.from(thing: string | object) : Temporal.Time
 
-## time.second: number
+### Temporal.Time.compare(one: Temporal.Time, two: Temporal.Time) : number;
 
-## time.millisecond: number
+## Properties
 
-## time.microsecond: number
+### time.hour: number
 
-## time.nanosecond: number
+### time.minute: number
 
-## time.with({ hour: number = this.hour, minute: number = this.minute, second: numer = this.second ...}, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
+### time.second: number
 
-## time.plus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
+### time.millisecond: number
 
-## time.minus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
+### time.microsecond: number
 
-## time.difference(other: Temporal.Time) : Temporal.Duration
+### time.nanosecond: number
 
-## time.toString() : string
+## Methods
 
-## time.toLocaleString(locale?:string, options?: object) : string
+### time.with({ hour: number = this.hour, minute: number = this.minute, second: numer = this.second ...}, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
 
-## time.withDate(date: Temporal.Date) : Temporal.DateTime
+### time.plus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
 
-## Temporal.Time.compare(one: Temporal.Time, two: Temporal.Time) : number;
+### time.minus(duration: string | object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
+
+### time.difference(other: Temporal.Time) : Temporal.Duration
+
+### time.toString() : string
+
+### time.toLocaleString(locale?:string, options?: object) : string
+
+### time.withDate(date: Temporal.Date) : Temporal.DateTime
 
 <script type="application/javascript" src="./prism.js"></script>
 <link rel="stylesheet" type="text/css" href="./prism.css">

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -6,7 +6,9 @@ Since `Temporal.Absolute` and `Temporal.DateTime` do not contain any time zone i
 
 Finally, the `Temporal.TimeZone` object itself provides access to a list of the time zones in the IANA time zone database.
 
-## new Temporal.TimeZone(timeZoneIdentifier: string) : Temporal.TimeZone
+## Constructor
+
+### new Temporal.TimeZone(timeZoneIdentifier: string) : Temporal.TimeZone
 
 **Parameters:**
 - `timeZoneIdentifier` (string): A description of the time zone; either its IANA name, or a UTC offset.
@@ -31,7 +33,7 @@ tz = new Temporal.TimeZone('+645');
 /* WRONG */ tz = new Temporal.TimeZone('local');  // not a time zone, throws
 ```
 
-### Difference between IANA time zones and UTC offsets
+#### Difference between IANA time zones and UTC offsets
 
 The returned time zone object behaves slightly differently depending on whether an IANA time zone name (e.g. `Europe/Berlin`) is given, or a UTC offset (e.g. `+01:00`).
 IANA time zones may have DST transitions, and UTC offsets do not.
@@ -45,12 +47,34 @@ tz1.getTransitions(now).next().done;  // => true
 tz2.getTransitions(now).next().done;  // => false
 ```
 
-## timeZone.name : string
+## Static methods
+
+### Temporal.TimeZone: iterator<Temporal.TimeZone>
+
+The `Temporal.TimeZone` object is itself iterable, and can be used to iterate through all of the IANA time zones supported by the implementation.
+
+Example usage:
+
+```javascript
+// List all supported IANA time zones
+for (let zone of Temporal.TimeZone) console.log(zone.name);
+// example output:
+// Africa/Abidjan
+// Africa/Accra
+// Africa/Addis_Ababa
+// ...and many more
+```
+
+## Properties
+
+### timeZone.name : string
 
 The `name` property gives an unambiguous identifier for the time zone.
 Effectively, this is the canonicalized version of whatever `timeZoneIdentifier` was passed as a parameter to the constructor.
 
-## timeZone.getOffsetFor(absolute: Temporal.Absolute) : string
+## Methods
+
+### timeZone.getOffsetFor(absolute: Temporal.Absolute) : string
 
 **Parameters:**
 - `absolute` (`Temporal.Absolute`): The time for which to compute the time zone's UTC offset.
@@ -77,7 +101,7 @@ tz = new Temporal.TimeZone('UTC');
 tz.getOffsetFor(timestamp);  // => +00:00
 ```
 
-## timeZone.getDateTimeFor(absolute: Temporal.Absolute) : Temporal.DateTime
+### timeZone.getDateTimeFor(absolute: Temporal.Absolute) : Temporal.DateTime
 
 **Parameters:**
 - `absolute` (`Temporal.Absolute`): An absolute time to convert.
@@ -100,7 +124,7 @@ tz = new Temporal.TimeZone('America/New_York');
 tz.getDateTimeFor(epoch);  // => 1969-12-31T19:00
 ```
 
-## timeZone.getAbsoluteFor(dateTime: Temporal.DateTime, disambiguation: 'earlier' | 'later' | 'reject' = 'earlier') : Temporal.Absolute
+### timeZone.getAbsoluteFor(dateTime: Temporal.DateTime, disambiguation: 'earlier' | 'later' | 'reject' = 'earlier') : Temporal.Absolute
 
 **Parameters:**
 - `dateTime` (`Temporal.DateTime`): A calendar date and wall-clock time to convert.
@@ -112,7 +136,7 @@ tz.getDateTimeFor(epoch);  // => 1969-12-31T19:00
 
 This method is one way to convert a `Temporal.DateTime` to a `Temporal.Absolute`.
 
-### Resolving ambiguity
+#### Resolving ambiguity
 
 > This explanation was adapted from the [moment-timezone documentation](https://github.com/moment/momentjs.com/blob/master/docs/moment-timezone/01-using-timezones/02-parsing-ambiguous-inputs.md).
 
@@ -167,7 +191,7 @@ In this example, the wall-clock time 23:45 exists twice.
 
 > *Compatibility Note*: The built-in behaviour of the Moment Timezone and Luxon libraries is to give the same result as `earlier` when turning the clock back, and `later` when setting the clock forward.
 
-## timeZone.getTransitions(startingPoint: Temporal.Absolute) : iterator<Temporal.Absolute>
+### timeZone.getTransitions(startingPoint: Temporal.Absolute) : iterator<Temporal.Absolute>
 
 **Parameters:**
 - `startingPoint` (`Temporal.Absolute`): Time after which to start calculating DST transitions.
@@ -190,27 +214,11 @@ duration = nextTransition.difference(now);
 duration.toLocaleString();  // output will vary
 ```
 
-## timeZone.toString() : string
+### timeZone.toString() : string
 
 **Returns:** The string given by `timeZone.name`.
 
 This method overrides `Object.prototype.toString()` and provides the time zone's `name` property as a human-readable description.
-
-## Temporal.TimeZone: iterator<Temporal.TimeZone>
-
-The `Temporal.TimeZone` object is itself iterable, and can be used to iterate through all of the IANA time zones supported by the implementation.
-
-Example usage:
-
-```javascript
-// List all supported IANA time zones
-for (let zone of Temporal.TimeZone) console.log(zone.name);
-// example output:
-// Africa/Abidjan
-// Africa/Accra
-// Africa/Addis_Ababa
-// ...and many more
-```
 
 <script type="application/javascript" src="./prism.js"></script>
 <link rel="stylesheet" type="text/css" href="./prism.css">

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -2,35 +2,43 @@
 
 A representation of a calendar date.
 
-## new Temporal.YearMonth(year: number, month: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
+## Constructor
 
-## Temporal.YearMonth.from(thing: string | object) : Temporal.YearMonth
+### new Temporal.YearMonth(year: number, month: number, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
 
-## yearMonth.year : number
+## Static methods
 
-## yearMonth.month : number
+### Temporal.YearMonth.from(thing: string | object) : Temporal.YearMonth
 
-## yearMonth.daysInMonth : number
+### Temporal.YearMonth.compare(one: Temporal.YearMonth, two: Temporal.YearMonth) : number
 
-## yearMonth.daysInYear : number
+## Properties
 
-## yearMonth.leapYear : boolean
+### yearMonth.year : number
 
-## yearMonth.with(yearMonthLike: object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
+### yearMonth.month : number
 
-## yearMonth.plus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
+### yearMonth.daysInMonth : number
 
-## yearMonth.minus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
+### yearMonth.daysInYear : number
 
-## yearMonth.difference(other: Temporal.YearMonth) : Temporal.Duration
+### yearMonth.leapYear : boolean
 
-## yearMonth.toString() : string
+## Methods
 
-## yearMonth.toLocaleString(locale?: string, options?: object) : string
+### yearMonth.with(yearMonthLike: object, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
 
-## yearMonth.withDay(day: number) : Temporal.Date
+### yearMonth.plus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
 
-## Temporal.YearMonth.compare(one: Temporal.YearMonth, two: Temporal.YearMonth) : number
+### yearMonth.minus(duration: Temporal.Duration | object | string, disambiguation: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
+
+### yearMonth.difference(other: Temporal.YearMonth) : Temporal.Duration
+
+### yearMonth.toString() : string
+
+### yearMonth.toLocaleString(locale?: string, options?: object) : string
+
+### yearMonth.withDay(day: number) : Temporal.Date
 
 <script type="application/javascript" src="./prism.js"></script>
 <link rel="stylesheet" type="text/css" href="./prism.css">


### PR DESCRIPTION
This is intended to make the difference between methods and static
methods clearer in the reference docs.