### PR TITLE
Document all default values in JSDoc. Fixes #765

### DIFF
--- a/docs/buildDocs.js
+++ b/docs/buildDocs.js
@@ -1,5 +1,6 @@
 const fs = require('fs').promises;
 const marked = require('marked');
+const mkdirp = require('mkdirp');
 const path = require('path');
 const Prism = require('prismjs');
 const loadLanguages = require('prismjs/components/');
@@ -92,6 +93,7 @@ class CustomRenderer extends marked.Renderer {
 }
 
 async function render(markdownFile, head, tail) {
+  await mkdirp('../out/docs/assets');
   let markdownText = await fs.readFile(markdownFile, { encoding });
 
   // Resolve transcludes

--- a/docs/cookbook/getInstantWithLocalTimeInZone.mjs
+++ b/docs/cookbook/getInstantWithLocalTimeInZone.mjs
@@ -16,7 +16,7 @@
  *   convert
  * @param {Temporal.TimeZone} timeZone - Time zone in which to consider the
  *   wall-clock time
- * @param {string} disambiguation - Disambiguation mode, see description.
+ * @param {string} [disambiguation='earlier'] - Disambiguation mode, see description.
  * @returns {Temporal.Absolute} Absolute time in timeZone at the time of the
  *   calendar date and wall-clock time from dateTime
  */

--- a/docs/cookbook/getSortedLocalDateTimes.mjs
+++ b/docs/cookbook/getSortedLocalDateTimes.mjs
@@ -4,7 +4,7 @@
  *
  *
  * @param {Temporal.DateTime[]} dateTimes - This is a DateTime instance
- * @param {boolean} direction - reverse
+ * @param {boolean} [reverse=false] - Return in reversed order
  * @returns {Temporal.DateTime[]} the array from dateTimes, sorted
  */
 function getSortedLocalDateTimes(dateTimes, reverse = false) {

--- a/docs/cookbook/sortAbsoluteInstants.mjs
+++ b/docs/cookbook/sortAbsoluteInstants.mjs
@@ -5,7 +5,7 @@
  * sequentially).
  *
  * @param {string[]} parseableAbsoluteStrings - a group of ISO Strings
- * @param {boolean} reverse - ascending or descending order
+ * @param {boolean} [reverse=false] - ascending or descending order
  * @returns {string[]} the array from parseableAbsoluteStrings, sorted
  */
 function getSortedInstants(parseableAbsoluteStrings, reverse = false) {

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/tc39/proposal-temporal#readme",
   "devDependencies": {
     "marked": "^0.7.0",
+    "mkdirp": "^1.0.4",
     "prismjs": "^1.20.0"
   }
 }


### PR DESCRIPTION
I found one more instance while working on #765.

Also, on a clean clone, the `npm run build:docs` command errors because of missing target directory structure with

```sh
[Error: ENOENT: no such file or directory, open 'PROJECT_ROOT/out/docs/README.html'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '$PROJECT_ROOT/out/docs/README.html'
}
```

(multiple places, I replaced the actual value with `$PROJECT_ROOT` here).