### PR TITLE
Custom time zones, phase 2

### DIFF
--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -45,7 +45,15 @@ export class TimeZone {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalAbsolute(absolute)) throw new TypeError('invalid Absolute object');
     const ns = GetSlot(absolute, EPOCHNANOSECONDS);
-    const {
+    const offsetNs = this.getOffsetNanosecondsFor(absolute);
+    if (typeof offsetNs !== 'number') {
+      throw new TypeError('bad return from getOffsetNanosecondsFor');
+    }
+    if (!Number.isInteger(offsetNs) || Math.abs(offsetNs) > 86400e9) {
+      throw new RangeError('out-of-range return from getOffsetNanosecondsFor');
+    }
+    let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.GetPartsFromEpoch(ns);
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.BalanceDateTime(
       year,
       month,
       day,
@@ -54,8 +62,8 @@ export class TimeZone {
       second,
       millisecond,
       microsecond,
-      nanosecond
-    } = ES.GetTimeZoneDateTimeParts(ns, GetSlot(this, TIMEZONE_ID));
+      nanosecond + offsetNs
+    ));
     const DateTime = GetIntrinsic('%Temporal.DateTime%');
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -34,9 +34,14 @@ export class TimeZone {
     return ES.GetTimeZoneOffsetNanoseconds(GetSlot(absolute, EPOCHNANOSECONDS), GetSlot(this, TIMEZONE_ID));
   }
   getOffsetStringFor(absolute) {
-    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
-    if (!ES.IsTemporalAbsolute(absolute)) throw new TypeError('invalid Absolute object');
-    return ES.GetTimeZoneOffsetString(GetSlot(absolute, EPOCHNANOSECONDS), GetSlot(this, TIMEZONE_ID));
+    const offsetNs = this.getOffsetNanosecondsFor(absolute);
+    if (typeof offsetNs !== 'number') {
+      throw new TypeError('bad return from getOffsetNanosecondsFor');
+    }
+    if (!Number.isInteger(offsetNs) || Math.abs(offsetNs) > 86400e9) {
+      throw new RangeError('out-of-range return from getOffsetNanosecondsFor');
+    }
+    return ES.FormatTimeZoneOffsetString(offsetNs);
   }
   getDateTimeFor(absolute) {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');

--- a/polyfill/test/ecmascript.mjs
+++ b/polyfill/test/ecmascript.mjs
@@ -11,7 +11,7 @@ import { ES } from '../lib/ecmascript.mjs';
 import { GetSlot, TIMEZONE_ID } from '../lib/slots.mjs';
 
 describe('ECMAScript', () => {
-  describe('GetTimeZoneDateTimeParts', () => {
+  describe('GetIANATimeZoneDateTimeParts', () => {
     describe('epoch', () => {
       test(0n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
@@ -378,7 +378,7 @@ describe('ECMAScript', () => {
     });
 
     function test(nanos, zone, expected) {
-      it(`${nanos} @ ${zone}`, () => deepEqual(ES.GetTimeZoneDateTimeParts(nanos, zone), expected));
+      it(`${nanos} @ ${zone}`, () => deepEqual(ES.GetIANATimeZoneDateTimeParts(nanos, zone), expected));
     }
   });
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -659,6 +659,7 @@
       1. Let _z_, _sign_, _hour_, _minute_, and _name_ be the parts of _isoString_ produced respectively by the |UTCDesignator|, |TimeZoneUTCOffsetSign|, |TimeZoneUTCOffsetHour|, |TimeZoneUTCOffsetMinute| and |TimeZoneIANAName| productions, or *undefined* if not present.
       1. If _z_ is not *undefined*, then
         1. Return the new Record: {
+          [[OffsetSign]]: *undefined*,
           [[OffsetHour]]: *undefined*,
           [[OffsetMinute]]: *undefined*,
           [[Name]]: `"UTC"`
@@ -667,12 +668,15 @@
         1. Assert: _sign_ is not *undefined*.
         1. Set _hour_ to ! ToInteger(_hour_).
         1. If _sign_ = `"-"`, then
-          1. Set _hour_ to &minus;1 &times; _hour_.
+          1. Set _sign_ to &minus;1.
+        1. Else,
+          1. Set _sign_ to 1.
         1. Set _minute_ to ! ToInteger(_minute_).
       1. If _name_ is not *undefined*, then
         1. Assert ! IsValidTimeZoneName(_name_).
         1. Let _name_ be ! CanonicalizeTimeZoneName(_name_).
       1. Return the new Record: {
+        [[OffsetSign]]: _sign_,
         [[OffsetHour]]: _hour_,
         [[OffsetMinute]]: _minute_,
         [[Name]]: _name_

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -150,7 +150,13 @@
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
-        1. Return ? GetTimeZoneOffsetString(_absolute_.[[Nanoseconds]], _timeZone_.[[Identifier]]).
+        1. Let _getOffsetNanosecondsFor_ be ? Get(_timeZone_, *"getOffsetNanosecondsFor"*).
+        1. Let _offsetNanoseconds_ be ? Call(_getOffsetNanosecondsFor_, _timeZone_, « _absolute_ »).
+        1. If Type(_offsetNanoseconds_) is not Number, then
+          1. Throw a *TypeError* exception.
+        1. If _offsetNanoseconds_ is not an integer Number value between &minus;86400 &times; 10<sup>9</sup> and 86400 &times; 10<sup>9</sup> exclusive, then
+          1. Throw a *RangeError* exception.
+        1. Return ? FormatTimeZoneOffsetString(_offsetNanoseconds_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -185,6 +185,27 @@
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _disambiguation_ be ? ToTimeZoneTemporalDisambiguation(_options_).
+        1. Let _getPossibleAbsolutesFor_ be ? Get(_timeZone_, *"getPossibleAbsolutesFor"*).
+        1. Let _possibleAbsolutes_ be ? Call(_getPossibleAbsolutesFor_, _timeZone_, « _dateTime_ »).
+        1. If ? IsArray(_possibleAbsolutes_) is *false*, then
+          1. Throw a *TypeError* exception.
+        1. Let _n_ be ? Get(_possibleAbsolutes_, *"length"*).
+        1. If _n_ = 1, then
+          1. Let _absolute_ be ? Get(_possibleAbsolutes_, *"0"*).
+          1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
+          1. Return _absolute_.
+        1. If _n_ ≠ 0, then
+          1. If _disambiguation_ is *"earlier"*, then
+            1. Let _absolute_ be ? Get(_possibleAbsolutes_, *"0"*).
+            1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
+            1. Return _absolute_.
+          1. If _disambiguation_ is *"later"*, then
+            1. Let _index_ be ? ToString(_n_ &minus; 1).
+            1. Let _absolute_ be ? Get(_possibleAbsolutes_, _index_).
+            1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
+            1. Return _absolute_.
+          1. If _disambiguation_ is *"reject"*, then
+            1. Throw a *RangeError* exception.
         1. <mark>TODO</mark>
       </emu-alg>
     </emu-clause>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -256,7 +256,11 @@
       <emu-alg>
         1. Assert: Type(_string_) is String.
         1. Let _result_ be ? ParseTemporalTimeZoneString(_string_).
-        1. Let _offset_ be ! FormatTimeZoneOffset(_result_.[[TimeZoneOffsetHour]], _result_.[[TimeZoneOffsetMinute]]).
+        1. If any of _result_.[[OffsetSign]], _result_.[[OffsetHour]], or _result_.[[OffsetMinute]] are *undefined*, then
+          1. Let _offset_ be *undefined*.
+        1. Else,
+          1. Let _offsetNanoseconds_ be _result_.[[OffsetSign]] &times; (_result_.[[OffsetHour]] &times; 60 + _result_.[[OffsetMinute]]) &times; 60 &times; 10<sup>9</sup>.
+          1. Let _offset_ be ! FormatTimeZoneOffsetString(_offsetNanoseconds_).
         1. Let _identifier_ be the first one of _result_.[[TimeZoneName]], _offset_, or *"UTC"* that is not *undefined*.
         1. If ! IsValidTimeZoneName(_identifier_) is *false*, then
           1. Throw a *TypeError* exception.
@@ -287,14 +291,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-formattimezoneoffset" aoid="FormatTimeZoneOffset">
-      <h1>FormatTimeZoneOffset ( _hour_, _minute_ )</h1>
+    <emu-clause id="sec-temporal-formattimezoneoffsetstring" aoid="FormatTimeZoneOffsetString">
+      <h1>FormatTimeZoneOffsetString ( _offsetNanoseconds_ )</h1>
       <emu-alg>
-        1. If either of _hour_ or _minute_ are *undefined*, return *undefined*.
-        1. Assert: _hour_ and _minute_ are integer Number values.
-        1. If _hour_ ≥ 0, let _sign_ be `"+"`; otherwise, let _sign_ be `"-"`.
-        1. Let _h_ be abs(_hour_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-        1. Let _m_ be abs(_minute_), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+        1. Assert: _offsetNanoseconds_ is an integer Number value.
+        1. If _offsetNanoseconds_ ≥ 0, let _sign_ be *"+"*; otherwise, let _sign_ be *"-"*.
+        1. Let _offsetMinutes_ be floor(abs(_offsetNanoseconds_) / (60 &times; 10<sup>9</sup>)).
+        1. Let _h_ be floor(_offsetMinutes_ / 60), formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+        1. Let _m_ be _offsetMinutes_ modulo 60, formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Return the string-concatenation of _sign_, _h_, the code unit 0x003A (COLON), and _m_.
       </emu-alg>
     </emu-clause>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -170,7 +170,15 @@
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
-        1. Return ? GetTemporalDateTimeFor(_timeZone_, _absolute_).
+        1. Let _getOffsetNanosecondsFor_ be ? Get(_timeZone_, *"getOffsetNanosecondsFor"*).
+        1. Let _offsetNanoseconds_ be ? Call(_getOffsetNanosecondsFor_, _timeZone_, « _absolute_ »).
+        1. If Type(_offsetNanoseconds_) is not Number, then
+          1. Throw a *TypeError* exception.
+        1. If _offsetNanoseconds_ is not an integer Number value between &minus;86400 &times; 10<sup>9</sup> and 86400 &times; 10<sup>9</sup> exclusive, then
+          1. Throw a *RangeError* exception.
+        1. <mark>TODO:</mark> Let _result_ be the moment _absolute_.[[Nanosecond]] nanoseconds from the epoch, in the UTC time zone.
+        1. Set _result_ to ? BalanceDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).
+        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
 
@@ -303,18 +311,6 @@
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Temporal.TimeZone.prototype%"`, « [[InitializedTemporalTimeZone]], [[Identifier]] »).
         1. Set _object_.[[Identifier]] to _identifier_.
         1. Return _object_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-gettemporaldatetimefor" aoid="GetTemporalDateTimeFor">
-      <h1>GetTemporalDateTimeFor ( _timeZone_, _absolute_ )</h1>
-      <emu-alg>
-        1. Assert: Type(_timeZone_) is Object.
-        1. Assert: _timeZone_ has an [[InitializedTemporalTimeZone]] internal slot.
-        1. Assert: Type(_absolute_) is Object.
-        1. Assert: _absolute_ has an [[InitializedTemporalAbsolute]] internal slot.
-        1. Let _result_ be the moment _absolute_.[[Nanosecond]] nanoseconds from the epoch, in the time zone _timeZone_.[[Identifier]].
-        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Spec changes are present where they are straightforward, but I haven't concentrated on writing a complete spec for these changes. since the time zone spec was already not complete yet anyway.

According to the time zone draft, custom time zones have to implement three methods: `getOffsetNanosecondsFor`, `getPossibleAbsolutesFor`, and `getTransitions`. All other methods of Temporal.TimeZone should be implemented in terms of these three, resulting in observable calls.

With this code, all the pieces are in place now for custom time zones. This will be followed shortly by a "phase 3" pull request which adds tests proving that custom time zones work (and will need to remove some brand checks and fix a few other things.)