### PR TITLE
Fix calendar-related errors in index.d.ts

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -249,7 +249,11 @@ export namespace Temporal {
       options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
-    difference?(smaller: Temporal.Date, larger: Temporal.Date, options: DifferenceOptions);
+    difference?(
+      smaller: Temporal.Date,
+      larger: Temporal.Date,
+      options: DifferenceOptions<'years' | 'months' | 'weeks' | 'days'>
+    );
   };
 
   /**
@@ -276,32 +280,36 @@ export namespace Temporal {
     isLeapYear(date: Temporal.Date): boolean;
     dateFromFields(
       fields: DateLike,
-      options?: AssignmentOptions,
+      options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
     yearMonthFromFields(
       fields: YearMonthLike,
-      options?: AssignmentOptions,
+      options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.YearMonth>
     ): Temporal.YearMonth;
     monthDayFromFields(
       fields: MonthDayLike,
-      options?: AssignmentOptions,
+      options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.MonthDay>
     ): Temporal.MonthDay;
     plus(
       date: Temporal.Date,
       duration: Temporal.Duration,
-      options?: ArithmeticOptions,
+      options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
     minus(
       date: Temporal.Date,
       duration: Temporal.Duration,
-      options?: ArithmeticOptions,
+      options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
-    difference(smaller: Temporal.Date, larger: Temporal.Date, options?: DifferenceOptions);
+    difference(
+      smaller: Temporal.Date,
+      larger: Temporal.Date,
+      options?: DifferenceOptions<'years' | 'months' | 'weeks' | 'days'>
+    );
     toString(): string;
   }
 


### PR DESCRIPTION
This PR fixes two problems in the latest .d.ts's calendar types: 

* Make `options` required in `Calendar`/`CalendarProtocol` methods
  because you can't put a non-optional `constructor` param after an
  optional param.
* Added required `'years' | 'months' | 'weeks' | 'days'` generic type
  parameter to `Calendar`/`CalendarProtocol` use of `DifferenceOptions`

Q: are `'years' | 'months' | 'weeks' | 'days'` the correct valid options?  The `Calendar` docs say only `'years' | 'months' | 'days'` but I assumed that the docs are out of date. 
