### PR TITLE
Fix year zero leap day

### DIFF
--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -38,7 +38,7 @@ test262-harness \
   --test262Dir ../test262 \
   --prelude "../$PRELUDE" \
   --transformer ./transform.test262.js \
-  $TESTS \
+  "$TESTS" \
   | ./parseResults.py
 RESULT=$?
 

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -697,10 +697,13 @@ export const ES = ObjectAssign({}, ES2019, {
     return `${sign}${offsetHourString}:${offsetMinuteString}`;
   },
   GetEpochFromParts: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
-    let ms = Date.UTC(year, month - 1, day, hour, minute, second, millisecond);
+    // Note: Date.UTC() interprets one and two-digit years as being in the
+    // 20th century, so don't use it
+    const legacyDate = new Date();
+    legacyDate.setUTCHours(hour, minute, second, millisecond);
+    legacyDate.setUTCFullYear(year, month - 1, day);
+    const ms = legacyDate.getTime();
     if (Number.isNaN(ms)) return null;
-    // Date.UTC interprets one and two-digit years as being in the 20th century
-    if (year >= 0 && year < 100) ms = new Date(ms).setUTCFullYear(year);
     let ns = bigInt(ms).multiply(1e6);
     ns = ns.plus(bigInt(microsecond).multiply(1e3));
     ns = ns.plus(bigInt(nanosecond));

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -512,6 +512,11 @@ describe('DateTime', () => {
       dt = DateTime.from('-001000-10-29T10:46:38.271986102');
       equal(`${dt.toAbsolute('+06:00')}`, '-001000-10-29T04:46:38.271986102Z');
     });
+    it('year 0 leap day', () => {
+      const dt = Temporal.DateTime.from('+000000-02-29T00:00');
+      const tz = Temporal.TimeZone.from('Europe/London');
+      equal(`${dt.toAbsolute(tz)}`, '+000000-02-29T00:01:15Z');
+    });
     it('datetime with multiple absolute - Fall DST in Brazil', () => {
       const dt = DateTime.from('2019-02-16T23:45');
       equal(`${dt.toAbsolute('America/Sao_Paulo')}`, '2019-02-17T01:45Z');

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -218,6 +218,11 @@ describe('TimeZone', () => {
       dt = Temporal.DateTime.from('-001000-10-29T10:46:38.271986102');
       equal(`${tz.getAbsoluteFor(dt)}`, '-001000-10-29T04:46:38.271986102Z');
     });
+    it('year 0 leap day', () => {
+      const dt = Temporal.DateTime.from('+000000-02-29T00:00');
+      const tz = Temporal.TimeZone.from('Europe/London');
+      equal(`${tz.getAbsoluteFor(dt)}`, '+000000-02-29T00:01:15Z');
+    });
   });
   describe('getAbsoluteFor disambiguation', () => {
     const dtm = new Temporal.DateTime(2019, 2, 16, 23, 45);


### PR DESCRIPTION
Found by attempting to run the date-fns test suite with Temporal