### PR TITLE
Rounding, Part 1

### DIFF
--- a/docs/absolute.md
+++ b/docs/absolute.md
@@ -356,6 +356,55 @@ billion.toDateTime(utc).difference(epoch.toDateTime(utc), { largestUnit: 'years'
   // => P31Y8M8DT1H46M40S
 ```
 
+### absolute.**round**(_options_: object) : Temporal.Absolute
+
+**Parameters:**
+- `options` (object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `smallestUnit` (required string): The unit to round to.
+    Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+  - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
+    The default is 1.
+  - `roundingMode` (string): How to handle the remainder.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    The default is `'nearest'`.
+
+**Returns:** a new `Temporal.Absolute` object which is `absolute` rounded to `roundingIncrement` of `smallestUnit`.
+
+Rounds `absolute` to the given unit and increment, and returns the result as a new `Temporal.Absolute` object.
+
+The `smallestUnit` option determines the unit to round to.
+For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
+This option is required.
+
+The `roundingIncrement` option allows rounding to an integer number of units.
+For example, to round to increments of a half hour, use `smallestUnit: 'minute', roundingIncrement: 30`.
+
+The combination of `roundingIncrement` and `smallestUnit` must make an increment that divides evenly into 86400 seconds (one 24-hour solar day).
+(For example, increments of 15 minutes and 45 seconds are both allowed.
+25 minutes, and 7 seconds are both not allowed.) Hour increments are not allowed either, since `Temporal.Absolute` has no time zone and therefore it is not defined where the starting point of the hour is.
+
+The `roundingMode` option controls how the rounding is performed.
+  - `ceil`: Always round up, towards the end of time.
+  - `floor`, `trunc`: Always round down, towards the beginning of time.
+    (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
+  - `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+    When there is a tie, round up, like `ceil`.
+
+Example usage:
+```javascript
+abs = Temporal.Absolute.from('2019-03-30T02:45:59.999999999Z');
+
+// Round to a particular unit
+abs.round({ smallestUnit: 'second' });  // => 2019-03-30T02:46Z
+// Round to an increment of a unit, e.g. an hour:
+abs.round({ roundingIncrement: 60, smallestUnit: 'minute' });
+  // => 2019-03-30T03:00Z
+// Round to the same increment but round down instead:
+abs.round({ roundingIncrement: 60, smallestUnit: 'minute', roundingMode: 'floor' });
+  // => 2019-03-30T02:00Z
+```
+
 ### absolute.**equals**(_other_: Temporal.Absolute) : boolean
 
 **Parameters:**

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -123,15 +123,25 @@ Sort a list of ISO 8601 date/time strings, for example to place log entries in o
 
 ### Round a time down to whole hours
 
-Use the `with()` method of each Temporal type (except `Temporal.Absolute`) if you want to round or balance the fields.
+Use the `round()` method of each Temporal type if you want to round the time fields.
 Here's an example of rounding a time _down_ to the previously occurring whole hour:
 
 ```javascript
 {{cookbook/roundDownToWholeHours.mjs}}
 ```
 
-`Temporal.Absolute` is an absolute timestamp and doesn't have any concept of a calendar or wall clock, so it can't be rounded to a certain field value.
-If you need to round a `Temporal.Absolute` instance, convert it to a type such as `Temporal.DateTime`.
+### Round a date to the nearest start of the month
+
+Rounding is only defined for time fields.
+Rounding a date field can be ambiguous, so date-only types such as `Temporal.Date` don't have a `round()` method.
+If you need to round a date to the nearest month, for example, then you must explicitly pick what kind of rounding you want.
+Here is an example of rounding to the nearest start of a month, rounding up in case of a tie:
+
+```javascript
+{{cookbook/roundToNearestMonth.mjs}}
+```
+
+See also [Push back a launch date](#push-back-a-launch-date) for an easier way to round up unconditionally to the _next_ start of a month.
 
 ## Time zone conversion
 

--- a/docs/cookbook/roundDownToWholeHours.mjs
+++ b/docs/cookbook/roundDownToWholeHours.mjs
@@ -1,9 +1,5 @@
 const time = Temporal.Time.from('12:38:28.138818731');
 
-// explicitly:
-let wholeHour = time.with({ minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 });
-assert.equal(wholeHour.toString(), '12:00');
+const wholeHour = time.round({ smallestUnit: 'hour', roundingMode: 'floor' });
 
-// or, taking advantage of 0 being the default for time fields:
-wholeHour = Temporal.Time.from({ hour: time.hour });
 assert.equal(wholeHour.toString(), '12:00');

--- a/docs/cookbook/roundToNearestMonth.mjs
+++ b/docs/cookbook/roundToNearestMonth.mjs
@@ -1,0 +1,11 @@
+const date = Temporal.Date.from('2018-09-16');
+
+let { year, month } = date;
+if ((date.day - 1) / date.daysInMonth >= 0.5) month++;
+if (month > 12) {
+  month %= 12;
+  year++;
+}
+const nearestMonth = Temporal.Date.from({ year, month, day: 1 });
+
+assert.equal(nearestMonth.toString(), '2018-10-01');

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -510,6 +510,58 @@ mar1.difference(feb1, { largestUnit: 'months' });        // => P1M
 may1.difference(jan1);                                   // => P121D
 ```
 
+### datetime.**round**(_options_: object) : Temporal.DateTime
+
+**Parameters:**
+- `options` (object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `smallestUnit` (required string): The unit to round to.
+    Valid values are `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+  - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
+    The default is 1.
+  - `roundingMode` (string): How to handle the remainder.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    The default is `'nearest'`.
+
+**Returns:** a new `Temporal.DateTime` object which is `datetime` rounded to `roundingIncrement` of `smallestUnit`.
+
+Rounds `datetime` to the given unit and increment, and returns the result as a new `Temporal.DateTime` object.
+
+The `smallestUnit` option determines the unit to round to.
+For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
+This option is required.
+
+The `roundingIncrement` option allows rounding to an integer number of units.
+For example, to round to increments of a half hour, use `smallestUnit: 'minute', roundingIncrement: 30`.
+
+The value given as `roundingIncrement` must divide evenly into the next highest unit after `smallestUnit`, and must not be equal to it.
+(For example, if `smallestUnit` is `'minutes'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
+The valid values in this case are 1 (default), 2, 3, 4, 5, 6, 10, 12, 15, 20, and 30.
+Instead of 60 minutes, use 1 hour.)
+
+If `smallestUnit` is `'day'`, then 1 is the only allowed value for `roundingIncrement`.
+
+The `roundingMode` option controls how the rounding is performed.
+  - `ceil`: Always round up, towards the end of time.
+  - `floor`, `trunc`: Always round down, towards the beginning of time.
+    (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
+  - `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+    When there is a tie, round up, like `ceil`.
+
+Example usage:
+```javascript
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
+
+// Round to a particular unit
+dt.round({ smallestUnit: 'hour' });  // => 1995-12-07T03:00
+// Round to an increment of a unit, e.g. half an hour:
+dt.round({ roundingIncrement: 30, smallestUnit: 'minute' });
+  // => 1995-12-07T03:30
+// Round to the same increment but round down instead:
+dt.round({ roundingIncrement: 30, smallestUnit: 'minute', roundingMode: 'floor' });
+  // => 1995-12-07T03:00
+```
+
 ### datetime.**equals**(_other_: Temporal.DateTime) : boolean
 
 **Parameters:**

--- a/docs/time.md
+++ b/docs/time.md
@@ -264,6 +264,56 @@ time.difference(Temporal.Time.from('19:39:09.068346205'))  // => PT34M11.9030518
 time.difference(Temporal.Time.from('22:39:09.068346205'))  // => -PT2H25M49.903051894S
 ```
 
+### time.**round**(_options_: object) : Temporal.Time
+
+**Parameters:**
+- `options` (object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `smallestUnit` (required string): The unit to round to.
+    Valid values are `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+  - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
+    The default is 1.
+  - `roundingMode` (string): How to handle the remainder.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    The default is `'nearest'`.
+
+**Returns:** a new `Temporal.Time` object which is `time` rounded to `roundingIncrement` of `smallestUnit`.
+
+Rounds `time` to the given unit and increment, and returns the result as a new `Temporal.Time` object.
+
+The `smallestUnit` option determines the unit to round to.
+For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
+This option is required.
+
+The `roundingIncrement` option allows rounding to an integer number of units.
+For example, to round to increments of a half hour, use `smallestUnit: 'minute', roundingIncrement: 30`.
+
+The value given as `roundingIncrement` must divide evenly into the next highest unit after `smallestUnit`, and must not be equal to it.
+(For example, if `smallestUnit` is `'minutes'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
+The valid values in this case are 1 (default), 2, 3, 4, 5, 6, 10, 12, 15, 20, and 30.
+Instead of 60 minutes, use 1 hour.)
+
+The `roundingMode` option controls how the rounding is performed.
+  - `ceil`: Always round up, towards 23:59:59.999999999.
+  - `floor`, `trunc`: Always round down, 00:00.
+    (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
+  - `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+    When there is a tie, round up, like `ceil`.
+
+Example usage:
+```javascript
+time = Temporal.Time.from('19:39:09.068346205');
+
+// Round to a particular unit
+time.round({ smallestUnit: 'hour' });  // => 20:00
+// Round to an increment of a unit, e.g. half an hour:
+time.round({ roundingIncrement: 30, smallestUnit: 'minute' });
+  // => 19:30
+// Round to the same increment but round up instead:
+time.round({ roundingIncrement: 30, smallestUnit: 'minute', roundingMode: 'ceil' });
+  // => 20:00
+```
+
 ### time.**equals**(_other_: Temporal.Time) : boolean
 
 **Parameters:**

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -100,6 +100,12 @@ export namespace Temporal {
     largestUnit: T;
   }
 
+  export interface RoundOptions<T extends string> {
+    smallestUnit: T;
+    roundingIncrement?: number;
+    roundingMode?: 'ceil' | 'floor' | 'trunc' | 'nearest';
+  }
+
   export type DurationLike = {
     years?: number;
     months?: number;
@@ -191,6 +197,7 @@ export namespace Temporal {
       other: Temporal.Absolute,
       options?: DifferenceOptions<'hours' | 'minutes' | 'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds'>
     ): Temporal.Duration;
+    round(options: RoundOptions<'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>): Temporal.Absolute;
     toDateTime(tzLike: TimeZoneProtocol | string, calendar?: CalendarProtocol | string): Temporal.DateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -591,6 +591,9 @@ export namespace Temporal {
       other: Temporal.Time,
       options?: DifferenceOptions<'hours' | 'minutes' | 'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds'>
     ): Temporal.Duration;
+    round(
+      options: RoundOptions<'hour' | 'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>
+    ): Temporal.Time;
     toDateTime(temporalDate: Temporal.Date): Temporal.DateTime;
     getFields(): TimeFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -484,6 +484,9 @@ export namespace Temporal {
         | 'nanoseconds'
       >
     ): Temporal.Duration;
+    round(
+      options: RoundOptions<'day' | 'hour' | 'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>
+    ): Temporal.DateTime;
     toAbsolute(tzLike: TimeZoneProtocol | string, options?: ToAbsoluteOptions): Temporal.Absolute;
     toDate(): Temporal.Date;
     toYearMonth(): Temporal.YearMonth;

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -434,6 +434,61 @@ export class DateTime {
       nanoseconds
     );
   }
+  round(options) {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (options === undefined) throw new TypeError('options parameter is required');
+    const smallestUnit = ES.ToSmallestTemporalUnit(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options);
+    const maximumIncrements = {
+      day: 1,
+      hour: 24,
+      minute: 60,
+      second: 60,
+      millisecond: 1000,
+      microsecond: 1000,
+      nanosecond: 1000
+    };
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+
+    let year = GetSlot(this, ISO_YEAR);
+    let month = GetSlot(this, ISO_MONTH);
+    let day = GetSlot(this, ISO_DAY);
+    let hour = GetSlot(this, HOUR);
+    let minute = GetSlot(this, MINUTE);
+    let second = GetSlot(this, SECOND);
+    let millisecond = GetSlot(this, MILLISECOND);
+    let microsecond = GetSlot(this, MICROSECOND);
+    let nanosecond = GetSlot(this, NANOSECOND);
+    let deltaDays = 0;
+    ({ deltaDays, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundTime(
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      roundingIncrement,
+      smallestUnit,
+      roundingMode
+    ));
+    ({ year, month, day } = ES.BalanceDate(year, month, day + deltaDays));
+
+    const Construct = ES.SpeciesConstructor(this, DateTime);
+    const result = new Construct(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      GetSlot(this, CALENDAR)
+    );
+    if (!ES.IsTemporalDateTime(result)) throw new TypeError('invalid result');
+    return result;
+  }
   equals(other) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalDateTime(other)) throw new TypeError('invalid Date object');

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1,4 +1,10 @@
 const IntlDateTimeFormat = globalThis.Intl.DateTimeFormat;
+const MathAbs = Math.abs;
+const MathCeil = Math.ceil;
+const MathFloor = Math.floor;
+const MathSign = Math.sign;
+const MathTrunc = Math.trunc;
+const NumberIsNaN = Number.isNaN;
 const ObjectAssign = Object.assign;
 const ObjectCreate = Object.create;
 
@@ -476,6 +482,21 @@ export const ES = ObjectAssign({}, ES2019, {
     options = ES.NormalizeOptionsObject(options);
     return ES.GetOption(options, 'disambiguation', ['compatible', 'earlier', 'later', 'reject'], 'compatible');
   },
+  ToTemporalRoundingMode: (options) => {
+    options = ES.NormalizeOptionsObject(options);
+    return ES.GetOption(options, 'roundingMode', ['ceil', 'floor', 'trunc', 'nearest'], 'nearest');
+  },
+  ToTemporalRoundingIncrement: (options, dividend, inclusive) => {
+    options = ES.NormalizeOptionsObject(options);
+    let maximum = Infinity;
+    if (dividend !== undefined) maximum = dividend;
+    if (!inclusive && dividend !== undefined) maximum = dividend > 1 ? dividend - 1 : 1;
+    const increment = ES.GetNumberOption(options, 'roundingIncrement', 1, maximum, 1);
+    if (dividend !== undefined && dividend % increment !== 0) {
+      throw new RangeError(`Rounding increment must divide evenly into ${dividend}`);
+    }
+    return increment;
+  },
   ToLargestTemporalUnit: (options, fallback, disallowedStrings = []) => {
     const allowed = new Set([
       'years',
@@ -494,6 +515,31 @@ export const ES = ObjectAssign({}, ES2019, {
     }
     options = ES.NormalizeOptionsObject(options);
     return ES.GetOption(options, 'largestUnit', [...allowed], fallback);
+  },
+  ToSmallestTemporalUnit: (options, disallowedStrings = []) => {
+    const singular = new Map([
+      ['days', 'day'],
+      ['hours', 'hour'],
+      ['minutes', 'minute'],
+      ['seconds', 'second'],
+      ['milliseconds', 'millisecond'],
+      ['microseconds', 'microsecond'],
+      ['nanoseconds', 'nanosecond']
+    ]);
+    const allowed = new Set(['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond']);
+    for (const s of disallowedStrings) {
+      allowed.delete(s);
+    }
+    const allowedValues = [...allowed];
+    options = ES.NormalizeOptionsObject(options);
+    let value = options.smallestUnit;
+    if (value === undefined) throw new RangeError('smallestUnit option is required');
+    value = ES.ToString(value);
+    if (singular.has(value)) value = singular.get(value);
+    if (!allowedValues.includes(value)) {
+      throw new RangeError(`smallestUnit must be one of ${allowedValues.join(', ')}, not ${value}`);
+    }
+    return value;
   },
   ToPartialRecord: (bag, fields) => {
     if (!bag || 'object' !== typeof bag) return false;
@@ -1576,6 +1622,26 @@ export const ES = ObjectAssign({}, ES2019, {
       overflow
     );
   },
+  RoundNumberToIncrement: (quantity, increment, mode) => {
+    const quotient = quantity / increment;
+    let round;
+    switch (mode) {
+      case 'ceil':
+        round = MathCeil(quotient);
+        break;
+      case 'floor':
+        round = MathFloor(quotient);
+        break;
+      case 'trunc':
+        round = MathTrunc(quotient);
+        break;
+      case 'nearest':
+        // "half away from zero"
+        round = MathSign(quotient) * MathFloor(MathAbs(quotient) + 0.5);
+        break;
+    }
+    return round * increment;
+  },
 
   AssertPositiveInteger: (num) => {
     if (!Number.isFinite(num) || Math.abs(num) !== num) throw new RangeError(`invalid positive integer: ${num}`);
@@ -1655,6 +1721,15 @@ export const ES = ObjectAssign({}, ES2019, {
       return value;
     }
     return fallback;
+  },
+  GetNumberOption: (options, property, minimum, maximum, fallback) => {
+    let value = options[property];
+    if (value === undefined) return fallback;
+    value = ES.ToNumber(value);
+    if (NumberIsNaN(value) || value < minimum || value > maximum) {
+      throw new RangeError(`${property} must be between ${minimum} and ${maximum}, not ${value}`);
+    }
+    return MathFloor(value);
   }
 });
 

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1642,6 +1642,50 @@ export const ES = ObjectAssign({}, ES2019, {
     }
     return round * increment;
   },
+  RoundTime: (hour, minute, second, millisecond, microsecond, nanosecond, increment, unit, roundingMode) => {
+    let quantity = 0;
+    switch (unit) {
+      case 'day':
+        quantity =
+          (((second + millisecond * 1e-3 + microsecond * 1e-6 + nanosecond * 1e-9) / 60 + minute) / 60 + hour) / 24;
+        break;
+      case 'hour':
+        quantity = ((second + millisecond * 1e-3 + microsecond * 1e-6 + nanosecond * 1e-9) / 60 + minute) / 60 + hour;
+        break;
+      case 'minute':
+        quantity = (second + millisecond * 1e-3 + microsecond * 1e-6 + nanosecond * 1e-9) / 60 + minute;
+        break;
+      case 'second':
+        quantity = second + millisecond * 1e-3 + microsecond * 1e-6 + nanosecond * 1e-9;
+        break;
+      case 'millisecond':
+        quantity = millisecond + microsecond * 1e-3 + nanosecond * 1e-9;
+        break;
+      case 'microsecond':
+        quantity = microsecond + nanosecond * 1e-3;
+        break;
+      case 'nanosecond':
+        quantity = nanosecond;
+        break;
+    }
+    const result = ES.RoundNumberToIncrement(quantity, increment, roundingMode);
+    switch (unit) {
+      case 'day':
+        return { deltaDays: result, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
+      case 'hour':
+        return ES.BalanceTime(result, 0, 0, 0, 0, 0);
+      case 'minute':
+        return ES.BalanceTime(hour, result, 0, 0, 0, 0);
+      case 'second':
+        return ES.BalanceTime(hour, minute, result, 0, 0, 0);
+      case 'millisecond':
+        return ES.BalanceTime(hour, minute, second, result, 0, 0);
+      case 'microsecond':
+        return ES.BalanceTime(hour, minute, second, millisecond, result, 0);
+      case 'nanosecond':
+        return ES.BalanceTime(hour, minute, second, millisecond, microsecond, result);
+    }
+  },
 
   AssertPositiveInteger: (num) => {
     if (!Number.isFinite(num) || Math.abs(num) !== num) throw new RangeError(`invalid positive integer: ${num}`);

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -254,6 +254,44 @@ export class Time {
     const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
+  round(options) {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (options === undefined) throw new TypeError('options parameter is required');
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, ['day']);
+    const roundingMode = ES.ToTemporalRoundingMode(options);
+    const maximumIncrements = {
+      hour: 24,
+      minute: 60,
+      second: 60,
+      millisecond: 1000,
+      microsecond: 1000,
+      nanosecond: 1000
+    };
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+
+    let hour = GetSlot(this, HOUR);
+    let minute = GetSlot(this, MINUTE);
+    let second = GetSlot(this, SECOND);
+    let millisecond = GetSlot(this, MILLISECOND);
+    let microsecond = GetSlot(this, MICROSECOND);
+    let nanosecond = GetSlot(this, NANOSECOND);
+    ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundTime(
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      roundingIncrement,
+      smallestUnit,
+      roundingMode
+    ));
+
+    const Construct = ES.SpeciesConstructor(this, Time);
+    const result = new Construct(hour, minute, second, millisecond, microsecond, nanosecond);
+    if (!ES.IsTemporalTime(result)) throw new TypeError('invalid result');
+    return result;
+  }
   equals(other) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalTime(other)) throw new TypeError('invalid Time object');

--- a/spec/absolute.html
+++ b/spec/absolute.html
@@ -292,6 +292,45 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.absolute.prototype.round">
+      <h1>Temporal.Absolute.prototype.round ( _options_ )</h1>
+      <p>
+        The `round` method takes one argument, _options_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _absolute_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_absolute_, [[InitializedTemporalAbsolute]]).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"*, *"hour"* »).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
+        1. If _smallestUnit_ is *"minute"*, then
+          1. Let _maximum_ be 1440.
+        1. Else if _smallestUnit_ is *"second"*, then
+          1. Let _maximum_ be 86400.
+        1. Else if _smallestUnit_ is *"millisecond"*, then
+          1. Let _maximum_ be 8.64 × 10<sup>7</sup>.
+        1. Else if _smallestUnit_ is *"microsecond"*, then
+          1. Let _maximum_ be 8.64 × 10<sup>10</sup>.
+        1. Else,
+          1. Assert: _smallestUnit_ is *"nanosecond"*.
+          1. Let _maximum_ be 8.64 × 10<sup>13</sup>.
+        1. Let _roundingIncrement_ be the mathematical value of ? ToTemporalRoundingIncrement(_options_, _maximum_, *true*).
+        1. If _smallestUnit_ is *"minute"*, then
+          1. Let _incrementNs_ be _roundingIncrement_ × 6 × 10<sup>10</sup>.
+        1. Else if _smallestUnit_ is *"second"*, then
+          1. Let _incrementNs_ be _roundingIncrement_ × 10<sup>9</sup>.
+        1. Else if _smallestUnit_ is *"millisecond"*, then
+          1. Let _incrementNs_ be _roundingIncrement_ × 10<sup>6</sup>.
+        1. Else if _smallestUnit_ is *"microsecond"*, then
+          1. Let _incrementNs_ be _roundingIncrement_ × 10<sup>3</sup>.
+        1. Else,
+          1. Let _incrementNs_ be _roundingIncrement_.
+        1. Let _ns_ be the mathematical value of _absolute_.[[Nanoseconds]].
+        1. Let _roundedNs_ be ? RoundNumberToIncrement(_ns_, _incrementNs_, _roundingMode_).
+        1. Return ? CreateTemporalAbsoluteFromInstance(_absolute_, _roundedNs_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.absolute.prototype.equals">
       <h1>Temporal.Absolute.prototype.equals ( _other_ )</h1>
       <p>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -56,6 +56,36 @@
     </emu-alg>
   </emu-clause>
 
+  <!-- Copied from ECMA-402 9.2.12 -->
+  <emu-clause id="sec-defaultnumberoption" aoid="DefaultNumberOption">
+    <h1>DefaultNumberOption ( _value_, _minimum_, _maximum_, _fallback_ )</h1>
+
+    <p>
+      The abstract operation DefaultNumberOption converts _value_ to a Number value, checks whether it is in the allowed range, and fills in a _fallback_ value if necessary.
+    </p>
+
+    <emu-alg>
+      1. If _value_ is *undefined*, return _fallback_.
+      1. Let _value_ be ? ToNumber(_value_).
+      1. If _value_ is *NaN* or less than _minimum_ or greater than _maximum_, throw a *RangeError* exception.
+      1. Return floor(_value_).
+    </emu-alg>
+  </emu-clause>
+
+  <!-- Copied from ECMA-402 9.2.13 -->
+  <emu-clause id="sec-getnumberoption" aoid="GetNumberOption">
+    <h1>GetNumberOption ( _options_, _property_, _minimum_, _maximum_, _fallback_ )</h1>
+
+    <p>
+      The abstract operation GetNumberOption extracts the value of the property named _property_ from the provided _options_ object, converts it to a Number value, checks whether it is in the allowed range, and fills in a _fallback_ value if necessary.
+    </p>
+    <emu-alg>
+      1. Assert: Type(_options_) is Object.
+      1. Let _value_ be ? Get(_options_, _property_).
+      1. Return ? DefaultNumberOption(_value_, _minimum_, _maximum_, _fallback_).
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-totemporaldurationoverflow" aoid="ToTemporalDurationOverflow">
     <h1>ToTemporalDurationOverflow ( _options_ )</h1>
     <emu-alg>
@@ -80,6 +110,33 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-totemporalroundingmode" aoid="ToTemporalRoundingMode">
+    <h1>ToTemporalRoundingMode ( _options_ )</h1>
+    <emu-alg>
+      1. Set _options_ to ? NormalizeOptionsObject(_options_).
+      1. Return ? GetOption(_options_, *"roundingMode"*, *"string"*, « *"ceil"*, *"floor"*, *"trunc"*, *"nearest"* », *"nearest"*).
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-totemporalroundingincrement" aoid="ToTemporalRoundingIncrement">
+    <h1>ToTemporalRoundingIncrement ( _options_, _dividend_, _inclusive_ )</h1>
+    <emu-alg>
+      1. Set _options_ to ? NormalizeOptionsObject(_options_).
+      1. If _dividend_ is *undefined*, then
+        1. Let _maximum_ be *+∞*.
+      1. Else if _inclusive_ is *true*, then
+        1. Let _maximum_ be _dividend_.
+      1. Else if _dividend_ is more than 1, then
+        1. Let _maximum_ be _dividend_ − 1.
+      1. Else,
+        1. Let _maximum_ be 1.
+      1. Let _increment_ be ? GetNumberOption(_options_, *"roundingIncrement"*, 1, _maximum_, 1).
+      1. If _dividend_ is not *undefined* and _dividend_ modulo _increment_ is not zero, then
+        1. Throw a *RangeError* exception.
+      1. Return _increment_.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-tolargesttemporalunit" aoid="ToLargestTemporalUnit">
     <h1>ToLargestTemporalUnit ( _options_, _disallowedUnits_, _defaultUnit_ )</h1>
     <emu-alg>
@@ -89,6 +146,33 @@
       1. If _disallowedUnits_ contains _largestUnit_, then
         1. Throw a *RangeError* exception.
       1. Return _largestUnit_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-tosmallesttemporalunit" aoid="ToSmallestTemporalUnit">
+    <h1>ToSmallestTemporalUnit ( _options_, _disallowedUnits_ )</h1>
+    <emu-alg>
+      1. Set _options_ to ? NormalizeOptionsObject(_options_).
+      1. Let _smallestUnit_ be ? GetOption(_options_, *"smallestUnit"*, *"string"*, « *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *"not present"*).
+      1. If _smallestUnit_ is *"not present"*, then
+        1. Throw a *RangeError* exception.
+      1. If _smallestUnit_ is *"days"*, then
+        1. Set _smallestUnit_ to *"day"*.
+      1. Else if _smallestUnit_ is *"hours"*, then
+        1. Set _smallestUnit_ to *"hour"*.
+      1. Else if _smallestUnit_ is *"minutes"*, then
+        1. Set _smallestUnit_ to *"minute"*.
+      1. Else if _smallestUnit_ is *"seconds"*, then
+        1. Set _smallestUnit_ to *"second"*.
+      1. Else if _smallestUnit_ is *"milliseconds"*, then
+        1. Set _smallestUnit_ to *"millisecond"*.
+      1. Else if _smallestUnit_ is *"microseconds"*, then
+        1. Set _smallestUnit_ to *"microsecond"*.
+      1. Else if _smallestUnit_ is *"nanoseconds"*, then
+        1. Set _smallestUnit_ to *"nanosecond"*.
+      1. If _disallowedUnits_ contains _smallestUnit_, then
+        1. Throw a *RangeError* exception.
+      1. Return _smallestUnit_.
     </emu-alg>
   </emu-clause>
 
@@ -137,6 +221,32 @@
     <h1>RoundTowardsZero ( _x_ )</h1>
     <emu-alg>
       1. Return the mathematical value that is the same sign as _x_ and whose magnitude is floor(abs(_x_)).
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-roundhalfawayfromzero" aoid="RoundHalfAwayFromZero">
+    <h1>RoundHalfAwayFromZero ( _x_ )</h1>
+    <emu-alg>
+      1. Return the mathematical value that is closest to _x_ and is an integer.
+         If two integers are equally close to _x_, then the result is the integer that is farther away from 0. If _x_ is already an integer, then the result is _x_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-roundnumbertoincrement" aoid="RoundNumberToIncrement">
+    <h1>RoundNumberToIncrement ( _x_, _increment_, _roundingMode_ )</h1>
+    <emu-alg>
+      1. Assert: _x_ and _increment_ are mathematical values.
+      1. Assert: _roundingMode_ is *"ceil"*, *"floor"*, *"trunc"*, or *"nearest"*.
+      1. Let _quotient_ be _x_ ÷ _increment_.
+      1. If _roundingMode_ is *"ceil"*, then
+        1. Let _rounded_ be &minus;floor(&minus;_quotient_).
+      1. Else if _roundingMode_ is *"floor"*, then
+        1. Let _rounded_ be floor(_quotient_).
+      1. Else if _roundingMode_ is *"trunc"*, then
+        1. Let _rounded_ be the integral part of _quotient_, removing any fractional digits.
+      1. Else,
+        1. Let _rounded_ be ! RoundHalfAwayFromZero(_quotient_).
+      1. Return _rounded_ × _increment_.
     </emu-alg>
   </emu-clause>
 

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -497,6 +497,34 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.datetime.prototype.round">
+      <h1>Temporal.DateTime.prototype.round ( _options_ )</h1>
+      <p>
+        The `round` method takes one argument, _options_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _dateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
+        1. If _options_ is *undefined*, then
+          1. Throw a *TypeError* exception.
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « »).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
+        1. If _smallestUnit_ is *"day"*, then
+          1. Let _maximum_ be 1.
+        1. Else if _smallestUnit_ is *"hour"*, then
+          1. Let _maximum_ be 24.
+        1. Else if _smallestUnit_ is *"minute"* or *"second"*, then
+          1. Let _maximum_ be 60.
+        1. Else,
+          1. Let _maximum_ be 1000.
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. Let _result_ be ? RoundTime(_dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Let _balanceResult_ be ? BalanceDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]] + _result_.[[Days]]).
+        1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _balanceResult_.[[Year]], _balanceResult_.[[Month]], _balanceResult_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.datetime.prototype.equals">
       <h1>Temporal.DateTime.prototype.equals ( _other_ )</h1>
       <p>

--- a/spec/time.html
+++ b/spec/time.html
@@ -299,6 +299,31 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.time.prototype.round">
+      <h1>Temporal.Time.prototype.round ( _options_ )</h1>
+      <p>
+        The `round` method takes one argument, _options_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _temporalTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
+        1. If _options_ is *undefined*, then
+          1. Throw a *TypeError* exception.
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"* »).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
+        1. If _smallestUnit_ is *"hour"*, then
+          1. Let _maximum_ be 24.
+        1. Else if _smallestUnit_ is *"minute"* or *"second"*, then
+          1. Let _maximum_ be 60.
+        1. Else,
+          1. Let _maximum_ be 1000.
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. Let _result_ be ? RoundTime(_temporalTime_.[[Hour]], _temporalTime_.[[Minute]], _temporalTime_.[[Second]], _temporalTime_.[[Millisecond]], _temporalTime_.[[Microsecond]], _temporalTime_.[[Nanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Return ? CreateTemporalTimeFromInstance(_temporalTime_, _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.time.prototype.equals">
       <h1>Temporal.Time.prototype.equals ( _other_ )</h1>
       <p>

--- a/spec/time.html
+++ b/spec/time.html
@@ -718,5 +718,51 @@
         1. Return ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-temporal-roundtime" aoid="RoundTime">
+      <h1>RoundTime ( _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_ )</h1>
+      <emu-alg>
+        1. Let _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, and _increment_ each be the mathematical values of themselves.
+        1. Let _fractionalSecond_ be _nanosecond_ × 10<sup>−9</sup> + _microsecond_ × 10<sup>−6</sup> + _millisecond_ × 10<sup>−3</sup> + _second_.
+        1. If _unit_ is *"day"*, then
+          1. Let _quantity_ be ((_fractionalSecond_ ÷ 60 + _minute_) ÷ 60 + _hour_) ÷ 24.
+        1. Else if _unit_ is *"hour"*, then
+          1. Let _quantity_ be (_fractionalSecond_ ÷ 60 + _minute_) ÷ 60 + _hour_.
+        1. Else if _unit_ is *"minute"*, then
+          1. Let _quantity_ be _fractionalSecond_ ÷ 60 + _minute_.
+        1. Else if _unit_ is *"second"*, then
+          1. Let _quantity_ be _fractionalSecond_.
+        1. Else if _unit_ is *"millisecond"*, then
+          1. Let _quantity_ be _nanosecond_ × 10<sup>−6</sup> + _microsecond_ × 10<sup>−3</sup> + _millisecond_.
+        1. Else if _unit_ is *"microsecond"*, then
+          1. Let _quantity_ be _nanosecond_ × 10<sup>−3</sup> + _microsecond_.
+        1. Else,
+          1. Assert: _unit_ is *"nanosecond"*.
+          1. Let _quantity_ be _nanosecond_.
+        1. Let _result_ be ! RoundNumberToIncrement(_quantity_, _increment_, _roundingMode_).
+        1. If _unit_ is *"day"*, then
+          1. Return the new Record {
+            [[Days]]: _result_,
+            [[Hour]]: 0,
+            [[Minute]]: 0,
+            [[Second]]: 0,
+            [[Millisecond]]: 0,
+            [[Microsecond]]: 0,
+            [[Nanosecond]]: 0
+          }.
+        1. If _unit_ is *"hour"*, then
+          1. Return ? BalanceTime(_result_, 0, 0, 0, 0, 0).
+        1. If _unit_ is *"minute"*, then
+          1. Return ? BalanceTime(_hour_, _result_, 0, 0, 0, 0).
+        1. If _unit_ is *"second"*, then
+          1. Return ? BalanceTime(_hour_, _minute_, _result_, 0, 0, 0).
+        1. If _unit_ is *"millisecond"*, then
+          1. Return ? BalanceTime(_hour_, _minute_, _second_, _result_, 0, 0).
+        1. If _unit_ is *"microsecond"*, then
+          1. Return ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _result_, 0).
+        1. Assert: _unit_ is *"nanosecond"*.
+        1. Return ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _result_).
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
This is Part 1 of the implementation of rounding. It encompasses the `round()` methods of Absolute, Date, and DateTime.
(Part 2 will add rounding to the `difference()` methods of those types, and Part 3 will add a `round()` method to Duration.)

See: #827