### PR TITLE
Add nextWeeklyOccurrence example to cookbook

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -166,3 +166,11 @@ Example of getting a `Temporal.Date` representing the first Tuesday of the given
 ```javascript
 {{cookbook/getFirstTuesdayOfMonth.mjs}}
 ```
+
+### Next weekly occurrence
+
+From a `Temporal.Absolute` instance and a local `Temporal.TimeZone`, get a `Temporal.DateTime` representing the next occurrence of a weekly event that is scheduled on a particular weekday and time in a particular time zone. (For example, "weekly on Thursdays at 08:45 California time").
+
+```javascript
+{{cookbook/nextWeeklyOccurrence.mjs}}
+```

--- a/docs/cookbook/all.mjs
+++ b/docs/cookbook/all.mjs
@@ -16,4 +16,5 @@ import './getUtcOffsetDifferenceSecondsAtInstant.mjs';
 import './getUtcOffsetSecondsAtInstant.mjs';
 import './getUtcOffsetStringAtInstant.mjs';
 import './legacyDateFromDateTime.mjs';
+import './nextWeeklyOccurrence.mjs';
 import './sortAbsoluteInstants.mjs';

--- a/docs/cookbook/nextWeeklyOccurrence.mjs
+++ b/docs/cookbook/nextWeeklyOccurrence.mjs
@@ -1,0 +1,37 @@
+/**
+ * Returns the local date and time for the next occurrence of a weekly occurring
+ * event.
+ *
+ * @param {Temporal.Absolute} now - Starting point
+ * @param {Temporal.TimeZone} localTimeZone - Time zone for return value
+ * @param {number} weekday - Weekday event occurs on (Monday=1, Sunday=7)
+ * @param {Temporal.Time} eventTime - Time event occurs at
+ * @param {Temporal.TimeZone} eventTimeZone - Time zone where event is planned
+ * @returns {Temporal.DateTime} Local date and time of next occurrence
+ */
+function nextWeeklyOccurrence(now, localTimeZone, weekday, eventTime, eventTimeZone) {
+  const dateTime = now.inTimeZone(eventTimeZone);
+  const nextDate = dateTime.getDate().plus({ days: (weekday + 7 - dateTime.dayOfWeek) % 7 });
+  let nextOccurrence = nextDate.withTime(eventTime);
+
+  // Handle the case where the event is today but already happened
+  if (Temporal.DateTime.compare(dateTime, nextOccurrence) > 0) {
+    nextOccurrence = nextOccurrence.plus({ days: 7 });
+  }
+
+  return nextOccurrence.inTimeZone(eventTimeZone).inTimeZone(localTimeZone);
+}
+
+// "Weekly on Thursdays at 08:45 California time":
+const weekday = 4;
+const eventTime = Temporal.Time.from('08:45');
+const eventTimeZone = Temporal.TimeZone.from('America/Los_Angeles');
+
+const rightBefore = Temporal.Absolute.from('2020-03-26T08:30-07:00[America/Los_Angeles]');
+const localTimeZone = Temporal.TimeZone.from('Europe/London');
+let next = nextWeeklyOccurrence(rightBefore, localTimeZone, weekday, eventTime, eventTimeZone);
+assert.equal(`${next}`, '2020-03-26T15:45');
+
+const rightAfter = Temporal.Absolute.from('2020-03-26T09:00-07:00[America/Los_Angeles]');
+next = nextWeeklyOccurrence(rightAfter, localTimeZone, weekday, eventTime, eventTimeZone);
+assert.equal(`${next}`, '2020-04-02T16:45');


### PR DESCRIPTION
This is a generalization of the code snippet that I use to calculate the next occurrence of the weekly Temporal call!

See: #240