### PR TITLE
Pin @babel/plugin-transform-for-of version

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -29,9 +29,13 @@
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "marked": "^0.7.0",
+    "npm-force-resolutions": "0.0.3",
     "rollup": "^1.23.1",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-uglify": "^6.0.4"
+  },
+  "resolutions": {
+    "@babel/plugin-transform-for-of": "7.8.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint . --ext js,mjs",
     "build:prepare": "mkdirp out && mkdirp out/docs",
     "build:polyfill": "cd polyfill && npm install && npm run build && cd ..",
-    "build:javascript": "npm run build:polyfill && cd docs && npm install && npm run build:javascript && cd .. && cp docs/*.js docs/*.js.map out/docs/",
+    "build:javascript": "npm run build:polyfill && cd docs && npm install && npx npm-force-resolutions && npm install && npm run build:javascript && cd .. && cp docs/*.js docs/*.js.map out/docs/",
     "build:docs": "cd docs && npm install && npm run build:html && cd .. && cp docs/*.html docs/*.css out/docs/",
     "build:spec": "ecmarkup spec.html out/index.html",
     "prebuild": "mkdirp out && mkdirp out/docs",


### PR DESCRIPTION
This seems to be a regression with Babel 7.9.0 that wasn't yet caught
in any of their emergency releases today.