### PR TITLE
Fix calendar circular dependency

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -96,13 +96,13 @@ export class Calendar {
   static from(item) {
     if (ES.IsTemporalCalendar(item) || (typeof item === 'object' && item)) return item;
     const stringIdent = ES.ToString(item);
-    return ES.GetBuiltinCalendar(stringIdent);
+    return GetBuiltinCalendar(stringIdent);
   }
 }
 
 MakeIntrinsicClass(Calendar, 'Temporal.Calendar');
 
-export class ISO8601 extends Calendar {
+class ISO8601 extends Calendar {
   constructor(id = 'iso8601') {
     // Needs to be subclassable, that's why the ID is a default argument
     super(id);
@@ -207,7 +207,7 @@ export class ISO8601 extends Calendar {
 // According to documentation for Intl.Locale.prototype.calendar on MDN,
 // 'iso8601' calendar is equivalent to 'gregory' except for ISO 8601 week
 // numbering rules, which we do not currently use in Temporal.
-export class Gregorian extends ISO8601 {
+class Gregorian extends ISO8601 {
   constructor() {
     super('gregory');
   }
@@ -275,7 +275,7 @@ const jpn = {
   }
 };
 
-export class Japanese extends ISO8601 {
+class Japanese extends ISO8601 {
   constructor() {
     super('japanese');
   }
@@ -300,4 +300,19 @@ export class Japanese extends ISO8601 {
     const isoYear = jpn.isoYear(fields.year, fields.era);
     return super.yearMonthFromFields({ ...fields, year: isoYear }, options, constructor);
   }
+}
+
+const BUILTIN_CALENDARS = {
+  gregory: Gregorian,
+  iso8601: ISO8601,
+  japanese: Japanese
+  // To be filled in as builtin calendars are implemented
+};
+
+function GetBuiltinCalendar(id) {
+  if (!(id in BUILTIN_CALENDARS)) throw new RangeError(`unknown calendar ${id}`);
+  return new BUILTIN_CALENDARS[id]();
+}
+export function GetDefaultCalendar() {
+  return GetBuiltinCalendar('iso8601');
 }

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -1,3 +1,4 @@
+import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import {
@@ -23,7 +24,7 @@ export class Date {
     isoYear = ES.ToInteger(isoYear);
     isoMonth = ES.ToInteger(isoMonth);
     isoDay = ES.ToInteger(isoDay);
-    if (calendar === undefined) calendar = ES.GetDefaultCalendar();
+    if (calendar === undefined) calendar = GetDefaultCalendar();
     ES.RejectDate(isoYear, isoMonth, isoDay);
     ES.RejectDateRange(isoYear, isoMonth, isoDay);
     if (!calendar || typeof calendar !== 'object') throw new RangeError('invalid calendar');
@@ -242,7 +243,7 @@ export class Date {
         result = new this(year, month, day, calendar);
       } else {
         let calendar = item.calendar;
-        if (calendar === undefined) calendar = ES.GetDefaultCalendar();
+        if (calendar === undefined) calendar = GetDefaultCalendar();
         calendar = TemporalCalendar.from(calendar);
         result = calendar.dateFromFields(item, options, this);
       }
@@ -250,7 +251,7 @@ export class Date {
       let { year, month, day, calendar } = ES.ParseTemporalDateString(ES.ToString(item));
       ({ year, month, day } = ES.RegulateDate(year, month, day, disambiguation));
       ({ year, month, day } = ES.RegulateDateRange(year, month, day, disambiguation));
-      if (!calendar) calendar = ES.GetDefaultCalendar();
+      if (!calendar) calendar = GetDefaultCalendar();
       calendar = TemporalCalendar.from(calendar);
       result = new this(year, month, day, calendar);
     }

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -1,3 +1,4 @@
+import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 
@@ -41,7 +42,7 @@ export class DateTime {
     millisecond = ES.ToInteger(millisecond);
     microsecond = ES.ToInteger(microsecond);
     nanosecond = ES.ToInteger(nanosecond);
-    if (calendar === undefined) calendar = ES.GetDefaultCalendar();
+    if (calendar === undefined) calendar = GetDefaultCalendar();
     ES.RejectDateTime(isoYear, isoMonth, isoDay, hour, minute, second, millisecond, microsecond, nanosecond);
     ES.RejectDateTimeRange(isoYear, isoMonth, isoDay, hour, minute, second, millisecond, microsecond, nanosecond);
     if (!calendar || typeof calendar !== 'object') throw new RangeError('invalid calendar');
@@ -598,7 +599,7 @@ export class DateTime {
         result = new this(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
       } else {
         let calendar = item.calendar;
-        if (calendar === undefined) calendar = ES.GetDefaultCalendar();
+        if (calendar === undefined) calendar = GetDefaultCalendar();
         calendar = TemporalCalendar.from(calendar);
         const fields = ES.ToTemporalDateTimeRecord(item);
         const TemporalDate = GetIntrinsic('%Temporal.Date%');
@@ -674,7 +675,7 @@ export class DateTime {
         nanosecond,
         disambiguation
       ));
-      if (!calendar) calendar = ES.GetDefaultCalendar();
+      if (!calendar) calendar = GetDefaultCalendar();
       calendar = TemporalCalendar.from(calendar);
       result = new this(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
     }

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -7,11 +7,6 @@ import bigInt from 'big-integer';
 
 import { GetIntrinsic } from './intrinsicclass.mjs';
 import {
-  Gregorian as CalendarGregorian,
-  ISO8601 as CalendarISO8601,
-  Japanese as CalendarJapanese
-} from './calendar.mjs';
-import {
   GetSlot,
   HasSlot,
   EPOCHNANOSECONDS,
@@ -46,13 +41,6 @@ const NS_MAX = bigInt(86400).multiply(1e17);
 const YEAR_MIN = -271821;
 const YEAR_MAX = 275760;
 
-const BUILTIN_CALENDARS = {
-  gregory: CalendarGregorian,
-  iso8601: CalendarISO8601,
-  japanese: CalendarJapanese
-  // To be filled in as builtin calendars are implemented
-};
-
 import * as PARSE from './regex.mjs';
 
 export const ES = ObjectAssign({}, ES2019, {
@@ -83,11 +71,6 @@ export const ES = ObjectAssign({}, ES2019, {
     }
     return result;
   },
-  GetBuiltinCalendar: (id) => {
-    if (!(id in BUILTIN_CALENDARS)) throw new RangeError(`unknown calendar ${id}`);
-    return new BUILTIN_CALENDARS[id]();
-  },
-  GetDefaultCalendar: () => ES.GetBuiltinCalendar('iso8601'),
   FormatCalendarAnnotation: (calendar) => {
     if (calendar.id === 'iso8601') return '';
     return `[c=${calendar.id}]`;

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -1,3 +1,4 @@
+import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { ISO_MONTH, ISO_DAY, REF_ISO_YEAR, CALENDAR, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
@@ -8,7 +9,7 @@ export class MonthDay {
   constructor(isoMonth, isoDay, calendar = undefined, refISOYear = 1972) {
     isoMonth = ES.ToInteger(isoMonth);
     isoDay = ES.ToInteger(isoDay);
-    if (calendar === undefined) calendar = ES.GetDefaultCalendar();
+    if (calendar === undefined) calendar = GetDefaultCalendar();
     refISOYear = ES.ToInteger(refISOYear);
     ES.RejectDate(refISOYear, isoMonth, isoDay);
     ES.RejectDateRange(refISOYear, isoMonth, isoDay);
@@ -119,14 +120,14 @@ export class MonthDay {
         result = new this(month, day, calendar, refISOYear);
       } else {
         let calendar = item.calendar;
-        if (calendar === undefined) calendar = ES.GetDefaultCalendar();
+        if (calendar === undefined) calendar = GetDefaultCalendar();
         calendar = TemporalCalendar.from(calendar);
         result = calendar.monthDayFromFields(item, options, this);
       }
     } else {
       let { month, day, refISOYear, calendar } = ES.ParseTemporalMonthDayString(ES.ToString(item));
       ({ month, day } = ES.RegulateMonthDay(month, day, disambiguation));
-      if (!calendar) calendar = ES.GetDefaultCalendar();
+      if (!calendar) calendar = GetDefaultCalendar();
       calendar = TemporalCalendar.from(calendar);
       if (refISOYear === undefined) refISOYear = 1972;
       result = new this(month, day, calendar, refISOYear);

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -1,3 +1,4 @@
+import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { ISO_YEAR, ISO_MONTH, REF_ISO_DAY, CALENDAR, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
@@ -8,7 +9,7 @@ export class YearMonth {
   constructor(isoYear, isoMonth, calendar = undefined, refISODay = 1) {
     isoYear = ES.ToInteger(isoYear);
     isoMonth = ES.ToInteger(isoMonth);
-    if (calendar === undefined) calendar = ES.GetDefaultCalendar();
+    if (calendar === undefined) calendar = GetDefaultCalendar();
     refISODay = ES.ToInteger(refISODay);
     ES.RejectDate(isoYear, isoMonth, refISODay);
     ES.RejectYearMonthRange(isoYear, isoMonth);
@@ -196,7 +197,7 @@ export class YearMonth {
         result = new this(year, month, calendar, refISODay);
       } else {
         let calendar = item.calendar;
-        if (calendar === undefined) calendar = ES.GetDefaultCalendar();
+        if (calendar === undefined) calendar = GetDefaultCalendar();
         calendar = TemporalCalendar.from(calendar);
         result = calendar.yearMonthFromFields(item, options, this);
       }
@@ -204,7 +205,7 @@ export class YearMonth {
       let { year, month, refISODay, calendar } = ES.ParseTemporalYearMonthString(ES.ToString(item));
       ({ year, month } = ES.RegulateYearMonth(year, month, disambiguation));
       ({ year, month } = ES.RegulateYearMonthRange(year, month, disambiguation));
-      if (!calendar) calendar = ES.GetDefaultCalendar();
+      if (!calendar) calendar = GetDefaultCalendar();
       calendar = TemporalCalendar.from(calendar);
       if (refISODay === undefined) refISODay = 1;
       result = new this(year, month, calendar, refISODay);


### PR DESCRIPTION
This moves the registry of built-in calendars into the calendar file, so
that there is no longer a circular dependency between calendar.mjs and
ecmascript.mjs.

Closes: #674