### PR TITLE
Clarify what "outside the allowed range" means

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -248,7 +248,7 @@ The `years` and `months` fields of `duration` must be zero, because adding a yea
 `Temporal.Absolute` is independent of time zones and calendars, and so years and months may be different lengths.
 If you need to do this, convert the `Temporal.Absolute` to a `Temporal.DateTime` by specifying the desired time zone, add the duration, and then convert it back.
 
-If the result is outside the allowed range for `Temporal.Absolute`, a `RangeError` will be thrown.
+If the result is earlier or later than the range that `Temporal.Absolute` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), a `RangeError` will be thrown.
 
 Example usage:
 ```js
@@ -273,7 +273,7 @@ The `years` and `months` fields of `duration` must be zero, because subtracting 
 `Temporal.Absolute` is independent of time zones and calendars, and so years and months may be different lengths.
 If you need to do this, convert the `Temporal.Absolute` to a `Temporal.DateTime` by specifying the desired time zone, subtract the duration, and then convert it back.
 
-If the result is outside the allowed range for `Temporal.Absolute`, a `RangeError` will be thrown.
+If the result is earlier or later than the range that `Temporal.Absolute` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), a `RangeError` will be thrown.
 
 Example usage:
 ```js

--- a/docs/date.md
+++ b/docs/date.md
@@ -283,7 +283,7 @@ For these cases, the `disambiguation` option tells what to do:
 - In `constrain` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `reject` mode, an addition that would result in an out-of-range value fails, and a `RangeError` is thrown.
 
-Additionally, if the result is outside the range of dates that `Temporal.Date` can represent, then `constrain` mode will clamp the result to the allowed range.
+Additionally, if the result is earlier or later than the range of dates that `Temporal.Date` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then `constrain` mode will clamp the result to the allowed range.
 The `reject` mode will throw a `RangeError` in this case.
 
 Usage example:
@@ -318,7 +318,7 @@ For these cases, the `disambiguation` option tells what to do:
 - In `constrain` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `reject` mode, an addition that would result in an out-of-range value fails, and a `RangeError` is thrown.
 
-Additionally, if the result is outside the range of dates that `Temporal.Date` can represent, then `constrain` mode will clamp the result to the allowed range.
+Additionally, if the result is earlier or later than the range of dates that `Temporal.Date` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then `constrain` mode will clamp the result to the allowed range.
 The `reject` mode will throw a `RangeError` in this case.
 
 Usage example:

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -343,7 +343,7 @@ For these cases, the `disambiguation` option tells what to do:
 - In `constrain` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `reject` mode, an addition that would result in an out-of-range value fails, and a `RangeError` is thrown.
 
-Additionally, if the result is outside the range that `Temporal.DateTime` can represent, then `constrain` mode will clamp the result to the allowed range.
+Additionally, if the result is earlier or later than the range that `Temporal.DateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then `constrain` mode will clamp the result to the allowed range.
 The `reject` mode will throw a `RangeError` in this case.
 
 Usage example:
@@ -378,7 +378,7 @@ For these cases, the `disambiguation` option tells what to do:
 - In `constrain` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `reject` mode, an addition that would result in an out-of-range value fails, and a `RangeError` is thrown.
 
-Additionally, if the result is outside the range that `Temporal.DateTime` can represent, then `constrain` mode will clamp the result to the allowed range.
+Additionally, if the result is earlier or later than the range that `Temporal.DateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then `constrain` mode will clamp the result to the allowed range.
 The `reject` mode will throw a `RangeError` in this case.
 
 Usage example:
@@ -548,7 +548,7 @@ In the case of ambiguity, the `disambiguation` option controls what absolute tim
 
 For usage examples and a more complete explanation of how this disambiguation works and why it is necessary, see [Resolving ambiguity](./ambiguity.md).
 
-If the result is outside the range that `Temporal.Absolute` can represent, then a `RangeError` will be thrown, no matter the value of `disambiguation`.
+If the result is earlier or later than the range that `Temporal.Absolute` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
 
 ### datetime.**getDate**() : Temporal.Date
 

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -209,7 +209,7 @@ In the case of ambiguity, the `disambiguation` option controls what absolute tim
 
 For usage examples and a more complete explanation of how this disambiguation works and why it is necessary, see [Resolving ambiguity](./ambiguity.md).
 
-If the result is outside the range that `Temporal.Absolute` can represent, then a `RangeError` will be thrown, no matter the value of `disambiguation`.
+If the result is earlier or later than the range that `Temporal.Absolute` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
 
 ### timeZone.**getPossibleAbsolutesFor**(_dateTime_: Temporal.DateTime) : array&lt;Temporal.Absolute&gt;
 

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -233,7 +233,7 @@ This method adds `duration` to `yearMonth`, returning a month that is in the fut
 
 The `duration` argument is an object with properties denoting a duration, such as `{ months: 5 }`, or a `Temporal.Duration` object.
 
-If the result is outside the range of dates that `Temporal.YearMonth` can represent, then `constrain` mode will clamp the result to the allowed range.
+If the result is earlier or later than the range of dates that `Temporal.YearMonth` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then `constrain` mode will clamp the result to the allowed range.
 The `reject` mode will throw a `RangeError` in this case.
 
 Other than for out-of-range values, the `disambiguation` option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous.
@@ -262,7 +262,7 @@ This method subtracts `duration` from `yearMonth`, returning a month that is in 
 
 The `duration` argument is an object with properties denoting a duration, such as `{ months: 5 }`, or a `Temporal.Duration` object.
 
-If the result is outside the range of dates that `Temporal.YearMonth` can represent, then `constrain` mode will clamp the result to the allowed range.
+If the result is earlier or later than the range of dates that `Temporal.YearMonth` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then `constrain` mode will clamp the result to the allowed range.
 The `reject` mode will throw a `RangeError` in this case.
 
 Other than for out-of-range values, the `disambiguation` option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous.


### PR DESCRIPTION
This is to remove any potential confusion between overflowing the range
of a Temporal type and hitting an invalid time during a daylight saving
transition.

Closes: #598