### PR TITLE
Allow sub-second largestUnit values

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -294,7 +294,7 @@ Temporal.now.absolute().minus(oneDay);
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
+    Valid values are `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
     The default is `"seconds"`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `absolute` and `other`.
@@ -314,6 +314,9 @@ You cannot determine the start and end date of a difference between `Temporal.Ab
 
 If you do need to calculate the difference between two `Temporal.Absolute`s in years, months, or weeks, then you can make an explicit choice on how to eliminate this ambiguity, choosing your starting point by converting to a `Temporal.DateTime`.
 For example, you might decide to base the calculation on your user's current time zone, or on UTC.
+
+Take care when using milliseconds, microseconds, or nanoseconds as the largest unit.
+For some dates, the resulting value may overflow `Number.MAX_SAFE_INTEGER`.
 
 Example usage:
 ```js

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -438,7 +438,7 @@ dt.minus({ months: 1 })  // => throws
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
+    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
     The default is `days`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `datetime` and `other`.
@@ -453,6 +453,9 @@ However, a difference of 30 seconds will still be 30 seconds even if `largestUni
 
 By default, the largest unit in the result is days.
 This is because months and years can be different lengths depending on which month is meant and whether the year is a leap year.
+
+Take care when using milliseconds, microseconds, or nanoseconds as the largest unit.
+For some dates, the resulting value may overflow `Number.MAX_SAFE_INTEGER`.
 
 Usage example:
 ```javascript

--- a/docs/time.md
+++ b/docs/time.md
@@ -239,7 +239,7 @@ time.minus({ minutes: 5, nanoseconds: 800 })  // => 19:34:09.068345405
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, and `'seconds'`.
+    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
     The default is effectively `'hours'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `time` and `other`.

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -165,7 +165,14 @@ class ISO8601 extends Calendar {
   }
   dateDifference(smaller, larger, options) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
-    const largestUnit = ES.ToLargestTemporalUnit(options, 'days', ['hours', 'minutes', 'seconds']);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'days', [
+      'hours',
+      'minutes',
+      'seconds',
+      'milliseconds',
+      'microseconds',
+      'nanoseconds'
+    ]);
     const { years, months, weeks, days } = ES.DifferenceDate(smaller, larger, largestUnit);
     const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -478,7 +478,18 @@ export const ES = ObjectAssign({}, ES2019, {
     return ES.GetOption(options, 'disambiguation', ['balanceConstrain', 'balance'], 'balanceConstrain');
   },
   ToLargestTemporalUnit: (options, fallback, disallowedStrings = []) => {
-    const allowed = new Set(['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds']);
+    const allowed = new Set([
+      'years',
+      'months',
+      'weeks',
+      'days',
+      'hours',
+      'minutes',
+      'seconds',
+      'milliseconds',
+      'microseconds',
+      'nanoseconds'
+    ]);
     for (const s of disallowedStrings) {
       allowed.delete(s);
     }
@@ -1118,6 +1129,19 @@ export const ES = ObjectAssign({}, ES2019, {
       case 'seconds':
         seconds += 60 * (minutes + 60 * (hours + 24 * days));
         minutes = hours = days = 0;
+        break;
+      case 'milliseconds':
+        milliseconds += 1000 * (seconds + 60 * (minutes + 60 * (hours + 24 * days)));
+        seconds = minutes = hours = days = 0;
+        break;
+      case 'microseconds':
+        microseconds += 1000 * (milliseconds + 1000 * (seconds + 60 * (minutes + 60 * (hours + 24 * days))));
+        milliseconds = seconds = minutes = hours = days = 0;
+        break;
+      case 'nanoseconds':
+        nanoseconds +=
+          1000 * (microseconds + 1000 * (milliseconds + 1000 * (seconds + 60 * (minutes + 60 * (hours + 24 * days)))));
+        microseconds = milliseconds = seconds = minutes = hours = days = 0;
         break;
       case 'years':
       case 'months':

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -135,7 +135,16 @@ export class YearMonth {
     if (calendar.id !== GetSlot(other, CALENDAR).id) {
       other = new Date(GetSlot(other, ISO_YEAR), GetSlot(other, ISO_MONTH), calendar, GetSlot(other, REF_ISO_DAY));
     }
-    const largestUnit = ES.ToLargestTemporalUnit(options, 'years', ['weeks', 'days', 'hours', 'minutes', 'seconds']);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'years', [
+      'weeks',
+      'days',
+      'hours',
+      'minutes',
+      'seconds',
+      'milliseconds',
+      'microseconds',
+      'nanoseconds'
+    ]);
     const comparison = YearMonth.compare(this, other);
     if (comparison < 0) throw new RangeError('other instance cannot be larger than `this`');
 

--- a/polyfill/test/absolute.mjs
+++ b/polyfill/test/absolute.mjs
@@ -453,6 +453,24 @@ describe('Absolute', () => {
       equal(`${feb21.difference(feb20, { largestUnit: 'minutes' })}`, 'PT527040M');
       equal(`${feb21.difference(feb20, { largestUnit: 'days' })}`, 'P366D');
     });
+    it('can return subseconds', () => {
+      const later = feb20.plus({ days: 1, milliseconds: 250, microseconds: 250, nanoseconds: 250 });
+
+      const msDiff = later.difference(feb20, { largestUnit: 'milliseconds' });
+      equal(msDiff.seconds, 0);
+      equal(msDiff.milliseconds, 86400250);
+      equal(msDiff.microseconds, 250);
+      equal(msDiff.nanoseconds, 250);
+
+      const µsDiff = later.difference(feb20, { largestUnit: 'microseconds' });
+      equal(µsDiff.milliseconds, 0);
+      equal(µsDiff.microseconds, 86400250250);
+      equal(µsDiff.nanoseconds, 250);
+
+      const nsDiff = later.difference(feb20, { largestUnit: 'nanoseconds' });
+      equal(nsDiff.microseconds, 0);
+      equal(nsDiff.nanoseconds, 86400250250250);
+    });
     it('cannot return weeks, months, and years', () => {
       throws(() => feb21.difference(feb20, { largestUnit: 'weeks' }), RangeError);
       throws(() => feb21.difference(feb20, { largestUnit: 'months' }), RangeError);

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -227,6 +227,9 @@ describe('Date', () => {
       throws(() => feb21.difference(feb20, { largestUnit: 'hours' }), RangeError);
       throws(() => feb21.difference(feb20, { largestUnit: 'minutes' }), RangeError);
       throws(() => feb21.difference(feb20, { largestUnit: 'seconds' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'milliseconds' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'microseconds' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'nanoseconds' }), RangeError);
     });
     it('does not include higher units than necessary', () => {
       const lastFeb20 = Date.from('2020-02-29');

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -389,6 +389,24 @@ describe('DateTime', () => {
       equal(`${feb21.difference(feb20, { largestUnit: 'minutes' })}`, 'PT527040M');
       equal(`${feb21.difference(feb20, { largestUnit: 'seconds' })}`, 'PT31622400S');
     });
+    it('can return subseconds', () => {
+      const later = feb20.plus({ days: 1, milliseconds: 250, microseconds: 250, nanoseconds: 250 });
+
+      const msDiff = later.difference(feb20, { largestUnit: 'milliseconds' });
+      equal(msDiff.seconds, 0);
+      equal(msDiff.milliseconds, 86400250);
+      equal(msDiff.microseconds, 250);
+      equal(msDiff.nanoseconds, 250);
+
+      const µsDiff = later.difference(feb20, { largestUnit: 'microseconds' });
+      equal(µsDiff.milliseconds, 0);
+      equal(µsDiff.microseconds, 86400250250);
+      equal(µsDiff.nanoseconds, 250);
+
+      const nsDiff = later.difference(feb20, { largestUnit: 'nanoseconds' });
+      equal(nsDiff.microseconds, 0);
+      equal(nsDiff.nanoseconds, 86400250250250);
+    });
     it('does not include higher units than necessary', () => {
       const lastFeb20 = DateTime.from('2020-02-29T00:00');
       const lastFeb21 = DateTime.from('2021-02-28T00:00');

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -238,6 +238,24 @@ describe('Time', () => {
         equal(`${time2.difference(time1, { largestUnit: 'minutes' })}`, 'PT412M42S');
         equal(`${time2.difference(time1, { largestUnit: 'seconds' })}`, 'PT24762S');
       });
+      it('can return subseconds', () => {
+        const time3 = time2.plus({ milliseconds: 250, microseconds: 250, nanoseconds: 250 });
+
+        const msDiff = time3.difference(time1, { largestUnit: 'milliseconds' });
+        equal(msDiff.seconds, 0);
+        equal(msDiff.milliseconds, 24762250);
+        equal(msDiff.microseconds, 250);
+        equal(msDiff.nanoseconds, 250);
+
+        const µsDiff = time3.difference(time1, { largestUnit: 'microseconds' });
+        equal(µsDiff.milliseconds, 0);
+        equal(µsDiff.microseconds, 24762250250);
+        equal(µsDiff.nanoseconds, 250);
+
+        const nsDiff = time3.difference(time1, { largestUnit: 'nanoseconds' });
+        equal(nsDiff.microseconds, 0);
+        equal(nsDiff.nanoseconds, 24762250250250);
+      });
     });
     describe('Time.compare() works', () => {
       const t1 = Time.from('08:44:15.321');

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -202,6 +202,9 @@ describe('YearMonth', () => {
       throws(() => feb21.difference(feb20, { largestUnit: 'hours' }), RangeError);
       throws(() => feb21.difference(feb20, { largestUnit: 'minutes' }), RangeError);
       throws(() => feb21.difference(feb20, { largestUnit: 'seconds' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'milliseconds' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'microseconds' }), RangeError);
+      throws(() => feb21.difference(feb20, { largestUnit: 'nanoseconds' }), RangeError);
     });
   });
   describe('YearMonth.plus() works', () => {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -58,7 +58,7 @@
     <h1>ToLargestTemporalUnit ( _largestUnit_, _disallowedUnits_, _defaultUnit_ )</h1>
     <emu-alg>
       1. Assert: _disallowedUnits_ does not contain _defaultUnit_.
-      1. Let _largestUnit_ be GetOption(_options_, *"largestUnit"*, « *"years"*, *"months"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"* », _defaultUnit_).
+      1. Let _largestUnit_ be GetOption(_options_, *"largestUnit"*, « *"years"*, *"months"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », _defaultUnit_).
       1. If _disallowedUnits_ contains _largestUnit_, then
         1. Throw a *RangeError* exception.
       1. Return _largestUnit_.

--- a/spec/date.html
+++ b/spec/date.html
@@ -366,7 +366,7 @@
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalDate]]).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"* », *"days"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
         1. If ! CompareTemporalDate(_temporalDate_, _other_) &lt; 0, then
           1. Throw a *RangeError* exception.
         1. Let _greater_ be _temporalDate_.

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -433,20 +433,8 @@
         1. Let _timeDifference_ be ! DifferenceTime(_smaller_, _greater_).
         1. Let _balanceResult_ be ? BalanceDate(_greater_.[[ISOYear]], _greater_.[[ISOMonth]], _greater_.[[ISODay]] + _timeDifference_.[[Days]]).
         1. Let _dateDifference_ be ! DifferenceDate(_smaller_, _balanceResult_, _largestUnit_).
-        1. Let _days_ be _dateDifference_.[[Days]].
-        1. Let _hours_ be _timeDifference_.[[Hour]].
-        1. Let _minutes_ be _timeDifference_.[[Minute]].
-        1. Let _seconds_ be _timeDifference_.[[Second]].
-        1. If _largestUnit_ is `"hours"`, `"minutes"`, or `"seconds"`, then
-          1. Set _hours_ to _hours_ + 24 × _days_.
-          1. Set _days_ to 0.
-        1. If _largestUnit_ is `"minutes"` or `"seconds"`, then
-          1. Set _minutes_ to _minutes_ + 60 × _hours_.
-          1. Set _hours_ to 0.
-        1. If _largestUnit_ is `"seconds"`, then
-          1. Set _seconds_ to _seconds_ + 60 × _minutes_.
-          1. Set _minutes_ to 0.
-        1. Return ? CreateTemporalDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _days_, _hours_, _minutes_, _seconds_, _timeDifference_.[[Millisecond]], _timeDifference_.[[Microsecond]], _timeDifference_.[[Nanosecond]]).
+        1. Let _result_ be ! BalanceDuration(_dateDifference_.[[Days]], _timeDifference.[[Hour]], _timeDifference_.[[Minute]], _timeDifference_.[[Second]], _timeDifference.[[Millisecond]], _timeDifference_.[[Microsecond]], _timeDifference_.[[Nanosecond]], _largestUnit_).
+        1. Return ? CreateTemporalDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -531,23 +531,35 @@
         1. Set _hours_ to _bt_.[[Hour]].
         1. Set _minutes_ to _bt_.[[Minute]].
         1. Set _seconds_ to _bt_.[[Second]].
-        1. If _largestUnit_ is *"hours"*, *"minutes"*, or *"seconds"*, then
+        1. Set _milliseconds_ to _bt_.[[Millisecond]].
+        1. Set _microseconds_ to _bt_.[[Microsecond]].
+        1. Set _nanoseconds_ to _bt_.[[Nanosecond]].
+        1. If _largestUnit_ is *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*, then
           1. Increment _hours_ by 24 × _days_.
           1. Set _days_ to 0.
-        1. If _largestUnit_ is *"minutes"* or *"seconds"*, then
+        1. If _largestUnit_ is *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*, then
           1. Increment _minutes_ by 60 × _hours_.
           1. Set _hours_ to 0.
-        1. If _largestUnit_ is *"seconds"*, then
+        1. If _largestUnit_ is *"seconds"*, *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*, then
           1. Increment _seconds_ by 60 × _minutes_.
           1. Set _minutes_ to 0.
+        1. If _largestUnit_ is *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*, then
+          1. Increment _milliseconds_ by 1000 × _seconds_.
+          1. Set _seconds_ to 0.
+        1. If _largestUnit_ is *"microseconds"* or *"nanoseconds"*, then
+          1. Increment _microseconds_ by 1000 × _milliseconds_.
+          1. Set _milliseconds_ to 0.
+        1. If _largestUnit_ is *"nanoseconds"*, then
+          1. Increment _nanoseconds_ by 1000 × _microseconds_.
+          1. Set _microseconds_ to 0.
         1. Return the new Record {
           [[Days]]: _days_,
           [[Hours]]: _hours_,
           [[Minutes]]: _minutes_,
           [[Seconds]]: _seconds_,
-          [[Milliseconds]]: _bt_.[[Millisecond]],
-          [[Microseconds]]: _bt_.[[Microsecond]],
-          [[Nanoseconds]]: _bt_.[[Nanosecond]].
+          [[Milliseconds]]: _milliseconds_,
+          [[Microseconds]]: _microseconds_,
+          [[Nanoseconds]]: _nanoseconds_
           }.
       </emu-alg>
     </emu-clause>

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -255,7 +255,7 @@
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalYearMonth]]).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"weeks"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"* », *"years"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"weeks"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"years"*).
         1. If ! CompareTemporalYearMonth(_yearMonth_, _other_) &lt; 0, then
           1. Throw a *RangeError* exception.
         1. Let _greater_ be _yearMonth_.


### PR DESCRIPTION
In Absolute.difference, DateTime.difference, and Time.difference, now
'milliseconds', 'microseconds', and 'nanoseconds' are valid values for
the largestUnit option.

Closes: #805