### PR TITLE
Add throwing valueOf() to Temporal types

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -439,3 +439,9 @@ function reviver(key, value) {
 }
 JSON.parse(str, reviver);
 ```
+
+### absolute.**valueOf**()
+
+This method overrides `Object.prototype.valueOf()` and always throws an exception.
+This is because it's not possible to compare `Temporal.Absolute` objects with the relational operators `<`, `<=`, `>`, or `>=`.
+Use `Temporal.Absolute.compare()` for this, or `absolute.equals()` for equality.

--- a/docs/date.md
+++ b/docs/date.md
@@ -464,6 +464,12 @@ function reviver(key, value) {
 JSON.parse(str, reviver);
 ```
 
+### date.**valueOf**()
+
+This method overrides `Object.prototype.valueOf()` and always throws an exception.
+This is because it's not possible to compare `Temporal.Date` objects with the relational operators `<`, `<=`, `>`, or `>=`.
+Use `Temporal.Date.compare()` for this, or `date.equals()` for equality.
+
 ### date.**withTime**(_time_: Temporal.Time) : Temporal.DateTime
 
 **Parameters:**

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -526,6 +526,12 @@ function reviver(key, value) {
 JSON.parse(str, reviver);
 ```
 
+### datetime.**valueOf**()
+
+This method overrides `Object.prototype.valueOf()` and always throws an exception.
+This is because it's not possible to compare `Temporal.DateTime` objects with the relational operators `<`, `<=`, `>`, or `>=`.
+Use `Temporal.DateTime.compare()` for this, or `datetime.equals()` for equality.
+
 ### datetime.**inTimeZone**(_timeZone_ : Temporal.TimeZone | string, _options_?: object) : Temporal.Absolute
 
 **Parameters:**

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -398,3 +398,8 @@ d.toLocaleString()  // => 1 day 6 hours 30 minutes
 d.toLocaleString('de-DE')  // => 1 Tag 6 Stunden 30 Minuten
 d.toLocaleString('en-US', {day: 'numeric', hour: 'numeric'})  // => 1 day 6 hours
 ```
+
+### duration.**valueOf**()
+
+This method overrides `Object.prototype.valueOf()` and always throws an exception.
+This is because it's not possible to compare `Temporal.Duration` objects with the relational operators `<`, `<=`, `>`, or `>=`.

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -239,6 +239,12 @@ function reviver(key, value) {
 JSON.parse(str, reviver);
 ```
 
+### monthDay.**valueOf**()
+
+This method overrides `Object.prototype.valueOf()` and always throws an exception.
+This is because it's not possible to compare `Temporal.MonthDay` objects with the relational operators `<`, `<=`, `>`, or `>=`.
+Instead, use `monthDay.equals()` to check for equality.
+
 ### monthDay.**withYear**(_year_: number | object) : Temporal.Date
 
 **Parameters:**

--- a/docs/time.md
+++ b/docs/time.md
@@ -365,6 +365,12 @@ function reviver(key, value) {
 JSON.parse(str, reviver);
 ```
 
+### time.**valueOf**()
+
+This method overrides `Object.prototype.valueOf()` and always throws an exception.
+This is because it's not possible to compare `Temporal.Time` objects with the relational operators `<`, `<=`, `>`, or `>=`.
+Use `Temporal.Time.compare()` for this, or `time.equals()` for equality.
+
 ### time.**withDate**(_date_: Temporal.Date) : Temporal.DateTime
 
 **Parameters:**

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -412,6 +412,12 @@ function reviver(key, value) {
 JSON.parse(str, reviver);
 ```
 
+### yearMonth.**valueOf**()
+
+This method overrides `Object.prototype.valueOf()` and always throws an exception.
+This is because it's not possible to compare `Temporal.YearMonth` objects with the relational operators `<`, `<=`, `>`, or `>=`.
+Use `Temporal.YearMonth.compare()` for this, or `yearMonth.equals()` for equality.
+
 ### yearMonth.**withDay**(_day_: number) : Temporal.Date
 
 **Parameters:**

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -140,6 +140,9 @@ export class Absolute {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
     return new Intl.DateTimeFormat(...args).format(this);
   }
+  valueOf() {
+    throw new TypeError('use compare() or equals() to compare Temporal.Absolute');
+  }
   inTimeZone(temporalTimeZoneLike = 'UTC') {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -153,6 +153,9 @@ export class Date {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     return new Intl.DateTimeFormat(...args).format(this);
   }
+  valueOf() {
+    throw new TypeError('use compare() or equals() to compare Temporal.Date');
+  }
   withTime(temporalTime) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalTime(temporalTime)) throw new TypeError('invalid Temporal.Time object');

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -299,6 +299,9 @@ export class DateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return new Intl.DateTimeFormat(...args).format(this);
   }
+  valueOf() {
+    throw new TypeError('use compare() or equals() to compare Temporal.DateTime');
+  }
 
   inTimeZone(temporalTimeZoneLike = 'UTC', options) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -241,6 +241,9 @@ export class Duration {
     console.warn('Temporal.Duration.prototype.toLocaleString() requires Intl.DurationFormat.');
     return ES.TemporalDurationToString(this);
   }
+  valueOf() {
+    throw new TypeError('not possible to compare Temporal.Duration');
+  }
   static from(item, options = undefined) {
     const disambiguation = ES.ToTemporalDisambiguation(options);
     let years, months, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds;

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -58,6 +58,9 @@ export class MonthDay {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
     return new Intl.DateTimeFormat(...args).format(this);
   }
+  valueOf() {
+    throw new TypeError('use equals() to compare Temporal.MonthDay');
+  }
   withYear(item) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
     let year;

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -219,6 +219,9 @@ export class Time {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     return new Intl.DateTimeFormat(...args).format(this);
   }
+  valueOf() {
+    throw new TypeError('use compare() or equals() to compare Temporal.Time');
+  }
 
   withDate(temporalDate) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -133,6 +133,9 @@ export class YearMonth {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     return new Intl.DateTimeFormat(...args).format(this);
   }
+  valueOf() {
+    throw new TypeError('use compare() or equals() to compare Temporal.YearMonth');
+  }
   withDay(day) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     const year = GetSlot(this, ISO_YEAR);

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -409,6 +409,17 @@ describe('Absolute', () => {
       throws(() => abs1.equals({}), TypeError);
     });
   });
+  describe("Comparison operators don't work", () => {
+    const abs1 = Absolute.from('1963-02-13T09:36:29.123456789Z');
+    const abs1again = Absolute.from('1963-02-13T09:36:29.123456789Z');
+    const abs2 = Absolute.from('1976-11-18T15:23:30.123456789Z');
+    it('=== is object equality', () => equal(abs1, abs1));
+    it('!== is object equality', () => notEqual(abs1, abs1again));
+    it('<', () => throws(() => abs1 < abs2));
+    it('>', () => throws(() => abs1 > abs2));
+    it('<=', () => throws(() => abs1 <= abs2));
+    it('>=', () => throws(() => abs1 >= abs2));
+  });
   describe('Absolute.difference works', () => {
     const earlier = Absolute.from('1976-11-18T15:23:30.123456789Z');
     const later = Absolute.from('2019-10-29T10:46:38.271986102Z');

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -442,6 +442,17 @@ describe('Date', () => {
       throws(() => d2.equals('1976-11-18'), TypeError);
     });
   });
+  describe("Comparison operators don't work", () => {
+    const d1 = Date.from('1963-02-13');
+    const d1again = Date.from('1963-02-13');
+    const d2 = Date.from('1976-11-18');
+    it('=== is object equality', () => equal(d1, d1));
+    it('!== is object equality', () => notEqual(d1, d1again));
+    it('<', () => throws(() => d1 < d2));
+    it('>', () => throws(() => d1 > d2));
+    it('<=', () => throws(() => d1 <= d2));
+    it('>=', () => throws(() => d1 >= d2));
+  });
   describe('Min/max range', () => {
     it('constructing from numbers', () => {
       throws(() => new Date(-271821, 4, 18), RangeError);

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -285,6 +285,17 @@ describe('DateTime', () => {
       throws(() => dt2.equals('1976-11-18T15:23:30.123456789'), TypeError);
     });
   });
+  describe("Comparison operators don't work", () => {
+    const dt1 = DateTime.from('1963-02-13T09:36:29.123456789');
+    const dt1again = DateTime.from('1963-02-13T09:36:29.123456789');
+    const dt2 = DateTime.from('1976-11-18T15:23:30.123456789');
+    it('=== is object equality', () => equal(dt1, dt1));
+    it('!== is object equality', () => notEqual(dt1, dt1again));
+    it('<', () => throws(() => dt1 < dt2));
+    it('>', () => throws(() => dt1 > dt2));
+    it('<=', () => throws(() => dt1 <= dt2));
+    it('>=', () => throws(() => dt1 >= dt2));
+  });
   describe('date/time maths', () => {
     const earlier = DateTime.from('1976-11-18T15:23:30.123456789');
     const later = DateTime.from('2019-10-29T10:46:38.271986102');

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -465,6 +465,17 @@ describe('Duration', () => {
       equal(d2.nanoseconds, 5);
     });
   });
+  describe("Comparison operators don't work", () => {
+    const d1 = Duration.from('P3DT1H');
+    const d1again = Duration.from('P3DT1H');
+    const d2 = Duration.from('PT2H20M30S');
+    it('=== is object equality', () => equal(d1, d1));
+    it('!== is object equality', () => notEqual(d1, d1again));
+    it('<', () => throws(() => d1 < d2));
+    it('>', () => throws(() => d1 > d2));
+    it('<=', () => throws(() => d1 <= d2));
+    it('>=', () => throws(() => d1 >= d2));
+  });
 });
 
 import { normalize } from 'path';

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -139,6 +139,17 @@ describe('MonthDay', () => {
       throws(() => md1.equals({ month: 1, day: 22 }), TypeError);
     });
   });
+  describe("Comparison operators don't work", () => {
+    const md1 = MonthDay.from('02-13');
+    const md1again = MonthDay.from('02-13');
+    const md2 = MonthDay.from('11-18');
+    it('=== is object equality', () => equal(md1, md1));
+    it('!== is object equality', () => notEqual(md1, md1again));
+    it('<', () => throws(() => md1 < md2));
+    it('>', () => throws(() => md1 > md2));
+    it('<=', () => throws(() => md1 <= md2));
+    it('>=', () => throws(() => md1 >= md2));
+  });
   describe('MonthDay.withYear()', () => {
     const md = MonthDay.from('01-22');
     it('takes a number argument', () => {

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -334,6 +334,17 @@ describe('Time', () => {
         throws(() => t1.equals({ hour: 8, minute: 44, second: 15, millisecond: 321 }), TypeError);
       });
     });
+    describe("Comparison operators don't work", () => {
+      const t1 = Time.from('09:36:29.123456789');
+      const t1again = Time.from('09:36:29.123456789');
+      const t2 = Time.from('15:23:30.123456789');
+      it('=== is object equality', () => equal(t1, t1));
+      it('!== is object equality', () => notEqual(t1, t1again));
+      it('<', () => throws(() => t1 < t2));
+      it('>', () => throws(() => t1 > t2));
+      it('<=', () => throws(() => t1 <= t2));
+      it('>=', () => throws(() => t1 >= t2));
+    });
     describe('time.plus() works', () => {
       const time = new Time(15, 23, 30, 123, 456, 789);
       it(`(${time}).plus({ hours: 16 })`, () => {

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -144,6 +144,17 @@ describe('YearMonth', () => {
       throws(() => nov94.equals('1994-11'), TypeError);
     });
   });
+  describe("Comparison operators don't work", () => {
+    const ym1 = YearMonth.from('1963-02');
+    const ym1again = YearMonth.from('1963-02');
+    const ym2 = YearMonth.from('1976-11');
+    it('=== is object equality', () => equal(ym1, ym1));
+    it('!== is object equality', () => notEqual(ym1, ym1again));
+    it('<', () => throws(() => ym1 < ym2));
+    it('>', () => throws(() => ym1 > ym2));
+    it('<=', () => throws(() => ym1 <= ym2));
+    it('>=', () => throws(() => ym1 >= ym2));
+  });
   describe('YearMonth.difference() works', () => {
     const nov94 = YearMonth.from('1994-11');
     const jun13 = YearMonth.from('2013-06');

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -359,6 +359,16 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.absolute.prototype.valueof">
+      <h1>Temporal.Absolute.prototype.valueOf ( )</h1>
+      <p>
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.absolute.prototype.intimezone">
       <h1>Temporal.Absolute.prototype.inTimeZone ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>

--- a/spec/date.html
+++ b/spec/date.html
@@ -450,6 +450,16 @@
     </emu-clause>
   </emu-clause>
 
+    <emu-clause id="sec-temporal.date.prototype.valueof">
+      <h1>Temporal.Date.prototype.valueOf ( )</h1>
+      <p>
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+    </emu-clause>
+
   <emu-clause id="sec-properties-of-temporal-date-instances">
     <h1>Properties of Temporal.Date Instances</h1>
     <p>Temporal.Date instances are ordinary objects that inherit properties from the %Temporal.Date.prototype%.</p>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -510,6 +510,16 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.datetime.prototype.valueof">
+      <h1>Temporal.DateTime.prototype.valueOf ( )</h1>
+      <p>
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.datetime.prototype.intimezone">
       <h1>Temporal.DateTime.prototype.inTimeZone ( [ _temporalTimeZoneLike_ [ , _options_ ] ] )</h1>
       <p>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -379,6 +379,16 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-temporal.duration.prototype.valueof">
+    <h1>Temporal.Duration.prototype.valueOf ( )</h1>
+    <p>
+      The following steps are taken:
+    </p>
+    <emu-alg>
+      1. Throw a *TypeError* exception.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-duration-abstract-ops">
     <h1>Abstract Operations</h1>
 

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -208,6 +208,16 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.monthday.prototype.valueof">
+      <h1>Temporal.MonthDay.prototype.valueOf ( )</h1>
+      <p>
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.monthday.prototype.withyear">
       <h1>Temporal.MonthDay.prototype.withYear ( _item_ )</h1>
       <p>

--- a/spec/time.html
+++ b/spec/time.html
@@ -399,6 +399,16 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-temporal.time.prototype.valueof">
+    <h1>Temporal.Time.prototype.valueOf ( )</h1>
+    <p>
+      The following steps are taken:
+    </p>
+    <emu-alg>
+      1. Throw a *TypeError* exception.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-time-abstract-ops">
     <h1>Abstract operations</h1>
 

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -327,6 +327,16 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.yearmonth.prototype.valueof">
+      <h1>Temporal.YearMonth.prototype.valueOf ( )</h1>
+      <p>
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.yearmonth.prototype.withday">
       <h1>Temporal.YearMonth.prototype.withDay ( _day_ )</h1>
       <p>


### PR DESCRIPTION
This adds a valueOf() method to Absolute, Date, DateTime, Duration,
MonthDay, Time, and YearMonth, which throws a TypeError. This is in
order to prevent spurious comparisons using <, <=, >, and >= from
working.

Closes: #517