### PR TITLE
Version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Bug fixes.
+
 ## 0.3.0
 
 - Bug fixes.

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proposal-temporal",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Experimental polyfill for the TC39 Temporal proposal",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
We need to release a new version so that we get a version on NPM that
includes the absolute path fix, so that RunKit will work again.