### PR TITLE
Fix docs navigation

### DIFF
--- a/docs/buildDocs.js
+++ b/docs/buildDocs.js
@@ -45,6 +45,10 @@ class CustomRenderer extends marked.Renderer {
   heading(text, level, raw, slugger) {
     let id = this.options.headerPrefix + slugger.slug(raw); // marked.js default
 
+    // slugger increments it's internal 'seen' accumulator every time we call slug()
+    // we don't want that, we just want the slug output, this reverses the change
+    if (slugger.seen[id] === 0) delete slugger.seen[id];
+
     if (level !== 3) {
       this.toc.push({ id, level, raw });
       return super.heading(text, level, raw, slugger);


### PR DESCRIPTION
For a bit of background on this PR please see this issue: #754 

Essentially a call to `slugger.slug` in the `buildDocs.js` file was causing marked's slugger to increment an internal accumulator and subsequently suffix our headings with a `-1` even though there was only one occurrence of them. This meant items in our TOC were referencing for example `frequently-asked-questions`, but marked was outputting the header with an id set to `frequently-asked-questions-1`.

This PR reverses the accumulator action erroneously caused.