### PR TITLE
timezone: fix issues with getTransitions

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -797,12 +797,12 @@ export const ES = ObjectAssign({}, ES2019, {
     let rightOffset = leftOffset;
     let weeks = 0;
     while (leftOffset === rightOffset && weeks < 104) {
-      rightNanos = bigInt(leftNanos).plus(7 * 24 * DAYMILLIS * 1e6);
+      rightNanos = bigInt(leftNanos).plus(2 * 7 * DAYMILLIS * 1e6);
       rightOffset = ES.GetTimeZoneOffsetString(rightNanos, timeZone);
       if (leftOffset === rightOffset) {
         leftNanos = rightNanos;
       }
-      weeks++;
+      weeks += 2;
     }
     if (leftOffset === rightOffset) return null;
     const result = bisect(
@@ -1484,9 +1484,7 @@ export const ES = ObjectAssign({}, ES2019, {
     let ns = Date.now() % 1e6;
     return () => {
       const ms = Date.now();
-      const result = bigInt(ms)
-        .multiply(1e6)
-        .plus(ns);
+      const result = bigInt(ms).multiply(1e6).plus(ns);
       ns = ms % 1e6;
       return result;
     };

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -791,18 +791,18 @@ export const ES = ObjectAssign({}, ES2019, {
       return null;
     }
 
+    const current = new TemporalAbsolute(ES.SystemUTCEpochNanoSeconds());
+    const uppercap = current.plus({ days: 366 }).getEpochNanoseconds();
     let leftNanos = epochNanoseconds;
     let leftOffset = ES.GetTimeZoneOffsetString(leftNanos, timeZone);
     let rightNanos = leftNanos;
     let rightOffset = leftOffset;
-    let weeks = 0;
-    while (leftOffset === rightOffset && weeks < 104) {
+    while (leftOffset === rightOffset && bigInt(leftNanos).compare(uppercap) === -1) {
       rightNanos = bigInt(leftNanos).plus(2 * 7 * DAYMILLIS * 1e6);
       rightOffset = ES.GetTimeZoneOffsetString(rightNanos, timeZone);
       if (leftOffset === rightOffset) {
         leftNanos = rightNanos;
       }
-      weeks += 2;
     }
     if (leftOffset === rightOffset) return null;
     const result = bisect(

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -10,8 +10,7 @@ export const now = {
 };
 
 function absolute() {
-  const ns = ES.SystemUTCEpochNanoSeconds();
-  return new Absolute(ns);
+  return new Absolute(ES.SystemUTCEpochNanoSeconds());
 }
 function dateTime(temporalTimeZoneLike = timeZone()) {
   const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -209,7 +209,7 @@ describe('TimeZone', () => {
       // See https://github.com/tc39/proposal-temporal/issues/510 for more.
       const nyc = Temporal.TimeZone.from('America/New_York');
       const a1 = Temporal.Absolute.from('2020-04-16T21:01Z');
-      const a2 = Temporal.Absolute.from('1882-01-01T00:00Z');
+      const a2 = Temporal.Absolute.from('1800-01-01T00:00Z');
 
       equal(nyc.getTransitions(a1).next().value.toString(), '2020-11-01T06:00Z');
       equal(nyc.getTransitions(a2).next().value.toString(), '1883-11-18T17:00Z');

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -204,6 +204,17 @@ describe('TimeZone', () => {
       );
     });
   });
+  describe('getTransitions works as expected', () => {
+    it('should not have bug #510', () => {
+      // See https://github.com/tc39/proposal-temporal/issues/510 for more.
+      const nyc = Temporal.TimeZone.from('America/New_York');
+      const a1 = Temporal.Absolute.from('2020-04-16T21:01Z');
+      const a2 = Temporal.Absolute.from('1882-01-01T00:00Z');
+
+      equal(nyc.getTransitions(a1).next().value.toString(), '2020-11-01T06:00Z');
+      equal(nyc.getTransitions(a2).next().value.toString(), '1883-11-18T17:00Z');
+    });
+  });
 });
 
 function ArrayFrom(iter, limit = Number.POSITIVE_INFINITY) {


### PR DESCRIPTION
Fixes: #510 

1. Change window size to 2 weeks.
2. Bump up upper search limit from lower start + 2y to now + 1y.