### PR TITLE
Use options bags for all methods with options

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -278,20 +278,22 @@ oneDay = new Temporal.Duration(0, 0, 1);
 Temporal.now.absolute().minus(oneDay);
 ```
 
-### absolute.**difference**(_other_: Temporal.Absolute, _largestUnit_: string = 'seconds') : Temporal.Duration
+### absolute.**difference**(_other_: Temporal.Absolute, _options_?: object) : Temporal.Duration
 
 **Parameters:**
 - `other` (`Temporal.Absolute`): Another time with which to compute the difference.
-- `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-  Valid values are `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
-  The default is `"seconds"`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
+    Valid values are `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
+    The default is `"seconds"`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `absolute` and `other`.
 
 This method computes the difference between the two times represented by `absolute` and `other`, and returns it as a `Temporal.Duration` object.
 The difference is always positive, no matter the order of `absolute` and `other`, because `Temporal.Duration` objects cannot represent negative durations.
 
-The `largestUnit` parameter controls how the resulting duration is expressed.
+The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`, for example.
 However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `"hours"`.
@@ -305,22 +307,26 @@ Example usage:
 ```js
 startOfMoonMission = Temporal.Absolute.from('1969-07-16T13:32:00Z');
 endOfMoonMission = Temporal.Absolute.from('1969-07-24T16:50:35Z');
-missionLength = startOfMoonMission.difference(endOfMoonMission, 'days');  // => P8DT3H18M35S
-endOfMoonMission.difference(startOfMoonMission, 'days');  // => P8DT3H18M35S
-missionLength.toLocaleString();  // example output: '8 days 3 hours 18 minutes 35 seconds'
+missionLength = startOfMoonMission.difference(endOfMoonMission, { largestUnit: 'days' });
+  // => P8DT3H18M35S
+endOfMoonMission.difference(startOfMoonMission, { largestUnit: 'days' });
+  // => P8DT3H18M35S
+missionLength.toLocaleString();
+  // example output: '8 days 3 hours 18 minutes 35 seconds'
 
 // A billion (10^9) seconds since the epoch in different units
 epoch = new Temporal.Absolute(0n);
 billion = Temporal.Absolute.fromEpochSeconds(1e9);
 epoch.difference(billion);  // => PT1000000000S
-epoch.difference(billion, 'hours')  // => PT277777H46M40S
-epoch.difference(billion, 'days')  // => P11574DT1H46M40S
+epoch.difference(billion, { largestUnit: 'hours' })  // => PT277777H46M40S
+epoch.difference(billion, { largestUnit: 'days' })  // => P11574DT1H46M40S
 
 // If you really need to calculate the difference between two Absolutes
 // in years, you can eliminate the ambiguity by choosing your starting
 // point explicitly. For example, using the corresponding UTC date:
 utc = Temporal.TimeZone.from('UTC');
-epoch.inTimeZone(utc).difference(billion.inTimeZone(utc), 'years');  // => P31Y8M8DT1H46M40S
+epoch.inTimeZone(utc).difference(billion.inTimeZone(utc), { largestUnit: 'years' });
+  // => P31Y8M8DT1H46M40S
 ```
 
 ### absolute.**toString**(_timeZone_?: Temporal.TimeZone | string) : string

--- a/docs/ambiguity.md
+++ b/docs/ambiguity.md
@@ -6,7 +6,7 @@ Converting a [`Temporal.DateTime`](./datetime.md) wall-clock time to a [`Tempora
 Due to DST time changes, there is a possibility that a wall-clock time either does not exist, or has existed twice.
 
 There are two mostly equivalent methods that accomplish this conversion: [`Temporal.DateTime.prototype.inTimeZone`](./datetime.html#inTimeZone) and [`Temporal.TimeZone.prototype.getAbsoluteFor`](./timezone.html#getAbsoluteFor).
-The `disambiguation` argument to these methods controls what absolute time to return in the case of ambiguity:
+The `disambiguation` option to these methods controls what absolute time to return in the case of ambiguity:
 - `earlier` (the default): The earlier of two possible absolute times will be returned.
 - `later`: The later of two possible absolute times will be returned.
 - `reject`: A `RangeError` will be thrown.
@@ -31,16 +31,16 @@ In `later` mode, the absolute time that is returned will be as if the pre-change
 ```javascript
 tz = new Temporal.TimeZone('Europe/Berlin');
 dt = new Temporal.DateTime(2019, 3, 31, 2, 45);
-tz.getAbsoluteFor(dt, 'earlier');  // => 2019-03-31T00:45Z
-tz.getAbsoluteFor(dt, 'later');    // => 2019-03-31T01:45Z
-tz.getAbsoluteFor(dt, 'reject');   // throws
+tz.getAbsoluteFor(dt, { disambiguation: 'earlier' });  // => 2019-03-31T00:45Z
+tz.getAbsoluteFor(dt, { disambiguation: 'later' });    // => 2019-03-31T01:45Z
+tz.getAbsoluteFor(dt, { disambiguation: 'reject' });   // throws
 ```
 
 In this example, the wall-clock time 2:45 doesn't exist, so it is treated as either 1:45 +01:00 or 3:45 +02:00, which can be seen by converting the absolute back to a wall-clock time in the time zone:
 
 ```javascript
-tz.getAbsoluteFor(dt, 'earlier').inTimeZone(tz);  // => 2019-03-31T01:45
-tz.getAbsoluteFor(dt, 'later').inTimeZone(tz);  // => 2019-03-31T03:45
+tz.getAbsoluteFor(dt, { disambiguation: 'earlier' }).inTimeZone(tz);  // => 2019-03-31T01:45
+tz.getAbsoluteFor(dt, { disambiguation: 'later' }).inTimeZone(tz);  // => 2019-03-31T03:45
 ```
 
 Likewise, at the end of DST, clocks move backward an hour.
@@ -51,9 +51,9 @@ In `later` mode, the absolute time will be the later instance of the duplicated 
 ```javascript
 tz = new Temporal.TimeZone('America/Sao_Paulo');
 dt = new Temporal.DateTime(2019, 2, 16, 23, 45);
-dt.inTimeZone(tz, 'earlier');  // => 2019-02-17T01:45Z
-dt.inTimeZone(tz, 'later');    // => 2019-02-17T02:45Z
-dt.inTimeZone(tz, 'reject');   // throws
+dt.inTimeZone(tz, { disambiguation: 'earlier' });  // => 2019-02-17T01:45Z
+dt.inTimeZone(tz, { disambiguation: 'later' });    // => 2019-02-17T02:45Z
+dt.inTimeZone(tz, { disambiguation: 'reject' });   // throws
 ```
 
 In this example, the wall-clock time 23:45 exists twice.

--- a/docs/date.md
+++ b/docs/date.md
@@ -225,13 +225,15 @@ date.with({year: 2100}).leapYear  // => false
 
 ## Methods
 
-### date.**with**(_dateLike_: object, _disambiguation_: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Date
+### date.**with**(_dateLike_: object, _options_?: object) : Temporal.Date
 
 **Parameters:**
 - `dateLike` (object): an object with some or all of the properties of a `Temporal.Date`.
-- `disambiguation` (optional string): How to deal with out-of-range values.
-  Allowed values are `constrain`, `balance`, and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `disambiguation` (string): How to deal with out-of-range values.
+    Allowed values are `constrain`, `balance`, and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.Date` object.
 
@@ -243,16 +245,18 @@ Usage example:
 ```javascript
 date = Temporal.Date.from('2006-08-24');
 // What's the first of the following month?
-date.with({day: 1, month: date.month + 1}, 'balance')  // => 2006-09-01
+date.with({day: 1, month: date.month + 1}, { disambiguation: 'balance' })  // => 2006-09-01
 ```
 
-### date.**plus**(_duration_: string | object, _disambiguation_: 'constrain' | 'reject' = 'constrain') : Temporal.Date
+### date.**plus**(_duration_: string | object, _options_?: object) : Temporal.Date
 
 **Parameters:**
 - `duration` (string or object): A `Temporal.Duration` object, a duration-like object, or a string from which to create a `Temporal.Duration`.
-- `disambiguation` (optional string): How to deal with additions that result in out-of-range values.
-  Allowed values are `constrain` and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the addition.
+  The following options are recognized:
+  - `disambiguation` (optional string): How to deal with additions that result in out-of-range values.
+    Allowed values are `constrain` and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.Date` object which is the date indicated by `date` plus `duration`.
 
@@ -265,7 +269,7 @@ The `duration` argument can be any value that could be passed to `Temporal.Durat
 
 Some additions may be ambiguous, because months have different lengths.
 For example, adding one month to August 31 would result in September 31, which doesn't exist.
-For these cases, the `disambiguation` argument tells what to do:
+For these cases, the `disambiguation` option tells what to do:
 - In `constrain` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `reject` mode, an addition that would result in an out-of-range value fails, and a `RangeError` is thrown.
 
@@ -279,17 +283,19 @@ date.plus({years: 20, months: 4})  // => 2026-12-24
 date.plus('P14Y8D')  // => 2020-09-01
 
 date = Temporal.Date.from('2019-01-31')
-date.plus({months: 1}, 'constrain')  // => 2019-02-28
-date.plus({months: 1}, 'reject')  // => throws
+date.plus({ months: 1 })  // => 2019-02-28
+date.plus({ months: 1 }, { disambiguation: 'reject' })  // => throws
 ```
 
-### date.**minus**(_duration_: string | object, _disambiguation_: 'constrain' | 'reject' = 'constrain') : Temporal.Date
+### date.**minus**(_duration_: string | object, _options_?: object) : Temporal.Date
 
 **Parameters:**
 - `duration` (string or object): A `Temporal.Duration` object, a duration-like object, or a string from which to create a `Temporal.Duration`.
-- `disambiguation` (optional string): How to deal with subtractions that result in out-of-range values.
-  Allowed values are `constrain` and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the subtraction.
+  The following options are recognized:
+  - `disambiguation` (string): How to deal with subtractions that result in out-of-range values.
+    Allowed values are `constrain` and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.Date` object which is the date indicated by `date` minus `duration`.
 
@@ -302,7 +308,7 @@ The `duration` argument can be any value that could be passed to `Temporal.Durat
 
 Some subtractions may be ambiguous, because months have different lengths.
 For example, subtracting one month from July 31 would result in June 31, which doesn't exist.
-For these cases, the `disambiguation` argument tells what to do:
+For these cases, the `disambiguation` option tells what to do:
 - In `constrain` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `reject` mode, an addition that would result in an out-of-range value fails, and a `RangeError` is thrown.
 
@@ -316,24 +322,26 @@ date.minus({years: 20, months: 4})  // => 1986-04-24
 date.minus('P14Y8D')  // => 1992-08-16
 
 date = Temporal.Date.from('2019-03-31')
-date.minus({months: 1}, 'constrain')  // => 2019-02-28
-date.minus({months: 1}, 'reject')  // => throws
+date.minus({ months: 1 })  // => 2019-02-28
+date.minus({ months: 1 }, { disambiguation: 'reject' })  // => throws
 ```
 
-### date.**difference**(_other_: Temporal.Date, _largestUnit_: string = 'days') : Temporal.Duration
+### date.**difference**(_other_: Temporal.Date, _options_?: object) : Temporal.Duration
 
 **Parameters:**
 - `other` (`Temporal.Date`): Another date with which to compute the difference.
-- `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-  Valid values are `'years'`, `'months'`, and `'days'`.
-  The default is `days`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
+    Valid values are `'years'`, `'months'`, and `'days'`.
+    The default is `days`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `date` and `other`.
 
 This method computes the difference between the two dates represented by `date` and `other`, and returns it as a `Temporal.Duration` object.
 The difference is always positive, no matter the order of `date` and `other`, because `Temporal.Duration` objects cannot represent negative durations.
 
-The `largestUnit` parameter controls how the resulting duration is expressed.
+The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two years will become 24 months when `largestUnit` is `"months"`, for example.
 However, a difference of two months will still be two months even if `largestUnit` is `"years"`.
@@ -346,15 +354,16 @@ Usage example:
 ```javascript
 date = Temporal.Date.from('2006-08-24');
 other = Temporal.Date.from('2019-01-31');
-date.difference(other)           // => P4543D
-date.difference(other, 'years')  // => P12Y5M7D
+date.difference(other)                            // => P4543D
+date.difference(other, { largestUnit: 'years' })  // => P12Y5M7D
 
 // If you really need to calculate the difference between two Dates in
 // hours, you can eliminate the ambiguity by explicitly choosing the
 // point in time from which you want to reckon the difference. For
 // example, using midnight:
 midnight = Temporal.Time.from('00:00');
-date.withTime(midnight).difference(other.withTime(midnight), 'hours')  // => PT109032H
+date.withTime(midnight).difference(other.withTime(midnight), { largestUnit: 'hours' })
+  // => PT109032H
 ```
 
 ### date.**toString**() : string

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -282,13 +282,15 @@ dt.with({year: 2100}).isLeapYear  // => false
 
 ## Methods
 
-### datetime.**with**(_dateTimeLike_: object, _disambiguation_: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.DateTime
+### datetime.**with**(_dateTimeLike_: object, _options_?: object) : Temporal.DateTime
 
 **Parameters:**
 - `dateTimeLike` (object): an object with some or all of the properties of a `Temporal.DateTime`.
-- `disambiguation` (optional string): How to deal with out-of-range values.
-  Allowed values are `constrain`, `balance`, and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `disambiguation` (string): How to deal with out-of-range values.
+    Allowed values are `constrain`, `balance`, and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.DateTime` object.
 
@@ -302,13 +304,15 @@ dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
 dt.with({year: 2015, second: 31})  // => 2015-12-07T03:24:31.000003500
 ```
 
-### datetime.**plus**(_duration_: string | object, _disambiguation_: 'constrain' | 'reject' = 'constrain') : Temporal.DateTime
+### datetime.**plus**(_duration_: string | object, _options_?: object) : Temporal.DateTime
 
 **Parameters:**
 - `duration` (string or object): A `Temporal.Duration` object, a duration-like object, or a string from which to create a `Temporal.Duration`.
-- `disambiguation` (optional string): How to deal with additions that result in out-of-range values.
-  Allowed values are `constrain` and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the addition.
+  The following options are recognized:
+  - `disambiguation` (string): How to deal with additions that result in out-of-range values.
+    Allowed values are `constrain` and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.DateTime` object which is the date and time indicated by `datetime` plus `duration`.
 
@@ -321,7 +325,7 @@ The `duration` argument can be any value that could be passed to `Temporal.Durat
 
 Some additions may be ambiguous, because months have different lengths.
 For example, adding one month to August 31 would result in September 31, which doesn't exist.
-For these cases, the `disambiguation` argument tells what to do:
+For these cases, the `disambiguation` option tells what to do:
 - In `constrain` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `reject` mode, an addition that would result in an out-of-range value fails, and a `RangeError` is thrown.
 
@@ -335,17 +339,19 @@ dt.plus({years: 20, months: 4, nanoseconds: 500})  // => 2016-04-07T03:24:30.000
 dt.plus('P14Y7MT7H14M21S')  // => 2010-07-07T10:38:51.000003500
 
 dt = Temporal.DateTime.from('2019-01-31T15:30')
-dt.plus({months: 1}, 'constrain')  // => 2019-02-28T15:30
-dt.plus({months: 1}, 'reject')  // => throws
+dt.plus({ months: 1 })  // => 2019-02-28T15:30
+dt.plus({ months: 1 }, { disambiguation: 'reject' })  // => throws
 ```
 
-### datetime.**minus**(_duration_: string | object, _disambiguation_: 'constrain' | 'reject' = 'constrain') : Temporal.DateTime
+### datetime.**minus**(_duration_: string | object, _options_?: object) : Temporal.DateTime
 
 **Parameters:**
 - `duration` (string or object): A `Temporal.Duration` object, a duration-like object, or a string from which to create a `Temporal.Duration`.
-- `disambiguation` (optional string): How to deal with subtractions that result in out-of-range values.
-  Allowed values are `constrain` and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the subtraction.
+  The following options are recognized:
+  - `disambiguation` (string): How to deal with subtractions that result in out-of-range values.
+    Allowed values are `constrain` and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.DateTime` object which is the time indicated by `datetime` minus `duration`.
 
@@ -358,7 +364,7 @@ The `duration` argument can be any value that could be passed to `Temporal.Durat
 
 Some subtractions may be ambiguous, because months have different lengths.
 For example, subtracting one month from July 31 would result in June 31, which doesn't exist.
-For these cases, the `disambiguation` argument tells what to do:
+For these cases, the `disambiguation` option tells what to do:
 - In `constrain` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `reject` mode, an addition that would result in an out-of-range value fails, and a `RangeError` is thrown.
 
@@ -372,24 +378,26 @@ dt.minus({years: 20, months: 4, nanoseconds: 500})  // => 1975-08-07T03:24:30.00
 dt.minus('P14Y7MT7H14M21S')  // => 1981-05-06T20:10:09.000003500
 
 dt = Temporal.DateTime.from('2019-03-31T15:30')
-dt.minus({months: 1}, 'constrain')  // => 2019-02-28T15:30
-dt.minus({months: 1}, 'reject')  // => throws
+dt.minus({ months: 1 }, { disambiguation: 'constrain' })  // => 2019-02-28T15:30
+dt.minus({ months: 1 })  // => throws
 ```
 
-### datetime.**difference**(_other_: Temporal.DateTime, _largestUnit_: string = 'days') : Temporal.Duration
+### datetime.**difference**(_other_: Temporal.DateTime, _options_?: object) : Temporal.Duration
 
 **Parameters:**
 - `other` (`Temporal.DateTime`): Another date/time with which to compute the difference.
-- `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-  Valid values are `'years'`, `'months'`, `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
-  The default is `days`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
+    Valid values are `'years'`, `'months'`, `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
+    The default is `days`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `datetime` and `other`.
 
 This method computes the difference between the two times represented by `datetime` and `other`, and returns it as a `Temporal.Duration` object.
 The difference is always positive, no matter the order of `datetime` and `other`, because `Temporal.Duration` objects cannot represent negative durations.
 
-The `largestUnit` parameter controls how the resulting duration is expressed.
+The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`, for example.
 However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `"hours"`.
@@ -401,15 +409,15 @@ Usage example:
 ```javascript
 dt1 = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 dt2 = Temporal.DateTime.from('2019-01-31T15:30');
-dt1.difference(dt2);           // =>    P8456DT12H5M29.999996500S
-dt1.difference(dt2), 'years')  // => P23Y1M24DT12H5M29.999996500S
+dt1.difference(dt2);                            // =>    P8456DT12H5M29.999996500S
+dt1.difference(dt2), { largestUnit: 'years' })  // => P23Y1M24DT12H5M29.999996500S
 
 // Months and years can be different lengths
 [jan1, feb1, mar1] = [1, 2, 3].map(month => Temporal.DateTime.from({year: 2020, month, day: 1}));
-jan1.difference(feb1);            // => P31D
-jan1.difference(feb1, 'months');  // => P1M
-feb1.difference(mar1);            // => P29D
-feb1.difference(mar1, 'months');  // => P1M
+jan1.difference(feb1);                             // => P31D
+jan1.difference(feb1, { largestUnit: 'months' });  // => P1M
+feb1.difference(mar1);                             // => P29D
+feb1.difference(mar1, { largestUnit: 'months' });  // => P1M
 ```
 
 ### datetime.**toString**() : string
@@ -448,20 +456,22 @@ dt.toLocaleString('de-DE', { timeZone: 'Europe/Berlin', weekday: 'long' });  // 
 dt.toLocaleString('en-US-u-nu-fullwide-hc-h12');  // => １２/７/１９９５, ３:２４:３０ AM
 ```
 
-### datetime.**inTimeZone**(_timeZone_ : Temporal.TimeZone | string, _disambiguation_ : 'earlier' | 'later' | 'reject' = 'earlier') : Temporal.Absolute
+### datetime.**inTimeZone**(_timeZone_ : Temporal.TimeZone | string, _options_?: object) : Temporal.Absolute
 
 **Parameters:**
 - `timeZone` (optional string or `Temporal.TimeZone`): The time zone in which to interpret `dateTime`.
-- `disambiguation` (optional `string`): How to disambiguate if the date and time given by `dateTime` does not exist in the time zone, or exists more than once.
-  Allowed values are `earlier`, `later`, and `reject`.
-  The default is `earlier`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `disambiguation` (string): How to disambiguate if the date and time given by `dateTime` does not exist in the time zone, or exists more than once.
+    Allowed values are `earlier`, `later`, and `reject`.
+    The default is `earlier`.
 
 **Returns:** A `Temporal.Absolute` object indicating the absolute time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
 
 This method is one way to convert a `Temporal.DateTime` to a `Temporal.Absolute`.
 It is identical to [`(Temporal.TimeZone.from(timeZone || 'UTC')).getAbsoluteFor(dateTime, disambiguation)`](./timezone.html#getAbsoluteFor).
 
-In the case of ambiguity, the `disambiguation` parameter controls what absolute time to return:
+In the case of ambiguity, the `disambiguation` option controls what absolute time to return:
 - `earlier`: The earlier of two possible times.
 - `later`: The later of two possible times.
 - `reject`: Throw a `RangeError` instead.

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -130,13 +130,15 @@ md.day    // => 24
 
 ## Methods
 
-### monthDay.**with**(_monthDayLike_: object, _disambiguation_: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.MonthDay
+### monthDay.**with**(_monthDayLike_: object, _options_?: object) : Temporal.MonthDay
 
 **Parameters:**
 - `monthDayLike` (object): an object with some or all of the properties of a `Temporal.MonthDay`.
-- `disambiguation` (optional string): How to deal with out-of-range values.
-  Allowed values are `constrain`, `balance`, and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `disambiguation` (string): How to deal with out-of-range values.
+    Allowed values are `constrain`, `balance`, and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.MonthDay` object.
 
@@ -155,8 +157,8 @@ Usage example:
 ```javascript
 md = Temporal.MonthDay.from('11-15');
 // What's the last day of that month?
-md.with({day: 31}, 'constrain')  // => 11-30
-Temporal.MonthDay.from('02-01').with({day: 31}, 'constrain');  // => 02-29
+md.with({ day: 31 })  // => 11-30
+Temporal.MonthDay.from('02-01').with({ day: 31 });  // => 02-29
 ```
 
 ### monthDay.**toString**() : string

--- a/docs/time.md
+++ b/docs/time.md
@@ -28,19 +28,21 @@ A representation of wall-clock time.
 
 ## Methods
 
-### time.**with**({ hour: number = this.hour, minute: number = this.minute, second: numer = this.second ...}, _disambiguation_: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.Time
+### time.**with**({ hour: number = this.hour, minute: number = this.minute, second: numer = this.second ...}, _options_?: object) : Temporal.Time
 
-### time.**plus**(_duration_: string | object, _disambiguation_: 'constrain' | 'reject' = 'constrain') : Temporal.Time
+### time.**plus**(_duration_: string | object, _options_?: object) : Temporal.Time
 
-### time.**minus**(_duration_: string | object, _disambiguation_: 'constrain' | 'reject' = 'constrain') : Temporal.Time
+### time.**minus**(_duration_: string | object, _options_?: object) : Temporal.Time
 
-### time.**difference**(_other_: Temporal.Time, _largestUnit_: string = 'hours') : Temporal.Duration
+### time.**difference**(_other_: Temporal.Time, _options_?: object) : Temporal.Duration
 
 **Parameters:**
 - `other` (`Temporal.Time`): Another time with which to compute the difference.
-- `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-  Valid values are `'years'`, `'months'`, `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
-  The default is `days`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
+    Valid values are `'years'`, `'months'`, `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
+    The default is `days`.
 
 **TODO:** Rest of the documentation in another pull request, this to be rebased
 

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -168,20 +168,22 @@ tz = new Temporal.TimeZone('America/New_York');
 tz.getDateTimeFor(epoch);  // => 1969-12-31T19:00
 ```
 
-### timeZone.**getAbsoluteFor**(_dateTime_: Temporal.DateTime, _disambiguation_: 'earlier' | 'later' | 'reject' = 'earlier') : Temporal.Absolute
+### timeZone.**getAbsoluteFor**(_dateTime_: Temporal.DateTime, _options_?: object) : Temporal.Absolute
 
 **Parameters:**
 - `dateTime` (`Temporal.DateTime`): A calendar date and wall-clock time to convert.
-- `disambiguation` (optional `string`): How to disambiguate if the date and time given by `dateTime` does not exist in the time zone, or exists more than once.
-  Allowed values are `earlier`, `later`, and `reject`.
-  The default is `earlier`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `disambiguation` (string): How to disambiguate if the date and time given by `dateTime` does not exist in the time zone, or exists more than once.
+    Allowed values are `earlier`, `later`, and `reject`.
+    The default is `earlier`.
 
 **Returns:** A `Temporal.Absolute` object indicating the absolute time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
 
 This method is one way to convert a `Temporal.DateTime` to a `Temporal.Absolute`.
 It is identical to [`dateTime.inTimeZone(timeZone, disambiguation)`](./datetime.html#inTimeZone).
 
-In the case of ambiguity, the `disambiguation` parameter controls what absolute time to return:
+In the case of ambiguity, the `disambiguation` option controls what absolute time to return:
 - `earlier`: The earlier of two possible times.
 - `later`: The later of two possible times.
 - `reject`: Throw a `RangeError` instead.

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -181,13 +181,15 @@ ym.with({year: 2100}).isLeapYear  // => false
 
 ## Methods
 
-### yearMonth.**with**(_yearMonthLike_: object, _disambiguation_: 'constrain' | 'balance' | 'reject' = 'constrain') : Temporal.YearMonth
+### yearMonth.**with**(_yearMonthLike_: object, _options_?: object) : Temporal.YearMonth
 
 **Parameters:**
 - `yearMonthLike` (object): an object with some or all of the properties of a `Temporal.YearMonth`.
-- `disambiguation` (optional string): How to deal with out-of-range values.
-  Allowed values are `constrain`, `balance`, and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `disambiguation` (string): How to deal with out-of-range values.
+    Allowed values are `constrain`, `balance`, and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.YearMonth` object.
 
@@ -202,13 +204,15 @@ ym = Temporal.YearMonth.from('2019-06');
 ym.with({month: 12})  // => 2019-12
 ```
 
-### yearMonth.**plus**(_duration_: string | object, _disambiguation_: 'constrain' | 'reject' = 'constrain') : Temporal.YearMonth
+### yearMonth.**plus**(_duration_: string | object, _options_?: object) : Temporal.YearMonth
 
 **Parameters:**
 - `duration` (string or object): A `Temporal.Duration` object, a duration-like object, or a string from which to create a `Temporal.Duration`.
-- `disambiguation` (optional string): How to deal with additions that result in out-of-range values.
-  Allowed values are `constrain` and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the addition.
+  The following options are recognized:
+  - `disambiguation` (string): How to deal with additions that result in out-of-range values.
+    Allowed values are `constrain` and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.YearMonth` object which is the month indicated by `yearMonth` plus `duration`.
 
@@ -222,7 +226,7 @@ The `duration` argument can be any value that could be passed to `Temporal.Durat
 If the result is outside the range of dates that `Temporal.YearMonth` can represent, then `constrain` mode will clamp the result to the allowed range.
 The `reject` mode will throw a `RangeError` in this case.
 
-Other than for out-of-range values, the `disambiguation` parameter has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous.
+Other than for out-of-range values, the `disambiguation` option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous.
 It doesn't matter in this case that years and months can be different numbers of days, as the resolution of `Temporal.YearMonth` does not distinguish days.
 However, disambiguation may have an effect in other calendars where years can be different numbers of months.
 
@@ -233,13 +237,15 @@ ym.plus({years: 20, months: 4})  // => 2039-10
 ym.plus('P14Y')  // => 2033-06
 ```
 
-### yearMonth.**minus**(_duration_: string | object, _disambiguation_: 'constrain' | 'reject' = 'constrain') : Temporal.YearMonth
+### yearMonth.**minus**(_duration_: string | object, _options_?: object) : Temporal.YearMonth
 
 **Parameters:**
 - `duration` (string or object): A `Temporal.Duration` object, a duration-like object, or a string from which to create a `Temporal.Duration`.
-- `disambiguation` (optional string): How to deal with additions that result in out-of-range values.
-  Allowed values are `constrain` and `reject`.
-  The default is `constrain`.
+- `options` (optional object): An object with properties representing options for the subtraction.
+  The following options are recognized:
+  - `disambiguation` (string): How to deal with additions that result in out-of-range values.
+    Allowed values are `constrain` and `reject`.
+    The default is `constrain`.
 
 **Returns:** a new `Temporal.YearMonth` object which is the month indicated by `yearMonth` minus `duration`.
 
@@ -253,7 +259,7 @@ The `duration` argument can be any value that could be passed to `Temporal.Durat
 If the result is outside the range of dates that `Temporal.YearMonth` can represent, then `constrain` mode will clamp the result to the allowed range.
 The `reject` mode will throw a `RangeError` in this case.
 
-Other than for out-of-range values, the `disambiguation` parameter has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous.
+Other than for out-of-range values, the `disambiguation` option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous.
 It doesn't matter in this case that years and months can be different numbers of days, as the resolution of `Temporal.YearMonth` does not distinguish days.
 However, disambiguation may have an effect in other calendars where years can be different numbers of months.
 
@@ -264,13 +270,15 @@ ym.minus({years: 20, months: 4})  // => 1999-02
 ym.minus('P14Y')  // => 2005-06
 ```
 
-### yearMonth.**difference**(_other_: Temporal.YearMonth, _largestUnit_: string = 'years') : Temporal.Duration
+### yearMonth.**difference**(_other_: Temporal.YearMonth, _options_?: object) : Temporal.Duration
 
 **Parameters:**
 - `other` (`Temporal.YearMonth`): Another month with which to compute the difference.
-- `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-  Valid values are `'years'` and `'months'`.
-  The default is `years`.
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
+    Valid values are `'years'` and `'months'`.
+    The default is `years`.
 
 
 **Returns:** a `Temporal.Duration` representing the difference between `yearMonth` and `other`.
@@ -278,7 +286,7 @@ ym.minus('P14Y')  // => 2005-06
 This method computes the difference between the two months represented by `yearMonth` and `other`, and returns it as a `Temporal.Duration` object.
 The difference is always positive, no matter the order of `yearMonth` and `other`, because `Temporal.Duration` objects cannot represent negative durations.
 
-The `largestUnit` parameter controls how the resulting duration is expressed.
+The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of one year and two months will become 14 months when `largestUnit` is `"months"`, for example.
 However, a difference of one month will still be one month even if `largestUnit` is `"years"`.
@@ -289,15 +297,15 @@ Usage example:
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
 other = Temporal.YearMonth.from('2006-08');
-ym.difference(other)            // => P12Y10M
-ym.difference(other, 'months')  // => P154M
+ym.difference(other)                             // => P12Y10M
+ym.difference(other, { largestUnit: 'months' })  // => P154M
 
 // If you really need to calculate the difference between two YearMonths
 // in days, you can eliminate the ambiguity by explicitly choosing the
 // day of the month (and if applicable, the time of that day) from which
 // you want to reckon the difference. For example, using the first of
 // the month to calculate a number of days:
-ym.withDay(1).difference(other.withDay(1), 'days');  // => P4687D
+ym.withDay(1).difference(other.withDay(1), { largestUnit: 'days' });  // => P4687D
 ```
 
 ### yearMonth.**toString**() : string

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -90,10 +90,10 @@ export class Absolute {
     const Construct = ES.SpeciesConstructor(this, Absolute);
     return new Construct(bigInt(ns));
   }
-  difference(other, largestUnit = 'seconds') {
+  difference(other, options) {
     if (!ES.IsAbsolute(this)) throw new TypeError('invalid receiver');
     if (!ES.IsAbsolute(other)) throw new TypeError('invalid Absolute object');
-    largestUnit = ES.ToLargestTemporalUnit(largestUnit, ['years', 'months']);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'seconds', ['years', 'months']);
 
     const [one, two] = [this, other].sort(Absolute.compare);
     const onens = GetSlot(one, EPOCHNANOSECONDS);

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -62,9 +62,9 @@ export class Date {
     if (!ES.IsDate(this)) throw new TypeError('invalid receiver');
     return ES.LeapYear(GetSlot(this, YEAR));
   }
-  with(dateLike = {}, disambiguation = 'constrain') {
+  with(dateLike = {}, options) {
     if (!ES.IsDate(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToDisambiguation(disambiguation);
+    const disambiguation = ES.ToDisambiguation(options);
     const props = ES.ValidPropertyBag(dateLike, ['year', 'month', 'day']);
     if (!props) {
       throw new RangeError('invalid date-like');
@@ -78,9 +78,9 @@ export class Date {
       GetSlot(result, DAY),
     );
   }
-  plus(durationLike = {}, disambiguation = 'constrain') {
+  plus(durationLike = {}, options) {
     if (!ES.IsDate(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToArithmeticDisambiguation(disambiguation);
+    const disambiguation = ES.ToArithmeticDisambiguation(options);
     const duration = ES.ToLimitedDuration(durationLike, [HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS]);
     let { year, month, day } = this;
     const { years, months, days } = duration;
@@ -93,9 +93,9 @@ export class Date {
       GetSlot(result, DAY),
     );
   }
-  minus(durationLike = {}, disambiguation = 'constrain') {
+  minus(durationLike = {}, options) {
     if (!ES.IsDate(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToArithmeticDisambiguation(disambiguation);
+    const disambiguation = ES.ToArithmeticDisambiguation(options);
     const duration = ES.ToLimitedDuration(durationLike, [HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS]);
     let { year, month, day } = this;
     const { years, months, days } = duration;
@@ -108,10 +108,10 @@ export class Date {
       GetSlot(result, DAY),
     );
   }
-  difference(other, largestUnit = 'days') {
+  difference(other, options) {
     if (!ES.IsDate(this)) throw new TypeError('invalid receiver');
     if (!ES.IsDate(other)) throw new TypeError('invalid Date object');
-    largestUnit = ES.ToLargestTemporalUnit(largestUnit, ['hours', 'minutes', 'seconds']);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'days', ['hours', 'minutes', 'seconds']);
     const [smaller, larger] = [this, other].sort(Date.compare);
     const { years, months, days } = ES.DifferenceDate(smaller, larger, largestUnit);
     const Duration = ES.GetIntrinsic('%Temporal.Duration%');
@@ -150,7 +150,7 @@ export class Date {
     return new MonthDay(GetSlot(this, MONTH), GetSlot(this, DAY));
   }
   static from(arg, options) {
-    const disambiguation = ES.GetOption(options, 'disambiguation', ES.ToDisambiguation, 'constrain');
+    const disambiguation = ES.ToDisambiguation(options);
     let result = ES.ToDate(arg, disambiguation);
     return this === Date ? result : new this(
       GetSlot(result, YEAR),

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -109,9 +109,9 @@ export class DateTime {
     if (!ES.IsDateTime(this)) throw new TypeError('invalid receiver');
     return ES.LeapYear(GetSlot(this, YEAR));
   }
-  with(dateTimeLike, disambiguation = 'constrain') {
+  with(dateTimeLike, options) {
     if (!ES.IsDateTime(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToDisambiguation(disambiguation);
+    const disambiguation = ES.ToDisambiguation(options);
     const props = ES.ValidPropertyBag(dateTimeLike, [
       'year',
       'month',
@@ -161,9 +161,9 @@ export class DateTime {
       GetSlot(result, NANOSECOND),
     );
   }
-  plus(durationLike, disambiguation = 'constrain') {
+  plus(durationLike, options) {
     if (!ES.IsDateTime(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToArithmeticDisambiguation(disambiguation);
+    const disambiguation = ES.ToArithmeticDisambiguation(options);
     const duration = ES.ToLimitedDuration(durationLike);
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
@@ -209,9 +209,9 @@ export class DateTime {
       GetSlot(result, NANOSECOND),
     );
   }
-  minus(durationLike, disambiguation = 'constrain') {
+  minus(durationLike, options) {
     if (!ES.IsDateTime(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToArithmeticDisambiguation(disambiguation);
+    const disambiguation = ES.ToArithmeticDisambiguation(options);
     const duration = ES.ToLimitedDuration(durationLike);
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = this;
     let { years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
@@ -256,10 +256,10 @@ export class DateTime {
       GetSlot(result, NANOSECOND),
     );
   }
-  difference(other, largestUnit = 'days') {
+  difference(other, options) {
     if (!ES.IsDateTime(this)) throw new TypeError('invalid receiver');
     if (!ES.IsDateTime(other)) throw new TypeError('invalid DateTime object');
-    largestUnit = ES.ToLargestTemporalUnit(largestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'days');
     const [smaller, larger] = [this, other].sort(DateTime.compare);
     let { deltaDays, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(
       smaller,
@@ -310,10 +310,10 @@ export class DateTime {
     return new Intl.DateTimeFormat(...args).format(this);
   }
 
-  inTimeZone(timeZoneParam = 'UTC', disambiguation = 'earlier') {
+  inTimeZone(timeZoneParam = 'UTC', options) {
     if (!ES.IsDateTime(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTimeZone(timeZoneParam);
-    disambiguation = ES.ToTimeZoneDisambiguation(disambiguation);
+    const disambiguation = ES.ToTimeZoneDisambiguation(options);
     return timeZone.getAbsoluteFor(this, disambiguation);
   }
   getDate() {
@@ -345,7 +345,7 @@ export class DateTime {
   }
 
   static from(arg, options) {
-    const disambiguation = ES.GetOption(options, 'disambiguation', ES.ToDisambiguation, 'constrain');
+    const disambiguation = ES.ToDisambiguation(options);
     let result = ES.ToDateTime(arg, disambiguation);
     return this === DateTime ? result : new this(
       GetSlot(result, YEAR),

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -128,7 +128,7 @@ export class Duration {
     return new Intl.DateTimeFormat(...args).format(this);
   }
   static from(arg, options) {
-    const disambiguation = ES.GetOption(options, 'disambiguation', ES.ToDisambiguation, 'constrain');
+    const disambiguation = ES.ToDisambiguation(options);
     let result = ES.ToDuration(arg, disambiguation);
     return this === Duration ? result : new this(
       GetSlot(result, YEARS),

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -493,34 +493,20 @@ export const ES = ObjectAssign(ObjectAssign({}, ES2019), {
     }
     return duration;
   },
-  ToDisambiguation: (disambiguation) => {
-    disambiguation = ES.ToString(disambiguation);
-    if (!['constrain', 'balance', 'reject'].includes(disambiguation)) {
-      throw new RangeError(`disambiguation should be constrain, balance, or reject, not ${disambiguation}`);
-    }
-    return disambiguation;
+  ToDisambiguation: (options) => {
+    return ES.GetOption(options, 'disambiguation', ['constrain', 'balance', 'reject'], 'constrain');
   },
-  ToArithmeticDisambiguation: (disambiguation) => {
-    disambiguation = ES.ToString(disambiguation);
-    if (disambiguation !== 'constrain' && disambiguation !== 'reject') {
-      throw new RangeError(`disambiguation should be constrain or reject, not ${disambiguation}`);
-    }
-    return disambiguation;
+  ToArithmeticDisambiguation: (options) => {
+    return ES.GetOption(options, 'disambiguation', ['constrain', 'reject'], 'constrain');
   },
-  ToTimeZoneDisambiguation: (disambiguation) => {
-    disambiguation = ES.ToString(disambiguation);
-    if (!['earlier', 'later', 'reject'].includes(disambiguation)) {
-      throw new RangeError(`disambiguation should be earlier, later, or reject, not ${disambiguation}`);
-    }
-    return disambiguation;
+  ToTimeZoneDisambiguation: (options) => {
+    return ES.GetOption(options, 'disambiguation', ['earlier', 'later', 'reject'], 'earlier');
   },
-  ToLargestTemporalUnit: (largestUnit, disallowedStrings = []) => {
-    largestUnit = ES.ToString(largestUnit);
+  ToLargestTemporalUnit: (options, fallback, disallowedStrings = []) => {
+    const largestUnit = ES.GetOption(options, 'largestUnit',
+      ['years', 'months', 'days', 'hours', 'minutes', 'seconds'], fallback);
     if (disallowedStrings.includes(largestUnit)) {
       throw new RangeError(`${largestUnit} not allowed as the largest unit here`);
-    }
-    if (!['years', 'months', 'days', 'hours', 'minutes', 'seconds'].includes(largestUnit)) {
-      throw new RangeError(`invalid largest unit ${largestUnit}`);
     }
     return largestUnit;
   },
@@ -1253,11 +1239,17 @@ export const ES = ObjectAssign(ObjectAssign({}, ES2019), {
     return ES.ToTimeZone(fmt.resolvedOptions().timeZone);
   },
   ComparisonResult: (value) => (value < 0 ? -1 : value > 0 ? 1 : value),
-  GetOption: (options, property, validation, fallback) => {
+  GetOption: (options, property, allowedValues, fallback) => {
     if (options === null || options === undefined) return fallback;
     options = ES.ToObject(options);
     let value = options[property];
-    if (value !== undefined) return validation(value);
+    if (value !== undefined) {
+      value = ES.ToString(value);
+      if (!allowedValues.includes(value)) {
+        throw new RangeError(`${property} must be one of ${allowedValues.join(', ')}, not ${value}`)
+      }
+      return value;
+    }
     return fallback;
   },
 });

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -23,9 +23,9 @@ export class MonthDay {
     return GetSlot(this, DAY);
   }
 
-  with(dateLike, disambiguation = 'constrain') {
+  with(dateLike, options) {
     if (!ES.IsMonthDay(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToDisambiguation(disambiguation);
+    const disambiguation = ES.ToDisambiguation(options);
     const props = ES.ValidPropertyBag(dateLike, ['month', 'day']);
     if (!props) {
       throw new RangeError('invalid month-day-like');
@@ -57,7 +57,7 @@ export class MonthDay {
     return new Date(year, month, day);
   }
   static from(arg, options) {
-    const disambiguation = ES.GetOption(options, 'disambiguation', ES.ToDisambiguation, 'constrain');
+    const disambiguation = ES.ToDisambiguation(options);
     let result = ES.ToMonthDay(arg, disambiguation);
     return this === MonthDay ? result : new this(
       GetSlot(result, MONTH),

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -67,9 +67,9 @@ export class Time {
     return GetSlot(this, NANOSECOND);
   }
 
-  with(timeLike = {}, disambiguation = 'constrain') {
+  with(timeLike = {}, options) {
     if (!ES.IsTime(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToDisambiguation(disambiguation);
+    const disambiguation = ES.ToDisambiguation(options);
     const props = ES.ValidPropertyBag(timeLike, [
       'hour',
       'minute',
@@ -100,11 +100,11 @@ export class Time {
       GetSlot(result, NANOSECOND),
     );
   }
-  plus(durationLike, disambiguation = 'constrain') {
+  plus(durationLike, options) {
     if (!ES.IsTime(this)) throw new TypeError('invalid receiver');
     let { hour, minute, second, millisecond, microsecond, nanosecond } = this;
     const duration = ES.ToLimitedDuration(durationLike, [YEARS, MONTHS, DAYS]);
-    disambiguation = ES.ToArithmeticDisambiguation(disambiguation);
+    const disambiguation = ES.ToArithmeticDisambiguation(options);
     const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.AddTime(
       hour,
@@ -131,11 +131,11 @@ export class Time {
       GetSlot(result, NANOSECOND),
     );
   }
-  minus(durationLike, disambiguation = 'constrain') {
+  minus(durationLike, options) {
     if (!ES.IsTime(this)) throw new TypeError('invalid receiver');
     let { hour, minute, second, millisecond, microsecond, nanosecond } = this;
     const duration = ES.ToLimitedDuration(durationLike, [YEARS, MONTHS, DAYS]);
-    disambiguation = ES.ToArithmeticDisambiguation(disambiguation);
+    const disambiguation = ES.ToArithmeticDisambiguation(options);
     const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     ({ hour, minute, second, minute, microsecond, nanosecond } = ES.SubtractTime(
       hour,
@@ -162,10 +162,10 @@ export class Time {
       GetSlot(result, NANOSECOND),
     );
   }
-  difference(other, largestUnit = 'hours') {
+  difference(other, options) {
     if (!ES.IsTime(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTime(other)) throw new TypeError('invalid Time object');
-    largestUnit = ES.ToLargestTemporalUnit(largestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'hours');
     const [earlier, later] = [this, other].sort(Time.compare);
     let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(earlier, later);
     if (hours >= 12) {
@@ -215,7 +215,7 @@ export class Time {
   }
 
   static from(arg, options) {
-    const disambiguation = ES.GetOption(options, 'disambiguation', ES.ToDisambiguation, 'constrain');
+    const disambiguation = ES.ToDisambiguation(options);
     let result = ES.ToTime(arg, disambiguation);
     return this === Time ? result : new this(
       GetSlot(result, HOUR),

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -37,14 +37,14 @@ export class TimeZone {
     const DateTime = ES.GetIntrinsic('%Temporal.DateTime%');
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }
-  getAbsoluteFor(dateTime, disambiguation = 'earlier') {
+  getAbsoluteFor(dateTime, options) {
     if (!ES.IsTimeZone(this)) throw new TypeError('invalid receiver');
     dateTime = ES.ToDateTime(dateTime, 'reject');
-    disambiguation = ES.ToTimeZoneDisambiguation(disambiguation);
+    const disambiguation = ES.ToTimeZoneDisambiguation(options);
 
     const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = dateTime;
-    const options = ES.GetTimeZoneEpochValue(
+    const possibleEpochNs = ES.GetTimeZoneEpochValue(
       GetSlot(this, IDENTIFIER),
       year,
       month,
@@ -56,13 +56,13 @@ export class TimeZone {
       microsecond,
       nanosecond
     );
-    if (options.length === 1) return new Absolute(options[0]);
-    if (options.length) {
+    if (possibleEpochNs.length === 1) return new Absolute(possibleEpochNs[0]);
+    if (possibleEpochNs.length) {
       switch (disambiguation) {
         case 'earlier':
-          return new Absolute(options[0]);
+          return new Absolute(possibleEpochNs[0]);
         case 'later':
-          return new Absolute(options[1]);
+          return new Absolute(possibleEpochNs[1]);
         case 'reject': {
           throw new RangeError(`multiple absolute found`);
         }

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -44,9 +44,9 @@ export class YearMonth {
     if (!ES.IsYearMonth(this)) throw new TypeError('invalid receiver');
     return ES.LeapYear(GetSlot(this, YEAR));
   }
-  with(dateLike = {}, disambiguation = 'constrain') {
+  with(dateLike = {}, options) {
     if (!ES.IsYearMonth(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToDisambiguation(disambiguation);
+    const disambiguation = ES.ToDisambiguation(options);
     const props = ES.ValidPropertyBag(dateLike, ['year', 'month']);
     if (!props) {
       throw new RangeError('invalid year-month-like');
@@ -59,9 +59,9 @@ export class YearMonth {
       GetSlot(result, MONTH),
     );
   }
-  plus(durationLike, disambiguation = 'constrain') {
+  plus(durationLike, options) {
     if (!ES.IsYearMonth(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToArithmeticDisambiguation(disambiguation);
+    const disambiguation = ES.ToArithmeticDisambiguation(options);
     const duration = ES.ToLimitedDuration(durationLike, [DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS]);
     let { year, month } = this;
     const { years, months } = duration;
@@ -74,9 +74,9 @@ export class YearMonth {
       GetSlot(result, MONTH),
     );
   }
-  minus(durationLike, disambiguation = 'constrain') {
+  minus(durationLike, options) {
     if (!ES.IsYearMonth(this)) throw new TypeError('invalid receiver');
-    disambiguation = ES.ToArithmeticDisambiguation(disambiguation);
+    const disambiguation = ES.ToArithmeticDisambiguation(options);
     const duration = ES.ToLimitedDuration(durationLike, [DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS]);
     let { year, month } = this;
     const { years, months } = duration;
@@ -89,10 +89,10 @@ export class YearMonth {
       GetSlot(result, MONTH),
     );
   }
-  difference(other, largestUnit = 'years') {
+  difference(other, options) {
     if (!ES.IsYearMonth(this)) throw new TypeError('invalid receiver');
     if (!ES.IsYearMonth(other)) throw new TypeError('invalid YearMonth object');
-    largestUnit = ES.ToLargestTemporalUnit(largestUnit, ['days', 'hours', 'minutes', 'seconds']);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'years', ['days', 'hours', 'minutes', 'seconds']);
     const [one, two] = [this, other].sort(YearMonth.compare);
     let years = two.year - one.year;
     let months = two.month - one.month;
@@ -126,7 +126,7 @@ export class YearMonth {
     return new Date(year, month, day);
   }
   static from(arg, options) {
-    const disambiguation = ES.GetOption(options, 'disambiguation', ES.ToDisambiguation, 'constrain');
+    const disambiguation = ES.ToDisambiguation(options);
     let result = ES.ToYearMonth(arg, disambiguation);
     return this === YearMonth ? result : new this(
       GetSlot(result, YEAR),

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -297,18 +297,18 @@ describe('Absolute', () => {
     const feb21 = Absolute.from('2021-02-01T00:00Z');
     it('defaults to returning seconds', () => {
       equal(`${feb21.difference(feb20)}`, 'PT31622400S');
-      equal(`${feb21.difference(feb20, 'seconds')}`, 'PT31622400S');
+      equal(`${feb21.difference(feb20, { largestUnit: 'seconds' })}`, 'PT31622400S');
       equal(`${Absolute.from('2021-02-01T00:00:00.000000001Z').difference(feb20)}`, 'PT31622400.000000001S');
       equal(`${feb21.difference(Absolute.from('2020-02-01T00:00:00.000000001Z'))}`, 'PT31622399.999999999S');
     });
     it('can return minutes, hours, and days', () => {
-      equal(`${feb21.difference(feb20, 'hours')}`, 'PT8784H');
-      equal(`${feb21.difference(feb20, 'minutes')}`, 'PT527040M');
-      equal(`${feb21.difference(feb20, 'days')}`, 'P366D');
+      equal(`${feb21.difference(feb20, { largestUnit: 'hours' })}`, 'PT8784H');
+      equal(`${feb21.difference(feb20, { largestUnit: 'minutes' })}`, 'PT527040M');
+      equal(`${feb21.difference(feb20, { largestUnit: 'days' })}`, 'P366D');
     });
     it('cannot return months and years', () => {
-      throws(() => feb21.difference(feb20, 'months'), RangeError);
-      throws(() => feb21.difference(feb20, 'years'), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'months' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'years' }), RangeError);
     });
   });
   describe('Min/max range', () => {

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -122,7 +122,7 @@ describe('Date', () => {
     });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'xyz', 3, null].forEach((disambiguation) =>
-        throws(() => original.with({ day: 17 }, disambiguation), RangeError));
+        throws(() => original.with({ day: 17 }, { disambiguation }), RangeError));
     });
   });
   describe('Date.withTime() works', () => {
@@ -150,8 +150,8 @@ describe('Date', () => {
       equal(duration.microseconds, 0);
       equal(duration.nanoseconds, 0);
     });
-    it('date.difference({ year: 2019, month: 11, day: 18 }, "years")', () => {
-      const duration = date.difference(Date.from({ year: 2019, month: 11, day: 18 }), 'years');
+    it('date.difference({ year: 2019, month: 11, day: 18 }, { largestUnit: "years" })', () => {
+      const duration = date.difference(Date.from({ year: 2019, month: 11, day: 18 }), { largestUnit: 'years' });
       equal(duration.years, 43);
       equal(duration.months, 0);
       equal(duration.days, 0);
@@ -193,23 +193,23 @@ describe('Date', () => {
     const feb21 = Date.from('2021-02-01');
     it('defaults to returning days', () => {
       equal(`${feb21.difference(feb20)}`, 'P366D');
-      equal(`${feb21.difference(feb20, 'days')}`, 'P366D');
+      equal(`${feb21.difference(feb20, { largestUnit: 'days' })}`, 'P366D');
     });
     it('can return higher units', () => {
-      equal(`${feb21.difference(feb20, 'years')}`, 'P1Y');
-      equal(`${feb21.difference(feb20, 'months')}`, 'P12M');
+      equal(`${feb21.difference(feb20, { largestUnit: 'years' })}`, 'P1Y');
+      equal(`${feb21.difference(feb20, { largestUnit: 'months' })}`, 'P12M');
     });
     it('cannot return lower units', () => {
-      throws(() => feb21.difference(feb20, 'hours'), RangeError);
-      throws(() => feb21.difference(feb20, 'minutes'), RangeError);
-      throws(() => feb21.difference(feb20, 'seconds'), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'hours' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'minutes' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'seconds' }), RangeError);
     });
     it('does not include higher units than necessary', () => {
       const lastFeb20 = Date.from('2020-02-29');
       const lastFeb21 = Date.from('2021-02-28');
       equal(`${lastFeb21.difference(lastFeb20)}`, 'P365D');
-      equal(`${lastFeb21.difference(lastFeb20, 'months')}`, 'P11M30D');
-      equal(`${lastFeb21.difference(lastFeb20, 'years')}`, 'P11M30D');
+      equal(`${lastFeb21.difference(lastFeb20, { largestUnit: 'months' })}`, 'P11M30D');
+      equal(`${lastFeb21.difference(lastFeb20, { largestUnit: 'years' })}`, 'P11M30D');
     });
   });
   describe('date.plus() works', () => {
@@ -232,15 +232,15 @@ describe('Date', () => {
     it('constrain when ambiguous result', () => {
       const jan31 = Date.from('2020-01-31');
       equal(`${jan31.plus({ months: 1 })}`, '2020-02-29');
-      equal(`${jan31.plus({ months: 1 }, 'constrain')}`, '2020-02-29');
+      equal(`${jan31.plus({ months: 1 }, { disambiguation: 'constrain' })}`, '2020-02-29');
     });
     it('throw when ambiguous result with reject', () => {
       const jan31 = Date.from('2020-01-31');
-      throws(() => jan31.plus({ months: 1 }, 'reject'), RangeError);
+      throws(() => jan31.plus({ months: 1 }, { disambiguation: 'reject' }), RangeError);
     });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
-        throws(() => date.plus({ months: 1 }, disambiguation), RangeError));
+        throws(() => date.plus({ months: 1 }, { disambiguation }), RangeError));
     });
   });
   describe('date.minus() works', () => {
@@ -263,15 +263,15 @@ describe('Date', () => {
     it('constrain when ambiguous result', () => {
       const mar31 = Date.from('2020-03-31');
       equal(`${mar31.minus({ months: 1 })}`, '2020-02-29');
-      equal(`${mar31.minus({ months: 1 }, 'constrain')}`, '2020-02-29');
+      equal(`${mar31.minus({ months: 1 }, { disambiguation: 'constrain' })}`, '2020-02-29');
     });
     it('throw when ambiguous result with reject', () => {
       const mar31 = Date.from('2020-03-31');
-      throws(() => mar31.minus({ months: 1 }, 'reject'), RangeError);
+      throws(() => mar31.minus({ months: 1 }, { disambiguation: 'reject' }), RangeError);
     });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
-        throws(() => date.minus({ months: 1 }, disambiguation), RangeError));
+        throws(() => date.minus({ months: 1 }, { disambiguation }), RangeError));
     });
   });
   describe('date.toString() works', () => {

--- a/polyfill/test/datemath.mjs
+++ b/polyfill/test/datemath.mjs
@@ -70,11 +70,11 @@ function build(name, sone, stwo) {
 function buildSub(one, two, largestUnits) {
   largestUnits.forEach(largestUnit => {
     describe(`< ${one} : ${two} (${largestUnit})>`, () => {
-      const dif = two.difference(one, largestUnit);
+      const dif = two.difference(one, { largestUnit });
       it(`(${one}).plus(${dif}) => ${two}`, () =>
-        equal(`${one.plus(dif, 'reject')}`, `${two}`, `(${one}).plus(${dif}) => ${two}`));
+        equal(`${one.plus(dif, { disambiguation: 'reject' })}`, `${two}`, `(${one}).plus(${dif}) => ${two}`));
       it(`(${two}).minus(${dif}) => ${one}`, () =>
-        equal(`${two.minus(dif, 'reject')}`, `${one}`, `(${two}).minus(${dif}) => ${one}`));
+        equal(`${two.minus(dif, { disambiguation: 'reject' })}`, `${one}`, `(${two}).minus(${dif}) => ${one}`));
     });
   });
 }

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -247,7 +247,7 @@ describe('DateTime', () => {
     });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'xyz', 3, null].forEach((disambiguation) =>
-        throws(() => datetime.with({ day: 5 }, disambiguation), RangeError));
+        throws(() => datetime.with({ day: 5 }, { disambiguation }), RangeError));
     });
   });
   describe('DateTime.compare() works', () => {
@@ -268,10 +268,10 @@ describe('DateTime', () => {
   describe('date/time maths', () => {
     const earlier = DateTime.from('1976-11-18T15:23:30.123456789');
     const later = DateTime.from('2019-10-29T10:46:38.271986102');
-    ['years', 'months', 'days', 'hours', 'minutes', 'seconds'].forEach(largest => {
-      const diff = earlier.difference(later, largest);
-      it(`(${earlier}).difference(${later}, ${largest}) == (${later}).difference(${earlier}, ${largest})`, () =>
-        equal(`${later.difference(earlier, largest)}`, `${diff}`));
+    ['years', 'months', 'days', 'hours', 'minutes', 'seconds'].forEach((largestUnit) => {
+      const diff = earlier.difference(later, { largestUnit });
+      it(`(${earlier}).difference(${later}, ${largestUnit}) == (${later}).difference(${earlier}, ${largestUnit})`, () =>
+        equal(`${later.difference(earlier, { largestUnit })}`, `${diff}`));
       it(`(${earlier}).plus(${diff}) == (${later})`, () => equal(`${earlier.plus(diff)}`, `${later}`));
       it(`(${later}).minus(${diff}) == (${earlier})`, () => equal(`${later.minus(diff)}`, `${earlier}`));
     })
@@ -285,30 +285,30 @@ describe('DateTime', () => {
     it('constrain when ambiguous result', () => {
       const jan31 = DateTime.from('2020-01-31T15:00');
       equal(`${jan31.plus({ months: 1 })}`, '2020-02-29T15:00');
-      equal(`${jan31.plus({ months: 1 }, 'constrain')}`, '2020-02-29T15:00');
+      equal(`${jan31.plus({ months: 1 }, { disambiguation: 'constrain' })}`, '2020-02-29T15:00');
     });
     it('throw when ambiguous result with reject', () => {
       const jan31 = DateTime.from('2020-01-31T15:00:00');
-      throws(() => jan31.plus({ months: 1 }, 'reject'), RangeError);
+      throws(() => jan31.plus({ months: 1 }, { disambiguation: 'reject' }), RangeError);
     });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
-        throws(() => DateTime.from('2019-11-18T15:00').plus({ months: 1 }, disambiguation), RangeError));
+        throws(() => DateTime.from('2019-11-18T15:00').plus({ months: 1 }, { disambiguation }), RangeError));
     });
   });
   describe('date.minus() works', () => {
     it('constrain when ambiguous result', () => {
       const mar31 = DateTime.from('2020-03-31T15:00');
       equal(`${mar31.minus({ months: 1 })}`, '2020-02-29T15:00');
-      equal(`${mar31.minus({ months: 1 }, 'constrain')}`, '2020-02-29T15:00');
+      equal(`${mar31.minus({ months: 1 }, { disambiguation: 'constrain' })}`, '2020-02-29T15:00');
     });
     it('throw when ambiguous result with reject', () => {
       const mar31 = DateTime.from('2020-03-31T15:00');
-      throws(() => mar31.minus({ months: 1 }, 'reject'), RangeError);
+      throws(() => mar31.minus({ months: 1 }, { disambiguation: 'reject' }), RangeError);
     });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
-        throws(() => DateTime.from('2019-11-18T15:00').minus({ months: 1 }, disambiguation), RangeError));
+        throws(() => DateTime.from('2019-11-18T15:00').minus({ months: 1 }, { disambiguation }), RangeError));
     });
   });
   describe('DateTime.difference()', () => {
@@ -321,23 +321,23 @@ describe('DateTime', () => {
     const feb21 = DateTime.from('2021-02-01T00:00');
     it('defaults to returning days', () => {
       equal(`${feb21.difference(feb20)}`, 'P366D');
-      equal(`${feb21.difference(feb20, 'days')}`, 'P366D');
+      equal(`${feb21.difference(feb20, { largestUnit: 'days' })}`, 'P366D');
       equal(`${DateTime.from('2021-02-01T00:00:00.000000001').difference(feb20)}`, 'P366DT0.000000001S');
       equal(`${feb21.difference(DateTime.from('2020-02-01T00:00:00.000000001'))}`, 'P365DT23H59M59.999999999S');
     });
     it('can return lower or higher units', () => {
-      equal(`${feb21.difference(feb20, 'years')}`, 'P1Y');
-      equal(`${feb21.difference(feb20, 'months')}`, 'P12M');
-      equal(`${feb21.difference(feb20, 'hours')}`, 'PT8784H');
-      equal(`${feb21.difference(feb20, 'minutes')}`, 'PT527040M');
-      equal(`${feb21.difference(feb20, 'seconds')}`, 'PT31622400S');
+      equal(`${feb21.difference(feb20, { largestUnit: 'years' })}`, 'P1Y');
+      equal(`${feb21.difference(feb20, { largestUnit: 'months' })}`, 'P12M');
+      equal(`${feb21.difference(feb20, { largestUnit: 'hours' })}`, 'PT8784H');
+      equal(`${feb21.difference(feb20, { largestUnit: 'minutes' })}`, 'PT527040M');
+      equal(`${feb21.difference(feb20, { largestUnit: 'seconds' })}`, 'PT31622400S');
     });
     it('does not include higher units than necessary', () => {
       const lastFeb20 = DateTime.from('2020-02-29T00:00');
       const lastFeb21 = DateTime.from('2021-02-28T00:00');
       equal(`${lastFeb21.difference(lastFeb20)}`, 'P365D');
-      equal(`${lastFeb21.difference(lastFeb20, 'months')}`, 'P11M30D');
-      equal(`${lastFeb21.difference(lastFeb20, 'years')}`, 'P11M30D');
+      equal(`${lastFeb21.difference(lastFeb20, { largestUnit: 'months' })}`, 'P11M30D');
+      equal(`${lastFeb21.difference(lastFeb20, { largestUnit: 'years' })}`, 'P11M30D');
     });
   });
   describe('DateTime.from() works', () => {
@@ -401,7 +401,7 @@ describe('DateTime', () => {
     });
     it('throws on bad disambiguation', () => {
       ['', 'EARLIER', 'xyz', 3, null].forEach((disambiguation) =>
-        throws(() => DateTime.from('2019-10-29T10:46').inTimeZone('UTC', disambiguation), RangeError));
+        throws(() => DateTime.from('2019-10-29T10:46').inTimeZone('UTC', { disambiguation }), RangeError));
     });
   });
   describe('Min/max range', () => {
@@ -459,8 +459,8 @@ describe('DateTime', () => {
       const max = DateTime.from('+275760-09-13T23:59:59.999999999');
       equal(`${min.minus({nanoseconds: 1})}`, '-271821-04-19T00:00:00.000000001');
       equal(`${max.plus({nanoseconds: 1})}`, '+275760-09-13T23:59:59.999999999');
-      throws(() => min.minus({nanoseconds: 1}, 'reject'), RangeError);
-      throws(() => max.plus({nanoseconds: 1}, 'reject'), RangeError);
+      throws(() => min.minus({nanoseconds: 1}, { disambiguation: 'reject' }), RangeError);
+      throws(() => max.plus({nanoseconds: 1}, { disambiguation: 'reject' }), RangeError);
     });
   });
 });

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -93,7 +93,7 @@ describe('MonthDay', () => {
   describe('MonthDay.with()', () => {
     it('throws on bad disambiguation', () => {
       ['', 'CONSTRAIN', 'xyz', 3, null].forEach((disambiguation) =>
-        throws(() => MonthDay.from('01-15').with({ day: 1 }, disambiguation), RangeError));
+        throws(() => MonthDay.from('01-15').with({ day: 1 }, { disambiguation }), RangeError));
     });
   });
 });

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -183,7 +183,7 @@ describe('Time', () => {
       });
       it('invalid disambiguation', () => {
         ['', 'CONSTRAIN', 'xyz', 3, null].forEach((disambiguation) =>
-          throws(() => time.with({ hour: 3 }, disambiguation), RangeError));
+          throws(() => time.with({ hour: 3 }, { disambiguation }), RangeError));
       });
     });
   describe('time.withDate() works', () => {
@@ -280,16 +280,16 @@ describe('Time', () => {
       const time2 = Time.from('17:15:57');
       it('the default largest unit is at least hours', () => {
         equal(`${time1.difference(time2)}`, 'PT6H52M42S');
-        equal(`${time1.difference(time2, 'hours')}`, 'PT6H52M42S');
+        equal(`${time1.difference(time2, { largestUnit: 'hours' })}`, 'PT6H52M42S');
       });
       it('higher units have no effect', () => {
-        equal(`${time1.difference(time2, 'days')}`, 'PT6H52M42S');
-        equal(`${time1.difference(time2, 'months')}`, 'PT6H52M42S');
-        equal(`${time1.difference(time2, 'years')}`, 'PT6H52M42S');
+        equal(`${time1.difference(time2, { largestUnit: 'days' })}`, 'PT6H52M42S');
+        equal(`${time1.difference(time2, { largestUnit: 'months' })}`, 'PT6H52M42S');
+        equal(`${time1.difference(time2, { largestUnit: 'years' })}`, 'PT6H52M42S');
       });
       it('can return lower units', () => {
-        equal(`${time1.difference(time2, 'minutes')}`, 'PT412M42S');
-        equal(`${time1.difference(time2, 'seconds')}`, 'PT24762S');
+        equal(`${time1.difference(time2, { largestUnit: 'minutes' })}`, 'PT412M42S');
+        equal(`${time1.difference(time2, { largestUnit: 'seconds' })}`, 'PT24762S');
       });
     });
     describe('Time.compare() works', () => {
@@ -323,7 +323,7 @@ describe('Time', () => {
       });
       it('invalid disambiguation', () => {
         ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
-          throws(() => time.plus({ hours: 1 }, disambiguation), RangeError));
+          throws(() => time.plus({ hours: 1 }, { disambiguation }), RangeError));
       });
     });
     describe('time.minus() works', () => {
@@ -339,7 +339,7 @@ describe('Time', () => {
       });
       it('invalid disambiguation', () => {
         ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
-          throws(() => time.minus({ hours: 1 }, disambiguation), RangeError));
+          throws(() => time.minus({ hours: 1 }, { disambiguation }), RangeError));
       });
     });
     describe('time.toString() works', () => {

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -140,16 +140,16 @@ describe('TimeZone', ()=>{
         it('clock moving forward', () => {
             const zone = new Temporal.TimeZone('Europe/Berlin');
             const dtm = new Temporal.DateTime(2019, 3, 31, 2, 45);
-            equal(`${zone.getAbsoluteFor(dtm, 'earlier')}`, '2019-03-31T00:45Z');
-            equal(`${zone.getAbsoluteFor(dtm, 'later')}`, '2019-03-31T01:45Z');
-            throws(() => zone.getAbsoluteFor(dtm, 'reject'), RangeError);
+            equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'earlier' })}`, '2019-03-31T00:45Z');
+            equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'later' })}`, '2019-03-31T01:45Z');
+            throws(() => zone.getAbsoluteFor(dtm, { disambiguation: 'reject' }), RangeError);
         });
         it('clock moving backward', () => {
             const zone = new Temporal.TimeZone('America/Sao_Paulo');
             const dtm = new Temporal.DateTime(2019, 2, 16, 23, 45);
-            equal(`${zone.getAbsoluteFor(dtm, 'earlier')}`, '2019-02-17T01:45Z');
-            equal(`${zone.getAbsoluteFor(dtm, 'later')}`, '2019-02-17T02:45Z');
-            throws(() => zone.getAbsoluteFor(dtm, 'reject'), RangeError);
+            equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'earlier' })}`, '2019-02-17T01:45Z');
+            equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'later' })}`, '2019-02-17T02:45Z');
+            throws(() => zone.getAbsoluteFor(dtm, { disambiguation: 'reject' }), RangeError);
         });
     });
     describe('Casting', () => {
@@ -189,12 +189,12 @@ describe('TimeZone', ()=>{
         const dtm = new Temporal.DateTime(2019, 2, 16, 23, 45);
         it("getAbsoluteFor() disambiguation", () => {
             for (const disambiguation of [undefined, 'earlier', 'later', 'reject']) {
-                assert(zone.getAbsoluteFor(dtm, disambiguation) instanceof Temporal.Absolute);
+                assert(zone.getAbsoluteFor(dtm, { disambiguation }) instanceof Temporal.Absolute);
             }
         });
         it('throws on bad disambiguation', () => {
             ['', 'EARLIER', 'test', 3, null].forEach((disambiguation) =>
-                throws(() => zone.getAbsoluteFor(dtm, disambiguation), RangeError));
+                throws(() => zone.getAbsoluteFor(dtm, { disambiguation }), RangeError));
         });
     });
 });

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -109,16 +109,16 @@ describe('YearMonth', () => {
     const feb21 = YearMonth.from('2021-02');
     it('defaults to returning years', () => {
       equal(`${feb21.difference(feb20)}`, 'P1Y');
-      equal(`${feb21.difference(feb20, 'years')}`, 'P1Y');
+      equal(`${feb21.difference(feb20, { largestUnit: 'years' })}`, 'P1Y');
     });
     it('can return months', () => {
-      equal(`${feb21.difference(feb20, 'months')}`, 'P12M');
+      equal(`${feb21.difference(feb20, { largestUnit: 'months' })}`, 'P12M');
     });
     it('cannot return lower units', () => {
-      throws(() => feb21.difference(feb20, 'days'), RangeError);
-      throws(() => feb21.difference(feb20, 'hours'), RangeError);
-      throws(() => feb21.difference(feb20, 'minutes'), RangeError);
-      throws(() => feb21.difference(feb20, 'seconds'), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'days' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'hours' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'minutes' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'seconds' }), RangeError);
     });
   });
   describe('YearMonth.plus() works', () => {
@@ -132,7 +132,7 @@ describe('YearMonth', () => {
     });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
-        throws(() => ym.plus({ months: 1 }, disambiguation), RangeError));
+        throws(() => ym.plus({ months: 1 }, { disambiguation }), RangeError));
     });
   });
   describe('YearMonth.minus() works', () => {
@@ -146,7 +146,7 @@ describe('YearMonth', () => {
     });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
-        throws(() => ym.minus({ months: 1 }, disambiguation), RangeError));
+        throws(() => ym.minus({ months: 1 }, { disambiguation }), RangeError));
     });
   });
   describe('Min/max range', () => {
@@ -191,14 +191,14 @@ describe('YearMonth', () => {
       const max = YearMonth.from('+275760-09');
       equal(`${min.minus({months: 1})}`, '-271821-04');
       equal(`${max.plus({months: 1})}`, '+275760-09');
-      throws(() => min.minus({months: 1}, 'reject'), RangeError);
-      throws(() => max.plus({months: 1}, 'reject'), RangeError);
+      throws(() => min.minus({months: 1}, { disambiguation: 'reject' }), RangeError);
+      throws(() => max.plus({months: 1}, { disambiguation: 'reject' }), RangeError);
     });
   });
   describe('YearMonth.with()', () => {
     it('throws on bad disambiguation', () => {
       ['', 'CONSTRAIN', 'xyz', 3, null].forEach((disambiguation) =>
-        throws(() => YearMonth.from(2019, 1).with({ month: 2 }, disambiguation), RangeError));
+        throws(() => YearMonth.from(2019, 1).with({ month: 2 }, { disambiguation }), RangeError));
     })
   });
 });

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -246,16 +246,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.absolute.prototype.difference">
-      <h1>Temporal.Absolute.prototype.difference ( _otherAbsolute_ [, _largestUnit_ ] )</h1>
+      <h1>Temporal.Absolute.prototype.difference ( _otherAbsolute_ [, _options_ ] )</h1>
       <p>
-        The `difference` method takes two arguments, _otherAbsolute_ and _largestUnit_.
+        The `difference` method takes two arguments, _otherAbsolute_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _absolute_ be the *this* value.
         1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
         1. Perform ? RequireInternalSlot(_otherAbsolute_, [[InitializedTemporalAbsolute]]).
-        1. Set _largestUnit_ to ? ToLargestTemporalUnit(_largestUnit_, « `"years"`, `"months"` », `"seconds"`).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"* », *"seconds"*).
         1. If ! AbsoluteCompare(_absolute_, _otherAbsolute_) &lt; 0, then
           1. Let _greater_ be _otherAbsolute_.
           1. Let _smaller_ be _absolute_.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -27,38 +27,23 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-todisambiguation" aoid="ToDisambiguation">
-    <h1>ToDisambiguation ( _disambiguation_ )</h1>
+    <h1>ToDisambiguation ( _options_ )</h1>
     <emu-alg>
-      1. If _disambiguation_ is *undefined*, then
-        1. Return `"constrain"`.
-      1. Set _disambiguation_ to ? ToString(_disambiguation_).
-      1. If _disambiguation_ is not one of `"constrain"`, `"balance"`, or `"reject"`, then
-        1. Throw a *RangeError* exception.
-      1. Return _disambiguation_.
+      1. Return ? GetOption(_options_, *"disambiguation"*, « *"constrain"*, *"balance"*, *"reject"* », *"constrain"*).
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-toarithmeticdisambiguation" aoid="ToArithmeticDisambiguation">
-    <h1>ToArithmeticDisambiguation ( _disambiguation_ )</h1>
+    <h1>ToArithmeticDisambiguation ( _options_ )</h1>
     <emu-alg>
-      1. If _disambiguation_ is *undefined*, then
-        1. Return `"constrain"`.
-      1. Set _disambiguation_ to ? ToString(_disambiguation_).
-      1. If _disambiguation_ is not one of `"constrain"` or `"reject"`, then
-        1. Throw a *RangeError* exception.
-      1. Return _disambiguation_.
+      1. Return ? GetOption(_options_, *"disambiguation"*, « *"constrain"*, *"reject"* », *"constrain"*).
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-totimezonedisambiguation" aoid="ToTimeZoneDisambiguation">
-    <h1>ToTimeZoneDisambiguation ( _disambiguation_ )</h1>
+    <h1>ToTimeZoneDisambiguation ( _options_ )</h1>
     <emu-alg>
-      1. If _disambiguation_ is *undefined*, then
-        1. Return `"earlier"`.
-      1. Set _disambiguation_ to ? ToString(_disambiguation_).
-      1. If _disambiguation_ is not one of `"earlier"`, `"later"`, or `"reject"`, then
-        1. Throw a *RangeError* exception.
-      1. Return _disambiguation_.
+      1. Return ? GetOption(_options_, *"disambiguation"*, « *"earlier"*, *"later"*, *"reject"* », *"earlier"*).
     </emu-alg>
   </emu-clause>
 
@@ -66,12 +51,8 @@
     <h1>ToLargestTemporalUnit ( _largestUnit_, _disallowedUnits_, _defaultUnit_ )</h1>
     <emu-alg>
       1. Assert: _disallowedUnits_ does not contain _defaultUnit_.
-      1. If _largestUnit_ is *undefined*, then
-        1. Return _defaultUnit_.
-      1. Set _largestUnit_ to ? ToString(_largestUnit_).
+      1. Let _largestUnit_ be GetOption(_options_, *"largestUnit"*, « *"years"*, *"months"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"* », _defaultUnit_).
       1. If _disallowedUnits_ contains _largestUnit_, then
-        1. Throw a *RangeError* exception.
-      1. If _largestUnit_ is not one of `"years"`, `"months"`, `"days"`, `"hours"`, `"minutes"`, or `"seconds"`, then
         1. Throw a *RangeError* exception.
       1. Return _largestUnit_.
     </emu-alg>

--- a/spec/date.html
+++ b/spec/date.html
@@ -50,7 +50,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _disambiguation_ be ? GetOption(_options_, *"disambiguation"*, « *"constrain"*, *"balance"*, *"reject"* », *"constrain"*).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If Type(_arg_) is Object, then
           1. Return ? ToDate(_arg_, _disambiguation_).
         1. Let _string_ be ? ToString(_arg_).
@@ -240,48 +240,48 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.date.prototype.plus">
-      <h1>Temporal.Date.prototype.plus ( _duration_, _disambiguation_ )</h1>
+      <h1>Temporal.Date.prototype.plus ( _duration_ [ , _options_ ] )</h1>
       <p>
-        The `plus` method takes two arguments, _duration_ and _disambiguation_.
+        The `plus` method takes two arguments, _duration_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _date_ be the *this* value.
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* »).
-        1. Set _disambiguation_ to ? ToArithmeticDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToArithmeticDisambiguation(_options_).
         1. Let _result_ be ? AddDate(_date_.[[Year]], _date_.[[Month]], _date_.[[Day]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Days]], _disambiguation_).
         1. Return ? CreateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal.date.prototype.minus">
-      <h1>Temporal.Date.prototype.minus ( _duration_, _disambiguation_ )</h1>
+      <h1>Temporal.Date.prototype.minus ( _duration_ [ , _options_ ] )</h1>
       <p>
-        The `minus` method takes two arguments, _duration_ and _disambiguation_.
+        The `minus` method takes two arguments, _duration_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _date_ be the *this* value.
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* »).
-        1. Set _disambiguation_ to ? ToArithmeticDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToArithmeticDisambiguation(_options_).
         1. Let _result_ be ? SubtractDate(_date_.[[Year]], _date_.[[Month]], _date_.[[Day]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Days]], _disambiguation_).
         1. Return ? CreateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal.date.prototype.with">
-      <h1>Temporal.Date.prototype.with ( _otherDate_, _disambiguation_ )</h1>
+      <h1>Temporal.Date.prototype.with ( _otherDate_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _otherDate_ and _disambiguation_.
+        The `with` method takes two arguments, _otherDate_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _date_ be the *this* value.
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Let _otherDate_ be ? ToPartialDate(_otherDate_).
-        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If _otherDate_.[[Year]] is not *undefined*, then
           1. Let _y_ be _otherDate_.[[Year]].
         1. Else
@@ -300,16 +300,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.date.prototype.difference">
-      <h1>Temporal.Date.prototype.difference ( _otherDate_, [ _largestUnit_ ] )</h1>
+      <h1>Temporal.Date.prototype.difference ( _otherDate_ [ , _options_ ] )</h1>
       <p>
-        The `difference` method takes two arguments, _otherDate_ and _largestUnit_.
+        The `difference` method takes two arguments, _otherDate_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _date_ be the *this* value.
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Perform ? RequireInternalSlot(_otherDate_, [[InitializedTemporalDate]]).
-        1. Set _largestUnitInResult_ to ? ToLargestTemporalUnit(_largestUnitInResult_, « `"hours"`, `"minutes"`, `"seconds"` », `"days"`).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"* », *"days"*).
         1. If ! DateCompare(_date_, _otherDate_) &lt; 0, then
           1. Let _greater_ be _otherDate_.
           1. Let _smaller_ be _date_.

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -58,7 +58,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _disambiguation_ be ? GetOption(_options_, *"disambiguation"*, « *"constrain"*, *"balance"*, *"reject"* », *"constrain"*).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If Type(_arg_) is Object, then
           1. Return ? ToDateTime(_arg_, _disambiguation_).
         1. Let _string_ be ? ToString(_arg_).
@@ -302,16 +302,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.datetime.prototype.with">
-      <h1>Temporal.DateTime.prototype.with ( _dateTimeLike_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.DateTime.prototype.with ( _dateTimeLike_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _dateTimeLike_ and _disambiguation_.
+        The `with` method takes two arguments, _dateTimeLike_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _dateTimeLike_ be ? ToPartialDateTime(_dateTimeLike_).
-        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If _dateTimeLike_.[[Year]] is not *undefined*, then
           1. Let _year_ be _dateTimeLike_.[[Year]].
         1. Else
@@ -354,16 +354,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.datetime.prototype.plus">
-      <h1>Temporal.DateTime.prototype.plus ( _duration_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.DateTime.prototype.plus ( _duration_ [ , _options_ ] )</h1>
       <p>
-        The `plus` method takes two arguments, _duration_ and _disambiguation_.
+        The `plus` method takes two arguments, _duration_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « »).
-        1. Set _disambiguation_ to ? ToArithmeticDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToArithmeticDisambiguation(_options_).
         1. Let _timePart_ be ? AddTime(_dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _datePart_ be ? AddDate(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Days]], _disambiguation_).
         1. Let _datePart_ be ! BalanceDate(_datePart_.[[Year]], _datePart_.[[Month]], _datePart_.[[Day]] + _timePart_.[[Day]]).
@@ -373,16 +373,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.datetime.prototype.minus">
-      <h1>Temporal.DateTime.prototype.minus ( _duration_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.DateTime.prototype.minus ( _duration_ [ , _options_ ] )</h1>
       <p>
-        The `minus` method takes two arguments, _duration_ and _disambiguation_.
+        The `minus` method takes two arguments, _duration_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « »).
-        1. Set _disambiguation_ to ? ToArithmeticDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToArithmeticDisambiguation(_options_).
         1. Let _timePart_ be ? SubtractTime(_dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _datePart_ be ? SubtractDate(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Days]] - _timePart_.[[Day]], _disambiguation_).
         1. Let _result_ be ? RegulateDateTime(_datePart_.[[Year]], _datePart_.[[Month]], _datePart_.[[Day]], _timePart_.[[Hour]], _timePart_.[[Minute]], _timePart_.[[Second]], _timePart_.[[Millisecond]], _timePart_.[[Microsecond]], _timePart_.[[Nanosecond]], _disambiguation_).
@@ -391,16 +391,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.datetime.prototype.difference">
-      <h1>Temporal.DateTime.prototype.difference ( _otherDateTime_, [ _largestUnit_ ] )</h1>
+      <h1>Temporal.DateTime.prototype.difference ( _otherDateTime_ [ , _options_ ] )</h1>
       <p>
-        The `difference` method takes two arguments, _otherDateTime_ and _largestUnit_.
+        The `difference` method takes two arguments, _otherDateTime_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Perform ? RequireInternalSlot(_otherDateTime_, [[InitializedTemporalDateTime]]).
-        1. Set _largestUnit_ to ? ToLargestTemporalUnit(_largestUnit_, « », `"days"`).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"days"*).
         1. If ! DateTimeCompare(_dateTime_, _otherDateTime_) &lt; 0, then
           1. Let _greater_ be _otherDateTime_.
           1. Let _smaller_ be _dateTime_.
@@ -468,9 +468,9 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.datetime.prototype.intimezone">
-      <h1>Temporal.DateTime.prototype.inTimeZone ( [ _timeZoneParam_ [ , _disambiguation_ ] ] )</h1>
+      <h1>Temporal.DateTime.prototype.inTimeZone ( [ _timeZoneParam_ [ , _options_ ] ] )</h1>
       <p>
-        The `inTimeZone` method takes two arguments, _timeZoneParam_ and _disambiguation_.
+        The `inTimeZone` method takes two arguments, _timeZoneParam_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
@@ -479,7 +479,7 @@
         1. If _timeZoneParam_ is *undefined*, then
           1. Set _timeZoneParam_ to `"UTC"`.
         1. Let _timeZone_ be ? ToTimeZone(_timeZoneParam_).
-        1. Set _disambiguation_ to ? ToTimeZoneDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToTimeZoneDisambiguation(_options_).
         1. Return ? GetAbsoluteFor(_timeZone_, _dateTime_, _disambiguation_).
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -141,7 +141,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _disambiguation_ be ? GetOption(_options_, *"disambiguation"*, « *"constrain"*, *"balance"*, *"reject"* », *"constrain"*).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If Type(_arg_) is Object, then
           1. Return ? ToDuration(_arg_, _disambiguation_).
         1. If Type(_arg_) is String, then

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -50,7 +50,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _disambiguation_ be ? GetOption(_options_, *"disambiguation"*, « *"constrain"*, *"balance"*, *"reject"* », *"constrain"*).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If Type(_arg_) is Object, then
           1. Return ? ToMonthDay(_arg_, _disambiguation_).
         1. Let _string_ be ? ToString(_arg_).
@@ -125,16 +125,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.monthday.prototype.with">
-      <h1>Temporal.MonthDay.prototype.with ( _otherMonthDay_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.MonthDay.prototype.with ( _otherMonthDay_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _otherMonthDay_ and _disambiguation_.
+        The `with` method takes two arguments, _otherMonthDay_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Let _otherMonthDay_ be ? ToPartialMonthDay(_otherMonthDay_).
-        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If _otherMonthDay_.[[Month]] is not *undefined*, then
           1. Let _m_ be _otherMonthDay_.[[Month]].
         1. Else

--- a/spec/time.html
+++ b/spec/time.html
@@ -57,7 +57,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _disambiguation_ be ? GetOption(_options_, *"disambiguation"*, « *"constrain"*, *"balance"*, *"reject"* », *"constrain"*).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If Type(_arg_) is Object, then
           1. Return ? ToTime(_arg_, _disambiguation_).
         1. Let _string_ be ? ToString(_arg_).
@@ -184,16 +184,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.time.prototype.plus">
-      <h1>Temporal.Time.prototype.plus ( _duration_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.Time.prototype.plus ( _duration_ [ , _options_ ] )</h1>
       <p>
-        The `plus` method takes two arguments, _duration_ and _disambiguation_.
+        The `plus` method takes two arguments, _duration_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _time_ be the *this* value.
         1. Perform ? RequireInternalSlot(_time_, [[InitializedTemporalTime]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"years"*, *"months"*, *"days"* »).
-        1. Perform ? ToArithmeticDisambiguation(_disambiguation_).
+        1. Perform ? ToArithmeticDisambiguation(_options_).
         1. Let _result_ be ! AddTime(_time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _result_ be ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. Return ? CreateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
@@ -201,16 +201,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.time.prototype.minus">
-      <h1>Temporal.Time.prototype.minus ( _duration_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.Time.prototype.minus ( _duration_ [ , _options_ ] )</h1>
       <p>
-        The `minus` method takes two arguments, _duration_ and _disambiguation_.
+        The `minus` method takes two arguments, _duration_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _time_ be the *this* value.
         1. Perform ? RequireInternalSlot(_time_, [[InitializedTemporalTime]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"years"*, *"months"*, *"days"* »).
-        1. Perform ? ToArithmeticDisambiguation(_disambiguation_).
+        1. Perform ? ToArithmeticDisambiguation(_options_).
         1. Let _hour_ be _time_.[[Hour]] - _duration_.[[Hour]].
         1. Let _minute_ be _time_.[[Minute]] - _duration_.[[Minute]].
         1. Let _second_ be _time_.[[Second]] - _duration_.[[Second]].
@@ -223,16 +223,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.time.prototype.with">
-      <h1>Temporal.Time.prototype.with ( _timelike_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.Time.prototype.with ( _timelike_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _timelike_ and _disambiguation_.
+        The `with` method takes two arguments, _timelike_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _time_ be the *this* value.
         1. Perform ? RequireInternalSlot(_time_, [[InitializedTemporalTime]]).
         1. Let _timelike_ be ? ToPartialTime(_timelike_).
-        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If _timelike_.[[Hour]] is not *undefined*, then
           1. Let _hour_ be _timelike_.[[Hour]].
         1. Else
@@ -263,16 +263,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.time.prototype.difference">
-      <h1>Temporal.Time.prototype.difference ( _otherTime_ [, _largestUnit_ ] )</h1>
+      <h1>Temporal.Time.prototype.difference ( _otherTime_ [ , _options_ ] )</h1>
       <p>
-        The `difference` method takes two arguments, _otherTime_ and _largestUnit_.
+        The `difference` method takes two arguments, _otherTime_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _time_ be the *this* value.
         1. Perform ? RequireInternalSlot(_time_, [[InitializedTemporalTime]]).
         1. Perform ? RequireInternalSlot(_otherTime_, [[InitializedTemporalTime]]).
-        1. Set _largestUnit_ to ? ToLargestTemporalUnit(_largestUnit_, « », `"hours"`).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"hours"*).
         1. If ! TimeCompare(_time_, _otherTime_) &lt; 0, then
           1. Let _greater_ be _otherTime_.
           1. Let _smaller_ be _time_.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -134,15 +134,15 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.timezone.prototype.getabsolutefor">
-      <h1>Temporal.TimeZone.prototype.getAbsoluteFor ( _dateTime_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.TimeZone.prototype.getAbsoluteFor ( _dateTime_ [ , _options_ ] )</h1>
       <p>
-        The `getAbsoluteFor` method takes two arguments, _dateTime_ and _disambiguation_.
+        The `getAbsoluteFor` method takes two arguments, _dateTime_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. Set _disambiguation_ to ? ToTimeZoneDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToTimeZoneDisambiguation(_options_).
         1. <mark>TODO</mark>
       </emu-alg>
     </emu-clause>

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -50,7 +50,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _disambiguation_ be ? GetOption(_options_, *"disambiguation"*, « *"constrain"*, *"balance"*, *"reject"* », *"constrain"*).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If Type(_arg_) is Object, then
           1. Return ? ToYearMonth(_arg_, _disambiguation_).
         1. Let _string_ be ? ToString(_arg_).
@@ -164,16 +164,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.yearmonth.prototype.with">
-      <h1>Temporal.YearMonth.prototype.with ( _otherYearMonth_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.YearMonth.prototype.with ( _otherYearMonth_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _otherYearMonth_ and _disambiguation_.
+        The `with` method takes two arguments, _otherYearMonth_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _otherYearMonth_ be ? ToPartialYearMonth(_otherYearMonth_).
-        1. Set _disambiguation_ to ? ToDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToDisambiguation(_options_).
         1. If _otherYearMonth_.[[Year]] is not *undefined*, then
           1. Let _y_ be _otherYearMonth_.[[Year]].
         1. Else
@@ -188,16 +188,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.yearmonth.prototype.plus">
-      <h1>Temporal.YearMonth.prototype.plus ( _duration_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.YearMonth.prototype.plus ( _duration_ [ , _options_ ] )</h1>
       <p>
-        The `plus` method takes two arguments, _duration_ and _disambiguation_.
+        The `plus` method takes two arguments, _duration_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* »).
-        1. Set _disambiguation_ to ? ToArithmeticDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToArithmeticDisambiguation(_options_).
         1. Let _y_ be _yearMonth_.[[Year]] + _duration_.[[Years]].
         1. Let _m_ be _yearMonth_.[[Month]] + _duration_.[[Months]].
         1. Let _result_ be ? RegulateYearMonth(_y_, _m_, _disambiguation_).
@@ -206,16 +206,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.yearmonth.prototype.minus">
-      <h1>Temporal.YearMonth.prototype.minus ( _duration_ [ , _disambiguation_ ] )</h1>
+      <h1>Temporal.YearMonth.prototype.minus ( _duration_ [ , _options_ ] )</h1>
       <p>
-        The `minus` method takes two arguments, _duration_ and _disambiguation_.
+        The `minus` method takes two arguments, _duration_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _duration_ be ? ToLimitedDuration(_duration_, « *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* »).
-        1. Set _disambiguation_ to ? ToArithmeticDisambiguation(_disambiguation_).
+        1. Let _disambiguation_ be ? ToArithmeticDisambiguation(_options_).
         1. Let _y_ be _yearMonth_.[[Year]] - _duration_.[[Years]].
         1. Let _m_ be _yearMonth_.[[Month]] - _duration_.[[Months]].
         1. Let _result_ be ? RegulateYearMonth(_y_, _m_, _disambiguation_).
@@ -224,16 +224,16 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.yearmonth.prototype.difference">
-      <h1>Temporal.YearMonth.prototype.difference ( _otherYearMonth_ [, _largestUnit_ ]. )</h1>
+      <h1>Temporal.YearMonth.prototype.difference ( _otherYearMonth_ [, _options_ ]. )</h1>
       <p>
-        The `difference` method takes two arguments, _otherYearMonth_ and _largestUnit_.
+        The `difference` method takes two arguments, _otherYearMonth_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Perform ? RequireInternalSlot(_otherYearMonth_, [[InitializedTemporalYearMonth]]).
-        1. Set _largestUnit_ to ? ToLargestTemporalUnit(_largestUnit_, « `"days"`, `"hours"`, `"minutes"`, `"seconds"` », `"years"`).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"days"*, *"hours"*, *"minutes"*, *"seconds"* », *"years"*).
         1. If ! YearMonthCompare(_yearMonth_, _otherYearMonth_) &lt; 0, then
           1. Let _greater_ be _otherYearMonth_.
           1. Let _smaller_ be _yearMonth_.


### PR DESCRIPTION
Instead of plain 'disambiguation' and 'largestUnit' arguments, use
options bags for better readability and future-proofing.

Closes: #359