### PR TITLE
TimeZone `getTransitions` -> `getNextTransition` & `getPreviousTransition`

### DIFF
--- a/docs/cookbook/getInstantOfNearestOffsetTransitionToInstant.mjs
+++ b/docs/cookbook/getInstantOfNearestOffsetTransitionToInstant.mjs
@@ -12,9 +12,9 @@ function getInstantOfNearestOffsetTransitionToInstant(absolute, timeZone, inclus
   let nearest;
   if (inclusive) {
     // In case absolute itself is the moment of a transition:
-    [nearest] = timeZone.getTransitions(absolute.minus({ nanoseconds: 1 }));
+    nearest = timeZone.getNextTransition(absolute.minus({ nanoseconds: 1 }));
   } else {
-    [nearest] = timeZone.getTransitions(absolute);
+    nearest = timeZone.getNextTransition(absolute);
   }
   return nearest;
 }

--- a/docs/cookbook/getInstantWithLocalTimeInZone.mjs
+++ b/docs/cookbook/getInstantWithLocalTimeInZone.mjs
@@ -41,16 +41,13 @@ function getInstantWithLocalTimeInZone(dateTime, timeZone, disambiguation = 'ear
     case 'clipEarlier':
       if (possible.length === 0) {
         const before = dateTime.inTimeZone(timeZone, { disambiguation: 'earlier' });
-        return timeZone
-          .getTransitions(before)
-          .next()
-          .value.minus({ nanoseconds: 1 });
+        return timeZone.getNextTransition(before).minus({ nanoseconds: 1 });
       }
       return possible[0];
     case 'clipLater':
       if (possible.length === 0) {
         const before = dateTime.inTimeZone(timeZone, { disambiguation: 'earlier' });
-        return timeZone.getTransitions(before).next().value;
+        return timeZone.getNextTransition(before);
       }
       return possible[possible.length - 1];
   }

--- a/docs/now.md
+++ b/docs/now.md
@@ -45,7 +45,7 @@ Example usage:
 // When is the next daylight saving change from now, in the current location?
 tz = Temporal.now.timeZone();
 now = Temporal.now.absolute();
-[nextTransition] = tz.getTransitions(now);
+nextTransition = tz.getNextTransition(now);
 before = tz.getOffsetStringFor(nextTransition.minus({nanoseconds: 1}));
 after = tz.getOffsetStringFor(nextTransition.plus({nanoseconds: 1}));
 console.log(`On ${nextTransition.inTimeZone(tz)} the clock will change from UTC ${before} to ${after}`);

--- a/docs/timezone-draft.md
+++ b/docs/timezone-draft.md
@@ -115,9 +115,11 @@ class Temporal.TimeZone {
    * selected, depending on the disambiguation option. */
   getPossibleAbsolutesFor(dateTime : Temporal.DateTime) : array<Temporal.Absolute>;
 
-  /** Returns an iterator of all following offset transitions, starting
-   * from @startingPoint. */
-  *getTransitions(startingPoint : Temporal.Absolute) : iterator<Temporal.Absolute>;
+  /** Return the next time zone transition after `startingPoint`. */
+  getNextTransition(startingPoint : Temporal.Absolute) : Temporal.Absolute;
+
+  /** Return the previous time zone transition before `startingPoint`. */
+  getPreviousTransition(startingPoint : Temporal.Absolute) : Temporal.Absolute;
 
   // API methods that a subclassed custom time zone doesn't need to touch
 
@@ -173,8 +175,12 @@ class OffsetTimeZone extends Temporal.TimeZone {
     return [new Temporal.Absolute(epochNs + BigInt(this.#offsetNs))];
   }
 
-  *getTransitions(/* startingPoint */) {
-    // no transitions ever
+  getNextTransition(/* startingPoint */) {
+    return undefined; // no transitions ever
+  }
+
+  getPreviousTransition(/* startingPoint */) {
+    return undefined; // no transitions ever
   }
 }
 ```

--- a/docs/timezone-draft.md
+++ b/docs/timezone-draft.md
@@ -116,10 +116,10 @@ class Temporal.TimeZone {
   getPossibleAbsolutesFor(dateTime : Temporal.DateTime) : array<Temporal.Absolute>;
 
   /** Return the next time zone transition after `startingPoint`. */
-  getNextTransition(startingPoint : Temporal.Absolute) : Temporal.Absolute;
+  getNextTransition(startingPoint : Temporal.Absolute) : Temporal.Absolute | null;
 
   /** Return the previous time zone transition before `startingPoint`. */
-  getPreviousTransition(startingPoint : Temporal.Absolute) : Temporal.Absolute;
+  getPreviousTransition(startingPoint : Temporal.Absolute) : Temporal.Absolute | null;
 
   // API methods that a subclassed custom time zone doesn't need to touch
 
@@ -176,11 +176,11 @@ class OffsetTimeZone extends Temporal.TimeZone {
   }
 
   getNextTransition(/* startingPoint */) {
-    return undefined; // no transitions ever
+    return null; // no transitions ever
   }
 
   getPreviousTransition(/* startingPoint */) {
-    return undefined; // no transitions ever
+    return null; // no transitions ever
   }
 }
 ```

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -61,7 +61,7 @@ For example:
 tz1 = new Temporal.TimeZone('-08:00');
 tz2 = new Temporal.TimeZone('America/Vancouver');
 abs = Temporal.DateTime.from({year: 2020, month: 1, day: 1}).inTimeZone(tz2);
-tz1.getNextTransition(abs);  // => undefined
+tz1.getNextTransition(abs);  // => null
 tz2.getPreviousTransition(abs);  // => 2020-03-08T10:00Z
 ```
 
@@ -248,7 +248,7 @@ This method is used to calculate future DST transitions after `startingPoint` fo
 
 
 Note that if the time zone was constructed from a UTC offset, there will be no DST transitions.
-In that case, this method will return `undefined`.
+In that case, this method will return `null`.
 
 Example usage:
 
@@ -271,7 +271,7 @@ duration.toLocaleString();  // output will vary
 This method is used to calculate past DST transitions before `startingPoint` for this time zone.
 
 Note that if the time zone was constructed from a UTC offset, there will be no DST transitions.
-In that case, this method will return `undefined`.
+In that case, this method will return `null`.
 
 Example usage:
 

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -569,8 +569,8 @@ export namespace Temporal {
     getOffsetStringFor?(absolute: Temporal.Absolute): string;
     getDateTimeFor?(absolute: Temporal.Absolute): Temporal.DateTime;
     getAbsoluteFor?(dateTime: Temporal.DateTime, options?: ToAbsoluteOptions): Temporal.Absolute;
-    getNextTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null | undefined;
-    getPreviousTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null | undefined;
+    getNextTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null;
+    getPreviousTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null;
     getPossibleAbsolutesFor(dateTime: Temporal.DateTime): Temporal.Absolute[];
     toString(): string;
     toJSON?(): string;
@@ -597,8 +597,8 @@ export namespace Temporal {
     getOffsetStringFor(absolute: Temporal.Absolute): string;
     getDateTimeFor(absolute: Temporal.Absolute, calendar?: CalendarProtocol | string): Temporal.DateTime;
     getAbsoluteFor(dateTime: Temporal.DateTime, options?: ToAbsoluteOptions): Temporal.Absolute;
-    getNextTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null | undefined;
-    getPreviousTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null | undefined;
+    getNextTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null;
+    getPreviousTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null;
     getPossibleAbsolutesFor(dateTime: Temporal.DateTime): Temporal.Absolute[];
     toString(): string;
     toJSON(): string;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -597,8 +597,8 @@ export namespace Temporal {
     getOffsetStringFor(absolute: Temporal.Absolute): string;
     getDateTimeFor(absolute: Temporal.Absolute, calendar?: CalendarProtocol | string): Temporal.DateTime;
     getAbsoluteFor(dateTime: Temporal.DateTime, options?: ToAbsoluteOptions): Temporal.Absolute;
-    getNextTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null;
-    getPreviousTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null;
+    getNextTransition(startingPoint: Temporal.Absolute): Temporal.Absolute | null;
+    getPreviousTransition(startingPoint: Temporal.Absolute): Temporal.Absolute | null;
     getPossibleAbsolutesFor(dateTime: Temporal.DateTime): Temporal.Absolute[];
     toString(): string;
     toJSON(): string;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -569,7 +569,8 @@ export namespace Temporal {
     getOffsetStringFor?(absolute: Temporal.Absolute): string;
     getDateTimeFor?(absolute: Temporal.Absolute): Temporal.DateTime;
     getAbsoluteFor?(dateTime: Temporal.DateTime, options?: ToAbsoluteOptions): Temporal.Absolute;
-    getTransitions?(startingPoint: Temporal.Absolute): IteratorResult<Temporal.Absolute>;
+    getNextTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null | undefined;
+    getPreviousTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null | undefined;
     getPossibleAbsolutesFor(dateTime: Temporal.DateTime): Temporal.Absolute[];
     toString(): string;
     toJSON?(): string;
@@ -596,7 +597,8 @@ export namespace Temporal {
     getOffsetStringFor(absolute: Temporal.Absolute): string;
     getDateTimeFor(absolute: Temporal.Absolute, calendar?: CalendarProtocol | string): Temporal.DateTime;
     getAbsoluteFor(dateTime: Temporal.DateTime, options?: ToAbsoluteOptions): Temporal.Absolute;
-    getTransitions(startingPoint: Temporal.Absolute): IteratorResult<Temporal.Absolute>;
+    getNextTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null | undefined;
+    getPreviousTransition?(startingPoint: Temporal.Absolute): Temporal.Absolute | null | undefined;
     getPossibleAbsolutesFor(dateTime: Temporal.DateTime): Temporal.Absolute[];
     toString(): string;
     toJSON(): string;

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -195,7 +195,7 @@ export class TimeZone {
 
     // Offset time zones have no transitions
     if (parseOffsetString(id) !== null) {
-      return undefined;
+      return null;
     }
 
     let epochNanoseconds = GetSlot(startingPoint, EPOCHNANOSECONDS);
@@ -210,7 +210,7 @@ export class TimeZone {
 
     // Offset time zones have no transitions
     if (parseOffsetString(id) !== null) {
-      return undefined;
+      return null;
     }
 
     let epochNanoseconds = GetSlot(startingPoint, EPOCHNANOSECONDS);

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -193,8 +193,8 @@ export class TimeZone {
     if (!ES.IsTemporalAbsolute(startingPoint)) throw new TypeError('invalid Absolute object');
     const id = GetSlot(this, TIMEZONE_ID);
 
-    // Offset time zones have no transitions
-    if (parseOffsetString(id) !== null) {
+    // Offset time zones or UTC have no transitions
+    if (parseOffsetString(id) !== null || id === 'UTC') {
       return null;
     }
 
@@ -208,8 +208,8 @@ export class TimeZone {
     if (!ES.IsTemporalAbsolute(startingPoint)) throw new TypeError('invalid Absolute object');
     const id = GetSlot(this, TIMEZONE_ID);
 
-    // Offset time zones have no transitions
-    if (parseOffsetString(id) !== null) {
+    // Offset time zones or UTC have no transitions
+    if (parseOffsetString(id) !== null || id === 'UTC') {
       return null;
     }
 

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -188,38 +188,35 @@ export class TimeZone {
     );
     return possibleEpochNs.map((ns) => new Absolute(ns));
   }
-  getTransitions(startingPoint) {
+  getNextTransition(startingPoint) {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalAbsolute(startingPoint)) throw new TypeError('invalid Absolute object');
     const id = GetSlot(this, TIMEZONE_ID);
 
     // Offset time zones have no transitions
     if (parseOffsetString(id) !== null) {
-      const result = {
-        next() {
-          return { value: undefined, done: true };
-        }
-      };
-      if (typeof Symbol === 'function') {
-        result[Symbol.iterator] = () => result;
-      }
-      return result;
+      return undefined;
     }
 
     let epochNanoseconds = GetSlot(startingPoint, EPOCHNANOSECONDS);
     const Absolute = GetIntrinsic('%Temporal.Absolute%');
-    const result = {
-      next: () => {
-        epochNanoseconds = ES.GetIANATimeZoneNextTransition(epochNanoseconds, id);
-        const done = epochNanoseconds === null;
-        const value = epochNanoseconds === null ? null : new Absolute(epochNanoseconds);
-        return { done, value };
-      }
-    };
-    if (typeof Symbol === 'function') {
-      result[Symbol.iterator] = () => result;
+    epochNanoseconds = ES.GetIANATimeZoneNextTransition(epochNanoseconds, id);
+    return epochNanoseconds === null ? null : new Absolute(epochNanoseconds);
+  }
+  getPreviousTransition(startingPoint) {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalAbsolute(startingPoint)) throw new TypeError('invalid Absolute object');
+    const id = GetSlot(this, TIMEZONE_ID);
+
+    // Offset time zones have no transitions
+    if (parseOffsetString(id) !== null) {
+      return undefined;
     }
-    return result;
+
+    let epochNanoseconds = GetSlot(startingPoint, EPOCHNANOSECONDS);
+    const Absolute = GetIntrinsic('%Temporal.Absolute%');
+    epochNanoseconds = ES.GetIANATimeZonePreviousTransition(epochNanoseconds, id);
+    return epochNanoseconds === null ? null : new Absolute(epochNanoseconds);
   }
   toString() {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -32,8 +32,10 @@ describe('TimeZone', () => {
         equal(typeof Temporal.TimeZone.prototype.getAbsoluteFor, 'function'));
       it('Temporal.TimeZone.prototype has getPossibleAbsolutesFor', () =>
         equal(typeof Temporal.TimeZone.prototype.getPossibleAbsolutesFor, 'function'));
-      it('Temporal.TimeZone.prototype has getTransitions', () =>
-        equal(typeof Temporal.TimeZone.prototype.getTransitions, 'function'));
+      it('Temporal.TimeZone.prototype has getNextTransition', () =>
+        equal(typeof Temporal.TimeZone.prototype.getNextTransition, 'function'));
+      it('Temporal.TimeZone.prototype has getPreviousTransition', () =>
+        equal(typeof Temporal.TimeZone.prototype.getPreviousTransition, 'function'));
       it('Temporal.TimeZone.prototype has toString', () =>
         equal(typeof Temporal.TimeZone.prototype.toString, 'function'));
     });
@@ -121,7 +123,8 @@ describe('TimeZone', () => {
     it(`${zone} has offset +01:00`, () => equal(zone.getOffsetStringFor(abs), '+01:00'));
     it(`(${zone}).getDateTimeFor(${abs})`, () => assert(zone.getDateTimeFor(abs) instanceof Temporal.DateTime));
     it(`(${zone}).getAbsoluteFor(${dtm})`, () => assert(zone.getAbsoluteFor(dtm) instanceof Temporal.Absolute));
-    it(`(${zone}).getTransitions() => []`, () => equal(ArrayFrom(zone.getTransitions(abs), 4).length, 0));
+    it(`(${zone}).getNextTransition(${abs})`, () => zone.getNextTransition(abs), undefined);
+    it(`(${zone}).getPreviousTransition(${abs})`, () => zone.getPreviousTransition(abs), undefined);
     it('wraps around to the next day', () =>
       equal(`${zone.getDateTimeFor(Temporal.Absolute.from('2020-02-06T23:59Z'))}`, '2020-02-07T00:59'));
   });
@@ -134,7 +137,8 @@ describe('TimeZone', () => {
     it(`${zone} has offset +00:00`, () => equal(zone.getOffsetStringFor(abs), '+00:00'));
     it(`(${zone}).getDateTimeFor(${abs})`, () => assert(zone.getDateTimeFor(abs) instanceof Temporal.DateTime));
     it(`(${zone}).getAbsoluteFor(${dtm})`, () => assert(zone.getAbsoluteFor(dtm) instanceof Temporal.Absolute));
-    it(`(${zone}).getTransitions() => []`, () => equal(ArrayFrom(zone.getTransitions(abs), 4).length, 0));
+    it(`(${zone}).getNextTransition(${abs})`, () => zone.getNextTransition(abs), null);
+    it(`(${zone}).getPreviousTransition(${abs})`, () => zone.getPreviousTransition(abs), null);
   });
   describe('America/Los_Angeles', () => {
     const zone = new Temporal.TimeZone('America/Los_Angeles');
@@ -145,7 +149,18 @@ describe('TimeZone', () => {
     it(`${zone} has offset -08:00`, () => equal(zone.getOffsetStringFor(abs), '-08:00'));
     it(`(${zone}).getDateTimeFor(${abs})`, () => assert(zone.getDateTimeFor(abs) instanceof Temporal.DateTime));
     it(`(${zone}).getAbsoluteFor(${dtm})`, () => assert(zone.getAbsoluteFor(dtm) instanceof Temporal.Absolute));
-    it(`(${zone}).getTransitions() => [4-transitions]`, () => equal(ArrayFrom(zone.getTransitions(abs), 4).length, 4));
+    it(`(${zone}).getNextTransition() x 4 transitions`, () => {
+      for (let i = 0, txn = abs; i < 4; i++) {
+        const transition = zone.getNextTransition(txn);
+        assert(transition);
+      }
+    });
+    it(`(${zone}).getPreviousTransition() x 4 transitions`, () => {
+      for (let i = 0, txn = abs; i < 4; i++) {
+        const transition = zone.getPreviousTransition(txn);
+        assert(transition);
+      }
+    });
   });
   describe('with DST change', () => {
     it('clock moving forward', () => {
@@ -245,39 +260,30 @@ describe('TimeZone', () => {
       );
     });
   });
-  describe('getTransitions works as expected', () => {
+  describe('getNextTransition works as expected', () => {
     it('should not have bug #510', () => {
       // See https://github.com/tc39/proposal-temporal/issues/510 for more.
       const nyc = Temporal.TimeZone.from('America/New_York');
       const a1 = Temporal.Absolute.from('2019-04-16T21:01Z');
       const a2 = Temporal.Absolute.from('1800-01-01T00:00Z');
 
-      equal(
-        nyc
-          .getTransitions(a1)
-          .next()
-          .value.toString(),
-        '2019-11-03T06:00Z'
-      );
-      equal(
-        nyc
-          .getTransitions(a2)
-          .next()
-          .value.toString(),
-        '1883-11-18T17:00Z'
-      );
+      equal(nyc.getNextTransition(a1).toString(), '2019-11-03T06:00Z');
+      equal(nyc.getNextTransition(a2).toString(), '1883-11-18T17:00Z');
+    });
+  });
+
+  describe('getPreviousTransition works as expected', () => {
+    it('should return first and last transition', () => {
+      const london = Temporal.TimeZone.from('Europe/London');
+      const a1 = Temporal.Absolute.from('2020-06-11T21:01Z');
+      const a2 = Temporal.Absolute.from('1848-01-01T00:00Z');
+
+      equal(london.getPreviousTransition(a1).toString(), '2020-03-29T01:00Z');
+      equal(london.getPreviousTransition(a2).toString(), '1847-12-01T00:01:15Z');
     });
   });
 });
 
-function ArrayFrom(iter, limit = Number.POSITIVE_INFINITY) {
-  const result = [];
-  for (let item of iter) {
-    if (result.length >= limit) return result;
-    result.push(item);
-  }
-  return result;
-}
 import { normalize } from 'path';
 if (normalize(import.meta.url.slice(8)) === normalize(process.argv[1])) {
   report(reporter).then((failed) => process.exit(failed ? 1 : 0));

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -123,8 +123,8 @@ describe('TimeZone', () => {
     it(`${zone} has offset +01:00`, () => equal(zone.getOffsetStringFor(abs), '+01:00'));
     it(`(${zone}).getDateTimeFor(${abs})`, () => assert(zone.getDateTimeFor(abs) instanceof Temporal.DateTime));
     it(`(${zone}).getAbsoluteFor(${dtm})`, () => assert(zone.getAbsoluteFor(dtm) instanceof Temporal.Absolute));
-    it(`(${zone}).getNextTransition(${abs})`, () => zone.getNextTransition(abs), undefined);
-    it(`(${zone}).getPreviousTransition(${abs})`, () => zone.getPreviousTransition(abs), undefined);
+    it(`(${zone}).getNextTransition(${abs})`, () => zone.getNextTransition(abs), null);
+    it(`(${zone}).getPreviousTransition(${abs})`, () => zone.getPreviousTransition(abs), null);
     it('wraps around to the next day', () =>
       equal(`${zone.getDateTimeFor(Temporal.Absolute.from('2020-02-06T23:59Z'))}`, '2020-02-07T00:59'));
   });

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -61,8 +61,8 @@ describe('Userland time zone', () => {
     it('converts to string', () => equal(`${obj}`, obj.name));
     it('prints in absolute.toString', () =>
       equal(abs.toString(obj), '1970-01-01T00:00+00:00[Etc/Custom_UTC_Subclass]'));
-    it('has no next transitions', () => obj.getNextTransition());
-    it('has no previous transitions', () => obj.getPreviousTransition());
+    it('has no next transitions', () => assert.equal(obj.getNextTransition(), null));
+    it('has no previous transitions', () => assert.equal(obj.getPreviousTransition(), null));
     it('works in Temporal.now', () => {
       assert(Temporal.now.dateTime(obj) instanceof Temporal.DateTime);
       assert(Temporal.now.date(obj) instanceof Temporal.Date);

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -30,8 +30,12 @@ describe('Userland time zone', () => {
         const epochNs = MakeDate(dayNum, time);
         return [new Temporal.Absolute(epochNs)];
       }
-      getNextTransition(/* absolute */) {}
-      getPreviousTransition(/* absolute */) {}
+      getNextTransition(/* absolute */) {
+        return null;
+      }
+      getPreviousTransition(/* absolute */) {
+        return null;
+      }
     }
 
     const obj = new CustomUTCSubclass();

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -30,7 +30,8 @@ describe('Userland time zone', () => {
         const epochNs = MakeDate(dayNum, time);
         return [new Temporal.Absolute(epochNs)];
       }
-      *getTransitions(/* absolute */) {}
+      getNextTransition(/* absolute */) {}
+      getPreviousTransition(/* absolute */) {}
     }
 
     const obj = new CustomUTCSubclass();
@@ -56,7 +57,8 @@ describe('Userland time zone', () => {
     it('converts to string', () => equal(`${obj}`, obj.name));
     it('prints in absolute.toString', () =>
       equal(abs.toString(obj), '1970-01-01T00:00+00:00[Etc/Custom_UTC_Subclass]'));
-    it('transitions -> []', () => equal(Array.from(obj.getTransitions()).length, 0));
+    it('has no next transitions', () => obj.getNextTransition());
+    it('has no previous transitions', () => obj.getPreviousTransition());
     it('works in Temporal.now', () => {
       assert(Temporal.now.dateTime(obj) instanceof Temporal.DateTime);
       assert(Temporal.now.date(obj) instanceof Temporal.Date);

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -232,10 +232,24 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.timezone.prototype.gettransitions">
-      <h1>Temporal.TimeZone.prototype.getTransitions ( _startingPoint_ )</h1>
+    <emu-clause id="sec-temporal.timezone.prototype.getnexttransition">
+      <h1>Temporal.TimeZone.prototype.getNextTransition ( _startingPoint_ )</h1>
       <p>
-        The `getTransitions` method takes one argument _startingPoint_.
+        The `getNextTransition` method takes one argument _startingPoint_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _timeZone_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
+        1. Perform ? RequireInternalSlot(_startingPoint_, [[InitializedTemporalAbsolute]]).
+        1. <mark>TODO</mark>
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.timezone.prototype.getprevioustransition">
+      <h1>Temporal.TimeZone.prototype.getPreviousTransition ( _startingPoint_ )</h1>
+      <p>
+        The `getPreviousTransition` method takes one argument _startingPoint_.
         The following steps are taken:
       </p>
       <emu-alg>


### PR DESCRIPTION
Replaces `TimeZone.prototype.getTransitions()` with `getPreviousTransition` and `getNextTransition` methods.  Goals of this PR: 
* Support use cases that require looking backwards in time, e.g. "was there a transition last weekend?"
* Simplify what will almost certainly be the most common use case: finding only one next/prev transition. Although actual production use will be more sophisticated than our samples, this PR reduces code (by removing calls to `.next()`, `.value`, and `.done`) in existing cookbook entries, in existing tests (except the one test specifically for array iteration), and in sample code in the docs.

Some issues needing feedback: 
* Should UTC get a fast-path special case (for both next and previous) given that it will be a common time zone used and we know it will return no transitions?  If yes, then what's the right test for UTC?  `id === 'UTC'` ? `id.toUpperCase() === 'UTC'` ? Something else?
* The first transition in the TZ database is Europe/London at 1847-12-01T00:01:15Z, so I set the lower bound of `getPreviousTransition` to be 1847-01-01.  This means that time zones with no DST and stable rules for a long time may have to run hundreds or even as many as 4000 iterations before giving up. That's a lot.  For a 50% savings, would it be safe to extend the iteration step from every 2 weeks to every 4 weeks?  And are there other optimizations that might be worthwhile?  Or is it not worth optimizing because real browser implementations will have access to the underlying tzdata so any optimizations we do in the polyfill are not very relevant for this relatively-little-used method?
* The previous implementation of `getTransitions` returned `undefined` results for offset-only timezones, but `null` results for IANA timezones that lacked any transitions (or at least lacked them during the period that was checked).  I kept this behavior under the assumption that this was intentional. Is it OK that there are different nullish values returned in different cases?
* The spec was incomplete for `getTransitions` so I left it incomplete for the new methods too. Is this OK?

Fixes #613. Also fixes my habit of spelling "previous" in 5 different typo ways. ;-)