### PR TITLE
Make time zone parameter required `inTimeZone` methods

### DIFF
--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -143,7 +143,7 @@ export class Absolute {
   valueOf() {
     throw new TypeError('use compare() or equals() to compare Temporal.Absolute');
   }
-  inTimeZone(temporalTimeZoneLike = 'UTC') {
+  inTimeZone(temporalTimeZoneLike) {
     if (!ES.IsTemporalAbsolute(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
     return timeZone.getDateTimeFor(this);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -303,7 +303,7 @@ export class DateTime {
     throw new TypeError('use compare() or equals() to compare Temporal.DateTime');
   }
 
-  inTimeZone(temporalTimeZoneLike = 'UTC', options) {
+  inTimeZone(temporalTimeZoneLike, options) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
     const disambiguation = ES.ToTimeZoneTemporalDisambiguation(options);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -161,12 +161,12 @@ export const ES = ObjectAssign({}, ES2019, {
   },
   ParseTemporalTimeZoneString: (stringIdent) => {
     try {
-      try {
-        const canonicalIdent = ES.GetCanonicalTimeZoneIdentifier(stringIdent);
-        if (canonicalIdent) return { zone: canonicalIdent.toString() };
-      } catch {
-        // fall through
-      }
+      const canonicalIdent = ES.GetCanonicalTimeZoneIdentifier(stringIdent);
+      if (canonicalIdent) return { zone: canonicalIdent.toString() };
+    } catch {
+      // fall through
+    }
+    try {
       // Try parsing ISO string instead
       return ES.ParseISODateTime(stringIdent, { zoneRequired: true });
     } catch {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -161,13 +161,17 @@ export const ES = ObjectAssign({}, ES2019, {
   },
   ParseTemporalTimeZoneString: (stringIdent) => {
     try {
-      const canonicalIdent = ES.GetCanonicalTimeZoneIdentifier(stringIdent);
-      if (canonicalIdent) return { zone: canonicalIdent.toString() };
+      try {
+        const canonicalIdent = ES.GetCanonicalTimeZoneIdentifier(stringIdent);
+        if (canonicalIdent) return { zone: canonicalIdent.toString() };
+      } catch {
+        // fall through
+      }
+      // Try parsing ISO string instead
+      return ES.ParseISODateTime(stringIdent, { zoneRequired: true });
     } catch {
-      // fall through
+      throw new RangeError(`Invalid time zone: ${stringIdent}`);
     }
-    // Try parsing ISO string instead
-    return ES.ParseISODateTime(stringIdent, { zoneRequired: true });
   },
   ParseTemporalDurationString: (isoString) => {
     const match = PARSE.duration.exec(isoString);

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -491,18 +491,16 @@ describe('Absolute', () => {
   describe('Absolute.inTimeZone works', () => {
     const iso = '1976-11-18T14:23:30.123456789Z';
     const abs = Absolute.from(iso);
-    it('without optional parameter', () => {
-      const dt = abs.inTimeZone();
-      equal(abs.getEpochNanoseconds(), dt.inTimeZone().getEpochNanoseconds());
-      equal(`${dt}`, '1976-11-18T14:23:30.123456789');
+    it('without parameter', () => {
+      throws(() => abs.inTimeZone(), RangeError);
     });
-    it('optional time zone parameter UTC', () => {
+    it('time zone parameter UTC', () => {
       const tz = Temporal.TimeZone.from('UTC');
       const dt = abs.inTimeZone(tz);
       equal(abs.getEpochNanoseconds(), dt.inTimeZone(tz).getEpochNanoseconds());
       equal(`${dt}`, '1976-11-18T14:23:30.123456789');
     });
-    it('optional time zone parameter non-UTC', () => {
+    it('time zone parameter non-UTC', () => {
       const tz = Temporal.TimeZone.from('America/New_York');
       const dt = abs.inTimeZone(tz);
       equal(abs.getEpochNanoseconds(), dt.inTimeZone(tz).getEpochNanoseconds());

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -573,16 +573,15 @@ describe('DateTime', () => {
   });
   describe('DateTime.inTimeZone() works', () => {
     const dt = DateTime.from('1976-11-18T15:23:30.123456789');
-    it('without optional parameter', () => {
-      const abs = dt.inTimeZone();
-      equal(`${abs}`, '1976-11-18T15:23:30.123456789Z');
+    it('without parameter', () => {
+      throws(() => dt.inTimeZone(), RangeError);
     });
-    it('optional time zone parameter UTC', () => {
+    it('time zone parameter UTC', () => {
       const tz = Temporal.TimeZone.from('UTC');
       const abs = dt.inTimeZone(tz);
       equal(`${abs}`, '1976-11-18T15:23:30.123456789Z');
     });
-    it('optional time zone parameter non-UTC', () => {
+    it('time zone parameter non-UTC', () => {
       const tz = Temporal.TimeZone.from('America/New_York');
       const abs = dt.inTimeZone(tz);
       equal(`${abs}`, '1976-11-18T20:23:30.123456789Z');

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -370,7 +370,7 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.absolute.prototype.intimezone">
-      <h1>Temporal.Absolute.prototype.inTimeZone ( [ _temporalTimeZoneLike_ ] )</h1>
+      <h1>Temporal.Absolute.prototype.inTimeZone ( _temporalTimeZoneLike_ )</h1>
       <p>
         The `inTimeZone` method takes one argument _temporalTimeZoneLike_.
         The following steps are taken:
@@ -378,8 +378,6 @@
       <emu-alg>
         1. Let _absolute_ be the *this* value.
         1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
-        1. If _temporalTimeZoneLike_ is *undefined*, then
-          1. Throw a *RangeError* exception.
         1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
         1. Return ? GetTemporalDateTimeFor(_timeZone_, _absolute_).
       </emu-alg>

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -379,7 +379,7 @@
         1. Let _absolute_ be the *this* value.
         1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
         1. If _temporalTimeZoneLike_ is *undefined*, then
-          1. Set _temporalTimeZoneLike_ to *"UTC"*.
+          1. Throw a *RangeError* exception.
         1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
         1. Return ? GetTemporalDateTimeFor(_timeZone_, _absolute_).
       </emu-alg>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -521,7 +521,7 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.datetime.prototype.intimezone">
-      <h1>Temporal.DateTime.prototype.inTimeZone ( [ _temporalTimeZoneLike_ [ , _options_ ] ] )</h1>
+      <h1>Temporal.DateTime.prototype.inTimeZone ( _temporalTimeZoneLike_ [ , _options_ ] )</h1>
       <p>
         The `inTimeZone` method takes two arguments, _temporalTimeZoneLike_ and _options_.
         The following steps are taken:
@@ -529,8 +529,6 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. If _temporalTimeZoneLike_ is *undefined*, then
-          1. Throw a *RangeError* exception.
         1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
         1. Let _disambiguation_ be ? ToTimeZoneTemporalDisambiguation(_options_).
         1. Return ? GetAbsoluteFor(_timeZone_, _dateTime_, _disambiguation_).

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -530,7 +530,7 @@
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. If _temporalTimeZoneLike_ is *undefined*, then
-          1. Set _temporalTimeZoneLike_ to *"UTC"*.
+          1. Throw a *RangeError* exception.
         1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
         1. Let _disambiguation_ be ? ToTimeZoneTemporalDisambiguation(_options_).
         1. Return ? GetAbsoluteFor(_timeZone_, _dateTime_, _disambiguation_).


### PR DESCRIPTION
Fixes #648.  This PR updates the polyfill and the spec to match the docs, which say that the time zone parameter for `DateTime.prototype.inTimeZone` and `Absolute.prototype.inTimeZone` should be required.

Given that the meaning of an omitted time zone parameter (UTC?  local time zone?) is not clear without reading the docs, it seems wise to require the user to explicitly provide a time zone when converting between time zones.

Also, given that a design goal of Temporal is to remove ambiguity (especially including around time zones), enforcing an explicit time zone choice seems to support that goal. 
