### PR TITLE
adjust rollup config for debugging purposes

### DIFF
--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -32,24 +32,24 @@
   "homepage": "https://github.com/tc39/proposal-temporal#readme",
   "dependencies": {
     "big-integer": "^1.6.48",
-    "codecov": "^3.6.1",
-    "es-abstract": "^1.14.2"
+    "codecov": "^3.6.5",
+    "es-abstract": "^1.17.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.6.2",
-    "@babel/preset-env": "^7.6.2",
+    "@babel/core": "^7.8.4",
+    "@babel/preset-env": "^7.8.4",
     "@pipobscure/demitasse": "^1.0.10",
     "@pipobscure/demitasse-pretty": "^1.0.10",
     "@types/big-integer": "0.0.31",
     "c8": "^6.0.1",
-    "core-js": "^3.2.1",
+    "core-js": "^3.6.4",
     "full-icu": "^1.3.0",
     "prettier": "^1.18.2",
-    "rollup": "^1.23.1",
+    "rollup": "^1.31.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-uglify": "^6.0.3"
+    "rollup-plugin-uglify": "^6.0.4"
   },
   "prettier": {
     "printWidth": 120,

--- a/polyfill/rollup.config.js
+++ b/polyfill/rollup.config.js
@@ -1,15 +1,17 @@
-import commonjs from "rollup-plugin-commonjs";
-import resolve from "rollup-plugin-node-resolve";
-import babel from "rollup-plugin-babel";
-import {uglify} from 'rollup-plugin-uglify';
+import commonjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
+import babel from 'rollup-plugin-babel';
+import { uglify } from 'rollup-plugin-uglify';
+import { env } from 'process';
 
-export default {
-  input: "lib/index.mjs",
+const config = {
+  input: 'lib/index.mjs',
   output: {
-    name: "temporal",
-    file: "index.js",
-    format: "commonjs",
-    lib: ["es6"]
+    name: 'temporal',
+    file: 'index.js',
+    format: 'commonjs',
+    lib: ['es6'],
+    sourcemap: true
   },
   plugins: [
     commonjs(),
@@ -18,15 +20,20 @@ export default {
       exclude: 'node_modules/**',
       presets: [
         [
-          "@babel/preset-env",
+          '@babel/preset-env',
           {
             corejs: 3,
-            useBuiltIns: "entry",
-            targets: "> 0.25%, not dead"
+            useBuiltIns: 'entry',
+            targets: '> 0.25%, not dead'
           }
         ]
       ]
-    }),
-    uglify()
+    })
   ]
 };
+
+if (env.NODE_ENV === 'production') {
+  config.plugins.push(uglify());
+}
+
+export default config;


### PR DESCRIPTION
So i wanted to step into the .mjs code, but rollup currently has both sourcemaps off and uglify mangling the variable names, so in development mode ive turned these off, (sourcemaps i've just turned on for all environments as it causes no harm).

If anyone uses vscode i can also share the launch profile i have, but that could be a separate PR.

I also updated the dependencies as rollup was a few version behind.
p.s we should probably unignore the package-lock.json file