### PR TITLE
meta: unbreak CI

### DIFF
--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -5,15 +5,15 @@
   "main": "index.js",
   "scripts": {
     "coverage": "c8 report --reporter html",
-    "test": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu/icudt64l.dat --loader ./test/resolve.source.mjs ./test/all.mjs",
-    "cookbook": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu/icudt64l.dat --loader ./test/resolve.cookbook.mjs ../docs/cookbook/all.mjs",
+    "test": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu --loader ./test/resolve.source.mjs ./test/all.mjs",
+    "cookbook": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu --loader ./test/resolve.cookbook.mjs ../docs/cookbook/all.mjs",
     "test262": "./ci_test.sh",
     "codecov:tests": "NODE_V8_COVERAGE=coverage/tmp npm run test && c8 report --reporter=text-lcov > coverage/tests.lcov && codecov -F tests -f coverage/tests.lcov",
     "codecov:test262": "COVERAGE=yes npm run test262 && codecov -F test262 -f coverage/test262.lcov",
     "build": "rollup -c rollup.config.js",
     "build-script": "rollup -c rollup-script.config.js",
     "prepublishOnly": "npm run build",
-    "playground": "npm run build && node --experimental-modules --no-warnings --icu-data-dir ./node_modules/full-icu/ -r ./lib/initialise.js"
+    "playground": "npm run build && node --experimental-modules --no-warnings --icu-data-dir node_modules/full-icu -r ./lib/initialise.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The CI was broken at some point, likely because of some breaking change
in the full-icu npm module. While I couldn't reproduce the issue locally
on Linux, this is a best guess PR which should ideally fix it.

I have confirmed that it builds locally with the changes, so best case,
it doesn't further break anything.