### PR TITLE
Editorial: Remove obsolete todo notes from the specification.

### DIFF
--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -211,7 +211,6 @@
         1. Let _absolute_ be the *this* value.
         1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"years"*, *"months"* »).
-        1. <mark>TODO: Handling year, month, day?</mark>
         1. Let _ns_ be _absolute_.[[Nanoseconds]] +
             _duration_.[[Nanoseconds]] +
             _duration_.[[Microseconds]] × 1000 +
@@ -234,7 +233,6 @@
         1. Let _absolute_ be the *this* value.
         1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"years"*, *"months"* »).
-        1. <mark>TODO: Handling year, month, day?</mark>
         1. Let _ns_ be _absolute_.[[Nanoseconds]] -
             _duration_.[[Nanoseconds]] -
             _duration_.[[Microseconds]] × 1000 -


### PR DESCRIPTION
These were resolved in #385.