### PR TITLE
Fix Intl test failure when running in other time zones

### DIFF
--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -15,7 +15,7 @@ describe('Intl', () => {
   // TODO: move these to their respective test files.
 
   function maybeGetWeekdayOnlyFormat() {
-    const fmt = new Intl.DateTimeFormat('en', { weekday: 'long' });
+    const fmt = new Intl.DateTimeFormat('en', { weekday: 'long', timeZone: 'Europe/Vienna' });
     if (
       ['era', 'year', 'month', 'day', 'hour', 'minute', 'second', 'timeZoneName'].some(
         (prop) => prop in fmt.resolvedOptions()

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -29,7 +29,7 @@ describe('Intl', () => {
 
   describe('absolute.toLocaleString()', () => {
     const absolute = Temporal.Absolute.from('1976-11-18T14:23:30Z');
-    it(`(${absolute.toString()}).toLocaleString('en-US', { timeZone: 'Europe/Vienna' })`, () =>
+    it(`(${absolute.toString()}).toLocaleString('en-US', { timeZone: 'America/New_York' })`, () =>
       equal(`${absolute.toLocaleString('en', { timeZone: 'America/New_York' })}`, '11/18/1976, 9:23:30 AM'));
     it(`(${absolute.toString()}).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })`, () =>
       equal(`${absolute.toLocaleString('de', { timeZone: 'Europe/Vienna' })}`, '18.11.1976, 15:23:30'));
@@ -38,7 +38,7 @@ describe('Intl', () => {
   });
   describe('datetime.toLocaleString()', () => {
     const datetime = Temporal.DateTime.from('1976-11-18T15:23:30');
-    it(`(${datetime.toString()}).toLocaleString('en-US', { timeZone: 'Europe/Vienna' })`, () =>
+    it(`(${datetime.toString()}).toLocaleString('en-US', { timeZone: 'America/New_York' })`, () =>
       equal(`${datetime.toLocaleString('en', { timeZone: 'America/New_York' })}`, '11/18/1976, 3:23:30 PM'));
     it(`(${datetime.toString()}).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })`, () =>
       equal(`${datetime.toLocaleString('de', { timeZone: 'Europe/Vienna' })}`, '18.11.1976, 15:23:30'));
@@ -54,7 +54,7 @@ describe('Intl', () => {
   });
   describe('time.toLocaleString()', () => {
     const time = Temporal.Time.from('1976-11-18T15:23:30');
-    it(`(${time.toString()}).toLocaleString('en-US', { timeZone: 'Europe/Vienna' })`, () =>
+    it(`(${time.toString()}).toLocaleString('en-US', { timeZone: 'America/New_York' })`, () =>
       equal(`${time.toLocaleString('en', { timeZone: 'America/New_York' })}`, '3:23:30 PM'));
     it(`(${time.toString()}).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })`, () =>
       equal(`${time.toLocaleString('de', { timeZone: 'Europe/Vienna' })}`, '15:23:30'));
@@ -68,7 +68,7 @@ describe('Intl', () => {
   });
   describe('date.toLocaleString()', () => {
     const date = Temporal.Date.from('1976-11-18T15:23:30');
-    it(`(${date.toString()}).toLocaleString('en-US', { timeZone: 'Europe/Vienna' })`, () =>
+    it(`(${date.toString()}).toLocaleString('en-US', { timeZone: 'America/New_York' })`, () =>
       equal(`${date.toLocaleString('en', { timeZone: 'America/New_York' })}`, '11/18/1976'));
     it(`(${date.toString()}).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })`, () =>
       equal(`${date.toLocaleString('de', { timeZone: 'Europe/Vienna' })}`, '18.11.1976'));
@@ -83,7 +83,7 @@ describe('Intl', () => {
   });
   describe('yearmonth.toLocaleString()', () => {
     const yearmonth = Temporal.YearMonth.from('1976-11-18T15:23:30');
-    it(`(${yearmonth.toString()}).toLocaleString('en-US', { timeZone: 'Europe/Vienna' })`, () =>
+    it(`(${yearmonth.toString()}).toLocaleString('en-US', { timeZone: 'America/New_York' })`, () =>
       equal(`${yearmonth.toLocaleString('en', { timeZone: 'America/New_York' })}`, '11/1976'));
     it(`(${yearmonth.toString()}).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })`, () =>
       equal(`${yearmonth.toLocaleString('de', { timeZone: 'Europe/Vienna' })}`, '11.1976'));
@@ -98,7 +98,7 @@ describe('Intl', () => {
   });
   describe('monthday.toLocaleString()', () => {
     const monthday = Temporal.MonthDay.from('1976-11-18T15:23:30');
-    it(`(${monthday.toString()}).toLocaleString('en-US', { timeZone: 'Europe/Vienna' })`, () =>
+    it(`(${monthday.toString()}).toLocaleString('en-US', { timeZone: 'America/New_York' })`, () =>
       equal(`${monthday.toLocaleString('en', { timeZone: 'America/New_York' })}`, '11/18'));
     it(`(${monthday.toString()}).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })`, () =>
       equal(`${monthday.toLocaleString('de', { timeZone: 'Europe/Vienna' })}`, '18.11.'));


### PR DESCRIPTION
When I ran the polyfill test suite on my local machine I got one test failure. Since the tests pass in CI I figured it was a time zone thing (it often is). My computer runs on `Australia/Sydney` time, so I'm used to tests that fail by complaining about being a day ahead 😉 .

This was the failure:

```
Intl
  absolute.toLocaleString()
    ☑ (1976-11-18T14:23:30Z).toLocaleString('en-US', { timeZone: 'Europe/Vienna' })
    ☑ (1976-11-18T14:23:30Z).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })
    ☒ uses only the options in resolvedOptions
        assertion: Expected values to be strictly equal:
+ actual - expected

+ 'Friday'
- 'Thursday'
        expected: 'Thursday'
        actual: 'Friday'
```

This PR tweaks the test in question to always format using a specific time zone. I also fixed up some test descriptions that said `Europe/Vienna` but were actually testing `America/New_York` (looked like a copy pasta problem).