### PR TITLE
Add "kinds of durations" section to `Duration` docs

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -82,7 +82,7 @@ addAbsoluteDifference(dt, abs, absLater, 'America/Los_Angeles').toString();
 // => "2020-11-01T12:00" (12 clock hours, but 13 real-world hours)
 ```
 3. **Don't combine different kinds of durations.**<br/>
-Dont mix kinds of durations when using `Temporal.Duration`'s  `plus()`, `minus()`, `difference()`, or `with()` methods.  First convert one of them to the other kind and only then combine the durations.
+Don't mix kinds of durations when using `Temporal.Duration`'s  `plus()`, `minus()`, `difference()`, or `with()` methods.  First convert one of them to the other kind and only then combine the durations.
 ```js
 const dt = new Temporal.DateTime(2020, 11, 1); // midnight on the day DST starts
 const dtLater = new Temporal.DateTime(2020, 11, 1, 12); // noon is 13 hours later


### PR DESCRIPTION
Per the discussion in #559, `Duration` is challenging to make DST-safe because (unlike `DateTime` vs. `Absolute`), there's no way to know that the duration in a particular `Duration` instance represents an "absolute" duration or a "date/time" duration.

This PR adds a new section in the summary of the `Duration` documentation that: 
* explains the difference between "absolute" and "date/time" durations _(UPDATE: I'm planning to add more content about the third kind: RFC 5545 durations that combine a "date/time" date part and an "absolute" time part)_
* explains why that difference is important for correctly dealing with DST issues
* provides 3 simple best practices to follow: 
  * _Don't assume that every day is 24 hours long._
  * _Only use absolute durations with `Temporal.Absolute` methods._
  * _Don't combine different kinds of durations._
* provides code samples illustrating correct and incorrect application of each best practice. 
