### PR TITLE
Replace IDENTIFIER slot with TIMEZONE_ID

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -10,7 +10,7 @@ import {
   GetSlot,
   HasSlot,
   EPOCHNANOSECONDS,
-  IDENTIFIER,
+  TIMEZONE_ID,
   ISO_YEAR,
   ISO_MONTH,
   ISO_DAY,
@@ -41,7 +41,7 @@ import * as PARSE from './regex.mjs';
 
 export const ES = ObjectAssign({}, ES2019, {
   IsTemporalAbsolute: (item) => HasSlot(item, EPOCHNANOSECONDS),
-  IsTemporalTimeZone: (item) => HasSlot(item, IDENTIFIER),
+  IsTemporalTimeZone: (item) => HasSlot(item, TIMEZONE_ID),
   IsTemporalDuration: (item) =>
     HasSlot(item, YEARS, MONTHS, DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS),
   IsTemporalDate: (item) =>

--- a/polyfill/lib/slots.mjs
+++ b/polyfill/lib/slots.mjs
@@ -2,7 +2,7 @@
 export const EPOCHNANOSECONDS = 'slot-epochNanoSeconds';
 
 // TimeZone
-export const IDENTIFIER = 'slot-identifier';
+export const TIMEZONE_ID = 'slot-timezone-identifier';
 
 // DateTime, Date, Time, YearMonth, MonthDay
 export const ISO_YEAR = 'slot-year';

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -1,7 +1,7 @@
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import {
-  IDENTIFIER,
+  TIMEZONE_ID,
   EPOCHNANOSECONDS,
   ISO_YEAR,
   ISO_MONTH,
@@ -22,21 +22,21 @@ import bigInt from 'big-integer';
 export class TimeZone {
   constructor(timeZoneIdentifier) {
     CreateSlots(this);
-    SetSlot(this, IDENTIFIER, ES.GetCanonicalTimeZoneIdentifier(timeZoneIdentifier));
+    SetSlot(this, TIMEZONE_ID, ES.GetCanonicalTimeZoneIdentifier(timeZoneIdentifier));
   }
   get name() {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
-    return String(GetSlot(this, IDENTIFIER));
+    return String(GetSlot(this, TIMEZONE_ID));
   }
   getOffsetNanosecondsFor(absolute) {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalAbsolute(absolute)) throw new TypeError('invalid Absolute object');
-    return ES.GetTimeZoneOffsetNanoseconds(GetSlot(absolute, EPOCHNANOSECONDS), GetSlot(this, IDENTIFIER));
+    return ES.GetTimeZoneOffsetNanoseconds(GetSlot(absolute, EPOCHNANOSECONDS), GetSlot(this, TIMEZONE_ID));
   }
   getOffsetStringFor(absolute) {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalAbsolute(absolute)) throw new TypeError('invalid Absolute object');
-    return ES.GetTimeZoneOffsetString(GetSlot(absolute, EPOCHNANOSECONDS), GetSlot(this, IDENTIFIER));
+    return ES.GetTimeZoneOffsetString(GetSlot(absolute, EPOCHNANOSECONDS), GetSlot(this, TIMEZONE_ID));
   }
   getDateTimeFor(absolute) {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
@@ -52,7 +52,7 @@ export class TimeZone {
       millisecond,
       microsecond,
       nanosecond
-    } = ES.GetTimeZoneDateTimeParts(ns, GetSlot(this, IDENTIFIER));
+    } = ES.GetTimeZoneDateTimeParts(ns, GetSlot(this, TIMEZONE_ID));
     const DateTime = GetIntrinsic('%Temporal.DateTime%');
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }
@@ -63,7 +63,7 @@ export class TimeZone {
 
     const Absolute = GetIntrinsic('%Temporal.Absolute%');
     const possibleEpochNs = ES.GetTimeZoneEpochValue(
-      GetSlot(this, IDENTIFIER),
+      GetSlot(this, TIMEZONE_ID),
       GetSlot(dateTime, ISO_YEAR),
       GetSlot(dateTime, ISO_MONTH),
       GetSlot(dateTime, ISO_DAY),
@@ -99,8 +99,8 @@ export class TimeZone {
       GetSlot(dateTime, NANOSECOND)
     );
     if (utcns === null) throw new RangeError('DateTime outside of supported range');
-    const before = ES.GetTimeZoneOffsetNanoseconds(utcns.minus(bigInt(86400 * 1e9)), GetSlot(this, IDENTIFIER));
-    const after = ES.GetTimeZoneOffsetNanoseconds(utcns.plus(bigInt(86400 * 1e9)), GetSlot(this, IDENTIFIER));
+    const before = ES.GetTimeZoneOffsetNanoseconds(utcns.minus(bigInt(86400 * 1e9)), GetSlot(this, TIMEZONE_ID));
+    const after = ES.GetTimeZoneOffsetNanoseconds(utcns.plus(bigInt(86400 * 1e9)), GetSlot(this, TIMEZONE_ID));
     const nanoseconds = after - before;
     const diff = ES.ToTemporalDurationRecord({ nanoseconds }, 'reject');
     switch (disambiguation) {
@@ -123,7 +123,7 @@ export class TimeZone {
     if (!ES.IsTemporalDateTime(dateTime)) throw new TypeError('invalid DateTime object');
     const Absolute = GetIntrinsic('%Temporal.Absolute%');
     const possibleEpochNs = ES.GetTimeZoneEpochValue(
-      GetSlot(this, IDENTIFIER),
+      GetSlot(this, TIMEZONE_ID),
       GetSlot(dateTime, ISO_YEAR),
       GetSlot(dateTime, ISO_MONTH),
       GetSlot(dateTime, ISO_DAY),
@@ -141,7 +141,7 @@ export class TimeZone {
     if (!ES.IsTemporalAbsolute(startingPoint)) throw new TypeError('invalid Absolute object');
     let epochNanoseconds = GetSlot(startingPoint, EPOCHNANOSECONDS);
     const Absolute = GetIntrinsic('%Temporal.Absolute%');
-    const timeZone = GetSlot(this, IDENTIFIER);
+    const timeZone = GetSlot(this, TIMEZONE_ID);
     const result = {
       next: () => {
         epochNanoseconds = ES.GetTimeZoneNextTransition(epochNanoseconds, timeZone);
@@ -162,7 +162,7 @@ export class TimeZone {
   static from(item) {
     let timeZone;
     if (ES.IsTemporalTimeZone(item)) {
-      timeZone = GetSlot(item, IDENTIFIER);
+      timeZone = GetSlot(item, TIMEZONE_ID);
     } else {
       timeZone = ES.TemporalTimeZoneFromString(ES.ToString(item));
     }

--- a/polyfill/test/ecmascript.mjs
+++ b/polyfill/test/ecmascript.mjs
@@ -8,12 +8,12 @@ import { strict as assert } from 'assert';
 const { deepEqual } = assert;
 
 import { ES } from '../lib/ecmascript.mjs';
-import { GetSlot, IDENTIFIER } from '../lib/slots.mjs';
+import { GetSlot, TIMEZONE_ID } from '../lib/slots.mjs';
 
 describe('ECMAScript', () => {
   describe('GetTimeZoneDateTimeParts', () => {
     describe('epoch', () => {
-      test(0n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), IDENTIFIER), {
+      test(0n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -24,7 +24,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), IDENTIFIER), {
+      test(0n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -35,7 +35,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), IDENTIFIER), {
+      test(0n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -46,7 +46,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), IDENTIFIER), {
+      test(0n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -57,7 +57,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), IDENTIFIER), {
+      test(0n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -68,7 +68,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), IDENTIFIER), {
+      test(0n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -81,7 +81,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('epoch-1', () => {
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), IDENTIFIER), {
+      test(-1n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -92,7 +92,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), IDENTIFIER), {
+      test(-1n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -103,7 +103,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), IDENTIFIER), {
+      test(-1n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -114,7 +114,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), IDENTIFIER), {
+      test(-1n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -125,7 +125,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), IDENTIFIER), {
+      test(-1n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -136,7 +136,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), IDENTIFIER), {
+      test(-1n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -149,7 +149,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('epoch+1', () => {
-      test(1n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), IDENTIFIER), {
+      test(1n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -160,7 +160,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), IDENTIFIER), {
+      test(1n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -171,7 +171,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), IDENTIFIER), {
+      test(1n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -182,7 +182,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), IDENTIFIER), {
+      test(1n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -193,7 +193,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), IDENTIFIER), {
+      test(1n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -204,7 +204,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), IDENTIFIER), {
+      test(1n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -217,7 +217,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('epoch-6300000000001', () => {
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), IDENTIFIER), {
+      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -228,7 +228,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), IDENTIFIER), {
+      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -239,7 +239,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), IDENTIFIER), {
+      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -250,7 +250,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), IDENTIFIER), {
+      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -261,7 +261,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), IDENTIFIER), {
+      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -272,7 +272,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), IDENTIFIER), {
+      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -285,7 +285,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('epoch+6300000000001', () => {
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), IDENTIFIER), {
+      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -296,7 +296,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), IDENTIFIER), {
+      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -307,7 +307,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), IDENTIFIER), {
+      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -318,7 +318,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), IDENTIFIER), {
+      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -329,7 +329,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), IDENTIFIER), {
+      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -340,7 +340,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), IDENTIFIER), {
+      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -353,7 +353,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('dst', () => {
-      test(1553993999999999999n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), IDENTIFIER), {
+      test(1553993999999999999n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
         year: 2019,
         month: 3,
         day: 31,
@@ -364,7 +364,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(1553994000000000000n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), IDENTIFIER), {
+      test(1553994000000000000n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
         year: 2019,
         month: 3,
         day: 31,
@@ -384,7 +384,7 @@ describe('ECMAScript', () => {
 
   describe('GetFormatterParts', () => {
     // https://github.com/tc39/proposal-temporal/issues/575
-    test(1589670000000, GetSlot(ES.ToTemporalTimeZone('Europe/London'), IDENTIFIER), [
+    test(1589670000000, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), [
       { type: 'year', value: 2020 },
       { type: 'month', value: 5 },
       { type: 'day', value: 17 },


### PR DESCRIPTION
Temporal.Calendar is also going to have an identifier, but we will need
to have separate internal slots in order to tell the two types apart.

No change in the spec is needed because the spec has additional
[[InitializedTemporalX]] slots which we don't have in the polyfill.