### PR TITLE
Ensure future proof for time-based calendars

### DIFF
--- a/docs/calendar-draft.md
+++ b/docs/calendar-draft.md
@@ -20,6 +20,9 @@ The acclaimed researchers Edward M. Reingold and Nachum Dershowitz discuss this 
 
 Some historical calendars, such as the Hawaiian Moon Calendar, define a day as the time it takes for the Earth to complete one rotation relative to the moon (instead of the Sun), which is slightly shorter on average.  For calendars that use a lunar day, a Temporal.DateTime can be used instead of Temporal.Date when the distinction is important.
 
+At this time, Temporal does not support subdividing a solar day into anything other than hours, minutes, and seconds.
+However, we have taken a future-proof approach so that if a use case presents itself, we can add `timePlus()`, `timeMinus()`, and `timeDifference()` methods to Temporal.Calendar.
+
 ### Temporal.DateTime and Temporal.Time internal slots
 
 As with Temporal.Date, all of these types will gain a `[[Calendar]]` slot, and year, month, and day will be renamed `[[IsoYear]]`, `[[IsoMonth]]`, and `[[IsoDay]]`.
@@ -70,18 +73,6 @@ class Temporal.Calendar {
 		constructor: function
 	) : Temporal.Date;
 
-	/** Constructs a Temporal.DateTime from a free-form option bag */
-	dateTimeFromFields(
-		fields: object,
-		constructor: function
-	) : Temporal.DateTime;
-
-	/** Constructs a Temporal.Time from a free-form option bag */
-	timeFromFields(
-		fields: object,
-		constructor: function
-	) : Temporal.Time;
-
 	/** Constructs a Temporal.YearMonth from a free-form option bag */
 	yearMonthFromFields(
 		fields: object,
@@ -102,7 +93,7 @@ class Temporal.Calendar {
 	//////////////////
 
 	/** Returns input plus duration according to the calendar rules. */
-	plus(
+	datePlus(
 		input: Temporal.Date,
 		duration: Temporal.Duration,
 		options: /* options bag */,
@@ -110,7 +101,7 @@ class Temporal.Calendar {
 	) : Temporal.Date;
 
 	/** Returns input minus duration according to the calendar rules. */
-	minus(
+	dateMinus(
 		input: Temporal.Date,
 		duration: Temporal.Duration,
 		options: /* options bag */,
@@ -118,7 +109,7 @@ class Temporal.Calendar {
 	) : Temporal.Date;
 
 	/** Returns larger minus smaller, which are dates in the same calendar. */
-	difference(
+	dateDifference(
 		smaller: Temporal.Date,
 		larger: Temporal.Date,
 		options: /* options bag */
@@ -212,7 +203,7 @@ const PartialIsoCalendar = {
 	// Same for dateTimeFromFields, etc.
 
 	// ALL OTHER METHODS:
-	plus() {
+	datePlus() {
 		throw new TypeError("Unsupported operation: full calendar required");
 	}
 	// Same for minus, etc.
@@ -637,7 +628,7 @@ Temporal.Date.prototype.difference = function(other, options) {
 		// Note: call intrinsic versions of this method
 		other = other.withCalendar(this.calendar);
 	}
-	return this.calendar.difference(this, other, options);
+	return this.calendar.dateDifference(this, other, options);
 }
 
 Temporal.Date.prototype.with = function(overrides) {

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -206,9 +206,9 @@ date.day         // => 6
 date.toString()  // => 2020-05-29[c=hebrew]
 ```
 
-### calendar.**plus**(_date_: Temporal.Date, _duration_: Temporal.Duration, _options_: object, _constructor_: function) : Temporal.Date
+### calendar.**datePlus**(_date_: Temporal.Date, _duration_: Temporal.Duration, _options_: object, _constructor_: function) : Temporal.Date
 
-### calendar.**minus**(_date_: Temporal.Date, _duration_: Temporal.Duration, _options_: object, _constructor_: function) : Temporal.Date
+### calendar.**dateMinus**(_date_: Temporal.Date, _duration_: Temporal.Duration, _options_: object, _constructor_: function) : Temporal.Date
 
 The above two methods are similar.
 They provide a way to do date arithmetic in the calendar's date reckoning.
@@ -241,7 +241,7 @@ date.day         // => 7
 date.toString()  // => 2020-06-28[c=islamic]
 
 // same result, but calling the method directly:
-date = Temporal.Calendar.from('islamic').plus(
+date = Temporal.Calendar.from('islamic').datePlus(
     Temporal.Date.from('2020-05-29'),
     Temporal.Duration.from({ months: 1 }),
     { disambiguation: 'reject' },
@@ -253,7 +253,7 @@ date.day         // => 7
 date.toString()  // => 2020-06-28[c=islamic]
 ```
 
-### calendar.**difference**(_smaller_: Temporal.Date, _larger_: Temporal.Date, _options_: object) : Temporal.Duration
+### calendar.**dateDifference**(_smaller_: Temporal.Date, _larger_: Temporal.Date, _options_: object) : Temporal.Duration
 
 **Parameters:**
 - `smaller` (`Temporal.Date`): A date.
@@ -276,7 +276,7 @@ d2 = Temporal.Date.from('2020-08-29').withCalendar('chinese');
 d2.difference(d1, { largestUnit: 'months' })  // => P1M2D
 
 // same result, but calling the method directly:
-Temporal.Calendar.from('chinese').difference(
+Temporal.Calendar.from('chinese').dateDifference(
     Temporal.Date.from('2020-08-29'),
     Temporal.Date.from('2020-07-29'),
     { largestUnit: 'months' }

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -242,19 +242,19 @@ export namespace Temporal {
       options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.MonthDay>
     ): Temporal.MonthDay;
-    plus?(
+    datePlus?(
       date: Temporal.Date,
       duration: Temporal.Duration,
       options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
-    minus?(
+    dateMinus?(
       date: Temporal.Date,
       duration: Temporal.Duration,
       options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
-    difference?(
+    dateDifference?(
       smaller: Temporal.Date,
       larger: Temporal.Date,
       options: DifferenceOptions<'years' | 'months' | 'weeks' | 'days'>
@@ -298,19 +298,19 @@ export namespace Temporal {
       options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.MonthDay>
     ): Temporal.MonthDay;
-    plus(
+    datePlus(
       date: Temporal.Date,
       duration: Temporal.Duration,
       options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
-    minus(
+    dateMinus(
       date: Temporal.Date,
       duration: Temporal.Duration,
       options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
-    difference(
+    dateDifference(
       smaller: Temporal.Date,
       larger: Temporal.Date,
       options?: DifferenceOptions<'years' | 'months' | 'weeks' | 'days'>

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -40,21 +40,21 @@ export class Calendar {
     void constructor;
     throw new Error('not implemented');
   }
-  plus(date, duration, options, constructor) {
+  datePlus(date, duration, options, constructor) {
     void date;
     void duration;
     void options;
     void constructor;
     throw new Error('not implemented');
   }
-  minus(date, duration, options, constructor) {
+  dateMinus(date, duration, options, constructor) {
     void date;
     void duration;
     void options;
     void constructor;
     throw new Error('not implemented');
   }
-  difference(smaller, larger, options) {
+  dateDifference(smaller, larger, options) {
     void smaller;
     void larger;
     void options;
@@ -142,7 +142,7 @@ class ISO8601 extends Calendar {
     ({ month, day } = ES.RegulateMonthDay(month, day, disambiguation));
     return new constructor(month, day, this, /* refIsoYear = */ 1972);
   }
-  plus(date, duration, options, constructor) {
+  datePlus(date, duration, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const disambiguation = ES.ToTemporalDisambiguation(options);
     const { years, months, weeks, days } = duration;
@@ -152,7 +152,7 @@ class ISO8601 extends Calendar {
     ({ year, month, day } = ES.AddDate(year, month, day, years, months, weeks, days, disambiguation));
     return new constructor(year, month, day, this);
   }
-  minus(date, duration, options, constructor) {
+  dateMinus(date, duration, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const disambiguation = ES.ToTemporalDisambiguation(options);
     const { years, months, weeks, days } = duration;
@@ -162,7 +162,7 @@ class ISO8601 extends Calendar {
     ({ year, month, day } = ES.SubtractDate(year, month, day, years, months, weeks, days, disambiguation));
     return new constructor(year, month, day, this);
   }
-  difference(smaller, larger, options) {
+  dateDifference(smaller, larger, options) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const largestUnit = ES.ToLargestTemporalUnit(options, 'days', ['hours', 'minutes', 'seconds']);
     const { years, months, weeks, days } = ES.DifferenceDate(smaller, larger, largestUnit);

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -137,7 +137,7 @@ export class Date {
     );
     duration = { years, months, weeks, days };
     const Construct = ES.SpeciesConstructor(this, Date);
-    const result = GetSlot(this, CALENDAR).plus(this, duration, options, Construct);
+    const result = GetSlot(this, CALENDAR).datePlus(this, duration, options, Construct);
     if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');
     return result;
   }
@@ -157,7 +157,7 @@ export class Date {
     );
     duration = { years, months, weeks, days };
     const Construct = ES.SpeciesConstructor(this, Date);
-    const result = GetSlot(this, CALENDAR).minus(this, duration, options, Construct);
+    const result = GetSlot(this, CALENDAR).dateMinus(this, duration, options, Construct);
     if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');
     return result;
   }
@@ -170,7 +170,7 @@ export class Date {
     }
     const comparison = Date.compare(this, other);
     if (comparison < 0) throw new RangeError('other instance cannot be larger than `this`');
-    return calendar.difference(other, this, options);
+    return calendar.dateDifference(other, this, options);
   }
   equals(other) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -272,7 +272,7 @@ export class DateTime {
       GetSlot(this, ISO_DAY),
       calendar
     );
-    const addedDate = calendar.plus(datePart, duration, options, TemporalDate);
+    const addedDate = calendar.datePlus(datePart, duration, options, TemporalDate);
     let year = GetSlot(addedDate, ISO_YEAR);
     let month = GetSlot(addedDate, ISO_MONTH);
     let day = GetSlot(addedDate, ISO_DAY);
@@ -337,7 +337,7 @@ export class DateTime {
       GetSlot(this, ISO_DAY),
       calendar
     );
-    const subtractedDate = calendar.minus(datePart, duration, options, TemporalDate);
+    const subtractedDate = calendar.dateMinus(datePart, duration, options, TemporalDate);
     let year = GetSlot(subtractedDate, ISO_YEAR);
     let month = GetSlot(subtractedDate, ISO_MONTH);
     let day = GetSlot(subtractedDate, ISO_DAY);
@@ -395,7 +395,7 @@ export class DateTime {
       dateLargestUnit = largestUnit;
     }
     const dateOptions = ObjectAssign({}, options, { largestUnit: dateLargestUnit });
-    const dateDifference = calendar.difference(other, adjustedLarger, dateOptions);
+    const dateDifference = calendar.dateDifference(other, adjustedLarger, dateOptions);
 
     let days;
     ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -94,7 +94,7 @@ export class YearMonth {
     const calendar = GetSlot(this, CALENDAR);
     const fields = ES.ToTemporalYearMonthRecord(this);
     const firstOfCalendarMonth = calendar.dateFromFields({ ...fields, day: 1 }, {}, TemporalDate);
-    const addedDate = calendar.plus(firstOfCalendarMonth, { ...duration, days }, options, TemporalDate);
+    const addedDate = calendar.datePlus(firstOfCalendarMonth, { ...duration, days }, options, TemporalDate);
 
     const Construct = ES.SpeciesConstructor(this, YearMonth);
     const result = calendar.yearMonthFromFields(addedDate, options, Construct);
@@ -121,7 +121,7 @@ export class YearMonth {
     const fields = ES.ToTemporalYearMonthRecord(this);
     const lastDay = calendar.daysInMonth(this);
     const lastOfCalendarMonth = calendar.dateFromFields({ ...fields, day: lastDay }, {}, TemporalDate);
-    const subtractedDate = calendar.minus(lastOfCalendarMonth, { ...duration, days }, options, TemporalDate);
+    const subtractedDate = calendar.dateMinus(lastOfCalendarMonth, { ...duration, days }, options, TemporalDate);
 
     const Construct = ES.SpeciesConstructor(this, YearMonth);
     const result = calendar.yearMonthFromFields(subtractedDate, options, Construct);
@@ -144,7 +144,7 @@ export class YearMonth {
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
     const smaller = calendar.dateFromFields({ ...smallerFields, day: 1 }, {}, TemporalDate);
     const larger = calendar.dateFromFields({ ...largerFields, day: 1 }, {}, TemporalDate);
-    return calendar.difference(smaller, larger, { ...options, largestUnit });
+    return calendar.dateDifference(smaller, larger, { ...options, largestUnit });
   }
   equals(other) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');


### PR DESCRIPTION
Calendar.plus -> Calendar.datePlus
Calendar.minus -> Calendar.dateMinus
Calendar.difference -> Calendar.dateDifference

Rename some methods to have `date` in the name so that if there are use
cases for a time-based calendar then later timePlus, timeMinus, and
timeDifference can be added.

Closes: #522