### PR TITLE
Fix file paths to be relative in polyfill package.json

### DIFF
--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -3,8 +3,8 @@
   "version": "0.3.0",
   "description": "Experimental polyfill for the TC39 Temporal proposal",
   "type": "commonjs",
-  "main": "/dist/index.js",
-  "browser": "/dist/index.umd.js",
+  "main": "dist/index.js",
+  "browser": "dist/index.umd.js",
   "types": "index.d.ts",
   "scripts": {
     "coverage": "c8 report --reporter html",


### PR DESCRIPTION
The polyfill had the `main` and `browser` fields containing absolute file paths, when [they should be relative](https://docs.npmjs.com/configuring-npm/package-json#main). This caused CommonJS `require()` to fail in NodeJS when following the usage instructions in the README:

```sh
$ npm init -y
$ npm install --save proposal-temporal
$ node
Welcome to Node.js v14.0.0.
Type ".help" for more information.
> const { Temporal } = require('proposal-temporal')
Uncaught:
Error: Cannot find module '/dist/index.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (internal/modules/cjs/loader.js:323:19)
    at Function.Module._findPath (internal/modules/cjs/loader.js:680:18)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:1001:27)
    at Function.Module._load (internal/modules/cjs/loader.js:884:27)
    at Module.require (internal/modules/cjs/loader.js:1074:19)
    at require (internal/modules/cjs/helpers.js:72:18) {
  code: 'MODULE_NOT_FOUND',
  path: '/path/to/temp/temporal-npm/node_modules/proposal-temporal/package.json',
  requestPath: 'proposal-temporal'
}
```