### PR TITLE
Require `options` bags to be object or undefined

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1533,6 +1533,9 @@ export const ES = ObjectAssign({}, ES2019, {
   ComparisonResult: (value) => (value < 0 ? -1 : value > 0 ? 1 : value),
   GetOption: (options, property, allowedValues, fallback) => {
     if (options === null || options === undefined) return fallback;
+    if (typeof options !== 'object') {
+      throw new TypeError(`Options parameter must be 'object', not '${typeof options}'`);
+    }
     options = ES.ToObject(options);
     let value = options[property];
     if (value !== undefined) {

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -226,7 +226,7 @@ function extractOverrides(datetime, main) {
   if (datetime instanceof DateTime) {
     calendar = calendar || datetime.calendar.id;
     formatter = formatter || main[DATETIME];
-    datetime = main[TIMEZONE].getAbsoluteFor(datetime, 'earlier');
+    datetime = main[TIMEZONE].getAbsoluteFor(datetime);
   }
   if (datetime instanceof Absolute) {
     formatter = formatter || main[DATETIME];

--- a/polyfill/test/ecmascript.mjs
+++ b/polyfill/test/ecmascript.mjs
@@ -5,7 +5,7 @@ import Pretty from '@pipobscure/demitasse-pretty';
 const { reporter } = Pretty;
 
 import { strict as assert } from 'assert';
-const { deepEqual } = assert;
+const { deepEqual, throws } = assert;
 
 import { ES } from '../lib/ecmascript.mjs';
 import { GetSlot, TIMEZONE_ID } from '../lib/slots.mjs';
@@ -397,6 +397,15 @@ describe('ECMAScript', () => {
     function test(nanos, zone, expected) {
       it(`${nanos} @ ${zone}`, () => deepEqual(ES.GetFormatterParts(zone, nanos), expected));
     }
+  });
+
+  describe('GetOption', () => {
+    // https://github.com/tc39/proposal-temporal/issues/692
+    it('Options parameter must be `object` or `undefined`', () => {
+      [1, 'hello', () => 1, true, Symbol('1'), BigInt(1)].forEach((options) =>
+        throws(() => ES.GetOption(options, 'disambiguation', ['constrain', 'reject'], 'constrain'), TypeError)
+      );
+    });
   });
 });
 

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -349,7 +349,7 @@ describe('YearMonth', () => {
   describe('YearMonth.with()', () => {
     it('throws on bad disambiguation', () => {
       ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
-        throws(() => YearMonth.from(2019, 1).with({ month: 2 }, { disambiguation }), RangeError)
+        throws(() => YearMonth.from({ year: 2019, month: 1 }).with({ month: 2 }, { disambiguation }), RangeError)
       );
     });
   });

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -15,6 +15,7 @@
     <emu-alg>
       1. If _options_ is *undefined* or *null*, then
         1. Return _fallback_.
+      1. Assert: Type(_options_) is Object.
       1. Set _options_ to ? ToObject(_options_).
       1. Let _value_ be ? Get(_options_, _property_).
       1. If _value_ is not *undefined*, then


### PR DESCRIPTION
Options parameters should be required to be object or undefined. Fixes #692.

I found two spots in existing polyfill code where non-object `options` parameters were used. This PR fixes these too. Note that one of these fixes (in intl.mjs) matches the exact same fix in #691. Hopefully this won't cause a merge conflict, or if it does then it should be easy to resolve.