### PR TITLE
Switch to ES2020 imports in es-abstract to fix #949

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/tc39/proposal-temporal#readme",
   "devDependencies": {
-    "marked": "^1.1.1",
+    "marked": "^1.2.0",
     "mkdirp": "^1.0.4",
     "prismjs": "^1.21.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,13 +257,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.1.0.tgz",
-      "integrity": "sha512-U+nRJx8XDUqJxYF0FCXbpmD9nWt/xHDDG0zsw1vrVYAmEAuD/r49iowfurjSL2uTA2JsgtpsyG7mjO7PHf2dYw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.3.0.tgz",
+      "integrity": "sha512-RqEcaHuEKnn3oPFislZ6TNzsBLqpZjN93G69SS+laav/I8w/iGMuMq97P0D2/2/kW4SCebHggqhbcCfbDaaX+g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.1.0",
-        "@typescript-eslint/scope-manager": "4.1.0",
+        "@typescript-eslint/experimental-utils": "4.3.0",
+        "@typescript-eslint/scope-manager": "4.3.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -272,55 +272,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.1.0.tgz",
-      "integrity": "sha512-paEYLA37iqRIDPeQwAmoYSiZ3PiHsaAc3igFeBTeqRHgPnHjHLJ9OGdmP6nwAkF65p2QzEsEBtpjNUBWByNWzA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.3.0.tgz",
+      "integrity": "sha512-cmmIK8shn3mxmhpKfzMMywqiEheyfXLV/+yPDnOTvQX/ztngx7Lg/OD26J8gTZfkLKUmaEBxO2jYP3keV7h2OQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.1.0",
-        "@typescript-eslint/types": "4.1.0",
-        "@typescript-eslint/typescript-estree": "4.1.0",
+        "@typescript-eslint/scope-manager": "4.3.0",
+        "@typescript-eslint/types": "4.3.0",
+        "@typescript-eslint/typescript-estree": "4.3.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.1.0.tgz",
-      "integrity": "sha512-hM/WNCQTzDHgS0Ke3cR9zPndL3OTKr9OoN9CL3UqulsAjYDrglSwIIgswSmHBcSbOzLmgaMARwrQEbIumIglvQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.3.0.tgz",
+      "integrity": "sha512-JyfRnd72qRuUwItDZ00JNowsSlpQGeKfl9jxwO0FHK1qQ7FbYdoy5S7P+5wh1ISkT2QyAvr2pc9dAemDxzt75g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.1.0",
-        "@typescript-eslint/types": "4.1.0",
-        "@typescript-eslint/typescript-estree": "4.1.0",
+        "@typescript-eslint/scope-manager": "4.3.0",
+        "@typescript-eslint/types": "4.3.0",
+        "@typescript-eslint/typescript-estree": "4.3.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.1.0.tgz",
-      "integrity": "sha512-HD1/u8vFNnxwiHqlWKC/Pigdn0Mvxi84Y6GzbZ5f5sbLrFKu0al02573Er+D63Sw67IffVUXR0uR8rpdfdk+vA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.3.0.tgz",
+      "integrity": "sha512-cTeyP5SCNE8QBRfc+Lgh4Xpzje46kNUhXYfc3pQWmJif92sjrFuHT9hH4rtOkDTo/si9Klw53yIr+djqGZS1ig==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.1.0",
-        "@typescript-eslint/visitor-keys": "4.1.0"
+        "@typescript-eslint/types": "4.3.0",
+        "@typescript-eslint/visitor-keys": "4.3.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-rkBqWsO7m01XckP9R2YHVN8mySOKKY2cophGM8K5uDK89ArCgahItQYdbg/3n8xMxzu2elss+an1TphlUpDuJw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.3.0.tgz",
+      "integrity": "sha512-Cx9TpRvlRjOppGsU6Y6KcJnUDOelja2NNCX6AZwtVHRzaJkdytJWMuYiqi8mS35MRNA3cJSwDzXePfmhU6TANw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.1.0.tgz",
-      "integrity": "sha512-r6et57qqKAWU173nWyw31x7OfgmKfMEcjJl9vlJEzS+kf9uKNRr4AVTRXfTCwebr7bdiVEkfRY5xGnpPaNPe4Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.3.0.tgz",
+      "integrity": "sha512-ZAI7xjkl+oFdLV/COEz2tAbQbR3XfgqHEGy0rlUXzfGQic6EBCR4s2+WS3cmTPG69aaZckEucBoTxW9PhzHxxw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.1.0",
-        "@typescript-eslint/visitor-keys": "4.1.0",
+        "@typescript-eslint/types": "4.3.0",
+        "@typescript-eslint/visitor-keys": "4.3.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -330,12 +330,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.1.0.tgz",
-      "integrity": "sha512-+taO0IZGCtCEsuNTTF2Q/5o8+fHrlml8i9YsZt2AiDCdYEJzYlsmRY991l/6f3jNXFyAWepdQj7n8Na6URiDRQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.3.0.tgz",
+      "integrity": "sha512-xZxkuR7XLM6RhvLkgv9yYlTcBHnTULzfnw4i6+z2TGBLy9yljAypQaZl9c3zFvy7PNI7fYWyvKYtohyF8au3cw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.1.0",
+        "@typescript-eslint/types": "4.3.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "dependencies": {
@@ -956,9 +956,9 @@
       }
     },
     "eslint": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
-      "integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.10.0.tgz",
+      "integrity": "sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -969,7 +969,7 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
-        "eslint-scope": "^5.1.0",
+        "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^1.3.0",
         "espree": "^7.3.0",
@@ -1159,9 +1159,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
-      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
+      "integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -2089,9 +2089,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
-      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -2566,9 +2566,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
   },
   "main": "polyfill/lib/index.mjs",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.1.0",
-    "@typescript-eslint/parser": "^4.1.0",
+    "@typescript-eslint/eslint-plugin": "^4.3.0",
+    "@typescript-eslint/parser": "^4.3.0",
     "ecmarkup": "^4.1.3",
-    "eslint": "^7.9.0",
-    "eslint-config-prettier": "^6.11.0",
+    "eslint": "^7.10.0",
+    "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-prettier": "^3.1.4",
     "mkdirp": "^1.0.4",
-    "prettier": "^2.1.1",
-    "typescript": "^4.0.2"
+    "prettier": "^2.1.2",
+    "typescript": "^4.0.3"
   },
   "scripts": {
     "test": "cd polyfill && npm install && npm test && npm run test-cookbook && npm run test262",

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -9,13 +9,13 @@ const ObjectAssign = Object.assign;
 const ObjectCreate = Object.create;
 
 import bigInt from 'big-integer';
-import Call from 'es-abstract/2019/Call.js';
-import SpeciesConstructor from 'es-abstract/2019/SpeciesConstructor.js';
-import ToInteger from 'es-abstract/2019/ToInteger.js';
-import ToNumber from 'es-abstract/2019/ToNumber.js';
-import ToPrimitive from 'es-abstract/2019/ToPrimitive.js';
-import ToString from 'es-abstract/2019/ToString.js';
-import Type from 'es-abstract/2019/Type.js';
+import Call from 'es-abstract/2020/Call.js';
+import SpeciesConstructor from 'es-abstract/2020/SpeciesConstructor.js';
+import ToInteger from 'es-abstract/2020/ToInteger.js';
+import ToNumber from 'es-abstract/2020/ToNumber.js';
+import ToPrimitive from 'es-abstract/2020/ToPrimitive.js';
+import ToString from 'es-abstract/2020/ToString.js';
+import Type from 'es-abstract/2020/Type.js';
 
 import { GetIntrinsic } from './intrinsicclass.mjs';
 import {

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -64,7 +64,7 @@
   ],
   "dependencies": {
     "big-integer": "^1.6.48",
-    "es-abstract": "^1.17.6"
+    "es-abstract": "^1.18.0-next.1"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
@@ -73,15 +73,15 @@
     "@pipobscure/demitasse-pretty": "^1.0.10",
     "@pipobscure/demitasse-run": "^1.0.10",
     "@rollup/plugin-babel": "^5.2.1",
-    "@rollup/plugin-commonjs": "^15.0.0",
+    "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-replace": "^2.3.3",
-    "c8": "^7.3.0",
+    "c8": "^7.3.1",
     "codecov": "^3.7.2",
     "core-js": "^3.6.4",
     "full-icu": "^1.3.0",
     "nyc": "^15.1.0",
-    "rollup": "^2.26.11",
+    "rollup": "^2.28.2",
     "rollup-plugin-terser": "^7.0.2",
     "test262-harness": "^7.5.2",
     "timezones.json": "^1.5.2",

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -242,6 +242,17 @@ describe('DateTime', () => {
       const datetime = new DateTime(1976, 11, 18);
       it('`${datetime}` is 1976-11-18T00:00', () => equal(`${datetime}`, '1976-11-18T00:00'));
     });
+    describe('constructor treats -0 as 0', () => {
+      it('ignores the sign of -0', () => {
+        const datetime = new DateTime(1976, 11, 18, -0, -0, -0, -0, -0);
+        equal(datetime.hour, 0);
+        equal(datetime.minute, 0);
+        equal(datetime.second, 0);
+        equal(datetime.millisecond, 0);
+        equal(datetime.microsecond, 0);
+        equal(datetime.nanosecond, 0);
+      });
+    });
   });
   describe('.with manipulation', () => {
     const datetime = new DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -85,6 +85,20 @@ describe('Duration', () => {
       equal(d.microseconds, 0);
       equal(d.nanoseconds, 0);
     });
+    it('constructor treats -0 as 0', () => {
+      const d = new Duration(-0, -0, -0, -0, -0, -0, -0, -0, -0, -0);
+      equal(d.sign, 0);
+      equal(d.years, 0);
+      equal(d.months, 0);
+      equal(d.weeks, 0);
+      equal(d.days, 0);
+      equal(d.hours, 0);
+      equal(d.minutes, 0);
+      equal(d.seconds, 0);
+      equal(d.milliseconds, 0);
+      equal(d.microseconds, 0);
+      equal(d.nanoseconds, 0);
+    });
     it('mixed positive and negative values throw', () => {
       throws(() => new Duration(-1, 1, 1, 1, 1, 1, 1, 1, 1, 1), RangeError);
       throws(() => new Duration(1, -1, 1, 1, 1, 1, 1, 1, 1, 1), RangeError);
@@ -662,6 +676,16 @@ describe('Duration', () => {
       equal(`${zero}`, `${zero2}`);
       notEqual(zero, zero2);
       equal(zero2.sign, 0);
+      equal(zero2.years, 0);
+      equal(zero2.months, 0);
+      equal(zero2.weeks, 0);
+      equal(zero2.days, 0);
+      equal(zero2.hours, 0);
+      equal(zero2.minutes, 0);
+      equal(zero2.seconds, 0);
+      equal(zero2.milliseconds, 0);
+      equal(zero2.microseconds, 0);
+      equal(zero2.nanoseconds, 0);
     });
   });
   describe('Duration.abs()', () => {

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -824,6 +824,17 @@ describe('Time', () => {
         it('constrain leap second', () => equal(`${Time.from(leap)}`, '23:59:59'));
       });
     });
+    describe('constructor treats -0 as 0', () => {
+      it('ignores the sign of -0', () => {
+        const datetime = new Time(-0, -0, -0, -0, -0);
+        equal(datetime.hour, 0);
+        equal(datetime.minute, 0);
+        equal(datetime.second, 0);
+        equal(datetime.millisecond, 0);
+        equal(datetime.microsecond, 0);
+        equal(datetime.nanosecond, 0);
+      });
+    });
   });
   describe('time operations', () => {
     const datetime = { year: 2019, month: 10, day: 1, hour: 14, minute: 20, second: 36 };


### PR DESCRIPTION
This PR fixes #949 by: 
* Updating es-abstract to pick up a fix to https://github.com/ljharb/es-abstract/issues/116 which was the root cause of #949 
* Changing polyfill/lib/ecmascript.mjs to use the ES2020 imports (previously it was using ES2019 imports)
* Adding tests to verify that #949 is indeed fixed

While I was in the neighborhood, I also bumped all dev dependencies (except demitasse) that were outdated. 