### PR TITLE
parse: add basic implementation and tests

### DIFF
--- a/polyfill/lib/parse.mjs
+++ b/polyfill/lib/parse.mjs
@@ -1,0 +1,17 @@
+import { ES } from './ecmascript.mjs';
+const DateTime = ES.GetIntrinsic('%Temporal.DateTime%');
+const TimeZone = ES.GetIntrinsic('%Temporal.TimeZone%');
+
+export function parse(isoString) {
+  if (typeof isoString !== 'string') {
+    throw new TypeError('Expected string.');
+  }
+  const zIndex = isoString.indexOf('Z');
+  if (zIndex < 0) {
+    throw new RangeError('Not a valid ISO string.');
+  }
+  return {
+    DateTime: DateTime.from(isoString.slice(0, zIndex)),
+    TimeZone: new TimeZone(isoString.slice(zIndex + 1))
+  };
+}

--- a/polyfill/lib/temporal.mjs
+++ b/polyfill/lib/temporal.mjs
@@ -30,3 +30,4 @@ export const Time = ES.GetIntrinsic('%Temporal.Time%');
 export const Duration = ES.GetIntrinsic('%Temporal.Duration%');
 
 export { now } from './now.mjs';
+export { parse } from './parse.mjs';

--- a/polyfill/test/all.mjs
+++ b/polyfill/test/all.mjs
@@ -27,9 +27,10 @@ import * as duration from './duration.mjs';
 import * as yearmonth from './yearmonth.mjs';
 import * as monthday from './monthday.mjs';
 import * as intl from './intl.mjs';
+import * as parse from './parse.mjs';
 
 void datemath, regex, ecmascript, exports, now, timezone, absolute, date, time,
-  datetime, duration, yearmonth, monthday, intl;
+  datetime, duration, yearmonth, monthday, intl, parse;
 
 Promise.resolve()
   .then(() => {

--- a/polyfill/test/exports.mjs
+++ b/polyfill/test/exports.mjs
@@ -19,7 +19,7 @@ import * as Temporal from 'tc39-temporal';
 describe('Exports', () => {
   const named = Object.keys(Temporal);
   it(`should be 9 things`, () => {
-    equal(named.length, 9);
+    equal(named.length, 10);
   });
   it('should contain `Absolute`', () => {
     assert(named.includes('Absolute'));

--- a/polyfill/test/parse.mjs
+++ b/polyfill/test/parse.mjs
@@ -12,7 +12,7 @@ import Pretty from '@pipobscure/demitasse-pretty';
 const { reporter } = Pretty;
 
 import Assert from 'assert';
-const { ok: assert, strictEqual: equal, deepStrictEqual: dEqual } = Assert;
+const { ok: assert, strictEqual: equal, deepStrictEqual: dEqual, throws } = Assert;
 
 import * as Temporal from 'tc39-temporal';
 
@@ -23,10 +23,14 @@ describe('Temporal.parse', () => {
     it('is a function', () => equal(typeof Temporal.parse, 'function'));
     it('returns an object', () => equal(typeof Temporal.parse(sample), 'object'));
     it('returns an object with 2 properties', () => equal(Object.keys(Temporal.parse(sample)).length, 2));
-    it('has a TimeZone property', () => assert(Temporal.parse(sample).hasOwnProperty('TimeZone')));
-    it('has a DateTime property', () => assert(Temporal.parse(sample).hasOwnProperty('DateTime')));
+    it('has a TimeZone property', () =>
+      assert(Object.prototype.hasOwnProperty.call(Temporal.parse(sample), 'TimeZone')));
+    it('has a DateTime property', () =>
+      assert(Object.prototype.hasOwnProperty.call(Temporal.parse(sample), 'DateTime')));
   });
   describe('Behavior', () => {
+    it('should throw a TypeError on non-string arguments', () => throws(() => Temporal.parse(42), TypeError));
+    it('should throw a RangeError on invalid string arguments', () => throws(() => Temporal.parse('not a valid string'), RangeError));
     it('should work', () => {
       const result = Temporal.parse(sample);
       dEqual(result.DateTime, Temporal.DateTime.from('2019-10-29T10:46:38.271986102'));

--- a/polyfill/test/parse.mjs
+++ b/polyfill/test/parse.mjs
@@ -1,0 +1,45 @@
+#! /usr/bin/env -S node --experimental-modules
+
+/*
+ ** Copyright (C) 2020 Igalia S.L. All rights reserved.
+ ** This code is governed by the license found in the LICENSE file.
+ */
+
+import Demitasse from '@pipobscure/demitasse';
+const { describe, it, report } = Demitasse;
+
+import Pretty from '@pipobscure/demitasse-pretty';
+const { reporter } = Pretty;
+
+import Assert from 'assert';
+const { ok: assert, strictEqual: equal, deepStrictEqual: dEqual } = Assert;
+
+import * as Temporal from 'tc39-temporal';
+
+const sample = '2019-10-29T10:46:38.271986102Z+01:00';
+
+describe('Temporal.parse', () => {
+  describe('Structure', () => {
+    it('is a function', () => equal(typeof Temporal.parse, 'function'));
+    it('returns an object', () => equal(typeof Temporal.parse(sample), 'object'));
+    it('returns an object with 2 properties', () => equal(Object.keys(Temporal.parse(sample)).length, 2));
+    it('has a TimeZone property', () => assert(Temporal.parse(sample).hasOwnProperty('TimeZone')));
+    it('has a DateTime property', () => assert(Temporal.parse(sample).hasOwnProperty('DateTime')));
+  });
+  describe('Behavior', () => {
+    it('should work', () => {
+      const result = Temporal.parse(sample);
+      dEqual(result.DateTime, Temporal.DateTime.from('2019-10-29T10:46:38.271986102'));
+      dEqual(result.TimeZone, new Temporal.TimeZone('+01:00'));
+    });
+    it('should roundtrip', () => {
+      const result = Temporal.parse(sample);
+      equal(sample, `${result.DateTime.toString()}Z${result.TimeZone.toString()}`);
+    });
+  });
+});
+
+import { normalize } from 'path';
+if (normalize(import.meta.url.slice(8)) === normalize(process.argv[1])) {
+  report(reporter).then((failed) => process.exit(failed ? 1 : 0));
+}


### PR DESCRIPTION
Add `Temporal.parse` with the semantics as suggested by @sffc. 

#### Checklist
- [X] Basic implementation
- [X] Tests
- [ ] Improve implementation
- [ ] Add spec text

/cc @maggiepint @ljharb @gibson042 @pdunkel @ptomato @Ms2ger