### PR TITLE
Don't need to import Intl from proposal-temporal module

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -25,12 +25,12 @@ $ npm install --save proposal-temporal
 
 In code:
 ```javascript
-const { Temporal, Intl } = require('proposal-temporal');
+const { Temporal } = require('proposal-temporal');
 ```
 
 Or, import the polyfill as an ES6 module:
 ```javascript
-import { Temporal, Intl } from 'proposal-temporal/lib/index.mjs';
+import { Temporal } from 'proposal-temporal/lib/index.mjs';
 ```
 
 ## Node REPL with Temporal

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1,4 +1,4 @@
-const IntlDateTimeFormat = Intl.DateTimeFormat;
+const IntlDateTimeFormat = globalThis.Intl.DateTimeFormat;
 const ObjectAssign = Object.assign;
 
 import bigInt from 'big-integer';

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -18,7 +18,7 @@ const descriptor = (value) => {
   };
 };
 
-const IntlDateTimeFormat = Intl.DateTimeFormat;
+const IntlDateTimeFormat = globalThis.Intl.DateTimeFormat;
 const ObjectAssign = Object.assign;
 
 export function DateTimeFormat(locale = IntlDateTimeFormat().resolvedOptions().locale, options = {}) {


### PR DESCRIPTION
The Intl object is already patched when you require() or import the
module. In addition, if you do it from the Node.js REPL, then the Intl
binding will end up in the temporal dead zone.

Closes: #753