### PR TITLE
Remove notes about weeks combined with other units in Duration strings

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -30,9 +30,8 @@ For more detailed information, see the ISO 8601 standard or the [Wikipedia page]
 | **PT0S**             | Zero |
 | **P0D**              | Zero |
 
-> **NOTE:** According to the ISO 8601 standard, weeks are not allowed to appear together with any other units, and durations can only be positive.
-> As an extension to the standard, ISO 8601-2 allows a sign character at the start of the string.
-> As an additional extension, Temporal supports combining weeks with other units.
+> **NOTE:** According to the ISO 8601-1 standard, weeks are not allowed to appear together with any other units, and durations can only be positive.
+> As extensions to the standard, ISO 8601-2 allows a sign character at the start of the string, and allows combining weeks with other units.
 > If you intend to use a string such as **P3W1D**, **+P1M**, or **-P1M** for interoperability, note that other programs may not accept it.
 
 ## Constructor
@@ -106,11 +105,8 @@ In the default ISO calendar, a year can be 365 or 366 days, and a month can be 2
 Therefore, any `Duration` object with nonzero years or months can refer to a different length of time depending on when the start date is.
 No conversion is ever performed between years, months, weeks, and days, even in `balance` disambiguation mode, because such conversion would be ambiguous.
 
-> **NOTE:** This function understands strings where weeks and other units are combined, which are technically not valid ISO 8601 strings.
-> (For example, `P3W1D` is understood to mean three weeks and one day, although it is not valid according to ISO 8601.)
-
-> **NOTE:** This function understands a single sign character at the start of a string, which is an extension to the ISO 8601 standard described in ISO 8601-2.
-> (For example, `-P1Y1M` is a negative duration of one year and one month, and `+P1Y1M` is one year and one month.)
+> **NOTE:** This function understands strings where weeks and other units are combined, and strings with a single sign character at the start, which are extensions to the ISO 8601 standard described in ISO 8601-2.
+> (For example, `P3W1D` is understood to mean three weeks and one day, `-P1Y1M` is a negative duration of one year and one month, and `+P1Y1M` is one year and one month.)
 > If no sign character is present, then the sign is assumed to be positive.
 
 Usage examples:
@@ -392,9 +388,6 @@ This method overrides `Object.prototype.toString()` and provides the ISO 8601 de
 
 > **NOTE**: If any of `duration.milliseconds`, `duration.microseconds`, or `duration.nanoseconds` are over 999, then deserializing from the result of `duration.toString()` will yield an equal but different object.
 > See [Duration balancing](./balancing.md#serialization) for more information.
-
-> **NOTE**: The output of `duration.toString()` may combine weeks with other units, which is technically invalid according to ISO 8601.
-> (For example, `P3W` for three weeks is valid, but `P3W1D` for three weeks and one day is not.)
 
 Usage examples:
 ```javascript

--- a/docs/iso-string-ext.md
+++ b/docs/iso-string-ext.md
@@ -90,8 +90,3 @@ When expressed as an ISO string, we would say:
     2020-04-25{hebrew}
 
 Since it is ambiguous whether that string represents a Date, YearMonth, or MonthDay, the appropriate Temporal constructor must be chosen in order to get the expected data type back out.
-
-## Duration weeks
-
-The ISO 8601 standard allows durations in units of weeks (`P3W` for three weeks), but weeks are not allowed to appear together with any other units.
-Temporal.Duration does support combining weeks with other units, so we propose the convention of strings such as `P3W1DT1H` for three weeks, one day, and one hour.


### PR DESCRIPTION
These are allowed extensions in ISO 8601-2, so instead of noting that
they are not valid ISO, note that they are extensions. Remove them from
our custom ISO extensions page, since they are not custom to Temporal
anymore.