### PR TITLE
Deal with input containing leap seconds

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -87,7 +87,8 @@ export const ES = ObjectAssign(ObjectAssign({}, ES2019), {
     const day = ES.ToInteger(match[3]);
     const hour = ES.ToInteger(match[4]);
     const minute = ES.ToInteger(match[5]);
-    const second = ES.ToInteger(match[6]);
+    let second = ES.ToInteger(match[6]);
+    if (second === 60) second = 59;
     const millisecond = ES.ToInteger(match[7]);
     const microsecond = ES.ToInteger(match[8]);
     const nanosecond = ES.ToInteger(match[9]);
@@ -140,7 +141,8 @@ export const ES = ObjectAssign(ObjectAssign({}, ES2019), {
     const day = ES.ToInteger(match[3]);
     const hour = ES.ToInteger(match[4]);
     const minute = ES.ToInteger(match[5]);
-    const second = ES.ToInteger(match[6]);
+    let second = ES.ToInteger(match[6]);
+    if (second === 60) second = 59;
     const millisecond = ES.ToInteger(match[7]);
     const microsecond = ES.ToInteger(match[8]);
     const nanosecond = ES.ToInteger(match[9]);
@@ -195,7 +197,8 @@ export const ES = ObjectAssign(ObjectAssign({}, ES2019), {
     if (!match) throw new RangeError(`invalid date: ${isoString}`);
     const hour = ES.ToInteger(match[1]);
     const minute = ES.ToInteger(match[2]);
-    const second = ES.ToInteger(match[3]);
+    let second = ES.ToInteger(match[3]);
+    if (second === 60) second = 59;
     const millisecond = ES.ToInteger(match[4]);
     const microsecond = ES.ToInteger(match[5]);
     const nanosecond = ES.ToInteger(match[6]);
@@ -699,7 +702,7 @@ export const ES = ObjectAssign(ObjectAssign({}, ES2019), {
   RejectTime: (hour, minute, second, millisecond, microsecond, nanosecond) => {
     hour = ES.RejectToRange(hour, 0, 23);
     minute = ES.RejectToRange(minute, 0, 59);
-    second = ES.RejectToRange(second, 0, 60);
+    second = ES.RejectToRange(second, 0, 59);
     millisecond = ES.RejectToRange(millisecond, 0, 999);
     microsecond = ES.RejectToRange(microsecond, 0, 999);
     nanosecond = ES.RejectToRange(nanosecond, 0, 999);

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -238,6 +238,9 @@ describe('Absolute', () => {
       equal(`${ Absolute.from(-1n) }`, '1969-12-31T23:59:59.999999999Z');
     });
     it('Absolute.from({}) throws', () => throws(() => Absolute.from({}), RangeError));
+    it('Absolute.from(ISO string leap second) is constrained', () => {
+      equal(`${Absolute.from('2016-12-31T23:59:60Z')}`, '2016-12-31T23:59:59Z');
+    });
   });
   describe('Absolute.plus works', ()=>{
     describe('cross epoch in ms', ()=>{

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -209,6 +209,9 @@ describe('DateTime', () => {
       it('balance', () => equal(`${new DateTime(2019, 1, 32, 0, 0, 0, 0, 0, 0, 'balance')}`, '2019-02-01T00:00'));
       it('throw when bad disambiguation', () =>
         throws(() => new DateTime(2019, 1, 1, 0, 0, 0, 0, 0, 0, 'xyz'), TypeError));
+      it('reject leap second', () => throws(() => new DateTime(2016, 12, 31, 23, 59, 60, 0, 0, 0, 'reject'), RangeError));
+      it('constrain leap second', () => equal(`${new DateTime(2016, 12, 31, 23, 59, 60, 0, 0, 0, 'constrain')}`, '2016-12-31T23:59:59'));
+      it('balance leap second', () => equal(`${new DateTime(2016, 12, 31, 23, 59, 60, 0, 0, 0, 'balance')}`, '2017-01-01T00:00'));
     });
   });
   describe('.with manipulation', () => {
@@ -288,6 +291,12 @@ describe('DateTime', () => {
     it('DateTime.from({ year: 1976, month: 11, day: 18 }) == 1976-11-18T00:00', () => equal(`${DateTime.from({ year: 1976, month: 11, day: 18 })}`, '1976-11-18T00:00'));
     it('DateTime.from({ year: 1976, month: 11, day: 18, millisecond: 123 }) == 1976-11-18T00:00:00.123', () => equal(`${DateTime.from({ year: 1976, month: 11, day: 18, millisecond: 123 })}`, '1976-11-18T00:00:00.123'));
     it('DateTime.from({}) throws', () => throws(() => DateTime.from({}), RangeError));
+    it('DateTime.from(ISO string leap second) is constrained', () => {
+      equal(`${DateTime.from('2016-12-31T23:59:60')}`, '2016-12-31T23:59:59');
+    });
+    it('DateTime.from(property bag leap second) throws', () => {
+      throws(() => DateTime.from({ year: 2016, month: 12, day: 31, hour: 23, minute: 59, second: 60 }), RangeError);
+    });
   });
 });
 

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -296,12 +296,21 @@ describe('Time', () => {
         equal(`${Time.from('15:23:30.123456789')}`, '15:23:30.123456789');
       });
       it('Time.from({}) throws', () => throws(() => Time.from({}), RangeError));
+      it('Time.from(ISO string leap second) is constrained', () => {
+        equal(`${Time.from('23:59:60')}`, '23:59:59');
+      });
+      it('Time.from(property bag leap second) throws', () => {
+        throws(() => Time.from({ hour: 23, minute: 59, second: 60 }), RangeError);
+      });
     });
     describe('Disambiguation', () => {
       it('reject', () => throws(() => new Time(0, 0, 0, 0, 0, 1000, 'reject'), RangeError));
       it('constrain', () => equal(`${new Time(0, 0, 0, 0, 0, 1000, 'constrain')}`, '00:00:00.000000999'));
       it('balance', () => equal(`${new Time(0, 0, 0, 0, 0, 1000, 'balance')}`, '00:00:00.000001'));
       it('throw when bad disambiguation', () => throws(() => new Time(0, 0, 0, 0, 0, 1, 'xyz'), TypeError));
+      it('reject leap second', () => throws(() => new Time(23, 59, 60, 0, 0, 0, 'reject'), RangeError));
+      it('constrain leap second', () => equal(`${new Time(23, 59, 60, 0, 0, 0, 'constrain')}`, '23:59:59'));
+      it('balance leap second', () => equal(`${new Time(23, 59, 60, 0, 0, 0, 'balance')}`, '00:00'));
     });
   });
   describe('time operations', () => {


### PR DESCRIPTION
When parsing an ISO string with a :60 seconds value, silently convert it
to :59, which is the behaviour specified by POSIX. In all other cases,
treat it as any other out-of-range value, which means following the same
behaviour that would happen, for example, with :61 seconds.

(Note that the disambiguation argument will be moved out of the constructor in #260, so this is not identical to the final desired behaviour we agreed upon in the meeting — which assumes #260 is already implemented.)

Closes: #339