### PR TITLE
Add disambiguation: 'compatible' option to TimeZone.prototype.getAbsoluteFor and DateTime.prototype.inTimeZone 

### DIFF
--- a/docs/ambiguity.md
+++ b/docs/ambiguity.md
@@ -7,9 +7,12 @@ Due to DST time changes, there is a possibility that a wall-clock time either do
 
 There are two mostly equivalent methods that accomplish this conversion: [`Temporal.DateTime.prototype.inTimeZone`](./datetime.html#inTimeZone) and [`Temporal.TimeZone.prototype.getAbsoluteFor`](./timezone.html#getAbsoluteFor).
 The `disambiguation` option to these methods controls what absolute time to return in the case of ambiguity:
-- `earlier` (the default): The earlier of two possible absolute times will be returned.
-- `later`: The later of two possible absolute times will be returned.
-- `reject`: A `RangeError` will be thrown.
+
+- `'compatible'` (the default): Acts like `'earlier'` for backward transitions like the start of DST in the Spring, and `'later'` for forward transitions like the end of DST in the Fall.
+  This matches the behavior of legacy `Date`, of libraries like moment.js, Luxon, and date-fns, and of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
+- `'earlier'`: The earlier of two possible absolute times will be returned.
+- `'later'`: The later of two possible absolute times will be returned.
+- `'reject'`: A `RangeError` will be thrown.
 
 When entering DST, clocks move forward an hour.
 In reality, it is not time that is moving, it is the offset moving.
@@ -25,48 +28,50 @@ It is easier to see what is actually happening when you include the offset.
 ```
 
 The result is that any time between 1:59:59 and 3:00:00 never actually happened.
-In `earlier` mode, the absolute time that is returned will be as if the post-change UTC offset had continued before the change, effectively skipping backwards by the amount of the DST gap (usually 1 hour).
-In `later` mode, the absolute time that is returned will be as if the pre-change UTC offset had continued after the change, effectively skipping forwards by the amount of the DST gap.
+In `'earlier'` mode, the absolute time that is returned will be as if the post-change UTC offset had continued before the change, effectively skipping backwards by the amount of the DST gap (usually 1 hour).
+In `'later'` mode, the absolute time that is returned will be as if the pre-change UTC offset had continued after the change, effectively skipping forwards by the amount of the DST gap.
+In `'compatible'` mode, the same time is returned as `'later'` mode, which matches the behavior of existing JavaScript code that uses legacy `Date`.
 
 ```javascript
 tz = new Temporal.TimeZone('Europe/Berlin');
 dt = new Temporal.DateTime(2019, 3, 31, 2, 45);
-tz.getAbsoluteFor(dt, { disambiguation: 'earlier' });  // => 2019-03-31T00:45Z
-tz.getAbsoluteFor(dt, { disambiguation: 'later' });    // => 2019-03-31T01:45Z
-tz.getAbsoluteFor(dt, { disambiguation: 'reject' });   // throws
+tz.getAbsoluteFor(dt, { disambiguation: 'earlier' }); // => 2019-03-31T00:45Z
+tz.getAbsoluteFor(dt, { disambiguation: 'later' }); // => 2019-03-31T01:45Z
+tz.getAbsoluteFor(dt, { disambiguation: 'compatible' }); // => 2019-03-31T01:45Z
+tz.getAbsoluteFor(dt, { disambiguation: 'reject' }); // throws
 ```
 
 In this example, the wall-clock time 2:45 doesn't exist, so it is treated as either 1:45 +01:00 or 3:45 +02:00, which can be seen by converting the absolute back to a wall-clock time in the time zone:
 
 ```javascript
-tz.getAbsoluteFor(dt, { disambiguation: 'earlier' }).inTimeZone(tz);  // => 2019-03-31T01:45
-tz.getAbsoluteFor(dt, { disambiguation: 'later' }).inTimeZone(tz);  // => 2019-03-31T03:45
+tz.getAbsoluteFor(dt, { disambiguation: 'earlier' }).inTimeZone(tz); // => 2019-03-31T01:45
+tz.getAbsoluteFor(dt, { disambiguation: 'later' }).inTimeZone(tz); // => 2019-03-31T03:45
+tz.getAbsoluteFor(dt, { disambiguation: 'compatible' }).inTimeZone(tz); // => 2019-03-31T03:45
 ```
 
 Using [`Temporal.TimeZone.prototype.getPossibleAbsolutesFor`](./timezone.html#getPossibleAbsolutesFor) we can show that the wall-clock time doesn't exist:
 
 ```javascript
-tz.getPossibleAbsolutesFor(dt);  // => []
+tz.getPossibleAbsolutesFor(dt); // => []
 ```
 
 Likewise, at the end of DST, clocks move backward an hour.
 In this case, the illusion is that an hour repeats itself.
-In `earlier` mode, the absolute time will be the earlier instance of the duplicated wall-clock time.
-In `later` mode, the absolute time will be the later instance of the duplicated time.
+In `'earlier'` mode, the absolute time will be the earlier instance of the duplicated wall-clock time.
+In `'later'` mode, the absolute time will be the later instance of the duplicated time.
+In `'compatible'` mode, the same time is returned as `'earlier'` mode, which matches the behavior of existing JavaScript code that uses legacy `Date`.
 
 ```javascript
 tz = new Temporal.TimeZone('America/Sao_Paulo');
 dt = new Temporal.DateTime(2019, 2, 16, 23, 45);
-dt.inTimeZone(tz, { disambiguation: 'earlier' });  // => 2019-02-17T01:45Z
-dt.inTimeZone(tz, { disambiguation: 'later' });    // => 2019-02-17T02:45Z
-dt.inTimeZone(tz, { disambiguation: 'reject' });   // throws
+dt.inTimeZone(tz, { disambiguation: 'earlier' }); // => 2019-02-17T01:45Z
+dt.inTimeZone(tz, { disambiguation: 'later' }); // => 2019-02-17T02:45Z
+dt.inTimeZone(tz, { disambiguation: 'compatible' }); // => 2019-02-17T01:45Z
+dt.inTimeZone(tz, { disambiguation: 'reject' }); // throws
 ```
 
 In this example, the wall-clock time 23:45 exists twice, which can also be verified with `getPossibleAbsolutesFor`:
 
 ```javascript
-tz.getPossibleAbsolutesFor(dt)  // => [2019-02-17T01:45Z, 2019-02-17T02:45Z]
+tz.getPossibleAbsolutesFor(dt); // => [2019-02-17T01:45Z, 2019-02-17T02:45Z]
 ```
-
-> *Compatibility Note*: The built-in behaviour of the Moment Timezone and Luxon libraries is to give the same result as `earlier` when turning the clock back, and `later` when setting the clock forward.
-This disambiguation behaviour isn't available by default in Temporal, but you can implement it yourself using `getPossibleAbsolutesFor`.

--- a/docs/ambiguity.md
+++ b/docs/ambiguity.md
@@ -8,11 +8,13 @@ Due to DST time changes, there is a possibility that a wall-clock time either do
 There are two mostly equivalent methods that accomplish this conversion: [`Temporal.DateTime.prototype.inTimeZone`](./datetime.html#inTimeZone) and [`Temporal.TimeZone.prototype.getAbsoluteFor`](./timezone.html#getAbsoluteFor).
 The `disambiguation` option to these methods controls what absolute time to return in the case of ambiguity:
 
-- `'compatible'` (the default): Acts like `'earlier'` for backward transitions like the start of DST in the Spring, and `'later'` for forward transitions like the end of DST in the Fall.
-  This matches the behavior of legacy `Date`, of libraries like moment.js, Luxon, and date-fns, and of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
+- `'compatible'` (the default): Acts like `'earlier'` for backward transitions and `'later'` for forward transitions.
 - `'earlier'`: The earlier of two possible absolute times will be returned.
 - `'later'`: The later of two possible absolute times will be returned.
 - `'reject'`: A `RangeError` will be thrown.
+
+When interoperating with existing code or services, `'compatible'` mode matches the behavior of legacy `Date` as well as libraries like moment.js, Luxon, and date-fns.
+This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
 
 When entering DST, clocks move forward an hour.
 In reality, it is not time that is moving, it is the offset moving.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -132,7 +132,7 @@ Here's an example of rounding a time _down_ to the previously occurring whole ho
 ### Preserving local time
 
 Map a zoneless date and time of day into a `Temporal.Absolute` instance at which the local date and time of day in a specified time zone matches it.
-This is easily done with `dateTime.inTimeZone()`, but here is an example of implementing different disambiguation behaviours than the `"earlier"`, `"later"`, and `"reject'` ones built in to Temporal.
+This is easily done with `dateTime.inTimeZone()`, but here is an example of implementing different disambiguation behaviors than the `'compatible'`, `'earlier'`, `'later'`, and `'reject'` ones built in to Temporal.
 
 ```javascript
 {{cookbook/getInstantWithLocalTimeInZone.mjs}}

--- a/docs/cookbook/getInstantWithLocalTimeInZone.mjs
+++ b/docs/cookbook/getInstantWithLocalTimeInZone.mjs
@@ -3,12 +3,9 @@
  * a particular time zone, the same as Temporal.TimeZone.getAbsoluteFor() or
  * Temporal.DateTime.inTimeZone(), but with more disambiguation options.
  *
- * As well as the default Temporal disambiguation options 'earlier', 'later',
- * and 'reject', there are additional options possible:
+ * As well as the default Temporal disambiguation options 'compatible',
+ * 'earlier', 'later', and 'reject', there are additional options possible:
  *
- * - 'earlierLater': Same as what the Moment Timezone and Luxon libraries do;
- *   equivalent to 'earlier' when turning the clock back, and 'later' when
- *   setting the clock forward.
  * - 'clipEarlier': Equivalent to 'earlier' when turning the clock back, and
  *   when setting the clock forward returns the time just before the clock
  *   changes.
@@ -25,7 +22,7 @@
  */
 function getInstantWithLocalTimeInZone(dateTime, timeZone, disambiguation = 'earlier') {
   // Handle the built-in modes first
-  if (['earlier', 'later', 'reject'].includes(disambiguation)) {
+  if (['compatible', 'earlier', 'later', 'reject'].includes(disambiguation)) {
     return timeZone.getAbsoluteFor(dateTime, { disambiguation });
   }
 
@@ -35,9 +32,6 @@ function getInstantWithLocalTimeInZone(dateTime, timeZone, disambiguation = 'ear
   if (possible.length === 1) return possible[0];
 
   switch (disambiguation) {
-    case 'earlierLater':
-      if (possible.length === 0) return timeZone.getAbsoluteFor(dateTime, { disambiguation: 'later' });
-      return possible[0];
     case 'clipEarlier':
       if (possible.length === 0) {
         const before = dateTime.inTimeZone(timeZone, { disambiguation: 'earlier' });
@@ -60,7 +54,7 @@ const nonexistentGermanWallTime = Temporal.DateTime.from('2019-03-31T02:45');
 const germanResults = {
   earlier: /*     */ '2019-03-31T01:45+01:00[Europe/Berlin]',
   later: /*       */ '2019-03-31T03:45+02:00[Europe/Berlin]',
-  earlierLater: /**/ '2019-03-31T03:45+02:00[Europe/Berlin]',
+  compatible: /*  */ '2019-03-31T03:45+02:00[Europe/Berlin]',
   clipEarlier: /* */ '2019-03-31T01:59:59.999999999+01:00[Europe/Berlin]',
   clipLater: /*   */ '2019-03-31T03:00+02:00[Europe/Berlin]'
 };
@@ -77,7 +71,7 @@ const doubleEasternBrazilianWallTime = Temporal.DateTime.from('2019-02-16T23:45'
 const brazilianResults = {
   earlier: /*     */ '2019-02-16T23:45-02:00[America/Sao_Paulo]',
   later: /*       */ '2019-02-16T23:45-03:00[America/Sao_Paulo]',
-  earlierLater: /**/ '2019-02-16T23:45-02:00[America/Sao_Paulo]',
+  compatible: /*  */ '2019-02-16T23:45-02:00[America/Sao_Paulo]',
   clipEarlier: /* */ '2019-02-16T23:45-02:00[America/Sao_Paulo]',
   clipLater: /*   */ '2019-02-16T23:45-03:00[America/Sao_Paulo]'
 };

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -565,8 +565,8 @@ Use `Temporal.DateTime.compare()` for this, or `datetime.equals()` for equality.
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `disambiguation` (string): How to disambiguate if the date and time given by `dateTime` does not exist in the time zone, or exists more than once.
-    Allowed values are `earlier`, `later`, and `reject`.
-    The default is `earlier`.
+    Allowed values are `'compatible'`, `'earlier'`, `'later'`, and `'reject'`.
+    The default is `'compatible'`.
 
 **Returns:** A `Temporal.Absolute` object indicating the absolute time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
 
@@ -574,9 +574,14 @@ This method is one way to convert a `Temporal.DateTime` to a `Temporal.Absolute`
 It is identical to [`(Temporal.TimeZone.from(timeZone || 'UTC')).getAbsoluteFor(dateTime, disambiguation)`](./timezone.html#getAbsoluteFor).
 
 In the case of ambiguity, the `disambiguation` option controls what absolute time to return:
-- `earlier`: The earlier of two possible times.
-- `later`: The later of two possible times.
-- `reject`: Throw a `RangeError` instead.
+- `'compatible'` (the default): Acts like `'earlier'` for backward transitions like the start of DST in the Spring, and `'later'` for forward transitions like the end of DST in the Fall.
+  This matches the behavior of legacy `Date`, of libraries like moment.js, Luxon, and date-fns, and of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
+- `'earlier'`: The earlier of two possible times.
+- `'later'`: The later of two possible times.
+- `'reject'`: Throw a `RangeError` instead.
+
+During "skipped" clock time like the hour after DST starts in the Spring, this method interprets invalid times using the pre-transition time zone offset if `'compatible'` or `'later'` is used or the post-transition time zone offset if `'earlier'` is used.
+This behavior avoids exceptions when converting non-existent `Temporal.DateTime` values to `Temporal.Absolute`, but it also means that values during these periods will result in a different `Temporal.DateTime` in "round-trip" conversions to `Temporal.Absolute` and back again.
 
 For usage examples and a more complete explanation of how this disambiguation works and why it is necessary, see [Resolving ambiguity](./ambiguity.md).
 

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -574,11 +574,13 @@ This method is one way to convert a `Temporal.DateTime` to a `Temporal.Absolute`
 It is identical to [`(Temporal.TimeZone.from(timeZone || 'UTC')).getAbsoluteFor(dateTime, disambiguation)`](./timezone.html#getAbsoluteFor).
 
 In the case of ambiguity, the `disambiguation` option controls what absolute time to return:
-- `'compatible'` (the default): Acts like `'earlier'` for backward transitions like the start of DST in the Spring, and `'later'` for forward transitions like the end of DST in the Fall.
-  This matches the behavior of legacy `Date`, of libraries like moment.js, Luxon, and date-fns, and of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
+- `'compatible'` (the default): Acts like `'earlier'` for backward transitions and `'later'` for forward transitions.
 - `'earlier'`: The earlier of two possible times.
 - `'later'`: The later of two possible times.
 - `'reject'`: Throw a `RangeError` instead.
+
+When interoperating with existing code or services, `'compatible'` mode matches the behavior of legacy `Date` as well as libraries like moment.js, Luxon, and date-fns.
+This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
 
 During "skipped" clock time like the hour after DST starts in the Spring, this method interprets invalid times using the pre-transition time zone offset if `'compatible'` or `'later'` is used or the post-transition time zone offset if `'earlier'` is used.
 This behavior avoids exceptions when converting non-existent `Temporal.DateTime` values to `Temporal.Absolute`, but it also means that values during these periods will result in a different `Temporal.DateTime` in "round-trip" conversions to `Temporal.Absolute` and back again.

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -214,11 +214,13 @@ This method is one way to convert a `Temporal.DateTime` to a `Temporal.Absolute`
 It is identical to [`dateTime.inTimeZone(timeZone, disambiguation)`](./datetime.html#inTimeZone).
 
 In the case of ambiguity, the `disambiguation` option controls what absolute time to return:
-- `'compatible'` (the default): Acts like `'earlier'` for backward transitions like the start of DST in the Spring, and `'later'` for forward transitions like the end of DST in the Fall.
-  This matches the behavior of legacy `Date`, of libraries like moment.js, Luxon, and date-fns, and of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
+- `'compatible'` (the default): Acts like `'earlier'` for backward transitions and `'later'` for forward transitions.
 - `'earlier'`: The earlier of two possible times.
 - `'later'`: The later of two possible times.
 - `'reject'`: Throw a `RangeError` instead.
+
+When interoperating with existing code or services, `'compatible'` mode matches the behavior of legacy `Date` as well as libraries like moment.js, Luxon, and date-fns.
+This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
 
 During "skipped" clock time like the hour after DST starts in the Spring, this method interprets invalid times using the pre-transition time zone offset if `'compatible'` or `'later'` is used or the post-transition time zone offset if `'earlier'` is used.
 This behavior avoids exceptions when converting non-existent `Temporal.DateTime` values to `Temporal.Absolute`, but it also means that values during these periods will result in a different `Temporal.DateTime` in "round-trip" conversions to `Temporal.Absolute` and back again.

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -54,18 +54,20 @@ export namespace Temporal {
      *
      * In case of ambiguous or non-existent times, this option controls what
      * absolute time to return:
+     * - `'compatible'`: Equivalent to `'earlier'` for backward transitions like
+     *   the start of DST in the Spring, and `'later'` for forward transitions
+     *   like the end of DST in the Fall. This matches the behavior of legacy
+     *   `Date`, of libraries like moment.js, Luxon, or date-fns, and of
+     *   cross-platform standards like [RFC 5545
+     *   (iCalendar)](https://tools.ietf.org/html/rfc5545).
      * - `'earlier'`: The earlier time of two possible times
      * - `'later'`: The later of two possible times
-     * - `'reject'`: Throw a RangeError instead.
+     * - `'reject'`: Throw a RangeError instead
      *
-     * The default is `'earlier'`.
-     *
-     * Compatibility Note: the legacy `Date` object (and libraries like
-     * moment.js and Luxon) gives the same result as `earlier` when turning the
-     * clock back, and `later` when setting the clock forward.
+     * The default is `'compatible'`.
      *
      * */
-    disambiguation: 'earlier' | 'later' | 'reject';
+    disambiguation: 'compatible' | 'earlier' | 'later' | 'reject';
   };
 
   /**

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -504,7 +504,7 @@ export const ES = ObjectAssign({}, ES2019, {
     return ES.GetOption(options, 'disambiguation', ['constrain', 'reject'], 'constrain');
   },
   ToTimeZoneTemporalDisambiguation: (options) => {
-    return ES.GetOption(options, 'disambiguation', ['earlier', 'later', 'reject'], 'earlier');
+    return ES.GetOption(options, 'disambiguation', ['compatible', 'earlier', 'later', 'reject'], 'compatible');
   },
   ToDurationSubtractionTemporalDisambiguation: (options) => {
     return ES.GetOption(options, 'disambiguation', ['balanceConstrain', 'balance'], 'balanceConstrain');

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -226,7 +226,7 @@ function extractOverrides(datetime, main) {
   if (datetime instanceof DateTime) {
     calendar = calendar || datetime.calendar.id;
     formatter = formatter || main[DATETIME];
-    datetime = main[TIMEZONE].getAbsoluteFor(datetime, 'earlier');
+    datetime = main[TIMEZONE].getAbsoluteFor(datetime);
   }
   if (datetime instanceof Absolute) {
     formatter = formatter || main[DATETIME];

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -109,6 +109,8 @@ export class TimeZone {
     if (numAbsolutes === 1) return validateAbsolute(possibleAbsolutes[0]);
     if (numAbsolutes) {
       switch (disambiguation) {
+        case 'compatible':
+        // fall through because 'compatible' means 'earlier' for "fall back" transitions
         case 'earlier':
           return validateAbsolute(possibleAbsolutes[0]);
         case 'later':
@@ -142,6 +144,8 @@ export class TimeZone {
         const earlier = dateTime.minus(diff);
         return this.getPossibleAbsolutesFor(earlier)[0];
       }
+      case 'compatible':
+      // fall through because 'compatible' means 'later' for "spring forward" transitions
       case 'later': {
         const later = dateTime.plus(diff);
         const possible = this.getPossibleAbsolutesFor(later);

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -496,11 +496,21 @@ describe('DateTime', () => {
       dt = DateTime.from('-001000-10-29T10:46:38.271986102');
       equal(`${dt.inTimeZone('+06:00')}`, '-001000-10-29T04:46:38.271986102Z');
     });
-    it('datetime with multiple absolute', () => {
+    it('datetime with multiple absolute - Fall DST in Brazil', () => {
       const dt = DateTime.from('2019-02-16T23:45');
+      equal(`${dt.inTimeZone('America/Sao_Paulo')}`, '2019-02-17T01:45Z');
+      equal(`${dt.inTimeZone('America/Sao_Paulo', { disambiguation: 'compatible' })}`, '2019-02-17T01:45Z');
       equal(`${dt.inTimeZone('America/Sao_Paulo', { disambiguation: 'earlier' })}`, '2019-02-17T01:45Z');
       equal(`${dt.inTimeZone('America/Sao_Paulo', { disambiguation: 'later' })}`, '2019-02-17T02:45Z');
       throws(() => dt.inTimeZone('America/Sao_Paulo', { disambiguation: 'reject' }), RangeError);
+    });
+    it('datetime with multiple absolute - Spring DST in Los Angeles', () => {
+      const dt = DateTime.from('2020-03-08T02:30');
+      equal(`${dt.inTimeZone('America/Los_Angeles')}`, '2020-03-08T10:30Z');
+      equal(`${dt.inTimeZone('America/Los_Angeles', { disambiguation: 'compatible' })}`, '2020-03-08T10:30Z');
+      equal(`${dt.inTimeZone('America/Los_Angeles', { disambiguation: 'earlier' })}`, '2020-03-08T09:30Z');
+      equal(`${dt.inTimeZone('America/Los_Angeles', { disambiguation: 'later' })}`, '2020-03-08T10:30Z');
+      throws(() => dt.inTimeZone('America/Los_Angeles', { disambiguation: 'reject' }), RangeError);
     });
     it('throws on bad disambiguation', () => {
       ['', 'EARLIER', 'xyz', 3, null].forEach((disambiguation) =>

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -30,6 +30,10 @@ describe('Intl', () => {
     it('should ignore units not in the data type', () => {
       equal(datetime.toLocaleString('en', { timeZoneName: 'long' }), '11/18/1976, 3:23:30 PM');
     });
+    it('should use compatible disambiguation option', () => {
+      const dstStart = new Temporal.DateTime(2020, 3, 8, 2, 30);
+      equal(`${dstStart.toLocaleString('en', { timeZone: 'America/Los_Angeles' })}`, '3/8/2020, 3:30:00 AM');
+    });
   });
   describe('time.toLocaleString()', () => {
     const time = Temporal.Time.from('1976-11-18T15:23:30');

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -166,15 +166,19 @@ describe('TimeZone', () => {
     it('clock moving forward', () => {
       const zone = new Temporal.TimeZone('Europe/Berlin');
       const dtm = new Temporal.DateTime(2019, 3, 31, 2, 45);
+      equal(`${zone.getAbsoluteFor(dtm)}`, '2019-03-31T01:45Z');
       equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'earlier' })}`, '2019-03-31T00:45Z');
       equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'later' })}`, '2019-03-31T01:45Z');
+      equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'compatible' })}`, '2019-03-31T01:45Z');
       throws(() => zone.getAbsoluteFor(dtm, { disambiguation: 'reject' }), RangeError);
     });
     it('clock moving backward', () => {
       const zone = new Temporal.TimeZone('America/Sao_Paulo');
       const dtm = new Temporal.DateTime(2019, 2, 16, 23, 45);
+      equal(`${zone.getAbsoluteFor(dtm)}`, '2019-02-17T01:45Z');
       equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'earlier' })}`, '2019-02-17T01:45Z');
       equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'later' })}`, '2019-02-17T02:45Z');
+      equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'compatible' })}`, '2019-02-17T01:45Z');
       throws(() => zone.getAbsoluteFor(dtm, { disambiguation: 'reject' }), RangeError);
     });
   });
@@ -219,16 +223,26 @@ describe('TimeZone', () => {
     const dtm = new Temporal.DateTime(2019, 2, 16, 23, 45);
     it('with constant offset', () => {
       const zone = Temporal.TimeZone.from('+03:30');
-      for (const disambiguation of [undefined, 'earlier', 'later', 'reject']) {
+      for (const disambiguation of [undefined, 'compatible', 'earlier', 'later', 'reject']) {
         assert(zone.getAbsoluteFor(dtm, { disambiguation }) instanceof Temporal.Absolute);
       }
     });
-    it('with daylight saving change', () => {
+    it('with daylight saving change - Fall', () => {
       const zone = Temporal.TimeZone.from('America/Sao_Paulo');
       equal(`${zone.getAbsoluteFor(dtm)}`, '2019-02-17T01:45Z');
       equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'earlier' })}`, '2019-02-17T01:45Z');
       equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'later' })}`, '2019-02-17T02:45Z');
+      equal(`${zone.getAbsoluteFor(dtm, { disambiguation: 'compatible' })}`, '2019-02-17T01:45Z');
       throws(() => zone.getAbsoluteFor(dtm, { disambiguation: 'reject' }), RangeError);
+    });
+    it('with daylight saving change - Spring', () => {
+      const dtmLA = new Temporal.DateTime(2020, 3, 8, 2, 30);
+      const zone = Temporal.TimeZone.from('America/Los_Angeles');
+      equal(`${zone.getAbsoluteFor(dtmLA)}`, '2020-03-08T10:30Z');
+      equal(`${zone.getAbsoluteFor(dtmLA, { disambiguation: 'earlier' })}`, '2020-03-08T09:30Z');
+      equal(`${zone.getAbsoluteFor(dtmLA, { disambiguation: 'later' })}`, '2020-03-08T10:30Z');
+      equal(`${zone.getAbsoluteFor(dtmLA, { disambiguation: 'compatible' })}`, '2020-03-08T10:30Z');
+      throws(() => zone.getAbsoluteFor(dtmLA, { disambiguation: 'reject' }), RangeError);
     });
     it('throws on bad disambiguation', () => {
       const zone = Temporal.TimeZone.from('+03:30');

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -43,7 +43,7 @@
   <emu-clause id="sec-temporal-totimezonetemporaldisambiguation" aoid="ToTimeZoneTemporalDisambiguation">
     <h1>ToTimeZoneTemporalDisambiguation ( _options_ )</h1>
     <emu-alg>
-      1. Return ? GetOption(_options_, *"disambiguation"*, « *"earlier"*, *"later"*, *"reject"* », *"earlier"*).
+      1. Return ? GetOption(_options_, *"disambiguation"*, « *"compatible"*, *"earlier"*, *"later"*, *"reject"* », *"compatible"*).
     </emu-alg>
   </emu-clause>
 
@@ -120,7 +120,7 @@
       1. Let _date_ be the date given by _year_, _month_, and _day_.
       1. Return _date_'s week number according to ISO-8601.
     </emu-alg>
-    <emu-note>Beware that dates at the begining of a year may be part of a week from the preceding year, and dates at the end of a year may be part of a week at the beginning of the next year, as the first week of any year is defined as the week that contains the first Thursday of the year.</emu-note>
+    <emu-note>Beware that dates at the beginning of a year may be part of a week from the preceding year, and dates at the end of a year may be part of a week at the beginning of the next year, as the first week of any year is defined as the week that contains the first Thursday of the year.</emu-note>
   </emu-clause>
 
   <emu-clause id="sec-temporal-formatsecondsstringpart" aoid="FormatSecondsStringPart">

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -214,7 +214,7 @@
             1. Return _absolute_.
           1. If _disambiguation_ is *"reject"*, then
             1. Throw a *RangeError* exception.
-        1. <mark>TODO - handle skipped times like Spring DST where "compatible" means "later"</mark>
+        1. <mark>TODO - handle n=0 (skipped times like Spring DST)</mark>
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -203,7 +203,7 @@
           1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
           1. Return _absolute_.
         1. If _n_ ≠ 0, then
-          1. If _disambiguation_ is *"earlier"*, then
+          1. If _disambiguation_ is *"earlier"* or *"compatible"*, then
             1. Let _absolute_ be ? Get(_possibleAbsolutes_, *"0"*).
             1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
             1. Return _absolute_.
@@ -214,7 +214,7 @@
             1. Return _absolute_.
           1. If _disambiguation_ is *"reject"*, then
             1. Throw a *RangeError* exception.
-        1. <mark>TODO.</mark>
+        1. <mark>TODO - handle skipped times like Spring DST where "compatible" means "later"</mark>
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Adds a new `disambiguation: 'compatible'` option to `TimeZone.prototype.getAbsoluteFor` and `DateTime.prototype.inTimeZone`, and makes this new option the default.  Fixes #318.

This new option acts like `'later'` for "Spring Forward" DST transitions, and acts like `'earlier'` for "Fall Back" DST transitions. This behavior matches the disambiguation behavior of legacy `Date`, as well as libraries like moment.js, Luxon, and date-fns that are built on top of legacy `Date`.  It also matches RFC 5545 (iCalendar) required behavior.

To maximize compatibility between Temporal and existing code and to help interop when interoperating with other apps and services, this new 'compatible' option will be the default.

Existing options `'later'`, `'earlier'`, and `'reject'` are still available and their behavior is unchanged.