### PR TITLE
Re-enable regex tests

### DIFF
--- a/polyfill/test/all.mjs
+++ b/polyfill/test/all.mjs
@@ -8,11 +8,16 @@
 import Demitasse from '@pipobscure/demitasse';
 import Pretty from '@pipobscure/demitasse-pretty';
 
-import * as exports from './exports.mjs';
-// import * as regex from './regex.mjs';
-import * as now from './now.mjs';
+// tests with long tedious output
+import * as datemath from './datemath.mjs';
+import * as regex from './regex.mjs';
+
+// tests of internals
 import * as ecmascript from './ecmascript.mjs';
 
+// tests of public API
+import * as exports from './exports.mjs';
+import * as now from './now.mjs';
 import * as timezone from './timezone.mjs';
 import * as absolute from './absolute.mjs';
 import * as date from './date.mjs';
@@ -23,7 +28,6 @@ import * as yearmonth from './yearmonth.mjs';
 import * as monthday from './monthday.mjs';
 import * as intl from './intl.mjs';
 
-import * as datemath from './datemath.mjs';
 
 Promise.resolve()
   .then(() => {

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -356,12 +356,14 @@ describe('fromString regex', ()=>{
       day = day.concat(day.map((p) => `${p}${n}`));
     }
 
-    const tp = ['4H', '5M', '6S', '7.123S', '8.123456S', '9.123456789S', '0.123S', '0.123456S', '0.123456789S'];
+    const tp = ['4H', '5M'];
+    const sec = ['', '6S', '7.123S', '8.123456S', '9.123456789S', '0.123S', '0.123456S', '0.123456789S'];
     let tim = [''];
     while (tp.length) {
       const n = tp.shift();
       tim = tim.concat(tim.map((p) => `${p}${n}`));
     }
+    tim = tim.concat(...sec.map((s) => tim.map((p) => `${p}${s}`)));
 
     day.forEach((p) => test(duration, `P${p}`));
     tim.forEach((p) => test(duration, `PT${p}`));

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -349,21 +349,10 @@ describe('fromString regex', ()=>{
   });
 
   describe('duration', () => {
-    const dp = ['1Y', '2M', '3D'];
-    let day = [''];
-    while (dp.length) {
-      const n = dp.shift();
-      day = day.concat(day.map((p) => `${p}${n}`));
-    }
-
-    const tp = ['4H', '5M'];
+    const day = ['', '1Y', '2M', '3D', '1Y2M', '1Y3D', '2M3D', '1Y2M3D'];
+    const times = ['', '4H', '5M', '4H5M'];
     const sec = ['', '6S', '7.123S', '8.123456S', '9.123456789S', '0.123S', '0.123456S', '0.123456789S'];
-    let tim = [''];
-    while (tp.length) {
-      const n = tp.shift();
-      tim = tim.concat(tim.map((p) => `${p}${n}`));
-    }
-    tim = tim.concat(...sec.map((s) => tim.map((p) => `${p}${s}`)));
+    const tim = sec.reduce((arr, s) => arr.concat(times.map((p) => `${p}${s}`)), []);
 
     day.forEach((p) => test(duration, `P${p}`));
     tim.forEach((p) => test(duration, `PT${p}`));


### PR DESCRIPTION
- Re-enable regex tests which were commented out
- Fix bug in generating test expressions which was giving durations with multiple seconds components