### PR TITLE
Test262 coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 polyfill/index.js
 polyfill/index.js.map
 polyfill/script.js
+polyfill/script.js.map
 polyfill/test262/
 out/
 .vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ matrix:
     - npm run lint
   - name: "Polyfill tests"
     script:
-    - npm run codecov
+    - npm run codecov:tests
   - name: "test262 tests"
     script:
-    - npm run test262
+    - npm run codecov:test262
   - name: "cookbook"
     script:
     - npm run cookbook

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        flags:
+          - tests
+          - test262
+      tests:
+        flags:
+          - tests
+      test262:
+        flags:
+          - test262
+    patch:
+      default:
+        flags:
+          - tests
+          - test262

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,12 +26,12 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
+    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-node-resolve": "^7.1.1",
     "marked": "^0.7.0",
     "rollup": "^1.23.1",
     "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-builtins": "^2.1.2",
-    "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-uglify": "^6.0.4"
   }
 }

--- a/docs/rollup.config.ejs
+++ b/docs/rollup.config.ejs
@@ -1,7 +1,7 @@
-import commonjs from "rollup-plugin-commonjs";
+import commonjs from "@rollup/plugin-commonjs";
 import babel from "rollup-plugin-babel";
 import builtins from "rollup-plugin-node-builtins";
-import resolve from "rollup-plugin-node-resolve";
+import resolve from "@rollup/plugin-node-resolve";
 import {uglify} from 'rollup-plugin-uglify';
 
 export default {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "test": "cd polyfill && npm install && npm test && npm run cookbook && npm run test262 && cd ..",
-    "codecov": "cd polyfill && npm install && npm run codecov && cd ..",
+    "codecov:tests": "cd polyfill && npm install && npm run codecov:tests && cd ..",
+    "codecov:test262": "cd polyfill && npm install && npm run codecov:test262 && cd ..",
     "cookbook": "cd polyfill && npm install && npm run cookbook && cd ..",
     "test262": "cd polyfill && npm install && npm run test262",
     "lint": "eslint . --ext js,mjs",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "cd polyfill && npm install && npm test && npm run cookbook && npm run test262 && cd ..",
     "codecov": "cd polyfill && npm install && npm run codecov && cd ..",
     "cookbook": "cd polyfill && npm install && npm run cookbook && cd ..",
-    "test262": "cd polyfill && npm run test262",
+    "test262": "cd polyfill && npm install && npm run test262",
     "lint": "eslint . --ext js,mjs",
     "build:prepare": "mkdirp out && mkdirp out/docs",
     "build:polyfill": "cd polyfill && npm install && npm run build && cd ..",

--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -11,15 +11,32 @@ else
   cd ..
 fi
 
+PRELUDE=script.js
+if [ "x$COVERAGE" = xyes ]; then
+    nyc instrument script.js > script-instrumented.js
+    PRELUDE=script-instrumented.js
+fi
+
 cd test/
 
 test262-harness \
   -r json \
   --test262Dir ../test262 \
-  --prelude ../script.js \
+  --prelude "../$PRELUDE" \
+  --transformer ./transform.test262.js \
   "./*/**/*.js" \
   > ../exec.out
 ./parseResults.py ../exec.out
 RESULT=$?
-rm ../exec.out
+
+cd ..
+
+if [ "x$COVERAGE" = xyes ]; then
+    nyc report -t coverage/tmp/transformer --reporter=text-lcov > coverage/test262.lcov
+fi
+
+rm exec.out
+rm -f script-instrumented.js
+rm -rf coverage/tmp/transformer
+
 exit $RESULT

--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 export NODE_PATH=$PWD/node_modules
-npm install
 npm run build-script
-npm install test262-harness
 if [ ! -d "test262" ]; then
   git clone --depth 1 https://github.com/tc39/test262.git
 else

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -8,7 +8,7 @@
     "test": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu/icudt64l.dat --loader ./test/resolve.source.mjs ./test/all.mjs",
     "cookbook": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu/icudt64l.dat --loader ./test/resolve.cookbook.mjs ../docs/cookbook/all.mjs",
     "test262": "./ci_test.sh",
-    "codecov": "npm install codecov && NODE_V8_COVERAGE=coverage/tmp npm run test && c8 report --reporter=text-lcov > coverage/tests.lcov && codecov",
+    "codecov": "NODE_V8_COVERAGE=coverage/tmp npm run test && c8 report --reporter=text-lcov > coverage/tests.lcov && codecov",
     "pretty": "prettier --write lib/*.*(m)js test/*.*(m)js",
     "build": "rollup -c rollup.config.js",
     "build-script": "rollup -c rollup-script.config.js",
@@ -36,9 +36,7 @@
   "homepage": "https://github.com/tc39/proposal-temporal#readme",
   "dependencies": {
     "big-integer": "^1.6.48",
-    "codecov": "^3.6.5",
-    "es-abstract": "^1.17.4",
-    "test262-harness": "^6.7.0"
+    "es-abstract": "^1.17.4"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
@@ -47,6 +45,7 @@
     "@pipobscure/demitasse-pretty": "^1.0.10",
     "@types/big-integer": "0.0.31",
     "c8": "^6.0.1",
+    "codecov": "^3.6.5",
     "core-js": "^3.6.4",
     "full-icu": "^1.3.0",
     "prettier": "^1.18.2",
@@ -54,7 +53,8 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-uglify": "^6.0.4"
+    "rollup-plugin-uglify": "^6.0.4",
+    "test262-harness": "^6.7.0"
   },
   "prettier": {
     "printWidth": 120,

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -43,6 +43,7 @@
     "@babel/preset-env": "^7.8.4",
     "@pipobscure/demitasse": "^1.0.10",
     "@pipobscure/demitasse-pretty": "^1.0.10",
+    "@pipobscure/demitasse-run": "^1.0.10",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "c8": "^6.0.1",

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -8,7 +8,8 @@
     "test": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu/icudt64l.dat --loader ./test/resolve.source.mjs ./test/all.mjs",
     "cookbook": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu/icudt64l.dat --loader ./test/resolve.cookbook.mjs ../docs/cookbook/all.mjs",
     "test262": "./ci_test.sh",
-    "codecov": "NODE_V8_COVERAGE=coverage/tmp npm run test && c8 report --reporter=text-lcov > coverage/tests.lcov && codecov",
+    "codecov:tests": "NODE_V8_COVERAGE=coverage/tmp npm run test && c8 report --reporter=text-lcov > coverage/tests.lcov && codecov -F tests -f coverage/tests.lcov",
+    "codecov:test262": "COVERAGE=yes npm run test262 && codecov -F test262 -f coverage/test262.lcov",
     "pretty": "prettier --write lib/*.*(m)js test/*.*(m)js",
     "build": "rollup -c rollup.config.js",
     "build-script": "rollup -c rollup-script.config.js",
@@ -50,11 +51,13 @@
     "codecov": "^3.6.5",
     "core-js": "^3.6.4",
     "full-icu": "^1.3.0",
+    "nyc": "^15.0.0",
     "prettier": "^1.18.2",
     "rollup": "^1.31.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-uglify": "^6.0.4",
-    "test262-harness": "^6.7.0"
+    "test262-harness": "^6.7.0",
+    "uuid": "^7.0.2"
   },
   "prettier": {
     "printWidth": 120,

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -43,7 +43,8 @@
     "@babel/preset-env": "^7.8.4",
     "@pipobscure/demitasse": "^1.0.10",
     "@pipobscure/demitasse-pretty": "^1.0.10",
-    "@types/big-integer": "0.0.31",
+    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-node-resolve": "^7.1.1",
     "c8": "^6.0.1",
     "codecov": "^3.6.5",
     "core-js": "^3.6.4",
@@ -51,8 +52,6 @@
     "prettier": "^1.18.2",
     "rollup": "^1.31.0",
     "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-uglify": "^6.0.4",
     "test262-harness": "^6.7.0"
   },

--- a/polyfill/rollup-script.config.js
+++ b/polyfill/rollup-script.config.js
@@ -1,5 +1,5 @@
-import commonjs from "rollup-plugin-commonjs";
-import resolve from "rollup-plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
 
 export default {
   input: "lib/index.mjs",

--- a/polyfill/rollup-script.config.js
+++ b/polyfill/rollup-script.config.js
@@ -8,6 +8,7 @@ export default {
     file: "script.js",
     format: "iife",
     lib: ["es6"],
+    sourcemap: true,
   },
   plugins: [
     commonjs(),

--- a/polyfill/rollup.config.js
+++ b/polyfill/rollup.config.js
@@ -1,5 +1,5 @@
-import commonjs from 'rollup-plugin-commonjs';
-import resolve from 'rollup-plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 import { uglify } from 'rollup-plugin-uglify';
 import { env } from 'process';

--- a/polyfill/test/transform.test262.js
+++ b/polyfill/test/transform.test262.js
@@ -1,0 +1,9 @@
+module.exports = function addCoverageOutput(code) {
+  return `${code}
+const fs = require('fs');
+const {v4: uuid} = require('uuid');
+const filename = '../coverage/tmp/transformer/' + uuid() + '.json';
+fs.mkdirSync('../coverage/tmp/transformer/', { recursive: true });
+fs.writeFileSync(filename, JSON.stringify(globalThis.__coverage__), 'utf-8');
+`;
+};


### PR DESCRIPTION
This is pretty hacky due to a bunch of shortcomings in the available tooling, as detailed in the commit message, but it merges the code coverage from the test262 tests into the lcov file submitted to codecov.io.