### PR TITLE
Disallow difference() between two different calendars

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -391,6 +391,9 @@ By default, the largest unit in the result is days.
 This is because months and years can be different lengths depending on which month is meant and whether the year is a leap year.
 Unlike other Temporal types, hours and lower are not allowed, because the data model of `Temporal.Date` doesn't have that accuracy.
 
+Computing the difference between two dates in different calendar systems is not supported.
+If you need to do this, choose the calendar in which the computation takes place by converting one of the dates with `date.withCalendar()`.
+
 Usage example:
 ```javascript
 date = Temporal.Date.from('2019-01-31');

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -458,6 +458,9 @@ Take care when using milliseconds, microseconds, or nanoseconds as the largest u
 For some durations, the resulting value may overflow `Number.MAX_SAFE_INTEGER` and lose precision in its least significant digit(s).
 Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.
 
+Computing the difference between two dates in different calendar systems is not supported.
+If you need to do this, choose the calendar in which the computation takes place by converting one of the dates with `datetime.withCalendar()`.
+
 Usage example:
 ```javascript
 dt1 = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -308,6 +308,8 @@ However, a difference of one month will still be one month even if `largestUnit`
 
 Unlike other Temporal types, days and lower units are not allowed, because the data model of `Temporal.YearMonth` doesn't have that accuracy.
 
+Computing the difference between two months in different calendar systems is not supported.
+
 Usage example:
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -165,8 +165,11 @@ export class Date {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalDate(other)) throw new TypeError('invalid Date object');
     const calendar = GetSlot(this, CALENDAR);
-    if (calendar.id !== GetSlot(other, CALENDAR).id) {
-      other = new Date(GetSlot(other, ISO_YEAR), GetSlot(other, ISO_MONTH), GetSlot(other, ISO_DAY), calendar);
+    const otherCalendar = GetSlot(other, CALENDAR);
+    if (calendar.id !== otherCalendar.id) {
+      throw new RangeError(
+        `cannot compute difference between dates of ${calendar.id} and ${otherCalendar.id} calendars`
+      );
     }
     const comparison = Date.compare(this, other);
     if (comparison < 0) throw new RangeError('other instance cannot be larger than `this`');

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -363,18 +363,10 @@ export class DateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalDateTime(other)) throw new TypeError('invalid DateTime object');
     const calendar = GetSlot(this, CALENDAR);
-    if (calendar.id !== GetSlot(other, CALENDAR).id) {
-      other = new DateTime(
-        GetSlot(other, ISO_YEAR),
-        GetSlot(other, ISO_MONTH),
-        GetSlot(other, ISO_DAY),
-        GetSlot(other, HOUR),
-        GetSlot(other, MINUTE),
-        GetSlot(other, SECOND),
-        GetSlot(other, MILLISECOND),
-        GetSlot(other, MICROSECOND),
-        GetSlot(other, NANOSECOND),
-        calendar
+    const otherCalendar = GetSlot(other, CALENDAR);
+    if (calendar.id !== otherCalendar.id) {
+      throw new RangeError(
+        `cannot compute difference between dates of ${calendar.id} and ${otherCalendar.id} calendars`
       );
     }
     const largestUnit = ES.ToLargestTemporalUnit(options, 'days');
@@ -390,7 +382,7 @@ export class DateTime {
     ({ year, month, day } = ES.BalanceDate(year, month, day));
 
     const TemporalDate = GetIntrinsic('%Temporal.Date%');
-    const adjustedLarger = new TemporalDate(year, month, day, GetSlot(this, CALENDAR));
+    const adjustedLarger = new TemporalDate(year, month, day, calendar);
     let dateLargestUnit = 'days';
     if (largestUnit === 'years' || largestUnit === 'months' || largestUnit === 'weeks') {
       dateLargestUnit = largestUnit;

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -59,7 +59,7 @@ function resolvedOptions() {
 
 function adjustFormatterCalendar(formatter, calendar) {
   const options = formatter.resolvedOptions();
-  if (!calendar || calendar === options.calendar || calendar === 'gregory' || calendar === 'iso8601') return formatter;
+  if (!calendar || calendar === options.calendar || calendar === 'iso8601') return formatter;
   const locale = `${options.locale}-u-ca-${calendar}`;
   return new IntlDateTimeFormat(locale, options);
 }
@@ -68,8 +68,6 @@ function pickRangeCalendar(a, b) {
   if (!a) return b;
   if (!b) return a;
   if (a === b) return a;
-  if (a === 'iso8601' || a === 'gregory') return b;
-  if (b === 'iso8601' || b === 'gregory') return a;
   throw new RangeError(`cannot format range between two dates of ${a} and ${b} calendars`);
 }
 

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -132,8 +132,11 @@ export class YearMonth {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalYearMonth(other)) throw new TypeError('invalid YearMonth object');
     const calendar = GetSlot(this, CALENDAR);
-    if (calendar.id !== GetSlot(other, CALENDAR).id) {
-      other = new Date(GetSlot(other, ISO_YEAR), GetSlot(other, ISO_MONTH), calendar, GetSlot(other, REF_ISO_DAY));
+    const otherCalendar = GetSlot(other, CALENDAR);
+    if (calendar.id !== otherCalendar.id) {
+      throw new RangeError(
+        `cannot compute difference between months of ${calendar.id} and ${otherCalendar.id} calendars`
+      );
     }
     const largestUnit = ES.ToLargestTemporalUnit(options, 'years', [
       'weeks',

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -247,6 +247,11 @@ describe('Date', () => {
       equal(monthsDifference.weeks, 0);
       notEqual(monthsDifference.months, 0);
     });
+    it('no two different calendars', () => {
+      const date1 = new Date(2000, 1, 1);
+      const date2 = new Date(2000, 1, 1, Temporal.Calendar.from('japanese'));
+      throws(() => date1.difference(date2), RangeError);
+    });
   });
   describe('date.plus() works', () => {
     let date = new Date(1976, 11, 18);

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -423,6 +423,11 @@ describe('DateTime', () => {
       equal(monthsDifference.weeks, 0);
       notEqual(monthsDifference.months, 0);
     });
+    it('no two different calendars', () => {
+      const dt1 = new DateTime(2000, 1, 1, 0, 0, 0, 0, 0, 0);
+      const dt2 = new DateTime(2000, 1, 1, 0, 0, 0, 0, 0, 0, Temporal.Calendar.from('japanese'));
+      throws(() => dt1.difference(dt2), RangeError);
+    });
   });
   describe('DateTime.from() works', () => {
     it('DateTime.from("1976-11-18 15:23:30")', () =>

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -334,6 +334,16 @@ describe('Intl', () => {
       });
       it('should throw a TypeError when called with dissimilar types', () =>
         throws(() => us.formatRange(Temporal.Absolute.from(t1), Temporal.DateTime.from(t2)), TypeError));
+      it('should throw a RangeError when called with different calendars', () => {
+        throws(
+          () => us.formatRange(Temporal.DateTime.from(t1), Temporal.DateTime.from(t2).withCalendar('japanese')),
+          RangeError
+        );
+        throws(
+          () => us.formatRange(Temporal.Date.from(t1), Temporal.Date.from(t2).withCalendar('japanese')),
+          RangeError
+        );
+      });
     });
     describe('formatRangeToParts', () => {
       it('should work for Absolute', () => {
@@ -579,6 +589,16 @@ describe('Intl', () => {
       });
       it('should throw a TypeError when called with dissimilar types', () =>
         throws(() => at.formatRangeToParts(Temporal.Absolute.from(t1), Temporal.DateTime.from(t2)), TypeError));
+      it('should throw a RangeError when called with different calendars', () => {
+        throws(
+          () => at.formatRangeToParts(Temporal.DateTime.from(t1), Temporal.DateTime.from(t2).withCalendar('japanese')),
+          RangeError
+        );
+        throws(
+          () => at.formatRangeToParts(Temporal.Date.from(t1), Temporal.Date.from(t2).withCalendar('japanese')),
+          RangeError
+        );
+      });
     });
   });
 });

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -206,6 +206,11 @@ describe('YearMonth', () => {
       throws(() => feb21.difference(feb20, { largestUnit: 'microseconds' }), RangeError);
       throws(() => feb21.difference(feb20, { largestUnit: 'nanoseconds' }), RangeError);
     });
+    it('no two different calendars', () => {
+      const ym1 = new YearMonth(2000, 1);
+      const ym2 = new YearMonth(2000, 1, Temporal.Calendar.from('japanese'));
+      throws(() => ym1.difference(ym2), RangeError);
+    });
   });
   describe('YearMonth.plus() works', () => {
     const ym = YearMonth.from('2019-11');


### PR DESCRIPTION
In the difference() methods of Date, DateTime, and YearMonth, check if
the calendars of the two operands are different. If they are different, then throw.

This is because the result of a difference between two dates in
different calendars would be ambiguous as to which calendar the
resulting duration would be expressed in.

Makes the corresponding change for Intl.DateTimeFormat.formatRange() and
formatRangeToParts() and adds a test for that.

Closes: #587