### PR TITLE
Stop importing regex.mjs twice in ecmascript.mjs

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1546,8 +1546,7 @@ export const ES = ObjectAssign({}, ES2019, {
   }
 });
 
-import * as REGEX from './regex.mjs';
-const OFFSET = new RegExp(`^${REGEX.offset.source}$`);
+const OFFSET = new RegExp(`^${PARSE.offset.source}$`);
 
 function parseOffsetString(string) {
   const match = OFFSET.exec(String(string));


### PR DESCRIPTION
regex.mjs was being imported twice: once as `PARSE` and again as `REGEX`.  With this PR it's now just `PARSE`.