### PR TITLE
feat: include UMD as output target

### DIFF
--- a/polyfill/.gitignore
+++ b/polyfill/.gitignore
@@ -2,3 +2,4 @@ package-lock.json
 index.js
 node_modules/
 coverage/
+dist/

--- a/polyfill/.npmrc
+++ b/polyfill/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.0",
   "description": "Experimental polyfill for the TC39 Temporal proposal",
   "type": "commonjs",
-  "main": "index.js",
-  "browser": "index.js",
+  "main": "/dist/index.js",
+  "browser": "/dist/index.umd.js",
   "types": "index.d.ts",
   "scripts": {
     "coverage": "c8 report --reporter html",
@@ -60,10 +60,8 @@
   "homepage": "https://tc39.es/proposal-temporal/docs/index.html",
   "files": [
     "index.d.ts",
-    "index.js.map",
-    "rollup.config.js",
-    "rollup-script.config.js",
-    "lib/*"
+    "dist",
+    "lib"
   ],
   "dependencies": {
     "big-integer": "^1.6.48",

--- a/polyfill/rollup.config.js
+++ b/polyfill/rollup.config.js
@@ -4,14 +4,14 @@ import babel from '@rollup/plugin-babel';
 import { terser } from 'rollup-plugin-terser';
 import { env } from 'process';
 
+const libName = 'temporal';
+
 const config = {
   input: 'lib/index.mjs',
-  output: {
-    name: 'temporal',
-    file: 'index.js',
-    format: 'commonjs',
-    sourcemap: true
-  },
+  output: [
+    { name: libName, file: './dist/index.js', format: 'cjs', sourcemap: true },
+    { name: libName, file: './dist/index.umd.js', format: 'umd', sourcemap: true }
+  ],
   plugins: [
     commonjs(),
     resolve({ preferBuiltins: false }),


### PR DESCRIPTION
Summary:

This pull request as intention of adding an extra output "umd". That way i can easily use it with script tag an consume it globally.

Main reason : 
Prototype and Play with proposal-temporal from cdn without having to use import. same as the cookbook is doing with https://tc39.es/proposal-temporal/docs/playground.js