### PR TITLE
Throw if `difference()` is out-of-order & stop limiting `Time.prototype.difference` to 12 hours

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -300,7 +300,7 @@ Temporal.now.absolute().minus(oneDay);
 **Returns:** a `Temporal.Duration` representing the difference between `absolute` and `other`.
 
 This method computes the difference between the two times represented by `absolute` and `other`, and returns it as a `Temporal.Duration` object.
-The difference is always positive, no matter the order of `absolute` and `other`, because `Temporal.Duration` objects cannot represent negative durations.
+A `RangeError` will be thrown if `other` is later than `absolute`, because `Temporal.Duration` objects cannot represent negative durations.
 
 The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
@@ -316,25 +316,25 @@ Example usage:
 ```js
 startOfMoonMission = Temporal.Absolute.from('1969-07-16T13:32:00Z');
 endOfMoonMission = Temporal.Absolute.from('1969-07-24T16:50:35Z');
-missionLength = startOfMoonMission.difference(endOfMoonMission, { largestUnit: 'days' });
+missionLength = endOfMoonMission.difference(startOfMoonMission, { largestUnit: 'days' });
   // => P8DT3H18M35S
-endOfMoonMission.difference(startOfMoonMission, { largestUnit: 'days' });
-  // => P8DT3H18M35S
+startOfMoonMission.difference(endOfMoonMission, { largestUnit: 'days' });
+  // => throws RangeError
 missionLength.toLocaleString();
   // example output: '8 days 3 hours 18 minutes 35 seconds'
 
 // A billion (10^9) seconds since the epoch in different units
 epoch = new Temporal.Absolute(0n);
 billion = Temporal.Absolute.fromEpochSeconds(1e9);
-epoch.difference(billion);  // => PT1000000000S
-epoch.difference(billion, { largestUnit: 'hours' })  // => PT277777H46M40S
-epoch.difference(billion, { largestUnit: 'days' })  // => P11574DT1H46M40S
+billion.difference(epoch);  // => PT1000000000S
+billion.difference(epoch, { largestUnit: 'hours' })  // => PT277777H46M40S
+billion.difference(epoch, { largestUnit: 'days' })  // => P11574DT1H46M40S
 
 // If you really need to calculate the difference between two Absolutes
 // in years, you can eliminate the ambiguity by choosing your starting
 // point explicitly. For example, using the corresponding UTC date:
 utc = Temporal.TimeZone.from('UTC');
-epoch.inTimeZone(utc).difference(billion.inTimeZone(utc), { largestUnit: 'years' });
+billion.inTimeZone(utc).difference(epoch.inTimeZone(utc), { largestUnit: 'years' });
   // => P31Y8M8DT1H46M40S
 ```
 

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -273,12 +273,12 @@ For example:
 ```javascript
 d1 = Temporal.Date.from('2020-07-29').withCalendar('chinese');
 d2 = Temporal.Date.from('2020-08-29').withCalendar('chinese');
-d1.difference(d2, { largestUnit: 'months' })  // => P1M2D
+d2.difference(d1, { largestUnit: 'months' })  // => P1M2D
 
 // same result, but calling the method directly:
 Temporal.Calendar.from('chinese').difference(
-    Temporal.Date.from('2020-07-29'),
     Temporal.Date.from('2020-08-29'),
+    Temporal.Date.from('2020-07-29'),
     { largestUnit: 'months' }
 )  // => P1M2D
 ```

--- a/docs/cookbook/futureDateForm.js
+++ b/docs/cookbook/futureDateForm.js
@@ -14,8 +14,8 @@ function englishPlural(n, singular, plural) {
 if (futuredateParam !== null) {
   const futureDate = Temporal.Date.from(futuredateParam);
   const today = Temporal.now.date();
-  const until = today.difference(futureDate, { largestUnit: 'days' });
-  const untilMonths = today.difference(futureDate, { largestUnit: 'months' });
+  const until = futureDate.difference(today, { largestUnit: 'days' });
+  const untilMonths = futureDate.difference(today, { largestUnit: 'months' });
 
   const dayString = englishPlural(until.days, 'day', 'days');
   const monthString =

--- a/docs/cookbook/getElapsedDurationSinceInstant.mjs
+++ b/docs/cookbook/getElapsedDurationSinceInstant.mjs
@@ -14,7 +14,7 @@
  */
 function getElapsedDurationSinceInstant(then, now, largestUnit = 'days') {
   const sign = Temporal.Absolute.compare(now, then) < 0 ? '-' : '+';
-  const duration = now.difference(then, { largestUnit });
+  const duration = sign === '-' ? then.difference(now, { largestUnit }) : now.difference(then, { largestUnit });
   return { sign, duration };
 }
 

--- a/docs/cookbook/getTripDurationInHrMinSec.mjs
+++ b/docs/cookbook/getTripDurationInHrMinSec.mjs
@@ -9,7 +9,7 @@
 function getTripDurationInHrMinSec(parseableDeparture, parseableArrival) {
   const departure = Temporal.Absolute.from(parseableDeparture);
   const arrival = Temporal.Absolute.from(parseableArrival);
-  return departure.difference(arrival, { largestUnit: 'hours' });
+  return arrival.difference(departure, { largestUnit: 'hours' });
 }
 
 const flightTime = getTripDurationInHrMinSec(

--- a/docs/date.md
+++ b/docs/date.md
@@ -372,7 +372,7 @@ date.minus({ months: 1 }, { disambiguation: 'reject' })  // => throws
 **Returns:** a `Temporal.Duration` representing the difference between `date` and `other`.
 
 This method computes the difference between the two dates represented by `date` and `other`, and returns it as a `Temporal.Duration` object.
-The difference is always positive, no matter the order of `date` and `other`, because `Temporal.Duration` objects cannot represent negative durations.
+A `RangeError` will be thrown if `other` is later than `date`, because `Temporal.Duration` objects cannot represent negative durations.
 
 The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
@@ -385,10 +385,11 @@ Unlike other Temporal types, hours and lower are not allowed, because the data m
 
 Usage example:
 ```javascript
-date = Temporal.Date.from('2006-08-24');
-other = Temporal.Date.from('2019-01-31');
+date = Temporal.Date.from('2019-01-31');
+other = Temporal.Date.from('2006-08-24');
 date.difference(other)                            // => P4543D
 date.difference(other, { largestUnit: 'years' })  // => P12Y5M7D
+other.difference(date, { largestUnit: 'years' })  // => throws RangeError
 
 // If you really need to calculate the difference between two Dates in
 // hours, you can eliminate the ambiguity by explicitly choosing the

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -429,7 +429,7 @@ dt.minus({ months: 1 })  // => throws
 **Returns:** a `Temporal.Duration` representing the difference between `datetime` and `other`.
 
 This method computes the difference between the two times represented by `datetime` and `other`, and returns it as a `Temporal.Duration` object.
-The difference is always positive, no matter the order of `datetime` and `other`, because `Temporal.Duration` objects cannot represent negative durations.
+A `RangeError` will be thrown if `other` is later than `datetime`, because `Temporal.Duration` objects cannot represent negative durations.
 
 The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
@@ -443,15 +443,16 @@ Usage example:
 ```javascript
 dt1 = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 dt2 = Temporal.DateTime.from('2019-01-31T15:30');
-dt1.difference(dt2);                            // =>    P8456DT12H5M29.999996500S
-dt1.difference(dt2), { largestUnit: 'years' })  // => P23Y1M24DT12H5M29.999996500S
+dt2.difference(dt1);                            // =>    P8456DT12H5M29.999996500S
+dt2.difference(dt1), { largestUnit: 'years' })  // => P23Y1M24DT12H5M29.999996500S
+dt1.difference(dt2), { largestUnit: 'years' })  // => throws RangeError
 
 // Months and years can be different lengths
 [jan1, feb1, mar1] = [1, 2, 3].map(month => Temporal.DateTime.from({year: 2020, month, day: 1}));
-jan1.difference(feb1);                             // => P31D
-jan1.difference(feb1, { largestUnit: 'months' });  // => P1M
-feb1.difference(mar1);                             // => P29D
-feb1.difference(mar1, { largestUnit: 'months' });  // => P1M
+feb1.difference(jan1);                             // => P31D
+feb1.difference(jan1, { largestUnit: 'months' });  // => P1M
+mar1.difference(feb1);                             // => P29D
+mar1.difference(feb1, { largestUnit: 'months' });  // => P1M
 ```
 
 ### datetime.**equals**(_other_: Temporal.DateTime) : boolean

--- a/docs/time.md
+++ b/docs/time.md
@@ -245,23 +245,21 @@ time.minus({ minutes: 5, nanoseconds: 800 })  // => 19:34:09.068345405
 **Returns:** a `Temporal.Duration` representing the difference between `time` and `other`.
 
 This method computes the difference between the two times represented by `time` and `other`, and returns it as a `Temporal.Duration` object.
-The difference is always positive, and always 12 hours or less, no matter the order of `time` and `other`, because `Temporal.Duration` objects cannot represent negative durations.
+A `RangeError` will be thrown if `other` is later than `time`, because `Temporal.Duration` objects cannot represent negative durations.
 
 The `largestUnit` parameter controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
-A difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`, for example.
-However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `"hours"`.
+A difference of two hours will become 7200 seconds when `largestUnit` is `'seconds'`, for example.
+However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `'hours'`.
 
-The default largest unit in the result is technically days, for consistency with other Temporal types' `difference` methods.
-However, since this method never returns any duration longer than 12 hours, largest units of years, months, or days, are by definition treated as hours.
+The default largest unit in the result is technically `'days'`, for consistency with other Temporal types' `difference` methods.
+However, since time differences are always shorter than one day, largest units of `'years'`, `'months'`, or `'days'` are treated as `'hours'`.
 
 Usage example:
 ```javascript
-time = Temporal.Time.from('19:39:09.068346205');
-time.difference(Temporal.Time.from('20:13:20.971398099'))  // => PT34M11.903051894S
-
-// The difference is always less than 12 hours, crossing midnight if needed
-Temporal.Time.from('01:00').difference(Temporal.Time.from('23:00'))  // => P2H
+time = Temporal.Time.from('20:13:20.971398099');
+time.difference(Temporal.Time.from('19:39:09.068346205'))  // => PT34M11.903051894S
+time.difference(Temporal.Time.from('22:39:09.068346205'))  // => throws RangeError
 ```
 
 ### time.**equals**(_other_: Temporal.Time) : boolean

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -298,7 +298,7 @@ ym.minus({years: 20, months: 4})  // => 1999-02
 **Returns:** a `Temporal.Duration` representing the difference between `yearMonth` and `other`.
 
 This method computes the difference between the two months represented by `yearMonth` and `other`, and returns it as a `Temporal.Duration` object.
-The difference is always positive, no matter the order of `yearMonth` and `other`, because `Temporal.Duration` objects cannot represent negative durations.
+A `RangeError` will be thrown if `other` is later than `yearMonth`, because `Temporal.Duration` objects cannot represent negative durations.
 
 The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
@@ -313,6 +313,7 @@ ym = Temporal.YearMonth.from('2019-06');
 other = Temporal.YearMonth.from('2006-08');
 ym.difference(other)                             // => P12Y10M
 ym.difference(other, { largestUnit: 'months' })  // => P154M
+other.difference(ym, { largestUnit: 'months' })  // => throws RangeError
 
 // If you really need to calculate the difference between two YearMonths
 // in days, you can eliminate the ambiguity by explicitly choosing the

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -95,9 +95,10 @@ export class Absolute {
     if (!ES.IsTemporalAbsolute(other)) throw new TypeError('invalid Absolute object');
     const largestUnit = ES.ToLargestTemporalUnit(options, 'seconds', ['years', 'months', 'weeks']);
 
-    const [one, two] = [this, other].sort(Absolute.compare);
-    const onens = GetSlot(one, EPOCHNANOSECONDS);
-    const twons = GetSlot(two, EPOCHNANOSECONDS);
+    const comparison = Absolute.compare(this, other);
+    if (comparison < 0) throw new RangeError('other instance cannot be larger than `this`');
+    const onens = GetSlot(other, EPOCHNANOSECONDS);
+    const twons = GetSlot(this, EPOCHNANOSECONDS);
     const diff = twons.minus(onens);
 
     const ns = +diff.mod(1e3);

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -156,8 +156,9 @@ export class Date {
     if (calendar.id !== GetSlot(other, CALENDAR).id) {
       other = new Date(GetSlot(other, ISO_YEAR), GetSlot(other, ISO_MONTH), GetSlot(other, ISO_DAY), calendar);
     }
-    const [smaller, larger] = [this, other].sort(Date.compare);
-    return calendar.difference(smaller, larger, options);
+    const comparison = Date.compare(this, other);
+    if (comparison < 0) throw new RangeError('other instance cannot be larger than `this`');
+    return calendar.difference(other, this, options);
   }
   equals(other) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -439,24 +439,25 @@ export class DateTime {
       );
     }
     const largestUnit = ES.ToLargestTemporalUnit(options, 'days');
-    const [smaller, larger] = [this, other].sort(DateTime.compare);
+    const comparison = DateTime.compare(this, other);
+    if (comparison < 0) throw new RangeError('other instance cannot be larger than `this`');
     let { deltaDays, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(
-      smaller,
-      larger
+      other,
+      this
     );
-    let year = GetSlot(larger, ISO_YEAR);
-    let month = GetSlot(larger, ISO_MONTH);
-    let day = GetSlot(larger, ISO_DAY) + deltaDays;
+    let year = GetSlot(this, ISO_YEAR);
+    let month = GetSlot(this, ISO_MONTH);
+    let day = GetSlot(this, ISO_DAY) + deltaDays;
     ({ year, month, day } = ES.BalanceDate(year, month, day));
 
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
-    const adjustedLarger = new TemporalDate(year, month, day, GetSlot(larger, CALENDAR));
+    const adjustedLarger = new TemporalDate(year, month, day, GetSlot(this, CALENDAR));
     let dateLargestUnit = 'days';
     if (largestUnit === 'years' || largestUnit === 'months' || largestUnit === 'weeks') {
       dateLargestUnit = largestUnit;
     }
     const dateOptions = ObjectAssign({}, options, { largestUnit: dateLargestUnit });
-    const dateDifference = calendar.difference(smaller, adjustedLarger, dateOptions);
+    const dateDifference = calendar.difference(other, adjustedLarger, dateOptions);
 
     let days;
     ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -169,16 +169,9 @@ export class Time {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalTime(other)) throw new TypeError('invalid Time object');
     const largestUnit = ES.ToLargestTemporalUnit(options, 'hours');
-    const [earlier, later] = [this, other].sort(Time.compare);
-    let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(earlier, later);
-    if (hours >= 12) {
-      hours = 24 - hours;
-      minutes *= -1;
-      seconds *= -1;
-      milliseconds *= -1;
-      microseconds *= -1;
-      nanoseconds *= -1;
-    }
+    const comparison = Time.compare(this, other);
+    if (comparison < 0) throw new RangeError('other instance cannot be larger than `this`');
+    let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(other, this);
     ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
       0,
       hours,

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -124,10 +124,11 @@ export class YearMonth {
       other = new Date(GetSlot(other, ISO_YEAR), GetSlot(other, ISO_MONTH), calendar, GetSlot(other, REF_ISO_DAY));
     }
     const largestUnit = ES.ToLargestTemporalUnit(options, 'years', ['weeks', 'days', 'hours', 'minutes', 'seconds']);
-    const [one, two] = [this, other].sort(YearMonth.compare);
+    const comparison = YearMonth.compare(this, other);
+    if (comparison < 0) throw new RangeError('other instance cannot be larger than `this`');
 
-    const smallerFields = ES.ToTemporalYearMonthRecord(one);
-    const largerFields = ES.ToTemporalYearMonthRecord(two);
+    const smallerFields = ES.ToTemporalYearMonthRecord(other);
+    const largerFields = ES.ToTemporalYearMonthRecord(this);
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
     const smaller = calendar.dateFromFields({ ...smallerFields, day: 1 }, {}, TemporalDate);
     const larger = calendar.dateFromFields({ ...largerFields, day: 1 }, {}, TemporalDate);

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -425,9 +425,8 @@ describe('Absolute', () => {
   describe('Absolute.difference works', () => {
     const earlier = Absolute.from('1976-11-18T15:23:30.123456789Z');
     const later = Absolute.from('2019-10-29T10:46:38.271986102Z');
-    const diff = earlier.difference(later);
-    it(`(${earlier}).difference(${later}) == (${later}).difference(${earlier})`, () =>
-      equal(`${later.difference(earlier)}`, `${diff}`));
+    const diff = later.difference(earlier);
+    it('throws if out of order', () => throws(() => earlier.difference(later), RangeError));
     it(`(${earlier}).plus(${diff}) == (${later})`, () => assert(earlier.plus(diff).equals(later)));
     it(`(${later}).minus(${diff}) == (${earlier})`, () => assert(later.minus(diff).equals(earlier)));
     it("doesn't cast argument", () => {

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -164,7 +164,8 @@ describe('Date', () => {
       equal(duration.nanoseconds, 0);
     });
     it('date.difference({ year: 2019, month: 11, day: 18 }, { largestUnit: "years" })', () => {
-      const duration = date.difference(Date.from({ year: 2019, month: 11, day: 18 }), { largestUnit: 'years' });
+      const later = Date.from({ year: 2019, month: 11, day: 18 });
+      const duration = later.difference(date, { largestUnit: 'years' });
       equal(duration.years, 43);
       equal(duration.months, 0);
       equal(duration.weeks, 0);
@@ -184,12 +185,12 @@ describe('Date', () => {
       const date1 = Date.from('2019-01-01');
       const date2 = Date.from('2019-02-01');
       const date3 = Date.from('2019-03-01');
-      equal(`${date1.difference(date2)}`, 'P31D');
-      equal(`${date2.difference(date3)}`, 'P28D');
+      equal(`${date2.difference(date1)}`, 'P31D');
+      equal(`${date3.difference(date2)}`, 'P28D');
 
       const date4 = Date.from('2020-02-01');
       const date5 = Date.from('2020-03-01');
-      equal(`${date4.difference(date5)}`, 'P29D');
+      equal(`${date5.difference(date4)}`, 'P29D');
     });
     it('takes days per year into account', () => {
       const date1 = Date.from('2019-01-01');
@@ -198,10 +199,10 @@ describe('Date', () => {
       const date4 = Date.from('2020-06-01');
       const date5 = Date.from('2021-01-01');
       const date6 = Date.from('2021-06-01');
-      equal(`${date1.difference(date3)}`, 'P365D');
-      equal(`${date3.difference(date5)}`, 'P366D');
-      equal(`${date2.difference(date4)}`, 'P366D');
-      equal(`${date4.difference(date6)}`, 'P365D');
+      equal(`${date3.difference(date1)}`, 'P365D');
+      equal(`${date5.difference(date3)}`, 'P366D');
+      equal(`${date4.difference(date2)}`, 'P366D');
+      equal(`${date6.difference(date4)}`, 'P365D');
     });
     const feb20 = Date.from('2020-02-01');
     const feb21 = Date.from('2021-02-01');

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -302,9 +302,12 @@ describe('DateTime', () => {
     const earlier = DateTime.from('1976-11-18T15:23:30.123456789');
     const later = DateTime.from('2019-10-29T10:46:38.271986102');
     ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds'].forEach((largestUnit) => {
-      const diff = earlier.difference(later, { largestUnit });
+      const diff = later.difference(earlier, { largestUnit });
+      /*
       it(`(${earlier}).difference(${later}, ${largestUnit}) == (${later}).difference(${earlier}, ${largestUnit})`, () =>
         equal(`${later.difference(earlier, { largestUnit })}`, `${diff}`));
+      */
+      it('throws if out of order', () => throws(() => earlier.difference(later), RangeError));
       it(`(${earlier}).plus(${diff}) == (${later})`, () => earlier.plus(diff).equals(later));
       it(`(${later}).minus(${diff}) == (${earlier})`, () => later.minus(diff).equals(earlier));
     });

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -303,10 +303,6 @@ describe('DateTime', () => {
     const later = DateTime.from('2019-10-29T10:46:38.271986102');
     ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds'].forEach((largestUnit) => {
       const diff = later.difference(earlier, { largestUnit });
-      /*
-      it(`(${earlier}).difference(${later}, ${largestUnit}) == (${later}).difference(${earlier}, ${largestUnit})`, () =>
-        equal(`${later.difference(earlier, { largestUnit })}`, `${diff}`));
-      */
       it('throws if out of order', () => throws(() => earlier.difference(later), RangeError));
       it(`(${earlier}).plus(${diff}) == (${later})`, () => earlier.plus(diff).equals(later));
       it(`(${later}).minus(${diff}) == (${earlier})`, () => later.minus(diff).equals(earlier));

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -215,79 +215,8 @@ describe('Time', () => {
         const duration = time.difference(two);
         equal(`${duration}`, 'PT1H53M');
       });
-      it('always returns a duration of 12 hours or less', () => {
-        const start1 = new Temporal.Time(11);
-        const start2 = new Temporal.Time(23);
-
-        let duration = Temporal.Duration.from('PT11H');
-        let end = start1.plus(duration);
-        equal(`${start1.difference(end)}`, 'PT11H');
-        end = start2.plus(duration);
-        equal(`${start2.difference(end)}`, 'PT11H');
-
-        duration = Temporal.Duration.from('PT11H45M');
-        end = start1.plus(duration);
-        equal(`${start1.difference(end)}`, 'PT11H45M');
-        end = start2.plus(duration);
-        equal(`${start2.difference(end)}`, 'PT11H45M');
-
-        duration = Temporal.Duration.from('PT12H');
-        end = start1.plus(duration);
-        equal(`${start1.difference(end)}`, 'PT12H');
-        end = start2.plus(duration);
-        equal(`${start2.difference(end)}`, 'PT12H');
-
-        duration = Temporal.Duration.from('PT12H15M');
-        end = start1.plus(duration);
-        equal(`${start1.difference(end)}`, 'PT11H45M');
-        end = start2.plus(duration);
-        equal(`${start2.difference(end)}`, 'PT11H45M');
-
-        duration = Temporal.Duration.from('PT13H');
-        end = start1.plus(duration);
-        equal(`${start1.difference(end)}`, 'PT11H');
-        end = start2.plus(duration);
-        equal(`${start2.difference(end)}`, 'PT11H');
-      });
-      it('returns the same duration no matter when the start time is', () => {
-        const hours = Array(24)
-          .fill()
-          .map((_, ix) => ix);
-        hours.forEach((hour) => {
-          const time1 = new Temporal.Time(hour);
-          const time2 = time1.plus(Temporal.Duration.from('PT9H'));
-          equal(`${time1.difference(time2)}`, 'PT9H');
-        });
-
-        const zeroTo59 = Array(60)
-          .fill()
-          .map((_, ix) => ix);
-        zeroTo59.forEach((num) => {
-          const minute1 = new Temporal.Time(23, num);
-          const minute2 = minute1.plus(Temporal.Duration.from('PT45M'));
-          equal(`${minute1.difference(minute2)}`, 'PT45M');
-
-          const second1 = new Temporal.Time(23, 59, num);
-          const second2 = second1.plus(Temporal.Duration.from('PT45S'));
-          equal(`${second1.difference(second2)}`, 'PT45S');
-        });
-
-        const last10 = Array(10)
-          .fill()
-          .map((_, ix) => ix + 990);
-        last10.forEach((num) => {
-          const ms1 = new Temporal.Time(23, 59, 59, num);
-          const ms2 = ms1.plus(Temporal.Duration.from('PT0.008S'));
-          equal(`${ms1.difference(ms2)}`, 'PT0.008S');
-
-          const µs1 = new Temporal.Time(23, 59, 59, 999, num);
-          const µs2 = µs1.plus(Temporal.Duration.from('PT0.000008S'));
-          equal(`${µs1.difference(µs2)}`, 'PT0.000008S');
-
-          const ns1 = new Temporal.Time(23, 59, 59, 999, 999, num);
-          const ns2 = ns1.plus(Temporal.Duration.from('PT0.000000008S'));
-          equal(`${ns1.difference(ns2)}`, 'PT0.000000008S');
-        });
+      it('reverse argument order will throw', () => {
+        throws(() => one.difference(time, { largestUnit: 'minutes' }), RangeError);
       });
       it("doesn't cast argument", () => {
         throws(() => time.difference({ hour: 16, minute: 34 }), TypeError);
@@ -296,18 +225,18 @@ describe('Time', () => {
       const time1 = Time.from('10:23:15');
       const time2 = Time.from('17:15:57');
       it('the default largest unit is at least hours', () => {
-        equal(`${time1.difference(time2)}`, 'PT6H52M42S');
-        equal(`${time1.difference(time2, { largestUnit: 'hours' })}`, 'PT6H52M42S');
+        equal(`${time2.difference(time1)}`, 'PT6H52M42S');
+        equal(`${time2.difference(time1, { largestUnit: 'hours' })}`, 'PT6H52M42S');
       });
       it('higher units have no effect', () => {
-        equal(`${time1.difference(time2, { largestUnit: 'days' })}`, 'PT6H52M42S');
-        equal(`${time1.difference(time2, { largestUnit: 'weeks' })}`, 'PT6H52M42S');
-        equal(`${time1.difference(time2, { largestUnit: 'months' })}`, 'PT6H52M42S');
-        equal(`${time1.difference(time2, { largestUnit: 'years' })}`, 'PT6H52M42S');
+        equal(`${time2.difference(time1, { largestUnit: 'days' })}`, 'PT6H52M42S');
+        equal(`${time2.difference(time1, { largestUnit: 'weeks' })}`, 'PT6H52M42S');
+        equal(`${time2.difference(time1, { largestUnit: 'months' })}`, 'PT6H52M42S');
+        equal(`${time2.difference(time1, { largestUnit: 'years' })}`, 'PT6H52M42S');
       });
       it('can return lower units', () => {
-        equal(`${time1.difference(time2, { largestUnit: 'minutes' })}`, 'PT412M42S');
-        equal(`${time1.difference(time2, { largestUnit: 'seconds' })}`, 'PT24762S');
+        equal(`${time2.difference(time1, { largestUnit: 'minutes' })}`, 'PT412M42S');
+        equal(`${time2.difference(time1, { largestUnit: 'seconds' })}`, 'PT24762S');
       });
     });
     describe('Time.compare() works', () => {

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -174,9 +174,8 @@ describe('YearMonth', () => {
   describe('YearMonth.difference() works', () => {
     const nov94 = YearMonth.from('1994-11');
     const jun13 = YearMonth.from('2013-06');
-    const diff = nov94.difference(jun13);
-    it(`${nov94}.difference(${jun13}) == ${jun13}.difference(${nov94})`, () =>
-      equal(`${diff}`, `${jun13.difference(nov94)}`));
+    const diff = jun13.difference(nov94);
+    it('throws if out of order', () => throws(() => nov94.difference(jun13), RangeError));
     it(`${nov94}.plus(${diff}) == ${jun13}`, () => nov94.plus(diff).equals(jun13));
     it(`${jun13}.minus(${diff}) == ${nov94}`, () => jun13.minus(diff).equals(nov94));
     it("doesn't cast argument", () => {

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -287,11 +287,9 @@
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalAbsolute]]).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"* », *"seconds"*).
         1. If ! CompareTemporalAbsolute(_absolute_, _other_) &lt; 0, then
-          1. Let _greater_ be _otherAbsolute_.
-          1. Let _smaller_ be _absolute_.
-        1. Else,
-          1. Let _greater_ be _absolute_.
-          1. Let _smaller_ be _otherAbsolute_.
+          1. Throw a *RangeError* exception.
+        1. Let _greater_ be _absolute_.
+        1. Let _smaller_ be _otherAbsolute_.
         1. Let _ns_ be _greater_.[[Nanoseconds]] - _smaller_.[[Nanoseconds]].
         1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _ns_, _largestUnit_).
         1. Return ? CreateTemporalDuration(0, 0, 0, _result_.[[Days]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).

--- a/spec/date.html
+++ b/spec/date.html
@@ -366,11 +366,9 @@
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalDate]]).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"* », *"days"*).
         1. If ! CompareTemporalDate(_temporalDate_, _other_) &lt; 0, then
-          1. Let _greater_ be _other_.
-          1. Let _smaller_ be _temporalDate_.
-        1. Else,
-          1. Let _greater_ be _temporalDate_.
-          1. Let _smaller_ be _other_.
+          1. Throw a *RangeError* exception.
+        1. Let _greater_ be _temporalDate_.
+        1. Let _smaller_ be _other_.
         1. Let _result_ be ? DifferenceDate(_smaller_, _greater_, _largestUnit_).
         1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -422,11 +422,9 @@
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalDateTime]]).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"days"*).
         1. If ! CompareTemporalDateTime(_dateTime_, _other_) &lt; 0, then
-          1. Let _greater_ be _other_.
-          1. Let _smaller_ be _dateTime_.
-        1. Else,
-          1. Let _greater_ be _dateTime_.
-          1. Let _smaller_ be _other_.
+          1. Throw a *RangeError* exception.
+        1. Let _greater_ be _dateTime_.
+        1. Let _smaller_ be _other_.
         1. Let _timeDifference_ be ! DifferenceTime(_smaller_, _greater_).
         1. Let _balanceResult_ be ? BalanceDate(_greater_.[[ISOYear]], _greater_.[[ISOMonth]], _greater_.[[ISODay]] + _timeDifference_.[[Days]]).
         1. Let _dateDifference_ be ! DifferenceDate(_smaller_, _balanceResult_, _largestUnit_).

--- a/spec/time.html
+++ b/spec/time.html
@@ -291,11 +291,9 @@
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalTime]]).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"hours"*).
         1. If ! CompareTemporalTime(_temporalTime_, _other_) &lt; 0, then
-          1. Let _greater_ be _other_.
-          1. Let _smaller_ be _temporalTime_.
-        1. Else,
-          1. Let _greater_ be _temporalTime_.
-          1. Let _smaller_ be _other_.
+          1. Throw a *RangeError* exception.
+        1. Let _greater_ be _temporalTime_.
+        1. Let _smaller_ be _other_.
         1. Let _result_ be ! DifferenceTime(_smaller_, _greater_).
         1. If _result_.[[Hour]] &geq; 12, then
           1. Set _result_ to ! BalanceDuration(0, 24 &minus; _result_.[[Hour]], &minus;_result_.[[Minute]], &minus;_result_.[[Second]], &minus;_result_.[[Millisecond]], &minus;_result_.[[Microsecond]], &minus;_result_.[[Nanosecond]], _largestUnit_).

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -257,11 +257,9 @@
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalYearMonth]]).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"weeks"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"* », *"years"*).
         1. If ! CompareTemporalYearMonth(_yearMonth_, _other_) &lt; 0, then
-          1. Let _greater_ be _other_.
-          1. Let _smaller_ be _yearMonth_.
-        1. Else,
-          1. Let _greater_ be _yearMonth_.
-          1. Let _smaller_ be _other_.
+          1. Throw a *RangeError* exception.
+        1. Let _greater_ be _yearMonth_.
+        1. Let _smaller_ be _other_.
         1. Let _years_ be _greater_.[[ISOYear]] - _smaller_.[[ISOYear]].
         1. Let _months_ be _greater_.[[ISOMonth]] - _smaller_.[[ISOMonth]].
         1. If _months_ &lt; 0, then


### PR DESCRIPTION
This PR:
a) Changes `difference()` to throw if `other` is larger than `this`, which prevents users from accidentally treating invalid negative differences as valid positive differences. Fixes #663.  
b) Because `difference()` is now unidirectional, it doesn't make sense to restrict `Time.prototype.difference` to 12 hours max. Fixes #597.  Ideally (a) and (b) would be separate PRs, but the implementation was hard to split so I combined into one PR.

Although (a) will likely be considered non-ideal ergonomics, the exception will likely be helpful to generate feedback from polyfill early adopters about what they want the behavior to be and what they think is the best long-term option, e.g.:

- option 1 - previous behavior: `difference()` returns an absolute value
- option 2 - behavior in this commit: throw if other is larger
- option 3 - negative durations (#558)

This PR updates tests to make it easy to choose any of the three options in a later release.  The (few) tests for option 1 are commented out but still checked in to make it easy to choose option 1 later.  The rest of test changes were reversing arguments which are compatible with all three options. This means that choosing either (1) or (3) later will break few existing tests.
