### PR TITLE
Editorial: Assert that ToTemporalDuration is only called with objects.

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -346,21 +346,18 @@
       <h1>ToTemporalDuration ( _temporalDurationLike_, _disambiguation_ )</h1>
       <emu-note>The value of ? ToInteger(*undefined*) is 0.</emu-note>
       <emu-alg>
+        1. Assert: Type(_temporalDurationLike_) is Object.
         1. Assert: _disambiguation_ is one of *"constrain"*, *"balance"*, or *"reject"*.
-        1. If Type(_temporalDurationLike_) is String, then
-          1. Return ? TemporalDurationFromString(_temporalDurationLike_, _disambiguation_).
-        1. If Type(_temporalDurationLike_) is Object, then
-          1. If _temporalDurationLike_ has an [[InitializedTemporalDuration]] internal slot, then
-            1. Return _temporalDurationLike_.
-          1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-temporaldurationlike-properties"></emu-xref>.
-          1. For each row of <emu-xref href="#table-temporal-temporaldurationlike-properties"></emu-xref>, except the header row, in table order, do
-            1. Let _prop_ be the Property value of the current row.
-            1. Let _val_ be ? Get(_temporalDurationLike_, _prop_).
-            1. Let _val_ be ? ToInteger(_val_).
-            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _val_.
-          1. Set _result_ to ? RegulateDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _disambiguation_).
-          1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
-        1. Throw a *RangeError* exception.
+        1. If _temporalDurationLike_ has an [[InitializedTemporalDuration]] internal slot, then
+          1. Return _temporalDurationLike_.
+        1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-temporaldurationlike-properties"></emu-xref>.
+        1. For each row of <emu-xref href="#table-temporal-temporaldurationlike-properties"></emu-xref>, except the header row, in table order, do
+          1. Let _prop_ be the Property value of the current row.
+          1. Let _val_ be ? Get(_temporalDurationLike_, _prop_).
+          1. Let _val_ be ? ToInteger(_val_).
+          1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _val_.
+        1. Set _result_ to ? RegulateDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _disambiguation_).
+        1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
I verified this abstract operation is only called from two places, both behind a Type check.