### PR TITLE
Remove days as allowed unit in Absolute.difference TS type

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -190,7 +190,7 @@ export namespace Temporal {
     difference(
       other: Temporal.Absolute,
       options?: DifferenceOptions<
-        'days' | 'hours' | 'minutes' | 'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds'
+        'hours' | 'minutes' | 'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds'
       >
     ): Temporal.Duration;
     toDateTime(tzLike: TimeZoneProtocol | string, calendar?: CalendarProtocol | string): Temporal.DateTime;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -189,9 +189,7 @@ export namespace Temporal {
     minus(durationLike: Temporal.Duration | DurationLike): Temporal.Absolute;
     difference(
       other: Temporal.Absolute,
-      options?: DifferenceOptions<
-        'hours' | 'minutes' | 'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds'
-      >
+      options?: DifferenceOptions<'hours' | 'minutes' | 'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds'>
     ): Temporal.Duration;
     toDateTime(tzLike: TimeZoneProtocol | string, calendar?: CalendarProtocol | string): Temporal.DateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;


### PR DESCRIPTION
#859 forgot to update the TS type declarations to remove `days` as a valid value for `largestUnit` in `Absolute.prototype.difference`.