### PR TITLE
Remove horizontal scrollbar on docs pages

### DIFF
--- a/docs/head.html.part
+++ b/docs/head.html.part
@@ -74,7 +74,7 @@
         position: absolute;
         text-align: center;
         top: 0;
-        width: 100vw;
+        width: 100%;
       }
     </style>
   </head>


### PR DESCRIPTION
This is a particularly unimportant change, but it was starting to really annoy me when scrolling.

The banner at the top of docs pages had `width: 100vw`. Unfortunately `vw` ignores the scrollbar, so in browsers with non-floating scrollbars, the page caused an extra bit of horizontal space (and therefore an unnecessary horizontal scrollbar).