### PR TITLE
Add back one of the examples from the old documentation

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -94,6 +94,14 @@ This could be used when converting user-input date-time values between time zone
 {{cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs}}
 ```
 
+### Daily occurrence in local time
+
+Similar to the previous recipe, calculate the absolute times of a daily occurrence that happens at a particular local time in a particular time zone.
+
+```javascript
+{{cookbook/calculateDailyOccurrence.mjs}}
+```
+
 ### UTC offset for a zoned event, as a string
 
 Use `Temporal.TimeZone.getOffsetFor()` to map a `Temporal.Absolute` instance and a time zone into the UTC offset at that instant in that time zone, as a string.

--- a/docs/cookbook/all.mjs
+++ b/docs/cookbook/all.mjs
@@ -1,4 +1,5 @@
 import './absoluteFromLegacyDate.mjs';
+import './calculateDailyOccurrence.mjs';
 import './dateTimeFromLegacyDate.mjs';
 import './getBusinessOpenStateText.mjs';
 import './getCurrentDate.mjs';

--- a/docs/cookbook/calculateDailyOccurrence.mjs
+++ b/docs/cookbook/calculateDailyOccurrence.mjs
@@ -1,0 +1,26 @@
+/**
+ * Returns an iterator of the absolute times corresponding to a daily occurrence
+ * starting on a particular date, and happening at a particular local time in a
+ * particular time zone.
+ *
+ * @param {Temporal.Date} startDate - Starting date
+ * @param {Temporal.Time} time - Local time that event occurs at
+ * @param {Temporal.TimeZone} timeZone - Time zone in which event is defined
+ */
+function* calculateDailyOccurrence(startDate, time, timeZone) {
+  for (let date = startDate; ; date = date.plus({ days: 1 })) {
+    yield date.withTime(time).inTimeZone(timeZone);
+  }
+}
+
+// Daily meeting at 8 AM California time
+const startDate = Temporal.Date.from('2017-03-10');
+const time = Temporal.Time.from('08:00');
+const timeZone = Temporal.TimeZone.from('America/Los_Angeles');
+const iter = calculateDailyOccurrence(startDate, time, timeZone);
+
+assert(iter.next().value.toString(), '2017-03-10T16:00:00.000000000Z');
+assert(iter.next().value.toString(), '2017-03-11T16:00:00.000000000Z');
+// DST change:
+assert(iter.next().value.toString(), '2017-03-12T15:00:00.000000000Z');
+assert(iter.next().value.toString(), '2017-03-13T15:00:00.000000000Z');


### PR DESCRIPTION
It was mentioned in #26 that the documentation used to have two use case
examples. This was one of them. (The other was already covered by
"Preserving absolute instant".)

See: #26, #240