### PR TITLE
Add getISOCalendarFields() method to calendar-dependent types

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -509,7 +509,6 @@ This method can be used to convert a `Temporal.Date` into a record-like data str
 It returns a new plain JavaScript object, with all the fields as enumerable, writable, own data properties.
 
 Note that if using a different calendar from ISO 8601, these will be the calendar-specific values.
-To get the ISO 8601 values, use `date.getISOFields()`.
 
 > **NOTE**: The possible values for the `month` property of the returned object start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
@@ -518,4 +517,18 @@ Usage example:
 date = Temporal.Date.from('2006-08-24');
 Object.assign({}, date).day  // => undefined
 Object.assign({}, date.getFields()).day  // => 24
+```
+
+### date.**getISOCalendarFields**(): { year: number, month: number, day: number }
+
+**Returns:** a plain object with properties expressing `date` in the ISO 8601 calendar.
+
+This method is mainly useful if you are implementing a custom calendar.
+Most code will not need to use it.
+Use `date.getFields()` instead.
+
+Usage example:
+```javascript
+date = Temporal.Date.from('2006-08-24');
+date.getISOCalendarFields().day  // => 24
 ```

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -586,7 +586,6 @@ This method can be used to convert a `Temporal.DateTime` into a record-like data
 It returns a new plain JavaScript object, with all the fields as enumerable, writable, own data properties.
 
 Note that if using a different calendar from ISO 8601, these will be the calendar-specific values.
-To get the ISO 8601 values, use `datetime.getISOFields()`.
 
 > **NOTE**: The possible values for the `month` property of the returned object start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
@@ -595,4 +594,18 @@ Usage example:
 dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 Object.assign({}, dt).day  // => undefined
 Object.assign({}, dt.getFields()).day  // => 7
+```
+
+### datetime.**getISOCalendarFields**(): { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number }
+
+**Returns:** a plain object with properties expressing `datetime` in the ISO 8601 calendar.
+
+This method is mainly useful if you are implementing a custom calendar.
+Most code will not need to use it.
+Use `datetime.getFields()` instead.
+
+Usage example:
+```javascript
+dt = Temporal.Date.from('1995-12-07T03:24:30.000003500');
+date.getISOCalendarFields().day  // => 7
 ```

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -270,7 +270,6 @@ This method can be used to convert a `Temporal.MonthDay` into a record-like data
 It returns a new plain JavaScript object, with all the fields as enumerable, writable, own data properties.
 
 Note that if using a different calendar from ISO 8601, these will be the calendar-specific values.
-To get the ISO 8601 values, use `datetime.getISOFields()`.
 
 > **NOTE**: The possible values for the `month` property of the returned object start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
@@ -279,4 +278,18 @@ Usage example:
 md = Temporal.MonthDay.from('08-24');
 Object.assign({}, md).day  // => undefined
 Object.assign({}, md.getFields()).day  // => 24
+```
+
+### monthDay.**getISOCalendarFields**(): { month: number, day: number }
+
+**Returns:** a plain object with properties expressing `monthDay` in the ISO 8601 calendar.
+
+This method is mainly useful if you are implementing a custom calendar.
+Most code will not need to use it.
+Use `monthDay.getFields()` instead.
+
+Usage example:
+```javascript
+md = Temporal.MonthDay.from('08-24');
+md.getISOCalendarFields().day  // => 24
 ```

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -436,7 +436,6 @@ This method can be used to convert a `Temporal.YearMonth` into a record-like dat
 It returns a new plain JavaScript object, with all the fields as enumerable, writable, own data properties.
 
 Note that if using a different calendar from ISO 8601, these will be the calendar-specific values.
-To get the ISO 8601 values, use `yearMonth.getISOFields()`.
 
 > **NOTE**: The possible values for the `month` property of the returned object start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
@@ -445,4 +444,18 @@ Usage example:
 ym = Temporal.DateTime.from('2019-06');
 Object.assign({}, ym).year  // => undefined
 Object.assign({}, ym.getFields()).year  // => 2019
+```
+
+### yearMonth.**getISOCalendarFields**(): { year: number, month: number }
+
+**Returns:** a plain object with properties expressing `yearMonth` in the ISO 8601 calendar.
+
+This method is mainly useful if you are implementing a custom calendar.
+Most code will not need to use it.
+Use `yearMonth.getFields()` instead.
+
+Usage example:
+```javascript
+ym = Temporal.YearMonth.from('2019-06');
+ym.getISOCalendarFields().year  // => 2019
 ```

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -191,6 +191,12 @@ export namespace Temporal {
     day?: number;
   };
 
+  export type DateISOCalendarFields = {
+    year: number;
+    month: number;
+    day: number;
+  };
+
   /**
    * A `Temporal.Date` represents a calendar date. "Calendar date" refers to the
    * concept of a date as expressed in everyday usage, independent of any time
@@ -222,6 +228,7 @@ export namespace Temporal {
     getYearMonth(): Temporal.YearMonth;
     getMonthDay(): Temporal.MonthDay;
     getFields(): Required<DateLike>;
+    getISOCalendarFields(): DateISOCalendarFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(): string;
@@ -237,6 +244,18 @@ export namespace Temporal {
     millisecond?: number;
     microsecond?: number;
     nanosecond?: number;
+  };
+
+  export type DateTimeISOCalendarFields = {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+    millisecond: number;
+    microsecond: number;
+    nanosecond: number;
   };
 
   /**
@@ -292,6 +311,7 @@ export namespace Temporal {
     getMonthDay(): Temporal.MonthDay;
     getTime(): Temporal.Time;
     getFields(): Required<DateTimeLike>;
+    getISOCalendarFields(): DateTimeISOCalendarFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(): string;
@@ -300,6 +320,11 @@ export namespace Temporal {
   export type MonthDayLike = {
     month?: number;
     day?: number;
+  };
+
+  export type MonthDayISOCalendarFields = {
+    month: number;
+    day: number;
   };
 
   /**
@@ -318,6 +343,7 @@ export namespace Temporal {
     with(monthDayLike: MonthDayLike, options?: AssignmentOptions): Temporal.MonthDay;
     withYear(year: number | { year: number }): Temporal.Date;
     getFields(): Required<MonthDayLike>;
+    getISOCalendarFields(): MonthDayISOCalendarFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(): string;
@@ -408,6 +434,11 @@ export namespace Temporal {
     month?: number;
   };
 
+  export type YearMonthISOCalendarFields = {
+    year: number;
+    month: number;
+  };
+
   /**
    * A `Temporal.YearMonth` represents a particular month on the calendar. For
    * example, it could be used to represent a particular instance of a monthly
@@ -431,6 +462,7 @@ export namespace Temporal {
     difference(other: Temporal.YearMonth, options: DifferenceOptions<'years' | 'months'>): Temporal.Duration;
     withDay(day: number): Temporal.Date;
     getFields(): Required<YearMonthLike>;
+    getISOCalendarFields(): YearMonthISOCalendarFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(): string;

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -183,6 +183,14 @@ export class Date {
     if (!fields) throw new TypeError('invalid receiver');
     return fields;
   }
+  getISOCalendarFields() {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return {
+      year: GetSlot(this, ISO_YEAR),
+      month: GetSlot(this, ISO_MONTH),
+      day: GetSlot(this, ISO_DAY)
+    };
+  }
   static from(item, options = undefined) {
     const disambiguation = ES.ToTemporalDisambiguation(options);
     let year, month, day;

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -348,6 +348,20 @@ export class DateTime {
     if (!fields) throw new TypeError('invalid receiver');
     return fields;
   }
+  getISOCalendarFields() {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return {
+      year: GetSlot(this, ISO_YEAR),
+      month: GetSlot(this, ISO_MONTH),
+      day: GetSlot(this, ISO_DAY),
+      hour: GetSlot(this, HOUR),
+      minute: GetSlot(this, MINUTE),
+      second: GetSlot(this, SECOND),
+      millisecond: GetSlot(this, MILLISECOND),
+      microsecond: GetSlot(this, MICROSECOND),
+      nanosecond: GetSlot(this, NANOSECOND)
+    };
+  }
 
   static from(item, options = undefined) {
     const disambiguation = ES.ToTemporalDisambiguation(options);

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -76,6 +76,13 @@ export class MonthDay {
     if (!fields) throw new TypeError('invalid receiver');
     return fields;
   }
+  getISOCalendarFields() {
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    return {
+      month: GetSlot(this, ISO_MONTH),
+      day: GetSlot(this, ISO_DAY)
+    };
+  }
   static from(item, options = undefined) {
     const disambiguation = ES.ToTemporalDisambiguation(options);
     let month, day;

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -145,6 +145,13 @@ export class YearMonth {
     if (!fields) throw new TypeError('invalid receiver');
     return fields;
   }
+  getISOCalendarFields() {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return {
+      year: GetSlot(this, ISO_YEAR),
+      month: GetSlot(this, ISO_MONTH)
+    };
+  }
   static from(item, options = undefined) {
     const disambiguation = ES.ToTemporalDisambiguation(options);
     let year, month;

--- a/polyfill/test/Date/prototype/getISOCalendarFields/branding.js
+++ b/polyfill/test/Date/prototype/getISOCalendarFields/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const getISOCalendarFields = Temporal.Date.prototype.getISOCalendarFields;
+
+assert.sameValue(typeof getISOCalendarFields, "function");
+
+assert.throws(TypeError, () => getISOCalendarFields.call(undefined), "undefined");
+assert.throws(TypeError, () => getISOCalendarFields.call(null), "null");
+assert.throws(TypeError, () => getISOCalendarFields.call(true), "true");
+assert.throws(TypeError, () => getISOCalendarFields.call(""), "empty string");
+assert.throws(TypeError, () => getISOCalendarFields.call(Symbol()), "symbol");
+assert.throws(TypeError, () => getISOCalendarFields.call(1), "1");
+assert.throws(TypeError, () => getISOCalendarFields.call({}), "plain object");
+assert.throws(TypeError, () => getISOCalendarFields.call(Temporal.Date), "Temporal.Date");
+assert.throws(TypeError, () => getISOCalendarFields.call(Temporal.Date.prototype), "Temporal.Date.prototype");

--- a/polyfill/test/Date/prototype/getISOCalendarFields/prop-desc.js
+++ b/polyfill/test/Date/prototype/getISOCalendarFields/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  typeof Temporal.Date.prototype.getISOCalendarFields,
+  "function",
+  "`typeof Date.prototype.getISOCalendarFields` is `function`"
+);
+
+verifyProperty(Temporal.Date.prototype, "getISOCalendarFields", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Date/prototype/getISOCalendarFields/subclass.js
+++ b/polyfill/test/Date/prototype/getISOCalendarFields/subclass.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.date.prototype.getisocalendarfields
+includes: [compareArray.js]
+---*/
+
+let called = 0;
+
+const constructorArguments = [
+  [2000, 5, 2]
+];
+
+class MyDate extends Temporal.Date {
+  constructor(year, month, day) {
+    assert.compareArray([year, month, day], constructorArguments.shift(), "constructor arguments");
+    ++called;
+    super(year, month, day);
+  }
+}
+
+const instance = MyDate.from("2000-05-02");
+assert.sameValue(called, 1);
+
+const result = instance.getISOCalendarFields();
+assert.sameValue(result.year, 2000, "year result");
+assert.sameValue(result.month, 5, "month result");
+assert.sameValue(result.day, 2, "day result");
+assert.sameValue(called, 1);
+assert.sameValue(Object.getPrototypeOf(result), Object.prototype);

--- a/polyfill/test/DateTime/prototype/getISOCalendarFields/branding.js
+++ b/polyfill/test/DateTime/prototype/getISOCalendarFields/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const getISOCalendarFields = Temporal.DateTime.prototype.getISOCalendarFields;
+
+assert.sameValue(typeof getISOCalendarFields, "function");
+
+assert.throws(TypeError, () => getISOCalendarFields.call(undefined), "undefined");
+assert.throws(TypeError, () => getISOCalendarFields.call(null), "null");
+assert.throws(TypeError, () => getISOCalendarFields.call(true), "true");
+assert.throws(TypeError, () => getISOCalendarFields.call(""), "empty string");
+assert.throws(TypeError, () => getISOCalendarFields.call(Symbol()), "symbol");
+assert.throws(TypeError, () => getISOCalendarFields.call(1), "1");
+assert.throws(TypeError, () => getISOCalendarFields.call({}), "plain object");
+assert.throws(TypeError, () => getISOCalendarFields.call(Temporal.DateTime), "Temporal.DateTime");
+assert.throws(TypeError, () => getISOCalendarFields.call(Temporal.DateTime.prototype), "Temporal.DateTime.prototype");

--- a/polyfill/test/DateTime/prototype/getISOCalendarFields/prop-desc.js
+++ b/polyfill/test/DateTime/prototype/getISOCalendarFields/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  typeof Temporal.DateTime.prototype.getISOCalendarFields,
+  "function",
+  "`typeof DateTime.prototype.getISOCalendarFields` is `function`"
+);
+
+verifyProperty(Temporal.DateTime.prototype, "getISOCalendarFields", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/DateTime/prototype/getISOCalendarFields/subclass.js
+++ b/polyfill/test/DateTime/prototype/getISOCalendarFields/subclass.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.datetime.prototype.getisocalendarfields
+includes: [compareArray.js]
+---*/
+
+let called = 0;
+
+const constructorArguments = [
+  [2000, 5, 2, 12, 34, 56, 987, 654, 321]
+];
+
+class MyDateTime extends Temporal.DateTime {
+  constructor(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) {
+    assert.compareArray([year, month, day, hour, minute, second, millisecond, microsecond, nanosecond], constructorArguments.shift(), "constructor arguments");
+    ++called;
+    super(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+  }
+}
+
+const instance = MyDateTime.from("2000-05-02T12:34:56.987654321");
+assert.sameValue(called, 1);
+
+const result = instance.getISOCalendarFields();
+assert.sameValue(result.year, 2000, "year result");
+assert.sameValue(result.month, 5, "month result");
+assert.sameValue(result.day, 2, "day result");
+assert.sameValue(result.hour, 12, "hour result");
+assert.sameValue(result.minute, 34, "minute result");
+assert.sameValue(result.second, 56, "second result");
+assert.sameValue(result.millisecond, 987, "millisecond result");
+assert.sameValue(result.microsecond, 654, "microsecond result");
+assert.sameValue(result.nanosecond, 321, "nanosecond result");
+assert.sameValue(called, 1);
+assert.sameValue(Object.getPrototypeOf(result), Object.prototype);

--- a/polyfill/test/MonthDay/prototype/getISOCalendarFields/branding.js
+++ b/polyfill/test/MonthDay/prototype/getISOCalendarFields/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const getISOCalendarFields = Temporal.MonthDay.prototype.getISOCalendarFields;
+
+assert.sameValue(typeof getISOCalendarFields, "function");
+
+assert.throws(TypeError, () => getISOCalendarFields.call(undefined), "undefined");
+assert.throws(TypeError, () => getISOCalendarFields.call(null), "null");
+assert.throws(TypeError, () => getISOCalendarFields.call(true), "true");
+assert.throws(TypeError, () => getISOCalendarFields.call(""), "empty string");
+assert.throws(TypeError, () => getISOCalendarFields.call(Symbol()), "symbol");
+assert.throws(TypeError, () => getISOCalendarFields.call(1), "1");
+assert.throws(TypeError, () => getISOCalendarFields.call({}), "plain object");
+assert.throws(TypeError, () => getISOCalendarFields.call(Temporal.MonthDay), "Temporal.MonthDay");
+assert.throws(TypeError, () => getISOCalendarFields.call(Temporal.MonthDay.prototype), "Temporal.MonthDay.prototype");

--- a/polyfill/test/MonthDay/prototype/getISOCalendarFields/prop-desc.js
+++ b/polyfill/test/MonthDay/prototype/getISOCalendarFields/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  typeof Temporal.MonthDay.prototype.getISOCalendarFields,
+  "function",
+  "`typeof MonthDay.prototype.getISOCalendarFields` is `function`"
+);
+
+verifyProperty(Temporal.MonthDay.prototype, "getISOCalendarFields", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/MonthDay/prototype/getISOCalendarFields/subclass.js
+++ b/polyfill/test/MonthDay/prototype/getISOCalendarFields/subclass.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.monthday.prototype.getisocalendarfields
+includes: [compareArray.js]
+---*/
+
+let called = 0;
+
+const constructorArguments = [
+  [5, 2]
+];
+
+class MyMonthDay extends Temporal.MonthDay {
+  constructor(month, day) {
+    assert.compareArray([month, day], constructorArguments.shift(), "constructor arguments");
+    ++called;
+    super(month, day);
+  }
+}
+
+const instance = MyMonthDay.from("05-02");
+assert.sameValue(called, 1);
+
+const result = instance.getISOCalendarFields();
+assert.sameValue(result.month, 5, "month result");
+assert.sameValue(result.day, 2, "day result");
+assert.sameValue(called, 1);
+assert.sameValue(Object.getPrototypeOf(result), Object.prototype);

--- a/polyfill/test/YearMonth/prototype/getISOCalendarFields/branding.js
+++ b/polyfill/test/YearMonth/prototype/getISOCalendarFields/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const getISOCalendarFields = Temporal.YearMonth.prototype.getISOCalendarFields;
+
+assert.sameValue(typeof getISOCalendarFields, "function");
+
+assert.throws(TypeError, () => getISOCalendarFields.call(undefined), "undefined");
+assert.throws(TypeError, () => getISOCalendarFields.call(null), "null");
+assert.throws(TypeError, () => getISOCalendarFields.call(true), "true");
+assert.throws(TypeError, () => getISOCalendarFields.call(""), "empty string");
+assert.throws(TypeError, () => getISOCalendarFields.call(Symbol()), "symbol");
+assert.throws(TypeError, () => getISOCalendarFields.call(1), "1");
+assert.throws(TypeError, () => getISOCalendarFields.call({}), "plain object");
+assert.throws(TypeError, () => getISOCalendarFields.call(Temporal.YearMonth), "Temporal.YearMonth");
+assert.throws(TypeError, () => getISOCalendarFields.call(Temporal.YearMonth.prototype), "Temporal.YearMonth.prototype");

--- a/polyfill/test/YearMonth/prototype/getISOCalendarFields/prop-desc.js
+++ b/polyfill/test/YearMonth/prototype/getISOCalendarFields/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(
+  typeof Temporal.YearMonth.prototype.getISOCalendarFields,
+  "function",
+  "`typeof YearMonth.prototype.getISOCalendarFields` is `function`"
+);
+
+verifyProperty(Temporal.YearMonth.prototype, "getISOCalendarFields", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/YearMonth/prototype/getISOCalendarFields/subclass.js
+++ b/polyfill/test/YearMonth/prototype/getISOCalendarFields/subclass.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.date.prototype.getisocalendarfields
+includes: [compareArray.js]
+---*/
+
+let called = 0;
+
+const constructorArguments = [
+  [2000, 5]
+];
+
+class MyYearMonth extends Temporal.YearMonth {
+  constructor(year, month) {
+    assert.compareArray([year, month], constructorArguments.shift(), "constructor arguments");
+    ++called;
+    super(year, month);
+  }
+}
+
+const instance = MyYearMonth.from("2000-05");
+assert.sameValue(called, 1);
+
+const result = instance.getISOCalendarFields();
+assert.sameValue(result.year, 2000, "year result");
+assert.sameValue(result.month, 5, "month result");
+assert.sameValue(called, 1);
+assert.sameValue(Object.getPrototypeOf(result), Object.prototype);

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -72,6 +72,9 @@ describe('Date', () => {
       it('Date.prototype.getFields is a Function', () => {
         equal(typeof Date.prototype.getFields, 'function');
       });
+      it('Date.prototype.getISOCalendarFields is a Function', () => {
+        equal(typeof Date.prototype.getISOCalendarFields, 'function');
+      });
       it('Date.prototype.toString is a Function', () => {
         equal(typeof Date.prototype.toString, 'function');
       });
@@ -506,6 +509,29 @@ describe('Date', () => {
   describe('date.getFields() works', () => {
     const d1 = Date.from('1976-11-18');
     const fields = d1.getFields();
+    it('fields', () => {
+      equal(fields.year, 1976);
+      equal(fields.month, 11);
+      equal(fields.day, 18);
+    });
+    it('enumerable', () => {
+      const fields2 = { ...fields };
+      equal(fields2.year, 1976);
+      equal(fields2.month, 11);
+      equal(fields2.day, 18);
+    });
+    it('as input to from()', () => {
+      const d2 = Date.from(fields);
+      equal(Date.compare(d1, d2), 0);
+    });
+    it('as input to with()', () => {
+      const d2 = Date.from('2019-06-30').with(fields);
+      equal(Date.compare(d1, d2), 0);
+    });
+  });
+  describe('date.getISOCalendarFields() works', () => {
+    const d1 = Date.from('1976-11-18');
+    const fields = d1.getISOCalendarFields();
     it('fields', () => {
       equal(fields.year, 1976);
       equal(fields.month, 11);

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -90,6 +90,9 @@ describe('DateTime', () => {
       it('DateTime.prototype.getFields is a Function', () => {
         equal(typeof DateTime.prototype.getFields, 'function');
       });
+      it('DateTime.prototype.getISOCalendarFields is a Function', () => {
+        equal(typeof DateTime.prototype.getISOCalendarFields, 'function');
+      });
       it('DateTime.prototype.toString is a Function', () => {
         equal(typeof DateTime.prototype.toString, 'function');
       });
@@ -575,6 +578,41 @@ describe('DateTime', () => {
   describe('dateTime.getFields() works', () => {
     const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
     const fields = dt1.getFields();
+    it('fields', () => {
+      equal(fields.year, 1976);
+      equal(fields.month, 11);
+      equal(fields.day, 18);
+      equal(fields.hour, 15);
+      equal(fields.minute, 23);
+      equal(fields.second, 30);
+      equal(fields.millisecond, 123);
+      equal(fields.microsecond, 456);
+      equal(fields.nanosecond, 789);
+    });
+    it('enumerable', () => {
+      const fields2 = { ...fields };
+      equal(fields2.year, 1976);
+      equal(fields2.month, 11);
+      equal(fields2.day, 18);
+      equal(fields2.hour, 15);
+      equal(fields2.minute, 23);
+      equal(fields2.second, 30);
+      equal(fields2.millisecond, 123);
+      equal(fields2.microsecond, 456);
+      equal(fields2.nanosecond, 789);
+    });
+    it('as input to from()', () => {
+      const dt2 = DateTime.from(fields);
+      equal(DateTime.compare(dt1, dt2), 0);
+    });
+    it('as input to with()', () => {
+      const dt2 = DateTime.from('2019-06-30').with(fields);
+      equal(DateTime.compare(dt1, dt2), 0);
+    });
+  });
+  describe('dateTime.getISOCalendarFields() works', () => {
+    const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
+    const fields = dt1.getISOCalendarFields();
     it('fields', () => {
       equal(fields.year, 1976);
       equal(fields.month, 11);

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -26,6 +26,9 @@ describe('MonthDay', () => {
       it('MonthDay.prototype.getFields is a Function', () => {
         equal(typeof MonthDay.prototype.getFields, 'function');
       });
+      it('MonthDay.prototype.getISOCalendarFields is a Function', () => {
+        equal(typeof MonthDay.prototype.getISOCalendarFields, 'function');
+      });
     });
   });
   describe('Construction', () => {
@@ -155,6 +158,27 @@ describe('MonthDay', () => {
   describe('monthDay.getFields() works', () => {
     const md1 = MonthDay.from('11-18');
     const fields = md1.getFields();
+    it('fields', () => {
+      equal(fields.month, 11);
+      equal(fields.day, 18);
+    });
+    it('enumerable', () => {
+      const fields2 = { ...fields };
+      equal(fields2.month, 11);
+      equal(fields2.day, 18);
+    });
+    it('as input to from()', () => {
+      const md2 = MonthDay.from(fields);
+      assert(md1.equals(md2));
+    });
+    it('as input to with()', () => {
+      const md2 = MonthDay.from('06-30').with(fields);
+      assert(md1.equals(md2));
+    });
+  });
+  describe('monthDay.getISOCalendarFields() works', () => {
+    const md1 = MonthDay.from('11-18');
+    const fields = md1.getISOCalendarFields();
     it('fields', () => {
       equal(fields.month, 11);
       equal(fields.day, 18);

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -29,6 +29,9 @@ describe('YearMonth', () => {
       it('YearMonth.prototype.getFields is a Function', () => {
         equal(typeof YearMonth.prototype.getFields, 'function');
       });
+      it('YearMonth.prototype.getISOCalendarFields is a Function', () => {
+        equal(typeof YearMonth.prototype.getISOCalendarFields, 'function');
+      });
       it('YearMonth.prototype has daysInYear', () => {
         assert('daysInYear' in YearMonth.prototype);
       });
@@ -330,6 +333,27 @@ describe('YearMonth', () => {
   describe('yearMonth.getFields() works', () => {
     const ym1 = YearMonth.from('1976-11');
     const fields = ym1.getFields();
+    it('fields', () => {
+      equal(fields.year, 1976);
+      equal(fields.month, 11);
+    });
+    it('enumerable', () => {
+      const fields2 = { ...fields };
+      equal(fields2.year, 1976);
+      equal(fields2.month, 11);
+    });
+    it('as input to from()', () => {
+      const ym2 = YearMonth.from(fields);
+      equal(YearMonth.compare(ym1, ym2), 0);
+    });
+    it('as input to with()', () => {
+      const ym2 = YearMonth.from('2019-06').with(fields);
+      equal(YearMonth.compare(ym1, ym2), 0);
+    });
+  });
+  describe('yearMonth.getISOCalendarFields() works', () => {
+    const ym1 = YearMonth.from('1976-11');
+    const fields = ym1.getISOCalendarFields();
     it('fields', () => {
       equal(fields.year, 1976);
       equal(fields.month, 11);

--- a/spec/date.html
+++ b/spec/date.html
@@ -273,6 +273,22 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.date.prototype.getisocalendarfields">
+      <h1>Temporal.Date.prototype.getISOCalendarFields ( )</h1>
+      <p>
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _temporalDate_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
+        1. Let _fields_ be ? ObjectCreate(%ObjectPrototype%).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"year"*, _temporalDate_.[[IsoYear]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"month"*, _temporalDate_.[[IsoMonth]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, _temporalDate_.[[IsoDay]]).
+        1. Return _fields_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.date.prototype.plus">
       <h1>Temporal.Date.prototype.plus ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -591,6 +591,28 @@
         1. Return _fields_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-temporal.datetime.prototype.getisocalendarfields">
+      <h1>Temporal.DateTime.prototype.getISOCalendarFields ( )</h1>
+      <p>
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _dateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
+        1. Let _fields_ be ? ObjectCreate(%ObjectPrototype%).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"year"*, _dateTime_.[[IsoYear]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"month"*, _dateTime_.[[IsoMonth]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, _dateTime_.[[IsoDay]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"hour"*, _dateTime_.[[Hour]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"minute"*, _dateTime_.[[Minute]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"second"*, _dateTime_.[[Second]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"millisecond"*, _dateTime_.[[Millisecond]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"microsecond"*, _dateTime_.[[Microsecond]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"nanosecond"*, _dateTime_.[[Nanosecond]]).
+        1. Return _fields_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-temporal-datetime-abstract-ops">

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -244,6 +244,21 @@
         1. Return _fields_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-temporal.monthday.prototype.getisocalendarfields">
+      <h1>Temporal.MonthDay.prototype.getISOCalendarFields ( )</h1>
+      <p>
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _monthDay_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
+        1. Let _fields_ be ? ObjectCreate(%ObjectPrototype%).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"month"*, _monthDay_.[[IsoMonth]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, _monthDay_.[[IsoDay]]).
+        1. Return _fields_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-temporal-monthday-abstract-ops">

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -357,6 +357,21 @@
         1. Return _fields_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-temporal.yearmonth.prototype.getisocalendarfields">
+      <h1>Temporal.YearMonth.prototype.getISOCalendarFields ( )</h1>
+      <p>
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _yearMonth_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
+        1. Let _fields_ be ? ObjectCreate(%ObjectPrototype%).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"year"*, _yearMonth_.[[IsoYear]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"month"*, _yearMonth_.[[IsoMonth]]).
+        1. Return _fields_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-temporal-yearmonth-abstract-ops">


### PR DESCRIPTION
This is in order to be able to get the underlying fields from the data
model, which are stored in the ISO 8601 calendar.

It's not expected to be used in normal Temporal usage, it really exists
only for calendar implementors.

Closes: #354