### PR TITLE
Fix EditorConfig indent size to agree with Prettier

### DIFF
--- a/.editorConfig
+++ b/.editorConfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
A small tweak to make sure the various formatting tools don't conflict.