### PR TITLE
Custom time zones, phase 3

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -206,10 +206,10 @@ Same as `getEpochSeconds()`, but with nanosecond (10<sup>&minus;9</sup> second) 
 
 The value returned from this method is suitable to be passed to `new Temporal.Absolute()`.
 
-### absolute.**inTimeZone**(_timeZone_: Temporal.TimeZone | string) : Temporal.DateTime
+### absolute.**inTimeZone**(_timeZone_: object | string) : Temporal.DateTime
 
 **Parameters:**
-- `timeZone` (object or string): A `Temporal.TimeZone` object, or a string description of the time zone; either its IANA name or UTC offset.
+- `timeZone` (object or string): A `Temporal.TimeZone` object, or an object implementing the [time zone protocol](./timezone.md#protocol), or a string description of the time zone; either its IANA name or UTC offset.
 
 **Returns:** a `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone` at the absolute time indicated by `absolute`.
 
@@ -355,10 +355,10 @@ one.equals(two)  // => false
 one.equals(one)  // => true
 ```
 
-### absolute.**toString**(_timeZone_?: Temporal.TimeZone | string) : string
+### absolute.**toString**(_timeZone_?: object | string) : string
 
 **Parameters:**
-- `timeZone` (optional string or `Temporal.TimeZone`): the time zone to express `absolute` in.
+- `timeZone` (optional string or object): the time zone to express `absolute` in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
   The default is to use UTC.
 
 **Returns:** a string in the ISO 8601 date format representing `absolute`.

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -522,10 +522,10 @@ This method overrides `Object.prototype.valueOf()` and always throws an exceptio
 This is because it's not possible to compare `Temporal.DateTime` objects with the relational operators `<`, `<=`, `>`, or `>=`.
 Use `Temporal.DateTime.compare()` for this, or `datetime.equals()` for equality.
 
-### datetime.**inTimeZone**(_timeZone_ : Temporal.TimeZone | string, _options_?: object) : Temporal.Absolute
+### datetime.**inTimeZone**(_timeZone_ : object | string, _options_?: object) : Temporal.Absolute
 
 **Parameters:**
-- `timeZone` (optional string or `Temporal.TimeZone`): The time zone in which to interpret `dateTime`.
+- `timeZone` (optional string or object): The time zone in which to interpret `dateTime`, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `disambiguation` (string): How to disambiguate if the date and time given by `dateTime` does not exist in the time zone, or exists more than once.

--- a/docs/now.md
+++ b/docs/now.md
@@ -54,10 +54,10 @@ nextTransition.inTimeZone(tz);
 // On 2020-03-08T03:00 the clock will change from UTC -08:00 to -07:00
 ```
 
-### Temporal.now.**dateTime**(_timeZone_: Temporal.TimeZone | string = Temporal.now.timeZone()) : Temporal.DateTime
+### Temporal.now.**dateTime**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.DateTime
 
 **Parameters:**
-- `timeZone` (optional `Temporal.TimeZone` or string): The time zone to get the current date and time in.
+- `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
   If not given, the current system time zone will be used.
 
 **Returns:** a `Temporal.DateTime` object representing the current system date and time.
@@ -83,10 +83,10 @@ Object.entries(financialCentres).forEach(([name, timeZone]) => {
 // Tokyo: 2020-01-25T14:52:14.759534758
 ```
 
-### Temporal.now.**date**(_timeZone_: Temporal.TimeZone | string = Temporal.now.timeZone()) : Temporal.Date
+### Temporal.now.**date**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Date
 
 **Parameters:**
-- `timeZone` (optional `Temporal.TimeZone` or string): The time zone to get the current date and time in.
+- `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
   If not given, the current system time zone will be used.
 
 **Returns:** a `Temporal.Date` object representing the current system date.
@@ -98,10 +98,10 @@ date = Temporal.now.date();
 if (date.month === 2 && date.day === 29) console.log('Leap Day!');
 ```
 
-### Temporal.now.**time**(_timeZone_: Temporal.TimeZone | string = Temporal.now.timeZone()) : Temporal.Time
+### Temporal.now.**time**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Time
 
 **Parameters:**
-- `timeZone` (optional `Temporal.TimeZone` or string): The time zone to get the current date and time in.
+- `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
   If not given, the current system time zone will be used.
 
 **Returns:** a `Temporal.Time` object representing the current system time.

--- a/docs/timezone-draft.md
+++ b/docs/timezone-draft.md
@@ -141,8 +141,6 @@ For example, `getOffsetStringFor()` and `getDateTimeFor()` call `getOffsetNanose
 Alternatively, a custom time zone doesn't have to be a subclass of `Temporal.TimeZone`.
 In this case, it can be a plain object, which must implement `getOffsetNanosecondsFor()`, `getPossibleAbsolutesFor()`, and `toString()`.
 
-> **FIXME:** This means we have to remove any checks for the _[[InitializedTemporalTimeZone]]_ slot in all APIs, so that plain objects can use them with e.g. `Temporal.TimeZone.prototype.getOffsetStringFor.call(plainObject, absolute)`.
-
 ## Show Me The Code
 
 Here's what it could look like to implement the built-in offset-based time zones as custom time zones.

--- a/docs/timezone-draft.md
+++ b/docs/timezone-draft.md
@@ -62,10 +62,6 @@ Temporal.TimeZone.from('1820-04-01T18:16:25-06:00[America/St_Louis]')
   // returns a new StLouisTime instance
 ```
 
-> **FIXME:** Passing a custom time zone's identifier to the built-in `Temporal.TimeZone` constructor currently doesn't work: `new Temporal.TimeZone('America/St_Louis')` throws.
-> However, this must change, because implementations would need to call `super(id)` to set the _[[Identifier]]_ and _[[InitializedTemporalTimeZone]]_ internal slots.
-> Maybe we need to only throw if `new.target === Temporal.TimeZone`?
-
 In order to lock down any leakage of information about the host system's time zone database, one would monkeypatch the `Temporal.TimeZone.from()` function which performs the built-in mapping, and replace `Temporal.now.timeZone()` to avoid exposing the current time zone.
 
 For example, to allow only offset time zones, and make the current time zone always UTC:

--- a/docs/timezone-draft.md
+++ b/docs/timezone-draft.md
@@ -30,7 +30,7 @@ In these examples we assume a custom time zone class `StLouisTime` with the iden
 When parsing an ISO 8601 string, the only places the time zone identifier is taken into account are `Temporal.Absolute.from()` and `Temporal.TimeZone.from()`.
 `Temporal.Absolute.from()` will call `Temporal.TimeZone.from()` to resolve the time zone identifier into a `Temporal.TimeZone` object.
 
-`Temporal.TimeZone.from()` and `Temporal.TimeZone[Symbol.iterator]` can be monkeypatched by time zone implementors if it is necessary to make new time zones available globally.
+`Temporal.TimeZone.from()` can be monkeypatched by time zone implementors if it is necessary to make new time zones available globally.
 The expectation is that it would rarely be necessary to do so, because if you have implemented a custom time zone for a particular calculation, you probably don't need it to be available globally.
 
 Example of monkeypatching to make St. Louis mean time available globally:
@@ -53,12 +53,6 @@ Temporal.TimeZone.from = function (item) {
   if (id === 'America/St_Louis')
     return new StLouisTime();
   return originalTemporalTimeZoneFrom.call(this, id);
-}
-
-const originalTemporalTimeZoneSymbolIterator = Temporal.TimeZone[Symbol.iterator];
-Temporal.TimeZone[Symbol.iterator] = function* () {
-  yield* originalTemporalTimeZoneSymbolIterator();
-  yield 'America/St_Louis';
 }
 
 Temporal.Absolute.from('1820-04-01T18:16:25-06:00[America/St_Louis]')

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -9,8 +9,11 @@ A `Temporal.TimeZone` is a representation of a time zone: either an [IANA time z
 
 Since `Temporal.Absolute` and `Temporal.DateTime` do not contain any time zone information, a `Temporal.TimeZone` object is required to convert between the two.
 
-An API for creating custom time zones is under discussion.
-See [Custom Time Zone Draft](./timezone-draft.md) for more information.
+## Custom time zones
+
+For specialized applications where you need to do calculations in a time zone that is not supported by Intl, you can also implement your own `Temporal.TimeZone` object.
+To do this, create a class inheriting from `Temporal.TimeZone`, call `super()` in the constructor with a time zone identifier, and implement the methods `getOffsetNanosecondsFor()`, `getPossibleAbsolutesFor()`, and `getTransitions()`.
+Any subclass of `Temporal.TimeZone` will be accepted in Temporal APIs where a built-in `Temporal.TimeZone` would work.
 
 ## Constructor
 

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -15,6 +15,12 @@ For specialized applications where you need to do calculations in a time zone th
 To do this, create a class inheriting from `Temporal.TimeZone`, call `super()` in the constructor with a time zone identifier, and implement the methods `getOffsetNanosecondsFor()`, `getPossibleAbsolutesFor()`, and `getTransitions()`.
 Any subclass of `Temporal.TimeZone` will be accepted in Temporal APIs where a built-in `Temporal.TimeZone` would work.
 
+### Protocol
+
+It's also possible for a plain object to be a custom time zone, without subclassing.
+The object must have `getOffsetNanosecondsFor()`, `getPossibleAbsolutesFor()`, and `toString()` methods.
+It is possible to pass such an object into any Temporal API that would normally take a built-in `Temporal.TimeZone`.
+
 ## Constructor
 
 ### **new Temporal.TimeZone**(_timeZoneIdentifier_: string) : Temporal.TimeZone

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -204,10 +204,10 @@ export namespace Temporal {
       other: Temporal.Absolute,
       options?: DifferenceOptions<'days' | 'hours' | 'minutes' | 'seconds'>
     ): Temporal.Duration;
-    inTimeZone(tzLike?: Temporal.TimeZone | string): Temporal.DateTime;
+    inTimeZone(tzLike?: TimeZoneProtocol | string): Temporal.DateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
-    toString(tzLike?: Temporal.TimeZone | string): string;
+    toString(tzLike?: TimeZoneProtocol | string): string;
   }
 
   /**
@@ -385,7 +385,7 @@ export namespace Temporal {
       other: Temporal.DateTime,
       options?: DifferenceOptions<'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'>
     ): Temporal.Duration;
-    inTimeZone(tzLike: Temporal.TimeZone | string, options?: ToAbsoluteOptions): Temporal.Absolute;
+    inTimeZone(tzLike: TimeZoneProtocol | string, options?: ToAbsoluteOptions): Temporal.Absolute;
     getDate(): Temporal.Date;
     getYearMonth(): Temporal.YearMonth;
     getMonthDay(): Temporal.MonthDay;
@@ -478,6 +478,21 @@ export namespace Temporal {
   }
 
   /**
+   * A plain object implementing the protocol for a custom time zone.
+   */
+  class TimeZoneProtocol {
+    name?: string;
+    getOffsetNanosecondsFor(absolute: Temporal.Absolute): number;
+    getOffsetStringFor?(absolute: Temporal.Absolute): string;
+    getDateTimeFor?(absolute: Temporal.Absolute): Temporal.DateTime;
+    getAbsoluteFor?(dateTime: Temporal.DateTime, options?: ToAbsoluteOptions): Temporal.Absolute;
+    getTransitions?(startingPoint: Temporal.Absolute): IteratorResult<Temporal.Absolute>;
+    getPossibleAbsolutesFor(dateTime: Temporal.DateTime): Temporal.Absolute[];
+    toString(): string;
+    toJSON?(): string;
+  }
+
+  /**
    * A `Temporal.TimeZone` is a representation of a time zone: either an
    * {@link https://www.iana.org/time-zones|IANA time zone}, including
    * information about the time zone such as the offset between the local time
@@ -490,7 +505,7 @@ export namespace Temporal {
    *
    * See https://tc39.es/proposal-temporal/docs/timezone.html for more details.
    */
-  export class TimeZone {
+  export class TimeZone implements Required<TimeZoneProtocol> {
     static from(timeZone: Temporal.TimeZone | string): Temporal.TimeZone;
     constructor(timeZoneIdentifier: string);
     readonly name: string;
@@ -558,32 +573,35 @@ export namespace Temporal {
     /**
      * Get the current calendar date and clock time in a specific time zone.
      *
-     * @param {Temporal.TimeZone | string} [tzLike] -
+     * @param {TimeZoneProtocol | string} [tzLike] -
      * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
-     * string (e.g. `'Europe/London'`) or a `Temporal.TimeZone` instance. If omitted,
-     * the environment's current time zone will be used.
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
      */
-    export function dateTime(tzLike?: Temporal.TimeZone | string): Temporal.DateTime;
+    export function dateTime(tzLike?: TimeZoneProtocol | string): Temporal.DateTime;
 
     /**
      * Get the current calendar date in a specific time zone.
      *
-     * @param {Temporal.TimeZone | string} [tzLike] -
+     * @param {TimeZoneProtocol | string} [tzLike] -
      * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
-     * string (e.g. `'Europe/London'`) or a `Temporal.TimeZone` instance. If omitted,
-     * the environment's current time zone will be used.
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
      */
-    export function date(tzLike?: Temporal.TimeZone | string): Temporal.Date;
+    export function date(tzLike?: TimeZoneProtocol | string): Temporal.Date;
 
     /**
      * Get the current clock time in a specific time zone.
      *
-     * @param {Temporal.TimeZone | string} [tzLike] -
+     * @param {TimeZoneProtocol | string} [tzLike] -
      * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
-     * string (e.g. `'Europe/London'`) or a `Temporal.TimeZone` instance. If omitted,
-     * the environment's current time zone will be used.
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
      */
-    export function time(tzLike?: Temporal.TimeZone | string): Temporal.Time;
+    export function time(tzLike?: TimeZoneProtocol | string): Temporal.Time;
 
     /**
      * Get the environment's current time zone.

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -127,7 +127,8 @@ export class Absolute {
   }
   toString(temporalTimeZoneLike = 'UTC') {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
-    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+    const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+    const timeZone = TemporalTimeZone.from(temporalTimeZoneLike);
     return ES.TemporalAbsoluteToString(this, timeZone);
   }
   toJSON() {
@@ -145,7 +146,8 @@ export class Absolute {
   }
   inTimeZone(temporalTimeZoneLike) {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
-    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+    const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+    const timeZone = TemporalTimeZone.from(temporalTimeZoneLike);
     return timeZone.getDateTimeFor(this);
   }
 

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -148,7 +148,8 @@ export class Absolute {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
     const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
     const timeZone = TemporalTimeZone.from(temporalTimeZoneLike);
-    return timeZone.getDateTimeFor(this);
+    if (typeof timeZone.getDateTimeFor === 'function') return timeZone.getDateTimeFor(this);
+    return TemporalTimeZone.prototype.getDateTimeFor.call(timeZone, this);
   }
 
   static fromEpochSeconds(epochSeconds) {

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -308,7 +308,8 @@ export class DateTime {
     const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
     const timeZone = TemporalTimeZone.from(temporalTimeZoneLike);
     const disambiguation = ES.ToTimeZoneTemporalDisambiguation(options);
-    return timeZone.getAbsoluteFor(this, { disambiguation });
+    if (typeof timeZone.getAbsoluteFor === 'function') return timeZone.getAbsoluteFor(this, { disambiguation });
+    return TemporalTimeZone.prototype.getAbsoluteFor.call(timeZone, this, { disambiguation });
   }
   getDate() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -305,7 +305,8 @@ export class DateTime {
 
   inTimeZone(temporalTimeZoneLike, options) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+    const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+    const timeZone = TemporalTimeZone.from(temporalTimeZoneLike);
     const disambiguation = ES.ToTimeZoneTemporalDisambiguation(options);
     return timeZone.getAbsoluteFor(this, { disambiguation });
   }

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -584,8 +584,7 @@ export const ES = ObjectAssign({}, ES2019, {
       minute: 'numeric',
       second: 'numeric'
     });
-    formatter.toString = tzIdent;
-    return formatter;
+    return formatter.resolvedOptions().timeZone;
   },
   GetIANATimeZoneOffsetNanoseconds: (epochNanoseconds, id) => {
     const {
@@ -1439,7 +1438,4 @@ function bisect(getState, left, right, lstate = getState(left), rstate = getStat
     }
   }
   return right;
-}
-function tzIdent() {
-  return this.resolvedOptions().timeZone;
 }

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -63,11 +63,6 @@ export const ES = ObjectAssign({}, ES2019, {
     HasSlot(item, ISO_YEAR, ISO_MONTH, ISO_DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND),
   IsTemporalYearMonth: (item) => HasSlot(item, ISO_YEAR, ISO_MONTH, REF_ISO_DAY),
   IsTemporalMonthDay: (item) => HasSlot(item, ISO_MONTH, ISO_DAY, REF_ISO_YEAR),
-  ToTemporalTimeZone: (item) => {
-    if (ES.IsTemporalTimeZone(item)) return item;
-    const TimeZone = GetIntrinsic('%Temporal.TimeZone%');
-    return new TimeZone(ES.TemporalTimeZoneFromString(ES.ToString(item)));
-  },
   TemporalTimeZoneFromString: (stringIdent) => {
     const { zone, ianaName, offset } = ES.ParseTemporalTimeZoneString(stringIdent);
     const result = ES.GetCanonicalTimeZoneIdentifier(zone);
@@ -211,7 +206,7 @@ export const ES = ObjectAssign({}, ES2019, {
     const TimeZone = GetIntrinsic('%Temporal.TimeZone%');
 
     const dt = new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
-    const tz = new TimeZone(zone);
+    const tz = TimeZone.from(zone);
 
     const possibleAbsolutes = tz.getPossibleAbsolutesFor(dt);
     if (possibleAbsolutes.length === 1) return GetSlot(possibleAbsolutes[0], EPOCHNANOSECONDS);
@@ -1386,7 +1381,8 @@ export const ES = ObjectAssign({}, ES2019, {
   })(),
   SystemTimeZone: () => {
     const fmt = new IntlDateTimeFormat('en-us');
-    return ES.ToTemporalTimeZone(fmt.resolvedOptions().timeZone);
+    const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+    return new TemporalTimeZone(ES.TemporalTimeZoneFromString(fmt.resolvedOptions().timeZone));
   },
   ComparisonResult: (value) => (value < 0 ? -1 : value > 0 ? 1 : value),
   GetOption: (options, property, allowedValues, fallback) => {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -479,7 +479,13 @@ export const ES = ObjectAssign({}, ES2019, {
     return result;
   },
   ISOTimeZoneString: (timeZone, absolute) => {
-    const offset = timeZone.getOffsetStringFor(absolute);
+    let offset;
+    if (typeof timeZone.getOffsetStringFor === 'function') {
+      offset = timeZone.getOffsetStringFor(absolute);
+    } else {
+      const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+      offset = TemporalTimeZone.prototype.getOffsetStringFor.call(timeZone, absolute);
+    }
     let timeZoneString;
     switch (true) {
       case 'UTC' === timeZone.name:
@@ -489,7 +495,7 @@ export const ES = ObjectAssign({}, ES2019, {
         timeZoneString = offset;
         break;
       default:
-        timeZoneString = `${offset}[${timeZone.name}]`;
+        timeZoneString = `${offset}[${timeZone.toString()}]`;
         break;
     }
     return timeZoneString;
@@ -518,7 +524,13 @@ export const ES = ObjectAssign({}, ES2019, {
     return `${secs}${post}`;
   },
   TemporalAbsoluteToString: (absolute, timeZone) => {
-    const dateTime = timeZone.getDateTimeFor(absolute);
+    let dateTime;
+    if (typeof timeZone.getDateTimeFor === 'function') {
+      dateTime = timeZone.getDateTimeFor(absolute);
+    } else {
+      const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+      dateTime = TemporalTimeZone.prototype.getDateTimeFor.call(timeZone, absolute);
+    }
     const year = ES.ISOYearString(dateTime.year);
     const month = ES.ISODateTimePartString(dateTime.month);
     const day = ES.ISODateTimePartString(dateTime.day);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -101,7 +101,14 @@ export const ES = ObjectAssign({}, ES2019, {
     const nanosecond = ES.ToInteger(fraction.slice(6, 9));
     const offset = `${match[14]}:${match[15] || '00'}`;
     let ianaName = match[16];
-    if (ianaName) ianaName = ES.GetCanonicalTimeZoneIdentifier(ianaName).toString();
+    if (ianaName) {
+      try {
+        // Canonicalize name if it is an IANA link name or is capitalized wrong
+        ianaName = ES.GetCanonicalTimeZoneIdentifier(ianaName).toString();
+      } catch {
+        // Not an IANA name, may be a custom ID, pass through unchanged
+      }
+    }
     const zone = match[13] ? 'UTC' : ianaName || offset;
     return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, zone, ianaName, offset };
   },

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -14,7 +14,8 @@ function absolute() {
   return new Absolute(ES.SystemUTCEpochNanoSeconds());
 }
 function dateTime(temporalTimeZoneLike = timeZone()) {
-  const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+  const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+  const timeZone = TemporalTimeZone.from(temporalTimeZoneLike);
   const abs = absolute();
   const dateTime = timeZone.getDateTimeFor(abs);
   return dateTime;

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -17,8 +17,8 @@ function dateTime(temporalTimeZoneLike = timeZone()) {
   const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
   const timeZone = TemporalTimeZone.from(temporalTimeZoneLike);
   const abs = absolute();
-  const dateTime = timeZone.getDateTimeFor(abs);
-  return dateTime;
+  if (typeof timeZone.getDateTimeFor === 'function') return timeZone.getDateTimeFor(abs);
+  return TemporalTimeZone.prototype.getDateTimeFor.call(timeZone, abs);
 }
 function date(temporalTimeZoneLike) {
   return dateTime(temporalTimeZoneLike).getDate();

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -62,7 +62,6 @@ export class TimeZone {
     return ES.FormatTimeZoneOffsetString(offsetNs);
   }
   getDateTimeFor(absolute) {
-    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalAbsolute(absolute)) throw new TypeError('invalid Absolute object');
     const ns = GetSlot(absolute, EPOCHNANOSECONDS);
     const offsetNs = this.getOffsetNanosecondsFor(absolute);
@@ -88,7 +87,6 @@ export class TimeZone {
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   }
   getAbsoluteFor(dateTime, options) {
-    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalDateTime(dateTime)) throw new TypeError('invalid DateTime object');
     const disambiguation = ES.ToTimeZoneTemporalDisambiguation(options);
 

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -31,8 +31,11 @@ function parseOffsetString(string) {
 
 export class TimeZone {
   constructor(timeZoneIdentifier) {
+    if (new.target === TimeZone) {
+      timeZoneIdentifier = ES.GetCanonicalTimeZoneIdentifier(timeZoneIdentifier);
+    }
     CreateSlots(this);
-    SetSlot(this, TIMEZONE_ID, ES.GetCanonicalTimeZoneIdentifier(timeZoneIdentifier));
+    SetSlot(this, TIMEZONE_ID, timeZoneIdentifier);
   }
   get name() {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -223,12 +223,8 @@ export class TimeZone {
     return this.name;
   }
   static from(item) {
-    let timeZone;
-    if (ES.IsTemporalTimeZone(item)) {
-      timeZone = GetSlot(item, TIMEZONE_ID);
-    } else {
-      timeZone = ES.TemporalTimeZoneFromString(ES.ToString(item));
-    }
+    if (ES.IsTemporalTimeZone(item) || (typeof item === 'object' && item)) return item;
+    const timeZone = ES.TemporalTimeZoneFromString(ES.ToString(item));
     const result = new this(timeZone);
     if (!ES.IsTemporalTimeZone(result)) throw new TypeError('invalid result');
     return result;

--- a/polyfill/test/all.mjs
+++ b/polyfill/test/all.mjs
@@ -28,6 +28,9 @@ import './yearmonth.mjs';
 import './monthday.mjs';
 import './intl.mjs';
 
+// tests of userland objects
+import './usertimezone.mjs';
+
 Promise.resolve()
   .then(() => {
     return Demitasse.report(Pretty.reporter);

--- a/polyfill/test/ecmascript.mjs
+++ b/polyfill/test/ecmascript.mjs
@@ -9,11 +9,12 @@ const { deepEqual } = assert;
 
 import { ES } from '../lib/ecmascript.mjs';
 import { GetSlot, TIMEZONE_ID } from '../lib/slots.mjs';
+import { TimeZone } from '../lib/timezone.mjs';
 
 describe('ECMAScript', () => {
   describe('GetIANATimeZoneDateTimeParts', () => {
     describe('epoch', () => {
-      test(0n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
+      test(0n, GetSlot(TimeZone.from('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -24,7 +25,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
+      test(0n, GetSlot(TimeZone.from('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -35,7 +36,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
+      test(0n, GetSlot(TimeZone.from('Europe/London'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -46,7 +47,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
+      test(0n, GetSlot(TimeZone.from('Europe/Berlin'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -57,7 +58,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
+      test(0n, GetSlot(TimeZone.from('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -68,7 +69,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 0
       });
-      test(0n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
+      test(0n, GetSlot(TimeZone.from('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -81,7 +82,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('epoch-1', () => {
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
+      test(-1n, GetSlot(TimeZone.from('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -92,7 +93,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
+      test(-1n, GetSlot(TimeZone.from('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -103,7 +104,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
+      test(-1n, GetSlot(TimeZone.from('Europe/London'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -114,7 +115,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
+      test(-1n, GetSlot(TimeZone.from('Europe/Berlin'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -125,7 +126,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
+      test(-1n, GetSlot(TimeZone.from('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -136,7 +137,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-1n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
+      test(-1n, GetSlot(TimeZone.from('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -149,7 +150,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('epoch+1', () => {
-      test(1n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
+      test(1n, GetSlot(TimeZone.from('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -160,7 +161,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
+      test(1n, GetSlot(TimeZone.from('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -171,7 +172,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
+      test(1n, GetSlot(TimeZone.from('Europe/London'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -182,7 +183,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
+      test(1n, GetSlot(TimeZone.from('Europe/Berlin'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -193,7 +194,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
+      test(1n, GetSlot(TimeZone.from('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -204,7 +205,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(1n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
+      test(1n, GetSlot(TimeZone.from('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -217,7 +218,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('epoch-6300000000001', () => {
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
+      test(-6300000000001n, GetSlot(TimeZone.from('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -228,7 +229,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
+      test(-6300000000001n, GetSlot(TimeZone.from('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -239,7 +240,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
+      test(-6300000000001n, GetSlot(TimeZone.from('Europe/London'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -250,7 +251,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
+      test(-6300000000001n, GetSlot(TimeZone.from('Europe/Berlin'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -261,7 +262,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
+      test(-6300000000001n, GetSlot(TimeZone.from('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -272,7 +273,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(-6300000000001n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
+      test(-6300000000001n, GetSlot(TimeZone.from('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -285,7 +286,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('epoch+6300000000001', () => {
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/Los_Angeles'), TIMEZONE_ID), {
+      test(6300000000001n, GetSlot(TimeZone.from('America/Los_Angeles'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -296,7 +297,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('America/New_York'), TIMEZONE_ID), {
+      test(6300000000001n, GetSlot(TimeZone.from('America/New_York'), TIMEZONE_ID), {
         year: 1969,
         month: 12,
         day: 31,
@@ -307,7 +308,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
+      test(6300000000001n, GetSlot(TimeZone.from('Europe/London'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -318,7 +319,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Berlin'), TIMEZONE_ID), {
+      test(6300000000001n, GetSlot(TimeZone.from('Europe/Berlin'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -329,7 +330,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Europe/Moscow'), TIMEZONE_ID), {
+      test(6300000000001n, GetSlot(TimeZone.from('Europe/Moscow'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -340,7 +341,7 @@ describe('ECMAScript', () => {
         microsecond: 0,
         nanosecond: 1
       });
-      test(6300000000001n, GetSlot(ES.ToTemporalTimeZone('Asia/Tokyo'), TIMEZONE_ID), {
+      test(6300000000001n, GetSlot(TimeZone.from('Asia/Tokyo'), TIMEZONE_ID), {
         year: 1970,
         month: 1,
         day: 1,
@@ -353,7 +354,7 @@ describe('ECMAScript', () => {
       });
     });
     describe('dst', () => {
-      test(1553993999999999999n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
+      test(1553993999999999999n, GetSlot(TimeZone.from('Europe/London'), TIMEZONE_ID), {
         year: 2019,
         month: 3,
         day: 31,
@@ -364,7 +365,7 @@ describe('ECMAScript', () => {
         microsecond: 999,
         nanosecond: 999
       });
-      test(1553994000000000000n, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), {
+      test(1553994000000000000n, GetSlot(TimeZone.from('Europe/London'), TIMEZONE_ID), {
         year: 2019,
         month: 3,
         day: 31,
@@ -384,7 +385,7 @@ describe('ECMAScript', () => {
 
   describe('GetFormatterParts', () => {
     // https://github.com/tc39/proposal-temporal/issues/575
-    test(1589670000000, GetSlot(ES.ToTemporalTimeZone('Europe/London'), TIMEZONE_ID), [
+    test(1589670000000, GetSlot(TimeZone.from('Europe/London'), TIMEZONE_ID), [
       { type: 'year', value: 2020 },
       { type: 'month', value: 5 },
       { type: 'day', value: 17 },

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -12,7 +12,7 @@ import Pretty from '@pipobscure/demitasse-pretty';
 const { reporter } = Pretty;
 
 import { strict as assert } from 'assert';
-const { deepEqual, equal, notEqual, throws } = assert;
+const { deepEqual, equal, throws } = assert;
 
 import * as Temporal from 'tc39-temporal';
 
@@ -89,21 +89,11 @@ describe('TimeZone', () => {
       it(`TimeZone.from(${zone}) is a time zone`, () => equal(typeof timezoneFrom, 'object'));
       it(`TimeZone.from(${zone}) does the same thing as new TimeZone(${zone})`, () =>
         equal(timezoneFrom.name, timezoneObj.name));
-      it(`TimeZone.from(new TimeZone(${zone})) is a different object`, () =>
-        notEqual(Temporal.TimeZone.from(timezoneObj), timezoneObj));
     }
     it('TimeZone.from throws with bad identifier', () => {
       throws(() => Temporal.TimeZone.from('local'));
       throws(() => Temporal.TimeZone.from('Z'));
       throws(() => Temporal.TimeZone.from('-08:00[America/Vancouver]'));
-    });
-    it('TimeZone.from(string-convertible) converts to string', () => {
-      const obj = {
-        toString() {
-          return '2020-02-12T11:42+01:00[Europe/Amsterdam]';
-        }
-      };
-      equal(`${Temporal.TimeZone.from(obj)}`, 'Europe/Amsterdam');
     });
   });
   describe('TimeZone.from(ISO string)', () => {

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -1,0 +1,154 @@
+#! /usr/bin/env -S node --experimental-modules
+
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import Demitasse from '@pipobscure/demitasse';
+const { after, before, describe, it, report } = Demitasse;
+
+import Pretty from '@pipobscure/demitasse-pretty';
+const { reporter } = Pretty;
+
+import { strict as assert } from 'assert';
+const { equal, throws } = assert;
+
+import * as Temporal from 'tc39-temporal';
+
+describe('Userland time zone', () => {
+  describe('Trivial subclass', () => {
+    class CustomUTCSubclass extends Temporal.TimeZone {
+      constructor() {
+        super('Etc/Custom_UTC_Subclass');
+      }
+      getOffsetNanosecondsFor(/* absolute */) {
+        return 0;
+      }
+      getPossibleAbsolutesFor(dateTime) {
+        const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = dateTime;
+        const dayNum = MakeDay(year, month, day);
+        const time = MakeTime(hour, minute, second, millisecond, microsecond, nanosecond);
+        const epochNs = MakeDate(dayNum, time);
+        return [new Temporal.Absolute(epochNs)];
+      }
+      *getTransitions(/* absolute */) {}
+    }
+
+    const obj = new CustomUTCSubclass();
+    const abs = Temporal.Absolute.fromEpochNanoseconds(0n);
+    const dt = new Temporal.DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
+
+    it('is a time zone', () => equal(typeof obj, 'object'));
+    it('.name property', () => equal(obj.name, 'Etc/Custom_UTC_Subclass'));
+    // FIXME: what should happen in Temporal.TimeZone.from(obj)?
+    it('.name is not available in from()', () => {
+      throws(() => Temporal.TimeZone.from('Etc/Custom_UTC_Subclass'), RangeError);
+      throws(() => Temporal.TimeZone.from('2020-05-26T16:02:46.251163036+00:00[Etc/Custom_UTC_Subclass]'), RangeError);
+    });
+    it('has offset string +00:00', () => equal(obj.getOffsetStringFor(abs), '+00:00'));
+    it('converts to DateTime', () => {
+      equal(`${obj.getDateTimeFor(abs)}`, '1970-01-01T00:00');
+      equal(`${abs.inTimeZone(obj)}`, '1970-01-01T00:00');
+    });
+    it('converts to Absolute', () => {
+      equal(`${obj.getAbsoluteFor(dt)}`, '1976-11-18T15:23:30.123456789Z');
+      equal(`${dt.inTimeZone(obj)}`, '1976-11-18T15:23:30.123456789Z');
+    });
+    it('converts to string', () => equal(`${obj}`, obj.name));
+    it('prints in absolute.toString', () =>
+      equal(abs.toString(obj), '1970-01-01T00:00+00:00[Etc/Custom_UTC_Subclass]'));
+    it('transitions -> []', () => equal(Array.from(obj.getTransitions()).length, 0));
+    it('works in Temporal.now', () => {
+      assert(Temporal.now.dateTime(obj) instanceof Temporal.DateTime);
+      assert(Temporal.now.date(obj) instanceof Temporal.Date);
+      assert(Temporal.now.time(obj) instanceof Temporal.Time);
+    });
+    describe('Making available globally', () => {
+      const originalTemporalTimeZoneFrom = Temporal.TimeZone.from;
+      before(() => {
+        Temporal.TimeZone.from = function(item) {
+          let id;
+          if (item instanceof Temporal.TimeZone) {
+            id = item.name;
+          } else {
+            id = `${item}`;
+            // TODO: Use Temporal.parse here to extract the ID from an ISO string
+          }
+          if (id === 'Etc/Custom_UTC_Subclass') return new CustomUTCSubclass();
+          return originalTemporalTimeZoneFrom.call(this, id);
+        };
+      });
+      it('works for TimeZone.from(id)', () => {
+        const tz = Temporal.TimeZone.from('Etc/Custom_UTC_Subclass');
+        assert(tz instanceof CustomUTCSubclass);
+      });
+      it.skip('works for TimeZone.from(ISO string)', () => {
+        const tz = Temporal.TimeZone.from('1970-01-01T00:00+00:00[Etc/Custom_UTC_Subclass]');
+        assert(tz instanceof CustomUTCSubclass);
+      });
+      it('works for Absolute.from', () => {
+        const abs = Temporal.Absolute.from('1970-01-01T00:00+00:00[Etc/Custom_UTC_Subclass]');
+        equal(`${abs}`, '1970-01-01T00:00Z');
+      });
+      it('works for Absolute.toString', () => {
+        const abs = Temporal.Absolute.fromEpochSeconds(0);
+        equal(abs.toString('Etc/Custom_UTC_Subclass'), '1970-01-01T00:00+00:00[Etc/Custom_UTC_Subclass]');
+      });
+      it('works for Absolute.inTimeZone', () => {
+        const abs = Temporal.Absolute.fromEpochSeconds(0);
+        equal(`${abs.inTimeZone('Etc/Custom_UTC_Subclass')}`, '1970-01-01T00:00');
+      });
+      it('works for DateTime.inTimeZone', () => {
+        const dt = Temporal.DateTime.from('1970-01-01T00:00');
+        equal(dt.inTimeZone('Etc/Custom_UTC_Subclass').getEpochSeconds(), 0);
+      });
+      it('works for Temporal.now', () => {
+        assert(Temporal.now.dateTime('Etc/Custom_UTC_Subclass') instanceof Temporal.DateTime);
+        assert(Temporal.now.date('Etc/Custom_UTC_Subclass') instanceof Temporal.Date);
+        assert(Temporal.now.time('Etc/Custom_UTC_Subclass') instanceof Temporal.Time);
+      });
+      after(() => {
+        Temporal.TimeZone.from = originalTemporalTimeZoneFrom;
+      });
+    });
+  });
+});
+
+const nsPerDay = 86400_000_000_000n;
+const nsPerMillisecond = 1_000_000n;
+
+function Day(t) {
+  return t / nsPerDay;
+}
+
+function MakeDate(day, time) {
+  return day * nsPerDay + time;
+}
+
+function MakeDay(year, month, day) {
+  const m = month - 1;
+  const ym = year + Math.floor(m / 12);
+  const mn = m % 12;
+  const t = BigInt(Date.UTC(ym, mn, 1)) * nsPerMillisecond;
+  return Day(t) + BigInt(day) - 1n;
+}
+
+function MakeTime(h, min, s, ms, µs, ns) {
+  const MinutesPerHour = 60n;
+  const SecondsPerMinute = 60n;
+  const nsPerSecond = 1_000_000_000n;
+  const nsPerMinute = nsPerSecond * SecondsPerMinute;
+  const nsPerHour = nsPerMinute * MinutesPerHour;
+  return (
+    BigInt(h) * nsPerHour +
+    BigInt(min) * nsPerMinute +
+    BigInt(s) * nsPerSecond +
+    BigInt(ms) * nsPerMillisecond +
+    BigInt(µs) * 1000n +
+    BigInt(ns)
+  );
+}
+
+import { normalize } from 'path';
+if (normalize(import.meta.url.slice(8)) === normalize(process.argv[1])) {
+  report(reporter).then((failed) => process.exit(failed ? 1 : 0));
+}

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -111,6 +111,92 @@ describe('Userland time zone', () => {
       });
     });
   });
+  describe('Trivial protocol implementation', () => {
+    const obj = {
+      getOffsetNanosecondsFor(/* absolute */) {
+        return 0;
+      },
+      getPossibleAbsolutesFor(dateTime) {
+        const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = dateTime;
+        const dayNum = MakeDay(year, month, day);
+        const time = MakeTime(hour, minute, second, millisecond, microsecond, nanosecond);
+        const epochNs = MakeDate(dayNum, time);
+        return [new Temporal.Absolute(epochNs)];
+      },
+      toString() {
+        return 'Etc/Custom_UTC_Protocol';
+      }
+    };
+
+    const abs = Temporal.Absolute.fromEpochNanoseconds(0n);
+    const dt = new Temporal.DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
+
+    it('has offset string +00:00', () =>
+      equal(Temporal.TimeZone.prototype.getOffsetStringFor.call(obj, abs), '+00:00'));
+    it('converts to DateTime', () => {
+      equal(`${Temporal.TimeZone.prototype.getDateTimeFor.call(obj, abs)}`, '1970-01-01T00:00');
+      equal(`${abs.inTimeZone(obj)}`, '1970-01-01T00:00');
+    });
+    it('converts to Absolute', () => {
+      equal(`${Temporal.TimeZone.prototype.getAbsoluteFor.call(obj, dt)}`, '1976-11-18T15:23:30.123456789Z');
+      equal(`${dt.inTimeZone(obj)}`, '1976-11-18T15:23:30.123456789Z');
+    });
+    it('prints in absolute.toString', () =>
+      equal(abs.toString(obj), '1970-01-01T00:00+00:00[Etc/Custom_UTC_Protocol]'));
+    it('works in Temporal.now', () => {
+      assert(Temporal.now.dateTime(obj) instanceof Temporal.DateTime);
+      assert(Temporal.now.date(obj) instanceof Temporal.Date);
+      assert(Temporal.now.time(obj) instanceof Temporal.Time);
+    });
+    describe('Making available globally', () => {
+      const originalTemporalTimeZoneFrom = Temporal.TimeZone.from;
+      before(() => {
+        Temporal.TimeZone.from = function(item) {
+          let id;
+          if (item instanceof Temporal.TimeZone) {
+            id = item.name;
+          } else {
+            id = `${item}`;
+            // TODO: Use Temporal.parse here to extract the ID from an ISO string
+          }
+          if (id === 'Etc/Custom_UTC_Protocol') return obj;
+          return originalTemporalTimeZoneFrom.call(this, id);
+        };
+      });
+      it('works for TimeZone.from(id)', () => {
+        const tz = Temporal.TimeZone.from('Etc/Custom_UTC_Protocol');
+        assert(Object.is(tz, obj));
+      });
+      it.skip('works for TimeZone.from(ISO string)', () => {
+        const tz = Temporal.TimeZone.from('1970-01-01T00:00+00:00[Etc/Custom_UTC_Protocol]');
+        assert(Object.is(tz, obj));
+      });
+      it('works for Absolute.from', () => {
+        const abs = Temporal.Absolute.from('1970-01-01T00:00+00:00[Etc/Custom_UTC_Protocol]');
+        equal(`${abs}`, '1970-01-01T00:00Z');
+      });
+      it('works for Absolute.toString', () => {
+        const abs = Temporal.Absolute.fromEpochSeconds(0);
+        equal(abs.toString('Etc/Custom_UTC_Protocol'), '1970-01-01T00:00+00:00[Etc/Custom_UTC_Protocol]');
+      });
+      it('works for Absolute.inTimeZone', () => {
+        const abs = Temporal.Absolute.fromEpochSeconds(0);
+        equal(`${abs.inTimeZone('Etc/Custom_UTC_Protocol')}`, '1970-01-01T00:00');
+      });
+      it('works for DateTime.inTimeZone', () => {
+        const dt = Temporal.DateTime.from('1970-01-01T00:00');
+        equal(dt.inTimeZone('Etc/Custom_UTC_Protocol').getEpochSeconds(), 0);
+      });
+      it('works for Temporal.now', () => {
+        assert(Temporal.now.dateTime('Etc/Custom_UTC_Protocol') instanceof Temporal.DateTime);
+        assert(Temporal.now.date('Etc/Custom_UTC_Protocol') instanceof Temporal.Date);
+        assert(Temporal.now.time('Etc/Custom_UTC_Protocol') instanceof Temporal.Time);
+      });
+      after(() => {
+        Temporal.TimeZone.from = originalTemporalTimeZoneFrom;
+      });
+    });
+  });
 });
 
 const nsPerDay = 86400_000_000_000n;


### PR DESCRIPTION
Stacked on top of #620, for the time being, and marked as a draft until that is merged. This is the rest of the support needed for custom time zones. Adds tests to make sure that passing in a subclass of Temporal.TimeZone and a plain object with the required methods both work.