### PR TITLE
Remove brand checks from CompareTemporalDate and CompareTemporalTime

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -193,7 +193,15 @@ class ISO8601Calendar extends Calendar {
       'microseconds',
       'nanoseconds'
     ]);
-    const { years, months, weeks, days } = ES.DifferenceDate(one, two, largestUnit);
+    const { years, months, weeks, days } = ES.DifferenceDate(
+      GetSlot(one, ISO_YEAR),
+      GetSlot(one, ISO_MONTH),
+      GetSlot(one, ISO_DAY),
+      GetSlot(two, ISO_YEAR),
+      GetSlot(two, ISO_MONTH),
+      GetSlot(two, ISO_DAY),
+      largestUnit
+    );
     const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
   }

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -385,8 +385,18 @@ export class DateTime {
     }
     const largestUnit = ES.ToLargestTemporalUnit(options, 'days');
     let { deltaDays, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(
-      other,
-      this
+      GetSlot(other, HOUR),
+      GetSlot(other, MINUTE),
+      GetSlot(other, SECOND),
+      GetSlot(other, MILLISECOND),
+      GetSlot(other, MICROSECOND),
+      GetSlot(other, NANOSECOND),
+      GetSlot(this, HOUR),
+      GetSlot(this, MINUTE),
+      GetSlot(this, SECOND),
+      GetSlot(this, MILLISECOND),
+      GetSlot(this, MICROSECOND),
+      GetSlot(this, NANOSECOND)
     );
     let year = GetSlot(this, ISO_YEAR);
     let month = GetSlot(this, ISO_MONTH);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1276,16 +1276,23 @@ export const ES = ObjectAssign({}, ES2019, {
     }
   },
 
-  DifferenceDate: (one, two, largestUnit = 'days') => {
+  DifferenceDate: (y1, m1, d1, y2, m2, d2, largestUnit = 'days') => {
     let larger, smaller, sign;
-    const TemporalDate = GetIntrinsic('%Temporal.Date%');
-    if (TemporalDate.compare(one, two) < 0) {
-      smaller = one;
-      larger = two;
+    let comparison = 0;
+    if (y1 !== y2) {
+      comparison = y1 - y2;
+    } else if (m1 !== m2) {
+      comparison = m1 - m2;
+    } else {
+      comparison = d1 - d2;
+    }
+    if (comparison < 0) {
+      smaller = { year: y1, month: m1, day: d1 };
+      larger = { year: y2, month: m2, day: d2 };
       sign = 1;
     } else {
-      smaller = two;
-      larger = one;
+      smaller = { year: y2, month: m2, day: d2 };
+      larger = { year: y1, month: m1, day: d1 };
       sign = -1;
     }
     let years = larger.year - smaller.year;
@@ -1346,13 +1353,13 @@ export const ES = ObjectAssign({}, ES2019, {
     days *= sign;
     return { years, months, weeks, days };
   },
-  DifferenceTime: (one, two) => {
-    let hours = two.hour - one.hour;
-    let minutes = two.minute - one.minute;
-    let seconds = two.second - one.second;
-    let milliseconds = two.millisecond - one.millisecond;
-    let microseconds = two.microsecond - one.microsecond;
-    let nanoseconds = two.nanosecond - one.nanosecond;
+  DifferenceTime: (h1, min1, s1, ms1, µs1, ns1, h2, min2, s2, ms2, µs2, ns2) => {
+    let hours = h2 - h1;
+    let minutes = min2 - min1;
+    let seconds = s2 - s1;
+    let milliseconds = ms2 - ms1;
+    let microseconds = µs2 - µs1;
+    let nanoseconds = ns2 - ns1;
 
     const sign = ES.DurationSign(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
     hours *= sign;

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -240,7 +240,20 @@ export class Time {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalTime(other)) throw new TypeError('invalid Time object');
     const largestUnit = ES.ToLargestTemporalUnit(options, 'hours', ['years', 'months', 'weeks', 'days']);
-    let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(other, this);
+    let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(
+      GetSlot(other, HOUR),
+      GetSlot(other, MINUTE),
+      GetSlot(other, SECOND),
+      GetSlot(other, MILLISECOND),
+      GetSlot(other, MICROSECOND),
+      GetSlot(other, NANOSECOND),
+      GetSlot(this, HOUR),
+      GetSlot(this, MINUTE),
+      GetSlot(this, SECOND),
+      GetSlot(this, MILLISECOND),
+      GetSlot(this, MICROSECOND),
+      GetSlot(this, NANOSECOND)
+    );
     ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
       0,
       hours,

--- a/spec/date.html
+++ b/spec/date.html
@@ -86,7 +86,7 @@
       <emu-alg>
         1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDate]]).
         1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalDate]]).
-        1. Return ! CompareTemporalDate(_one_, _two_).
+        1. Return ! CompareTemporalDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -431,7 +431,7 @@
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalDate]]).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
-        1. Let _result_ be ? DifferenceDate(_other_, _temporalDate_, _largestUnit_).
+        1. Let _result_ be ? DifferenceDate(_other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _largestUnit_).
         1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
@@ -581,26 +581,26 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-differencedate" aoid="DifferenceDate">
-      <h1>DifferenceDate ( _one_, _two_, _largestUnit_ )</h1>
+      <h1>DifferenceDate ( _y1_, _m1_, _d1_, _y2_, _m2_, _d2_, _largestUnit_ )</h1>
       <emu-alg>
         1. Assert: _largestUnit_ is one of *"years"*, *"months"*, *"weeks"*, *"days"*, *"hours"*, *"minutes"*, or *"seconds"*.
         1. If _largestUnit_ is not *"years"*, *"months"*, or *"weeks"*, then
           1. Set _largestUnit_ to `"days"`.
-        1. If ! CompareTemporalDate(_one_, _two_) &lt; 0, then
-          1. Let _smaller_ be _one_.
-          1. Let _greater_ be _two_.
+        1. If ! CompareTemporalDate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_) &lt; 0, then
+          1. Let _smaller_ be the new Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
+          1. Let _greater_ be the new Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
           1. Let _sign_ be 1.
         1. Else,
-          1. Let _smaller_ be _two_.
-          1. Let _greater_ be _one_.
+          1. Let _smaller_ be the new Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
+          1. Let _greater_ be the new Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
           1. Let _sign_ be −1.
-        1. Let _years_ be _greater_.[[ISOYear]] − _smaller_.[[ISOYear]].
+        1. Let _years_ be _greater_.[[Year]] − _smaller_.[[Year]].
         1. If _largestUnit_ is *"days"* or *"weeks"*, then
           1. Let _weeks_ be 0.
-          1. Let _days_ be ! ToDayOfYear(_greater_.[[ISOYear]], _greater_.[[ISOMonth]], _greater_.[[ISODay]]) − ! ToDayOfYear(_smaller_.[[ISOYear]], _smaller_.[[ISOMonth]], _smaller_.[[ISODay]]).
+          1. Let _days_ be ! ToDayOfYear(_greater_.[[Year]], _greater_.[[Month]], _greater_.[[Day]]) − ! ToDayOfYear(_smaller_.[[Year]], _smaller_.[[Month]], _smaller_.[[Day]]).
           1. Assert: _years_ ≥ 0.
           1. Repeat, while _years_ &gt; 0,
-            1. Set _days_ to _days_ + ! DaysInYear(_smaller_.[[ISOYear]] + _years_ − 1).
+            1. Set _days_ to _days_ + ! DaysInYear(_smaller_.[[Year]] + _years_ − 1).
             1. Set _years_ to _years_ − 1.
           1. If _largestUnit_ is *"weeks"*, then
             1. Set _weeks_ to floor(_days_ / 7).
@@ -611,18 +611,18 @@
             [[Weeks]]: _weeks_ &times; _sign_,
             [[Days]]: _days_ &times; _sign_
           }.
-        1. Let _months_ be _greater_.[[ISOMonth]] − _smaller_.[[ISOMonth]].
-        1. Let _balanceResult_ be ? BalanceDurationDate(_years_, _months_, _smaller_.[[ISOYear]], _smaller_.[[ISOMonth]], _smaller_.[[ISODay]]).
+        1. Let _months_ be _greater_.[[Month]] − _smaller_.[[Month]].
+        1. Let _balanceResult_ be ? BalanceDurationDate(_years_, _months_, _smaller_.[[Year]], _smaller_.[[Month]], _smaller_.[[Day]]).
         1. Set _years_ to _balanceResult_.[[Years]].
         1. Set _months_ to _balanceResult_.[[Months]].
-        1. Let _days_ be ! ToDayOfYear(_greater_.[[ISOYear]], _greater_.[[ISOMonth]], _greater_.[[ISODay]]) − ! ToDayOfYear(_balanceResult_.[[Year]], _balanceResult_.[[Month]], _smaller_.[[ISODay]]).
+        1. Let _days_ be ! ToDayOfYear(_greater_.[[Year]], _greater_.[[Month]], _greater_.[[Day]]) − ! ToDayOfYear(_balanceResult_.[[Year]], _balanceResult_.[[Month]], _smaller_.[[Day]]).
         1. If _days_ &lt; 0, then
           1. Set _months_ to _months_ − 1.
-          1. Set _balanceResult_ to ? BalanceDurationDate(_years_, _months_, _smaller_.[[ISOYear]], _smaller_.[[ISOMonth]], _smaller_.[[ISODay]]).
+          1. Set _balanceResult_ to ? BalanceDurationDate(_years_, _months_, _smaller_.[[Year]], _smaller_.[[Month]], _smaller_.[[Day]]).
           1. Set _years_ to _balanceResult_.[[Years]].
           1. Set _months_ to _balanceResult_.[[Months]].
-          1. Set _days_ to ! ToDayOfYear(_greater_.[[ISOYear]], _greater_.[[ISOMonth]], _greater_.[[ISODay]]) − ! ToDayOfYear(_balanceResult_.[[Year]], _balanceResult_.[[Month]], _smaller_.[[ISODay]]).
-          1. If _greater_.[[ISOYear]] &gt; _balanceResult_.[[Year]], then
+          1. Set _days_ to ! ToDayOfYear(_greater_.[[Year]], _greater_.[[Month]], _greater_.[[Day]]) − ! ToDayOfYear(_balanceResult_.[[Year]], _balanceResult_.[[Month]], _smaller_.[[Day]]).
+          1. If _greater_.[[Year]] &gt; _balanceResult_.[[Year]], then
             1. Set _days_ to _days_ + ! DaysInYear(_balanceResult_.[[Year]]).
         1. If _largestUnit_ is `"months"`, then
           1. Set _months_ to _years_ × 12.
@@ -880,18 +880,14 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-comparetemporaldate" aoid="CompareTemporalDate">
-      <h1>CompareTemporalDate ( _one_, _two_ )</h1>
+      <h1>CompareTemporalDate ( _y1_, _m1_, _d1_, _y2_, _m2_, _d2_ )</h1>
       <emu-alg>
-        1. Assert: Type(_one_) is Object.
-        1. Assert: _one_ has an [[InitializedTemporalDate]] internal slot.
-        1. Assert: Type(_two_) is Object.
-        1. Assert: _two_ has an [[InitializedTemporalDate]] internal slot.
-        1. If _one_.[[ISOYear]] &gt; _two_.[[ISOYear]], return 1.
-        1. If _one_.[[ISOYear]] &lt; _two_.[[ISOYear]], return -1.
-        1. If _one_.[[ISOMonth]] &gt; _two_.[[ISOMonth]], return 1.
-        1. If _one_.[[ISOMonth]] &lt; _two_.[[ISOMonth]], return -1.
-        1. If _one_.[[ISODay]] &gt; _two_.[[ISODay]], return 1.
-        1. If _one_.[[ISODay]] &lt; _two_.[[ISODay]], return -1.
+        1. If _y1_ &gt; _y2_, return 1.
+        1. If _y1_ &lt; _y2_, return -1.
+        1. If _m1_ &gt; _m2_, return 1.
+        1. If _m1_ &lt; _m2_, return -1.
+        1. If _d1_ &gt; _d2_, return 1.
+        1. If _d1_ &lt; _d2_, return -1.
         1. Return +0.
       </emu-alg>
     </emu-clause>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -97,7 +97,7 @@
       <emu-alg>
         1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDateTime]]).
         1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalDateTime]]).
-        1. Return ! CompareTemporalDateTime(_one_, _two_).
+        1. Return ! CompareTemporalDateTime(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -489,9 +489,9 @@
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalDateTime]]).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"days"*).
-        1. Let _timeDifference_ be ! DifferenceTime(_other_, _dateTime_).
+        1. Let _timeDifference_ be ! DifferenceTime(_other_.[[Hour]], _other_.[[Minute]], _other_.[[Second]], _other_.[[Millisecond]], _other_.[[Microsecond]], _other_.[[Nanosecond]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]]).
         1. Let _balanceResult_ be ? BalanceDate(_greater_.[[ISOYear]], _greater_.[[ISOMonth]], _greater_.[[ISODay]] + _timeDifference_.[[Days]]).
-        1. Let _dateDifference_ be ! DifferenceDate(_smaller_, _balanceResult_, _largestUnit_).
+        1. Let _dateDifference_ be ! DifferenceDate(_smaller_.[[ISOYear]], _smaller_.[[ISOMonth]], _smaller_.[[ISODay]], _balanceResult_.[[Year]], _balanceResult_.[[Month]], _balanceResult_.[[Day]], _largestUnit_).
         1. Let _result_ be ! BalanceDuration(_dateDifference_.[[Days]], _timeDifference.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
         1. Return ? CreateTemporalDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
@@ -978,30 +978,26 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-comparetemporaldatetime" aoid="CompareTemporalDateTime">
-      <h1>CompareTemporalDateTime ( _one_, _two_ )</h1>
+      <h1>CompareTemporalDateTime ( _y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_ )</h1>
       <emu-alg>
-        1. Assert: Type(_one_) is Object.
-        1. Assert: _one_ has an [[InitializedTemporalDateTime]] internal slot.
-        1. Assert: Type(_two_) is Object.
-        1. Assert: _two_ has an [[InitializedTemporalDateTime]] internal slot.
-        1. If _one_.[[ISOYear]] &gt; _two_.[[ISOYear]], return 1.
-        1. If _one_.[[ISOYear]] &lt; _two_.[[ISOYear]], return -1.
-        1. If _one_.[[ISOMonth]] &gt; _two_.[[ISOMonth]], return 1.
-        1. If _one_.[[ISOMonth]] &lt; _two_.[[ISOMonth]], return -1.
-        1. If _one_.[[ISODay]] &gt; _two_.[[ISODay]], return 1.
-        1. If _one_.[[ISODay]] &lt; _two_.[[ISODay]], return -1.
-        1. If _one_.[[Hour]] &gt; _two_.[[Hour]], return 1.
-        1. If _one_.[[Hour]] &lt; _two_.[[Hour]], return -1.
-        1. If _one_.[[Minute]] &gt; _two_.[[Minute]], return 1.
-        1. If _one_.[[Minute]] &lt; _two_.[[Minute]], return -1.
-        1. If _one_.[[Second]] &gt; _two_.[[Second]], return 1.
-        1. If _one_.[[Second]] &lt; _two_.[[Second]], return -1.
-        1. If _one_.[[Millisecond]] &gt; _two_.[[Millisecond]], return 1.
-        1. If _one_.[[Millisecond]] &lt; _two_.[[Millisecond]], return -1.
-        1. If _one_.[[Microsecond]] &gt; _two_.[[Microsecond]], return 1.
-        1. If _one_.[[Microsecond]] &lt; _two_.[[Microsecond]], return -1.
-        1. If _one_.[[Nanosecond]] &gt; _two_.[[Nanosecond]], return 1.
-        1. If _one_.[[Nanosecond]] &lt; _two_.[[Nanosecond]], return -1.
+        1. If _y1_ &gt; _y2_, return 1.
+        1. If _y1_ &lt; _y2_, return -1.
+        1. If _mon1_ &gt; _mon2_, return 1.
+        1. If _mon1_ &lt; _mon2_, return -1.
+        1. If _d1_ &gt; _d2_, return 1.
+        1. If _d1_ &lt; _d2_, return -1.
+        1. If _h1_ &gt; _h2_, return 1.
+        1. If _h1_ &lt; _h2_, return -1.
+        1. If _min1_ &gt; _min2_, return 1.
+        1. If _min1_ &lt; _min2_, return -1.
+        1. If _s1_ &gt; _s2_, return 1.
+        1. If _s1_ &lt; _s2_, return -1.
+        1. If _ms1_ &gt; _ms2_, return 1.
+        1. If _ms1_ &lt; _ms2_, return -1.
+        1. If _mus1_ &gt; _mus2_, return 1.
+        1. If _mus1_ &lt; _mus2_, return -1.
+        1. If _ns1_ &gt; _ns2_, return 1.
+        1. If _ns1_ &lt; _ns2_, return -1.
         1. Return +0.
       </emu-alg>
     </emu-clause>

--- a/spec/time.html
+++ b/spec/time.html
@@ -91,7 +91,7 @@
       <emu-alg>
         1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalTime]]).
         1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalTime]]).
-        1. Return ! CompareTemporalTime(_one_, _two_).
+        1. Return ! CompareTemporalTime(_one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -293,7 +293,7 @@
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalTime]]).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"hours"*).
-        1. Let _result_ be ! DifferenceTime(_other_, _temporalTime_).
+        1. Let _result_ be ! DifferenceTime(_other_.[[Hour]], _other_.[[Minute]], _other_.[[Second]], _other_.[[Millisecond]], _other_.[[Microsecond]], _other_.[[Nanosecond]], _temporalTime_.[[Hour]], _temporalTime_.[[Minute]], _temporalTime_.[[Second]], _temporalTime_.[[Millisecond]], _temporalTime_.[[Microsecond]], _temporalTime_.[[Nanosecond]]).
         1. Set _result_ to ! BalanceDuration(0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _largestUnit_).
         1. Return ? CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
@@ -407,14 +407,14 @@
     <h1>Abstract operations</h1>
 
     <emu-clause id="sec-temporal-differencetime" aoid="DifferenceTime">
-      <h1>DifferenceTime ( _one_, _two_ )</h1>
+      <h1>DifferenceTime ( _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_ )</h1>
       <emu-alg>
-        1. Let _hours_ be _two_.[[Hour]] - _one_.[[Hour]].
-        1. Let _minutes_ be _two_.[[Minute]] - _one_.[[Minute]].
-        1. Let _seconds_ be _two_.[[Second]] - _one_.[[Second]].
-        1. Let _milliseconds_ be _two_.[[Millisecond]] - _one_.[[Millisecond]].
-        1. Let _microseconds_ be _two_.[[Microsecond]] - _one_.[[Microsecond]].
-        1. Let _nanoseconds_ be _two_.[[Nanosecond]] - _one_.[[Nanosecond]].
+        1. Let _hours_ be _h2_ − _h1_.
+        1. Let _minutes_ be _min2_ − _min1_.
+        1. Let _seconds_ be _s2_ − _s1_.
+        1. Let _milliseconds_ be _ms2_ − _ms1_.
+        1. Let _microseconds_ be _mus2_ − _mus1_.
+        1. Let _nanoseconds_ be _ns2_ − _ns1_.
         1. Let _sign_ be ! DurationSign(0, 0, 0, 0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Let _bt_ be ? BalanceTime(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Return the new Record {
@@ -669,24 +669,20 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-comparetemporaltime" aoid="CompareTemporalTime">
-      <h1>CompareTemporalTime ( _one_, _two_ )</h1>
+      <h1>CompareTemporalTime ( _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_ )</h1>
       <emu-alg>
-        1. Assert: Type(_one_) is Object.
-        1. Assert: _one_ has an [[InitializedTemporalTime]] internal slot.
-        1. Assert: Type(_two_) is Object.
-        1. Assert: _two_ has an [[InitializedTemporalTime]] internal slot.
-        1. If _one_.[[Hour]] &gt; _two_.[[Hour]], return 1.
-        1. If _one_.[[Hour]] &lt; _two_.[[Hour]], return -1.
-        1. If _one_.[[Minute]] &gt; _two_.[[Minute]], return 1.
-        1. If _one_.[[Minute]] &lt; _two_.[[Minute]], return -1.
-        1. If _one_.[[Second]] &gt; _two_.[[Second]], return 1.
-        1. If _one_.[[Second]] &lt; _two_.[[Second]], return -1.
-        1. If _one_.[[Millisecond]] &gt; _two_.[[Millisecond]], return 1.
-        1. If _one_.[[Millisecond]] &lt; _two_.[[Millisecond]], return -1.
-        1. If _one_.[[Microsecond]] &gt; _two_.[[Microsecond]], return 1.
-        1. If _one_.[[Microsecond]] &lt; _two_.[[Microsecond]], return -1.
-        1. If _one_.[[Nanosecond]] &gt; _two_.[[Nanosecond]], return 1.
-        1. If _one_.[[Nanosecond]] &lt; _two_.[[Nanosecond]], return -1.
+        1. If _h1_ &gt; _h2_, return 1.
+        1. If _h1_ &lt; _h2_, return -1.
+        1. If _min1_ &gt; _min2_, return 1.
+        1. If _min1_ &lt; _min2_, return -1.
+        1. If _s1_ &gt; _s2_, return 1.
+        1. If _s1_ &lt; _s2_, return -1.
+        1. If _ms1_ &gt; _ms2_, return 1.
+        1. If _ms1_ &lt; _ms2_, return -1.
+        1. If _mus1_ &gt; _mus2_, return 1.
+        1. If _mus1_ &lt; _mus2_, return -1.
+        1. If _ns1_ &gt; _ns2_, return 1.
+        1. If _ns1_ &lt; _ns2_, return -1.
         1. Return +0.
       </emu-alg>
     </emu-clause>

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -88,7 +88,7 @@
       <emu-alg>
         1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalYearMonth]]).
         1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalYearMonth]]).
-        1. Return ! CompareTemporalYearMonth(_one_, _two_).
+        1. Return ! CompareTemporalDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[RefISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[RefISODay]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -596,23 +596,6 @@
         1. Let _year_ be ! PadYear(_yearMonth_.[[ISOYear]]).
         1. Let _month_ be _yearMonth_.[[ISOMonth]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Return the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _month_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-comparetemporalyearmonth" aoid="CompareTemporalYearMonth">
-      <h1>CompareTemporalYearMonth ( _one_, _two_ )</h1>
-      <emu-alg>
-        1. Assert: Type(_one_) is Object.
-        1. Assert: _one_ has an [[InitializedTemporalYearMonth]] internal slot.
-        1. Assert: Type(_two_) is Object.
-        1. Assert: _two_ has an [[InitializedTemporalYearMonth]] internal slot.
-        1. If _one_.[[ISOYear]] &gt; _two_.[[ISOYear]], return 1.
-        1. If _one_.[[ISOYear]] &lt; _two_.[[ISOYear]], return -1.
-        1. If _one_.[[ISOMonth]] &gt; _two_.[[ISOMonth]], return 1.
-        1. If _one_.[[ISOMonth]] &lt; _two_.[[ISOMonth]], return -1.
-        1. If _one_.[[RefISODay]] &gt; _two_.[[RefISODay]], return 1.
-        1. If _one_.[[RefISODay]] &lt; _two_.[[RefISODay]], return -1.
-        1. Return +0.
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
The abstract operations in the spec should have all the fields split out
and passed as number values, so that the abstract operations don't try to
read the internal slots. The public APIs should do the brand checks and
read the internal slots.

Closes: #864