### PR TITLE
Clarify that .with() methods can accept Temporal objects

### DIFF
--- a/docs/cookbook/meetingPlanner.js
+++ b/docs/cookbook/meetingPlanner.js
@@ -11,8 +11,7 @@ const timeZones = [
 // Start the table at midnight local time
 const calendarNow = now.inTimeZone(here);
 const startTime = calendarNow
-  .getDate()
-  .withTime(Temporal.Time.from('00:00')) // midnight
+  .with(Temporal.Time.from('00:00')) // midnight
   .inTimeZone(here);
 
 // Build the table

--- a/docs/cookbook/storageTank.js
+++ b/docs/cookbook/storageTank.js
@@ -7,8 +7,7 @@ const tankTimeZone = Temporal.TimeZone.from('Europe/Stockholm');
 const tankMidnight = Temporal.now
   .absolute()
   .inTimeZone(tankTimeZone)
-  .getDate()
-  .withTime(Temporal.Time.from('00:00'))
+  .with(Temporal.Time.from('00:00'))
   .inTimeZone(tankTimeZone);
 const atOrAfterMidnight = (x) => Temporal.Absolute.compare(x, tankMidnight) >= 0;
 const dataStartIndex = tankDataX.findIndex(atOrAfterMidnight);

--- a/docs/date.md
+++ b/docs/date.md
@@ -276,6 +276,12 @@ date = Temporal.Date.from('2006-01-24');
 date.with({day: 1});  // => 2006-01-01
 // What's the last day of the next month?
 date.plus({months: 1}).with({day: date.daysInMonth});  // => 2006-02-28
+// Temporal.YearMonth and Temporal.MonthDay also have some of the
+// properties of Temporal.Date:
+yearMonth = Temporal.YearMonth.from('2018-04');
+date.with(yearMonth)  // => 2018-04-24
+monthDay = Temporal.MonthDay.from('02-29')
+date.with(monthDay)  // => 2006-02-28
 ```
 
 ### date.**withCalendar**(_calendar_: object | string) : Temporal.Date

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -333,6 +333,19 @@ Usage example:
 ```javascript
 dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
 dt.with({year: 2015, second: 31})  // => 2015-12-07T03:24:31.000003500
+
+// Temporal.Time, Temporal.Date, Temporal.YearMonth and
+// Temporal.MonthDay also have some of the properties of
+// Temporal.DateTime:
+midnight = Temporal.Time.from({ hour: 0 });
+dt.with(midnight)  // => 1995-12-07T00:00
+// Note: not the same as dt.with({ hour: 0 })!
+date = Temporal.Date.from('2015-03-31');
+dt.with(date)  // => 2015-03-31T03:24:31.000003500
+yearMonth = Temporal.YearMonth.from('2018-04');
+date.with(yearMonth)  // => 2018-04-07T03:24:31.000003500
+monthDay = Temporal.MonthDay.from('02-29')
+date.with(monthDay)  // => 1995-02-28T03:24:30.000003500
 ```
 
 ### datetime.**withCalendar**(_calendar_: object | string) : Temporal.DateTime

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -131,6 +131,14 @@ describe('Date', () => {
       const date = original.with({ day: 17 });
       equal(`${date}`, '1976-11-17');
     });
+    it('date.with(monthDay) works', () => {
+      const date = original.with(Temporal.MonthDay.from('01-01'));
+      equal(`${date}`, '1976-01-01');
+    });
+    it('date.with(yearMonth) works', () => {
+      const date = original.with(Temporal.YearMonth.from('1977-10'));
+      equal(`${date}`, '1977-10-18');
+    });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
         throws(() => original.with({ day: 17 }, { disambiguation }), RangeError)

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -256,6 +256,22 @@ describe('DateTime', () => {
     it('datetime.with({ month: 5, second: 15 } works', () => {
       equal(`${datetime.with({ month: 5, second: 15 })}`, '1976-05-18T15:23:15.123456789');
     });
+    it('datetime.with(time) works', () => {
+      const noon = Temporal.Time.from({ hour: 12 });
+      equal(`${datetime.with(noon)}`, '1976-11-18T12:00');
+    });
+    it('datetimw.with(date) works', () => {
+      const date = Temporal.Date.from('1995-04-07');
+      equal(`${datetime.with(date)}`, '1995-04-07T15:23:30.123456789');
+    });
+    it('datetime.with(monthDay) works', () => {
+      const md = Temporal.MonthDay.from('01-01');
+      equal(`${datetime.with(md)}`, '1976-01-01T15:23:30.123456789');
+    });
+    it('datetime.with(yearMonth) works', () => {
+      const ym = Temporal.YearMonth.from('1977-10');
+      equal(`${datetime.with(ym)}`, '1977-10-18T15:23:30.123456789');
+    });
     it('invalid disambiguation', () => {
       ['', 'CONSTRAIN', 'balance', 3, null].forEach((disambiguation) =>
         throws(() => datetime.with({ day: 5 }, { disambiguation }), RangeError)


### PR DESCRIPTION
The cases where it could make sense to pass a Temporal object:

- Date.with(YearMonth)
- Date.with(MonthDay)
- DateTime.with(Time)
- DateTime.with(Date)
- DateTime.with(YearMonth)
- DateTime.with(MonthDay)

Closes: #713