### PR TITLE
Editorial: Replace some always-true checks with assertions in the spec.

### DIFF
--- a/spec/date.html
+++ b/spec/date.html
@@ -499,20 +499,19 @@
       <h1>ToDate ( _date_, _disambiguation_ )</h1>
       <emu-alg>
         1. Assert: _disambiguation_ is one of *"constrain"*, *"balance"*, or *"reject"*.
-        1. If Type(_date_) is Object, then
-          1. If _date_ has an [[InitializedTemporalDate]] internal slot, then
-            1. Return _date_.
-          1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-datelike-properties"></emu-xref>.
-          1. For each row of <emu-xref href="#table-temporal-datelike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_date_, _property_).
-            1. If _value_ is *undefined*, then
-              1. Throw a *TypeError* exception.
-            1. Let _value_ be ? ToInteger(_value_).
-            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. Set _result_ to ? RegulateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _disambiguation_).
-          1. Return ? CreateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
-        1. Throw a *TypeError* exception.
+        1. Assert: Type(_date_) is Object.
+        1. If _date_ has an [[InitializedTemporalDate]] internal slot, then
+          1. Return _date_.
+        1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-datelike-properties"></emu-xref>.
+        1. For each row of <emu-xref href="#table-temporal-datelike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_date_, _property_).
+          1. If _value_ is *undefined*, then
+            1. Throw a *TypeError* exception.
+          1. Let _value_ be ? ToInteger(_value_).
+          1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. Set _result_ to ? RegulateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _disambiguation_).
+        1. Return ? CreateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -358,20 +358,19 @@
       <h1>ToMonthDay ( _monthDay_, _disambiguation_ )</h1>
       <emu-alg>
         1. Assert: _disambiguation_ is one of *"constrain"*, *"balance"*, or *"reject"*.
-        1. If Type(_monthDay_) is Object, then
-          1. If _monthDay_ has an [[InitializedTemporalMonthDay]] internal slot, then
-            1. Return _monthDay_.
-          1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-monthdaylike-properties"></emu-xref>.
-          1. For each row of <emu-xref href="#table-temporal-monthdaylike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_monthDay_, _property_).
-            1. If _value_ is *undefined*, then
-              1. Throw a *TypeError* exception.
-            1. Let _value_ be ? ToInteger(_value_).
-            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. Set _result_ to ? RegulateMonthDay(_result_.[[Month]], _result_.[[Day]], _disambiguation_).
-          1. Return ? CreateMonthDay(_result_.[[Month]], _result_.[[Day]]).
-        1. Throw a *TypeError* exception.
+        1. Assert: Type(_monthDay_) is Object.
+        1. If _monthDay_ has an [[InitializedTemporalMonthDay]] internal slot, then
+          1. Return _monthDay_.
+        1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-monthdaylike-properties"></emu-xref>.
+        1. For each row of <emu-xref href="#table-temporal-monthdaylike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_monthDay_, _property_).
+          1. If _value_ is *undefined*, then
+            1. Throw a *TypeError* exception.
+          1. Let _value_ be ? ToInteger(_value_).
+          1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. Set _result_ to ? RegulateMonthDay(_result_.[[Month]], _result_.[[Day]], _disambiguation_).
+        1. Return ? CreateMonthDay(_result_.[[Month]], _result_.[[Day]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/time.html
+++ b/spec/time.html
@@ -616,18 +616,17 @@
       <emu-note>The value of ? ToInteger(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. Assert: _disambiguation_ is one of *"constrain"*, *"balance"*, or *"reject"*.
-        1. If Type(_time_) is Object, then
-          1. If _time_ has an [[InitializedTemporalTime]] internal slot, then
-            1. Return _time_.
-          1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-timelike-properties"></emu-xref>.
-          1. For each row of <emu-xref href="#table-temporal-timelike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_time_, _property_).
-            1. Let _value_ be ? ToInteger(_value_).
-            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. Set _result_ to ? RegulateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _disambiguation_).
-          1. Return ? CreateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
-        1. Throw a *TypeError* exception.
+        1. Assert: Type(_time_) is Object.
+        1. If _time_ has an [[InitializedTemporalTime]] internal slot, then
+          1. Return _time_.
+        1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-timelike-properties"></emu-xref>.
+        1. For each row of <emu-xref href="#table-temporal-timelike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_time_, _property_).
+          1. Let _value_ be ? ToInteger(_value_).
+          1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. Set _result_ to ? RegulateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _disambiguation_).
+        1. Return ? CreateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -494,20 +494,19 @@
       <h1>ToYearMonth ( _yearMonth_, _disambiguation_ )</h1>
       <emu-alg>
         1. Assert: _disambiguation_ is one of *"constrain"*, *"balance"*, or *"reject"*.
-        1. If Type(_yearMonth_) is Object, then
-          1. If _yearMonth_ has an [[InitializedTemporalYearMonth]] internal slot, then
-            1. Return _yearMonth_.
-          1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-yearmonthlike-properties"></emu-xref>.
-          1. For each row of <emu-xref href="#table-temporal-yearmonthlike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_yearMonth_, _property_).
-            1. If _value_ is *undefined*, then
-              1. Throw a *TypeError* exception.
-            1. Let _value_ be ? ToInteger(_value_).
-            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. Set _result_ to ? RegulateYearMonth(_result_.[[Year]], _result_.[[Month]], _disambiguation_).
-          1. Return ? CreateYearMonth(_result_.[[Year]], _result_.[[Month]]).
-        1. Throw a *TypeError* exception.
+        1. Assert: Type(_yearMonth_) is Object.
+        1. If _yearMonth_ has an [[InitializedTemporalYearMonth]] internal slot, then
+          1. Return _yearMonth_.
+        1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-yearmonthlike-properties"></emu-xref>.
+        1. For each row of <emu-xref href="#table-temporal-yearmonthlike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_yearMonth_, _property_).
+          1. If _value_ is *undefined*, then
+            1. Throw a *TypeError* exception.
+          1. Let _value_ be ? ToInteger(_value_).
+          1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. Set _result_ to ? RegulateYearMonth(_result_.[[Year]], _result_.[[Month]], _disambiguation_).
+        1. Return ? CreateYearMonth(_result_.[[Year]], _result_.[[Month]]).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
I verified these abstract operations are only called from the `from` static
methods, behind a Type check.