### PR TITLE
Note that Duration.toLocaleString requires Intl.DurationFormat

### DIFF
--- a/docs/cookbook/getElapsedDurationSinceInstant.mjs
+++ b/docs/cookbook/getElapsedDurationSinceInstant.mjs
@@ -37,4 +37,6 @@ const { sign, duration } = getElapsedDurationSinceInstant(
   Temporal.Absolute.from('2020-04-01T13:00-07:00[America/Los_Angeles]'),
   Temporal.now.absolute()
 );
+// Note that this does not work unless you have Intl.DurationFormat, which is
+// still an early-stage proposal.
 `It's ${duration.toLocaleString()} ${sign < 0 ? 'until' : 'since'} the TC39 Temporal presentation`;

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -403,7 +403,11 @@ JSON.parse(str, reviver);
 
 This method overrides `Object.prototype.toLocaleString()` to provide a human-readable, language-sensitive representation of `duration`.
 
-The `locales` and `options` arguments are the same as in the constructor to [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat).
+The `locales` and `options` arguments are the same as in the constructor to [`Intl.DurationFormat`](http://tc39.es/proposal-intl-duration-format/).
+
+> **NOTE**: This method requires that your JavaScript environment supports `Intl.DurationFormat`.
+> That is still an early-stage proposal and at the time of writing it is not supported anywhere.
+> If `Intl.DurationFormat` is not available, then the output of this method is the same as that of `duration.toString()`, and the `locales` and `options` arguments are ignored.
 
 Usage examples:
 ```javascript


### PR DESCRIPTION
Make a note of this in the documentation and the cookbook.

Closes: #760