### PR TITLE
Don't polyfill Temporal and Intl onto the global object

### DIFF
--- a/polyfill/lib/index.mjs
+++ b/polyfill/lib/index.mjs
@@ -1,24 +1,10 @@
+// This entry point treats Temporal as a library, and does not polyfill it onto
+// the global object.
+// This is in order to avoid breaking the web in the future, if the polyfill
+// gains wide adoption before the API is finalized. We do not want checks such
+// as `if (typeof Temporal === 'undefined')` in the wild, until browsers start
+// shipping the finalized API.
+
 import * as Temporal from './temporal.mjs';
 import * as Intl from './intl.mjs';
-
-Object.defineProperty(globalThis, 'Temporal', {
-  value: {},
-  writable: true,
-  enumerable: false,
-  configurable: true
-});
-copy(globalThis.Temporal, Temporal);
-copy(globalThis.Intl, Intl);
-
-function copy(target, source) {
-  for (const prop of Object.getOwnPropertyNames(source)) {
-    Object.defineProperty(target, prop, {
-      value: source[prop],
-      writable: true,
-      enumerable: false,
-      configurable: true
-    });
-  }
-}
-
 export { Temporal, Intl };

--- a/polyfill/lib/shim.mjs
+++ b/polyfill/lib/shim.mjs
@@ -1,0 +1,28 @@
+// This is an alternate entry point that polyfills Temporal onto the global
+// object. This is used only for the browser playground and the test262 tests.
+// See the note in index.mjs.
+
+import * as Temporal from './temporal.mjs';
+import * as Intl from './intl.mjs';
+
+Object.defineProperty(globalThis, 'Temporal', {
+  value: {},
+  writable: true,
+  enumerable: false,
+  configurable: true
+});
+copy(globalThis.Temporal, Temporal);
+copy(globalThis.Intl, Intl);
+
+function copy(target, source) {
+  for (const prop of Object.getOwnPropertyNames(source)) {
+    Object.defineProperty(target, prop, {
+      value: source[prop],
+      writable: true,
+      enumerable: false,
+      configurable: true
+    });
+  }
+}
+
+export { Temporal, Intl };

--- a/polyfill/rollup.config.js
+++ b/polyfill/rollup.config.js
@@ -48,7 +48,7 @@ export default [
     ]
   },
   {
-    input: 'lib/index.mjs',
+    input: 'lib/shim.mjs',
     plugins: [replace({ ...replaceConfig, __debug__: false }), commonjs(), resolve(resolveConfig)],
     output: {
       name: libName,
@@ -58,7 +58,7 @@ export default [
     }
   },
   {
-    input: 'lib/index.mjs',
+    input: 'lib/shim.mjs',
     output: {
       name: libName,
       file: '../out/docs/playground.js',


### PR DESCRIPTION
In order to avoid breaking the web when Temporal is shipped, don't
polyfill onto the global object. We don't want any `if (typeof Temporal
=== undefined)` checks in the wild until browsers actually start
shipping Temporal.

We do still need it on the global object for the browser playground and
the test262 tests, so we now have two separate entry points to the
library: index.mjs and polyfill.mjs.

Closes: #778