### PR TITLE
Consolidate getOffsetNanosecondsFor calls into ES.GetOffsetNanosecondsFor().

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -607,6 +607,16 @@ export const ES = ObjectAssign({}, ES2019, {
       GetSlot(dateTime, NANOSECOND)
     );
   },
+  GetOffsetNanosecondsFor: (timeZone, absolute) => {
+    const offsetNs = timeZone.getOffsetNanosecondsFor(absolute);
+    if (typeof offsetNs !== 'number') {
+      throw new TypeError('bad return from getOffsetNanosecondsFor');
+    }
+    if (!Number.isInteger(offsetNs) || Math.abs(offsetNs) > 86400e9) {
+      throw new RangeError('out-of-range return from getOffsetNanosecondsFor');
+    }
+    return offsetNs;
+  },
   GetOffsetStringFor: (timeZone, absolute) => {
     let getOffsetStringFor = timeZone.getOffsetStringFor;
     if (getOffsetStringFor === undefined) {

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -64,13 +64,7 @@ export class TimeZone {
   }
   getOffsetStringFor(absolute) {
     if (!ES.IsTemporalAbsolute(absolute)) throw new TypeError('invalid Absolute object');
-    const offsetNs = this.getOffsetNanosecondsFor(absolute);
-    if (typeof offsetNs !== 'number') {
-      throw new TypeError('bad return from getOffsetNanosecondsFor');
-    }
-    if (!Number.isInteger(offsetNs) || Math.abs(offsetNs) > 86400e9) {
-      throw new RangeError('out-of-range return from getOffsetNanosecondsFor');
-    }
+    const offsetNs = ES.GetOffsetNanosecondsFor(this, absolute);
     return ES.FormatTimeZoneOffsetString(offsetNs);
   }
   getDateTimeFor(absolute, calendar = GetDefaultCalendar()) {
@@ -78,13 +72,7 @@ export class TimeZone {
     calendar = ES.ToTemporalCalendar(calendar);
 
     const ns = GetSlot(absolute, EPOCHNANOSECONDS);
-    const offsetNs = this.getOffsetNanosecondsFor(absolute);
-    if (typeof offsetNs !== 'number') {
-      throw new TypeError('bad return from getOffsetNanosecondsFor');
-    }
-    if (!Number.isInteger(offsetNs) || Math.abs(offsetNs) > 86400e9) {
-      throw new RangeError('out-of-range return from getOffsetNanosecondsFor');
-    }
+    const offsetNs = ES.GetOffsetNanosecondsFor(this, absolute);
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.GetPartsFromEpoch(ns);
     ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.BalanceDateTime(
       year,

--- a/polyfill/test/TimeZone/prototype/getDateTimeFor/getOffsetNanosecondsFor-invalid-type.js
+++ b/polyfill/test/TimeZone/prototype/getDateTimeFor/getOffsetNanosecondsFor-invalid-type.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getdatetimefor
+---*/
+
+const values = [
+  undefined,
+  null,
+  true,
+  "100",
+  Symbol(),
+  0n,
+  {},
+  { valueOf() { return 20; } },
+];
+const absolute = Temporal.Absolute.from("1975-02-02T14:25:36.123456789Z");
+
+for (const value of values) {
+  const timeZone = Temporal.TimeZone.from("UTC");
+  let called = false;
+  timeZone.getOffsetNanosecondsFor = function(argument) {
+    assert.sameValue(argument, absolute);
+    called = true;
+    return value;
+  };
+  assert.throws(TypeError, () => timeZone.getDateTimeFor(absolute));
+  assert.sameValue(called, true);
+}

--- a/polyfill/test/TimeZone/prototype/getDateTimeFor/getOffsetNanosecondsFor-invalid-value.js
+++ b/polyfill/test/TimeZone/prototype/getDateTimeFor/getOffsetNanosecondsFor-invalid-value.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getdatetimefor
+---*/
+
+const values = [
+  0.1,
+  1.2,
+  NaN,
+  Infinity,
+  -Infinity,
+  86400000000001,
+  -86400000000001,
+];
+const absolute = Temporal.Absolute.from("1975-02-02T14:25:36.123456789Z");
+
+for (const value of values) {
+  const timeZone = Temporal.TimeZone.from("UTC");
+  let called = false;
+  timeZone.getOffsetNanosecondsFor = function(argument) {
+    assert.sameValue(argument, absolute);
+    called = true;
+    return value;
+  };
+  assert.throws(RangeError, () => timeZone.getDateTimeFor(absolute));
+  assert.sameValue(called, true);
+}

--- a/polyfill/test/TimeZone/prototype/getOffsetStringFor/getOffsetNanosecondsFor-invalid-type.js
+++ b/polyfill/test/TimeZone/prototype/getOffsetStringFor/getOffsetNanosecondsFor-invalid-type.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetstringfor
+---*/
+
+const values = [
+  undefined,
+  null,
+  true,
+  "100",
+  Symbol(),
+  0n,
+  {},
+  { valueOf() { return 20; } },
+];
+const absolute = Temporal.Absolute.from("1975-02-02T14:25:36.123456789Z");
+
+for (const value of values) {
+  const timeZone = Temporal.TimeZone.from("UTC");
+  let called = false;
+  timeZone.getOffsetNanosecondsFor = function(argument) {
+    assert.sameValue(argument, absolute);
+    called = true;
+    return value;
+  };
+  assert.throws(TypeError, () => timeZone.getOffsetStringFor(absolute));
+  assert.sameValue(called, true);
+}

--- a/polyfill/test/TimeZone/prototype/getOffsetStringFor/getOffsetNanosecondsFor-invalid-value.js
+++ b/polyfill/test/TimeZone/prototype/getOffsetStringFor/getOffsetNanosecondsFor-invalid-value.js
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getoffsetstringfor
+---*/
+
+const values = [
+  0.1,
+  1.2,
+  NaN,
+  Infinity,
+  -Infinity,
+  86400000000001,
+  -86400000000001,
+];
+const absolute = Temporal.Absolute.from("1975-02-02T14:25:36.123456789Z");
+
+for (const value of values) {
+  const timeZone = Temporal.TimeZone.from("UTC");
+  let called = false;
+  timeZone.getOffsetNanosecondsFor = function(argument) {
+    assert.sameValue(argument, absolute);
+    called = true;
+    return value;
+  };
+  assert.throws(RangeError, () => timeZone.getOffsetStringFor(absolute));
+  assert.sameValue(called, true);
+}


### PR DESCRIPTION
Also add tests for the result checks.