### PR TITLE
Update ecmarkup to ensure markup errors are caught.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "babel-eslint": "^10.0.3",
-    "ecmarkup": "^3.16.0",
+    "ecmarkup": "^3.19.1",
     "eslint": "^6.8.0",
     "mkdirp": "^1.0.0"
   },


### PR DESCRIPTION
This brings in the fix for https://github.com/bterlson/ecmarkup/issues/184 in particular.