### PR TITLE
Don't coerce the dateTime argument to TimeZone#getAbsoluteFor.

### DIFF
--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -39,7 +39,7 @@ export class TimeZone {
   }
   getAbsoluteFor(dateTime, options) {
     if (!ES.IsTimeZone(this)) throw new TypeError('invalid receiver');
-    dateTime = ES.ToDateTime(dateTime, 'reject');
+    if (!ES.IsDateTime(dateTime)) throw new TypeError('invalid DateTime object');
     const disambiguation = ES.ToTimeZoneDisambiguation(options);
 
     const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');

--- a/polyfill/test/TimeZone/prototype/getAbsoluteFor/argument-not-datetime.js
+++ b/polyfill/test/TimeZone/prototype/getAbsoluteFor/argument-not-datetime.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getabsolutefor
+---*/
+
+const timeZone = Temporal.TimeZone.from("UTC");
+assert.throws(TypeError, () => timeZone.getAbsoluteFor(undefined), "undefined");
+assert.throws(TypeError, () => timeZone.getAbsoluteFor(null), "null");
+assert.throws(TypeError, () => timeZone.getAbsoluteFor(true), "boolean");
+assert.throws(TypeError, () => timeZone.getAbsoluteFor("2020-01-02T12:34:56"), "string");
+assert.throws(TypeError, () => timeZone.getAbsoluteFor(Symbol()), "Symbol");
+assert.throws(TypeError, () => timeZone.getAbsoluteFor(5), "number");
+assert.throws(TypeError, () => timeZone.getAbsoluteFor(5n), "bigint");
+assert.throws(TypeError, () => timeZone.getAbsoluteFor({ year: 2020 }), "plain object");

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -155,7 +155,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. Set _dateTime_ to ? ToDateTime(_dateTime_, *"reject"*).
+        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _disambiguation_ be ? ToTimeZoneDisambiguation(_options_).
         1. <mark>TODO</mark>
       </emu-alg>


### PR DESCRIPTION
Fixes #451.