### PR TITLE
Improved debug output

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,6 +21,7 @@ parserOptions:
 ignorePatterns:
   - node_modules/
   - /out/
+  - /polyfill/dist/
   - /polyfill/test262/
   - /polyfill/venv/
   - /polyfill/coverage/

--- a/docs/head.html.part
+++ b/docs/head.html.part
@@ -11,6 +11,55 @@
     <script>
       Temporal = { ...temporal.Temporal };
       Object.assign(Intl, temporal.Intl);
+
+      // Customize output of Temporal objects for Chrome DevTools
+      if (!window.devtoolsFormatters)
+        window.devtoolsFormatters = [];
+      window.devtoolsFormatters.push({
+        header(x) {
+          for (const type of [
+            Temporal.Absolute,
+            Temporal.Calendar,
+            Temporal.Date,
+            Temporal.DateTime,
+            Temporal.Duration,
+            Temporal.MonthDay,
+            Temporal.Time,
+            Temporal.TimeZone,
+            Temporal.YearMonth
+          ]) {
+            if (x instanceof type) return ['span', {}, `${x[Symbol.toStringTag]} <${x}>`];
+          }
+          return null;
+        },
+        hasBody(x) {
+          return x instanceof Temporal.Duration;
+        },
+        body(x) {
+          const out = ['ol', { style: 'list-style-type: none;' }];
+          for (const prop of [
+            'years',
+            'months',
+            'weeks',
+            'days',
+            'hours',
+            'minutes',
+            'seconds',
+            'milliseconds',
+            'microseconds',
+            'nanoseconds'
+          ]) {
+            if (x[prop] !== 0) out.push([
+              'li',
+              {},
+              ['span', { style: 'color: purple;' }, prop],
+              `: `,
+              ['span', { style: 'color: blue;' }, x[prop]]
+            ]);
+          }
+          return out;
+        }
+      });
     </script>
     <style>
       /* https://github.com/kognise/water.css/blob/master/src/variables-light.css */

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,6 @@
     "marked": "^0.7.0",
     "prismjs": "^1.20.0",
     "rollup": "^2.17.1",
-    "rollup-plugin-node-builtins": "^2.1.2",
-    "rollup-plugin-terser": "^6.1.0"
+    "rollup-plugin-node-builtins": "^2.1.2"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,6 +29,7 @@
     "@rollup/plugin-babel": "^5.0.3",
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
+    "@rollup/plugin-replace": "^2.3.3",
     "marked": "^0.7.0",
     "prismjs": "^1.20.0",
     "rollup": "^2.17.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "build:javascript": "rollup -m -c rollup.config.ejs",
+    "build:javascript": "rollup -m -c rollup.config.js",
     "build:docs": "node buildDocs.js"
   },
   "repository": {

--- a/docs/rollup.config.ejs
+++ b/docs/rollup.config.ejs
@@ -2,7 +2,6 @@ import commonjs from "@rollup/plugin-commonjs";
 import babel from "@rollup/plugin-babel";
 import builtins from "rollup-plugin-node-builtins";
 import resolve from "@rollup/plugin-node-resolve";
-import { terser } from 'rollup-plugin-terser';
 
 export default {
   input: "../polyfill/lib/index.mjs",
@@ -28,7 +27,6 @@ export default {
           }
         ]
       ]
-    }),
-    terser()
+    })
   ]
 };

--- a/docs/rollup.config.ejs
+++ b/docs/rollup.config.ejs
@@ -1,6 +1,7 @@
 import commonjs from "@rollup/plugin-commonjs";
 import babel from "@rollup/plugin-babel";
 import builtins from "rollup-plugin-node-builtins";
+import replace from '@rollup/plugin-replace';
 import resolve from "@rollup/plugin-node-resolve";
 
 export default {
@@ -11,6 +12,10 @@ export default {
     format: "umd",
   },
   plugins: [
+    replace({
+      exclude: 'node_modules/**',
+      __debug__: true
+    }),
     commonjs(),
     builtins(),
     resolve({ preferBuiltins: false }),

--- a/docs/rollup.config.js
+++ b/docs/rollup.config.js
@@ -1,15 +1,15 @@
-import commonjs from "@rollup/plugin-commonjs";
-import babel from "@rollup/plugin-babel";
-import builtins from "rollup-plugin-node-builtins";
+import commonjs from '@rollup/plugin-commonjs';
+import babel from '@rollup/plugin-babel';
+import builtins from 'rollup-plugin-node-builtins';
 import replace from '@rollup/plugin-replace';
-import resolve from "@rollup/plugin-node-resolve";
+import resolve from '@rollup/plugin-node-resolve';
 
 export default {
-  input: "../polyfill/lib/index.mjs",
+  input: '../polyfill/lib/index.mjs',
   output: {
-    name: "temporal",
-    file: "playground.js",
-    format: "umd",
+    name: 'temporal',
+    file: 'playground.js',
+    format: 'umd'
   },
   plugins: [
     replace({
@@ -24,11 +24,11 @@ export default {
       babelHelpers: 'bundled',
       presets: [
         [
-          "@babel/preset-env",
+          '@babel/preset-env',
           {
             corejs: 3,
-            useBuiltIns: "entry",
-            targets: "> 0.25%, not dead"
+            useBuiltIns: 'entry',
+            targets: '> 0.25%, not dead'
           }
         ]
       ]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "codecov:test262": "cd polyfill && npm install && npm run codecov:test262 && cd ..",
     "test-cookbook": "cd polyfill && npm install && npm run test-cookbook && cd ..",
     "test262": "cd polyfill && npm install && npm run test262",
-    "lint": "eslint . --ext js,mjs,.d.ts --cache && npm run tscheck",
+    "lint": "eslint . --ext js,mjs,.d.ts --max-warnings 0 --cache && npm run tscheck",
     "tscheck": "tsc polyfill/index.d.ts --noEmit --strict --lib ESNext",
     "build:polyfill": "cd polyfill && npm install && npm run build && cd ..",
     "build:javascript": "npm run build:polyfill && cd docs && npm install && npm run build:javascript",

--- a/polyfill/lib/absolute.mjs
+++ b/polyfill/lib/absolute.mjs
@@ -1,3 +1,5 @@
+/* global __debug__ */
+
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { EPOCHNANOSECONDS, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
@@ -10,6 +12,15 @@ export class Absolute {
     ES.RejectAbsoluteRange(ns);
     CreateSlots(this);
     SetSlot(this, EPOCHNANOSECONDS, ns);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${this}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
   }
 
   getEpochSeconds() {

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1,3 +1,5 @@
+/* global __debug__ */
+
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { CALENDAR_ID, ISO_YEAR, ISO_MONTH, ISO_DAY, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
@@ -6,6 +8,15 @@ export class Calendar {
   constructor(id) {
     CreateSlots(this);
     SetSlot(this, CALENDAR_ID, id);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${this}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
   }
   get id() {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -1,3 +1,5 @@
+/* global __debug__ */
+
 import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
@@ -33,6 +35,15 @@ export class Date {
     SetSlot(this, ISO_MONTH, isoMonth);
     SetSlot(this, ISO_DAY, isoDay);
     SetSlot(this, CALENDAR, calendar);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${this}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
   }
   get year() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -230,7 +230,6 @@ export class DateTime {
   }
   plus(temporalDurationLike, options) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const disambiguation = ES.ToTemporalDisambiguation(options);
     let duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
     let { years, months, days, weeks, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
@@ -296,7 +295,6 @@ export class DateTime {
   }
   minus(temporalDurationLike, options) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const disambiguation = ES.ToTemporalDisambiguation(options);
     let duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
     let { years, months, days, weeks, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -1,3 +1,5 @@
+/* global __debug__ */
+
 import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
@@ -57,6 +59,15 @@ export class DateTime {
     SetSlot(this, MICROSECOND, microsecond);
     SetSlot(this, NANOSECOND, nanosecond);
     SetSlot(this, CALENDAR, calendar);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${this}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
   }
   get year() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -1,3 +1,5 @@
+/* global __debug__ */
+
 import { ES } from './ecmascript.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
 import {
@@ -56,6 +58,15 @@ export class Duration {
     SetSlot(this, MILLISECONDS, milliseconds);
     SetSlot(this, MICROSECONDS, microseconds);
     SetSlot(this, NANOSECONDS, nanoseconds);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${this}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
   }
   get years() {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/initialise.js
+++ b/polyfill/lib/initialise.js
@@ -1,3 +1,8 @@
+if (module.parent && module.parent.id === 'internal/preload') {
+  // Running unbundled as 'npm run playground'
+  globalThis.__debug__ = true;
+}
+
 import('./index.mjs')
   .then(({ Temporal, Intl }) => {
     globalThis.Temporal = { ...Temporal };

--- a/polyfill/lib/intrinsicclass.mjs
+++ b/polyfill/lib/intrinsicclass.mjs
@@ -1,6 +1,35 @@
+/* global __debug__ */
+
 import ESGetIntrinsic from 'es-abstract/GetIntrinsic.js';
 
 const INTRINSICS = {};
+
+const customUtilInspectFormatters = {
+  ['Temporal.Duration'](depth, options) {
+    const descr = options.stylize(`${this[Symbol.toStringTag]} <${this}>`, 'special');
+    if (depth < 1) return descr;
+    const entries = [];
+    for (const prop of [
+      'years',
+      'months',
+      'weeks',
+      'days',
+      'hours',
+      'minutes',
+      'seconds',
+      'milliseconds',
+      'microseconds',
+      'nanoseconds'
+    ]) {
+      if (this[prop] !== 0) entries.push(`  ${prop}: ${options.stylize(this[prop], 'number')}`);
+    }
+    return descr + ' {\n' + entries.join(',\n') + '\n}';
+  }
+};
+
+function defaultUtilInspectFormatter(depth, options) {
+  return options.stylize(`${this[Symbol.toStringTag]} <${this}>`, 'special');
+}
 
 export function MakeIntrinsicClass(Class, name) {
   Object.defineProperty(Class.prototype, Symbol.toStringTag, {
@@ -9,6 +38,14 @@ export function MakeIntrinsicClass(Class, name) {
     enumerable: false,
     configurable: true
   });
+  if (typeof __debug__ !== 'undefined' && __debug__) {
+    Object.defineProperty(Class.prototype, Symbol.for('nodejs.util.inspect.custom'), {
+      value: customUtilInspectFormatters[name] || defaultUtilInspectFormatter,
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
+  }
   const species = function () {
     return this;
   };

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -1,3 +1,5 @@
+/* global __debug__ */
+
 import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
@@ -20,6 +22,15 @@ export class MonthDay {
     SetSlot(this, ISO_DAY, isoDay);
     SetSlot(this, REF_ISO_YEAR, refISOYear);
     SetSlot(this, CALENDAR, calendar);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${this}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
   }
 
   get month() {

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -1,3 +1,5 @@
+/* global __debug__ */
+
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 
@@ -34,6 +36,15 @@ export class Time {
     SetSlot(this, MILLISECOND, millisecond);
     SetSlot(this, MICROSECOND, microsecond);
     SetSlot(this, NANOSECOND, nanosecond);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${this}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
   }
 
   get hour() {

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -1,3 +1,5 @@
+/* global __debug__ */
+
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
 import {
@@ -36,6 +38,15 @@ export class TimeZone {
     }
     CreateSlots(this);
     SetSlot(this, TIMEZONE_ID, timeZoneIdentifier);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${this}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
   }
   get name() {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -1,3 +1,5 @@
+/* global __debug__ */
+
 import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
@@ -19,6 +21,15 @@ export class YearMonth {
     SetSlot(this, ISO_MONTH, isoMonth);
     SetSlot(this, REF_ISO_DAY, refISODay);
     SetSlot(this, CALENDAR, calendar);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${this}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
   }
   get year() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -76,6 +76,7 @@
     "@rollup/plugin-babel": "^5.0.3",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.0.1",
+    "@rollup/plugin-replace": "^2.3.3",
     "c8": "^7.2.0",
     "codecov": "^3.7.0",
     "core-js": "^3.6.4",

--- a/polyfill/rollup.config.js
+++ b/polyfill/rollup.config.js
@@ -1,6 +1,7 @@
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
+import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import { env } from 'process';
 
@@ -13,6 +14,10 @@ const config = {
     { name: libName, file: './dist/index.umd.js', format: 'umd', sourcemap: true }
   ],
   plugins: [
+    replace({
+      exclude: 'node_modules/**',
+      __debug__: env.NODE_ENV !== 'production'
+    }),
     commonjs(),
     resolve({ preferBuiltins: false }),
     babel({


### PR DESCRIPTION
This adds a build-time debug mode, debug-only util.inspect formatters for the Node.js REPL for Temporal objects, a debug-only `_repr_` own data property that will improve devtools output in the various browsers, and a custom formatter for Chrome devtools (unfortunately only works if you enable an obscure setting.)

This is how it looks now, both expanded and unexpanded:

**Chromium** (normal)
![Screenshot from 2020-06-26 16-24-01](https://user-images.githubusercontent.com/459371/85910321-f6cf0900-b7d2-11ea-81ac-b026968b1ff0.png)

**Chromium** (with obscure setting enabled)
![Screenshot from 2020-06-26 17-25-48](https://user-images.githubusercontent.com/459371/85910326-fd5d8080-b7d2-11ea-9929-1c30ade92aa6.png)

**Firefox** (particularly dire as there is no way to change that `Object { … }`, unless you click the expander)
![Screenshot from 2020-06-26 16-15-15](https://user-images.githubusercontent.com/459371/85910343-1bc37c00-b7d3-11ea-98e0-b7923b8e96a5.png)

**Safari**
<img width="498" alt="Screen Shot 2020-06-26 at 5 10 55 PM" src="https://user-images.githubusercontent.com/459371/85910436-9e4c3b80-b7d3-11ea-830c-093ba38dca34.png">


Closes: #643