### PR TITLE
Use ijson to parse the test262 results.

### DIFF
--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+virtualenv -p python3 venv
+source venv/bin/activate
+pip install ijson
+
 export NODE_PATH=$PWD/node_modules
 npm run build-script
 if [ ! -d "test262" ]; then

--- a/polyfill/test/parseResults.py
+++ b/polyfill/test/parseResults.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import json
+import ijson
 import sys
 
 PREFIXES = [
@@ -25,19 +25,19 @@ def parse_expected_failures():
 def main(filename):
     expected_failures = parse_expected_failures()
     with open(filename, "r") as fp:
-        results = json.load(fp)
+        results = ijson.items(fp, "item")
 
-    unexpected_results = []
-    for test in results:
-        expected_failure = test["file"] in expected_failures
-        actual_result = test["result"]["pass"]
-        print("{} {} ({})".format(PREFIXES[expected_failure][actual_result], test["file"], test["scenario"]))
-        if actual_result == expected_failure:
-            if not actual_result:
-                print(test["rawResult"]["stderr"])
-                print(test["rawResult"]["stdout"])
-                print(test["result"]["message"])
-            unexpected_results.append(test)
+        unexpected_results = []
+        for test in results:
+            expected_failure = test["file"] in expected_failures
+            actual_result = test["result"]["pass"]
+            print("{} {} ({})".format(PREFIXES[expected_failure][actual_result], test["file"], test["scenario"]))
+            if actual_result == expected_failure:
+                if not actual_result:
+                    print(test["rawResult"]["stderr"])
+                    print(test["rawResult"]["stdout"])
+                    print(test["result"]["message"])
+                unexpected_results.append(test)
 
     if unexpected_results:
         print("{} unexpected results:".format(len(unexpected_results)))


### PR DESCRIPTION
Parsing the output all at once can cause out-of-memory errors in automated testing.