### PR TITLE
Clarify current date cookbook example

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -21,6 +21,9 @@ How to get the current date and time in the local time zone?
 {{cookbook/getCurrentDate.mjs}}
 ```
 
+Note that if you just want the date and not the time, you should use `Temporal.Date`.
+If you want both, use `Temporal.DateTime`.
+
 ### Unix timestamp
 
 How to get a Unix timestamp?

--- a/docs/cookbook/getCurrentDate.mjs
+++ b/docs/cookbook/getCurrentDate.mjs
@@ -5,5 +5,8 @@
  *
  */
 
-const dateTime = Temporal.now.dateTime(); // Gets the current date
-dateTime.toString(); // returns the date in ISO 8601 date format
+const date = Temporal.now.date(); // Gets the current date
+date.toString(); // returns the date in ISO 8601 date format
+
+// If you additionally want the time:
+Temporal.now.dateTime().toString(); // date and time in ISO 8601 format


### PR DESCRIPTION
As reported in the issue, the Stack Overflow question was about getting
the current date, not the current date and time. Change our example
accordingly, but also note how to get the date and time as well.

Closes: #752