### PR TITLE
Spec handling of invalid disambiguation values.

### DIFF
--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -39,6 +39,11 @@ export class TimeZone {
   getAbsoluteFor(dateTime, disambiguation = 'earlier') {
     if (!ES.IsTimeZone(this)) throw new TypeError('invalid receiver');
     dateTime = ES.ToDateTime(dateTime);
+    disambiguation = ES.ToString(disambiguation);
+    if (!~['earlier', 'later', 'reject'].indexOf(disambiguation)) {
+      throw new RangeError(`"${disambiguation}" is not a valid value for the disambiguation argument`);
+    }
+
     const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = dateTime;
     const options = ES.GetTimeZoneEpochValue(
@@ -73,12 +78,12 @@ export class TimeZone {
           SetSlot(result, EPOCHNANOSECONDS, options[1]);
           return result;
         }
-        default:
+        case 'reject': {
           throw new RangeError(`multiple absolute found`);
+        }
       }
     }
 
-    if (!~['earlier', 'later'].indexOf(disambiguation)) throw new RangeError(`no such absolute found`);
 
     const utcns = ES.GetEpochFromParts(
       year,
@@ -97,14 +102,17 @@ export class TimeZone {
       nanoseconds: after.minus(before)
     });
     switch (disambiguation) {
-      case 'earlier':
+      case 'earlier': {
         const earlier = dateTime.minus(diff);
         return this.getAbsoluteFor(earlier, disambiguation);
-      case 'later':
+      }
+      case 'later': {
         const later = dateTime.plus(diff);
         return this.getAbsoluteFor(later, disambiguation);
-      default:
+      }
+      case 'reject': {
         throw new RangeError(`no such absolute found`);
+      }
     }
   }
   getTransitions(startingPoint) {

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -119,6 +119,19 @@ describe('TimeZone', ()=>{
             throws(() => zone.getDateTimeFor({}), TypeError);
         });
     });
+    describe('getAbsoluteFor disambiguation', () => {
+        const zone = Temporal.TimeZone.from('+03:30');
+        const dtm = new Temporal.DateTime(2019, 2, 16, 23, 45);
+        it("getAbsoluteFor() disambiguation", () => {
+            for (const disambiguation of [undefined, 'earlier', 'later', 'reject']) {
+                assert(zone.getAbsoluteFor(dtm, disambiguation) instanceof Temporal.Absolute);
+            }
+            throws(() => zone.getAbsoluteFor(dtm, null), RangeError);
+            throws(() => zone.getAbsoluteFor(dtm, ''), RangeError);
+            throws(() => zone.getAbsoluteFor(dtm, 'EARLIER'), RangeError);
+            throws(() => zone.getAbsoluteFor(dtm, 'test'), RangeError);
+        });
+    });
 });
 
 function ArrayFrom(iter, limit = Number.POSITIVE_INFINITY) {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -4,6 +4,30 @@
 <emu-clause id="sec-temporal-abstract-ops">
   <h1>Abstract operations</h1>
 
+  <emu-clause id="sec-temporal-todisambiguation" aoid="ToDisambiguation">
+    <h1>ToDisambiguation ( _disambiguation_ )</h1>
+    <emu-alg>
+      1. If _disambiguation_ is *undefined*, then
+        1. Return `"constrain"`.
+      1. Set _disambiguation_ to ? ToString(_disambiguation_).
+      1. If _disambiguation_ is not one of `"constrain"`, `"balance"`, or `"reject"`, then
+        1. Throw a *RangeError* exception.
+      1. Return _disambiguation_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-totimezonedisambiguation" aoid="ToTimeZoneDisambiguation">
+    <h1>ToTimeZoneDisambiguation ( _disambiguation_ )</h1>
+    <emu-alg>
+      1. If _disambiguation_ is *undefined*, then
+        1. Return `"earlier"`.
+      1. Set _disambiguation_ to ? ToString(_disambiguation_).
+      1. If _disambiguation_ is not one of `"earlier"` or `"later"`, then
+        1. Throw a *RangeError* exception.
+      1. Return _disambiguation_.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-isleapyear" aoid="IsLeapYear">
     <h1>IsLeapYear ( _year_ )</h1>
     <emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -22,7 +22,7 @@
       1. If _disambiguation_ is *undefined*, then
         1. Return `"earlier"`.
       1. Set _disambiguation_ to ? ToString(_disambiguation_).
-      1. If _disambiguation_ is not one of `"earlier"` or `"later"`, then
+      1. If _disambiguation_ is not one of `"earlier"`, `"later"`, or `"reject"`, then
         1. Throw a *RangeError* exception.
       1. Return _disambiguation_.
     </emu-alg>

--- a/spec/date.html
+++ b/spec/date.html
@@ -26,7 +26,7 @@
         1. Let _y_ be ? ToInteger(_year_).
         1. Let _m_ be ? ToInteger(_month_).
         1. Let _d_ be ? ToInteger(_day_).
-        1. Let _disambiguation_ be ? ToString(_disambiguation_).
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _result_ be ? RegulateDate(_y_, _m_, _d_, _disambiguation_).
         1. Return ? CreateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], NewTarget).
       </emu-alg>
@@ -258,7 +258,7 @@
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Let _duration_ be ? ToDurationLike(_duration_).
         1. <mark>TODO: Throw if any time properties are present?</mark>
-        1. Let _disambiguation_ be ? ToString(_disambiguation_).
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Return ? AddDate(_date_.[[Year]], _date_.[[Month]], _date_.[[Day]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Days]], _disambiguation_).
       </emu-alg>
     </emu-clause>
@@ -274,7 +274,7 @@
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Let _duration_ be ? ToDurationLike(_duration_).
         1. <mark>TODO: Throw if any time properties are present?</mark>
-        1. Let _disambiguation_ be ? ToString(_disambiguation_).
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _y_ be _date_.[[Year]] - _duration_.[[Years]].
         1. Let _m_ be _date_.[[Month]] - _duration_.[[Months]].
         1. Let _intermediate_ be ? RegulateDate(_y_, _m_, _date_.[[Day]], _disambiguation_).
@@ -294,7 +294,7 @@
         1. Let _date_ be the *this* value.
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Let _otherDate_ be ? ToPartialDate(_otherDate_).
-        1. Let _disambiguation_ be ? ToString(_disambiguation_).
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. If _otherDate_.[[Year]] is not *undefined*, then
           1. Let _y_ be _otherDate_.[[Year]].
         1. Else
@@ -313,9 +313,9 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.date.prototype.difference">
-      <h1>Temporal.Date.prototype.difference ( _otherDate_, _disambiguation_ )</h1>
+      <h1>Temporal.Date.prototype.difference ( _otherDate_ )</h1>
       <p>
-        The `difference` method takes two arguments, _otherDate_ and _disambiguation_.
+        The `difference` method takes one argument _otherDate_.
         The following steps are taken:
       </p>
       <emu-alg>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -46,10 +46,7 @@
           1. Let _nanosecond_ be ? ToInteger(_nanosecond_).
         1. Else
           1. Let _nanosecond_ be 0.
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _result_ be ? RegulateDateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _disambiguation_).
         1. Return ? CreateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], NewTarget).
       </emu-alg>
@@ -327,10 +324,7 @@
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _dateTimeLike_ be ? ToPartialDateTime(_dateTimeLike_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. If _dateTimeLike_.[[Year]] is not *undefined*, then
           1. Let _year_ be _dateTimeLike_.[[Year]].
         1. Else
@@ -382,10 +376,7 @@
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _duration_ be ? ToTimeDurationLike(_duration_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _timePart_ be ? AddTime(_dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _datePart_ be ? AddDate(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Days]], _disambiguation_).
         1. Let _datePart_ be ! BalanceDate(_datePart_.[[Year]], _datePart_.[[Month]], _datePart_.[[Day]] + _timePart_.[[Day]]).
@@ -403,10 +394,7 @@
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _duration_ be ? ToTimeDurationLike(_duration_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. <mark>TODO</mark>
       </emu-alg>
     </emu-clause>
@@ -483,10 +471,7 @@
         1. If _timeZoneParam_ is *undefined*, then
           1. Set _timeZoneParam_ to `"UTC"`.
         1. Let _timeZone_ be ? ToTimeZone(_timeZoneParam_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"earlier"`.
+        1. Set _disambiguation_ to ? ToTimeZoneDisambiguation(_disambiguation_).
         1. Return ? GetAbsoluteFor(_timeZone_, _dateTime_, _disambiguation_).
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -108,10 +108,7 @@
         1. Let _ms_ be ? ToInteger(_milliseconds_).
         1. Let _mis_ be ? ToInteger(_microseconds_).
         1. Let _ns_ be ? ToInteger(_nanoseconds_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. If _disambiguation_ is *"reject"*, then
           1. For each of _y_, _mo_, _d_, _h_, _m_, _s_, _ms_, _mis_, _ns_, if any of the values is negative, throw a *RangeError* exception.
         1. Else if _disambiguation_ is *"constrain"*, then
@@ -125,8 +122,6 @@
           1. Set _ms_ to _bt_.[[Millisecond]].
           1. Set _mis_ to _bt_.[[Microsecond]].
           1. Set _ns_ to _bt_.[[Nanosecond]].
-        1. Else,
-          1. Throw a *TypeError* exception.
         1. Return ? CreateDuration(_y_, _mo_, _d_, _h_, _m_, _s_, _ms_, _mis_, _ns_).
       </emu-alg>
     </emu-clause>

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -27,10 +27,7 @@
           1. Throw a *TypeError* exception.
         1. Let _m_ be ? ToInteger(_month_).
         1. Let _d_ be ? ToInteger(_day_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _result_ be ? RegulateMonthDay(_m_, _d_, _disambiguation_).
         1. Return ? CreateMonthDay(_result_.[[Month]], _result_.[[Day]], NewTarget).
       </emu-alg>
@@ -139,10 +136,7 @@
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Let _otherMonthDay_ be ? ToPartialMonthDay(_otherMonthDay_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. If _otherMonthDay_.[[Month]] is not *undefined*, then
           1. Let _m_ be _otherMonthDay_.[[Month]].
         1. Else
@@ -167,10 +161,7 @@
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Let _duration_ be ? ToDurationLike(_duration_).
         1. <mark>TODO: Throw if any year/time properties are present?</mark>
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _m_ be _monthDay_.[[Month]] + _duration_.[[Months]].
         1. Let _d_ be _monthDay_.[[Day]] + _duration_.[[Days]].
         1. Let _result_ be ? RegulateMonthDay(_m_, _d_, _disambiguation_).
@@ -189,10 +180,7 @@
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Let _duration_ be ? ToDurationLike(_duration_).
         1. <mark>TODO: Throw if any year/time properties are present?</mark>
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _m_ be _monthDay_.[[Month]] - _duration_.[[Months]].
         1. Let _d_ be _monthDay_.[[Day]] - _duration_.[[Days]].
         1. Let _result_ be ? RegulateMonthDay(_m_, _d_, _disambiguation_).
@@ -276,10 +264,7 @@
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Let _y_ be ? ToInteger(_year_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _result_ be ? RegulateDate(_y_, _monthDay_.[[Month]], _monthDay_.[[Day]], _disambiguation_).
         1. Return ? CreateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
       </emu-alg>

--- a/spec/time.html
+++ b/spec/time.html
@@ -44,10 +44,7 @@
           1. Let _nanosecond_ be ? ToInteger(_nanosecond_).
         1. Else
           1. Let _nanosecond_ be 0.
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _result_ be ? RegulateTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _disambiguation_).
         1. Return ? CreateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], NewTarget).
       </emu-alg>
@@ -246,10 +243,7 @@
         1. Let _time_ be the *this* value.
         1. Perform ? RequireInternalSlot(_time_, [[InitializedTemporalTime]]).
         1. Let _timelike_ be ? ToPartialTime(_timelike_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. If _timelike_.[[Hour]] is not *undefined*, then
           1. Let _hour_ be _timelike_.[[Hour]].
         1. Else
@@ -316,10 +310,7 @@
         1. Let _time_ be the *this* value.
         1. Perform ? RequireInternalSlot(_time_, [[InitializedTemporalTime]]).
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. <mark>TODO: Consider _disambiguation_.</mark>
         1. Return CreateDateTime(_date_.[[Year]], _date_.[[Month]], _date_.[[Day]],
           _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]],

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -142,6 +142,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
+        1. Set _disambiguation_ to ? ToTimeZoneDisambiguation(_disambiguation_).
         1. <mark>TODO</mark>
       </emu-alg>
     </emu-clause>

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -27,10 +27,7 @@
           1. Throw a *TypeError* exception.
         1. Let _y_ be ? ToInteger(_year_).
         1. Let _m_ be ? ToInteger(_month_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _result_ be ? RegulateYearMonth(_y_, _m_, _disambiguation_).
         1. Return ? CreateYearMonth(_result_.[[Year]], _result_.[[Month]], NewTarget).
       </emu-alg>
@@ -165,10 +162,7 @@
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _otherYearMonth_ be ? ToPartialYearMonth(_otherYearMonth_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. If _otherYearMonth_.[[Year]] is not *undefined*, then
           1. Let _y_ be _otherYearMonth_.[[Year]].
         1. Else
@@ -193,10 +187,7 @@
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _duration_ be ? ToDurationLike(_duration_).
         1. <mark>TODO: Throw if any day/time properties are present?</mark>
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _y_ be _yearMonth_.[[Year]] + _duration_.[[Years]].
         1. Let _m_ be _yearMonth_.[[Month]] + _duration_.[[Months]].
         1. Let _result_ be ? RegulateYearMonth(_y_, _m_, _disambiguation_).
@@ -215,10 +206,7 @@
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _duration_ be ? ToDurationLike(_duration_).
         1. <mark>TODO: Throw if any day/time properties are present?</mark>
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _y_ be _yearMonth_.[[Year]] - _duration_.[[Years]].
         1. Let _m_ be _yearMonth_.[[Month]] - _duration_.[[Months]].
         1. Let _result_ be ? RegulateYearMonth(_y_, _m_, _disambiguation_).
@@ -302,10 +290,7 @@
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _d_ be ? ToInteger(_day_).
-        1. If _disambiguation_ is not *undefined*, then
-          1. Set _disambiguation_ to ? ToString(_disambiguation_).
-        1. Else
-          1. Set _disambiguation_ to `"constrain"`.
+        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
         1. Let _result_ be ? RegulateDate(_yearMonth_.[[Year]], _yearMonth_.[[Month]], _d_, _disambiguation_).
         1. Return ? CreateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
       </emu-alg>


### PR DESCRIPTION
This also removes the unused argument to Temporal.Date.prototype.difference.

Fixes #254.