### PR TITLE
Convert -0 to 0 for all Temporal inputs

### DIFF
--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -23,9 +23,9 @@ const ObjectAssign = Object.assign;
 
 export class Date {
   constructor(isoYear, isoMonth, isoDay, calendar = undefined) {
-    isoYear = ES.ToInteger(isoYear);
-    isoMonth = ES.ToInteger(isoMonth);
-    isoDay = ES.ToInteger(isoDay);
+    isoYear = ES.ToIntegerNoNegativeZero(isoYear);
+    isoMonth = ES.ToIntegerNoNegativeZero(isoMonth);
+    isoDay = ES.ToIntegerNoNegativeZero(isoDay);
     if (calendar === undefined) calendar = GetDefaultCalendar();
     ES.RejectDate(isoYear, isoMonth, isoDay);
     ES.RejectDateRange(isoYear, isoMonth, isoDay);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -35,15 +35,15 @@ export class DateTime {
     nanosecond = 0,
     calendar = GetDefaultCalendar()
   ) {
-    isoYear = ES.ToInteger(isoYear);
-    isoMonth = ES.ToInteger(isoMonth);
-    isoDay = ES.ToInteger(isoDay);
-    hour = ES.ToInteger(hour);
-    minute = ES.ToInteger(minute);
-    second = ES.ToInteger(second);
-    millisecond = ES.ToInteger(millisecond);
-    microsecond = ES.ToInteger(microsecond);
-    nanosecond = ES.ToInteger(nanosecond);
+    isoYear = ES.ToIntegerNoNegativeZero(isoYear);
+    isoMonth = ES.ToIntegerNoNegativeZero(isoMonth);
+    isoDay = ES.ToIntegerNoNegativeZero(isoDay);
+    hour = ES.ToIntegerNoNegativeZero(hour);
+    minute = ES.ToIntegerNoNegativeZero(minute);
+    second = ES.ToIntegerNoNegativeZero(second);
+    millisecond = ES.ToIntegerNoNegativeZero(millisecond);
+    microsecond = ES.ToIntegerNoNegativeZero(microsecond);
+    nanosecond = ES.ToIntegerNoNegativeZero(nanosecond);
     calendar = ES.ToTemporalCalendar(calendar);
 
     ES.RejectDateTime(isoYear, isoMonth, isoDay, hour, minute, second, millisecond, microsecond, nanosecond);

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -31,16 +31,16 @@ export class Duration {
     microseconds = 0,
     nanoseconds = 0
   ) {
-    years = ES.ToInteger(years);
-    months = ES.ToInteger(months);
-    weeks = ES.ToInteger(weeks);
-    days = ES.ToInteger(days);
-    hours = ES.ToInteger(hours);
-    minutes = ES.ToInteger(minutes);
-    seconds = ES.ToInteger(seconds);
-    milliseconds = ES.ToInteger(milliseconds);
-    microseconds = ES.ToInteger(microseconds);
-    nanoseconds = ES.ToInteger(nanoseconds);
+    years = ES.ToIntegerNoNegativeZero(years);
+    months = ES.ToIntegerNoNegativeZero(months);
+    weeks = ES.ToIntegerNoNegativeZero(weeks);
+    days = ES.ToIntegerNoNegativeZero(days);
+    hours = ES.ToIntegerNoNegativeZero(hours);
+    minutes = ES.ToIntegerNoNegativeZero(minutes);
+    seconds = ES.ToIntegerNoNegativeZero(seconds);
+    milliseconds = ES.ToIntegerNoNegativeZero(milliseconds);
+    microseconds = ES.ToIntegerNoNegativeZero(microseconds);
+    nanoseconds = ES.ToIntegerNoNegativeZero(nanoseconds);
 
     const sign = ES.DurationSign(
       years,

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -60,7 +60,6 @@ import * as PARSE from './regex.mjs';
 const ES2019 = {
   Call,
   SpeciesConstructor,
-  ToInteger,
   ToNumber,
   ToPrimitive,
   ToString,
@@ -105,17 +104,17 @@ export const ES = ObjectAssign({}, ES2019, {
     if (!match) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
     let yearString = match[1];
     if (yearString[0] === '\u2212') yearString = `-${yearString.slice(1)}`;
-    const year = ES.ToInteger(yearString);
-    const month = ES.ToInteger(match[2] || match[4]);
-    const day = ES.ToInteger(match[3] || match[5]);
-    const hour = ES.ToInteger(match[6]);
-    const minute = ES.ToInteger(match[7] || match[10]);
-    let second = ES.ToInteger(match[8] || match[11]);
+    const year = ES.ToIntegerNoNegativeZero(yearString);
+    const month = ES.ToIntegerNoNegativeZero(match[2] || match[4]);
+    const day = ES.ToIntegerNoNegativeZero(match[3] || match[5]);
+    const hour = ES.ToIntegerNoNegativeZero(match[6]);
+    const minute = ES.ToIntegerNoNegativeZero(match[7] || match[10]);
+    let second = ES.ToIntegerNoNegativeZero(match[8] || match[11]);
     if (second === 60) second = 59;
     const fraction = (match[9] || match[12]) + '000000000';
-    const millisecond = ES.ToInteger(fraction.slice(0, 3));
-    const microsecond = ES.ToInteger(fraction.slice(3, 6));
-    const nanosecond = ES.ToInteger(fraction.slice(6, 9));
+    const millisecond = ES.ToIntegerNoNegativeZero(fraction.slice(0, 3));
+    const microsecond = ES.ToIntegerNoNegativeZero(fraction.slice(3, 6));
+    const nanosecond = ES.ToIntegerNoNegativeZero(fraction.slice(6, 9));
     const offsetSign = match[14] === '-' || match[14] === '\u2212' ? '-' : '+';
     const offset = `${offsetSign}${match[15] || '00'}:${match[16] || '00'}`;
     let ianaName = match[17];
@@ -158,14 +157,14 @@ export const ES = ObjectAssign({}, ES2019, {
     const match = PARSE.time.exec(isoString);
     let hour, minute, second, millisecond, microsecond, nanosecond;
     if (match) {
-      hour = ES.ToInteger(match[1]);
-      minute = ES.ToInteger(match[2] || match[5]);
-      second = ES.ToInteger(match[3] || match[6]);
+      hour = ES.ToIntegerNoNegativeZero(match[1]);
+      minute = ES.ToIntegerNoNegativeZero(match[2] || match[5]);
+      second = ES.ToIntegerNoNegativeZero(match[3] || match[6]);
       if (second === 60) second = 59;
       const fraction = (match[4] || match[7]) + '000000000';
-      millisecond = ES.ToInteger(fraction.slice(0, 3));
-      microsecond = ES.ToInteger(fraction.slice(3, 6));
-      nanosecond = ES.ToInteger(fraction.slice(6, 9));
+      millisecond = ES.ToIntegerNoNegativeZero(fraction.slice(0, 3));
+      microsecond = ES.ToIntegerNoNegativeZero(fraction.slice(3, 6));
+      nanosecond = ES.ToIntegerNoNegativeZero(fraction.slice(6, 9));
     } else {
       ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.ParseISODateTime(isoString, {
         zoneRequired: false
@@ -179,8 +178,8 @@ export const ES = ObjectAssign({}, ES2019, {
     if (match) {
       let yearString = match[1];
       if (yearString[0] === '\u2212') yearString = `-${yearString.slice(1)}`;
-      year = ES.ToInteger(yearString);
-      month = ES.ToInteger(match[2]);
+      year = ES.ToIntegerNoNegativeZero(yearString);
+      month = ES.ToIntegerNoNegativeZero(match[2]);
       calendar = match[3] || null;
     } else {
       ({ year, month, calendar, day: refISODay } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
@@ -192,8 +191,8 @@ export const ES = ObjectAssign({}, ES2019, {
     const match = PARSE.monthday.exec(isoString);
     let month, day, calendar, refISOYear;
     if (match) {
-      month = ES.ToInteger(match[1]);
-      day = ES.ToInteger(match[2]);
+      month = ES.ToIntegerNoNegativeZero(match[1]);
+      day = ES.ToIntegerNoNegativeZero(match[2]);
     } else {
       ({ month, day, calendar, year: refISOYear } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
       if (!calendar) refISOYear = undefined;
@@ -221,17 +220,17 @@ export const ES = ObjectAssign({}, ES2019, {
       throw new RangeError(`invalid duration: ${isoString}`);
     }
     const sign = match[1] === '-' || match[1] === '\u2212' ? -1 : 1;
-    const years = ES.ToInteger(match[2]) * sign;
-    const months = ES.ToInteger(match[3]) * sign;
-    const weeks = ES.ToInteger(match[4]) * sign;
-    const days = ES.ToInteger(match[5]) * sign;
-    const hours = ES.ToInteger(match[6]) * sign;
-    const minutes = ES.ToInteger(match[7]) * sign;
-    const seconds = ES.ToInteger(match[8]) * sign;
+    const years = ES.ToIntegerNoNegativeZero(match[2]) * sign;
+    const months = ES.ToIntegerNoNegativeZero(match[3]) * sign;
+    const weeks = ES.ToIntegerNoNegativeZero(match[4]) * sign;
+    const days = ES.ToIntegerNoNegativeZero(match[5]) * sign;
+    const hours = ES.ToIntegerNoNegativeZero(match[6]) * sign;
+    const minutes = ES.ToIntegerNoNegativeZero(match[7]) * sign;
+    const seconds = ES.ToIntegerNoNegativeZero(match[8]) * sign;
     const fraction = match[9] + '000000000';
-    const milliseconds = ES.ToInteger(fraction.slice(0, 3)) * sign;
-    const microseconds = ES.ToInteger(fraction.slice(3, 6)) * sign;
-    const nanoseconds = ES.ToInteger(fraction.slice(6, 9)) * sign;
+    const milliseconds = ES.ToIntegerNoNegativeZero(fraction.slice(0, 3)) * sign;
+    const microseconds = ES.ToIntegerNoNegativeZero(fraction.slice(3, 6)) * sign;
+    const nanoseconds = ES.ToIntegerNoNegativeZero(fraction.slice(6, 9)) * sign;
     return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
   },
   ParseTemporalInstant: (isoString) => {
@@ -587,7 +586,7 @@ export const ES = ObjectAssign({}, ES2019, {
         } else if (property === 'era') {
           any.era = value;
         } else {
-          any[property] = ES.ToInteger(value);
+          any[property] = ES.ToIntegerNoNegativeZero(value);
         }
       }
     }
@@ -612,7 +611,7 @@ export const ES = ObjectAssign({}, ES2019, {
       } else if (property === 'era') {
         result.era = value;
       } else {
-        result[property] = ES.ToInteger(value);
+        result[property] = ES.ToIntegerNoNegativeZero(value);
       }
     }
     return result;
@@ -1953,6 +1952,10 @@ export const ES = ObjectAssign({}, ES2019, {
       throw new RangeError(`${property} must be between ${minimum} and ${maximum}, not ${value}`);
     }
     return MathFloor(value);
+  },
+  ToIntegerNoNegativeZero: (value) => {
+    const result = ToInteger(value);
+    return result === 0 ? 0 : result; // avoid -0
   }
 });
 

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -9,10 +9,10 @@ const ObjectAssign = Object.assign;
 
 export class MonthDay {
   constructor(isoMonth, isoDay, calendar = undefined, refISOYear = 1972) {
-    isoMonth = ES.ToInteger(isoMonth);
-    isoDay = ES.ToInteger(isoDay);
+    isoMonth = ES.ToIntegerNoNegativeZero(isoMonth);
+    isoDay = ES.ToIntegerNoNegativeZero(isoDay);
     if (calendar === undefined) calendar = GetDefaultCalendar();
-    refISOYear = ES.ToInteger(refISOYear);
+    refISOYear = ES.ToIntegerNoNegativeZero(refISOYear);
     ES.RejectDate(refISOYear, isoMonth, isoDay);
     ES.RejectDateRange(refISOYear, isoMonth, isoDay);
     if (!calendar || typeof calendar !== 'object') throw new RangeError('invalid calendar');
@@ -97,7 +97,7 @@ export class MonthDay {
     if (typeof item === 'object' && item !== null) {
       ({ era, year } = ES.ToRecord(item, [['era', undefined], ['year']]));
     } else {
-      year = ES.ToInteger(item);
+      year = ES.ToIntegerNoNegativeZero(item);
     }
     const calendar = GetSlot(this, CALENDAR);
     const fields = ES.ToTemporalMonthDayRecord(this);

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -21,12 +21,12 @@ import {
 
 export class Time {
   constructor(hour = 0, minute = 0, second = 0, millisecond = 0, microsecond = 0, nanosecond = 0) {
-    hour = ES.ToInteger(hour);
-    minute = ES.ToInteger(minute);
-    second = ES.ToInteger(second);
-    millisecond = ES.ToInteger(millisecond);
-    microsecond = ES.ToInteger(microsecond);
-    nanosecond = ES.ToInteger(nanosecond);
+    hour = ES.ToIntegerNoNegativeZero(hour);
+    minute = ES.ToIntegerNoNegativeZero(minute);
+    second = ES.ToIntegerNoNegativeZero(second);
+    millisecond = ES.ToIntegerNoNegativeZero(millisecond);
+    microsecond = ES.ToIntegerNoNegativeZero(microsecond);
+    nanosecond = ES.ToIntegerNoNegativeZero(nanosecond);
     ES.RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
 
     CreateSlots(this);

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -9,10 +9,10 @@ const ObjectAssign = Object.assign;
 
 export class YearMonth {
   constructor(isoYear, isoMonth, calendar = undefined, refISODay = 1) {
-    isoYear = ES.ToInteger(isoYear);
-    isoMonth = ES.ToInteger(isoMonth);
+    isoYear = ES.ToIntegerNoNegativeZero(isoYear);
+    isoMonth = ES.ToIntegerNoNegativeZero(isoMonth);
     if (calendar === undefined) calendar = GetDefaultCalendar();
-    refISODay = ES.ToInteger(refISODay);
+    refISODay = ES.ToIntegerNoNegativeZero(refISODay);
     ES.RejectDate(isoYear, isoMonth, refISODay);
     ES.RejectYearMonthRange(isoYear, isoMonth);
     if (!calendar || typeof calendar !== 'object') throw new RangeError('invalid calendar');

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -242,6 +242,17 @@ describe('DateTime', () => {
       const datetime = new DateTime(1976, 11, 18);
       it('`${datetime}` is 1976-11-18T00:00', () => equal(`${datetime}`, '1976-11-18T00:00'));
     });
+    describe('constructor treats -0 as 0', () => {
+      it('ignores the sign of -0', () => {
+        const datetime = new DateTime(1976, 11, 18, -0, -0, -0, -0, -0);
+        equal(datetime.hour, 0);
+        equal(datetime.minute, 0);
+        equal(datetime.second, 0);
+        equal(datetime.millisecond, 0);
+        equal(datetime.microsecond, 0);
+        equal(datetime.nanosecond, 0);
+      });
+    });
   });
   describe('.with manipulation', () => {
     const datetime = new DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -85,6 +85,20 @@ describe('Duration', () => {
       equal(d.microseconds, 0);
       equal(d.nanoseconds, 0);
     });
+    it('minus zero is converted to zeroes', () => {
+      const d = new Duration(-0, -0, -0, -0, -0, -0, -0, -0, -0, -0);
+      equal(d.sign, 0);
+      equal(d.years, 0);
+      equal(d.months, 0);
+      equal(d.weeks, 0);
+      equal(d.days, 0);
+      equal(d.hours, 0);
+      equal(d.minutes, 0);
+      equal(d.seconds, 0);
+      equal(d.milliseconds, 0);
+      equal(d.microseconds, 0);
+      equal(d.nanoseconds, 0);
+    });
     it('mixed positive and negative values throw', () => {
       throws(() => new Duration(-1, 1, 1, 1, 1, 1, 1, 1, 1, 1), RangeError);
       throws(() => new Duration(1, -1, 1, 1, 1, 1, 1, 1, 1, 1), RangeError);
@@ -655,6 +669,23 @@ describe('Duration', () => {
       const pos = neg.negated();
       equal(`${pos}`, 'PT2H20M30S');
       equal(pos.sign, 1);
+    });
+    it('makes a copy of a zero duration', () => {
+      const zero = Duration.from('PT0S');
+      const zero2 = zero.negated();
+      equal(`${zero}`, `${zero2}`);
+      notEqual(zero, zero2);
+      equal(zero2.sign, 0);
+      equal(zero2.years, 0);
+      equal(zero2.months, 0);
+      equal(zero2.weeks, 0);
+      equal(zero2.days, 0);
+      equal(zero2.hours, 0);
+      equal(zero2.minutes, 0);
+      equal(zero2.seconds, 0);
+      equal(zero2.milliseconds, 0);
+      equal(zero2.microseconds, 0);
+      equal(zero2.nanoseconds, 0);
     });
     it('makes a copy of a zero duration', () => {
       const zero = Duration.from('PT0S');

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -824,6 +824,17 @@ describe('Time', () => {
         it('constrain leap second', () => equal(`${Time.from(leap)}`, '23:59:59'));
       });
     });
+    describe('constructor treats -0 as 0', () => {
+      it('ignores the sign of -0', () => {
+        const datetime = new Time(-0, -0, -0, -0, -0);
+        equal(datetime.hour, 0);
+        equal(datetime.minute, 0);
+        equal(datetime.second, 0);
+        equal(datetime.millisecond, 0);
+        equal(datetime.microsecond, 0);
+        equal(datetime.nanosecond, 0);
+      });
+    });
   });
   describe('time operations', () => {
     const datetime = { year: 2019, month: 10, day: 1, hour: 14, minute: 20, second: 36 };


### PR DESCRIPTION
Fixes #949 by replacing `ES.ToInteger` with a wrapper that converts `-0`=>`0`.

I wasn't sure if this was the right place to fix this, but it looks like all numeric inputs (including all constructor parameters) go through `ES.ToInteger`, so I figured that would be a good place to start. Feel free to suggest a better fix.

To make it obvious that this was a wrapper and not the real `ToInteger`, I gave the ES method a new name. If this isn't important, then a much-less-impactful version of this PR would be to name the wrapper `ToInteger`.  LMK if this would be desired.  

Also, I removed `ToInteger` from the `ES` object to make sure that no one would accidentally use the unsafe version. To enable this removal, I changed all usage of `ToInteger` to use the wrapper even though there were some places (e.g. Date units) that it might not be needed.

Also: is there any place in Temporal where we'd actually want to retain `-0`?  I assume the answer is no, but figured it was worth asking.