### PR TITLE
Fix Test262 on MacOS / Node14

### DIFF
--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -23,7 +23,11 @@ fi
 
 cd test/
 
-threads=$(nproc --ignore 1)
+if [ "$(uname)" = 'Darwin' ]; then
+  threads=$(sysctl -n hw.logicalcpu)
+else
+  threads=$(nproc --ignore 1)
+fi
 if [ $threads -gt 2 ]; then threads=2; fi
 
 test262-harness \

--- a/polyfill/test/transform.test262.js
+++ b/polyfill/test/transform.test262.js
@@ -4,6 +4,6 @@ const fs = require('fs');
 const {v4: uuid} = require('uuid');
 const filename = '../coverage/tmp/transformer/' + uuid() + '.json';
 fs.mkdirSync('../coverage/tmp/transformer/', { recursive: true });
-fs.writeFileSync(filename, JSON.stringify(globalThis.__coverage__), 'utf-8');
+fs.writeFileSync(filename, JSON.stringify(globalThis.__coverage__ || {}), 'utf-8');
 `;
 };


### PR DESCRIPTION
Fixes #687 which prevented Test262 tests from running in my MacOS/Node14 environment.
- if MacOS, use `sysctl -n hw.logicalcpu` instead of `nproc` in `ci_test.sh`
- defend against undefined `globalThis.__coverage__`