### PR TITLE
Untangle dependencies

### DIFF
--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -1,5 +1,5 @@
 import { ES } from './ecmascript.mjs';
-import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { EPOCHNANOSECONDS, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
 
 import bigInt from 'big-integer';
@@ -105,7 +105,7 @@ export class Absolute {
     const ms = +diff.divide(1e6).mod(1e3);
     const ss = +diff.divide(1e9);
 
-    const Duration = ES.GetIntrinsic('%Temporal.Duration%');
+    const Duration = GetIntrinsic('%Temporal.Duration%');
     const { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
       0,
       0,
@@ -125,7 +125,7 @@ export class Absolute {
   }
   toJSON() {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
-    const TemporalTimeZone = ES.GetIntrinsic('%Temporal.TimeZone%');
+    const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
     const timeZone = new TemporalTimeZone('UTC');
     return ES.TemporalAbsoluteToString(this, timeZone);
   }

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -1,5 +1,5 @@
 import { ES } from './ecmascript.mjs';
-import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import {
   YEAR,
   MONTH,
@@ -128,7 +128,7 @@ export class Date {
     const largestUnit = ES.ToLargestTemporalUnit(options, 'days', ['hours', 'minutes', 'seconds']);
     const [smaller, larger] = [this, other].sort(Date.compare);
     const { years, months, days } = ES.DifferenceDate(smaller, larger, largestUnit);
-    const Duration = ES.GetIntrinsic('%Temporal.Duration%');
+    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, days, 0, 0, 0, 0, 0, 0);
   }
   toString() {
@@ -155,17 +155,17 @@ export class Date {
     const millisecond = GetSlot(temporalTime, MILLISECOND);
     const microsecond = GetSlot(temporalTime, MICROSECOND);
     const nanosecond = GetSlot(temporalTime, NANOSECOND);
-    const DateTime = ES.GetIntrinsic('%Temporal.DateTime%');
+    const DateTime = GetIntrinsic('%Temporal.DateTime%');
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }
   getYearMonth() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
-    const YearMonth = ES.GetIntrinsic('%Temporal.YearMonth%');
+    const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
     return new YearMonth(GetSlot(this, YEAR), GetSlot(this, MONTH));
   }
   getMonthDay() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
-    const MonthDay = ES.GetIntrinsic('%Temporal.MonthDay%');
+    const MonthDay = GetIntrinsic('%Temporal.MonthDay%');
     return new MonthDay(GetSlot(this, MONTH), GetSlot(this, DAY));
   }
   static from(item, options = undefined) {

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -1,5 +1,5 @@
 import { ES } from './ecmascript.mjs';
-import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 
 import {
   YEAR,
@@ -256,7 +256,7 @@ export class DateTime {
       largestUnit
     ));
 
-    const Duration = ES.GetIntrinsic('%Temporal.Duration%');
+    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
   toString() {
@@ -288,22 +288,22 @@ export class DateTime {
   }
   getDate() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const Date = ES.GetIntrinsic('%Temporal.Date%');
+    const Date = GetIntrinsic('%Temporal.Date%');
     return new Date(GetSlot(this, YEAR), GetSlot(this, MONTH), GetSlot(this, DAY));
   }
   getYearMonth() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const YearMonth = ES.GetIntrinsic('%Temporal.YearMonth%');
+    const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
     return new YearMonth(GetSlot(this, YEAR), GetSlot(this, MONTH));
   }
   getMonthDay() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const MonthDay = ES.GetIntrinsic('%Temporal.MonthDay%');
+    const MonthDay = GetIntrinsic('%Temporal.MonthDay%');
     return new MonthDay(GetSlot(this, MONTH), GetSlot(this, DAY));
   }
   getTime() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const Time = ES.GetIntrinsic('%Temporal.Time%');
+    const Time = GetIntrinsic('%Temporal.Time%');
     return new Time(
       GetSlot(this, HOUR),
       GetSlot(this, MINUTE),

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1,20 +1,11 @@
-import GetIntrinsic from 'es-abstract/GetIntrinsic.js';
 import ES2019 from 'es-abstract/es2019.js';
 
 const IntlDateTimeFormat = Intl.DateTimeFormat;
 const ObjectAssign = Object.assign;
 
-import { DateTime as TemporalDateTime } from './datetime.mjs';
-import { Date as TemporalDate } from './date.mjs';
-import { YearMonth as TemporalYearMonth } from './yearmonth.mjs';
-import { MonthDay as TemporalMonthDay } from './monthday.mjs';
-import { Time as TemporalTime } from './time.mjs';
-import { Absolute as TemporalAbsolute } from './absolute.mjs';
-import { TimeZone as TemporalTimeZone } from './timezone.mjs';
-import { Duration as TemporalDuration } from './duration.mjs';
-
 import bigInt from 'big-integer';
 
+import { GetIntrinsic } from './intrinsicclass.mjs';
 import {
   GetSlot,
   HasSlot,
@@ -46,17 +37,6 @@ const NS_MAX = bigInt(86400).multiply(1e17);
 const YEAR_MIN = -271821;
 const YEAR_MAX = 275760;
 
-const INTRINSICS = {
-  '%Temporal.DateTime%': TemporalDateTime,
-  '%Temporal.Date%': TemporalDate,
-  '%Temporal.YearMonth%': TemporalYearMonth,
-  '%Temporal.MonthDay%': TemporalMonthDay,
-  '%Temporal.Time%': TemporalTime,
-  '%Temporal.TimeZone%': TemporalTimeZone,
-  '%Temporal.Absolute%': TemporalAbsolute,
-  '%Temporal.Duration%': TemporalDuration
-};
-
 import * as PARSE from './regex.mjs';
 
 export const ES = ObjectAssign({}, ES2019, {
@@ -74,7 +54,8 @@ export const ES = ObjectAssign({}, ES2019, {
   IsTemporalMonthDay: (item) => HasSlot(item, MONTH, DAY) && !HasSlot(item, YEAR),
   ToTemporalTimeZone: (item) => {
     if (ES.IsTemporalTimeZone(item)) return item;
-    return new TemporalTimeZone(ES.TemporalTimeZoneFromString(ES.ToString(item)));
+    const TimeZone = GetIntrinsic('%Temporal.TimeZone%');
+    return new TimeZone(ES.TemporalTimeZoneFromString(ES.ToString(item)));
   },
   TemporalTimeZoneFromString: (stringIdent) => {
     const { zone, ianaName, offset } = ES.ParseTemporalTimeZoneString(stringIdent);
@@ -458,9 +439,6 @@ export const ES = ObjectAssign({}, ES2019, {
       throw new RangeError(`${largestUnit} not allowed as the largest unit here`);
     }
     return largestUnit;
-  },
-  GetIntrinsic: (intrinsic) => {
-    return intrinsic in INTRINSICS ? INTRINSICS[intrinsic] : GetIntrinsic(intrinsic);
   },
   ToPartialRecord: (bag, fields) => {
     if (!bag || 'object' !== typeof bag) return false;

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -1,12 +1,5 @@
-import { ES } from './ecmascript.mjs';
+import { GetIntrinsic } from './intrinsicclass.mjs';
 import { TimeZone } from './timezone.mjs';
-
-const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');
-const DateTime = ES.GetIntrinsic('%Temporal.DateTime%');
-const Date = ES.GetIntrinsic('%Temporal.Date%');
-const Time = ES.GetIntrinsic('%Temporal.Time%');
-const YearMonth = ES.GetIntrinsic('%Temporal.YearMonth%');
-const MonthDay = ES.GetIntrinsic('%Temporal.MonthDay%');
 
 const DATE = Symbol('date');
 const YM = Symbol('ym');
@@ -165,6 +158,13 @@ function hasTimeOptions(options) {
 
 function extractOverrides(datetime, main) {
   let formatter;
+  const Absolute = GetIntrinsic('%Temporal.Absolute%');
+  const Date = GetIntrinsic('%Temporal.Date%');
+  const DateTime = GetIntrinsic('%Temporal.DateTime%');
+  const MonthDay = GetIntrinsic('%Temporal.MonthDay%');
+  const Time = GetIntrinsic('%Temporal.Time%');
+  const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
+
   if (datetime instanceof Time) {
     datetime = datetime.withDate(new Date(1970, 1, 1));
     formatter = main[TIME];

--- a/polyfill/lib/intrinsicclass.mjs
+++ b/polyfill/lib/intrinsicclass.mjs
@@ -1,3 +1,7 @@
+import ESGetIntrinsic from 'es-abstract/GetIntrinsic.js';
+
+const INTRINSICS = {};
+
 export function MakeIntrinsicClass(Class, name) {
   Object.defineProperty(Class.prototype, Symbol.toStringTag, {
     value: name,
@@ -31,4 +35,10 @@ export function MakeIntrinsicClass(Class, name) {
     desc.enumerable = false;
     Object.defineProperty(Class.prototype, prop, desc);
   }
+
+  INTRINSICS[`%${name}%`] = Class;
+}
+
+export function GetIntrinsic(intrinsic) {
+  return intrinsic in INTRINSICS ? INTRINSICS[intrinsic] : ESGetIntrinsic(intrinsic);
 }

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -1,5 +1,5 @@
 import { ES } from './ecmascript.mjs';
-import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { MONTH, DAY, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
 
 export class MonthDay {
@@ -52,7 +52,7 @@ export class MonthDay {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
     const month = GetSlot(this, MONTH);
     const day = GetSlot(this, DAY);
-    const Date = ES.GetIntrinsic('%Temporal.Date%');
+    const Date = GetIntrinsic('%Temporal.Date%');
     return new Date(year, month, day);
   }
   static from(item, options = undefined) {

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -1,5 +1,5 @@
 import { ES } from './ecmascript.mjs';
-const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');
+import { GetIntrinsic } from './intrinsicclass.mjs';
 
 export const now = {
   absolute,
@@ -10,6 +10,7 @@ export const now = {
 };
 
 function absolute() {
+  const Absolute = GetIntrinsic('%Temporal.Absolute%');
   return new Absolute(ES.SystemUTCEpochNanoSeconds());
 }
 function dateTime(temporalTimeZoneLike = timeZone()) {

--- a/polyfill/lib/temporal.mjs
+++ b/polyfill/lib/temporal.mjs
@@ -1,12 +1,9 @@
-import { ES } from './ecmascript.mjs';
-
-export const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');
-export const TimeZone = ES.GetIntrinsic('%Temporal.TimeZone%');
-export const DateTime = ES.GetIntrinsic('%Temporal.DateTime%');
-export const Date = ES.GetIntrinsic('%Temporal.Date%');
-export const YearMonth = ES.GetIntrinsic('%Temporal.YearMonth%');
-export const MonthDay = ES.GetIntrinsic('%Temporal.MonthDay%');
-export const Time = ES.GetIntrinsic('%Temporal.Time%');
-export const Duration = ES.GetIntrinsic('%Temporal.Duration%');
-
+export { Absolute } from './absolute.mjs';
+export { Date } from './date.mjs';
+export { DateTime } from './datetime.mjs';
+export { Duration } from './duration.mjs';
+export { MonthDay } from './monthday.mjs';
 export { now } from './now.mjs';
+export { Time } from './time.mjs';
+export { TimeZone } from './timezone.mjs';
+export { YearMonth } from './yearmonth.mjs';

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -1,5 +1,5 @@
 import { ES } from './ecmascript.mjs';
-import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 
 import {
   YEAR,
@@ -188,7 +188,7 @@ export class Time {
       nanoseconds,
       largestUnit
     ));
-    const Duration = ES.GetIntrinsic('%Temporal.Duration%');
+    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
 
@@ -222,7 +222,7 @@ export class Time {
     const millisecond = GetSlot(this, MILLISECOND);
     const microsecond = GetSlot(this, MICROSECOND);
     const nanosecond = GetSlot(this, NANOSECOND);
-    const DateTime = ES.GetIntrinsic('%Temporal.DateTime%');
+    const DateTime = GetIntrinsic('%Temporal.DateTime%');
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }
 

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -1,5 +1,5 @@
 import { ES } from './ecmascript.mjs';
-import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { IDENTIFIER, EPOCHNANOSECONDS, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
 import { ZONES } from './zones.mjs';
 
@@ -34,7 +34,7 @@ export class TimeZone {
       microsecond,
       nanosecond
     } = ES.GetTimeZoneDateTimeParts(ns, GetSlot(this, IDENTIFIER));
-    const DateTime = ES.GetIntrinsic('%Temporal.DateTime%');
+    const DateTime = GetIntrinsic('%Temporal.DateTime%');
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }
   getAbsoluteFor(dateTime, options) {
@@ -42,7 +42,7 @@ export class TimeZone {
     if (!ES.IsTemporalDateTime(dateTime)) throw new TypeError('invalid DateTime object');
     const disambiguation = ES.ToTimeZoneTemporalDisambiguation(options);
 
-    const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');
+    const Absolute = GetIntrinsic('%Temporal.Absolute%');
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = dateTime;
     const possibleEpochNs = ES.GetTimeZoneEpochValue(
       GetSlot(this, IDENTIFIER),
@@ -93,7 +93,7 @@ export class TimeZone {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalAbsolute(startingPoint)) throw new TypeError('invalid Absolute object');
     let epochNanoseconds = GetSlot(startingPoint, EPOCHNANOSECONDS);
-    const Absolute = ES.GetIntrinsic('%Temporal.Absolute%');
+    const Absolute = GetIntrinsic('%Temporal.Absolute%');
     const timeZone = GetSlot(this, IDENTIFIER);
     const result = {
       next: () => {

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -1,5 +1,5 @@
 import { ES } from './ecmascript.mjs';
-import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { YEAR, MONTH, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
 
 export class YearMonth {
@@ -109,7 +109,7 @@ export class YearMonth {
       months += 12 * years;
       years = 0;
     }
-    const Duration = ES.GetIntrinsic('%Temporal.Duration%');
+    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months);
   }
   toString() {
@@ -127,7 +127,7 @@ export class YearMonth {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     const year = GetSlot(this, YEAR);
     const month = GetSlot(this, MONTH);
-    const Date = ES.GetIntrinsic('%Temporal.Date%');
+    const Date = GetIntrinsic('%Temporal.Date%');
     return new Date(year, month, day);
   }
   static from(item, options = undefined) {

--- a/polyfill/test/all.mjs
+++ b/polyfill/test/all.mjs
@@ -9,39 +9,24 @@ import Demitasse from '@pipobscure/demitasse';
 import Pretty from '@pipobscure/demitasse-pretty';
 
 // tests with long tedious output
-import * as datemath from './datemath.mjs';
-import * as regex from './regex.mjs';
+import './datemath.mjs';
+import './regex.mjs';
 
 // tests of internals
-import * as ecmascript from './ecmascript.mjs';
+import './ecmascript.mjs';
 
 // tests of public API
-import * as exports from './exports.mjs';
-import * as now from './now.mjs';
-import * as timezone from './timezone.mjs';
-import * as absolute from './absolute.mjs';
-import * as date from './date.mjs';
-import * as time from './time.mjs';
-import * as datetime from './datetime.mjs';
-import * as duration from './duration.mjs';
-import * as yearmonth from './yearmonth.mjs';
-import * as monthday from './monthday.mjs';
-import * as intl from './intl.mjs';
-
-void datemath;
-void regex;
-void ecmascript;
-void exports;
-void now;
-void timezone;
-void absolute;
-void date;
-void time;
-void datetime;
-void duration;
-void yearmonth;
-void monthday;
-void intl;
+import './exports.mjs';
+import './now.mjs';
+import './timezone.mjs';
+import './absolute.mjs';
+import './date.mjs';
+import './time.mjs';
+import './datetime.mjs';
+import './duration.mjs';
+import './yearmonth.mjs';
+import './monthday.mjs';
+import './intl.mjs';
 
 Promise.resolve()
   .then(() => {


### PR DESCRIPTION
This removes the warning about circular dependencies that is printed when bundling the JS sources.