### PR TITLE
BigInt fixes

### DIFF
--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -24,12 +24,12 @@ export class Absolute {
   }
   getEpochMicroseconds() {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
-    const value = bigInt(GetSlot(this, EPOCHNANOSECONDS));
-    return value.divide(1e3).value;
+    const value = GetSlot(this, EPOCHNANOSECONDS);
+    return bigIntIfAvailable(value.divide(1e3));
   }
   getEpochNanoseconds() {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
-    return bigInt(GetSlot(this, EPOCHNANOSECONDS)).value;
+    return bigIntIfAvailable(GetSlot(this, EPOCHNANOSECONDS));
   }
 
   plus(temporalDurationLike) {
@@ -57,7 +57,7 @@ export class Absolute {
     ES.RejectAbsolute(ns);
 
     const Construct = ES.SpeciesConstructor(this, Absolute);
-    const result = new Construct(ns.value);
+    const result = new Construct(bigIntIfAvailable(ns));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
   }
@@ -86,7 +86,7 @@ export class Absolute {
     ES.RejectAbsolute(ns);
 
     const Construct = ES.SpeciesConstructor(this, Absolute);
-    const result = new Construct(ns.value);
+    const result = new Construct(bigIntIfAvailable(ns));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
   }
@@ -143,7 +143,7 @@ export class Absolute {
     epochSeconds = ES.ToNumber(epochSeconds);
     const epochNanoseconds = bigInt(epochSeconds).multiply(1e9);
     ES.RejectAbsolute(epochNanoseconds);
-    const result = new this(epochNanoseconds.value);
+    const result = new this(bigIntIfAvailable(epochNanoseconds));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
   }
@@ -151,7 +151,7 @@ export class Absolute {
     epochMilliseconds = ES.ToNumber(epochMilliseconds);
     const epochNanoseconds = bigInt(epochMilliseconds).multiply(1e6);
     ES.RejectAbsolute(epochNanoseconds);
-    const result = new this(epochNanoseconds.value);
+    const result = new this(bigIntIfAvailable(epochNanoseconds));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
   }
@@ -159,21 +159,21 @@ export class Absolute {
     epochMicroseconds = ES.ToBigInt(epochMicroseconds);
     const epochNanoseconds = epochMicroseconds.multiply(1e3);
     ES.RejectAbsolute(epochNanoseconds);
-    const result = new this(epochNanoseconds.value);
+    const result = new this(bigIntIfAvailable(epochNanoseconds));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
   }
   static fromEpochNanoseconds(epochNanoseconds) {
     epochNanoseconds = ES.ToBigInt(epochNanoseconds);
     ES.RejectAbsolute(epochNanoseconds);
-    const result = new this(epochNanoseconds.value);
+    const result = new this(bigIntIfAvailable(epochNanoseconds));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
   }
   static from(item) {
     const absolute = ES.ToTemporalAbsolute(item);
     if (this === Absolute) return absolute;
-    const result = new this(GetSlot(absolute, EPOCHNANOSECONDS).value);
+    const result = new this(bigIntIfAvailable(GetSlot(absolute, EPOCHNANOSECONDS)));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
   }
@@ -188,3 +188,7 @@ export class Absolute {
 }
 
 MakeIntrinsicClass(Absolute, 'Temporal.Absolute');
+
+function bigIntIfAvailable(wrapper) {
+  return typeof BigInt === 'undefined' ? wrapper : wrapper.value;
+}

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -6,10 +6,7 @@ import bigInt from 'big-integer';
 
 export class Absolute {
   constructor(epochNanoseconds) {
-    if ('bigint' !== typeof epochNanoseconds && !bigInt.isInstance(epochNanoseconds)) {
-      throw RangeError('bigint required');
-    }
-    const ns = bigInt(epochNanoseconds);
+    const ns = ES.ToBigInt(epochNanoseconds);
     ES.RejectAbsolute(ns);
     CreateSlots(this);
     SetSlot(this, EPOCHNANOSECONDS, ns);
@@ -143,6 +140,7 @@ export class Absolute {
   }
 
   static fromEpochSeconds(epochSeconds) {
+    epochSeconds = ES.ToNumber(epochSeconds);
     const epochNanoseconds = bigInt(epochSeconds).multiply(1e9);
     ES.RejectAbsolute(epochNanoseconds);
     const result = new this(epochNanoseconds.value);
@@ -150,6 +148,7 @@ export class Absolute {
     return result;
   }
   static fromEpochMilliseconds(epochMilliseconds) {
+    epochMilliseconds = ES.ToNumber(epochMilliseconds);
     const epochNanoseconds = bigInt(epochMilliseconds).multiply(1e6);
     ES.RejectAbsolute(epochNanoseconds);
     const result = new this(epochNanoseconds.value);
@@ -157,14 +156,15 @@ export class Absolute {
     return result;
   }
   static fromEpochMicroseconds(epochMicroseconds) {
-    const epochNanoseconds = bigInt(epochMicroseconds).multiply(1e3);
+    epochMicroseconds = ES.ToBigInt(epochMicroseconds);
+    const epochNanoseconds = epochMicroseconds.multiply(1e3);
     ES.RejectAbsolute(epochNanoseconds);
     const result = new this(epochNanoseconds.value);
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
   }
   static fromEpochNanoseconds(epochNanoseconds) {
-    epochNanoseconds = bigInt(epochNanoseconds);
+    epochNanoseconds = ES.ToBigInt(epochNanoseconds);
     ES.RejectAbsolute(epochNanoseconds);
     const result = new this(epochNanoseconds.value);
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1274,6 +1274,17 @@ export const ES = ObjectAssign(ObjectAssign({}, ES2019), {
     if (result < 0) result += y;
     return result;
   },
+  ToBigInt: (arg) => {
+    if (bigInt.isInstance(arg)) return arg;
+    const prim = ES.ToPrimitive(arg, Number);
+    if (typeof prim === 'number') throw new TypeError('Use BigInt() to convert Number to BigInt');
+    try {
+      return bigInt(prim);
+    } catch (e) {
+      if (e instanceof Error && e.message.startsWith('Invalid integer')) throw new SyntaxError(e.message);
+      throw e;
+    }
+  },
 
   // Note: This method returns values with bogus nanoseconds based on the previous iteration's
   // milliseconds. That way there is a guarantee that the full nanoseconds are always going to be

--- a/polyfill/test/Absolute/prototype/minus/subclass-out-of-range.js
+++ b/polyfill/test/Absolute/prototype/minus/subclass-out-of-range.js
@@ -3,6 +3,7 @@
 
 /*---
 esid: sec-temporal.absolute.prototype.minus
+features: [BigInt]
 ---*/
 
 let called = 0;
@@ -14,7 +15,7 @@ class MyAbsolute extends Temporal.Absolute {
   }
 }
 
-const instance = MyAbsolute.fromEpochNanoseconds(-8640000000000000000000);
+const instance = MyAbsolute.fromEpochNanoseconds(-8640000000000000000000n);
 assert.sameValue(called, 1);
 
 assert.throws(RangeError, () => instance.minus({ nanoseconds: 1 }));

--- a/polyfill/test/Absolute/prototype/plus/subclass-out-of-range.js
+++ b/polyfill/test/Absolute/prototype/plus/subclass-out-of-range.js
@@ -3,6 +3,7 @@
 
 /*---
 esid: sec-temporal.absolute.prototype.plus
+features: [BigInt]
 ---*/
 
 let called = 0;
@@ -14,7 +15,7 @@ class MyAbsolute extends Temporal.Absolute {
   }
 }
 
-const instance = MyAbsolute.fromEpochNanoseconds(8640000000000000000000);
+const instance = MyAbsolute.fromEpochNanoseconds(8640000000000000000000n);
 assert.sameValue(called, 1);
 
 assert.throws(RangeError, () => instance.plus({ nanoseconds: 1 }));

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -51,8 +51,9 @@ describe('Absolute', () => {
       equal(instant.getEpochSeconds(), Math.floor(Date.UTC(1976, 10, 18, 14, 23, 30, 123) / 1e3), 'getEpochSeconds');
       equal(instant.getEpochMilliseconds(), Date.UTC(1976, 10, 18, 14, 23, 30, 123), 'getEpochMilliseconds');
     });
-    it('throws on number', () => throws(() => new Absolute(1234)));
-    it('throws on string', () => throws(() => new Absolute('1234')));
+    it('constructs from string', () => equal(`${new Absolute('0')}`, '1970-01-01T00:00Z'));
+    it('throws on number', () => throws(() => new Absolute(1234), TypeError));
+    it('throws on string that does not convert to BigInt', () => throws(() => new Absolute('abc123'), SyntaxError));
   });
   describe('absolute.toString() works', () => {
     it('`1976-11-18T14:23:30.123456789Z`.toString()', () => {

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -134,7 +134,7 @@ describe('TimeZone', () => {
   });
   describe('America/Los_Angeles', () => {
     const zone = new Temporal.TimeZone('America/Los_Angeles');
-    const abs = Temporal.Absolute.fromEpochSeconds();
+    const abs = Temporal.Absolute.fromEpochSeconds(0n);
     const dtm = new Temporal.DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
     it(`${zone} has name ${zone}`, () => equal(zone.name, `${zone}`));
     it(`${zone} has offset -08:00`, () => equal(zone.getOffsetFor(abs), '-08:00'));

--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -2,6 +2,11 @@
   "https://tc39.es/ecma262/": [
     {
       "type": "op",
+      "aoid": "NumberToBigInt",
+      "id": "sec-numbertobigint"
+    },
+    {
+      "type": "op",
       "aoid": "RequireInternalSlot",
       "id": "sec-requireinternalslot"
     },


### PR DESCRIPTION
- implement ECMA-262 ToBigInt in terms of big-integer library so that our conversions are more compliant
- only get the `bigInt.value` property if it is actually a native BigInt, otherwise return the big-integer wrapper