### PR TITLE
Fix confusion about Temporal.Time.difference largest unit

### DIFF
--- a/docs/time.md
+++ b/docs/time.md
@@ -246,7 +246,7 @@ time.minus({ minutes: 5, nanoseconds: 800 })  // => 19:34:09.068345405
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
     Valid values are `'years'`, `'months'`, `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
-    The default is `days`.
+    The default is effectively `'hours'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `time` and `other`.
 
@@ -258,8 +258,8 @@ The returned `Temporal.Duration` object will not have any nonzero fields that ar
 A difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`, for example.
 However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `"hours"`.
 
-The default largest unit in the result is hours.
-Since this method never returns any duration longer than 12 hours, largest units of years, months, or days, are by definition ignored and treated as hours.
+The default largest unit in the result is technically days, for consistency with other Temporal types' `difference` methods.
+However, since this method never returns any duration longer than 12 hours, largest units of years, months, or days, are by definition treated as hours.
 
 Usage example:
 ```javascript


### PR DESCRIPTION
Clear up this language a bit and explain that the default is effectively
hours.

Closes: #580