### PR TITLE
Drop support for passing strings to with().

### DIFF
--- a/spec/date.html
+++ b/spec/date.html
@@ -460,24 +460,24 @@
     <emu-clause id="sec-temporal-topartialdate" aoid="ToPartialDate">
       <h1>ToPartialDate ( _date_ )</h1>
       <emu-alg>
-        1. If Type(_date_) is Object, then
-          1. Let _result_ be {
-            [[Year]]: *undefined*,
-            [[Month]]: *undefined*,
-            [[Day]]: *undefined*,
-            }.
-          1. Let _any_ be *false*.
-          1. For each row of <emu-xref href="#table-temporal-datelike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_date_, _property_).
-            1. If _value_ is not *undefined*, then
-              1. Set _any_ to *true*.
-              1. Set _value_ to ? ToInteger(_value_).
-              1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. If _any_ is *false*, then
-            1. Throw a *TypeError* exception.
-          1. Return _result_.
-        1. Throw a *TypeError* exception.
+        1. If Type(_date_) is not Object, then
+          1. Throw a *TypeError* exception.
+        1. Let _result_ be {
+          [[Year]]: *undefined*,
+          [[Month]]: *undefined*,
+          [[Day]]: *undefined*,
+          }.
+        1. Let _any_ be *false*.
+        1. For each row of <emu-xref href="#table-temporal-datelike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_date_, _property_).
+          1. If _value_ is not *undefined*, then
+            1. Set _any_ to *true*.
+            1. Set _value_ to ? ToInteger(_value_).
+            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. If _any_ is *false*, then
+          1. Throw a *TypeError* exception.
+        1. Return _result_.
       </emu-alg>
 
       <emu-table id="table-temporal-datelike-properties">

--- a/spec/date.html
+++ b/spec/date.html
@@ -460,21 +460,24 @@
     <emu-clause id="sec-temporal-topartialdate" aoid="ToPartialDate">
       <h1>ToPartialDate ( _date_ )</h1>
       <emu-alg>
-        1. Let _result_ be {
-          [[Year]]: *undefined*,
-          [[Month]]: *undefined*,
-          [[Day]]: *undefined*,
-          }.
-        1. If Type(_date_) is Undefined or Null, then
+        1. If Type(_date_) is Object, then
+          1. Let _result_ be {
+            [[Year]]: *undefined*,
+            [[Month]]: *undefined*,
+            [[Day]]: *undefined*,
+            }.
+          1. Let _any_ be *false*.
+          1. For each row of <emu-xref href="#table-temporal-datelike-properties"></emu-xref>, except the header row, in table order, do
+            1. Let _property_ be the Property value of the current row.
+            1. Let _value_ be ? Get(_date_, _property_).
+            1. If _value_ is not *undefined*, then
+              1. Set _any_ to *true*.
+              1. Set _value_ to ? ToInteger(_value_).
+              1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+          1. If _any_ is *false*, then
+            1. Throw a *TypeError* exception.
           1. Return _result_.
-        1. <mark>TODO: Handle strings?</mark>
-        1. If Type(_date_) is not Object, then
-          1. Throw a *TypeError* exception.
-        1. For each row of <emu-xref href="#table-temporal-datelike-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _property_ be the Property value of the current row.
-          1. Let _value_ be ? ToInteger(? Get(_date_, _property_)).
-          1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-        1. Return _result_.
+        1. Throw a *TypeError* exception.
       </emu-alg>
 
       <emu-table id="table-temporal-datelike-properties">

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -519,8 +519,6 @@
     <emu-clause id="sec-temporal-topartialdatetime" aoid="ToPartialDateTime">
       <h1>ToPartialDateTime ( _dateTime_ )</h1>
       <emu-alg>
-        1. If Type(_dateTime_) is String, then
-          1. Return ? ParseDateTimeString(_dateTime_).
         1. If Type(_dateTime_) is Object, then
           1. Let _result_ be the new Record {
               [[Year]]: *undefined*,

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -519,30 +519,30 @@
     <emu-clause id="sec-temporal-topartialdatetime" aoid="ToPartialDateTime">
       <h1>ToPartialDateTime ( _dateTime_ )</h1>
       <emu-alg>
-        1. If Type(_dateTime_) is Object, then
-          1. Let _result_ be the new Record {
-              [[Year]]: *undefined*,
-              [[Month]]: *undefined*,
-              [[Day]]: *undefined*,
-              [[Hour]]: *undefined*,
-              [[Minute]]: *undefined*,
-              [[Second]]: *undefined*,
-              [[Millisecond]]: *undefined*,
-              [[Microsecond]]: *undefined*,
-              [[Nanosecond]]: *undefined*
-            }.
-          1. Let _any_ be *false*.
-          1. For each row of <emu-xref href="#table-temporal-datetimelike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_dateTime_, _property_).
-            1. If _value_ is not *undefined*, then
-              1. Set _any_ to *true*.
-              1. Set _value_ to ? ToInteger(_value_).
-              1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. If _any_ is *false*, then
-            1. Throw a *TypeError* exception.
-          1. Return _result_.
-        1. Throw a *TypeError* exception.
+        1. If Type(_dateTime_) is not Object, then
+          1. Throw a *TypeError* exception.
+        1. Let _result_ be the new Record {
+            [[Year]]: *undefined*,
+            [[Month]]: *undefined*,
+            [[Day]]: *undefined*,
+            [[Hour]]: *undefined*,
+            [[Minute]]: *undefined*,
+            [[Second]]: *undefined*,
+            [[Millisecond]]: *undefined*,
+            [[Microsecond]]: *undefined*,
+            [[Nanosecond]]: *undefined*
+          }.
+        1. Let _any_ be *false*.
+        1. For each row of <emu-xref href="#table-temporal-datetimelike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_dateTime_, _property_).
+          1. If _value_ is not *undefined*, then
+            1. Set _any_ to *true*.
+            1. Set _value_ to ? ToInteger(_value_).
+            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. If _any_ is *false*, then
+          1. Throw a *TypeError* exception.
+        1. Return _result_.
       </emu-alg>
 
       <emu-table id="table-temporal-datetimelike-properties">

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -212,8 +212,6 @@
     <emu-clause id="sec-temporal-topartialmonthday" aoid="ToPartialMonthDay">
       <h1>ToPartialMonthDay ( _monthDay_ )</h1>
       <emu-alg>
-        1. If Type(_monthDay_) is String, then
-          1. Return ? ParseMonthDayString(_monthDay_).
         1. If Type(_monthDay_) is Object, then
           1. Let _result_ be the new Record {
               [[Month]]: *undefined*,

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -212,23 +212,23 @@
     <emu-clause id="sec-temporal-topartialmonthday" aoid="ToPartialMonthDay">
       <h1>ToPartialMonthDay ( _monthDay_ )</h1>
       <emu-alg>
-        1. If Type(_monthDay_) is Object, then
-          1. Let _result_ be the new Record {
-              [[Month]]: *undefined*,
-              [[Day]]: *undefined*
-            }.
-          1. Let _any_ be *false*.
-          1. For each row of <emu-xref href="#table-temporal-monthdaylike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_monthDay_, _property_).
-            1. If _value_ is not *undefined*, then
-              1. Set _any_ to *true*.
-              1. Set _value_ to ? ToInteger(_value_).
-              1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. If _any_ is *false*, then
-            1. Throw a *TypeError* exception.
-          1. Return _result_.
-        1. Throw a *TypeError* exception.
+        1. If Type(_monthDay_) is not Object, then
+          1. Throw a *TypeError* exception.
+        1. Let _result_ be the new Record {
+            [[Month]]: *undefined*,
+            [[Day]]: *undefined*
+          }.
+        1. Let _any_ be *false*.
+        1. For each row of <emu-xref href="#table-temporal-monthdaylike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_monthDay_, _property_).
+          1. If _value_ is not *undefined*, then
+            1. Set _any_ to *true*.
+            1. Set _value_ to ? ToInteger(_value_).
+            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. If _any_ is *false*, then
+          1. Throw a *TypeError* exception.
+        1. Return _result_.
       </emu-alg>
 
       <emu-table id="table-temporal-monthdaylike-properties">

--- a/spec/time.html
+++ b/spec/time.html
@@ -353,27 +353,27 @@
     <emu-clause id="sec-temporal-topartialtime" aoid="ToPartialTime">
       <h1>ToPartialTime ( _time_ )</h1>
       <emu-alg>
-        1. If Type(_time_) is Object, then
-          1. Let _result_ be the new Record {
-            [[Hour]]: *undefined*,
-            [[Minute]]: *undefined*,
-            [[Second]]: *undefined*,
-            [[Millisecond]]: *undefined*,
-            [[Microsecond]]: *undefined*,
-            [[Nanosecond]]: *undefined*,
-            }.
-          1. Let _any_ be *false*.
-          1. For each row of <emu-xref href="#table-temporal-timelike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_time_, _property_).
-            1. If _value_ is not *undefined*, then
-              1. Set _any_ to *true*.
-              1. Set _value_ to ? ToInteger(_value_).
-              1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. If _any_ is *false*, then
-            1. Throw a *TypeError* exception.
-          1. Return _result_.
-        1. Throw a *TypeError* exception.
+        1. If Type(_time_) is not Object, then
+          1. Throw a *TypeError* exception.
+        1. Let _result_ be the new Record {
+          [[Hour]]: *undefined*,
+          [[Minute]]: *undefined*,
+          [[Second]]: *undefined*,
+          [[Millisecond]]: *undefined*,
+          [[Microsecond]]: *undefined*,
+          [[Nanosecond]]: *undefined*,
+          }.
+        1. Let _any_ be *false*.
+        1. For each row of <emu-xref href="#table-temporal-timelike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_time_, _property_).
+          1. If _value_ is not *undefined*, then
+            1. Set _any_ to *true*.
+            1. Set _value_ to ? ToInteger(_value_).
+            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. If _any_ is *false*, then
+          1. Throw a *TypeError* exception.
+        1. Return _result_.
       </emu-alg>
 
       <emu-table id="table-temporal-timelike-properties">

--- a/spec/time.html
+++ b/spec/time.html
@@ -353,8 +353,6 @@
     <emu-clause id="sec-temporal-topartialtime" aoid="ToPartialTime">
       <h1>ToPartialTime ( _time_ )</h1>
       <emu-alg>
-        1. If Type(_time_) is String, then
-          1. Return ? ParseTimeString(_time_).
         1. If Type(_time_) is Object, then
           1. Let _result_ be the new Record {
             [[Hour]]: *undefined*,

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -300,8 +300,6 @@
     <emu-clause id="sec-temporal-topartialyearmonth" aoid="ToPartialYearMonth">
       <h1>ToPartialYearMonth ( _yearMonth_ )</h1>
       <emu-alg>
-        1. If Type(_yearMonth_) is String, then
-          1. Return ? ParseYearMonthString(_yearMonth_).
         1. If Type(_yearMonth_) is Object, then
           1. Let _result_ be the new Record {
               [[Year]]: *undefined*,

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -300,23 +300,23 @@
     <emu-clause id="sec-temporal-topartialyearmonth" aoid="ToPartialYearMonth">
       <h1>ToPartialYearMonth ( _yearMonth_ )</h1>
       <emu-alg>
-        1. If Type(_yearMonth_) is Object, then
-          1. Let _result_ be the new Record {
-              [[Year]]: *undefined*,
-              [[Month]]: *undefined*
-            }.
-          1. Let _any_ be *false*.
-          1. For each row of <emu-xref href="#table-temporal-yearmonthlike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_yearMonth_, _property_).
-            1. If _value_ is not *undefined*, then
-              1. Set _any_ to *true*.
-              1. Set _value_ to ? ToInteger(_value_).
-              1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. If _any_ is *false*, then
-            1. Throw a *TypeError* exception.
-          1. Return _result_.
-        1. Throw a *TypeError* exception.
+        1. If Type(_yearMonth_) is not Object, then
+          1. Throw a *TypeError* exception.
+        1. Let _result_ be the new Record {
+            [[Year]]: *undefined*,
+            [[Month]]: *undefined*
+          }.
+        1. Let _any_ be *false*.
+        1. For each row of <emu-xref href="#table-temporal-yearmonthlike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_yearMonth_, _property_).
+          1. If _value_ is not *undefined*, then
+            1. Set _any_ to *true*.
+            1. Set _value_ to ? ToInteger(_value_).
+            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. If _any_ is *false*, then
+          1. Throw a *TypeError* exception.
+        1. Return _result_.
       </emu-alg>
 
       <emu-table id="table-temporal-yearmonthlike-properties">


### PR DESCRIPTION
This is not a particularly useful thing to do, as the string parsing will
fill in all the fields, making the call little more than a more expensive
way to call from().

The polyfill does not support passing strings.