### PR TITLE
Fix Duration.toString for sub-second units > 999

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -38,4 +38,13 @@ Creates a new `Duration` object that represents a duration of time.
 
 ### duration.**toString**() : string
 
+**FIXME**: Rest of documentation in a different pull request, combine when rebasing.
+
+> **NOTE**: If any of the `milliseconds`, `microseconds`, or `nanoseconds` properties are greater than 999, then `Temporal.Duration.from(duration.toString())` will not yield an identical `Temporal.Duration` object.
+> The returned object will represent an identical duration, but the sub-second fields will be balanced with the `seconds` field so that they become 999 or less.
+> For example, 1000 nanoseconds will become 1 microsecond.
+>
+> This is because the ISO 8601 string format for durations does not allow for specifying sub-second units separately, only as a decimal fraction of seconds.
+> If you need to serialize a `Temporal.Duration` in a way that will preserve unbalanced sub-second fields, you will need to use a custom serialization format.
+
 ### duration.**toLocaleString**(_locale_?: string, _options_?: object) : string

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -129,15 +129,17 @@ export class Duration {
     if (GetSlot(this, MINUTES)) timeParts.push(`${GetSlot(this, MINUTES)}M`);
 
     const secondParts = [];
-    if (GetSlot(this, NANOSECONDS)) secondParts.unshift(`000${GetSlot(this, NANOSECONDS)}`.slice(-3));
-    if (GetSlot(this, MICROSECONDS) || secondParts.length) {
-      secondParts.unshift(`000${GetSlot(this, MICROSECONDS)}`.slice(-3));
-    }
-    if (GetSlot(this, MILLISECONDS) || secondParts.length) {
-      secondParts.unshift(`000${GetSlot(this, MILLISECONDS)}`.slice(-3));
-    }
+    let ms = GetSlot(this, MILLISECONDS);
+    let µs = GetSlot(this, MICROSECONDS);
+    let ns = GetSlot(this, NANOSECONDS);
+    let seconds;
+    ({ seconds, millisecond: ms, microsecond: µs, nanosecond: ns } = ES.BalanceSubSecond(ms, µs, ns));
+    const s = GetSlot(this, SECONDS) + seconds;
+    if (ns) secondParts.unshift(`${ns}`.padStart(3, '0'));
+    if (µs || secondParts.length) secondParts.unshift(`${µs}`.padStart(3, '0'));
+    if (ms || secondParts.length) secondParts.unshift(`${ms}`.padStart(3, '0'));
     if (secondParts.length) secondParts.unshift('.');
-    if (GetSlot(this, SECONDS) || secondParts.length) secondParts.unshift(`${this.seconds}`);
+    if (s || secondParts.length) secondParts.unshift(`${s}`);
     if (secondParts.length) timeParts.push(`${secondParts.join('')}S`);
     if (timeParts.length) timeParts.unshift('T');
     if (!dateParts.length && !timeParts.length) return 'PT0S';

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -690,7 +690,7 @@ export const ES = ObjectAssign(ObjectAssign({}, ES2019), {
 
     return { year, month, day };
   },
-  BalanceTime: (hour, minute, second, millisecond, microsecond, nanosecond) => {
+  BalanceSubSecond: (millisecond, microsecond, nanosecond) => {
     microsecond += Math.floor(nanosecond / 1000);
     nanosecond = nanosecond % 1000;
     nanosecond = nanosecond < 0 ? 1000 + nanosecond : nanosecond;
@@ -699,9 +699,17 @@ export const ES = ObjectAssign(ObjectAssign({}, ES2019), {
     microsecond = microsecond % 1000;
     microsecond = microsecond < 0 ? 1000 + microsecond : microsecond;
 
-    second += Math.floor(millisecond / 1000);
+    const seconds = Math.floor(millisecond / 1000);
     millisecond = millisecond % 1000;
     millisecond = millisecond < 0 ? 1000 + millisecond : millisecond;
+
+    return { seconds, millisecond, microsecond, nanosecond };
+  },
+  BalanceTime: (hour, minute, second, millisecond, microsecond, nanosecond) => {
+    let seconds;
+    ({ seconds, millisecond, microsecond, nanosecond } = ES.BalanceSubSecond(millisecond, microsecond, nanosecond));
+
+    second += seconds;
 
     minute += Math.floor(second / 60);
     second = second % 60;

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -34,6 +34,15 @@ describe('Duration', () => {
     it(`Duration.from("P1D") == P1D`, () => equal(`${ Duration.from("P1D") }`, 'P1D'));
     it('Duration.from({}) throws', () => throws(() => Duration.from({}), RangeError));
   });
+  describe('toString()', () => {
+    it('excessive sub-second units balance themselves when serializing', () => {
+      equal(`${Duration.from({ milliseconds: 3500 })}`, 'PT3.500S');
+      equal(`${Duration.from({ microseconds: 3500 })}`, 'PT0.003500S');
+      equal(`${Duration.from({ nanoseconds: 3500 })}`, 'PT0.000003500S');
+      equal(`${new Duration(0, 0, 0, 0, 0, 0, 1111, 1111, 1111, 'reject')}`, 'PT1.112112111S');
+      equal(`${Duration.from({ seconds: 120, milliseconds: 3500 })}`, 'PT123.500S');
+    });
+  });
 });
 
 import { normalize } from 'path';

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -413,10 +413,9 @@
         1. Let _hours_ be _duration_.[[Hours]].
         1. Let _minutes_ be _duration_.[[Minutes]].
         1. Let _seconds_ be _duration_.[[Seconds]].
-        1. Let _milliseconds_ be _duration_.[[Milliseconds]].
-        1. Let _microseconds_ be _duration_.[[Microseconds]].
-        1. Let _nanoseconds_ be _duration_.[[Nanoseconds]].
-        1. Return the concatenation of _years_, _months_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ in the format specified in RFC 3339 (https://www.ietf.org/rfc/rfc3339.txt) Appendix A.
+        1. Let _balanceResult_ be ! BalanceSubSecond(_duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Set _seconds_ to _seconds_ + _balanceResult_.[[Seconds]].
+        1. Return the concatenation of _years_, _months_, _days_, _hours_, _minutes_, _seconds_, _balanceResult_.[[Millisecond]], _balanceResult_.[[Microsecond]], _balanceResult_.[[Nanosecond]] in the format specified in RFC 3339 (https://www.ietf.org/rfc/rfc3339.txt) Appendix A.
       </emu-alg>
     </emu-clause>
 

--- a/spec/time.html
+++ b/spec/time.html
@@ -468,15 +468,30 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-balancesubsecond" aoid="BalanceSubSecond">
+      <h1>BalanceSubSecond ( _millisecond_, _microsecond_, _nanosecond_ )</h1>
+      <emu-alg>
+        1. Assert: _millisecond_, _microsecond_, and _nanosecond_ are integer Number values.
+        1. Set _microsecond_ to _microsecond_ + floor(_nanosecond_ / 1000).
+        1. Set _nanosecond_ to ! NonNegativeModulo(_nanosecond_, 1000).
+        1. Set _millisecond_ to _millisecond_ + floor(_microsecond_ / 1000).
+        1. Set _microsecond_ to ! NonNegativeModulo(_microsecond_, 1000).
+        1. Let _seconds_ be floor(_millisecond_ / 1000).
+        1. Return the new Record {
+          [[Seconds]]: _seconds_,
+          [[Millisecond]]: _millisecond_,
+          [[Microsecond]]: _microsecond_,
+          [[Nanosecond]]: _nanosecond_
+          }.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-balancetime" aoid="BalanceTime">
       <h1>BalanceTime ( _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
       <emu-alg>
         1. Assert: _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integer Number values.
-        1. Set _microsecond_ to _microsecond_ + floor(_nanosecond_ / 1000).
-        1. Set _nanosecond_ to NonNegativeModulo(_nanosecond_, 1000).
-        1. Set _millisecond_ to _millisecond_ + floor(_microsecond_ / 1000).
-        1. Set _microsecond_ to NonNegativeModulo(_microsecond_, 1000).
-        1. Set _second_ to _second_ + floor(_microsecond_ / 1000).
+        1. Let _balanceResult_ be ! BalanceSubSecond(_millisecond_, _microsecond_, _nanosecond_).
+        1. Set _second_ to _second_ + _balanceResult_.[[Seconds]].
         1. Set _microsecond_ to NonNegativeModulo(_microsecond_, 1000).
         1. Set _minute_ to _minute_ + floor(_second_ / 60).
         1. Set _second_ to NonNegativeModulo(_second_, 60).
@@ -489,9 +504,9 @@
           [[Hour]]: _hour_,
           [[Minute]]: _minute_,
           [[Second]]: _second_,
-          [[Millisecond]]: _millisecond_,
-          [[Microsecond]]: _microsecond_,
-          [[Nanosecond]]: _nanosecond_
+          [[Millisecond]]: _balanceResult_.[[Millisecond]],
+          [[Microsecond]]: _balanceResult_.[[Microsecond]],
+          [[Nanosecond]]: _balanceResult_.[[Nanosecond]]
           }.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Previously, the code assumed that the millisecond, microsecond, and
nanosecond fields of Duration all had 3 digits or less. This allows for
the possibility of values ≥ 1000. In order to allow this, roundtripping
via toString() is no longer preserved, we have to balance the sub-second
units with a new abstract operation BalanceSubSecond.

Closes: #396