### PR TITLE
Correct the TS declaration of `Absolute.prototype.inTimeZone` to make `tzLike` required

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -209,7 +209,7 @@ export namespace Temporal {
       other: Temporal.Absolute,
       options?: DifferenceOptions<'days' | 'hours' | 'minutes' | 'seconds'>
     ): Temporal.Duration;
-    inTimeZone(tzLike?: TimeZoneProtocol | string, calendar?: CalendarProtocol | string): Temporal.DateTime;
+    inTimeZone(tzLike: TimeZoneProtocol | string, calendar?: CalendarProtocol | string): Temporal.DateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(tzLike?: TimeZoneProtocol | string): string;


### PR DESCRIPTION
#649 made the time zone parameter required in `inTimeZone` methods, but in that PR I forgot to update the `Absolute.prototype.inTimeZone` TS declaration. (The declaration of `DateTime.prototype.inTimeZone` was already OK.)
