### PR TITLE
docs: shorten the storageTank coobook example

### DIFF
--- a/docs/cookbook/storageTank.js
+++ b/docs/cookbook/storageTank.js
@@ -4,11 +4,7 @@
 
 // Show data starting from the most recent midnight in the tank's location (Stockholm)
 const tankTimeZone = Temporal.TimeZone.from('Europe/Stockholm');
-const tankMidnight = Temporal.now
-  .absolute()
-  .inTimeZone(tankTimeZone)
-  .with(Temporal.Time.from('00:00'))
-  .inTimeZone(tankTimeZone);
+const tankMidnight = Temporal.now.dateTime(tankTimeZone).with(Temporal.Time.from('00:00')).inTimeZone(tankTimeZone);
 const atOrAfterMidnight = (x) => Temporal.Absolute.compare(x, tankMidnight) >= 0;
 const dataStartIndex = tankDataX.findIndex(atOrAfterMidnight);
 const labelFormatter = new Intl.DateTimeFormat(undefined, {


### PR DESCRIPTION
Shorten the storageTank.js cookbook example slightly. Nothing major, I
just spotted this while working on another PR.