### PR TITLE
Fix line numbering for debugging cookbook

### DIFF
--- a/polyfill/test/resolve.cookbook.mjs
+++ b/polyfill/test/resolve.cookbook.mjs
@@ -15,7 +15,7 @@ export function resolve(specifier, parent, defaultResolve) {
 export async function transformSource(source, { url, format }, defaultTransformSource) {
   if (typeof source === 'string' && url !== 'all.mjs' && !url.endsWith('polyfill/lib/index.mjs')) {
     return {
-      source: `import { Temporal } from '${PKG.name}';\nimport assert from 'assert';\n` + source
+      source: `import { Temporal } from '${PKG.name}';import assert from 'assert';` + source
     };
   } else {
     // source could be a buffer, e.g. for WASM


### PR DESCRIPTION
This PR removes line breaks from the extra code added by the cookbook test resolver.

Without this change, IDE debugger breakpoints will hit the wrong lines because the sourcemap line numbers won't match the runtime line numbers.   This makes cookbook tests much harder to run under an IDE debugger.  