### PR TITLE
Editorial: Assert that ToTemporalDateTime is only called with objects.

### DIFF
--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -865,21 +865,20 @@
       <h1>ToTemporalDateTime ( _temporalDateTimeLike_, _disambiguation_ )</h1>
       <emu-note>The value of ? ToInteger(*undefined*) is 0.</emu-note>
       <emu-alg>
+        1. Assert: Type(_temporalDateTimeLike_) is Object.
         1. Assert: _disambiguation_ is one of *"constrain"*, *"balance"*, or *"reject"*.
-        1. If Type(_temporalDateTimeLike_) is Object, then
-          1. If _temporalDateTimeLike_ has an [[InitializedTemporalDateTime]] internal slot, then
-            1. Return _temporalDateTimeLike_.
-          1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-temporaldatetimelike-properties"></emu-xref>.
-          1. For each row of <emu-xref href="#table-temporal-temporaldatetimelike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _property_ be the Property value of the current row.
-            1. Let _value_ be ? Get(_temporalDateTimeLike_, _property_).
-            1. If _value_ is *undefined* and the Optional value of the current row is *false*, then
-              1. Throw a *TypeError* exception.
-            1. Let _value_ be ? ToInteger(_value_).
-            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-          1. Set _result_ to ? RegulateDateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _disambiguation_).
-          1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
-        1. Throw a *TypeError* exception.
+        1. If _temporalDateTimeLike_ has an [[InitializedTemporalDateTime]] internal slot, then
+          1. Return _temporalDateTimeLike_.
+        1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-temporaldatetimelike-properties"></emu-xref>.
+        1. For each row of <emu-xref href="#table-temporal-temporaldatetimelike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _property_ be the Property value of the current row.
+          1. Let _value_ be ? Get(_temporalDateTimeLike_, _property_).
+          1. If _value_ is *undefined* and the Optional value of the current row is *false*, then
+            1. Throw a *TypeError* exception.
+          1. Let _value_ be ? ToInteger(_value_).
+          1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. Set _result_ to ? RegulateDateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _disambiguation_).
+        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
I verified this abstract operation is only called from the `from` static
method, behind a Type check.