### PR TITLE
WIP: Fix infinite loop (only in Chrome) in ES.GetFormatterParts

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -720,7 +720,7 @@ export const ES = ObjectAssign({}, ES2019, {
       { type: 'year', value: era === 'BC' ? -year + 1 : +year },
       { type: 'month', value: +month },
       { type: 'day', value: +day },
-      { type: 'hour', value: +hour },
+      { type: 'hour', value: hour === '24' ? 0 : +hour }, // bugs.chromium.org/p/chromium/issues/detail?id=1045791
       { type: 'minute', value: +minute },
       { type: 'second', value: +second }
     ];

--- a/polyfill/test/ecmascript.mjs
+++ b/polyfill/test/ecmascript.mjs
@@ -381,6 +381,22 @@ describe('ECMAScript', () => {
       it(`${nanos} @ ${zone}`, () => deepEqual(ES.GetTimeZoneDateTimeParts(nanos, zone), expected));
     }
   });
+
+  describe('GetFormatterParts', () => {
+    // https://github.com/tc39/proposal-temporal/issues/575
+    test(1589670000000, GetSlot(ES.ToTemporalTimeZone('Europe/London'), IDENTIFIER), [
+      { type: 'year', value: 2020 },
+      { type: 'month', value: 5 },
+      { type: 'day', value: 17 },
+      { type: 'hour', value: 0 },
+      { type: 'minute', value: 0 },
+      { type: 'second', value: 0 }
+    ]);
+
+    function test(nanos, zone, expected) {
+      it(`${nanos} @ ${zone}`, () => deepEqual(ES.GetFormatterParts(zone, nanos), expected));
+    }
+  });
 });
 
 import { normalize } from 'path';


### PR DESCRIPTION
Fixes #575, which is an infinite loop in Chrome caused by https://bugs.chromium.org/p/chromium/issues/detail?id=1045791, where Chrome reports "24:00" instead of "00:00" for midnight times. This breaks `ES.GetFormatterParts` which in turn causes the infinite loop.

This 1-line PR treats `hour==='24'` as if it were zero.

For some reason the Temporal test suites won't run on my Mac, so it may take a few pushes to get all tests passing. I'll commit the test changes first to validate that the tests work, then push the code changes. _EDIT: Actually this didn't help because CI tests don't run in a real browser.  This means that the test added in this PR won't actually catch the original problem. Probably should consider using a browser-hosted test runner like [Karma](https://karma-runner.github.io/latest/index.html). I suggested this in #600._