### PR TITLE
Add second example to "preserving absolute instant" in cookbook

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -94,6 +94,17 @@ This could be used when converting user-input date-time values between time zone
 {{cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs}}
 ```
 
+Here is another example similar to the previous one, using the time zone for future events.
+The times and locations of a series of future meetings are stored as a pair of strings: one for the calendar date and wall-clock time, and one for the time zone.
+They cannot be stored as an absolute point in UTC because between now and the time when the event happens, the time zone rules for daylight saving time could change &mdash; for example, Brazil abolished daylight saving time in 2019 &mdash; but the meeting would still be held at the same wall-clock time on that date.
+So if the time zone rules changed, the event's absolute point in time would change.
+
+This example calculates the starting times of all the Ecma TC39 meetings in 2019, in local time in Tokyo.
+
+```javascript
+{{cookbook/localTimeForFutureEvents.mjs}}
+```
+
 ### Daily occurrence in local time
 
 Similar to the previous recipe, calculate the absolute times of a daily occurrence that happens at a particular local time in a particular time zone.

--- a/docs/cookbook/all.mjs
+++ b/docs/cookbook/all.mjs
@@ -19,6 +19,7 @@ import './getUtcOffsetDifferenceSecondsAtInstant.mjs';
 import './getUtcOffsetSecondsAtInstant.mjs';
 import './getUtcOffsetStringAtInstant.mjs';
 import './legacyDateFromDateTime.mjs';
+import './localTimeForFutureEvents.mjs';
 import './nextWeeklyOccurrence.mjs';
 import './plusAndRoundToMonthStart.mjs';
 import './sortAbsoluteInstants.mjs';

--- a/docs/cookbook/localTimeForFutureEvents.mjs
+++ b/docs/cookbook/localTimeForFutureEvents.mjs
@@ -1,0 +1,48 @@
+// Dates of the 2019 TC39 meetings:
+const tc39meetings = [
+  {
+    dateTime: '2019-01-28T10:00',
+    timeZone: 'America/Phoenix'
+  },
+  {
+    dateTime: '2019-03-26T10:00',
+    timeZone: 'America/New_York'
+  },
+  {
+    dateTime: '2019-06-04T10:00',
+    timeZone: 'Europe/Berlin'
+  },
+  {
+    dateTime: '2019-07-23T10:00',
+    timeZone: 'America/Los_Angeles'
+  },
+  {
+    dateTime: '2019-10-01T10:00',
+    timeZone: 'America/New_York'
+  },
+  {
+    dateTime: '2019-12-03T10:00',
+    timeZone: 'America/Los_Angeles'
+  }
+];
+
+// To follow the meetings remotely from Tokyo, calculate the times you would
+// need to join:
+const localTimeZone = Temporal.TimeZone.from('Asia/Tokyo');
+const localTimes = tc39meetings.map(({ dateTime, timeZone }) => {
+  return Temporal.DateTime.from(dateTime)
+    .inTimeZone(timeZone, { disambiguation: 'reject' })
+    .inTimeZone(localTimeZone);
+});
+
+assert.deepEqual(
+  localTimes.map((dt) => dt.toString()),
+  [
+    '2019-01-29T02:00',
+    '2019-03-26T23:00',
+    '2019-06-04T17:00',
+    '2019-07-24T02:00',
+    '2019-10-01T23:00',
+    '2019-12-04T03:00'
+  ]
+);


### PR DESCRIPTION
This is adapted from Andrew's comment on #26.

See: #240