### PR TITLE
Remove arithmetic from MonthDay

### DIFF
--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -16,17 +16,9 @@
 
 ### monthDay.**day** : number
 
-### monthDay.**daysInMonth** : number
-
 ## Methods
 
 ### monthDay.**with**(_monthDayLike_: object, _disambiguation_: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
-
-### monthDay.**plus**(_duration_: Temporal.Duration | object | string, _disambiguation_: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
-
-### monthDay.**minus**(_duration_: Temporal.Duration | object | string, _disambiguation_: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
-
-### monthDay.**difference**(_other_: Temporal.MonthDay) : Temporal.Duration
 
 ### monthDay.**toString**() : string
 

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -48,69 +48,6 @@ export class MonthDay {
     const Construct = ES.SpeciesConstructor(this, MonthDay);
     return new Construct(month, day, disambiguation);
   }
-  plus(durationLike, disambiguation = 'constrain') {
-    if (!ES.IsMonthDay(this)) throw new TypeError('invalid receiver');
-    const duration = ES.ToDuration(durationLike);
-    if (
-      !ES.ValidDuration(duration, [
-        'years',
-        'hours',
-        'minutes',
-        'seconds',
-        'milliseconds',
-        'microseconds',
-        'nanoseconds'
-      ])
-    ) {
-      throw new RangeError('invalid duration');
-    }
-    let { month, day } = this;
-    const { months, days } = duration;
-    const year = 1970; // XXX #261 non-leap year
-    ({ month, day } = ES.AddDate(year, month, day, 0, months, days, disambiguation));
-    ({ month, day } = ES.BalanceDate(year, month, day));
-    const Construct = ES.SpeciesConstructor(this, MonthDay);
-    return new Construct(month, day);
-  }
-  minus(durationLike, disambiguation = 'constrain') {
-    if (!ES.IsMonthDay(this)) throw new TypeError('invalid receiver');
-    const duration = ES.ToDuration(durationLike);
-    if (
-      !ES.ValidDuration(duration, [
-        'years',
-        'hours',
-        'minutes',
-        'seconds',
-        'milliseconds',
-        'microseconds',
-        'nanoseconds'
-      ])
-    ) {
-      throw new RangeError('invalid duration');
-    }
-    let { month, day } = this;
-    const year = 1970; // XXX #261 non-leap year
-    const { months, days } = duration;
-    ({ month, day } = ES.SubtractDate(year, month, day, 0, months, days, disambiguation));
-    ({ month, day } = ES.BalanceDate(year, month, day));
-    const Construct = ES.SpeciesConstructor(this, MonthDay);
-    return new Construct(month, day);
-  }
-  difference(other) {
-    if (!ES.IsMonthDay(this)) throw new TypeError('invalid receiver');
-    if (!ES.IsMonthDay(other)) throw new TypeError('invalid MonthDay object');
-    const [one, two] = [this, other].sort(MonthDay.compare);
-    let months = two.month - one.month;
-    let days = two.day - one.day;
-    if (days < 0) {
-      months -= 1;
-      let month = one.month + months;
-      // XXX #261 leap days?
-      days = ES.DaysInMonth(1970, month) + days;
-    }
-    const Duration = ES.GetIntrinsic('%Temporal.Duration%');
-    return new Duration(0, months, days, 0, 0, 0, 0, 0, 0);
-  }
   toString() {
     if (!ES.IsMonthDay(this)) throw new TypeError('invalid receiver');
     let month = ES.ISODateTimePartString(GetSlot(this, MONTH));

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -18,11 +18,6 @@ describe('MonthDay', () => {
       assert(MonthDay.prototype);
       equal(typeof MonthDay.prototype, 'object');
     });
-    describe('MonthDay.prototype', () => {
-      it('MonthDay.prototype.difference is a Function', () => {
-        equal(typeof MonthDay.prototype.difference, 'function');
-      });
-    });
     it('MonthDay.compare is a Function', () => {
       equal(typeof MonthDay.compare, 'function');
     });
@@ -68,35 +63,6 @@ describe('MonthDay', () => {
         equal(`${md.day}`, '15');
       });
     });
-    describe('plus()', () => {
-      let jan15 = new MonthDay(1, 15);
-      let feb1 = new MonthDay(2, 1);
-      let april15 = new MonthDay(4, 15);
-      it(`(1-15) plus 1 day === '01-16'`, () => {
-        let duration = new Duration(0, 0, 1);
-        equal(`${jan15.plus(duration)}`, '01-16');
-      });
-      it(`(1-15) plus 16 days === '01-31'`, () => {
-        let duration = new Duration(0, 0, 16);
-        equal(`${jan15.plus(duration)}`, '01-31');
-      });
-      it(`(1-15) plus 17 days === '02-01'`, () => {
-        let duration = new Duration(0, 0, 17);
-        equal(`${jan15.plus(duration)}`, '02-01');
-      });
-      it(`(2-1) plus 28 days === '03-01'`, () => {
-        let duration = new Duration(0, 0, 28);
-        equal(`${feb1.plus(duration)}`, '03-01');
-      });
-      it(`(4-15) plus 16 days === '05-01'`, () => {
-        let duration = new Duration(0, 0, 16);
-        equal(`${april15.plus(duration)}`, '05-01');
-      });
-      it(`(4-15) plus 365 days === '04-15'`, () => {
-        let duration = new Duration(0, 0, 365);
-        equal(`${april15.plus(duration)}`, '04-15');
-      });
-    });
   });
   describe('MonthDay.compare() works', () => {
     const jan15 = MonthDay.from('01-15');
@@ -111,19 +77,6 @@ describe('MonthDay', () => {
     it("doesn't cast second argument", () => {
       throws(() => MonthDay.compare(jan15, { month: 2, day: 1 }), TypeError);
       throws(() => MonthDay.compare(jan15, '02-01'), TypeError);
-    });
-  });
-  describe('MonthDay.difference() works', () => {
-    const jan15 = MonthDay.from('01-15');
-    const feb1 = MonthDay.from('02-01');
-    const diff = jan15.difference(feb1);
-    it(`${jan15}.difference(${feb1}) == ${feb1}.difference(${jan15})`, () =>
-      equal(`${diff}`, `${feb1.difference(jan15)}`));
-    it(`${jan15}.plus(${diff}) == ${feb1}`, () => equal(`${jan15.plus(diff)}`, `${feb1}`));
-    it(`${feb1}.minus(${diff}) == ${jan15}`, () => equal(`${feb1.minus(diff)}`, `${jan15}`));
-    it("doesn't cast argument", () => {
-      throws(() => jan15.difference({ month: 2, day: 1 }), TypeError);
-      throws(() => jan15.difference('02-01'), TypeError);
     });
   });
 });

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -149,68 +149,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.monthday.prototype.plus">
-      <h1>Temporal.MonthDay.prototype.plus ( _duration_ [ , _disambiguation_ ] )</h1>
-      <p>
-        The `plus` method takes two arguments, _duration_ and _disambiguation_.
-        The following steps are taken:
-      </p>
-      <emu-alg>
-        1. Let _monthDay_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
-        1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"years"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* »).
-        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
-        1. Let _m_ be _monthDay_.[[Month]] + _duration_.[[Months]].
-        1. Let _d_ be _monthDay_.[[Day]] + _duration_.[[Days]].
-        1. Let _result_ be ? RegulateMonthDay(_m_, _d_, _disambiguation_).
-        1. Return ? CreateMonthDay(_result_.[[Month]], _result_.[[Day]]).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal.monthday.prototype.minus">
-      <h1>Temporal.MonthDay.prototype.minus ( _duration_ [ , _disambiguation_ ] )</h1>
-      <p>
-        The `minus` method takes two arguments, _duration_ and _disambiguation_.
-        The following steps are taken:
-      </p>
-      <emu-alg>
-        1. Let _monthDay_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
-        1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"years"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* »).
-        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
-        1. Let _m_ be _monthDay_.[[Month]] - _duration_.[[Months]].
-        1. Let _d_ be _monthDay_.[[Day]] - _duration_.[[Days]].
-        1. Let _result_ be ? RegulateMonthDay(_m_, _d_, _disambiguation_).
-        1. Return ? CreateMonthDay(_result_.[[Month]], _result_.[[Day]]).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal.monthday.prototype.difference">
-      <h1>Temporal.MonthDay.prototype.difference ( _otherMonthDay_ )</h1>
-      <p>
-        The `difference` method takes one argument _otherMonthDay_.
-        The following steps are taken:
-      </p>
-      <emu-alg>
-        1. Let _monthDay_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
-        1. Perform ? RequireInternalSlot(_otherMonthDay_, [[InitializedTemporalMonthDay]]).
-        1. If ! MonthDayCompare(_monthDay_, _otherMonthDay_) &lt; 0, then
-          1. Let _greater_ be _otherMonthDay_.
-          1. Let _smaller_ be _monthDay_.
-        1. Else,
-          1. Let _greater_ be _monthDay_.
-          1. Let _smaller_ be _otherMonthDay_.
-        1. Let _months_ be _greater_.[[Month]] - _smaller_.[[Month]].
-        1. Let _days_ be _greater_.[[Day]] - _smaller_.[[Day]].
-        1. If _days_ &lt; 0, then
-          1. Set _months_ to _months_ - 1.
-          1. Set _days_ to _days_ + DaysInMonth(1970, month).
-        1. <mark>Assert: _months_ ≥ 0.</mark>
-        1. Return ? CreateDuration(0, _months_, _days_, 0, 0, 0, 0, 0, 0).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.monthday.prototype.tostring">
       <h1>Temporal.MonthDay.prototype.toString ( )</h1>
       <p>


### PR DESCRIPTION
As discussed in the ticket, we'll consider MonthDay arithmetic undefined
without a year attached, because of not knowing whether the year is a
leap year or not.

Also remove MonthDay.daysInMonth which is meaningless without a year and
was not in the spec or polyfill anyway.

Closes: #261