### PR TITLE
[ci] Pin node version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 12
+node_js: 12.15.0
 matrix:
   include:
   - name: "Polyfill tests"


### PR DESCRIPTION
Travis has been broken since the automatic update to 12.16.0 with

TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".json" for /home/travis/build/tc39/proposal-temporal/polyfill/package.json

This pins the version for now, until we figure out what's wrong.