### PR TITLE
Define the Symbol.species properties.

### DIFF
--- a/polyfill/lib/intrinsicclass.mjs
+++ b/polyfill/lib/intrinsicclass.mjs
@@ -13,7 +13,7 @@ export function MakeIntrinsicClass(Class, name) {
       enumerable: false,
       configurable: true,
     });
-    Object.defineProperty(Class.prototype, Symbol.class, {
+    Object.defineProperty(Class, Symbol.species, {
       get: species,
       enumerable: false,
       configurable: true,

--- a/polyfill/test/Absolute/constructor/species/getter-length.js
+++ b/polyfill/test/Absolute/constructor/species/getter-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.absolute-@@species
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Absolute, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/constructor/species/getter-name.js
+++ b/polyfill/test/Absolute/constructor/species/getter-name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.absolute-@@species
+info: |
+    The value of the "name" property of this function is "get [Symbol.species]".
+
+    Unless otherwise specified, the "name" property of a built-in function object, if it exists,
+    has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Absolute, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "name", {
+  value: "get [Symbol.species]",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/constructor/species/prop-desc.js
+++ b/polyfill/test/Absolute/constructor/species/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.absolute-@@species
+info: |
+    Temporal.Absolute[@@species] is an accessor property whose set accessor function is undefined.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes
+    { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+    If only a get accessor function is described, the set accessor function is the default value,
+    undefined.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Absolute, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+assert.sameValue(typeof descriptor.get, "function");
+assert.sameValue(descriptor.set, undefined);
+
+verifyProperty(Temporal.Absolute, Symbol.species, {
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Absolute/constructor/species/return-value.js
+++ b/polyfill/test/Absolute/constructor/species/return-value.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.absolute-@@species
+info: |
+    Its get accessor function performs the following steps:
+    1. Return the this value.
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Absolute, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+
+const thisValue = {};
+assert.sameValue(descriptor.get.call(thisValue), thisValue);

--- a/polyfill/test/Date/.eslintrc.yml
+++ b/polyfill/test/Date/.eslintrc.yml
@@ -1,0 +1,5 @@
+---
+globals:
+  Temporal: readonly
+  assert: readonly
+  verifyProperty: readonly

--- a/polyfill/test/Date/constructor/species/getter-length.js
+++ b/polyfill/test/Date/constructor/species/getter-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.date-@@species
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Date, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Date/constructor/species/getter-name.js
+++ b/polyfill/test/Date/constructor/species/getter-name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.date-@@species
+info: |
+    The value of the "name" property of this function is "get [Symbol.species]".
+
+    Unless otherwise specified, the "name" property of a built-in function object, if it exists,
+    has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Date, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "name", {
+  value: "get [Symbol.species]",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Date/constructor/species/prop-desc.js
+++ b/polyfill/test/Date/constructor/species/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.date-@@species
+info: |
+    Temporal.Date[@@species] is an accessor property whose set accessor function is undefined.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes
+    { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+    If only a get accessor function is described, the set accessor function is the default value,
+    undefined.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Date, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+assert.sameValue(typeof descriptor.get, "function");
+assert.sameValue(descriptor.set, undefined);
+
+verifyProperty(Temporal.Date, Symbol.species, {
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Date/constructor/species/return-value.js
+++ b/polyfill/test/Date/constructor/species/return-value.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.date-@@species
+info: |
+    Its get accessor function performs the following steps:
+    1. Return the this value.
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Date, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+
+const thisValue = {};
+assert.sameValue(descriptor.get.call(thisValue), thisValue);

--- a/polyfill/test/DateTime/.eslintrc.yml
+++ b/polyfill/test/DateTime/.eslintrc.yml
@@ -1,0 +1,5 @@
+---
+globals:
+  Temporal: readonly
+  assert: readonly
+  verifyProperty: readonly

--- a/polyfill/test/DateTime/constructor/species/getter-length.js
+++ b/polyfill/test/DateTime/constructor/species/getter-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.datetime-@@species
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.DateTime, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/DateTime/constructor/species/getter-name.js
+++ b/polyfill/test/DateTime/constructor/species/getter-name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.datetime-@@species
+info: |
+    The value of the "name" property of this function is "get [Symbol.species]".
+
+    Unless otherwise specified, the "name" property of a built-in function object, if it exists,
+    has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.DateTime, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "name", {
+  value: "get [Symbol.species]",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/DateTime/constructor/species/prop-desc.js
+++ b/polyfill/test/DateTime/constructor/species/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.datetime-@@species
+info: |
+    Temporal.DateTime[@@species] is an accessor property whose set accessor function is undefined.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes
+    { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+    If only a get accessor function is described, the set accessor function is the default value,
+    undefined.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.DateTime, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+assert.sameValue(typeof descriptor.get, "function");
+assert.sameValue(descriptor.set, undefined);
+
+verifyProperty(Temporal.DateTime, Symbol.species, {
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/DateTime/constructor/species/return-value.js
+++ b/polyfill/test/DateTime/constructor/species/return-value.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.datetime-@@species
+info: |
+    Its get accessor function performs the following steps:
+    1. Return the this value.
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.DateTime, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+
+const thisValue = {};
+assert.sameValue(descriptor.get.call(thisValue), thisValue);

--- a/polyfill/test/Duration/.eslintrc.yml
+++ b/polyfill/test/Duration/.eslintrc.yml
@@ -1,0 +1,5 @@
+---
+globals:
+  Temporal: readonly
+  assert: readonly
+  verifyProperty: readonly

--- a/polyfill/test/Duration/constructor/species/getter-length.js
+++ b/polyfill/test/Duration/constructor/species/getter-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration-@@species
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Duration, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Duration/constructor/species/getter-name.js
+++ b/polyfill/test/Duration/constructor/species/getter-name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration-@@species
+info: |
+    The value of the "name" property of this function is "get [Symbol.species]".
+
+    Unless otherwise specified, the "name" property of a built-in function object, if it exists,
+    has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Duration, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "name", {
+  value: "get [Symbol.species]",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Duration/constructor/species/prop-desc.js
+++ b/polyfill/test/Duration/constructor/species/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration-@@species
+info: |
+    Temporal.Duration[@@species] is an accessor property whose set accessor function is undefined.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes
+    { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+    If only a get accessor function is described, the set accessor function is the default value,
+    undefined.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Duration, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+assert.sameValue(typeof descriptor.get, "function");
+assert.sameValue(descriptor.set, undefined);
+
+verifyProperty(Temporal.Duration, Symbol.species, {
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Duration/constructor/species/return-value.js
+++ b/polyfill/test/Duration/constructor/species/return-value.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.duration-@@species
+info: |
+    Its get accessor function performs the following steps:
+    1. Return the this value.
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Duration, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+
+const thisValue = {};
+assert.sameValue(descriptor.get.call(thisValue), thisValue);

--- a/polyfill/test/MonthDay/.eslintrc.yml
+++ b/polyfill/test/MonthDay/.eslintrc.yml
@@ -1,0 +1,5 @@
+---
+globals:
+  Temporal: readonly
+  assert: readonly
+  verifyProperty: readonly

--- a/polyfill/test/MonthDay/constructor/species/getter-length.js
+++ b/polyfill/test/MonthDay/constructor/species/getter-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.monthday-@@species
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.MonthDay, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/MonthDay/constructor/species/getter-name.js
+++ b/polyfill/test/MonthDay/constructor/species/getter-name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.monthday-@@species
+info: |
+    The value of the "name" property of this function is "get [Symbol.species]".
+
+    Unless otherwise specified, the "name" property of a built-in function object, if it exists,
+    has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.MonthDay, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "name", {
+  value: "get [Symbol.species]",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/MonthDay/constructor/species/prop-desc.js
+++ b/polyfill/test/MonthDay/constructor/species/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.monthday-@@species
+info: |
+    Temporal.MonthDay[@@species] is an accessor property whose set accessor function is undefined.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes
+    { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+    If only a get accessor function is described, the set accessor function is the default value,
+    undefined.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.MonthDay, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+assert.sameValue(typeof descriptor.get, "function");
+assert.sameValue(descriptor.set, undefined);
+
+verifyProperty(Temporal.MonthDay, Symbol.species, {
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/MonthDay/constructor/species/return-value.js
+++ b/polyfill/test/MonthDay/constructor/species/return-value.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.monthday-@@species
+info: |
+    Its get accessor function performs the following steps:
+    1. Return the this value.
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.MonthDay, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+
+const thisValue = {};
+assert.sameValue(descriptor.get.call(thisValue), thisValue);

--- a/polyfill/test/Time/.eslintrc.yml
+++ b/polyfill/test/Time/.eslintrc.yml
@@ -1,0 +1,5 @@
+---
+globals:
+  Temporal: readonly
+  assert: readonly
+  verifyProperty: readonly

--- a/polyfill/test/Time/constructor/species/getter-length.js
+++ b/polyfill/test/Time/constructor/species/getter-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.time-@@species
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Time, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Time/constructor/species/getter-name.js
+++ b/polyfill/test/Time/constructor/species/getter-name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.time-@@species
+info: |
+    The value of the "name" property of this function is "get [Symbol.species]".
+
+    Unless otherwise specified, the "name" property of a built-in function object, if it exists,
+    has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Time, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "name", {
+  value: "get [Symbol.species]",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Time/constructor/species/prop-desc.js
+++ b/polyfill/test/Time/constructor/species/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.time-@@species
+info: |
+    Temporal.Time[@@species] is an accessor property whose set accessor function is undefined.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes
+    { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+    If only a get accessor function is described, the set accessor function is the default value,
+    undefined.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Time, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+assert.sameValue(typeof descriptor.get, "function");
+assert.sameValue(descriptor.set, undefined);
+
+verifyProperty(Temporal.Time, Symbol.species, {
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Time/constructor/species/return-value.js
+++ b/polyfill/test/Time/constructor/species/return-value.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.time-@@species
+info: |
+    Its get accessor function performs the following steps:
+    1. Return the this value.
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.Time, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+
+const thisValue = {};
+assert.sameValue(descriptor.get.call(thisValue), thisValue);

--- a/polyfill/test/TimeZone/.eslintrc.yml
+++ b/polyfill/test/TimeZone/.eslintrc.yml
@@ -1,0 +1,5 @@
+---
+globals:
+  Temporal: readonly
+  assert: readonly
+  verifyProperty: readonly

--- a/polyfill/test/TimeZone/constructor/species/getter-length.js
+++ b/polyfill/test/TimeZone/constructor/species/getter-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.timezone-@@species
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.TimeZone, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/TimeZone/constructor/species/getter-name.js
+++ b/polyfill/test/TimeZone/constructor/species/getter-name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.timezone-@@species
+info: |
+    The value of the "name" property of this function is "get [Symbol.species]".
+
+    Unless otherwise specified, the "name" property of a built-in function object, if it exists,
+    has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.TimeZone, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "name", {
+  value: "get [Symbol.species]",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/TimeZone/constructor/species/prop-desc.js
+++ b/polyfill/test/TimeZone/constructor/species/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.timezone-@@species
+info: |
+    Temporal.TimeZone[@@species] is an accessor property whose set accessor function is undefined.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes
+    { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+    If only a get accessor function is described, the set accessor function is the default value,
+    undefined.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.TimeZone, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+assert.sameValue(typeof descriptor.get, "function");
+assert.sameValue(descriptor.set, undefined);
+
+verifyProperty(Temporal.TimeZone, Symbol.species, {
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/TimeZone/constructor/species/return-value.js
+++ b/polyfill/test/TimeZone/constructor/species/return-value.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.timezone-@@species
+info: |
+    Its get accessor function performs the following steps:
+    1. Return the this value.
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.TimeZone, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+
+const thisValue = {};
+assert.sameValue(descriptor.get.call(thisValue), thisValue);

--- a/polyfill/test/YearMonth/.eslintrc.yml
+++ b/polyfill/test/YearMonth/.eslintrc.yml
@@ -1,0 +1,5 @@
+---
+globals:
+  Temporal: readonly
+  assert: readonly
+  verifyProperty: readonly

--- a/polyfill/test/YearMonth/constructor/species/getter-length.js
+++ b/polyfill/test/YearMonth/constructor/species/getter-length.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.yearmonth-@@species
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.YearMonth, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/YearMonth/constructor/species/getter-name.js
+++ b/polyfill/test/YearMonth/constructor/species/getter-name.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.yearmonth-@@species
+info: |
+    The value of the "name" property of this function is "get [Symbol.species]".
+
+    Unless otherwise specified, the "name" property of a built-in function object, if it exists,
+    has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.YearMonth, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+verifyProperty(descriptor.get, "name", {
+  value: "get [Symbol.species]",
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/YearMonth/constructor/species/prop-desc.js
+++ b/polyfill/test/YearMonth/constructor/species/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.yearmonth-@@species
+info: |
+    Temporal.YearMonth[@@species] is an accessor property whose set accessor function is undefined.
+
+    Every accessor property described in clauses 18 through 26 and in Annex B.2 has the attributes
+    { [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+    If only a get accessor function is described, the set accessor function is the default value,
+    undefined.
+includes: [propertyHelper.js]
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.YearMonth, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+assert.sameValue(typeof descriptor.get, "function");
+assert.sameValue(descriptor.set, undefined);
+
+verifyProperty(Temporal.YearMonth, Symbol.species, {
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/YearMonth/constructor/species/return-value.js
+++ b/polyfill/test/YearMonth/constructor/species/return-value.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-temporal.yearmonth-@@species
+info: |
+    Its get accessor function performs the following steps:
+    1. Return the this value.
+features: [Symbol.species]
+---*/
+
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.YearMonth, Symbol.species);
+assert.sameValue(typeof descriptor, "object", "Symbol.species descriptor should exist");
+
+const thisValue = {};
+assert.sameValue(descriptor.get.call(thisValue), thisValue);

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -42,6 +42,19 @@
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.absolute-@@species">
+      <h1>get Temporal.Absolute [ @@species ]</h1>
+      <p>
+        `Temporal.Absolute[@@species]` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Return the *this* value.
+      </emu-alg>
+
+      <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.absolute.from">
       <h1>Temporal.Absolute.from ( _arg_ )</h1>
       <p>

--- a/spec/date.html
+++ b/spec/date.html
@@ -43,6 +43,19 @@
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.date-@@species">
+      <h1>get Temporal.Date [ @@species ]</h1>
+      <p>
+        `Temporal.Date[@@species]` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Return the *this* value.
+      </emu-alg>
+
+      <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.date.from">
       <h1>Temporal.Date.from ( _arg_ [ , _options_ ] )</h1>
       <p>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -51,6 +51,19 @@
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.datetime-@@species">
+      <h1>get Temporal.DateTime [ @@species ]</h1>
+      <p>
+        `Temporal.DateTime[@@species]` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Return the *this* value.
+      </emu-alg>
+
+      <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.datetime.from">
       <h1>Temporal.DateTime.from ( _arg_ [ , _options_ ] )</h1>
       <p>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -134,6 +134,19 @@
       </p>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.duration-@@species">
+      <h1>get Temporal.Duration [ @@species ]</h1>
+      <p>
+        `Temporal.Duration[@@species]` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Return the *this* value.
+      </emu-alg>
+
+      <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.duration.from">
       <h1>Temporal.Duration.from ( _arg_ [ , _options_ ] )</h1>
       <p>

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -43,6 +43,19 @@
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.monthday-@@species">
+      <h1>get Temporal.MonthDay [ @@species ]</h1>
+      <p>
+        `Temporal.MonthDay[@@species]` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Return the *this* value.
+      </emu-alg>
+
+      <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.monthday.from">
       <h1>Temporal.MonthDay.from ( _arg_ [ , _options_ ] )</h1>
       <p>

--- a/spec/time.html
+++ b/spec/time.html
@@ -50,6 +50,19 @@
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.time-@@species">
+      <h1>get Temporal.Time [ @@species ]</h1>
+      <p>
+        `Temporal.Time[@@species]` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Return the *this* value.
+      </emu-alg>
+
+      <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.time.from">
       <h1>Temporal.Time.from ( _arg_ [ , _options_ ] )</h1>
       <p>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -54,6 +54,19 @@
       </p>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.timezone-@@species">
+      <h1>get Temporal.TimeZone [ @@species ]</h1>
+      <p>
+        `Temporal.TimeZone[@@species]` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Return the *this* value.
+      </emu-alg>
+
+      <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.timezone.from">
       <h1>Temporal.TimeZone.from ( _arg_ )</h1>
       <p>

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -43,6 +43,19 @@
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.yearmonth-@@species">
+      <h1>get Temporal.YearMonth [ @@species ]</h1>
+      <p>
+        `Temporal.YearMonth[@@species]` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Return the *this* value.
+      </emu-alg>
+
+      <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.yearmonth.from">
       <h1>Temporal.YearMonth.from ( _arg_ [ , _options_ ] )</h1>
       <p>


### PR DESCRIPTION
This commit does not use the property yet; this will happen in a future commit.