### PR TITLE
Rename 'cookbook' npm script to 'test-cookbook'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - npm run codecov:test262
   - name: "cookbook"
     script:
-    - npm run cookbook
+    - npm run test-cookbook
   - name: "Specification compilation"
     script:
     - npm run build

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "cd polyfill && npm install && npm test && npm run cookbook && npm run test262 && cd ..",
     "codecov:tests": "cd polyfill && npm install && npm run codecov:tests && cd ..",
     "codecov:test262": "cd polyfill && npm install && npm run codecov:test262 && cd ..",
-    "cookbook": "cd polyfill && npm install && npm run cookbook && cd ..",
+    "test-cookbook": "cd polyfill && npm install && npm run test-cookbook && cd ..",
     "test262": "cd polyfill && npm install && npm run test262",
     "lint": "eslint . --ext js,mjs",
     "build:prepare": "mkdirp out && mkdirp out/docs",

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -32,8 +32,8 @@ From this directory:
 
 ```bash
 # Run all cookbook files:
-$ npm run cookbook
+$ npm run test-cookbook
 
 # Run a single cookbook file:
-$ env TEST=dateTimeFromLegacyDate npm run cookbook-one
+$ env TEST=dateTimeFromLegacyDate npm run test-cookbook-one
 ```

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "coverage": "c8 report --reporter html",
     "test": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu --loader ./test/resolve.source.mjs ./test/all.mjs",
-    "cookbook": "TEST=all npm run cookbook-one",
-    "cookbook-one": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu --loader ./test/resolve.cookbook.mjs ../docs/cookbook/$TEST.mjs",
+    "test-cookbook": "TEST=all npm run test-cookbook-one",
+    "test-cookbook-one": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu --loader ./test/resolve.cookbook.mjs ../docs/cookbook/$TEST.mjs",
     "test262": "./ci_test.sh",
     "codecov:tests": "NODE_V8_COVERAGE=coverage/tmp npm run test && c8 report --reporter=text-lcov > coverage/tests.lcov && codecov -F tests -f coverage/tests.lcov",
     "codecov:test262": "COVERAGE=yes npm run test262 && codecov -F test262 -f coverage/test262.lcov",


### PR DESCRIPTION
It could be confused with building the cookbook (npm run build:docs).

Closes: #565