### PR TITLE
ISO 8601 calendar

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -206,11 +206,11 @@ Same as `getEpochSeconds()`, but with nanosecond (10<sup>&minus;9</sup> second) 
 
 The value returned from this method is suitable to be passed to `new Temporal.Absolute()`.
 
-### absolute.**inTimeZone**(_timeZone_: object | string, _calendar_?: Temporal.Calendar | string) : Temporal.DateTime
+### absolute.**inTimeZone**(_timeZone_: object | string, _calendar_?: object | string) : Temporal.DateTime
 
 **Parameters:**
 - `timeZone` (object or string): A `Temporal.TimeZone` object, or an object implementing the [time zone protocol](./timezone.md#protocol), or a string description of the time zone; either its IANA name or UTC offset.
-- `calendar` (optional object or string): A `Temporal.Calendar` object, or a calendar identifier.
+- `calendar` (optional object or string): A `Temporal.Calendar` object, or a plain object, or a calendar identifier.
   The default is to use the ISO 8601 calendar.
 
 **Returns:** a `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the absolute time indicated by `absolute`.

--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -206,15 +206,19 @@ Same as `getEpochSeconds()`, but with nanosecond (10<sup>&minus;9</sup> second) 
 
 The value returned from this method is suitable to be passed to `new Temporal.Absolute()`.
 
-### absolute.**inTimeZone**(_timeZone_: object | string) : Temporal.DateTime
+### absolute.**inTimeZone**(_timeZone_: object | string, _calendar_?: Temporal.Calendar | string) : Temporal.DateTime
 
 **Parameters:**
 - `timeZone` (object or string): A `Temporal.TimeZone` object, or an object implementing the [time zone protocol](./timezone.md#protocol), or a string description of the time zone; either its IANA name or UTC offset.
+- `calendar` (optional object or string): A `Temporal.Calendar` object, or a calendar identifier.
+  The default is to use the ISO 8601 calendar.
 
-**Returns:** a `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone` at the absolute time indicated by `absolute`.
+**Returns:** a `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the absolute time indicated by `absolute`.
 
 For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
 A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
+
+For a list of calendar identifiers, see the documentation for [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#Parameters).
 
 This method is one way to convert a `Temporal.Absolute` to a `Temporal.DateTime`.
 

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -41,6 +41,12 @@ For specialized applications where you need to do calculations in a calendar sys
 To do this, create a class inheriting from `Temporal.Calendar`, call `super()` in the constructor with a calendar identifier, and implement all the methods.
 Any subclass of `Temporal.Calendar` will be accepted in Temporal APIs where a built-in `Temporal.Calendar` would work.
 
+### Protocol
+
+It's also possible for a plain object to be a custom calendar, without subclassing.
+The object must implement the `Temporal.Calendar` methods and have an `id` property.
+It is possible to pass such an object into any Temporal API that would normally take a built-in `Temporal.Calendar`.
+
 ## Constructor
 
 ### **new Temporal.Calendar**(_calendarIdentifier_: string) : Temporal.Calendar
@@ -97,8 +103,10 @@ cal = Temporal.Calendar.from('2020-01-13T16:31:00.065858086-08:00[America/Vancou
 // Existing calendar object
 cal2 = Temporal.Calendar.from(cal);
 
+// Custom calendar that is a plain object (this calendar does not do much)
+cal = Temporal.Calendar.from({id: 'mycalendar'});
+
 /*⚠️*/ cal = Temporal.Calendar.from('discordian');  // not a built-in calendar, throws
-/*⚠️*/ cal = Temporal.Calendar.from({id: 'iso8601'});  // not a Calendar object, throws
 /*⚠️*/ cal = Temporal.Calendar.from('[c=iso8601]');  // lone annotation not a valid ISO 8601 string
 ```
 

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -125,6 +125,8 @@ Effectively, this is whatever `calendarIdentifier` was passed as a parameter to 
 
 ### calendar.**day**(_date_: Temporal.Date) : number
 
+### calendar.**era**(_date_: Temporal.Date) : unknown
+
 ### calendar.**dayOfWeek**(_date_: Temporal.Date): number
 
 ### calendar.**dayOfYear**(_date_: Temporal.Date): number

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -35,6 +35,12 @@ const calendar = new Intl.DateTimeFormat().resolvedOptions().calendar;
 date.withCalendar(calendar).plus({ months: 1 })
 ```
 
+### Custom calendars
+
+For specialized applications where you need to do calculations in a calendar system that is not supported by Intl, you can also implement your own `Temporal.Calendar` object.
+To do this, create a class inheriting from `Temporal.Calendar`, call `super()` in the constructor with a calendar identifier, and implement all the methods.
+Any subclass of `Temporal.Calendar` will be accepted in Temporal APIs where a built-in `Temporal.Calendar` would work.
+
 ## Constructor
 
 ### **new Temporal.Calendar**(_calendarIdentifier_: string) : Temporal.Calendar

--- a/docs/date.md
+++ b/docs/date.md
@@ -16,13 +16,13 @@ A `Temporal.Date` can be converted into a `Temporal.DateTime` by combining it wi
 
 ## Constructor
 
-### **new Temporal.Date**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _calendar_?: Temporal.Calendar) : Temporal.Date
+### **new Temporal.Date**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _calendar_?: object) : Temporal.Date
 
 **Parameters:**
 - `isoYear` (number): A year.
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
 - `isoDay` (number): A day of the month, ranging between 1 and 31 inclusive.
-- `calendar` (optional `Temporal.Calendar`): A calendar to project the date into.
+- `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the date into.
 
 **Returns:** a new `Temporal.Date` object.
 
@@ -145,7 +145,7 @@ date.month  // => 8
 date.day    // => 24
 ```
 
-### date.**calendar** : Temporal.Calendar
+### date.**calendar** : object
 
 The `calendar` read-only property gives the calendar that the `year`, `month`, and `day` properties are interpreted in.
 
@@ -269,10 +269,10 @@ date.with({day: 1});  // => 2006-01-01
 date.plus({months: 1}).with({day: date.daysInMonth});  // => 2006-02-28
 ```
 
-### date.**withCalendar**(_calendar_: Temporal.Calendar | string) : Temporal.Date
+### date.**withCalendar**(_calendar_: object | string) : Temporal.Date
 
 **Parameters:**
-- `calendar` (`Temporal.Calendar` or string): The calendar into which to project `date`.
+- `calendar` (`Temporal.Calendar` or plain object or string): The calendar into which to project `date`.
 
 **Returns:** a new `Temporal.Date` object which is the date indicated by `date`, projected into `calendar`.
 
@@ -530,7 +530,7 @@ date.getYearMonth()  // => 2006-08
 date.getMonthDay()  // => 08-24
 ```
 
-### date.**getFields**() : { year: number, month: number, day: number, calendar: Temporal.Calendar, [propName: string]: unknown }
+### date.**getFields**() : { year: number, month: number, day: number, calendar: object, [propName: string]: unknown }
 
 **Returns:** a plain object with properties equal to the fields of `date`.
 

--- a/docs/date.md
+++ b/docs/date.md
@@ -269,6 +269,21 @@ date.with({day: 1});  // => 2006-01-01
 date.plus({months: 1}).with({day: date.daysInMonth});  // => 2006-02-28
 ```
 
+### date.**withCalendar**(_calendar_: Temporal.Calendar | string) : Temporal.Date
+
+**Parameters:**
+- `calendar` (`Temporal.Calendar` or string): The calendar into which to project `date`.
+
+**Returns:** a new `Temporal.Date` object which is the date indicated by `date`, projected into `calendar`.
+
+This method is the same as `date.with({ calendar })`, but may be more efficient.
+
+Usage example:
+```javascript
+date = Temporal.Date.from('2006-08-24[c=japanese]');
+date.withCalendar('iso8601')  // => 2006-08-24
+```
+
 ### date.**plus**(_duration_: object, _options_?: object) : Temporal.Date
 
 **Parameters:**

--- a/docs/date.md
+++ b/docs/date.md
@@ -149,6 +149,11 @@ date.day    // => 24
 
 The `calendar` read-only property gives the calendar that the `year`, `month`, and `day` properties are interpreted in.
 
+### date.**era** : unknown
+
+The `era` read-only property is `undefined` when using the ISO 8601 calendar.
+It's used for calendar systems that specify an era in addition to the year.
+
 ### date.**dayOfWeek** : number
 
 The `dayOfWeek` read-only property gives the weekday number that the date falls on.

--- a/docs/date.md
+++ b/docs/date.md
@@ -16,20 +16,21 @@ A `Temporal.Date` can be converted into a `Temporal.DateTime` by combining it wi
 
 ## Constructor
 
-### **new Temporal.Date**(_isoYear_: number, _isoMonth_: number, _isoDay_: number) : Temporal.Date
+### **new Temporal.Date**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _calendar_?: Temporal.Calendar) : Temporal.Date
 
 **Parameters:**
 - `isoYear` (number): A year.
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
 - `isoDay` (number): A day of the month, ranging between 1 and 31 inclusive.
+- `calendar` (optional `Temporal.Calendar`): A calendar to project the date into.
 
 **Returns:** a new `Temporal.Date` object.
 
-Use this constructor if you have the correct parameters for the date already as individual number values.
-Otherwise, `Temporal.Date.from()`, which accepts more kinds of input and allows disambiguation behaviour, is probably more convenient.
+Use this constructor if you have the correct parameters for the date already as individual number values in the ISO 8601 calendar.
+Otherwise, `Temporal.Date.from()`, which accepts more kinds of input, allows inputting dates in different calendar reckonings, and allows disambiguation behaviour, is probably more convenient.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
-Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in that calendar.
+Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in that calendar, even if you are passing a different calendar as the `calendar` parameter.
 
 The range of allowed values for this type is exactly enough that calling [`getDate()`](./datetime.html#getDate) on any valid `Temporal.DateTime` will succeed.
 If `isoYear`, `isoMonth`, and `isoDay` form a date outside of this range, then `constrain` mode will clamp the values to the limit of the allowed range, while `reject` mode will throw a `RangeError`.
@@ -58,7 +59,8 @@ date = new Temporal.Date(2020, 3, 14)  // => 2020-03-14
 
 This static method creates a new `Temporal.Date` object from another value.
 If the value is another `Temporal.Date` object, a new object representing the same date is returned.
-If the value is any other object, it must have `year`, `month`, and `day` properties, and a `Temporal.Date` will be constructed from them.
+If the value is any other object, it must have `year`, `month`, and `day` properties, and optionally a `calendar` property.
+A `Temporal.Date` will be constructed from these properties.
 
 Any non-object value is converted to a string, which is expected to be in ISO 8601 format.
 Any time or time zone part is optional and will be ignored.
@@ -82,6 +84,11 @@ date === Temporal.Date.from(date)  // => true
 date = Temporal.Date.from({year: 2006, month: 8, day: 24});  // => 2006-08-24
 date = Temporal.Date.from(Temporal.DateTime.from('2006-08-24T15:43:27'));
   // => same as above; Temporal.DateTime has year, month, and day properties
+
+calendar = Temporal.Calendar.from('islamic');
+date = Temporal.Date.from({ year: 1427, month; 8, day: 1, calendar });  // => 2006-08-24[c=islamic]
+date = Temporal.Date.from({ year: 1427, month: 8, day: 1, calendar: 'islamic' });
+  // => same as above
 
 // Different disambiguation modes
 date = Temporal.Date.from({ year: 2001, month: 13, day: 1 }, { disambiguation: 'constrain' })
@@ -138,10 +145,14 @@ date.month  // => 8
 date.day    // => 24
 ```
 
+### date.**calendar** : Temporal.Calendar
+
+The `calendar` read-only property gives the calendar that the `year`, `month`, and `day` properties are interpreted in.
+
 ### date.**dayOfWeek** : number
 
 The `dayOfWeek` read-only property gives the weekday number that the date falls on.
-The weekday number is defined as in the ISO 8601 standard: a value between 1 and 7, inclusive, with Monday being 1, and Sunday 7.
+For the ISO 8601 calendar, the weekday number is defined as in the ISO 8601 standard: a value between 1 and 7, inclusive, with Monday being 1, and Sunday 7.
 For an overview, see [ISO 8601 on Wikipedia](https://en.wikipedia.org/wiki/ISO_8601#Week_dates).
 
 Usage example:
@@ -153,7 +164,7 @@ date = Temporal.Date.from('2006-08-24');
 ### date.**dayOfYear** : number
 
 The `dayOfYear` read-only property gives the ordinal day of the year that the date falls on.
-This is a value between 1 and 365, or 366 in a leap year.
+For the ISO 8601 calendar, this is a value between 1 and 365, or 366 in a leap year.
 
 Usage example:
 ```javascript
@@ -165,7 +176,7 @@ console.log(date.year, date.dayOfYear);  // 2006 236
 ### date.**weekOfYear** : number
 
 The `weekOfYear` read-only property gives the ISO week number of the date.
-This is normally a value between 1 and 52, but in a few cases it can be 53 as well.
+For the ISO 8601 calendar, this is normally a value between 1 and 52, but in a few cases it can be 53 as well.
 ISO week 1 is the week containing the first Thursday of the year.
 For more information on ISO week numbers, see for example the Wikipedia article on [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date).
 
@@ -179,7 +190,7 @@ console.log(date.year, date.weekOfYear, date.dayOfWeek);  // 2006 34 4
 ### date.**daysInMonth** : number
 
 The `daysInMonth` read-only property gives the number of days in the month that the date falls in.
-This is 28, 29, 30, or 31, depending on the month and whether the year is a leap year.
+For the ISO 8601 calendar, this is 28, 29, 30, or 31, depending on the month and whether the year is a leap year.
 
 Usage example:
 ```javascript
@@ -202,7 +213,7 @@ console.log(poem);
 ### date.**daysInYear** : number
 
 The `daysInYear` read-only property gives the number of days in the year that the date falls in.
-This is 365 or 366, depending on whether the year is a leap year.
+For the ISO 8601 calendar, this is 365 or 366, depending on whether the year is a leap year.
 
 Usage example:
 ```javascript
@@ -245,6 +256,9 @@ This method creates a new `Temporal.Date` which is a copy of `date`, but any pro
 Since `Temporal.Date` objects are immutable, use this method instead of modifying one.
 
 > **NOTE**: The allowed values for the `dateLike.month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
+
+> **NOTE**: If a `calendar` property is provided on `dateLike`, the new calendar is applied first, before any of the other properties.
+> If you are passing in an object with _only_ a `calendar` property, it is recommended to use the `withCalendar` method instead.
 
 Usage example:
 ```javascript
@@ -501,7 +515,7 @@ date.getYearMonth()  // => 2006-08
 date.getMonthDay()  // => 08-24
 ```
 
-### date.**getFields**() : { year: number, month: number, day: number, [propName: string]: unknown }
+### date.**getFields**() : { year: number, month: number, day: number, calendar: Temporal.Calendar, [propName: string]: unknown }
 
 **Returns:** a plain object with properties equal to the fields of `date`.
 
@@ -525,10 +539,18 @@ Object.assign({}, date.getFields()).day  // => 24
 
 This method is mainly useful if you are implementing a custom calendar.
 Most code will not need to use it.
-Use `date.getFields()` instead.
+Use `date.getFields()` instead, or `date.withCalendar('iso8601').getFields()`.
 
 Usage example:
 ```javascript
 date = Temporal.Date.from('2006-08-24');
 date.getISOCalendarFields().day  // => 24
+
+// Date in other calendar
+date = date.withCalendar('hebrew');
+date.getFields().day  // => 30
+date.getISOCalendarFields().day  // => 24
+
+// Most likely what you need is this:
+date.withCalendar('iso8601').day  // => 24
 ```

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -209,6 +209,11 @@ dt.nanosecond   // => 500
 
 The `calendar` read-only property gives the calendar that the `year`, `month`, and `day` properties are interpreted in.
 
+### datetime.**era** : unknown
+
+The `era` read-only property is `undefined` when using the ISO 8601 calendar.
+It's used for calendar systems that specify an era in addition to the year.
+
 ### datetime.**dayOfWeek** : number
 
 The `dayOfWeek` read-only property gives the weekday number that the date falls on.

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -21,7 +21,7 @@ A `Temporal.DateTime` can also be converted into any of the other `Temporal` obj
 
 ## Constructor
 
-### **new Temporal.DateTime**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _hour_: number = 0, _minute_: number = 0, _second_: number = 0, _millisecond_: number = 0, _microsecond_: number = 0, _nanosecond_: number = 0) : Temporal.DateTime
+### **new Temporal.DateTime**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _hour_: number = 0, _minute_: number = 0, _second_: number = 0, _millisecond_: number = 0, _microsecond_: number = 0, _nanosecond_: number = 0, _calendar_?: Temporal.Calendar) : Temporal.DateTime
 
 **Parameters:**
 - `isoYear` (number): A year.
@@ -33,14 +33,15 @@ A `Temporal.DateTime` can also be converted into any of the other `Temporal` obj
 - `millisecond` (optional number): A number of milliseconds, ranging between 0 and 999 inclusive.
 - `microsecond` (optional number): A number of microseconds, ranging between 0 and 999 inclusive.
 - `nanosecond` (optional number): A number of nanoseconds, ranging between 0 and 999 inclusive.
+- `calendar` (optional `Temporal.Calendar`): A calendar to project the date into.
 
 **Returns:** a new `Temporal.DateTime` object.
 
-Use this constructor if you have the correct parameters for the date already as individual number values.
-Otherwise, `Temporal.DateTime.from()`, which accepts more kinds of input and allows disambiguation behaviour, is probably more convenient.
+Use this constructor if you have the correct parameters for the date already as individual number values in the ISO 8601 calendar.
+Otherwise, `Temporal.DateTime.from()`, which accepts more kinds of input, allows inputting dates in different calendar reckonings, and allows disambiguation behaviour, is probably more convenient.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
-Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in that calendar, and the time parameters must represent a valid time of day.
+Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in that calendar, even if you are passing a different calendar as the `calendar` parameter, and the time parameters must represent a valid time of day.
 
 > **NOTE**: Although Temporal does not deal with leap seconds, dates coming from other software may have a `second` value of 60.
 > This value will cause the constructor will throw, so if you have to interoperate with times that may contain leap seconds, use `Temporal.DateTime.from()` instead.
@@ -72,8 +73,9 @@ datetime = new Temporal.DateTime(2020, 3, 14, 13, 37)  // => 2020-03-14T13:37
 
 This static method creates a new `Temporal.DateTime` object from another value.
 If the value is another `Temporal.DateTime` object, a new object representing the same date and time is returned.
-If the value is any other object, a `Temporal.DateTime` will be constructed from the values of any `year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`, `microsecond`, and `nanosecond` properties that are present.
+If the value is any other object, a `Temporal.DateTime` will be constructed from the values of any `year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`, `microsecond`, `nanosecond`, and `calendar` properties that are present.
 At least the `year`, `month`, and `day` properties must be present.
+If `calendar` is missing, it will be assumed to be `Temporal.Calendar.from('iso8601')`.
 Any other missing ones will be assumed to be 0.
 
 Any non-object value is converted to a string, which is expected to be in ISO 8601 format.
@@ -112,6 +114,12 @@ dt = Temporal.DateTime.from({
 dt = Temporal.DateTime.from({year: 1995, month: 12, day: 7});  // => 1995-12-07T00:00
 dt = Temporal.DateTime.from(Temporal.Date.from('1995-12-07T03:24:30'));
   // => same as above; Temporal.Date has year, month, and day properties
+
+calendar = Temporal.Calendar.from('hebrew');
+dt = Temporal.DateTime.from({ year: 5756, month: 3, day: 14, hour: 3, minute: 24, second: 30, calendar });
+  // => 1995-12-07T03:24:30[c=hebrew]
+dt = Temporal.DateTime.from({ year: 5756, month: 3, day: 14, hour: 3, minute: 24, second: 30, calendar: 'hebrew' });
+  // => same as above
 
 // Different disambiguation modes
 dt = Temporal.DateTime.from({ year: 2001, month: 13, day: 1 }, { disambiguation: 'constrain' })
@@ -197,10 +205,14 @@ dt.microsecond  // => 3
 dt.nanosecond   // => 500
 ```
 
+### datetime.**calendar** : Temporal.Calendar
+
+The `calendar` read-only property gives the calendar that the `year`, `month`, and `day` properties are interpreted in.
+
 ### datetime.**dayOfWeek** : number
 
 The `dayOfWeek` read-only property gives the weekday number that the date falls on.
-The weekday number is defined as in the ISO 8601 standard: a value between 1 and 7, inclusive, with Monday being 1, and Sunday 7.
+For the ISO 8601 calendar, the weekday number is defined as in the ISO 8601 standard: a value between 1 and 7, inclusive, with Monday being 1, and Sunday 7.
 For an overview, see [ISO 8601 on Wikipedia](https://en.wikipedia.org/wiki/ISO_8601#Week_dates).
 
 Usage example:
@@ -212,7 +224,7 @@ dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
 ### datetime.**dayOfYear** : number
 
 The `dayOfYear` read-only property gives the ordinal day of the year that the date falls on.
-This is a value between 1 and 365, or 366 in a leap year.
+For the ISO 8601 calendar, this is a value between 1 and 365, or 366 in a leap year.
 
 Usage example:
 ```javascript
@@ -224,7 +236,7 @@ console.log(dt.year, dt.dayOfYear);  // => 1995 341
 ### datetime.**weekOfYear** : number
 
 The `weekOfYear` read-only property gives the ISO week number of the date.
-This is normally a value between 1 and 52, but in a few cases it can be 53 as well.
+For the ISO 8601 calendar, this is normally a value between 1 and 52, but in a few cases it can be 53 as well.
 ISO week 1 is the week containing the first Thursday of the year.
 For more information on ISO week numbers, see for example the Wikipedia article on [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date).
 
@@ -238,7 +250,7 @@ console.log(dt.year, dt.weekOfYear, dt.dayOfWeek);  // => 1995 49 4
 ### datetime.**daysInMonth** : number
 
 The `daysInMonth` read-only property gives the number of days in the month that the date falls in.
-This is 28, 29, 30, or 31, depending on the month and whether the year is a leap year.
+For the ISO 8601 calendar, this is 28, 29, 30, or 31, depending on the month and whether the year is a leap year.
 
 Usage example:
 ```javascript
@@ -261,7 +273,7 @@ console.log(poem);
 ### datetime.**daysInYear** : number
 
 The `daysInYear` read-only property gives the number of days in the year that the date falls in.
-This is 365 or 366, depending on whether the year is a leap year.
+For the ISO 8601 calendar, this is 365 or 366, depending on whether the year is a leap year.
 
 Usage example:
 ```javascript
@@ -304,6 +316,9 @@ This method creates a new `Temporal.DateTime` which is a copy of `datetime`, but
 Since `Temporal.DateTime` objects are immutable, use this method instead of modifying one.
 
 > **NOTE**: The allowed values for the `dateTimeLike.month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
+
+> **NOTE**: If a `calendar` property is provided on `dateTimeLike`, the new calendar is applied first, before any of the other properties.
+> If you are passing in an object with _only_ a `calendar` property, it is recommended to use the `withCalendar` method instead.
 
 Usage example:
 ```javascript
@@ -574,7 +589,7 @@ dt.getMonthDay()  // => 12-07
 dt.getTime()  // => 03:24:30.000003500
 ```
 
-### datetime.**getFields**() : { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, [propName: string]: unknown }
+### datetime.**getFields**() : { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: Temporal.Calendar, [propName: string]: unknown }
 
 **Returns:** a plain object with properties equal to the fields of `datetime`.
 
@@ -598,10 +613,18 @@ Object.assign({}, dt.getFields()).day  // => 7
 
 This method is mainly useful if you are implementing a custom calendar.
 Most code will not need to use it.
-Use `datetime.getFields()` instead.
+Use `datetime.getFields()` instead, or `datetime.withCalendar('iso8601').getFields()`.
 
 Usage example:
 ```javascript
 dt = Temporal.Date.from('1995-12-07T03:24:30.000003500');
 date.getISOCalendarFields().day  // => 7
+
+// Date in other calendar
+dt = dt.withCalendar('hebrew');
+dt.getFields().day  // => 14
+dt.getISOCalendarFields().day  // => 7
+
+// Most likely what you need is this:
+dt.withCalendar('iso8601').day  // => 7
 ```

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -21,7 +21,7 @@ A `Temporal.DateTime` can also be converted into any of the other `Temporal` obj
 
 ## Constructor
 
-### **new Temporal.DateTime**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _hour_: number = 0, _minute_: number = 0, _second_: number = 0, _millisecond_: number = 0, _microsecond_: number = 0, _nanosecond_: number = 0, _calendar_?: Temporal.Calendar) : Temporal.DateTime
+### **new Temporal.DateTime**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _hour_: number = 0, _minute_: number = 0, _second_: number = 0, _millisecond_: number = 0, _microsecond_: number = 0, _nanosecond_: number = 0, _calendar_?: object) : Temporal.DateTime
 
 **Parameters:**
 - `isoYear` (number): A year.
@@ -33,7 +33,7 @@ A `Temporal.DateTime` can also be converted into any of the other `Temporal` obj
 - `millisecond` (optional number): A number of milliseconds, ranging between 0 and 999 inclusive.
 - `microsecond` (optional number): A number of microseconds, ranging between 0 and 999 inclusive.
 - `nanosecond` (optional number): A number of nanoseconds, ranging between 0 and 999 inclusive.
-- `calendar` (optional `Temporal.Calendar`): A calendar to project the date into.
+- `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the date into.
 
 **Returns:** a new `Temporal.DateTime` object.
 
@@ -205,7 +205,7 @@ dt.microsecond  // => 3
 dt.nanosecond   // => 500
 ```
 
-### datetime.**calendar** : Temporal.Calendar
+### datetime.**calendar** : object
 
 The `calendar` read-only property gives the calendar that the `year`, `month`, and `day` properties are interpreted in.
 
@@ -326,10 +326,10 @@ dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
 dt.with({year: 2015, second: 31})  // => 2015-12-07T03:24:31.000003500
 ```
 
-### datetime.**withCalendar**(_calendar_: Temporal.Calendar | string) : Temporal.DateTime
+### datetime.**withCalendar**(_calendar_: object | string) : Temporal.DateTime
 
 **Parameters:**
-- `calendar` (`Temporal.Calendar` or string): The calendar into which to project `datetime`.
+- `calendar` (`Temporal.Calendar` or plain object or string): The calendar into which to project `datetime`.
 
 **Returns:** a new `Temporal.DateTime` object which is the date indicated by `datetime`, projected into `calendar`.
 
@@ -604,7 +604,7 @@ dt.getMonthDay()  // => 12-07
 dt.getTime()  // => 03:24:30.000003500
 ```
 
-### datetime.**getFields**() : { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: Temporal.Calendar, [propName: string]: unknown }
+### datetime.**getFields**() : { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: object, [propName: string]: unknown }
 
 **Returns:** a plain object with properties equal to the fields of `datetime`.
 

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -326,6 +326,21 @@ dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
 dt.with({year: 2015, second: 31})  // => 2015-12-07T03:24:31.000003500
 ```
 
+### datetime.**withCalendar**(_calendar_: Temporal.Calendar | string) : Temporal.DateTime
+
+**Parameters:**
+- `calendar` (`Temporal.Calendar` or string): The calendar into which to project `datetime`.
+
+**Returns:** a new `Temporal.DateTime` object which is the date indicated by `datetime`, projected into `calendar`.
+
+This method is the same as `datetime.with({ calendar })`, but may be more efficient.
+
+Usage example:
+```javascript
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500[c=japanese]');
+dt.withCalendar('iso8601')  // => 1995-12-07T03:24:30.000003500
+```
+
 ### datetime.**plus**(_duration_: object, _options_?: object) : Temporal.DateTime
 
 **Parameters:**

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -13,12 +13,12 @@ A `Temporal.MonthDay` can be converted into a `Temporal.Date` by combining it wi
 
 ## Constructor
 
-### **new Temporal.MonthDay**(_isoMonth_: number, _isoDay_: number, _calendar_?: Temporal.Calendar, _refISOYear_?: number) : Temporal.MonthDay
+### **new Temporal.MonthDay**(_isoMonth_: number, _isoDay_: number, _calendar_?: object, _refISOYear_?: number) : Temporal.MonthDay
 
 **Parameters:**
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
 - `isoDay` (number): A day of the month, ranging between 1 and 31 inclusive.
-- `calendar` (optional `Temporal.Calendar`): A calendar to project the date into.
+- `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the date into.
 - `refISOYear` (optional number): A reference year, used for disambiguation when implementing other calendar systems.
   The default is the first leap year after the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
   You can omit this parameter unless using a non-ISO-8601 calendar.
@@ -112,7 +112,7 @@ md.month  // => 8
 md.day    // => 24
 ```
 
-### monthDay.**calendar** : Temporal.Calendar
+### monthDay.**calendar** : object
 
 The `calendar` read-only property gives the calendar that the `month` and `day` properties are interpreted in.
 
@@ -272,7 +272,7 @@ md.withYear(2020)  // => 2020-02-29
 
 In calendars where more information than just the year is needed to convert a `Temporal.MonthDay` to a `Temporal.Date`, you can pass an object to `withYear()` that contains the necessary properties.
 
-### monthDay.**getFields**() : { month: number, day: number, calendar: Temporal.Calendar, [propName: string]: unknown }
+### monthDay.**getFields**() : { month: number, day: number, calendar: object, [propName: string]: unknown }
 
 **Returns:** a plain object with properties equal to the fields of `monthDay`.
 

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -272,6 +272,17 @@ md.withYear(2020)  // => 2020-02-29
 
 In calendars where more information than just the year is needed to convert a `Temporal.MonthDay` to a `Temporal.Date`, you can pass an object to `withYear()` that contains the necessary properties.
 
+Example:
+```javascript
+md = Temporal.MonthDay.from({
+  calendar: 'japanese',
+  month: 1,
+  day: 1
+});
+
+date = md.withYear({ era: 'reiwa', year: 2 });
+```
+
 ### monthDay.**getFields**() : { month: number, day: number, calendar: object, [propName: string]: unknown }
 
 **Returns:** a plain object with properties equal to the fields of `monthDay`.

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -13,11 +13,12 @@ A `Temporal.MonthDay` can be converted into a `Temporal.Date` by combining it wi
 
 ## Constructor
 
-### **new Temporal.MonthDay**(_isoMonth_: number, _isoDay_: number, _refISOYear_?: number) : Temporal.MonthDay
+### **new Temporal.MonthDay**(_isoMonth_: number, _isoDay_: number, _calendar_?: Temporal.Calendar, _refISOYear_?: number) : Temporal.MonthDay
 
 **Parameters:**
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
 - `isoDay` (number): A day of the month, ranging between 1 and 31 inclusive.
+- `calendar` (optional `Temporal.Calendar`): A calendar to project the date into.
 - `refISOYear` (optional number): A reference year, used for disambiguation when implementing other calendar systems.
   The default is the first leap year after the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
   You can omit this parameter unless using a non-ISO-8601 calendar.
@@ -25,7 +26,7 @@ A `Temporal.MonthDay` can be converted into a `Temporal.Date` by combining it wi
 **Returns:** a new `Temporal.MonthDay` object.
 
 Use this constructor if you have the correct parameters for the date already as individual number values, or you are implementing a custom calendar.
-Otherwise, `Temporal.MonthDay.from()`, which accepts more kinds of input and allows disambiguation behaviour, is probably more convenient.
+Otherwise, `Temporal.MonthDay.from()`, which accepts more kinds of input, allows inputting dates in different calendar reckonings, and allows disambiguation behaviour, is probably more convenient.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 Together, `refISOYear`, `isoMonth` and `isoDay` must represent a valid date in that calendar.
@@ -57,7 +58,7 @@ md = new Temporal.MonthDay(2, 29)  // => 02-29
 
 This static method creates a new `Temporal.MonthDay` object from another value.
 If the value is another `Temporal.MonthDay` object, a new object representing the same month and day is returned.
-If the value is any other object, it must have `month` and `day` properties, and a `Temporal.MonthDay` will be constructed from them.
+If the value is any other object, it must have `month` and `day` properties, and optionally a `calendar` property, and a `Temporal.MonthDay` will be constructed from these properties.
 
 Any non-object value will be converted to a string, which is expected to be in ISO 8601 format.
 Any parts of the string other than the month and the day are optional and will be ignored.
@@ -111,6 +112,10 @@ md.month  // => 8
 md.day    // => 24
 ```
 
+### monthDay.**calendar** : Temporal.Calendar
+
+The `calendar` read-only property gives the calendar that the `month` and `day` properties are interpreted in.
+
 ## Methods
 
 ### monthDay.**with**(_monthDayLike_: object, _options_?: object) : Temporal.MonthDay
@@ -136,6 +141,10 @@ The disambiguation parameter tells what should happen when out-of-range values a
 > **NOTE**: The allowed values for the `monthDayLike.month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
 Since `Temporal.MonthDay` objects are immutable, use this method instead of modifying one.
+
+> **NOTE**: Unlike in `Temporal.Date.prototype.with()`, a `calendar` property is not allowed on `monthDayLike`.
+> It is not possible to convert a `Temporal.MonthDay` to another calendar system without knowing the year.
+> If you need to do this, use `monthDay.withYear(year).withCalendar(calendar).getMonthDay()`.
 
 Usage example:
 ```javascript
@@ -263,7 +272,7 @@ md.withYear(2020)  // => 2020-02-29
 
 In calendars where more information than just the year is needed to convert a `Temporal.MonthDay` to a `Temporal.Date`, you can pass an object to `withYear()` that contains the necessary properties.
 
-### monthDay.**getFields**() : { month: number, day: number, [propName: string]: unknown }
+### monthDay.**getFields**() : { month: number, day: number, calendar: Temporal.Calendar, [propName: string]: unknown }
 
 **Returns:** a plain object with properties equal to the fields of `monthDay`.
 

--- a/docs/now.md
+++ b/docs/now.md
@@ -54,16 +54,18 @@ nextTransition.inTimeZone(tz);
 // On 2020-03-08T03:00 the clock will change from UTC -08:00 to -07:00
 ```
 
-### Temporal.now.**dateTime**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.DateTime
+### Temporal.now.**dateTime**(_timeZone_: object | string = Temporal.now.timeZone(), _calendar_: Temporal.Calendar | string = 'iso8601') : Temporal.DateTime
 
 **Parameters:**
 - `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
   If not given, the current system time zone will be used.
+- `calendar` (optional `Temporal.Calendar` or string): The calendar system to get the current date and time in.
+  If not given, the ISO 8601 calendar will be used.
 
 **Returns:** a `Temporal.DateTime` object representing the current system date and time.
 
 This method gets the current calendar date and wall-clock time according to the system settings.
-Optionally a time zone can be given in which the time is computed.
+Optionally a time zone can be given in which the time is computed, and a calendar system in which the date is reckoned.
 
 Example usage:
 ```js
@@ -83,11 +85,13 @@ Object.entries(financialCentres).forEach(([name, timeZone]) => {
 // Tokyo: 2020-01-25T14:52:14.759534758
 ```
 
-### Temporal.now.**date**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Date
+### Temporal.now.**date**(_timeZone_: object | string = Temporal.now.timeZone(), _calendar_: Temporal.Calendar | string = 'iso8601') : Temporal.Date
 
 **Parameters:**
 - `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
   If not given, the current system time zone will be used.
+- `calendar` (optional `Temporal.Calendar` or string): The calendar system to get the current date and time in.
+  If not given, the ISO 8601 calendar will be used.
 
 **Returns:** a `Temporal.Date` object representing the current system date.
 

--- a/docs/now.md
+++ b/docs/now.md
@@ -54,12 +54,12 @@ nextTransition.inTimeZone(tz);
 // On 2020-03-08T03:00 the clock will change from UTC -08:00 to -07:00
 ```
 
-### Temporal.now.**dateTime**(_timeZone_: object | string = Temporal.now.timeZone(), _calendar_: Temporal.Calendar | string = 'iso8601') : Temporal.DateTime
+### Temporal.now.**dateTime**(_timeZone_: object | string = Temporal.now.timeZone(), _calendar_: object | string = 'iso8601') : Temporal.DateTime
 
 **Parameters:**
 - `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
   If not given, the current system time zone will be used.
-- `calendar` (optional `Temporal.Calendar` or string): The calendar system to get the current date and time in.
+- `calendar` (optional `Temporal.Calendar`, plain object, or string): The calendar system to get the current date and time in.
   If not given, the ISO 8601 calendar will be used.
 
 **Returns:** a `Temporal.DateTime` object representing the current system date and time.
@@ -85,12 +85,12 @@ Object.entries(financialCentres).forEach(([name, timeZone]) => {
 // Tokyo: 2020-01-25T14:52:14.759534758
 ```
 
-### Temporal.now.**date**(_timeZone_: object | string = Temporal.now.timeZone(), _calendar_: Temporal.Calendar | string = 'iso8601') : Temporal.Date
+### Temporal.now.**date**(_timeZone_: object | string = Temporal.now.timeZone(), _calendar_: object | string = 'iso8601') : Temporal.Date
 
 **Parameters:**
 - `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
   If not given, the current system time zone will be used.
-- `calendar` (optional `Temporal.Calendar` or string): The calendar system to get the current date and time in.
+- `calendar` (optional `Temporal.Calendar`, plain object, or string): The calendar system to get the current date and time in.
   If not given, the ISO 8601 calendar will be used.
 
 **Returns:** a `Temporal.Date` object representing the current system date.

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -173,11 +173,11 @@ tz = new Temporal.TimeZone('-08:00');
 tz.getOffsetStringFor(timestamp);  // => -08:00
 ```
 
-### timeZone.**getDateTimeFor**(_absolute_: Temporal.Absolute, _calendar_?: Temporal.Calendar | string) : Temporal.DateTime
+### timeZone.**getDateTimeFor**(_absolute_: Temporal.Absolute, _calendar_?: object | string) : Temporal.DateTime
 
 **Parameters:**
 - `absolute` (`Temporal.Absolute`): An absolute time to convert.
-- `calendar` (optional object or string): A `Temporal.Calendar` object, or a calendar identifier.
+- `calendar` (optional object or string): A `Temporal.Calendar` object, or a plain object, or a calendar identifier.
   The default is to use the ISO 8601 calendar.
 
 **Returns:** A `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the absolute time indicated by `absolute`.

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -173,12 +173,14 @@ tz = new Temporal.TimeZone('-08:00');
 tz.getOffsetStringFor(timestamp);  // => -08:00
 ```
 
-### timeZone.**getDateTimeFor**(_absolute_: Temporal.Absolute) : Temporal.DateTime
+### timeZone.**getDateTimeFor**(_absolute_: Temporal.Absolute, _calendar_?: Temporal.Calendar | string) : Temporal.DateTime
 
 **Parameters:**
 - `absolute` (`Temporal.Absolute`): An absolute time to convert.
+- `calendar` (optional object or string): A `Temporal.Calendar` object, or a calendar identifier.
+  The default is to use the ISO 8601 calendar.
 
-**Returns:** A `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone` at the absolute time indicated by `absolute`.
+**Returns:** A `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the absolute time indicated by `absolute`.
 
 This method is one way to convert a `Temporal.Absolute` to a `Temporal.DateTime`.
 

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -140,6 +140,11 @@ ym.month  // => 6
 
 The `calendar` read-only property gives the calendar that the `year` and `month` properties are interpreted in.
 
+### yearmonth.**era** : unknown
+
+The `era` read-only property is `undefined` when using the ISO 8601 calendar.
+It's used for calendar systems that specify an era in addition to the year.
+
 ### yearMonth.**daysInMonth** : number
 
 The `daysInMonth` read-only property gives the number of days in the month.

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -13,21 +13,22 @@ A `Temporal.YearMonth` can be converted into a `Temporal.Date` by combining it w
 
 ## Constructor
 
-### **new Temporal.YearMonth**(_isoYear_: number, _isoMonth_: number, _refISODay_: number = 1) : Temporal.YearMonth
+### **new Temporal.YearMonth**(_isoYear_: number, _isoMonth_: number, _calendar_?: Temporal.Calendar, _refISODay_: number = 1) : Temporal.YearMonth
 
 **Parameters:**
 - `isoYear` (number): A year.
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
+- `calendar` (optional `Temporal.Calendar`): A calendar to project the month into.
 - `refISODay` (optional number): A reference day, used for disambiguation when implementing other calendar systems.
   You can omit this parameter unless using a non-ISO-8601 calendar.
 
 **Returns:** a new `Temporal.YearMonth` object.
 
-Use this constructor if you have the correct parameters already as individual number values, or you are implementing a custom calendar.
-Otherwise, `Temporal.YearMonth.from()`, which accepts more kinds of input and allows disambiguation behaviour, is probably more convenient.
+Use this constructor if you have the correct parameters already as individual number values in the ISO 8601 calendar, or you are implementing a custom calendar.
+Otherwise, `Temporal.YearMonth.from()`, which accepts more kinds of input, allows months in other calendar systems, and allows disambiguation behaviour, is probably more convenient.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
-Together, `isoYear`, `isoMonth`, and `refISODay` must represent a valid date in that calendar.
+Together, `isoYear`, `isoMonth`, and `refISODay` must represent a valid date in that calendar, even if you are passing a different calendar as the `calendar` parameter.
 
 The range of allowed values for this type is exactly enough that calling [`getYearMonth()`](./date.html#getYearMonth) on any valid `Temporal.Date` will succeed.
 If `isoYear` and `isoMonth` are outside of this range, then `constrain` mode will clamp the date to the limit of the allowed range.
@@ -135,6 +136,10 @@ ym.year   // => 2019
 ym.month  // => 6
 ```
 
+### yearMonth.**calendar** : Temporal.Calendar
+
+The `calendar` read-only property gives the calendar that the `year` and `month` properties are interpreted in.
+
 ### yearMonth.**daysInMonth** : number
 
 The `daysInMonth` read-only property gives the number of days in the month.
@@ -204,6 +209,10 @@ This method creates a new `Temporal.YearMonth` which is a copy of `yearMonth`, b
 Since `Temporal.YearMonth` objects are immutable, use this method instead of modifying one.
 
 > **NOTE**: The allowed values for the `yearMonthLike.month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
+
+> **NOTE**: Unlike in `Temporal.Date.prototype.with()`, a `calendar` property is not allowed on `yearMonthLike`.
+> It is not possible to convert a `Temporal.YearMonth` to another calendar system without knowing the day of the month.
+> If you need to do this, use `yearMonth.withDay(day).withCalendar(calendar).getYearMonth()`.
 
 Usage example:
 ```javascript
@@ -429,7 +438,7 @@ ym = Temporal.YearMonth.from('2019-06');
 ym.withDay(24)  // => 2019-06-24
 ```
 
-### yearMonth.**getFields**() : { year: number, month: number, [propName: string]: unknown }
+### yearMonth.**getFields**() : { year: number, month: number, calendar: Temporal.Calendar, [propName: string]: unknown }
 
 **Returns:** a plain object with properties equal to the fields of `yearMonth`.
 

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -13,12 +13,12 @@ A `Temporal.YearMonth` can be converted into a `Temporal.Date` by combining it w
 
 ## Constructor
 
-### **new Temporal.YearMonth**(_isoYear_: number, _isoMonth_: number, _calendar_?: Temporal.Calendar, _refISODay_: number = 1) : Temporal.YearMonth
+### **new Temporal.YearMonth**(_isoYear_: number, _isoMonth_: number, _calendar_?: object, _refISODay_: number = 1) : Temporal.YearMonth
 
 **Parameters:**
 - `isoYear` (number): A year.
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
-- `calendar` (optional `Temporal.Calendar`): A calendar to project the month into.
+- `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the month into.
 - `refISODay` (optional number): A reference day, used for disambiguation when implementing other calendar systems.
   You can omit this parameter unless using a non-ISO-8601 calendar.
 
@@ -136,7 +136,7 @@ ym.year   // => 2019
 ym.month  // => 6
 ```
 
-### yearMonth.**calendar** : Temporal.Calendar
+### yearMonth.**calendar** : object
 
 The `calendar` read-only property gives the calendar that the `year` and `month` properties are interpreted in.
 
@@ -438,7 +438,7 @@ ym = Temporal.YearMonth.from('2019-06');
 ym.withDay(24)  // => 2019-06-24
 ```
 
-### yearMonth.**getFields**() : { year: number, month: number, calendar: Temporal.Calendar, [propName: string]: unknown }
+### yearMonth.**getFields**() : { year: number, month: number, calendar: object, [propName: string]: unknown }
 
 **Returns:** a plain object with properties equal to the fields of `yearMonth`.
 

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -204,11 +204,52 @@ export namespace Temporal {
       other: Temporal.Absolute,
       options?: DifferenceOptions<'days' | 'hours' | 'minutes' | 'seconds'>
     ): Temporal.Duration;
-    inTimeZone(tzLike?: TimeZoneProtocol | string, calendar?: Temporal.Calendar | string): Temporal.DateTime;
+    inTimeZone(tzLike?: TimeZoneProtocol | string, calendar?: CalendarProtocol | string): Temporal.DateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(tzLike?: TimeZoneProtocol | string): string;
   }
+
+  type CalendarProtocol = {
+    id: string;
+    year(date: Temporal.Date): number;
+    month(date: Temporal.Date): number;
+    day(date: Temporal.Date): number;
+    dayOfWeek?(date: Temporal.Date): number;
+    dayOfYear?(date: Temporal.Date): number;
+    weekOfYear?(date: Temporal.Date): number;
+    daysInMonth?(date: Temporal.Date): number;
+    daysInYear?(date: Temporal.Date): number;
+    isLeapYear?(date: Temporal.Date): boolean;
+    dateFromFields(
+      fields: DateLike,
+      options: AssignmentOptions,
+      constructor: ConstructorOf<Temporal.Date>
+    ): Temporal.Date;
+    yearMonthFromFields(
+      fields: YearMonthLike,
+      options: AssignmentOptions,
+      constructor: ConstructorOf<Temporal.YearMonth>
+    ): Temporal.YearMonth;
+    monthDayFromFields(
+      fields: MonthDayLike,
+      options: AssignmentOptions,
+      constructor: ConstructorOf<Temporal.MonthDay>
+    ): Temporal.MonthDay;
+    plus?(
+      date: Temporal.Date,
+      duration: Temporal.Duration,
+      options: ArithmeticOptions,
+      constructor: ConstructorOf<Temporal.Date>
+    ): Temporal.Date;
+    minus?(
+      date: Temporal.Date,
+      duration: Temporal.Duration,
+      options: ArithmeticOptions,
+      constructor: ConstructorOf<Temporal.Date>
+    ): Temporal.Date;
+    difference?(smaller: Temporal.Date, larger: Temporal.Date, options: DifferenceOptions);
+  };
 
   /**
    * A `Temporal.Calendar` is a representation of a calendar system. It includes
@@ -218,7 +259,7 @@ export namespace Temporal {
    *
    * See https://tc39.es/proposal-temporal/docs/calendar.html for more details.
    */
-  export class Calendar {
+  export class Calendar implements Required<CalendarProtocol> {
     static from(item: Temporal.Calendar | string): Temporal.Calendar;
     constructor(calendarIdentifier: string);
     readonly id: string;
@@ -266,14 +307,14 @@ export namespace Temporal {
     year?: number;
     month?: number;
     day?: number;
-    calendar?: string | Temporal.Calendar;
+    calendar?: string | CalendarProtocol;
   };
 
   type DateFields = {
     year: number;
     month: number;
     day: number;
-    calendar: Temporal.Calendar;
+    calendar: CalendarProtocol;
   };
 
   type DateISOCalendarFields = {
@@ -294,11 +335,11 @@ export namespace Temporal {
   export class Date implements Required<DateLike> {
     static from(item: Temporal.Date | DateLike | string, options?: AssignmentOptions): Temporal.Date;
     static compare(one: Temporal.Date, two: Temporal.Date): ComparisonResult;
-    constructor(isoYear: number, isoMonth: number, isoDay: number, calendar?: Temporal.Calendar);
+    constructor(isoYear: number, isoMonth: number, isoDay: number, calendar?: CalendarProtocol);
     readonly year: number;
     readonly month: number;
     readonly day: number;
-    readonly calendar: Temporal.Calendar;
+    readonly calendar: CalendarProtocol;
     readonly dayOfWeek: number;
     readonly dayOfYear: number;
     readonly weekOfYear: number;
@@ -307,7 +348,7 @@ export namespace Temporal {
     readonly isLeapYear: boolean;
     equals(other: Temporal.Date): boolean;
     with(dateLike: DateLike, options?: AssignmentOptions): Temporal.Date;
-    withCalendar(calendar: string | Temporal.Calendar): Temporal.Date;
+    withCalendar(calendar: string | CalendarProtocol): Temporal.Date;
     plus(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.Date;
     minus(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.Date;
     difference(
@@ -334,7 +375,7 @@ export namespace Temporal {
     millisecond?: number;
     microsecond?: number;
     nanosecond?: number;
-    calendar?: string | Temporal.Calendar;
+    calendar?: string | CalendarProtocol;
   };
 
   type DateTimeFields = {
@@ -347,7 +388,7 @@ export namespace Temporal {
     millisecond: number;
     microsecond: number;
     nanosecond: number;
-    calendar: Temporal.Calendar;
+    calendar: CalendarProtocol;
   };
 
   type DateTimeISOCalendarFields = {
@@ -385,7 +426,7 @@ export namespace Temporal {
       millisecond?: number,
       microsecond?: number,
       nanosecond?: number,
-      calendar?: Temporal.Calendar
+      calendar?: CalendarProtocol
     );
     readonly year: number;
     readonly month: number;
@@ -396,7 +437,7 @@ export namespace Temporal {
     readonly millisecond: number;
     readonly microsecond: number;
     readonly nanosecond: number;
-    readonly calendar: Temporal.Calendar;
+    readonly calendar: CalendarProtocol;
     readonly dayOfWeek: number;
     readonly dayOfYear: number;
     readonly weekOfYear: number;
@@ -405,7 +446,7 @@ export namespace Temporal {
     readonly isLeapYear: boolean;
     equals(other: Temporal.DateTime): boolean;
     with(dateTimeLike: DateTimeLike, options?: AssignmentOptions): Temporal.DateTime;
-    withCalendar(calendar: string | Temporal.Calendar): Temporal.DateTime;
+    withCalendar(calendar: string | CalendarProtocol): Temporal.DateTime;
     plus(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.DateTime;
     minus(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.DateTime;
     difference(
@@ -432,7 +473,7 @@ export namespace Temporal {
   type MonthDayFields = {
     month: number;
     day: number;
-    calendar: Temporal.Calendar;
+    calendar: CalendarProtocol;
   };
 
   /**
@@ -444,10 +485,10 @@ export namespace Temporal {
    */
   export class MonthDay implements Required<MonthDayLike> {
     static from(item: Temporal.MonthDay | MonthDayLike | string, options?: AssignmentOptions): Temporal.MonthDay;
-    constructor(isoMonth: number, isoDay: number, calendar?: Temporal.Calendar, refISOYear?: number);
+    constructor(isoMonth: number, isoDay: number, calendar?: CalendarProtocol, refISOYear?: number);
     readonly month: number;
     readonly day: number;
-    readonly calendar: Temporal.Calendar;
+    readonly calendar: CalendarProtocol;
     equals(other: Temporal.MonthDay): boolean;
     with(monthDayLike: MonthDayLike, options?: AssignmentOptions): Temporal.MonthDay;
     withYear(year: number | { year: number }): Temporal.Date;
@@ -545,7 +586,7 @@ export namespace Temporal {
     readonly name: string;
     getOffsetNanosecondsFor(absolute: Temporal.Absolute): number;
     getOffsetStringFor(absolute: Temporal.Absolute): string;
-    getDateTimeFor(absolute: Temporal.Absolute, calendar?: Temporal.Calendar | string): Temporal.DateTime;
+    getDateTimeFor(absolute: Temporal.Absolute, calendar?: CalendarProtocol | string): Temporal.DateTime;
     getAbsoluteFor(dateTime: Temporal.DateTime, options?: ToAbsoluteOptions): Temporal.Absolute;
     getTransitions(startingPoint: Temporal.Absolute): IteratorResult<Temporal.Absolute>;
     getPossibleAbsolutesFor(dateTime: Temporal.DateTime): Temporal.Absolute[];
@@ -561,7 +602,7 @@ export namespace Temporal {
   type YearMonthFields = {
     year: number;
     month: number;
-    calendar: Temporal.Calendar;
+    calendar: CalendarProtocol;
   };
 
   /**
@@ -574,10 +615,10 @@ export namespace Temporal {
   export class YearMonth implements Required<YearMonthLike> {
     static from(item: Temporal.YearMonth | YearMonthLike | string, options?: AssignmentOptions): Temporal.YearMonth;
     static compare(one: Temporal.YearMonth, two: Temporal.YearMonth): ComparisonResult;
-    constructor(isoYear: number, isoMonth: number, calendar?: Temporal.Calendar, refISODay?: number);
+    constructor(isoYear: number, isoMonth: number, calendar?: CalendarProtocol, refISODay?: number);
     readonly year: number;
     readonly month: number;
-    readonly calendar: Temporal.Calendar;
+    readonly calendar: CalendarProtocol;
     readonly daysInMonth: number;
     readonly daysInYear: number;
     readonly isLeapYear: boolean;
@@ -619,12 +660,13 @@ export namespace Temporal {
      * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
      * object implementing the time zone protocol. If omitted,
      * the environment's current time zone will be used.
-     * @param {Temporal.Calendar | string} [calendar] - calendar identifier or a
-     * `Temporal.Calendar` instance. If omitted, the ISO 8601 calendar is used.
+     * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
+     * a `Temporal.Calendar` instance, or an object implementing the calendar
+     * protocol. If omitted, the ISO 8601 calendar is used.
      */
     export function dateTime(
       tzLike?: TimeZoneProtocol | string,
-      calendar?: Temporal.Calendar | string
+      calendar?: CalendarProtocol | string
     ): Temporal.DateTime;
 
     /**
@@ -635,10 +677,11 @@ export namespace Temporal {
      * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
      * object implementing the time zone protocol. If omitted,
      * the environment's current time zone will be used.
-     * @param {Temporal.Calendar | string} [calendar] - calendar identifier or a
-     * `Temporal.Calendar` instance. If omitted, the ISO 8601 calendar is used.
+     * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
+     * a `Temporal.Calendar` instance, or an object implementing the calendar
+     * protocol. If omitted, the ISO 8601 calendar is used.
      */
-    export function date(tzLike?: TimeZoneProtocol | string, calendar?: Temporal.Calendar | string): Temporal.Date;
+    export function date(tzLike?: TimeZoneProtocol | string, calendar?: CalendarProtocol | string): Temporal.Date;
 
     /**
      * Get the current clock time in a specific time zone.

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -204,7 +204,7 @@ export namespace Temporal {
       other: Temporal.Absolute,
       options?: DifferenceOptions<'days' | 'hours' | 'minutes' | 'seconds'>
     ): Temporal.Duration;
-    inTimeZone(tzLike?: TimeZoneProtocol | string): Temporal.DateTime;
+    inTimeZone(tzLike?: TimeZoneProtocol | string, calendar?: Temporal.Calendar | string): Temporal.DateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(tzLike?: TimeZoneProtocol | string): string;
@@ -545,7 +545,7 @@ export namespace Temporal {
     readonly name: string;
     getOffsetNanosecondsFor(absolute: Temporal.Absolute): number;
     getOffsetStringFor(absolute: Temporal.Absolute): string;
-    getDateTimeFor(absolute: Temporal.Absolute): Temporal.DateTime;
+    getDateTimeFor(absolute: Temporal.Absolute, calendar?: Temporal.Calendar | string): Temporal.DateTime;
     getAbsoluteFor(dateTime: Temporal.DateTime, options?: ToAbsoluteOptions): Temporal.Absolute;
     getTransitions(startingPoint: Temporal.Absolute): IteratorResult<Temporal.Absolute>;
     getPossibleAbsolutesFor(dateTime: Temporal.DateTime): Temporal.Absolute[];
@@ -617,10 +617,15 @@ export namespace Temporal {
      * @param {TimeZoneProtocol | string} [tzLike] -
      * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
      * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
-     * object implementing the time zone protocol. If omitted, the environment's
-     * current time zone will be used.
+     * object implementing the time zone protocol. If omitted,
+     * the environment's current time zone will be used.
+     * @param {Temporal.Calendar | string} [calendar] - calendar identifier or a
+     * `Temporal.Calendar` instance. If omitted, the ISO 8601 calendar is used.
      */
-    export function dateTime(tzLike?: TimeZoneProtocol | string): Temporal.DateTime;
+    export function dateTime(
+      tzLike?: TimeZoneProtocol | string,
+      calendar?: Temporal.Calendar | string
+    ): Temporal.DateTime;
 
     /**
      * Get the current calendar date in a specific time zone.
@@ -628,10 +633,12 @@ export namespace Temporal {
      * @param {TimeZoneProtocol | string} [tzLike] -
      * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
      * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
-     * object implementing the time zone protocol. If omitted, the environment's
-     * current time zone will be used.
+     * object implementing the time zone protocol. If omitted,
+     * the environment's current time zone will be used.
+     * @param {Temporal.Calendar | string} [calendar] - calendar identifier or a
+     * `Temporal.Calendar` instance. If omitted, the ISO 8601 calendar is used.
      */
-    export function date(tzLike?: TimeZoneProtocol | string): Temporal.Date;
+    export function date(tzLike?: TimeZoneProtocol | string, calendar?: Temporal.Calendar | string): Temporal.Date;
 
     /**
      * Get the current clock time in a specific time zone.

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -307,6 +307,7 @@ export namespace Temporal {
     readonly isLeapYear: boolean;
     equals(other: Temporal.Date): boolean;
     with(dateLike: DateLike, options?: AssignmentOptions): Temporal.Date;
+    withCalendar(calendar: string | Temporal.Calendar): Temporal.Date;
     plus(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.Date;
     minus(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.Date;
     difference(
@@ -404,6 +405,7 @@ export namespace Temporal {
     readonly isLeapYear: boolean;
     equals(other: Temporal.DateTime): boolean;
     with(dateTimeLike: DateTimeLike, options?: AssignmentOptions): Temporal.DateTime;
+    withCalendar(calendar: string | Temporal.Calendar): Temporal.DateTime;
     plus(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.DateTime;
     minus(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.DateTime;
     difference(

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -215,6 +215,7 @@ export namespace Temporal {
     year(date: Temporal.Date): number;
     month(date: Temporal.Date): number;
     day(date: Temporal.Date): number;
+    era(date: Temporal.Date): unknown;
     dayOfWeek?(date: Temporal.Date): number;
     dayOfYear?(date: Temporal.Date): number;
     weekOfYear?(date: Temporal.Date): number;
@@ -266,6 +267,7 @@ export namespace Temporal {
     year(date: Temporal.Date): number;
     month(date: Temporal.Date): number;
     day(date: Temporal.Date): number;
+    era(date: Temporal.Date): unknown;
     dayOfWeek(date: Temporal.Date): number;
     dayOfYear(date: Temporal.Date): number;
     weekOfYear(date: Temporal.Date): number;
@@ -304,6 +306,7 @@ export namespace Temporal {
   }
 
   export type DateLike = {
+    era?: unknown;
     year?: number;
     month?: number;
     day?: number;
@@ -311,6 +314,7 @@ export namespace Temporal {
   };
 
   type DateFields = {
+    era: unknown;
     year: number;
     month: number;
     day: number;
@@ -340,6 +344,7 @@ export namespace Temporal {
     readonly month: number;
     readonly day: number;
     readonly calendar: CalendarProtocol;
+    readonly era: unknown;
     readonly dayOfWeek: number;
     readonly dayOfYear: number;
     readonly weekOfYear: number;
@@ -366,6 +371,7 @@ export namespace Temporal {
   }
 
   export type DateTimeLike = {
+    era?: unknown;
     year?: number;
     month?: number;
     day?: number;
@@ -379,6 +385,7 @@ export namespace Temporal {
   };
 
   type DateTimeFields = {
+    era: unknown;
     year: number;
     month: number;
     day: number;
@@ -438,6 +445,7 @@ export namespace Temporal {
     readonly microsecond: number;
     readonly nanosecond: number;
     readonly calendar: CalendarProtocol;
+    readonly era: unknown;
     readonly dayOfWeek: number;
     readonly dayOfYear: number;
     readonly weekOfYear: number;
@@ -491,7 +499,7 @@ export namespace Temporal {
     readonly calendar: CalendarProtocol;
     equals(other: Temporal.MonthDay): boolean;
     with(monthDayLike: MonthDayLike, options?: AssignmentOptions): Temporal.MonthDay;
-    withYear(year: number | { year: number }): Temporal.Date;
+    withYear(year: number | { era?: unknown; year: number }): Temporal.Date;
     getFields(): MonthDayFields;
     getISOCalendarFields(): DateISOCalendarFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
@@ -595,11 +603,13 @@ export namespace Temporal {
   }
 
   export type YearMonthLike = {
+    era?: unknown;
     year?: number;
     month?: number;
   };
 
   type YearMonthFields = {
+    era: unknown;
     year: number;
     month: number;
     calendar: CalendarProtocol;
@@ -619,6 +629,7 @@ export namespace Temporal {
     readonly year: number;
     readonly month: number;
     readonly calendar: CalendarProtocol;
+    readonly era: unknown;
     readonly daysInMonth: number;
     readonly daysInYear: number;
     readonly isLeapYear: boolean;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -266,6 +266,14 @@ export namespace Temporal {
     year?: number;
     month?: number;
     day?: number;
+    calendar?: string | Temporal.Calendar;
+  };
+
+  type DateFields = {
+    year: number;
+    month: number;
+    day: number;
+    calendar: Temporal.Calendar;
   };
 
   type DateISOCalendarFields = {
@@ -286,10 +294,11 @@ export namespace Temporal {
   export class Date implements Required<DateLike> {
     static from(item: Temporal.Date | DateLike | string, options?: AssignmentOptions): Temporal.Date;
     static compare(one: Temporal.Date, two: Temporal.Date): ComparisonResult;
-    constructor(isoYear: number, isoMonth: number, isoDay: number);
+    constructor(isoYear: number, isoMonth: number, isoDay: number, calendar?: Temporal.Calendar);
     readonly year: number;
     readonly month: number;
     readonly day: number;
+    readonly calendar: Temporal.Calendar;
     readonly dayOfWeek: number;
     readonly dayOfYear: number;
     readonly weekOfYear: number;
@@ -307,7 +316,7 @@ export namespace Temporal {
     withTime(temporalTime: Temporal.Time): Temporal.DateTime;
     getYearMonth(): Temporal.YearMonth;
     getMonthDay(): Temporal.MonthDay;
-    getFields(): Required<DateLike>;
+    getFields(): DateFields;
     getISOCalendarFields(): DateISOCalendarFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
@@ -324,6 +333,20 @@ export namespace Temporal {
     millisecond?: number;
     microsecond?: number;
     nanosecond?: number;
+    calendar?: string | Temporal.Calendar;
+  };
+
+  type DateTimeFields = {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+    millisecond: number;
+    microsecond: number;
+    nanosecond: number;
+    calendar: Temporal.Calendar;
   };
 
   type DateTimeISOCalendarFields = {
@@ -360,7 +383,8 @@ export namespace Temporal {
       second?: number,
       millisecond?: number,
       microsecond?: number,
-      nanosecond?: number
+      nanosecond?: number,
+      calendar?: Temporal.Calendar
     );
     readonly year: number;
     readonly month: number;
@@ -371,6 +395,7 @@ export namespace Temporal {
     readonly millisecond: number;
     readonly microsecond: number;
     readonly nanosecond: number;
+    readonly calendar: Temporal.Calendar;
     readonly dayOfWeek: number;
     readonly dayOfYear: number;
     readonly weekOfYear: number;
@@ -390,7 +415,7 @@ export namespace Temporal {
     getYearMonth(): Temporal.YearMonth;
     getMonthDay(): Temporal.MonthDay;
     getTime(): Temporal.Time;
-    getFields(): Required<DateTimeLike>;
+    getFields(): DateTimeFields;
     getISOCalendarFields(): DateTimeISOCalendarFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
@@ -402,6 +427,12 @@ export namespace Temporal {
     day?: number;
   };
 
+  type MonthDayFields = {
+    month: number;
+    day: number;
+    calendar: Temporal.Calendar;
+  };
+
   /**
    * A `Temporal.MonthDay` represents a particular day on the calendar, but
    * without a year. For example, it could be used to represent a yearly
@@ -411,13 +442,14 @@ export namespace Temporal {
    */
   export class MonthDay implements Required<MonthDayLike> {
     static from(item: Temporal.MonthDay | MonthDayLike | string, options?: AssignmentOptions): Temporal.MonthDay;
-    constructor(isoMonth: number, isoDay: number);
+    constructor(isoMonth: number, isoDay: number, calendar?: Temporal.Calendar, refISOYear?: number);
     readonly month: number;
     readonly day: number;
+    readonly calendar: Temporal.Calendar;
     equals(other: Temporal.MonthDay): boolean;
     with(monthDayLike: MonthDayLike, options?: AssignmentOptions): Temporal.MonthDay;
     withYear(year: number | { year: number }): Temporal.Date;
-    getFields(): Required<MonthDayLike>;
+    getFields(): MonthDayFields;
     getISOCalendarFields(): DateISOCalendarFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
@@ -524,6 +556,12 @@ export namespace Temporal {
     month?: number;
   };
 
+  type YearMonthFields = {
+    year: number;
+    month: number;
+    calendar: Temporal.Calendar;
+  };
+
   /**
    * A `Temporal.YearMonth` represents a particular month on the calendar. For
    * example, it could be used to represent a particular instance of a monthly
@@ -534,9 +572,10 @@ export namespace Temporal {
   export class YearMonth implements Required<YearMonthLike> {
     static from(item: Temporal.YearMonth | YearMonthLike | string, options?: AssignmentOptions): Temporal.YearMonth;
     static compare(one: Temporal.YearMonth, two: Temporal.YearMonth): ComparisonResult;
-    constructor(isoYear: number, isoMonth: number);
+    constructor(isoYear: number, isoMonth: number, calendar?: Temporal.Calendar, refISODay?: number);
     readonly year: number;
     readonly month: number;
+    readonly calendar: Temporal.Calendar;
     readonly daysInMonth: number;
     readonly daysInYear: number;
     readonly isLeapYear: boolean;
@@ -546,7 +585,7 @@ export namespace Temporal {
     minus(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.YearMonth;
     difference(other: Temporal.YearMonth, options?: DifferenceOptions<'years' | 'months'>): Temporal.Duration;
     withDay(day: number): Temporal.Date;
-    getFields(): Required<YearMonthLike>;
+    getFields(): YearMonthFields;
     getISOCalendarFields(): DateISOCalendarFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -7,7 +7,7 @@ import bigInt from 'big-integer';
 export class Absolute {
   constructor(epochNanoseconds) {
     const ns = ES.ToBigInt(epochNanoseconds);
-    ES.RejectAbsolute(ns);
+    ES.RejectAbsoluteRange(ns);
     CreateSlots(this);
     SetSlot(this, EPOCHNANOSECONDS, ns);
   }
@@ -54,7 +54,7 @@ export class Absolute {
     add = add.plus(bigInt(days).multiply(24 * 60 * 60 * 1e9));
 
     const ns = bigInt(GetSlot(this, EPOCHNANOSECONDS)).plus(add);
-    ES.RejectAbsolute(ns);
+    ES.RejectAbsoluteRange(ns);
 
     const Construct = ES.SpeciesConstructor(this, Absolute);
     const result = new Construct(bigIntIfAvailable(ns));
@@ -83,7 +83,7 @@ export class Absolute {
     add = add.plus(bigInt(days).multiply(24 * 60 * 60 * 1e9));
 
     const ns = bigInt(GetSlot(this, EPOCHNANOSECONDS)).minus(add);
-    ES.RejectAbsolute(ns);
+    ES.RejectAbsoluteRange(ns);
 
     const Construct = ES.SpeciesConstructor(this, Absolute);
     const result = new Construct(bigIntIfAvailable(ns));
@@ -155,7 +155,7 @@ export class Absolute {
   static fromEpochSeconds(epochSeconds) {
     epochSeconds = ES.ToNumber(epochSeconds);
     const epochNanoseconds = bigInt(epochSeconds).multiply(1e9);
-    ES.RejectAbsolute(epochNanoseconds);
+    ES.RejectAbsoluteRange(epochNanoseconds);
     const result = new this(bigIntIfAvailable(epochNanoseconds));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
@@ -163,7 +163,7 @@ export class Absolute {
   static fromEpochMilliseconds(epochMilliseconds) {
     epochMilliseconds = ES.ToNumber(epochMilliseconds);
     const epochNanoseconds = bigInt(epochMilliseconds).multiply(1e6);
-    ES.RejectAbsolute(epochNanoseconds);
+    ES.RejectAbsoluteRange(epochNanoseconds);
     const result = new this(bigIntIfAvailable(epochNanoseconds));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
@@ -171,14 +171,14 @@ export class Absolute {
   static fromEpochMicroseconds(epochMicroseconds) {
     epochMicroseconds = ES.ToBigInt(epochMicroseconds);
     const epochNanoseconds = epochMicroseconds.multiply(1e3);
-    ES.RejectAbsolute(epochNanoseconds);
+    ES.RejectAbsoluteRange(epochNanoseconds);
     const result = new this(bigIntIfAvailable(epochNanoseconds));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;
   }
   static fromEpochNanoseconds(epochNanoseconds) {
     epochNanoseconds = ES.ToBigInt(epochNanoseconds);
-    ES.RejectAbsolute(epochNanoseconds);
+    ES.RejectAbsoluteRange(epochNanoseconds);
     const result = new this(bigIntIfAvailable(epochNanoseconds));
     if (!ES.IsTemporalAbsolute(result)) throw new TypeError('invalid result');
     return result;

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -144,12 +144,12 @@ export class Absolute {
   valueOf() {
     throw new TypeError('use compare() or equals() to compare Temporal.Absolute');
   }
-  inTimeZone(temporalTimeZoneLike) {
+  inTimeZone(temporalTimeZoneLike, calendar = undefined) {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
     const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
     const timeZone = TemporalTimeZone.from(temporalTimeZoneLike);
-    if (typeof timeZone.getDateTimeFor === 'function') return timeZone.getDateTimeFor(this);
-    return TemporalTimeZone.prototype.getDateTimeFor.call(timeZone, this);
+    if (typeof timeZone.getDateTimeFor === 'function') return timeZone.getDateTimeFor(this, calendar);
+    return TemporalTimeZone.prototype.getDateTimeFor.call(timeZone, this, calendar);
   }
 
   static fromEpochSeconds(epochSeconds) {

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -203,3 +203,12 @@ export class ISO8601 extends Calendar {
     return ES.LeapYear(GetSlot(date, ISO_YEAR));
   }
 }
+
+// According to documentation for Intl.Locale.prototype.calendar on MDN,
+// 'iso8601' calendar is equivalent to 'gregory' except for ISO 8601 week
+// numbering rules, which we do not currently use in Temporal.
+export class Gregorian extends ISO8601 {
+  constructor() {
+    super('gregory');
+  }
+}

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -61,6 +61,10 @@ export class Calendar {
     void date;
     throw new Error('not implemented');
   }
+  era(date) {
+    void date;
+    throw new Error('not implemented');
+  }
   dayOfWeek(date) {
     void date;
     throw new Error('not implemented');
@@ -107,7 +111,7 @@ export class ISO8601 extends Calendar {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const disambiguation = ES.ToTemporalDisambiguation(options);
     // Intentionally alphabetical
-    let { year, month, day } = ES.ToRecord(fields, [['day'], ['month'], ['year']]);
+    let { year, month, day } = ES.ToRecord(fields, [['day'], ['era', undefined], ['month'], ['year']]);
     ({ year, month, day } = ES.RegulateDate(year, month, day, disambiguation));
     ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
     return new constructor(year, month, day, this);
@@ -116,7 +120,7 @@ export class ISO8601 extends Calendar {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const disambiguation = ES.ToTemporalDisambiguation(options);
     // Intentionally alphabetical
-    let { year, month } = ES.ToRecord(fields, [['month'], ['year']]);
+    let { year, month } = ES.ToRecord(fields, [['era', undefined], ['month'], ['year']]);
     ({ year, month } = ES.RegulateYearMonth(year, month, disambiguation));
     ({ year, month } = ES.RegulateYearMonthRange(year, month, disambiguation));
     return new constructor(year, month, this, /* refIsoDay = */ 1);
@@ -169,6 +173,10 @@ export class ISO8601 extends Calendar {
   day(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     return GetSlot(date, ISO_DAY);
+  }
+  era(date) {
+    void date;
+    return undefined;
   }
   dayOfWeek(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1,6 +1,6 @@
 import { ES } from './ecmascript.mjs';
-import { MakeIntrinsicClass } from './intrinsicclass.mjs';
-import { CALENDAR_ID, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { CALENDAR_ID, ISO_YEAR, ISO_MONTH, ISO_DAY, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
 
 export class Calendar {
   constructor(id) {
@@ -97,3 +97,100 @@ export class Calendar {
 }
 
 MakeIntrinsicClass(Calendar, 'Temporal.Calendar');
+
+export class ISO8601 extends Calendar {
+  constructor() {
+    super('iso8601');
+  }
+  dateFromFields(fields, options, constructor) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    // Intentionally alphabetical
+    let { year, month, day } = ES.ToRecord(fields, [['day'], ['month'], ['year']]);
+    ({ year, month, day } = ES.RegulateDate(year, month, day, disambiguation));
+    ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
+    return new constructor(year, month, day, this);
+  }
+  yearMonthFromFields(fields, options, constructor) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    // Intentionally alphabetical
+    let { year, month } = ES.ToRecord(fields, [['month'], ['year']]);
+    ({ year, month } = ES.RegulateYearMonth(year, month, disambiguation));
+    ({ year, month } = ES.RegulateYearMonthRange(year, month, disambiguation));
+    return new constructor(year, month, this, /* refIsoDay = */ 1);
+  }
+  monthDayFromFields(fields, options, constructor) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    // Intentionally alphabetical
+    let { month, day } = ES.ToRecord(fields, [['day'], ['month']]);
+    ({ month, day } = ES.RegulateMonthDay(month, day, disambiguation));
+    return new constructor(month, day, this, /* refIsoYear = */ 1972);
+  }
+  plus(date, duration, options, constructor) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    const { years, months, weeks, days } = duration;
+    let year = GetSlot(date, ISO_YEAR);
+    let month = GetSlot(date, ISO_MONTH);
+    let day = GetSlot(date, ISO_DAY);
+    ({ year, month, day } = ES.AddDate(year, month, day, years, months, weeks, days, disambiguation));
+    ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
+    return new constructor(year, month, day, this);
+  }
+  minus(date, duration, options, constructor) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    const { years, months, weeks, days } = duration;
+    let year = GetSlot(date, ISO_YEAR);
+    let month = GetSlot(date, ISO_MONTH);
+    let day = GetSlot(date, ISO_DAY);
+    ({ year, month, day } = ES.SubtractDate(year, month, day, years, months, weeks, days, disambiguation));
+    ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
+    return new constructor(year, month, day, this);
+  }
+  difference(smaller, larger, options) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'days', ['hours', 'minutes', 'seconds']);
+    const { years, months, weeks, days } = ES.DifferenceDate(smaller, larger, largestUnit);
+    const Duration = GetIntrinsic('%Temporal.Duration%');
+    return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+  }
+  year(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return GetSlot(date, ISO_YEAR);
+  }
+  month(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return GetSlot(date, ISO_MONTH);
+  }
+  day(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return GetSlot(date, ISO_DAY);
+  }
+  dayOfWeek(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return ES.DayOfWeek(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
+  }
+  dayOfYear(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return ES.DayOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
+  }
+  weekOfYear(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return ES.WeekOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
+  }
+  daysInMonth(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return ES.DaysInMonth(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH));
+  }
+  daysInYear(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return ES.LeapYear(GetSlot(date, ISO_YEAR)) ? 366 : 365;
+  }
+  isLeapYear(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    return ES.LeapYear(GetSlot(date, ISO_YEAR));
+  }
+}

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -212,3 +212,92 @@ export class Gregorian extends ISO8601 {
     super('gregory');
   }
 }
+
+// Implementation details for Japanese calendar
+//
+// NOTE: For convenience, this hacky class only supports the most recent five
+// eras, those of the modern period. For the full list, see:
+// https://github.com/unicode-org/cldr/blob/master/common/supplemental/supplementalData.xml#L4310-L4546
+//
+// NOTE: Japan started using the Gregorian calendar in 6 Meiji, replacing a
+// lunisolar calendar. So the day before January 1 of 6 Meiji (1873) was not
+// December 31, but December 2, of 5 Meiji (1872). The existing Ecma-402
+// Japanese calendar doesn't seem to take this into account, so neither do we:
+// > args = ['en-ca-u-ca-japanese', { era: 'short' }]
+// > new Date('1873-01-01T12:00').toLocaleString(...args)
+// '1 1, 6 Meiji, 12:00:00 PM'
+// > new Date('1872-12-31T12:00').toLocaleString(...args)
+// '12 31, 5 Meiji, 12:00:00 PM'
+const jpn = {
+  eraStartDates: ['1868-09-08', '1912-07-30', '1926-12-25', '1989-01-08', '2019-05-01'],
+  eraAddends: [1867, 1911, 1925, 1988, 2018],
+
+  // This is what API consumers pass in as the value of the 'era' field. We use
+  // string constants consisting of the romanized name
+  // Unfortunately these are not unique throughout history, so this should be
+  // solved: https://github.com/tc39/proposal-temporal/issues/526
+  // Otherwise, we'd have to introduce some era numbering system, which (as far
+  // as I can tell from Wikipedia) the calendar doesn't have, so would be
+  // non-standard and confusing, requiring API consumers to figure out "now what
+  // number is the Reiwa (current) era?" My understanding is also that this
+  // starting point for eras (0645-06-19) is not the only possible one, since
+  // there are unofficial eras before that.
+  // https://en.wikipedia.org/wiki/Japanese_era_name
+  eraNames: ['meiji', 'taisho', 'showa', 'heisei', 'reiwa'],
+  // Note: C locale era names available at
+  // https://github.com/unicode-org/icu/blob/master/icu4c/source/data/locales/root.txt#L1582-L1818
+
+  compareDate(one, two) {
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
+      const val1 = GetSlot(one, slot);
+      const val2 = GetSlot(two, slot);
+      if (val1 !== val2) return ES.ComparisonResult(val1 - val2);
+    }
+  },
+
+  findEra(date) {
+    const TemporalDate = GetIntrinsic('%Temporal.Date%');
+    const idx = jpn.eraStartDates.findIndex((dateStr) => {
+      const { year, month, day } = ES.ParseTemporalDateString(dateStr);
+      const startDate = new TemporalDate(year, month, day);
+      return jpn.compareDate(date, startDate) < 0;
+    });
+    if (idx === -1) return jpn.eraStartDates.length - 1;
+    if (idx === 0) return 0;
+    return idx - 1;
+  },
+
+  isoYear(year, era) {
+    const eraIdx = jpn.eraNames.indexOf(era);
+    if (eraIdx === -1) throw new RangeError(`invalid era ${era}`);
+
+    return year + jpn.eraAddends[eraIdx];
+  }
+};
+
+export class Japanese extends ISO8601 {
+  constructor() {
+    super('japanese');
+  }
+
+  era(date) {
+    return jpn.eraNames[jpn.findEra(date)];
+  }
+  year(date) {
+    const eraIdx = jpn.findEra(date);
+    return GetSlot(date, ISO_YEAR) - jpn.eraAddends[eraIdx];
+  }
+
+  dateFromFields(fields, options, constructor) {
+    // Intentionally alphabetical
+    fields = ES.ToRecord(fields, [['day'], ['era'], ['month'], ['year']]);
+    const isoYear = jpn.isoYear(fields.year, fields.era);
+    return super.dateFromFields({ ...fields, year: isoYear }, options, constructor);
+  }
+  yearMonthFromFields(fields, options, constructor) {
+    // Intentionally alphabetical
+    fields = ES.ToRecord(fields, [['era'], ['month'], ['year']]);
+    const isoYear = jpn.isoYear(fields.year, fields.era);
+    return super.yearMonthFromFields({ ...fields, year: isoYear }, options, constructor);
+  }
+}

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -111,7 +111,7 @@ export class ISO8601 extends Calendar {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const disambiguation = ES.ToTemporalDisambiguation(options);
     // Intentionally alphabetical
-    let { year, month, day } = ES.ToRecord(fields, [['day'], ['era', undefined], ['month'], ['year']]);
+    let { year, month, day } = ES.ToTemporalDateRecord(fields);
     ({ year, month, day } = ES.RegulateDate(year, month, day, disambiguation));
     ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
     return new constructor(year, month, day, this);
@@ -120,7 +120,7 @@ export class ISO8601 extends Calendar {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const disambiguation = ES.ToTemporalDisambiguation(options);
     // Intentionally alphabetical
-    let { year, month } = ES.ToRecord(fields, [['era', undefined], ['month'], ['year']]);
+    let { year, month } = ES.ToTemporalYearMonthRecord(fields);
     ({ year, month } = ES.RegulateYearMonth(year, month, disambiguation));
     ({ year, month } = ES.RegulateYearMonthRange(year, month, disambiguation));
     return new constructor(year, month, this, /* refIsoDay = */ 1);
@@ -129,7 +129,7 @@ export class ISO8601 extends Calendar {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const disambiguation = ES.ToTemporalDisambiguation(options);
     // Intentionally alphabetical
-    let { month, day } = ES.ToRecord(fields, [['day'], ['month']]);
+    let { month, day } = ES.ToTemporalMonthDayRecord(fields);
     ({ month, day } = ES.RegulateMonthDay(month, day, disambiguation));
     return new constructor(month, day, this, /* refIsoYear = */ 1972);
   }

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -99,8 +99,9 @@ export class Calendar {
 MakeIntrinsicClass(Calendar, 'Temporal.Calendar');
 
 export class ISO8601 extends Calendar {
-  constructor() {
-    super('iso8601');
+  constructor(id = 'iso8601') {
+    // Needs to be subclassable, that's why the ID is a default argument
+    super(id);
   }
   dateFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -90,7 +90,7 @@ export class Calendar {
     return GetSlot(this, CALENDAR_ID);
   }
   static from(item) {
-    if (ES.IsTemporalCalendar(item)) return item;
+    if (ES.IsTemporalCalendar(item) || (typeof item === 'object' && item)) return item;
     const stringIdent = ES.ToString(item);
     return ES.GetBuiltinCalendar(stringIdent);
   }

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -49,6 +49,10 @@ export class Date {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     return GetSlot(this, CALENDAR);
   }
+  get era() {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).era(this);
+  }
   get dayOfWeek() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     return GetSlot(this, CALENDAR).dayOfWeek(this);
@@ -85,11 +89,11 @@ export class Date {
       calendar = GetSlot(this, CALENDAR);
       source = this;
     }
-    const props = ES.ToPartialRecord(temporalDateLike, ['day', 'month', 'year']);
+    const props = ES.ToPartialRecord(temporalDateLike, ['day', 'era', 'month', 'year']);
     if (!props) {
       throw new RangeError('invalid date-like');
     }
-    const fields = ES.ToRecord(source, [['day'], ['month'], ['year']]);
+    const fields = ES.ToRecord(source, [['day'], ['era', undefined], ['month'], ['year']]);
     ObjectAssign(fields, props);
     const Construct = ES.SpeciesConstructor(this, Date);
     const result = calendar.dateFromFields(fields, options, Construct);
@@ -201,7 +205,7 @@ export class Date {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
     const calendar = GetSlot(this, CALENDAR);
-    const fields = ES.ToRecord(this, [['month'], ['year']]);
+    const fields = ES.ToRecord(this, [['era', undefined], ['month'], ['year']]);
     return calendar.yearMonthFromFields(fields, {}, YearMonth);
   }
   getMonthDay() {
@@ -212,7 +216,7 @@ export class Date {
     return calendar.monthDayFromFields(fields, {}, MonthDay);
   }
   getFields() {
-    const fields = ES.ToRecord(this, [['day'], ['month'], ['year']]);
+    const fields = ES.ToRecord(this, [['day'], ['era', undefined], ['month'], ['year']]);
     if (!fields) throw new TypeError('invalid receiver');
     fields.calendar = GetSlot(this, CALENDAR);
     return fields;

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -96,6 +96,15 @@ export class Date {
     if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');
     return result;
   }
+  withCalendar(calendar) {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
+    calendar = TemporalCalendar.from(calendar);
+    const Construct = ES.SpeciesConstructor(this, Date);
+    const result = new Construct(GetSlot(this, ISO_YEAR), GetSlot(this, ISO_MONTH), GetSlot(this, ISO_DAY), calendar);
+    if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');
+    return result;
+  }
   plus(temporalDurationLike, options) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     let duration = ES.ToLimitedTemporalDuration(temporalDurationLike);

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -21,6 +21,7 @@ export class Date {
     isoMonth = ES.ToInteger(isoMonth);
     isoDay = ES.ToInteger(isoDay);
     ES.RejectDate(isoYear, isoMonth, isoDay);
+    ES.RejectDateRange(isoYear, isoMonth, isoDay);
     CreateSlots(this);
     SetSlot(this, ISO_YEAR, isoYear);
     SetSlot(this, ISO_MONTH, isoMonth);
@@ -71,6 +72,7 @@ export class Date {
     }
     let { year = GetSlot(this, ISO_YEAR), month = GetSlot(this, ISO_MONTH), day = GetSlot(this, ISO_DAY) } = props;
     ({ year, month, day } = ES.RegulateDate(year, month, day, disambiguation));
+    ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
     const Construct = ES.SpeciesConstructor(this, Date);
     const result = new Construct(year, month, day);
     if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');
@@ -93,7 +95,7 @@ export class Date {
       'days'
     );
     ({ year, month, day } = ES.AddDate(year, month, day, years, months, weeks, days, disambiguation));
-    ({ year, month, day } = ES.RegulateDate(year, month, day, disambiguation));
+    ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
     const Construct = ES.SpeciesConstructor(this, Date);
     const result = new Construct(year, month, day);
     if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');
@@ -116,7 +118,7 @@ export class Date {
       'days'
     );
     ({ year, month, day } = ES.SubtractDate(year, month, day, years, months, weeks, days, disambiguation));
-    ({ year, month, day } = ES.RegulateDate(year, month, day, disambiguation));
+    ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
     const Construct = ES.SpeciesConstructor(this, Date);
     const result = new Construct(year, month, day);
     if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');
@@ -210,6 +212,7 @@ export class Date {
       ({ year, month, day } = ES.ParseTemporalDateString(ES.ToString(item)));
     }
     ({ year, month, day } = ES.RegulateDate(year, month, day, disambiguation));
+    ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
     const result = new this(year, month, day);
     if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');
     return result;

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -93,7 +93,7 @@ export class Date {
     if (!props) {
       throw new RangeError('invalid date-like');
     }
-    const fields = ES.ToRecord(source, [['day'], ['era', undefined], ['month'], ['year']]);
+    const fields = ES.ToTemporalDateRecord(source);
     ObjectAssign(fields, props);
     const Construct = ES.SpeciesConstructor(this, Date);
     const result = calendar.dateFromFields(fields, options, Construct);
@@ -205,18 +205,18 @@ export class Date {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
     const calendar = GetSlot(this, CALENDAR);
-    const fields = ES.ToRecord(this, [['era', undefined], ['month'], ['year']]);
+    const fields = ES.ToTemporalDateRecord(this);
     return calendar.yearMonthFromFields(fields, {}, YearMonth);
   }
   getMonthDay() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     const MonthDay = GetIntrinsic('%Temporal.MonthDay%');
     const calendar = GetSlot(this, CALENDAR);
-    const fields = ES.ToRecord(this, [['day'], ['month']]);
+    const fields = ES.ToTemporalDateRecord(this);
     return calendar.monthDayFromFields(fields, {}, MonthDay);
   }
   getFields() {
-    const fields = ES.ToRecord(this, [['day'], ['era', undefined], ['month'], ['year']]);
+    const fields = ES.ToTemporalDateRecord(this);
     if (!fields) throw new TypeError('invalid receiver');
     fields.calendar = GetSlot(this, CALENDAR);
     return fields;

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -170,7 +170,8 @@ export class Date {
     let year = ES.ISOYearString(GetSlot(this, ISO_YEAR));
     let month = ES.ISODateTimePartString(GetSlot(this, ISO_MONTH));
     let day = ES.ISODateTimePartString(GetSlot(this, ISO_DAY));
-    let resultString = `${year}-${month}-${day}`;
+    const calendar = ES.FormatCalendarAnnotation(GetSlot(this, CALENDAR));
+    let resultString = `${year}-${month}-${day}${calendar}`;
     return resultString;
   }
   toLocaleString(...args) {
@@ -242,10 +243,11 @@ export class Date {
         result = calendar.dateFromFields(item, options, this);
       }
     } else {
-      let { year, month, day } = ES.ParseTemporalDateString(ES.ToString(item));
+      let { year, month, day, calendar } = ES.ParseTemporalDateString(ES.ToString(item));
       ({ year, month, day } = ES.RegulateDate(year, month, day, disambiguation));
       ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
-      const calendar = ES.GetDefaultCalendar();
+      if (!calendar) calendar = ES.GetDefaultCalendar();
+      calendar = TemporalCalendar.from(calendar);
       result = new this(year, month, day, calendar);
     }
     if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -38,6 +38,7 @@ export class DateTime {
     microsecond = ES.ToInteger(microsecond);
     nanosecond = ES.ToInteger(nanosecond);
     ES.RejectDateTime(isoYear, isoMonth, isoDay, hour, minute, second, millisecond, microsecond, nanosecond);
+    ES.RejectDateTimeRange(isoYear, isoMonth, isoDay, hour, minute, second, millisecond, microsecond, nanosecond);
     CreateSlots(this);
     SetSlot(this, ISO_YEAR, isoYear);
     SetSlot(this, ISO_MONTH, isoMonth);
@@ -149,6 +150,18 @@ export class DateTime {
       nanosecond,
       disambiguation
     ));
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateDateTimeRange(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      disambiguation
+    ));
     const Construct = ES.SpeciesConstructor(this, DateTime);
     const result = new Construct(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
     if (!ES.IsTemporalDateTime(result)) throw new TypeError('invalid result');
@@ -178,7 +191,7 @@ export class DateTime {
     ));
     day += deltaDays;
     ({ year, month, day } = ES.BalanceDate(year, month, day));
-    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateDateTime(
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateDateTimeRange(
       year,
       month,
       day,
@@ -218,7 +231,7 @@ export class DateTime {
     ));
     days -= deltaDays;
     ({ year, month, day } = ES.SubtractDate(year, month, day, years, months, weeks, days, disambiguation));
-    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateDateTime(
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateDateTimeRange(
       year,
       month,
       day,
@@ -409,6 +422,18 @@ export class DateTime {
       } = ES.ParseTemporalDateTimeString(ES.ToString(item)));
     }
     ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      disambiguation
+    ));
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateDateTimeRange(
       year,
       month,
       day,

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -213,6 +213,26 @@ export class DateTime {
     if (!ES.IsTemporalDateTime(result)) throw new TypeError('invalid result');
     return result;
   }
+  withCalendar(calendar) {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
+    calendar = TemporalCalendar.from(calendar);
+    const Construct = ES.SpeciesConstructor(this, DateTime);
+    const result = new Construct(
+      GetSlot(this, ISO_YEAR),
+      GetSlot(this, ISO_MONTH),
+      GetSlot(this, ISO_DAY),
+      GetSlot(this, HOUR),
+      GetSlot(this, MINUTE),
+      GetSlot(this, SECOND),
+      GetSlot(this, MILLISECOND),
+      GetSlot(this, MICROSECOND),
+      GetSlot(this, NANOSECOND),
+      calendar
+    );
+    if (!ES.IsTemporalDateTime(result)) throw new TypeError('invalid result');
+    return result;
+  }
   plus(temporalDurationLike, options) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const disambiguation = ES.ToTemporalDisambiguation(options);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -512,7 +512,8 @@ export class DateTime {
       GetSlot(this, MICROSECOND),
       GetSlot(this, NANOSECOND)
     );
-    let resultString = `${year}-${month}-${day}T${hour}:${minute}${second ? `:${second}` : ''}`;
+    const calendar = ES.FormatCalendarAnnotation(GetSlot(this, CALENDAR));
+    let resultString = `${year}-${month}-${day}T${hour}:${minute}${second ? `:${second}` : ''}${calendar}`;
     return resultString;
   }
   toLocaleString(...args) {
@@ -683,7 +684,8 @@ export class DateTime {
         second,
         millisecond,
         microsecond,
-        nanosecond
+        nanosecond,
+        calendar
       } = ES.ParseTemporalDateTimeString(ES.ToString(item));
       ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateDateTimeRange(
         year,
@@ -697,7 +699,8 @@ export class DateTime {
         nanosecond,
         disambiguation
       ));
-      const calendar = ES.GetDefaultCalendar();
+      if (!calendar) calendar = ES.GetDefaultCalendar();
+      calendar = TemporalCalendar.from(calendar);
       result = new this(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
     }
     if (!ES.IsTemporalDateTime(result)) throw new TypeError('invalid result');

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -164,18 +164,7 @@ export class DateTime {
     if (!props) {
       throw new RangeError('invalid date-time-like');
     }
-    const fields = ES.ToRecord(source, [
-      ['day'],
-      ['era', undefined],
-      ['hour'],
-      ['microsecond'],
-      ['millisecond'],
-      ['minute'],
-      ['month'],
-      ['nanosecond'],
-      ['second'],
-      ['year']
-    ]);
+    const fields = ES.ToTemporalDateTimeRecord(source);
     ObjectAssign(fields, props);
     const date = calendar.dateFromFields(fields, options, GetIntrinsic('%Temporal.Date%'));
     let year = GetSlot(date, ISO_YEAR);
@@ -547,14 +536,14 @@ export class DateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
     const calendar = GetSlot(this, CALENDAR);
-    const fields = ES.ToRecord(this, [['era', undefined], ['month'], ['year']]);
+    const fields = ES.ToTemporalDateTimeRecord(this);
     return calendar.yearMonthFromFields(fields, {}, YearMonth);
   }
   getMonthDay() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const MonthDay = GetIntrinsic('%Temporal.MonthDay%');
     const calendar = GetSlot(this, CALENDAR);
-    const fields = ES.ToRecord(this, [['day'], ['month']]);
+    const fields = ES.ToTemporalDateTimeRecord(this);
     return calendar.monthDayFromFields(fields, {}, MonthDay);
   }
   getTime() {
@@ -570,18 +559,7 @@ export class DateTime {
     );
   }
   getFields() {
-    const fields = ES.ToRecord(this, [
-      ['day'],
-      ['era', undefined],
-      ['hour'],
-      ['microsecond'],
-      ['millisecond'],
-      ['minute'],
-      ['month'],
-      ['nanosecond'],
-      ['second'],
-      ['year']
-    ]);
+    const fields = ES.ToTemporalDateTimeRecord(this);
     if (!fields) throw new TypeError('invalid receiver');
     fields.calendar = GetSlot(this, CALENDAR);
     return fields;
@@ -622,18 +600,7 @@ export class DateTime {
         let calendar = item.calendar;
         if (calendar === undefined) calendar = ES.GetDefaultCalendar();
         calendar = TemporalCalendar.from(calendar);
-        const fields = ES.ToRecord(item, [
-          ['day'],
-          ['era', undefined],
-          ['hour', 0],
-          ['microsecond', 0],
-          ['millisecond', 0],
-          ['minute', 0],
-          ['month'],
-          ['nanosecond', 0],
-          ['second', 0],
-          ['year']
-        ]);
+        const fields = ES.ToTemporalDateTimeRecord(item);
         const TemporalDate = GetIntrinsic('%Temporal.Date%');
         const date = calendar.dateFromFields(fields, options, TemporalDate);
         let year = GetSlot(date, ISO_YEAR);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -97,6 +97,10 @@ export class DateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return GetSlot(this, CALENDAR);
   }
+  get era() {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).era(this);
+  }
   get dayOfWeek() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return GetSlot(this, CALENDAR).dayOfWeek(this);
@@ -147,6 +151,7 @@ export class DateTime {
     }
     const props = ES.ToPartialRecord(temporalDateTimeLike, [
       'day',
+      'era',
       'hour',
       'microsecond',
       'millisecond',
@@ -161,6 +166,7 @@ export class DateTime {
     }
     const fields = ES.ToRecord(source, [
       ['day'],
+      ['era', undefined],
       ['hour'],
       ['microsecond'],
       ['millisecond'],
@@ -541,7 +547,7 @@ export class DateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
     const calendar = GetSlot(this, CALENDAR);
-    const fields = ES.ToRecord(this, [['month'], ['year']]);
+    const fields = ES.ToRecord(this, [['era', undefined], ['month'], ['year']]);
     return calendar.yearMonthFromFields(fields, {}, YearMonth);
   }
   getMonthDay() {
@@ -566,6 +572,7 @@ export class DateTime {
   getFields() {
     const fields = ES.ToRecord(this, [
       ['day'],
+      ['era', undefined],
       ['hour'],
       ['microsecond'],
       ['millisecond'],
@@ -617,6 +624,7 @@ export class DateTime {
         calendar = TemporalCalendar.from(calendar);
         const fields = ES.ToRecord(item, [
           ['day'],
+          ['era', undefined],
           ['hour', 0],
           ['microsecond', 0],
           ['millisecond', 0],

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -6,7 +6,7 @@ const ObjectAssign = Object.assign;
 import bigInt from 'big-integer';
 
 import { GetIntrinsic } from './intrinsicclass.mjs';
-import { ISO8601 as CalendarISO8601 } from './calendar.mjs';
+import { Gregorian as CalendarGregorian, ISO8601 as CalendarISO8601 } from './calendar.mjs';
 import {
   GetSlot,
   HasSlot,
@@ -43,6 +43,7 @@ const YEAR_MIN = -271821;
 const YEAR_MAX = 275760;
 
 const BUILTIN_CALENDARS = {
+  gregory: CalendarGregorian,
   iso8601: CalendarISO8601
   // To be filled in as builtin calendars are implemented
 };

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -6,7 +6,11 @@ const ObjectAssign = Object.assign;
 import bigInt from 'big-integer';
 
 import { GetIntrinsic } from './intrinsicclass.mjs';
-import { Gregorian as CalendarGregorian, ISO8601 as CalendarISO8601 } from './calendar.mjs';
+import {
+  Gregorian as CalendarGregorian,
+  ISO8601 as CalendarISO8601,
+  Japanese as CalendarJapanese
+} from './calendar.mjs';
 import {
   GetSlot,
   HasSlot,
@@ -44,7 +48,8 @@ const YEAR_MAX = 275760;
 
 const BUILTIN_CALENDARS = {
   gregory: CalendarGregorian,
-  iso8601: CalendarISO8601
+  iso8601: CalendarISO8601,
+  japanese: CalendarJapanese
   // To be filled in as builtin calendars are implemented
 };
 

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -575,6 +575,40 @@ export const ES = ObjectAssign({}, ES2019, {
     }
     return result;
   },
+  // field access in the following operations is intentionally alphabetical
+  ToTemporalDateRecord: (bag) => {
+    return ES.ToRecord(bag, [['day'], ['era', undefined], ['month'], ['year']]);
+  },
+  ToTemporalDateTimeRecord: (bag) => {
+    return ES.ToRecord(bag, [
+      ['day'],
+      ['era', undefined],
+      ['hour', 0],
+      ['microsecond', 0],
+      ['millisecond', 0],
+      ['minute', 0],
+      ['month'],
+      ['nanosecond', 0],
+      ['second', 0],
+      ['year']
+    ]);
+  },
+  ToTemporalMonthDayRecord: (bag) => {
+    return ES.ToRecord(bag, [['day'], ['month']]);
+  },
+  ToTemporalTimeRecord: (bag) => {
+    return ES.ToRecord(bag, [
+      ['hour', 0],
+      ['microsecond', 0],
+      ['millisecond', 0],
+      ['minute', 0],
+      ['nanosecond', 0],
+      ['second', 0]
+    ]);
+  },
+  ToTemporalYearMonthRecord: (bag) => {
+    return ES.ToRecord(bag, [['era', undefined], ['month'], ['year']]);
+  },
   ISOTimeZoneString: (timeZone, absolute) => {
     let offset;
     if (typeof timeZone.getOffsetStringFor === 'function') {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -542,6 +542,8 @@ export const ES = ObjectAssign({}, ES2019, {
           // FIXME: this is terrible
           const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
           any.calendar = TemporalCalendar.from(value);
+        } else if (property === 'era') {
+          any.era = value;
         } else {
           any[property] = ES.ToInteger(value);
         }
@@ -552,10 +554,11 @@ export const ES = ObjectAssign({}, ES2019, {
   ToRecord: (bag, fields) => {
     if (!bag || 'object' !== typeof bag) return false;
     const result = {};
-    for (const [property, defaultValue] of fields) {
+    for (const fieldRecord of fields) {
+      const [property, defaultValue] = fieldRecord;
       let value = bag[property];
       if (value === undefined) {
-        if (defaultValue === undefined) {
+        if (fieldRecord.length === 1) {
           throw new TypeError(`required property '${property}' missing or undefined`);
         }
         value = defaultValue;
@@ -564,6 +567,8 @@ export const ES = ObjectAssign({}, ES2019, {
         // FIXME: this is terrible
         const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
         result.calendar = TemporalCalendar.from(value);
+      } else if (property === 'era') {
+        result.era = value;
       } else {
         result[property] = ES.ToInteger(value);
       }

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -185,11 +185,13 @@ function extractOverrides(datetime, main) {
     formatter = main[TIME];
   }
   if (datetime instanceof YearMonth) {
-    datetime = datetime.withDay(1);
+    const { year, month, day } = datetime.getISOCalendarFields();
+    datetime = new Date(year, month, day, datetime.calendar);
     formatter = main[YM];
   }
   if (datetime instanceof MonthDay) {
-    datetime = datetime.withYear(2004); // use a leap-year for maximum range
+    const { year, month, day } = datetime.getISOCalendarFields();
+    datetime = new Date(year, month, day, datetime.calendar);
     formatter = main[MD];
   }
   if (datetime instanceof Date) {

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -43,7 +43,7 @@ export class MonthDay {
     if (!props) {
       throw new RangeError('invalid month-day-like');
     }
-    const fields = ES.ToRecord(this, [['day'], ['month']]);
+    const fields = ES.ToTemporalMonthDayRecord(this);
     ObjectAssign(fields, props);
     const Construct = ES.SpeciesConstructor(this, MonthDay);
     const result = GetSlot(this, CALENDAR).monthDayFromFields(fields, options, Construct);
@@ -88,13 +88,12 @@ export class MonthDay {
       year = ES.ToInteger(item);
     }
     const calendar = GetSlot(this, CALENDAR);
-    const day = calendar.day(this);
-    const month = calendar.month(this);
+    const fields = ES.ToTemporalMonthDayRecord(this);
     const Date = GetIntrinsic('%Temporal.Date%');
-    return calendar.dateFromFields({ era, year, month, day }, { disambiguation: 'reject' }, Date);
+    return calendar.dateFromFields({ ...fields, era, year }, { disambiguation: 'reject' }, Date);
   }
   getFields() {
-    const fields = ES.ToRecord(this, [['day'], ['month']]);
+    const fields = ES.ToTemporalMonthDayRecord(this);
     if (!fields) throw new TypeError('invalid receiver');
     fields.calendar = GetSlot(this, CALENDAR);
     return fields;

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -65,6 +65,11 @@ export class MonthDay {
     let month = ES.ISODateTimePartString(GetSlot(this, ISO_MONTH));
     let day = ES.ISODateTimePartString(GetSlot(this, ISO_DAY));
     let resultString = `${month}-${day}`;
+    const calendar = ES.FormatCalendarAnnotation(GetSlot(this, CALENDAR));
+    if (calendar) {
+      const year = ES.ISOYearString(GetSlot(this, REF_ISO_YEAR));
+      resultString = `${year}-${resultString}${calendar}`;
+    }
     return resultString;
   }
   toLocaleString(...args) {
@@ -120,10 +125,11 @@ export class MonthDay {
         result = calendar.monthDayFromFields(item, options, this);
       }
     } else {
-      let { month, day } = ES.ParseTemporalMonthDayString(ES.ToString(item));
+      let { month, day, refISOYear, calendar } = ES.ParseTemporalMonthDayString(ES.ToString(item));
       ({ month, day } = ES.RegulateMonthDay(month, day, disambiguation));
-      const calendar = ES.GetDefaultCalendar();
-      const refISOYear = 1972;
+      if (!calendar) calendar = ES.GetDefaultCalendar();
+      calendar = TemporalCalendar.from(calendar);
+      if (refISOYear === undefined) refISOYear = 1972;
       result = new this(month, day, calendar, refISOYear);
     }
     if (!ES.IsTemporalMonthDay(result)) throw new TypeError('invalid result');

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -81,9 +81,9 @@ export class MonthDay {
   }
   withYear(item) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
-    let year;
+    let era, year;
     if (typeof item === 'object' && item !== null) {
-      ({ year } = ES.ToRecord(item, [['year']]));
+      ({ era, year } = ES.ToRecord(item, [['era', undefined], ['year']]));
     } else {
       year = ES.ToInteger(item);
     }
@@ -91,7 +91,7 @@ export class MonthDay {
     const day = calendar.day(this);
     const month = calendar.month(this);
     const Date = GetIntrinsic('%Temporal.Date%');
-    return calendar.dateFromFields({ year, month, day }, { disambiguation: 'reject' }, Date);
+    return calendar.dateFromFields({ era, year, month, day }, { disambiguation: 'reject' }, Date);
   }
   getFields() {
     const fields = ES.ToRecord(this, [['day'], ['month']]);

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -8,6 +8,7 @@ export class MonthDay {
     isoDay = ES.ToInteger(isoDay);
     refISOYear = ES.ToInteger(refISOYear);
     ES.RejectDate(refISOYear, isoMonth, isoDay);
+    ES.RejectDateRange(refISOYear, isoMonth, isoDay);
 
     CreateSlots(this);
     SetSlot(this, ISO_MONTH, isoMonth);

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -13,15 +13,15 @@ function absolute() {
   const Absolute = GetIntrinsic('%Temporal.Absolute%');
   return new Absolute(ES.SystemUTCEpochNanoSeconds());
 }
-function dateTime(temporalTimeZoneLike = timeZone()) {
+function dateTime(temporalTimeZoneLike = timeZone(), calendar = undefined) {
   const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
   const timeZone = TemporalTimeZone.from(temporalTimeZoneLike);
   const abs = absolute();
-  if (typeof timeZone.getDateTimeFor === 'function') return timeZone.getDateTimeFor(abs);
-  return TemporalTimeZone.prototype.getDateTimeFor.call(timeZone, abs);
+  if (typeof timeZone.getDateTimeFor === 'function') return timeZone.getDateTimeFor(abs, calendar);
+  return TemporalTimeZone.prototype.getDateTimeFor.call(timeZone, abs, calendar);
 }
-function date(temporalTimeZoneLike) {
-  return dateTime(temporalTimeZoneLike).getDate();
+function date(temporalTimeZoneLike, calendar = undefined) {
+  return dateTime(temporalTimeZoneLike, calendar).getDate();
 }
 function time(temporalTimeZoneLike) {
   return dateTime(temporalTimeZoneLike).getTime();

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -1,15 +1,23 @@
 const yearpart = /(?:[+-]\d{6}|\d{4})/;
 const datesplit = new RegExp(`(${yearpart.source})(?:-(\\d{2})-(\\d{2})|(\\d{2})(\\d{2}))`);
 const timesplit = /(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?|(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?/;
-const zonesplit = /(?:(Z)|(?:([+-]\d{2})(?::?(\d{2}))?(?:\[([^\]\s]+)\])?))/i;
+const zonesplit = /(?:([zZ])|(?:([+-]\d{2})(?::?(\d{2}))?(?:\[([^c\]\s](?:[^=\]\s][^\]\s]*))?\])?))/;
+const calendar = /\[c=([^\]\s]+)\]/;
 
-export const absolute = new RegExp(`^${datesplit.source}(?:T|\\s+)${timesplit.source}${zonesplit.source}$`, 'i');
+export const absolute = new RegExp(
+  `^${datesplit.source}(?:T|\\s+)${timesplit.source}${zonesplit.source}(?:${calendar.source})?$`,
+  'i'
+);
 export const datetime = new RegExp(
-  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source}(?:${zonesplit.source})?)?$`,
+  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source}(?:${zonesplit.source})?)?(?:${calendar.source})?$`,
   'i'
 );
 
-export const time = new RegExp(`^${timesplit.source}(?:${zonesplit.source})?$`, 'i');
+export const time = new RegExp(`^${timesplit.source}(?:${zonesplit.source})?(?:${calendar.source})?$`, 'i');
+
+// The short forms of YearMonth and MonthDay are only for the ISO calendar.
+// Non-ISO calendar YearMonth and MonthDay have to parse as a Temporal.Date,
+// with the reference fields.
 // YYYYMM forbidden by ISO 8601, but since it is not ambiguous with anything
 // else we could parse in a YearMonth context, we allow it
 export const yearmonth = new RegExp(`^(${yearpart.source})-?(\\d{2})$`);

--- a/polyfill/lib/slots.mjs
+++ b/polyfill/lib/slots.mjs
@@ -16,6 +16,7 @@ export const MICROSECOND = 'slot-microsecond';
 export const NANOSECOND = 'slot-nanosecond';
 export const REF_ISO_YEAR = 'slot-ref-iso-year';
 export const REF_ISO_DAY = 'slot-ref-iso-day';
+export const CALENDAR = 'slot-calendar';
 
 // Duration
 export const YEARS = 'slot-years';

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -241,14 +241,7 @@ export class Time {
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
   }
   getFields() {
-    const fields = ES.ToRecord(this, [
-      ['hour'],
-      ['microsecond'],
-      ['millisecond'],
-      ['minute'],
-      ['nanosecond'],
-      ['second']
-    ]);
+    const fields = ES.ToTemporalTimeRecord(this);
     if (!fields) throw new TypeError('invalid receiver');
     return fields;
   }
@@ -265,14 +258,7 @@ export class Time {
         nanosecond = GetSlot(item, NANOSECOND);
       } else {
         // Intentionally alphabetical
-        ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.ToRecord(item, [
-          ['hour', 0],
-          ['microsecond', 0],
-          ['millisecond', 0],
-          ['minute', 0],
-          ['nanosecond', 0],
-          ['second', 0]
-        ]));
+        ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.ToTemporalTimeRecord(item));
       }
     } else {
       ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.ParseTemporalTimeString(ES.ToString(item)));

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -11,6 +11,7 @@ import {
   MILLISECOND,
   MICROSECOND,
   NANOSECOND,
+  CALENDAR,
   CreateSlots,
   GetSlot,
   SetSlot
@@ -235,8 +236,9 @@ export class Time {
     const millisecond = GetSlot(this, MILLISECOND);
     const microsecond = GetSlot(this, MICROSECOND);
     const nanosecond = GetSlot(this, NANOSECOND);
+    const calendar = GetSlot(temporalDate, CALENDAR);
     const DateTime = GetIntrinsic('%Temporal.DateTime%');
-    return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
   }
   getFields() {
     const fields = ES.ToRecord(this, [

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -61,7 +61,7 @@ export class TimeZone {
     }
     return ES.FormatTimeZoneOffsetString(offsetNs);
   }
-  getDateTimeFor(absolute) {
+  getDateTimeFor(absolute, calendar = 'iso8601') {
     if (!ES.IsTemporalAbsolute(absolute)) throw new TypeError('invalid Absolute object');
     const ns = GetSlot(absolute, EPOCHNANOSECONDS);
     const offsetNs = this.getOffsetNanosecondsFor(absolute);
@@ -83,8 +83,10 @@ export class TimeZone {
       microsecond,
       nanosecond + offsetNs
     ));
+    const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
+    calendar = TemporalCalendar.from(calendar);
     const DateTime = GetIntrinsic('%Temporal.DateTime%');
-    return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
   }
   getAbsoluteFor(dateTime, options) {
     if (!ES.IsTemporalDateTime(dateTime)) throw new TypeError('invalid DateTime object');

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -56,7 +56,7 @@ export class YearMonth {
     if (!props) {
       throw new RangeError('invalid year-month-like');
     }
-    const fields = ES.ToRecord(this, [['era', undefined], ['month'], ['year']]);
+    const fields = ES.ToTemporalYearMonthRecord(this);
     ObjectAssign(fields, props);
     const Construct = ES.SpeciesConstructor(this, YearMonth);
     const result = GetSlot(this, CALENDAR).yearMonthFromFields(fields, options, Construct);
@@ -80,10 +80,8 @@ export class YearMonth {
 
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
     const calendar = GetSlot(this, CALENDAR);
-    const era = calendar.era(this);
-    const year = calendar.year(this);
-    const month = calendar.month(this);
-    const firstOfCalendarMonth = calendar.dateFromFields({ era, year, month, day: 1 }, {}, TemporalDate);
+    const fields = ES.ToTemporalYearMonthRecord(this);
+    const firstOfCalendarMonth = calendar.dateFromFields({ ...fields, day: 1 }, {}, TemporalDate);
     const addedDate = calendar.plus(firstOfCalendarMonth, { ...duration, days }, options, TemporalDate);
 
     const Construct = ES.SpeciesConstructor(this, YearMonth);
@@ -108,11 +106,9 @@ export class YearMonth {
 
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
     const calendar = GetSlot(this, CALENDAR);
-    const era = calendar.era(this);
-    const year = calendar.year(this);
-    const month = calendar.month(this);
+    const fields = ES.ToTemporalYearMonthRecord(this);
     const lastDay = calendar.daysInMonth(this);
-    const lastOfCalendarMonth = calendar.dateFromFields({ era, year, month, day: lastDay }, {}, TemporalDate);
+    const lastOfCalendarMonth = calendar.dateFromFields({ ...fields, day: lastDay }, {}, TemporalDate);
     const subtractedDate = calendar.minus(lastOfCalendarMonth, { ...duration, days }, options, TemporalDate);
 
     const Construct = ES.SpeciesConstructor(this, YearMonth);
@@ -130,8 +126,8 @@ export class YearMonth {
     const largestUnit = ES.ToLargestTemporalUnit(options, 'years', ['weeks', 'days', 'hours', 'minutes', 'seconds']);
     const [one, two] = [this, other].sort(YearMonth.compare);
 
-    const smallerFields = ES.ToRecord(one, [['era', undefined], ['month'], ['year']]);
-    const largerFields = ES.ToRecord(two, [['era', undefined], ['month'], ['year']]);
+    const smallerFields = ES.ToTemporalYearMonthRecord(one);
+    const largerFields = ES.ToTemporalYearMonthRecord(two);
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
     const smaller = calendar.dateFromFields({ ...smallerFields, day: 1 }, {}, TemporalDate);
     const larger = calendar.dateFromFields({ ...largerFields, day: 1 }, {}, TemporalDate);
@@ -169,14 +165,12 @@ export class YearMonth {
   withDay(day) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
-    const era = calendar.era(this);
-    const month = calendar.month(this);
-    const year = calendar.year(this);
+    const fields = ES.ToTemporalYearMonthRecord(this);
     const Date = GetIntrinsic('%Temporal.Date%');
-    return calendar.dateFromFields({ era, year, month, day }, { disambiguation: 'reject' }, Date);
+    return calendar.dateFromFields({ ...fields, day }, { disambiguation: 'reject' }, Date);
   }
   getFields() {
-    const fields = ES.ToRecord(this, [['era', undefined], ['month'], ['year']]);
+    const fields = ES.ToTemporalYearMonthRecord(this);
     if (!fields) throw new TypeError('invalid receiver');
     fields.calendar = GetSlot(this, CALENDAR);
     return fields;

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -31,6 +31,10 @@ export class YearMonth {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     return GetSlot(this, CALENDAR);
   }
+  get era() {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).era(this);
+  }
   get daysInMonth() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     return GetSlot(this, CALENDAR).daysInMonth(this);
@@ -48,11 +52,11 @@ export class YearMonth {
     if ('calendar' in temporalYearMonthLike) {
       throw new RangeError('invalid calendar property in year-month-like');
     }
-    const props = ES.ToPartialRecord(temporalYearMonthLike, ['month', 'year']);
+    const props = ES.ToPartialRecord(temporalYearMonthLike, ['era', 'month', 'year']);
     if (!props) {
       throw new RangeError('invalid year-month-like');
     }
-    const fields = ES.ToRecord(this, [['month'], ['year']]);
+    const fields = ES.ToRecord(this, [['era', undefined], ['month'], ['year']]);
     ObjectAssign(fields, props);
     const Construct = ES.SpeciesConstructor(this, YearMonth);
     const result = GetSlot(this, CALENDAR).yearMonthFromFields(fields, options, Construct);
@@ -76,9 +80,10 @@ export class YearMonth {
 
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
     const calendar = GetSlot(this, CALENDAR);
+    const era = calendar.era(this);
     const year = calendar.year(this);
     const month = calendar.month(this);
-    const firstOfCalendarMonth = calendar.dateFromFields({ year, month, day: 1 }, {}, TemporalDate);
+    const firstOfCalendarMonth = calendar.dateFromFields({ era, year, month, day: 1 }, {}, TemporalDate);
     const addedDate = calendar.plus(firstOfCalendarMonth, { ...duration, days }, options, TemporalDate);
 
     const Construct = ES.SpeciesConstructor(this, YearMonth);
@@ -103,10 +108,11 @@ export class YearMonth {
 
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
     const calendar = GetSlot(this, CALENDAR);
+    const era = calendar.era(this);
     const year = calendar.year(this);
     const month = calendar.month(this);
     const lastDay = calendar.daysInMonth(this);
-    const lastOfCalendarMonth = calendar.dateFromFields({ year, month, day: lastDay }, {}, TemporalDate);
+    const lastOfCalendarMonth = calendar.dateFromFields({ era, year, month, day: lastDay }, {}, TemporalDate);
     const subtractedDate = calendar.minus(lastOfCalendarMonth, { ...duration, days }, options, TemporalDate);
 
     const Construct = ES.SpeciesConstructor(this, YearMonth);
@@ -124,8 +130,8 @@ export class YearMonth {
     const largestUnit = ES.ToLargestTemporalUnit(options, 'years', ['weeks', 'days', 'hours', 'minutes', 'seconds']);
     const [one, two] = [this, other].sort(YearMonth.compare);
 
-    const smallerFields = ES.ToRecord(one, [['month'], ['year']]);
-    const largerFields = ES.ToRecord(two, [['month'], ['year']]);
+    const smallerFields = ES.ToRecord(one, [['era', undefined], ['month'], ['year']]);
+    const largerFields = ES.ToRecord(two, [['era', undefined], ['month'], ['year']]);
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
     const smaller = calendar.dateFromFields({ ...smallerFields, day: 1 }, {}, TemporalDate);
     const larger = calendar.dateFromFields({ ...largerFields, day: 1 }, {}, TemporalDate);
@@ -163,13 +169,14 @@ export class YearMonth {
   withDay(day) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
+    const era = calendar.era(this);
     const month = calendar.month(this);
     const year = calendar.year(this);
     const Date = GetIntrinsic('%Temporal.Date%');
-    return calendar.dateFromFields({ year, month, day }, { disambiguation: 'reject' }, Date);
+    return calendar.dateFromFields({ era, year, month, day }, { disambiguation: 'reject' }, Date);
   }
   getFields() {
-    const fields = ES.ToRecord(this, [['month'], ['year']]);
+    const fields = ES.ToRecord(this, [['era', undefined], ['month'], ['year']]);
     if (!fields) throw new TypeError('invalid receiver');
     fields.calendar = GetSlot(this, CALENDAR);
     return fields;

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -7,7 +7,8 @@ export class YearMonth {
     isoYear = ES.ToInteger(isoYear);
     isoMonth = ES.ToInteger(isoMonth);
     refISODay = ES.ToInteger(refISODay);
-    ES.RejectYearMonth(isoYear, isoMonth, refISODay);
+    ES.RejectDate(isoYear, isoMonth, refISODay);
+    ES.RejectYearMonthRange(isoYear, isoMonth);
     CreateSlots(this);
     SetSlot(this, ISO_YEAR, isoYear);
     SetSlot(this, ISO_MONTH, isoMonth);
@@ -42,6 +43,7 @@ export class YearMonth {
     }
     let { year = GetSlot(this, ISO_YEAR), month = GetSlot(this, ISO_MONTH) } = props;
     ({ year, month } = ES.RegulateYearMonth(year, month, disambiguation));
+    ({ year, month } = ES.RegulateYearMonthRange(year, month, disambiguation));
     const Construct = ES.SpeciesConstructor(this, YearMonth);
     const result = new Construct(year, month);
     if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
@@ -65,7 +67,7 @@ export class YearMonth {
     );
     ({ year, month } = ES.AddDate(year, month, 1, years, months, weeks, days, disambiguation));
     ({ year, month } = ES.BalanceYearMonth(year, month));
-    ({ year, month } = ES.RegulateYearMonth(year, month, disambiguation));
+    ({ year, month } = ES.RegulateYearMonthRange(year, month, disambiguation));
     const Construct = ES.SpeciesConstructor(this, YearMonth);
     const result = new Construct(year, month);
     if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
@@ -90,7 +92,7 @@ export class YearMonth {
     const lastDay = ES.DaysInMonth(year, month);
     ({ year, month } = ES.SubtractDate(year, month, lastDay, years, months, weeks, days, disambiguation));
     ({ year, month } = ES.BalanceYearMonth(year, month));
-    ({ year, month } = ES.RegulateYearMonth(year, month, disambiguation));
+    ({ year, month } = ES.RegulateYearMonthRange(year, month, disambiguation));
     const Construct = ES.SpeciesConstructor(this, YearMonth);
     const result = new Construct(year, month);
     if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
@@ -176,6 +178,7 @@ export class YearMonth {
       refISODay = 1;
     }
     ({ year, month } = ES.RegulateYearMonth(year, month, disambiguation));
+    ({ year, month } = ES.RegulateYearMonthRange(year, month, disambiguation));
     const result = new this(year, month, refISODay);
     if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
     return result;

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -146,6 +146,11 @@ export class YearMonth {
     let year = ES.ISOYearString(GetSlot(this, ISO_YEAR));
     let month = ES.ISODateTimePartString(GetSlot(this, ISO_MONTH));
     let resultString = `${year}-${month}`;
+    const calendar = ES.FormatCalendarAnnotation(GetSlot(this, CALENDAR));
+    if (calendar) {
+      const day = ES.ISODateTimePartString(GetSlot(this, REF_ISO_DAY));
+      resultString = `${resultString}-${day}${calendar}`;
+    }
     return resultString;
   }
   toLocaleString(...args) {
@@ -199,6 +204,7 @@ export class YearMonth {
       ({ year, month } = ES.RegulateYearMonth(year, month, disambiguation));
       ({ year, month } = ES.RegulateYearMonthRange(year, month, disambiguation));
       if (!calendar) calendar = ES.GetDefaultCalendar();
+      calendar = TemporalCalendar.from(calendar);
       if (refISODay === undefined) refISODay = 1;
       result = new this(year, month, calendar, refISODay);
     }

--- a/polyfill/test/Date/constructor/from/order-of-operations.js
+++ b/polyfill/test/Date/constructor/from/order-of-operations.js
@@ -8,7 +8,6 @@ includes: [compareArray.js]
 
 const expected = [
   "get calendar",
-  "toString calendar",
   "get day",
   "valueOf day",
   "get month",
@@ -21,11 +20,11 @@ const fields = {
   year: 1.7,
   month: 1.7,
   day: 1.7,
-  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
     actual.push(`get ${key}`);
+    if (key === "calendar") return Temporal.Calendar.from('iso8601');
     const result = target[key];
     return {
       valueOf() {

--- a/polyfill/test/Date/constructor/from/order-of-operations.js
+++ b/polyfill/test/Date/constructor/from/order-of-operations.js
@@ -7,6 +7,8 @@ includes: [compareArray.js]
 ---*/
 
 const expected = [
+  "get calendar",
+  "toString calendar",
   "get day",
   "valueOf day",
   "get month",
@@ -19,6 +21,7 @@ const fields = {
   year: 1.7,
   month: 1.7,
   day: 1.7,
+  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
@@ -28,6 +31,10 @@ const argument = new Proxy(fields, {
       valueOf() {
         actual.push(`valueOf ${key}`);
         return result;
+      },
+      toString() {
+        actual.push(`toString ${key}`);
+        return result.toString();
       }
     };
   },
@@ -40,4 +47,5 @@ const result = Temporal.Date.from(argument);
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
 assert.sameValue(result.day, 1, "day result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/Date/constructor/from/order-of-operations.js
+++ b/polyfill/test/Date/constructor/from/order-of-operations.js
@@ -10,6 +10,7 @@ const expected = [
   "get calendar",
   "get day",
   "valueOf day",
+  "get era",
   "get month",
   "valueOf month",
   "get year",
@@ -43,6 +44,7 @@ const argument = new Proxy(fields, {
   },
 });
 const result = Temporal.Date.from(argument);
+assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
 assert.sameValue(result.day, 1, "day result");

--- a/polyfill/test/Date/prototype/with/order-of-operations.js
+++ b/polyfill/test/Date/prototype/with/order-of-operations.js
@@ -11,6 +11,7 @@ const expected = [
   "get calendar",
   "get day",
   "valueOf day",
+  "get era",
   "get month",
   "valueOf month",
   "get year",
@@ -47,6 +48,7 @@ const argument = new Proxy(fields, {
   },
 });
 const result = instance.with(argument);
+assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
 assert.sameValue(result.day, 1, "day result");

--- a/polyfill/test/Date/prototype/with/order-of-operations.js
+++ b/polyfill/test/Date/prototype/with/order-of-operations.js
@@ -8,6 +8,8 @@ includes: [compareArray.js]
 
 const instance = new Temporal.Date(2000, 5, 2);
 const expected = [
+  "get calendar",
+  "toString calendar",
   "get day",
   "valueOf day",
   "get month",
@@ -20,6 +22,7 @@ const fields = {
   year: 1.7,
   month: 1.7,
   day: 1.7,
+  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
@@ -32,6 +35,10 @@ const argument = new Proxy(fields, {
       valueOf() {
         actual.push(`valueOf ${key}`);
         return result;
+      },
+      toString() {
+        actual.push(`toString ${key}`);
+        return result.toString();
       }
     };
   },
@@ -44,4 +51,5 @@ const result = instance.with(argument);
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
 assert.sameValue(result.day, 1, "day result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/Date/prototype/with/order-of-operations.js
+++ b/polyfill/test/Date/prototype/with/order-of-operations.js
@@ -9,7 +9,6 @@ includes: [compareArray.js]
 const instance = new Temporal.Date(2000, 5, 2);
 const expected = [
   "get calendar",
-  "toString calendar",
   "get day",
   "valueOf day",
   "get month",
@@ -22,11 +21,11 @@ const fields = {
   year: 1.7,
   month: 1.7,
   day: 1.7,
-  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
     actual.push(`get ${key}`);
+    if (key === "calendar") return Temporal.Calendar.from('iso8601');
     const result = target[key];
     if (result === undefined) {
       return undefined;

--- a/polyfill/test/DateTime/constructor/from/order-of-operations.js
+++ b/polyfill/test/DateTime/constructor/from/order-of-operations.js
@@ -10,6 +10,7 @@ const expected = [
   "get calendar",
   "get day",
   "valueOf day",
+  "get era",
   "get hour",
   "valueOf hour",
   "get microsecond",
@@ -61,6 +62,7 @@ const argument = new Proxy(fields, {
   },
 });
 const result = Temporal.DateTime.from(argument);
+assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
 assert.sameValue(result.day, 1, "day result");

--- a/polyfill/test/DateTime/constructor/from/order-of-operations.js
+++ b/polyfill/test/DateTime/constructor/from/order-of-operations.js
@@ -8,7 +8,6 @@ includes: [compareArray.js]
 
 const expected = [
   "get calendar",
-  "toString calendar",
   "get day",
   "valueOf day",
   "get hour",
@@ -39,11 +38,11 @@ const fields = {
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
-  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
     actual.push(`get ${key}`);
+    if (key === "calendar") return Temporal.Calendar.from('iso8601');
     const result = target[key];
     return {
       valueOf() {

--- a/polyfill/test/DateTime/constructor/from/order-of-operations.js
+++ b/polyfill/test/DateTime/constructor/from/order-of-operations.js
@@ -7,6 +7,8 @@ includes: [compareArray.js]
 ---*/
 
 const expected = [
+  "get calendar",
+  "toString calendar",
   "get day",
   "valueOf day",
   "get hour",
@@ -37,6 +39,7 @@ const fields = {
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
+  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
@@ -46,6 +49,10 @@ const argument = new Proxy(fields, {
       valueOf() {
         actual.push(`valueOf ${key}`);
         return result;
+      },
+      toString() {
+        actual.push(`toString ${key}`);
+        return result.toString();
       }
     };
   },
@@ -64,4 +71,5 @@ assert.sameValue(result.second, 1, "second result");
 assert.sameValue(result.millisecond, 1, "millisecond result");
 assert.sameValue(result.microsecond, 1, "microsecond result");
 assert.sameValue(result.nanosecond, 1, "nanosecond result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/DateTime/prototype/with/order-of-operations.js
+++ b/polyfill/test/DateTime/prototype/with/order-of-operations.js
@@ -9,7 +9,6 @@ includes: [compareArray.js]
 const instance = new Temporal.DateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 const expected = [
   "get calendar",
-  "toString calendar",
   "get day",
   "valueOf day",
   "get hour",
@@ -40,11 +39,11 @@ const fields = {
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
-  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
     actual.push(`get ${key}`);
+    if (key === "calendar") return Temporal.Calendar.from('iso8601');
     const result = target[key];
     if (result === undefined) {
       return undefined;

--- a/polyfill/test/DateTime/prototype/with/order-of-operations.js
+++ b/polyfill/test/DateTime/prototype/with/order-of-operations.js
@@ -8,6 +8,8 @@ includes: [compareArray.js]
 
 const instance = new Temporal.DateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 const expected = [
+  "get calendar",
+  "toString calendar",
   "get day",
   "valueOf day",
   "get hour",
@@ -38,6 +40,7 @@ const fields = {
   millisecond: 1.7,
   microsecond: 1.7,
   nanosecond: 1.7,
+  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
@@ -50,6 +53,10 @@ const argument = new Proxy(fields, {
       valueOf() {
         actual.push(`valueOf ${key}`);
         return result;
+      },
+      toString() {
+        actual.push(`toString ${key}`);
+        return result.toString();
       }
     };
   },
@@ -68,4 +75,5 @@ assert.sameValue(result.second, 1, "second result");
 assert.sameValue(result.millisecond, 1, "millisecond result");
 assert.sameValue(result.microsecond, 1, "microsecond result");
 assert.sameValue(result.nanosecond, 1, "nanosecond result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/DateTime/prototype/with/order-of-operations.js
+++ b/polyfill/test/DateTime/prototype/with/order-of-operations.js
@@ -11,6 +11,7 @@ const expected = [
   "get calendar",
   "get day",
   "valueOf day",
+  "get era",
   "get hour",
   "valueOf hour",
   "get microsecond",
@@ -65,6 +66,7 @@ const argument = new Proxy(fields, {
   },
 });
 const result = instance.with(argument);
+assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
 assert.sameValue(result.day, 1, "day result");

--- a/polyfill/test/MonthDay/constructor/from/order-of-operations.js
+++ b/polyfill/test/MonthDay/constructor/from/order-of-operations.js
@@ -7,6 +7,8 @@ includes: [compareArray.js]
 ---*/
 
 const expected = [
+  "get calendar",
+  "toString calendar",
   "get day",
   "valueOf day",
   "get month",
@@ -16,6 +18,7 @@ const actual = [];
 const fields = {
   month: 1.7,
   day: 1.7,
+  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
@@ -25,6 +28,10 @@ const argument = new Proxy(fields, {
       valueOf() {
         actual.push(`valueOf ${key}`);
         return result;
+      },
+      toString() {
+        actual.push(`toString ${key}`);
+        return result.toString();
       }
     };
   },
@@ -36,4 +43,5 @@ const argument = new Proxy(fields, {
 const result = Temporal.MonthDay.from(argument);
 assert.sameValue(result.month, 1, "month result");
 assert.sameValue(result.day, 1, "day result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/MonthDay/constructor/from/order-of-operations.js
+++ b/polyfill/test/MonthDay/constructor/from/order-of-operations.js
@@ -8,7 +8,6 @@ includes: [compareArray.js]
 
 const expected = [
   "get calendar",
-  "toString calendar",
   "get day",
   "valueOf day",
   "get month",
@@ -18,11 +17,11 @@ const actual = [];
 const fields = {
   month: 1.7,
   day: 1.7,
-  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
     actual.push(`get ${key}`);
+    if (key === "calendar") return Temporal.Calendar.from('iso8601');
     const result = target[key];
     return {
       valueOf() {

--- a/polyfill/test/MonthDay/constructor/infinity-throws-rangeerror.js
+++ b/polyfill/test/MonthDay/constructor/infinity-throws-rangeerror.js
@@ -2,13 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Temporal.MonthDay throws a RangeError if any value is Infinity
+description: Temporal.MonthDay throws a RangeError if any numerical value is Infinity
 esid: sec-temporal.monthday
 ---*/
 
+const isoCalendar = Temporal.Calendar.from('iso8601');
+
 assert.throws(RangeError, () => new Temporal.MonthDay(Infinity, 1));
 assert.throws(RangeError, () => new Temporal.MonthDay(1, Infinity));
-assert.throws(RangeError, () => new Temporal.MonthDay(1, 1, Infinity));
+assert.throws(RangeError, () => new Temporal.MonthDay(1, 1, isoCalendar, Infinity));
 
 let calls = 0;
 const obj = {
@@ -22,5 +24,5 @@ assert.throws(RangeError, () => new Temporal.MonthDay(obj, 1));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 assert.throws(RangeError, () => new Temporal.MonthDay(1, obj));
 assert.sameValue(calls, 2, "it fails after fetching the primitive value");
-assert.throws(RangeError, () => new Temporal.MonthDay(1, 1, obj));
+assert.throws(RangeError, () => new Temporal.MonthDay(1, 1, isoCalendar, obj));
 assert.sameValue(calls, 3, "it fails after fetching the primitive value");

--- a/polyfill/test/MonthDay/constructor/negative-infinity-throws-rangeerror.js
+++ b/polyfill/test/MonthDay/constructor/negative-infinity-throws-rangeerror.js
@@ -2,13 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Temporal.MonthDay throws a RangeError if any value is -Infinity
+description: Temporal.MonthDay throws a RangeError if any numerical value is -Infinity
 esid: sec-temporal.monthday
 ---*/
 
+const isoCalendar = Temporal.Calendar.from('iso8601');
+
 assert.throws(RangeError, () => new Temporal.MonthDay(-Infinity, 1));
 assert.throws(RangeError, () => new Temporal.MonthDay(1, -Infinity));
-assert.throws(RangeError, () => new Temporal.MonthDay(1, 1, -Infinity));
+assert.throws(RangeError, () => new Temporal.MonthDay(1, 1, isoCalendar, -Infinity));
 
 let calls = 0;
 const obj = {
@@ -22,5 +24,5 @@ assert.throws(RangeError, () => new Temporal.MonthDay(obj, 1));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 assert.throws(RangeError, () => new Temporal.MonthDay(1, obj));
 assert.sameValue(calls, 2, "it fails after fetching the primitive value");
-assert.throws(RangeError, () => new Temporal.MonthDay(1, 1, obj));
+assert.throws(RangeError, () => new Temporal.MonthDay(1, 1, isoCalendar, obj));
 assert.sameValue(calls, 3, "it fails after fetching the primitive value");

--- a/polyfill/test/MonthDay/prototype/with/order-of-operations.js
+++ b/polyfill/test/MonthDay/prototype/with/order-of-operations.js
@@ -8,6 +8,7 @@ includes: [compareArray.js]
 
 const instance = new Temporal.MonthDay(5, 2);
 const expected = [
+  "has calendar",
   "get day",
   "valueOf day",
   "get month",

--- a/polyfill/test/YearMonth/constructor/from/order-of-operations.js
+++ b/polyfill/test/YearMonth/constructor/from/order-of-operations.js
@@ -8,7 +8,6 @@ includes: [compareArray.js]
 
 const expected = [
   "get calendar",
-  "toString calendar",
   "get month",
   "valueOf month",
   "get year",
@@ -18,11 +17,11 @@ const actual = [];
 const fields = {
   year: 1.7,
   month: 1.7,
-  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
     actual.push(`get ${key}`);
+    if (key === "calendar") return Temporal.Calendar.from('iso8601');
     const result = target[key];
     return {
       valueOf() {

--- a/polyfill/test/YearMonth/constructor/from/order-of-operations.js
+++ b/polyfill/test/YearMonth/constructor/from/order-of-operations.js
@@ -8,6 +8,7 @@ includes: [compareArray.js]
 
 const expected = [
   "get calendar",
+  "get era",
   "get month",
   "valueOf month",
   "get year",
@@ -40,6 +41,7 @@ const argument = new Proxy(fields, {
   },
 });
 const result = Temporal.YearMonth.from(argument);
+assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");

--- a/polyfill/test/YearMonth/constructor/from/order-of-operations.js
+++ b/polyfill/test/YearMonth/constructor/from/order-of-operations.js
@@ -7,6 +7,8 @@ includes: [compareArray.js]
 ---*/
 
 const expected = [
+  "get calendar",
+  "toString calendar",
   "get month",
   "valueOf month",
   "get year",
@@ -16,6 +18,7 @@ const actual = [];
 const fields = {
   year: 1.7,
   month: 1.7,
+  calendar: "iso8601",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
@@ -25,6 +28,10 @@ const argument = new Proxy(fields, {
       valueOf() {
         actual.push(`valueOf ${key}`);
         return result;
+      },
+      toString() {
+        actual.push(`toString ${key}`);
+        return result.toString();
       }
     };
   },
@@ -36,4 +43,5 @@ const argument = new Proxy(fields, {
 const result = Temporal.YearMonth.from(argument);
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/YearMonth/constructor/infinity-throws-rangeerror.js
+++ b/polyfill/test/YearMonth/constructor/infinity-throws-rangeerror.js
@@ -2,13 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Temporal.YearMonth throws a RangeError if any value is Infinity
+description: Temporal.YearMonth throws a RangeError if any numerical value is Infinity
 esid: sec-temporal.yearmonth
 ---*/
 
+const isoCalendar = Temporal.Calendar.from('iso8601');
+
 assert.throws(RangeError, () => new Temporal.YearMonth(Infinity, 1));
 assert.throws(RangeError, () => new Temporal.YearMonth(1970, Infinity));
-assert.throws(RangeError, () => new Temporal.YearMonth(1970, 1, Infinity));
+assert.throws(RangeError, () => new Temporal.YearMonth(1970, 1, isoCalendar, Infinity));
 
 let calls = 0;
 const obj = {
@@ -22,5 +24,5 @@ assert.throws(RangeError, () => new Temporal.YearMonth(obj, 1));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 assert.throws(RangeError, () => new Temporal.YearMonth(1970, obj));
 assert.sameValue(calls, 2, "it fails after fetching the primitive value");
-assert.throws(RangeError, () => new Temporal.YearMonth(1970, 1, obj));
+assert.throws(RangeError, () => new Temporal.YearMonth(1970, 1, isoCalendar, obj));
 assert.sameValue(calls, 3, "it fails after fetching the primitive value");

--- a/polyfill/test/YearMonth/constructor/negative-infinity-throws-rangeerror.js
+++ b/polyfill/test/YearMonth/constructor/negative-infinity-throws-rangeerror.js
@@ -2,13 +2,15 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Temporal.YearMonth throws a RangeError if any value is -Infinity
+description: Temporal.YearMonth throws a RangeError if any numerical value is -Infinity
 esid: sec-temporal.yearmonth
 ---*/
 
+const isoCalendar = Temporal.Calendar.from('iso8601');
+
 assert.throws(RangeError, () => new Temporal.YearMonth(-Infinity, 1));
 assert.throws(RangeError, () => new Temporal.YearMonth(1970, -Infinity));
-assert.throws(RangeError, () => new Temporal.YearMonth(1970, 1, -Infinity));
+assert.throws(RangeError, () => new Temporal.YearMonth(1970, 1, isoCalendar, -Infinity));
 
 let calls = 0;
 const obj = {
@@ -22,5 +24,5 @@ assert.throws(RangeError, () => new Temporal.YearMonth(obj, 1));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 assert.throws(RangeError, () => new Temporal.YearMonth(1970, obj));
 assert.sameValue(calls, 2, "it fails after fetching the primitive value");
-assert.throws(RangeError, () => new Temporal.YearMonth(1970, 1, obj));
+assert.throws(RangeError, () => new Temporal.YearMonth(1970, 1, isoCalendar, obj));
 assert.sameValue(calls, 3, "it fails after fetching the primitive value");

--- a/polyfill/test/YearMonth/prototype/with/order-of-operations.js
+++ b/polyfill/test/YearMonth/prototype/with/order-of-operations.js
@@ -9,6 +9,7 @@ includes: [compareArray.js]
 const instance = new Temporal.YearMonth(2000, 5);
 const expected = [
   "has calendar",
+  "get era",
   "get month",
   "valueOf month",
   "get year",
@@ -39,6 +40,7 @@ const argument = new Proxy(fields, {
   },
 });
 const result = instance.with(argument);
+assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/YearMonth/prototype/with/order-of-operations.js
+++ b/polyfill/test/YearMonth/prototype/with/order-of-operations.js
@@ -8,6 +8,7 @@ includes: [compareArray.js]
 
 const instance = new Temporal.YearMonth(2000, 5);
 const expected = [
+  "has calendar",
   "get month",
   "valueOf month",
   "get year",

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -342,6 +342,8 @@ describe('Absolute', () => {
       equal(`${Absolute.from('1976-11-18T15:23:30+00')}`, '1976-11-18T15:23:30Z');
       equal(`${Absolute.from('1976-11-18T15Z')}`, '1976-11-18T15:00Z');
     });
+    it('ignores any specified calendar', () =>
+      equal(`${Absolute.from('1976-11-18T15:23:30.123456789Z[c=discordian]')}`, '1976-11-18T15:23:30.123456789Z'));
   });
   describe('Absolute.plus works', () => {
     const abs = Absolute.from('1969-12-25T12:23:45.678901234Z');

--- a/polyfill/test/all.mjs
+++ b/polyfill/test/all.mjs
@@ -30,6 +30,7 @@ import './intl.mjs';
 
 // tests of userland objects
 import './usertimezone.mjs';
+import './usercalendar.mjs';
 
 Promise.resolve()
   .then(() => {

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -91,14 +91,16 @@ describe('Date', () => {
   });
   describe('Construction', () => {
     let date;
+    const calendar = Temporal.Calendar.from('iso8601');
     it('date can be constructed', () => {
-      date = new Date(1976, 11, 18);
+      date = new Date(1976, 11, 18, calendar);
       assert(date);
       equal(typeof date, 'object');
     });
     it('date.year is 1976', () => equal(date.year, 1976));
     it('date.month is 11', () => equal(date.month, 11));
     it('date.day is 18', () => equal(date.day, 18));
+    it('date.calendar is the object', () => equal(date.calendar, calendar));
     it('date.dayOfWeek is 4', () => equal(date.dayOfWeek, 4));
     it('date.dayOfYear is 323', () => equal(date.dayOfYear, 323));
     it('date.weekOfYear is 47', () => equal(date.weekOfYear, 47));
@@ -525,18 +527,21 @@ describe('Date', () => {
     });
   });
   describe('date.getFields() works', () => {
-    const d1 = Date.from('1976-11-18');
+    const calendar = Temporal.Calendar.from('iso8601');
+    const d1 = Date.from({ year: 1976, month: 11, day: 18, calendar });
     const fields = d1.getFields();
     it('fields', () => {
       equal(fields.year, 1976);
       equal(fields.month, 11);
       equal(fields.day, 18);
+      equal(fields.calendar, calendar);
     });
     it('enumerable', () => {
       const fields2 = { ...fields };
       equal(fields2.year, 1976);
       equal(fields2.month, 11);
       equal(fields2.day, 18);
+      equal(fields2.calendar, calendar);
     });
     it('as input to from()', () => {
       const d2 = Date.from(fields);

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -575,6 +575,16 @@ describe('Date', () => {
       equal(Date.compare(d1, d2), 0);
     });
   });
+  describe('date.withCalendar()', () => {
+    const d1 = Date.from('1976-11-18');
+    it('works', () => {
+      const calendar = Temporal.Calendar.from('iso8601');
+      equal(`${d1.withCalendar(calendar)}`, '1976-11-18');
+    });
+    it('casts its argument', () => {
+      equal(`${d1.withCalendar('iso8601')}`, '1976-11-18');
+    });
+  });
 });
 
 import { normalize } from 'path';

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -680,6 +680,16 @@ describe('DateTime', () => {
       equal(DateTime.compare(dt1, dt2), 0);
     });
   });
+  describe('dateTime.withCalendar()', () => {
+    const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
+    it('works', () => {
+      const calendar = Temporal.Calendar.from('iso8601');
+      equal(`${dt1.withCalendar(calendar)}`, '1976-11-18T15:23:30.123456789');
+    });
+    it('casts its argument', () => {
+      equal(`${dt1.withCalendar('iso8601')}`, '1976-11-18T15:23:30.123456789');
+    });
+  });
 });
 
 import { normalize } from 'path';

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -108,10 +108,11 @@ describe('DateTime', () => {
     });
   });
   describe('Construction', () => {
-    describe('new DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789)', () => {
+    describe('new DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789, calendar)', () => {
       let datetime;
+      const calendar = Temporal.Calendar.from('iso8601');
       it('datetime can be constructed', () => {
-        datetime = new DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
+        datetime = new DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789, calendar);
         assert(datetime);
         equal(typeof datetime, 'object');
       });
@@ -124,6 +125,7 @@ describe('DateTime', () => {
       it('datetime.millisecond is 123', () => equal(datetime.millisecond, 123));
       it('datetime.microsecond is 456', () => equal(datetime.microsecond, 456));
       it('datetime.nanosecond is 789', () => equal(datetime.nanosecond, 789));
+      it('datetime.calendar is the object', () => equal(datetime.calendar, calendar));
       it('datetime.dayOfWeek is 4', () => equal(datetime.dayOfWeek, 4));
       it('datetime.dayOfYear is 323', () => equal(datetime.dayOfYear, 323));
       it('datetime.weekOfYear is 47', () => equal(datetime.weekOfYear, 47));
@@ -595,7 +597,19 @@ describe('DateTime', () => {
     });
   });
   describe('dateTime.getFields() works', () => {
-    const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
+    const calendar = Temporal.Calendar.from('iso8601');
+    const dt1 = DateTime.from({
+      year: 1976,
+      month: 11,
+      day: 18,
+      hour: 15,
+      minute: 23,
+      second: 30,
+      millisecond: 123,
+      microsecond: 456,
+      nanosecond: 789,
+      calendar
+    });
     const fields = dt1.getFields();
     it('fields', () => {
       equal(fields.year, 1976);
@@ -607,6 +621,7 @@ describe('DateTime', () => {
       equal(fields.millisecond, 123);
       equal(fields.microsecond, 456);
       equal(fields.nanosecond, 789);
+      equal(fields.calendar, calendar);
     });
     it('enumerable', () => {
       const fields2 = { ...fields };
@@ -619,6 +634,7 @@ describe('DateTime', () => {
       equal(fields2.millisecond, 123);
       equal(fields2.microsecond, 456);
       equal(fields2.nanosecond, 789);
+      equal(fields2.calendar, calendar);
     });
     it('as input to from()', () => {
       const dt2 = DateTime.from(fields);

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -308,9 +308,16 @@ describe('DateTime', () => {
     });
   });
   describe('date/time maths: hours overflow', () => {
-    const later = DateTime.from('2019-10-29T10:46:38.271986102');
-    const earlier = later.minus({ hours: 12 });
-    it('result', () => equal(`${earlier}`, '2019-10-28T22:46:38.271986102'));
+    it('minus result', () => {
+      const later = DateTime.from('2019-10-29T10:46:38.271986102');
+      const earlier = later.minus({ hours: 12 });
+      equal(`${earlier}`, '2019-10-28T22:46:38.271986102');
+    });
+    it('plus result', () => {
+      const earlier = DateTime.from('2020-05-31T23:12:38.271986102');
+      const later = earlier.plus({ hours: 2 });
+      equal(`${later}`, '2020-06-01T01:12:38.271986102');
+    });
   });
   describe('DateTime.plus() works', () => {
     it('constrain when ambiguous result', () => {

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -123,6 +123,9 @@ describe('MonthDay', () => {
         throws(() => MonthDay.from('01-15').with({ day: 1 }, { disambiguation }), RangeError)
       );
     });
+    it('throws on trying to change the calendar', () => {
+      throws(() => MonthDay.from('01-15').with({ calendar: 'gregory' }), RangeError);
+    });
   });
   describe('MonthDay.equals()', () => {
     const md1 = MonthDay.from('01-22');
@@ -134,8 +137,9 @@ describe('MonthDay', () => {
       throws(() => md1.equals({ month: 1, day: 22 }), TypeError);
     });
     it('takes [[RefISOYear]] into account', () => {
-      const md1 = new MonthDay(1, 1, 1972);
-      const md2 = new MonthDay(1, 1, 2000);
+      const iso = Temporal.Calendar.from('iso8601');
+      const md1 = new MonthDay(1, 1, iso, 1972);
+      const md2 = new MonthDay(1, 1, iso, 2000);
       assert(!md1.equals(md2));
     });
   });
@@ -167,23 +171,22 @@ describe('MonthDay', () => {
     });
   });
   describe('monthDay.getFields() works', () => {
-    const md1 = MonthDay.from('11-18');
+    const calendar = Temporal.Calendar.from('iso8601');
+    const md1 = MonthDay.from({ month: 11, day: 18, calendar });
     const fields = md1.getFields();
     it('fields', () => {
       equal(fields.month, 11);
       equal(fields.day, 18);
+      equal(fields.calendar, calendar);
     });
     it('enumerable', () => {
       const fields2 = { ...fields };
       equal(fields2.month, 11);
       equal(fields2.day, 18);
+      equal(fields2.calendar, calendar);
     });
     it('as input to from()', () => {
       const md2 = MonthDay.from(fields);
-      assert(md1.equals(md2));
-    });
-    it('as input to with()', () => {
-      const md2 = MonthDay.from('06-30').with(fields);
       assert(md1.equals(md2));
     });
   });

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -70,7 +70,7 @@ describe('fromString regex', () => {
   describe('datetime', () => {
     function test(isoString, components) {
       it(isoString, () => {
-        const [y, mon, d, h = 0, min = 0, s = 0, ms = 0, µs = 0, ns = 0] = components;
+        const [y, mon, d, h = 0, min = 0, s = 0, ms = 0, µs = 0, ns = 0, cid = 'iso8601'] = components;
         const datetime = Temporal.DateTime.from(isoString);
         equal(datetime.year, y);
         equal(datetime.month, mon);
@@ -81,6 +81,7 @@ describe('fromString regex', () => {
         equal(datetime.millisecond, ms);
         equal(datetime.microsecond, µs);
         equal(datetime.nanosecond, ns);
+        equal(datetime.calendar.id, cid);
       });
     }
     function generateTest(dateTimeString, zoneString) {
@@ -115,16 +116,21 @@ describe('fromString regex', () => {
     // Representations with reduced precision
     test('1976-11-18T15', [1976, 11, 18, 15]);
     test('1976-11-18', [1976, 11, 18]);
+    // Representations with calendar
+    ['', 'Z', '+01:00[Europe/Vienna]'].forEach((zoneString) =>
+      test(`1976-11-18T15:23:30.123456789${zoneString}[c=iso8601]`, [1976, 11, 18, 15, 23, 30, 123, 456, 789])
+    );
   });
 
   describe('date', () => {
     function test(isoString, components) {
       it(isoString, () => {
-        const [y, m, d] = components;
+        const [y, m, d, cid = 'iso8601'] = components;
         const date = Temporal.Date.from(isoString);
         equal(date.year, y);
         equal(date.month, m);
         equal(date.day, d);
+        equal(date.calendar.id, cid);
       });
     }
     function generateTest(dateTimeString, zoneString) {
@@ -152,7 +158,7 @@ describe('fromString regex', () => {
       '19761118T152330.1234'
     ].forEach((str) => test(str, [1976, 11, 18]));
     // Representations with reduced precision
-    test('1976-11-18T15', [1976, 11, 18, 15]);
+    test('1976-11-18T15', [1976, 11, 18]);
     // Date-only forms
     test('1976-11-18', [1976, 11, 18]);
     test('19761118', [1976, 11, 18]);
@@ -162,6 +168,11 @@ describe('fromString regex', () => {
     test('-0003001118', [-300, 11, 18]);
     test('1512-11-18', [1512, 11, 18]);
     test('15121118', [1512, 11, 18]);
+    // Representations with calendar
+    ['', 'Z', '+01:00[Europe/Vienna]'].forEach((zoneString) =>
+      test(`1976-11-18T15:23:30.123456789${zoneString}[c=iso8601]`, [1976, 11, 18])
+    );
+    test('1976-11-18[c=iso8601]', [1976, 11, 18]);
   });
 
   describe('time', () => {
@@ -210,15 +221,21 @@ describe('fromString regex', () => {
     // Time-only forms
     generateTest('15:23', '');
     ['+01:00[Europe/Vienna]', '-04:00', 'Z', ''].forEach((zoneStr) => test(`15${zoneStr}`, [15]));
+    // Representations with calendar
+    ['', 'Z', '+01:00[Europe/Vienna]'].forEach((zoneString) =>
+      test(`1976-11-18T15:23:30.123456789${zoneString}[c=iso8601]`, [15, 23, 30, 123, 456, 789])
+    );
+    test('15:23:30.123456789[c=iso8601]', [15, 23, 30, 123, 456, 789]);
   });
 
   describe('yearmonth', () => {
     function test(isoString, components) {
       it(isoString, () => {
-        const [y, m] = components;
+        const [y, m, cid = 'iso8601'] = components;
         const yearMonth = Temporal.YearMonth.from(isoString);
         equal(yearMonth.year, y);
         equal(yearMonth.month, m);
+        equal(yearMonth.calendar.id, cid);
       });
     }
     function generateTest(dateTimeString, zoneString) {
@@ -265,15 +282,21 @@ describe('fromString regex', () => {
     test('-00030011', [-300, 11]);
     test('1512-11', [1512, 11]);
     test('151211', [1512, 11]);
+    // Representations with calendar
+    ['', 'Z', '+01:00[Europe/Vienna]'].forEach((zoneString) =>
+      test(`1976-11-18T15:23:30.123456789${zoneString}[c=iso8601]`, [1976, 11])
+    );
+    test('1976-11-01[c=iso8601]', [1976, 11]);
   });
 
   describe('monthday', () => {
     function test(isoString, components) {
       it(isoString, () => {
-        const [m, d] = components;
+        const [m, d, cid = 'iso8601'] = components;
         const monthDay = Temporal.MonthDay.from(isoString);
         equal(monthDay.month, m);
         equal(monthDay.day, d);
+        equal(monthDay.calendar.id, cid);
       });
     }
     function generateTest(dateTimeString, zoneString) {
@@ -323,6 +346,11 @@ describe('fromString regex', () => {
     // RFC 3339 month-day form
     test('--11-18', [11, 18]);
     test('--1118', [11, 18]);
+    // Representations with calendar
+    ['', 'Z', '+01:00[Europe/Vienna]'].forEach((zoneString) =>
+      test(`1976-11-18T15:23:30.123456789${zoneString}[c=iso8601]`, [11, 18])
+    );
+    test('1972-11-18[c=iso8601]', [11, 18]);
   });
 
   describe('timezone', () => {
@@ -382,6 +410,10 @@ describe('fromString regex', () => {
     test('-03:00', '-03:00');
     test('+03', '+03:00');
     test('-03', '-03:00');
+    // Representations with calendar
+    test('1976-11-18T15:23:30.123456789Z[c=iso8601]', 'UTC');
+    test('1976-11-18T15:23:30.123456789-04:00[c=iso8601]', '-04:00');
+    test('1976-11-18T15:23:30.123456789+01:00[Europe/Vienna][c=iso8601]', 'Europe/Vienna');
   });
 
   describe('duration', () => {

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -275,6 +275,9 @@ describe('Userland calendar', () => {
       day(date) {
         const { days } = isoToDecimal(date);
         return (days % 10) + 1;
+      },
+      era() {
+        return undefined;
       }
     };
 

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -1,0 +1,230 @@
+#! /usr/bin/env -S node --experimental-modules
+
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+import Demitasse from '@pipobscure/demitasse';
+const { after, before, describe, it, report } = Demitasse;
+
+import Pretty from '@pipobscure/demitasse-pretty';
+const { reporter } = Pretty;
+
+import { strict as assert } from 'assert';
+const { equal, throws } = assert;
+
+import * as Temporal from 'tc39-temporal';
+
+describe('Userland calendar', () => {
+  describe('Trivial subclass', () => {
+    // For the purposes of testing, a nonsensical calendar that uses 0-based
+    // month numbers, like legacy Date
+    const ISO8601Calendar = Temporal.Calendar.from('iso8601').constructor;
+    class ZeroBasedCalendar extends ISO8601Calendar {
+      constructor() {
+        super('zerobased');
+      }
+      dateFromFields(fields, options, constructor) {
+        fields.month++;
+        return super.dateFromFields(fields, options, constructor);
+      }
+      yearMonthFromFields(fields, options, constructor) {
+        fields.month++;
+        return super.yearMonthFromFields(fields, options, constructor);
+      }
+      monthDayFromFields(fields, options, constructor) {
+        fields.month++;
+        return super.monthDayFromFields(fields, options, constructor);
+      }
+      month(date) {
+        return date.getISOCalendarFields().month - 1;
+      }
+    }
+
+    const obj = new ZeroBasedCalendar();
+    const date = Temporal.Date.from({ year: 2020, month: 5, day: 5, calendar: obj });
+    const dt = Temporal.DateTime.from({ year: 2020, month: 5, day: 5, hour: 12, calendar: obj });
+    const ym = Temporal.YearMonth.from({ year: 2020, month: 5, calendar: obj });
+    const md = Temporal.MonthDay.from({ month: 5, day: 5, calendar: obj });
+
+    it('is a calendar', () => equal(typeof obj, 'object'));
+    it('.id property', () => equal(obj.id, 'zerobased'));
+    // FIXME: what should happen in Temporal.Calendar.from(obj)?
+    it('.id is not available in from()', () => {
+      throws(() => Temporal.Calendar.from('zerobased'), RangeError);
+      throws(() => Temporal.Calendar.from('2020-06-05T09:34-07:00[America/Vancouver][c=zerobased]'), RangeError);
+    });
+    it('Temporal.Date.from()', () => equal(`${date}`, '2020-06-05[c=zerobased]'));
+    it('Temporal.Date fields', () => {
+      equal(date.year, 2020);
+      equal(date.month, 5);
+      equal(date.day, 5);
+    });
+    it('date.with()', () => {
+      const date2 = date.with({ month: 0 });
+      equal(date2.month, 0);
+    });
+    it('date.withCalendar()', () => {
+      const date2 = Temporal.Date.from('2020-06-05');
+      assert(date2.withCalendar(obj).equals(date));
+    });
+    it('Temporal.DateTime.from()', () => equal(`${dt}`, '2020-06-05T12:00[c=zerobased]'));
+    it('Temporal.DateTime fields', () => {
+      equal(dt.year, 2020);
+      equal(dt.month, 5);
+      equal(dt.day, 5);
+      equal(dt.hour, 12);
+      equal(dt.minute, 0);
+      equal(dt.second, 0);
+      equal(dt.millisecond, 0);
+      equal(dt.microsecond, 0);
+      equal(dt.nanosecond, 0);
+    });
+    it('datetime.with()', () => {
+      const dt2 = dt.with({ month: 0 });
+      equal(dt2.month, 0);
+    });
+    it('datetime.withCalendar()', () => {
+      const dt2 = Temporal.DateTime.from('2020-06-05T12:00');
+      assert(dt2.withCalendar(obj).equals(dt));
+    });
+    it('Temporal.YearMonth.from()', () => equal(`${ym}`, '2020-06-01[c=zerobased]'));
+    it('Temporal.YearMonth fields', () => {
+      equal(dt.year, 2020);
+      equal(dt.month, 5);
+    });
+    it('yearmonth.with()', () => {
+      const ym2 = ym.with({ month: 0 });
+      equal(ym2.month, 0);
+    });
+    it('Temporal.MonthDay.from()', () => equal(`${md}`, '1972-06-05[c=zerobased]'));
+    it('Temporal.MonthDay fields', () => {
+      equal(dt.month, 5);
+      equal(dt.day, 5);
+    });
+    it('monthday.with()', () => {
+      const md2 = md.with({ month: 0 });
+      equal(md2.month, 0);
+    });
+    it('timezone.getDateTimeFor()', () => {
+      const tz = Temporal.TimeZone.from('UTC');
+      const abs = Temporal.Absolute.fromEpochSeconds(0);
+      const dt = tz.getDateTimeFor(abs, obj);
+      equal(dt.calendar.id, obj.id);
+    });
+    it('absolute.inTimeZone()', () => {
+      const abs = Temporal.Absolute.fromEpochSeconds(0);
+      const dt = abs.inTimeZone('UTC', obj);
+      equal(dt.calendar.id, obj.id);
+    });
+    it('Temporal.now.dateTime()', () => {
+      const nowDateTime = Temporal.now.dateTime('UTC', obj);
+      equal(nowDateTime.calendar.id, obj.id);
+    });
+    it('Temporal.now.date()', () => {
+      const nowDate = Temporal.now.date('UTC', obj);
+      equal(nowDate.calendar.id, obj.id);
+    });
+    describe('Making available globally', () => {
+      const originalTemporalCalendarFrom = Temporal.Calendar.from;
+      before(() => {
+        Temporal.Calendar.from = function(item) {
+          let id;
+          if (item instanceof Temporal.Calendar) {
+            id = item.id;
+          } else {
+            id = `${item}`;
+            // TODO: Use Temporal.parse here to extract the ID from an ISO string
+          }
+          if (id === 'zerobased') return new ZeroBasedCalendar();
+          return originalTemporalCalendarFrom.call(this, id);
+        };
+      });
+      it('works for Calendar.from(id)', () => {
+        const tz = Temporal.Calendar.from('zerobased');
+        assert(tz instanceof ZeroBasedCalendar);
+      });
+      const iso = '1970-01-01T00:00+00:00[c=zerobased]';
+      it.skip('works for Calendar.from(ISO string)', () => {
+        const tz = Temporal.Calendar.from(iso);
+        assert(tz instanceof ZeroBasedCalendar);
+      });
+      it('works for Date.from(iso)', () => {
+        const d = Temporal.Date.from(iso);
+        equal(`${d}`, '1970-01-01[c=zerobased]');
+      });
+      it('works for Date.from(props)', () => {
+        const d = Temporal.Date.from({ year: 1970, month: 0, day: 1, calendar: 'zerobased' });
+        equal(`${d}`, '1970-01-01[c=zerobased]');
+      });
+      it('works for Date.with', () => {
+        const d1 = Temporal.Date.from('1970-02-01');
+        const d2 = d1.with({ month: 0, calendar: 'zerobased' });
+        equal(`${d2}`, '1970-01-01[c=zerobased]');
+      });
+      it('works for Date.withCalendar', () => {
+        const d = Temporal.Date.from('1970-01-01');
+        assert(d.withCalendar('zerobased').equals(Temporal.Date.from(iso)));
+      });
+      it('works for DateTime.from(iso)', () => {
+        const dt = Temporal.DateTime.from(iso);
+        equal(`${dt}`, '1970-01-01T00:00[c=zerobased]');
+      });
+      it('works for DateTime.from(props)', () => {
+        const dt = Temporal.DateTime.from({ year: 1970, month: 0, day: 1, hour: 12, calendar: 'zerobased' });
+        equal(`${dt}`, '1970-01-01T12:00[c=zerobased]');
+      });
+      it('works for DateTime.with', () => {
+        const dt1 = Temporal.DateTime.from('1970-02-01T12:00');
+        const dt2 = dt1.with({ month: 0, calendar: 'zerobased' });
+        equal(`${dt2}`, '1970-01-01T12:00[c=zerobased]');
+      });
+      it('works for DateTime.withCalendar', () => {
+        const dt = Temporal.DateTime.from('1970-01-01T00:00');
+        assert(dt.withCalendar('zerobased').equals(Temporal.DateTime.from(iso)));
+      });
+      it('works for YearMonth.from(iso)', () => {
+        const ym = Temporal.YearMonth.from(iso);
+        equal(`${ym}`, '1970-01-01[c=zerobased]');
+      });
+      it('works for YearMonth.from(props)', () => {
+        const ym = Temporal.YearMonth.from({ year: 1970, month: 0, calendar: 'zerobased' });
+        equal(`${ym}`, '1970-01-01[c=zerobased]');
+      });
+      it('works for MonthDay.from(iso)', () => {
+        const md = Temporal.MonthDay.from(iso);
+        equal(`${md}`, '1970-01-01[c=zerobased]');
+      });
+      it('works for MonthDay.from(props)', () => {
+        const md = Temporal.MonthDay.from({ month: 0, day: 1, calendar: 'zerobased' });
+        equal(`${md}`, '1972-01-01[c=zerobased]');
+      });
+      it('works for TimeZone.getDateTimeFor', () => {
+        const tz = Temporal.TimeZone.from('UTC');
+        const abs = Temporal.Absolute.fromEpochSeconds(0);
+        const dt = tz.getDateTimeFor(abs, 'zerobased');
+        equal(dt.calendar.id, 'zerobased');
+      });
+      it('works for Absolute.inTimeZone', () => {
+        const abs = Temporal.Absolute.fromEpochSeconds(0);
+        const dt = abs.inTimeZone('UTC', 'zerobased');
+        equal(dt.calendar.id, 'zerobased');
+      });
+      it('works for Temporal.now.dateTime', () => {
+        const nowDateTime = Temporal.now.dateTime('UTC', 'zerobased');
+        equal(nowDateTime.calendar.id, 'zerobased');
+      });
+      it('works for Temporal.now.date', () => {
+        const nowDate = Temporal.now.date('UTC', 'zerobased');
+        equal(nowDate.calendar.id, 'zerobased');
+      });
+      after(() => {
+        Temporal.Calendar.from = originalTemporalCalendarFrom;
+      });
+    });
+  });
+});
+
+import { normalize } from 'path';
+if (normalize(import.meta.url.slice(8)) === normalize(process.argv[1])) {
+  report(reporter).then((failed) => process.exit(failed ? 1 : 0));
+}

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -222,6 +222,243 @@ describe('Userland calendar', () => {
       });
     });
   });
+  describe('Trivial protocol implementation', () => {
+    // For the purposes of testing, a nonsensical calendar that has 10-month
+    // years and 10-day months, and the year zero is at the Unix epoch
+    function decimalToISO(year, month, day, disambiguation) {
+      if (disambiguation === 'constrain') {
+        if (month < 1) month = 1;
+        if (month > 10) month = 10;
+        if (day < 1) day = 1;
+        if (day > 10) day = 10;
+      } else if (disambiguation === 'reject') {
+        if (month < 1 || month > 10 || day < 1 || day > 10) {
+          throw new RangeError('invalid value');
+        }
+      }
+      const days = year * 100 + (month - 1) * 10 + (day - 1);
+      return new Temporal.Date(1970, 1, 1).plus({ days });
+    }
+    function isoToDecimal(date) {
+      const iso = date.getISOCalendarFields();
+      const isoDate = new Temporal.Date(iso.year, iso.month, iso.day);
+      let { days } = isoDate.difference(new Temporal.Date(1970, 1, 1), { largestUnit: 'days' });
+      let year = Math.floor(days / 100);
+      if (iso.year < 1970) year *= -1;
+      days %= 100;
+      return { year, days };
+    }
+    const obj = {
+      id: 'decimal',
+      dateFromFields(fields, options, constructor) {
+        const { disambiguation = 'constrain' } = options ? options : {};
+        const isoDate = decimalToISO(fields.year, fields.month, fields.day, disambiguation);
+        return new constructor(isoDate.year, isoDate.month, isoDate.day, this);
+      },
+      yearMonthFromFields(fields, options, constructor) {
+        const { disambiguation = 'constrain' } = options ? options : {};
+        const isoDate = decimalToISO(fields.year, fields.month, 1, disambiguation);
+        return new constructor(isoDate.year, isoDate.month, this, isoDate.day);
+      },
+      monthDayFromFields(fields, options, constructor) {
+        const { disambiguation = 'constrain' } = options ? options : {};
+        const isoDate = decimalToISO(0, fields.month, fields.day, disambiguation);
+        return new constructor(isoDate.month, isoDate.day, this, isoDate.year);
+      },
+      year(date) {
+        return isoToDecimal(date).year;
+      },
+      month(date) {
+        const { days } = isoToDecimal(date);
+        return Math.floor(days / 10) + 1;
+      },
+      day(date) {
+        const { days } = isoToDecimal(date);
+        return (days % 10) + 1;
+      }
+    };
+
+    const date = Temporal.Date.from({ year: 184, month: 2, day: 9, calendar: obj });
+    const dt = Temporal.DateTime.from({ year: 184, month: 2, day: 9, hour: 12, calendar: obj });
+    const ym = Temporal.YearMonth.from({ year: 184, month: 2, calendar: obj });
+    const md = Temporal.MonthDay.from({ month: 2, day: 9, calendar: obj });
+
+    it('is a calendar', () => equal(typeof obj, 'object'));
+    it('.id property', () => equal(obj.id, 'decimal'));
+    // FIXME: what should happen in Temporal.Calendar.from(obj)?
+    it('.id is not available in from()', () => {
+      throws(() => Temporal.Calendar.from('decimal'), RangeError);
+      throws(() => Temporal.Calendar.from('2020-06-05T09:34-07:00[America/Vancouver][c=decimal]'), RangeError);
+    });
+    it('Temporal.Date.from()', () => equal(`${date}`, '2020-06-05[c=decimal]'));
+    it('Temporal.Date fields', () => {
+      equal(date.year, 184);
+      equal(date.month, 2);
+      equal(date.day, 9);
+    });
+    it('date.with()', () => {
+      const date2 = date.with({ year: 0 });
+      equal(date2.year, 0);
+    });
+    it('date.withCalendar()', () => {
+      const date2 = Temporal.Date.from('2020-06-05T12:00');
+      assert(date2.withCalendar(obj).equals(date));
+    });
+    it('Temporal.DateTime.from()', () => equal(`${dt}`, '2020-06-05T12:00[c=decimal]'));
+    it('Temporal.DateTime fields', () => {
+      equal(dt.year, 184);
+      equal(dt.month, 2);
+      equal(dt.day, 9);
+      equal(dt.hour, 12);
+      equal(dt.minute, 0);
+      equal(dt.second, 0);
+      equal(dt.millisecond, 0);
+      equal(dt.microsecond, 0);
+      equal(dt.nanosecond, 0);
+    });
+    it('datetime.with()', () => {
+      const dt2 = dt.with({ year: 0 });
+      equal(dt2.year, 0);
+    });
+    it('datetime.withCalendar()', () => {
+      const dt2 = Temporal.DateTime.from('2020-06-05T12:00');
+      assert(dt2.withCalendar(obj).equals(dt));
+    });
+    it('Temporal.YearMonth.from()', () => equal(`${ym}`, '2020-05-28[c=decimal]'));
+    it('Temporal.YearMonth fields', () => {
+      equal(dt.year, 184);
+      equal(dt.month, 2);
+    });
+    it('yearmonth.with()', () => {
+      const ym2 = ym.with({ year: 0 });
+      equal(ym2.year, 0);
+    });
+    it('Temporal.MonthDay.from()', () => equal(`${md}`, '1970-01-19[c=decimal]'));
+    it('Temporal.MonthDay fields', () => {
+      equal(dt.month, 2);
+      equal(dt.day, 9);
+    });
+    it('monthday.with()', () => {
+      const md2 = md.with({ month: 1 });
+      equal(md2.month, 1);
+    });
+    it('timezone.getDateTimeFor()', () => {
+      const tz = Temporal.TimeZone.from('UTC');
+      const abs = Temporal.Absolute.fromEpochSeconds(0);
+      const dt = tz.getDateTimeFor(abs, obj);
+      equal(dt.calendar.id, obj.id);
+    });
+    it('absolute.inTimeZone()', () => {
+      const abs = Temporal.Absolute.fromEpochSeconds(0);
+      const dt = abs.inTimeZone('UTC', obj);
+      equal(dt.calendar.id, obj.id);
+    });
+    it('Temporal.now.dateTime()', () => {
+      const nowDateTime = Temporal.now.dateTime('UTC', obj);
+      equal(nowDateTime.calendar.id, obj.id);
+    });
+    it('Temporal.now.date()', () => {
+      const nowDate = Temporal.now.date('UTC', obj);
+      equal(nowDate.calendar.id, obj.id);
+    });
+    describe('Making available globally', () => {
+      const originalTemporalCalendarFrom = Temporal.Calendar.from;
+      before(() => {
+        Temporal.Calendar.from = function(item) {
+          let id;
+          if (item instanceof Temporal.Calendar) {
+            id = item.id;
+          } else {
+            id = `${item}`;
+            // TODO: Use Temporal.parse here to extract the ID from an ISO string
+          }
+          if (id === 'decimal') return obj;
+          return originalTemporalCalendarFrom.call(this, id);
+        };
+      });
+      it('works for Calendar.from(id)', () => {
+        const cal = Temporal.Calendar.from('decimal');
+        assert(Object.is(cal, obj));
+      });
+      const iso = '1970-01-01T00:00+00:00[c=decimal]';
+      it.skip('works for Calendar.from(ISO string)', () => {
+        const cal = Temporal.Calendar.from(iso);
+        assert(Object.is(cal, obj));
+      });
+      it('works for Date.from(iso)', () => {
+        const d = Temporal.Date.from(iso);
+        equal(`${d}`, '1970-01-01[c=decimal]');
+      });
+      it('works for Date.from(props)', () => {
+        const d = Temporal.Date.from({ year: 0, month: 1, day: 1, calendar: 'decimal' });
+        equal(`${d}`, '1970-01-01[c=decimal]');
+      });
+      it('works for Date.with', () => {
+        const d1 = Temporal.Date.from('1970-01-01');
+        const d2 = d1.with({ month: 2, calendar: 'decimal' });
+        equal(`${d2}`, '1970-01-11[c=decimal]');
+      });
+      it('works for Date.withCalendar', () => {
+        const d = Temporal.Date.from('1970-01-01');
+        assert(d.withCalendar('decimal').equals(Temporal.Date.from(iso)));
+      });
+      it('works for DateTime.from(iso)', () => {
+        const dt = Temporal.DateTime.from(iso);
+        equal(`${dt}`, '1970-01-01T00:00[c=decimal]');
+      });
+      it('works for DateTime.from(props)', () => {
+        const dt = Temporal.DateTime.from({ year: 0, month: 1, day: 1, hour: 12, calendar: 'decimal' });
+        equal(`${dt}`, '1970-01-01T12:00[c=decimal]');
+      });
+      it('works for DateTime.with', () => {
+        const dt1 = Temporal.DateTime.from('1970-01-01T12:00');
+        const dt2 = dt1.with({ month: 2, calendar: 'decimal' });
+        equal(`${dt2}`, '1970-01-11T12:00[c=decimal]');
+      });
+      it('works for DateTime.withCalendar', () => {
+        const dt = Temporal.DateTime.from('1970-01-01T00:00');
+        assert(dt.withCalendar('decimal').equals(Temporal.DateTime.from(iso)));
+      });
+      it('works for YearMonth.from(iso)', () => {
+        const ym = Temporal.YearMonth.from(iso);
+        equal(`${ym}`, '1970-01-01[c=decimal]');
+      });
+      it('works for YearMonth.from(props)', () => {
+        const ym = Temporal.YearMonth.from({ year: 0, month: 1, calendar: 'decimal' });
+        equal(`${ym}`, '1970-01-01[c=decimal]');
+      });
+      it('works for MonthDay.from(iso)', () => {
+        const md = Temporal.MonthDay.from(iso);
+        equal(`${md}`, '1970-01-01[c=decimal]');
+      });
+      it('works for MonthDay.from(props)', () => {
+        const md = Temporal.MonthDay.from({ month: 1, day: 1, calendar: 'decimal' });
+        equal(`${md}`, '1970-01-01[c=decimal]');
+      });
+      it('works for TimeZone.getDateTimeFor', () => {
+        const tz = Temporal.TimeZone.from('UTC');
+        const abs = Temporal.Absolute.fromEpochSeconds(0);
+        const dt = tz.getDateTimeFor(abs, 'decimal');
+        equal(dt.calendar.id, 'decimal');
+      });
+      it('works for Absolute.inTimeZone', () => {
+        const abs = Temporal.Absolute.fromEpochSeconds(0);
+        const dt = abs.inTimeZone('UTC', 'decimal');
+        equal(dt.calendar.id, 'decimal');
+      });
+      it('works for Temporal.now.dateTime', () => {
+        const nowDateTime = Temporal.now.dateTime('UTC', 'decimal');
+        equal(nowDateTime.calendar.id, 'decimal');
+      });
+      it('works for Temporal.now.date', () => {
+        const nowDate = Temporal.now.date('UTC', 'decimal');
+        equal(nowDate.calendar.id, 'decimal');
+      });
+      after(() => {
+        Temporal.Calendar.from = originalTemporalCalendarFrom;
+      });
+    });
+  });
 });
 
 import { normalize } from 'path';

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -118,6 +118,11 @@ describe('YearMonth', () => {
       it('with(09)', () => equal(`${ym.with({ month: 9 })}`, '2019-09'));
     });
   });
+  describe('YearMonth.with() works', () => {
+    it('throws on trying to change the calendar', () => {
+      throws(() => YearMonth.from('2019-10').with({ calendar: 'gregory' }), RangeError);
+    });
+  });
   describe('YearMonth.compare() works', () => {
     const nov94 = YearMonth.from('1994-11');
     const jun13 = YearMonth.from('2013-06');
@@ -133,8 +138,9 @@ describe('YearMonth', () => {
       throws(() => YearMonth.compare(nov94, '2013-06'), TypeError);
     });
     it('takes [[RefISODay]] into account', () => {
-      const ym1 = new YearMonth(2000, 1, 1);
-      const ym2 = new YearMonth(2000, 1, 2);
+      const iso = Temporal.Calendar.from('iso8601');
+      const ym1 = new YearMonth(2000, 1, iso, 1);
+      const ym2 = new YearMonth(2000, 1, iso, 2);
       equal(YearMonth.compare(ym1, ym2), -1);
     });
   });
@@ -148,8 +154,9 @@ describe('YearMonth', () => {
       throws(() => nov94.equals('1994-11'), TypeError);
     });
     it('takes [[RefISODay]] into account', () => {
-      const ym1 = new YearMonth(2000, 1, 1);
-      const ym2 = new YearMonth(2000, 1, 2);
+      const iso = Temporal.Calendar.from('iso8601');
+      const ym1 = new YearMonth(2000, 1, iso, 1);
+      const ym2 = new YearMonth(2000, 1, iso, 2);
       assert(!ym1.equals(ym2));
     });
   });
@@ -348,23 +355,22 @@ describe('YearMonth', () => {
     });
   });
   describe('yearMonth.getFields() works', () => {
-    const ym1 = YearMonth.from('1976-11');
+    const calendar = Temporal.Calendar.from('iso8601');
+    const ym1 = YearMonth.from({ year: 1976, month: 11, calendar });
     const fields = ym1.getFields();
     it('fields', () => {
       equal(fields.year, 1976);
       equal(fields.month, 11);
+      equal(fields.calendar, calendar);
     });
     it('enumerable', () => {
       const fields2 = { ...fields };
       equal(fields2.year, 1976);
       equal(fields2.month, 11);
+      equal(fields2.calendar, calendar);
     });
     it('as input to from()', () => {
       const ym2 = YearMonth.from(fields);
-      equal(YearMonth.compare(ym1, ym2), 0);
-    });
-    it('as input to with()', () => {
-      const ym2 = YearMonth.from('2019-06').with(fields);
       equal(YearMonth.compare(ym1, ym2), 0);
     });
   });


### PR DESCRIPTION
This adds a built-in ISO 8601 calendar and delegates all calendar-sensitive operations to it.

This should be the last PR that needs to be merged before we can release the polyfill. It's ready for review and can be merged as-is, but here is a list of things I still intend to do, either in this pull request or a follow up:
- [x] Check if `calendar.dateTimeFromFields` can be removed
- [x] Add the in-progress Japanese calendar, if it's possible to get it into shape in time
- [x] Add tests for creating a custom calendar inheriting from `Temporal.Calendar`
- [x] Add tests for creating a custom calendar not inheriting from `Temporal.Calendar`