### PR TITLE
spec: cleanup and finalize spec text for date

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -121,6 +121,7 @@ export class Calendar {
 
 MakeIntrinsicClass(Calendar, 'Temporal.Calendar');
 DefineIntrinsic('Temporal.Calendar.from', Calendar.from);
+DefineIntrinsic('Temporal.Calendar.prototype.toString', Calendar.prototype.toString);
 
 class ISO8601Calendar extends Calendar {
   constructor(id = 'iso8601') {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -703,6 +703,13 @@ export const ES = ObjectAssign({}, ES2019, {
     }
     return calendar;
   },
+
+  CalendarToString: (calendar) => {
+    let toString = calendar.toString;
+    if (toString === undefined) toString = GetIntrinsic('%Temporal.Calendar.prototype.toString%');
+    return ES.ToString(ES.Call(toString, calendar));
+  },
+
   ToTemporalCalendar: (calendarLike) => {
     if (ES.Type(calendarLike) === 'Object') {
       return calendarLike;
@@ -1573,15 +1580,7 @@ export const ES = ObjectAssign({}, ES2019, {
 
   DifferenceDate: (y1, m1, d1, y2, m2, d2, largestUnit = 'days') => {
     let larger, smaller, sign;
-    let comparison = 0;
-    if (y1 !== y2) {
-      comparison = y1 - y2;
-    } else if (m1 !== m2) {
-      comparison = m1 - m2;
-    } else {
-      comparison = d1 - d2;
-    }
-    if (comparison < 0) {
+    if (ES.CompareTemporalDate(y1, m1, d1, y2, m2, d2) < 0) {
       smaller = { year: y1, month: m1, day: d1 };
       larger = { year: y2, month: m2, day: d2 };
       sign = 1;
@@ -2111,6 +2110,17 @@ export const ES = ObjectAssign({}, ES2019, {
         break;
     }
     return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+  },
+
+  CompareTemporalDate: (y1, m1, d1, y2, m2, d2) => {
+    for (const [x, y] of [
+      [y1, y2],
+      [m1, m2],
+      [d1, d2]
+    ]) {
+      if (x !== y) return ES.ComparisonResult(x - y);
+    }
+    return 0;
   },
 
   AssertPositiveInteger: (num) => {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -100,6 +100,16 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-isvalidcalendarname" aoid="IsValidCalendarName">
+    <h1>IsValidCalendarName ( _calendar_ )</h1>
+    <p>
+      The IsValidCalendarName abstract operation verifies that the _calendar_ argument (which must be a String value) represents a valid Unicode Calendar Identifier value, according to BCP47.
+    </p>
+    <p>
+      The abstract operation returns *true* if _calendar_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>, is equal to one of the Unicode Calendar Indentifier types, according to BCP47, converted to uppercase as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>. It returns *false* otherwise.
+    </p>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-totemporaldisambiguation" aoid="ToTemporalDisambiguation">
     <h1>ToTemporalDisambiguation ( _normalizedOptions_ )</h1>
     <emu-alg>
@@ -565,6 +575,12 @@
           TimeZoneUTCOffset
           TimeZoneUTCOffset `[` TimeZoneIANAName `]`
 
+      CalendarName :
+          &gt; any string for which IsValidCalendarName returns true
+
+      Calendar :
+          `[c=` CalendarName `]`
+
       TimeSpec :
           TimeHour
           TimeHour `:` TimeMinute
@@ -578,6 +594,9 @@
       DateTime :
           Date
           Date DateTimeSeparator Time
+
+      CalendarDateTime:
+          DateTime Calendar?
 
       DurationSeconds :
           Digits TimeFraction? SecondsDesignator
@@ -619,7 +638,7 @@
           Date DateTimeSeparator TimeSpec TimeZone
 
       TemporalDateString :
-          DateTime
+          CalendarDateTime
 
       TemporalDateTimeString :
           DateTime
@@ -652,12 +671,12 @@
   <emu-clause id="sec-temporal-parseisodatetime" aoid="ParseISODateTime">
     <h1>ParseISODateTime ( _isoString_ )</h1>
     <p>
-      The ParseISODateTime abstract operation examines any |Time| or |DateTime| string accepted by the grammar in <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref> and returns a record with all the date and time components found.
+      The ParseISODateTime abstract operation examines any |Time|, |DateTime| or |CalendarDateTime| string accepted by the grammar in <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref> and returns a record with all the date and time components found.
     </p>
     <emu-note>The value of ? ToInteger(*undefined*) is 0.</emu-note>
     <emu-alg>
       1. Assert: Type(_isoString_) is String.
-      1. Let _year_, _month_, _day_, _hour_, _minute_, _second_, and _fraction_ be the parts of _isoString_ produced respectively by the |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, and |TimeFractionalPart| productions, or *undefined* if not present.
+      1. Let _year_, _month_, _day_, _hour_, _minute_, _second_, _fraction_, and _calendar_ be the parts of _isoString_ produced respectively by the |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, |TimeFractionalPart|, and |CalendarName| productions, or *undefined* if not present.
       1. Let _year_ be the part of _isoString_ produced by the |DateYear| production.
       1. If the first code unit of _year_ is 0x2212 (MINUS SIGN), replace it with the code unit 0x002D (HYPHEN-MINUS).
       1. Set _year_ to ! ToInteger(_year_).
@@ -702,7 +721,8 @@
         [[Second]]: _second_,
         [[Millisecond]]: _millisecond_,
         [[Microsecond]]: _microsecond_,
-        [[Nanosecond]]: _nanosecond_
+        [[Nanosecond]]: _nanosecond_,
+        [[Calendar]], _calendar_
         }.
     </emu-alg>
   </emu-clause>
@@ -749,7 +769,8 @@
       1. Return the new Record {
         [[Year]]: _result_.[[Year]],
         [[Month]]: _result_.[[Month]],
-        [[Day]]: _result_.[[Day]]
+        [[Day]]: _result_.[[Day]],
+        [[Calendar]]: _calendar_
         }.
     </emu-alg>
   </emu-clause>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -106,7 +106,7 @@
       The IsValidCalendarName abstract operation verifies that the _calendar_ argument (which must be a String value) represents a valid Unicode Calendar Identifier value, according to BCP47.
     </p>
     <p>
-      The abstract operation returns *true* if _calendar_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>, is equal to one of the Unicode Calendar Indentifier types, according to BCP47, converted to uppercase as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>. It returns *false* otherwise.
+      The abstract operation returns *true* if _calendar_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>, is equal to one of the Unicode Calendar Identifier values, according to BCP47, converted to uppercase as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>. It returns *false* otherwise.
     </p>
   </emu-clause>
 

--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -56,6 +56,11 @@
       "type": "clause",
       "number": "get Intl.DateTimeFormat.prototype.format",
       "id": "sec-intl.datetimeformat.prototype.format"
+    },
+    {
+      "type": "clause",
+      "number": "6.1",
+      "id": "sec-case-sensitivity-and-case-mapping"
     }
   ]
 }

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -33,6 +33,14 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-calendardatedifference" aoid="CalendarDateDifference">
+      <h1>CalendarDateDifference ( _calendar_, _one_, _two_, _options_ )</h1>
+      <emu-alg>
+        1. Let _dateDifference_ be ? Get(_calendar_, *"dateDifference"*).
+        1. Return ? Call(_dateDifference_ , _calendar_, « _one_, _two_, _options_ »).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-totemporalcalendar" aoid="ToTemporalCalendar">
       <h1>ToTemporalCalendar ( _temporalCalendarLike_ )</h1>
       <emu-alg>

--- a/spec/date.html
+++ b/spec/date.html
@@ -787,7 +787,7 @@
             </tr>
             <tr>
               <td>[[Calendar]]</td>
-              <td>`"year"`</td>
+              <td>`"calendar"`</td>
             </tr>
           </tbody>
         </table>

--- a/spec/date.html
+++ b/spec/date.html
@@ -16,17 +16,20 @@
     </ul>
 
     <emu-clause id="sec-temporal.date">
-      <h1>Temporal.Date ( _isoYear_, _isoMonth_, _isoDay_ )</h1>
+      <h1>Temporal.Date ( _isoYear_, _isoMonth_, _isoDay_ [ , _calendar_ ] )</h1>
       <p>
         When the `Temporal.Date` function is called, the following steps are taken:
       </p>
       <emu-alg>
-        1. If NewTarget is *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _y_ be ? ToInteger(_isoYear_).
         1. Let _m_ be ? ToInteger(_isoMonth_).
         1. Let _d_ be ? ToInteger(_isoDay_).
-        1. Return ? CreateTemporalDate(_y_, _m_, _d_, NewTarget).
+        1. If _calendar_ is *undefined*, then
+          1. Set _calendar_ to ? GetDefaultCalendar().
+        1. Else,
+          1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+        1. Return ? CreateTemporalDate(_y_, _m_, _d_, _calendar_, NewTarget).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -35,7 +38,7 @@
     <h1>Properties of the Temporal.Date Constructor</h1>
     <p>The Temporal.Date constructor:</p>
     <ul>
-      <li>has a [[Prototype]] internal slot whose value is %FunctionPrototype%.</li>
+      <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       <li>has the following properties:</li>
     </ul>
 
@@ -74,7 +77,10 @@
           1. Let _result_ be ? ParseTemporalDateString(_string_).
         1. Let _constructor_ be the *this* value.
         1. Set _result_ to ? RegulateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _overflow_).
-        1. Return ? CreateTemporalDateFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
+        1. Let _calendar_ be _result_.[[Calendar]].
+        1. If _calendar_ is *undefined*, set _calendar_ to ! GetDefaultCalendar().
+        1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+        1. Return ? CreateTemporalDateFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -87,7 +93,15 @@
       <emu-alg>
         1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDate]]).
         1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalDate]]).
-        1. Return 𝔽(! CompareTemporalDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]])).
+        1. Let _result_ be ! 𝔽(! CompareTemporalDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]])).
+        1. If result ≠ 0, return _result_.
+        1. Let _calendarOne_ be ? CalendarToString(_one_.[[Calendar]]).
+        1. Let _calendarTwo_ be ? CalendarToString(_two_.[[Calendar]]).
+        1. Let _r_ be the result of performing Abstract Relational Comparison _calendarOne_ &lt; _calendarTwo_.
+        1. If _r_ is *true*, return -1.
+        1. Let _r_ be the result of performing Abstract Relational Comparison _calendarTwo_ &lt; _calendarOne_.
+        1. If _r_ is *true*, return 1.
+        1. Return +0.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -434,6 +448,11 @@
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalDate]]).
+        1. Let _calendar_ be _temporalDate_.[[Calendar]].
+        1. Let _calendarID_ be ? CalendarToString(_calendar_).
+        1. Let _otherCalendar_ be _other_.[[Calendar]].
+        1. Let _otherCalendarID_ be ? CalendarToString(_otherCalendar_).
+        1. If _calendarID_ ≠ _otherCalendarID_, throw a *RangeError* exception.
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _disallowedUnits_ be « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* ».
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"days"*, _disallowedUnits_).
@@ -441,8 +460,7 @@
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
-        1. <mark>TODO: delegate to calendar.</mark>
-        1. Let _result_ be ? DifferenceDate(_other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _largestUnit_).
+        1. Let _result_ be ? CalendarDateDifference(_calendar_, _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _largestUnit_).
         1. If _smallestUnit_ is not *"days"* or _roundingIncrement_ ≠ 1, then
           1. Let _relativeTo_ be ! CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], 0, 0, 0, 0, 0, 0, _temporalDate_.[[Calendar]]).
           1. Set _result_ to ? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
@@ -602,17 +620,17 @@
     <h1>Abstract Operations for Temporal.Date Objects</h1>
 
     <emu-clause id="sec-temporal-createtemporaldate" aoid="CreateTemporalDate">
-      <h1>CreateTemporalDate ( _isoYear_, _isoMonth_, _isoDay_ [ , _newTarget_ ] )</h1>
+      <h1>CreateTemporalDate ( _isoYear_, _isoMonth_, _isoDay_, _calendar_ [ , _newTarget_ ] )</h1>
       <emu-alg>
         1. Perform ? RejectDate(_isoYear_, _isoMonth_, _isoDay_).
-        1. If ! DateTimeWithinLimits(_isoYear_, _isoMonth_, _isoDay_, 12, 0, 0, 0, 0, 0) is not ~in range~, then
-          1. Throw a *RangeError* exception.
+        1. If ! DateTimeWithinLimits(_isoYear_, _isoMonth_, _isoDay_, 12, 0, 0, 0, 0, 0) is not ~in range~, throw a *RangeError* exception.
+        1. If Type(_calendar_) is not Object, throw a *RangeError* exception.
         1. If _newTarget_ is not given, set it to %Temporal.Date%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Temporal.Date.prototype%"`, « [[InitializedTemporalDate]], [[ISOYear]], [[ISOMonth]], [[ISODay]], [[Calendar]] »).
         1. Set _object_.[[ISOYear]] to _isoYear_.
         1. Set _object_.[[ISOMonth]] to _isoMonth_.
         1. Set _object_.[[ISODay]] to _isoDay_.
-        1. <mark>TODO: Set it to the correct calendar.</mark> Set _object_.[[Calendar]] to ! GetDefaultCalendar().
+        1. Set _object_.[[Calendar]] to _calendar_.
         1. Return _object_.
       </emu-alg>
       <emu-note>
@@ -633,12 +651,12 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporaldatefromstatic" aoid="CreateTemporalDateFromStatic">
-      <h1>CreateTemporalDateFromStatic ( _constructor_, _year_, _month_, _day_ )</h1>
+      <h1>CreateTemporalDateFromStatic ( _constructor_, _year_, _month_, _day_, _calendar_ )</h1>
       <emu-alg>
         1. Assert: ! ValidateDate(_year_, _month_, _day_) is *true*.
         1. If ! IsConstructor(_constructor_) is *false*, then
           1. Throw a *TypeError* exception.
-        1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _day_ »).
+        1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _day_, _calendar_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalDate]]).
         1. Return _result_.
       </emu-alg>
@@ -765,6 +783,10 @@
             </tr>
             <tr>
               <td>[[Year]]</td>
+              <td>`"year"`</td>
+            </tr>
+            <tr>
+              <td>[[Calendar]]</td>
               <td>`"year"`</td>
             </tr>
           </tbody>


### PR DESCRIPTION
### TODO

- [x] Properties of `Temporal.Date` instances.
- [x] Constructor
- [x] Properties of Constructor
  - [x] `prototype`
  - [x] `@@species`
  - [x] `from`
  - [x] `compare`
- [ ] Properties of `Temporal.Date.prototype`.
- [ ] Abstract Operations
