### PR TITLE
Add test files and build scripts to polyfill's .npmignore

### DIFF
--- a/polyfill/.npmignore
+++ b/polyfill/.npmignore
@@ -1,1 +1,7 @@
 rollup.config.js
+rollup-script.config.js
+test
+test262
+types
+tsconfig.json
+*.sh


### PR DESCRIPTION
The polyfill package currently installs over 80MB of test files. Real users of the polyfill won't need those, right?

This PR reduces polyfill download size from 11.4MB to to 400KB (and on-disk size from 89MB to 2.3MB, and `npm pack` time by >90%) by adding the following to .npmignore: 
* test folders
* build scripts
* (selfishly for me) typescript-related tooling files I keep in my fork that don't need to be in the package

Before: 
```
npm notice === Tarball Details === 
npm notice name:          tc39-temporal                           
npm notice version:       1.0.0                                   
npm notice filename:      tc39-temporal-1.0.0.tgz                 
npm notice package size:  11.4 MB                                 
npm notice unpacked size: 89.6 MB                                 
npm notice shasum:        fe211943463190c8a2004118e2ba406c0c7cdab6
npm notice integrity:     sha512-VsM+zQTZlpRs3[...]IH/680se/ZGsQ==
npm notice total files:   46430                                   
npm notice 
```

After: 
```
npm notice === Tarball Details === 
npm notice name:          tc39-temporal                           
npm notice version:       1.0.0                                   
npm notice filename:      tc39-temporal-1.0.0.tgz                 
npm notice package size:  396.4 kB                                
npm notice unpacked size: 2.3 MB                                  
npm notice shasum:        7778d6ad13249cfe4f2c84d16ed351b6ec30edd8
npm notice integrity:     sha512-L73IWSyyvRvIO[...]F/l/9Y4n6Pq3g==
npm notice total files:   26  
```
