### PR TITLE
Calendar must be equal to locale calendar in toLocaleString()

### DIFF
--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -200,13 +200,31 @@ This method overrides `Object.prototype.toLocaleString()` to provide a human-rea
 
 The `locales` and `options` arguments are the same as in the constructor to [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat).
 
-Example usage:
+The calendar in the output locale (given by `new Intl.DateTimeFormat(locales, options).resolvedOptions().calendar`) must match `monthDay.calendar`, or this method will throw an exception.
+This is because it's not possible to convert a Temporal.MonthDay from one calendar to another without more information.
+In order to ensure that the output always matches `monthDay`'s internal calendar, you must either explicitly construct `monthDay` with the locale's calendar, or explicitly specify the calendar in the `options` parameter:
+
 ```js
-md = Temporal.MonthDay.from('08-24');
-md.toLocaleString();  // => example output: 08-24
-md.toLocaleString('de-DE');  // => example output: 24.8.
-md.toLocaleString('de-DE', {month: 'long', day: 'numeric'});  // => 24. August
-md.toLocaleString('en-US-u-nu-fullwide');  // => ８/２４
+monthDay.toLocaleString(locales, { calendar: monthDay.calendar });
+
+// OR
+
+monthDay = Temporal.MonthDay.from({ /* ... */, calendar: localeCalendar });
+monthDay.toLocaleString();
+```
+
+Example usage:
+
+```js
+({ calendar } = new Intl.DateTimeFormat().resolvedOptions());
+md = Temporal.MonthDay.from({ month: 8, day: 24, calendar });
+md.toLocaleString(); // => example output: 08-24
+// Same as above, but explicitly specifying the calendar:
+md.toLocaleString(undefined, { calendar });
+
+md.toLocaleString('de-DE', { calendar });  // => example output: 24.8.
+md.toLocaleString('de-DE', { month: 'long', day: 'numeric', calendar });  // => 24. August
+md.toLocaleString(`en-US-u-nu-fullwide-u-ca-${calendar}`);  // => ８/２４
 ```
 
 ### monthDay.**toJSON**() : string

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -389,13 +389,30 @@ This method overrides `Object.prototype.toLocaleString()` to provide a human-rea
 
 The `locales` and `options` arguments are the same as in the constructor to [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat).
 
+The calendar in the output locale (given by `new Intl.DateTimeFormat(locales, options).resolvedOptions().calendar`) must match `monthDay.calendar`, or this method will throw an exception.
+This is because it's not possible to convert a Temporal.MonthDay from one calendar to another without more information.
+In order to ensure that the output always matches `monthDay`'s internal calendar, you must either explicitly construct `monthDay` with the locale's calendar, or explicitly specify the calendar in the `options` parameter:
+
+```js
+yearMonth.toLocaleString(locales, { calendar: yearMonth.calendar });
+
+// OR
+
+yearMonth = Temporal.YearMonth.from({ /* ... */, calendar: localeCalendar });
+yearMonth.toLocaleString();
+```
+
 Example usage:
 ```js
-ym = Temporal.YearMonth.from('2019-06');
+({ calendar } = new Intl.DateTimeFormat().resolvedOptions());
+ym = Temporal.YearMonth.from({ year: 2019, month: 6, calendar });
 ym.toLocaleString();  // => example output: 2019-06
-ym.toLocaleString('de-DE');  // => example output: 6.2019
-ym.toLocaleString('de-DE', {month: 'long', year: 'numeric'});  // => Juni 2019
-ym.toLocaleString('en-US-u-nu-fullwide');  // => ６/２０１９
+// Same as above, but explicitly specifying the calendar:
+ym.toLocaleString(undefined, { calendar });
+
+ym.toLocaleString('de-DE', { calendar });  // => example output: 6.2019
+ym.toLocaleString('de-DE', { month: 'long', year: 'numeric', calendar });  // => Juni 2019
+ym.toLocaleString(`en-US-u-nu-fullwide-u-ca-${calendar}`);  // => ６/２０１９
 ```
 
 ### yearMonth.**toJSON**() : string

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -51,6 +51,35 @@ describe('Intl', () => {
       const dstStart = new Temporal.DateTime(2020, 3, 8, 2, 30);
       equal(`${dstStart.toLocaleString('en', { timeZone: 'America/Los_Angeles' })}`, '3/8/2020, 3:30:00 AM');
     });
+    it("works when the object's calendar is the same as the locale's calendar", () => {
+      const dt = Temporal.DateTime.from({
+        era: 'showa',
+        year: 51,
+        month: 11,
+        day: 18,
+        hour: 15,
+        minute: 23,
+        second: 30,
+        calendar: 'japanese'
+      });
+      equal(`${dt.toLocaleString('en-US-u-ca-japanese')}`, '11/18/51, 3:23:30 PM');
+    });
+    it("adopts the locale's calendar when the object's calendar is ISO", () => {
+      const dt = Temporal.DateTime.from('1976-11-18T15:23:30');
+      equal(`${dt.toLocaleString('en-US-u-ca-japanese')}`, '11/18/51, 3:23:30 PM');
+    });
+    it('throws when the calendars are different and not ISO', () => {
+      const dt = Temporal.DateTime.from({
+        year: 1976,
+        month: 11,
+        day: 18,
+        hour: 15,
+        minute: 23,
+        second: 30,
+        calendar: 'gregory'
+      });
+      throws(() => dt.toLocaleString('en-US-u-ca-japanese'));
+    });
   });
   describe('time.toLocaleString()', () => {
     const time = Temporal.Time.from('1976-11-18T15:23:30');
@@ -80,13 +109,26 @@ describe('Intl', () => {
       equal(date.toLocaleString('en', { minute: 'numeric' }), '11/18/1976');
       equal(date.toLocaleString('en', { second: 'numeric' }), '11/18/1976');
     });
+    it("works when the object's calendar is the same as the locale's calendar", () => {
+      const d = Temporal.Date.from({ era: 'showa', year: 51, month: 11, day: 18, calendar: 'japanese' });
+      equal(`${d.toLocaleString('en-US-u-ca-japanese')}`, '11/18/51');
+    });
+    it("adopts the locale's calendar when the object's calendar is ISO", () => {
+      const d = Temporal.Date.from('1976-11-18');
+      equal(`${d.toLocaleString('en-US-u-ca-japanese')}`, '11/18/51');
+    });
+    it('throws when the calendars are different and not ISO', () => {
+      const d = Temporal.Date.from({ year: 1976, month: 11, day: 18, calendar: 'gregory' });
+      throws(() => d.toLocaleString('en-US-u-ca-japanese'));
+    });
   });
   describe('yearmonth.toLocaleString()', () => {
-    const yearmonth = Temporal.YearMonth.from('1976-11-18T15:23:30');
+    const calendar = new Intl.DateTimeFormat('en').resolvedOptions().calendar;
+    const yearmonth = Temporal.YearMonth.from({ year: 1976, month: 11, calendar });
     it(`(${yearmonth.toString()}).toLocaleString('en-US', { timeZone: 'America/New_York' })`, () =>
       equal(`${yearmonth.toLocaleString('en', { timeZone: 'America/New_York' })}`, '11/1976'));
     it(`(${yearmonth.toString()}).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })`, () =>
-      equal(`${yearmonth.toLocaleString('de', { timeZone: 'Europe/Vienna' })}`, '11.1976'));
+      equal(`${yearmonth.toLocaleString('de', { timeZone: 'Europe/Vienna', calendar })}`, '11.1976'));
     it('should ignore units not in the data type', () => {
       equal(yearmonth.toLocaleString('en', { timeZoneName: 'long' }), '11/1976');
       equal(yearmonth.toLocaleString('en', { day: 'numeric' }), '11/1976');
@@ -95,13 +137,22 @@ describe('Intl', () => {
       equal(yearmonth.toLocaleString('en', { second: 'numeric' }), '11/1976');
       equal(yearmonth.toLocaleString('en', { weekday: 'long' }), '11/1976');
     });
+    it("works when the object's calendar is the same as the locale's calendar", () => {
+      const ym = Temporal.YearMonth.from({ era: 'showa', year: 51, month: 11, calendar: 'japanese' });
+      equal(`${ym.toLocaleString('en-US-u-ca-japanese')}`, '11/51');
+    });
+    it('throws when the calendar is not equal to the locale calendar', () => {
+      const ymISO = Temporal.YearMonth.from({ year: 1976, month: 11 });
+      throws(() => ymISO.toLocaleString('en-US-u-ca-japanese'), RangeError);
+    });
   });
   describe('monthday.toLocaleString()', () => {
-    const monthday = Temporal.MonthDay.from('1976-11-18T15:23:30');
+    const calendar = new Intl.DateTimeFormat('en').resolvedOptions().calendar;
+    const monthday = Temporal.MonthDay.from({ month: 11, day: 18, calendar });
     it(`(${monthday.toString()}).toLocaleString('en-US', { timeZone: 'America/New_York' })`, () =>
       equal(`${monthday.toLocaleString('en', { timeZone: 'America/New_York' })}`, '11/18'));
     it(`(${monthday.toString()}).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })`, () =>
-      equal(`${monthday.toLocaleString('de', { timeZone: 'Europe/Vienna' })}`, '18.11.'));
+      equal(`${monthday.toLocaleString('de', { timeZone: 'Europe/Vienna', calendar })}`, '18.11.'));
     it('should ignore units not in the data type', () => {
       equal(monthday.toLocaleString('en', { timeZoneName: 'long' }), '11/18');
       equal(monthday.toLocaleString('en', { year: 'numeric' }), '11/18');
@@ -109,6 +160,14 @@ describe('Intl', () => {
       equal(monthday.toLocaleString('en', { minute: 'numeric' }), '11/18');
       equal(monthday.toLocaleString('en', { second: 'numeric' }), '11/18');
       equal(monthday.toLocaleString('en', { weekday: 'long' }), '11/18');
+    });
+    it("works when the object's calendar is the same as the locale's calendar", () => {
+      const md = Temporal.MonthDay.from({ month: 11, day: 18, calendar: 'japanese' });
+      equal(`${md.toLocaleString('en-US-u-ca-japanese')}`, '11/18');
+    });
+    it('throws when the calendar is not equal to the locale calendar', () => {
+      const mdISO = Temporal.MonthDay.from({ month: 11, day: 18 });
+      throws(() => mdISO.toLocaleString('en-US-u-ca-japanese'), RangeError);
     });
   });
 
@@ -119,6 +178,8 @@ describe('Intl', () => {
 
     const us = new Intl.DateTimeFormat('en-US', { timeZone: 'America/New_York' });
     const at = new Intl.DateTimeFormat('de-AT', { timeZone: 'Europe/Vienna' });
+    const usCalendar = us.resolvedOptions().calendar;
+    const atCalendar = at.resolvedOptions().calendar;
     const t1 = '1976-11-18T14:23:30Z';
     const t2 = '2020-02-20T15:44:56-05:00[America/New_York]';
     const start = new Date('1922-12-30'); // ☭
@@ -142,12 +203,14 @@ describe('Intl', () => {
         equal(at.format(Temporal.Date.from(t1)), '18.11.1976');
       });
       it('should work for YearMonth', () => {
-        equal(us.format(Temporal.YearMonth.from(t1)), '11/1976');
-        equal(at.format(Temporal.YearMonth.from(t1)), '11.1976');
+        const fields = Temporal.YearMonth.from(t1).getFields();
+        equal(us.format(Temporal.YearMonth.from({ ...fields, calendar: usCalendar })), '11/1976');
+        equal(at.format(Temporal.YearMonth.from({ ...fields, calendar: atCalendar })), '11.1976');
       });
       it('should work for MonthDay', () => {
-        equal(us.format(Temporal.MonthDay.from(t1)), '11/18');
-        equal(at.format(Temporal.MonthDay.from(t1)), '18.11.');
+        const fields = Temporal.MonthDay.from(t1).getFields();
+        equal(us.format(Temporal.MonthDay.from({ ...fields, calendar: usCalendar })), '11/18');
+        equal(at.format(Temporal.MonthDay.from({ ...fields, calendar: atCalendar })), '18.11.');
       });
       it('should not break legacy Date', () => {
         equal(us.format(start), '12/29/1922');
@@ -250,24 +313,26 @@ describe('Intl', () => {
         ]);
       });
       it('should work for YearMonth', () => {
-        deepEqual(us.formatToParts(Temporal.YearMonth.from(t2)), [
+        const fields = Temporal.YearMonth.from(t2).getFields();
+        deepEqual(us.formatToParts(Temporal.YearMonth.from({ ...fields, calendar: usCalendar })), [
           { type: 'month', value: '2' },
           { type: 'literal', value: '/' },
           { type: 'year', value: '2020' }
         ]);
-        deepEqual(at.formatToParts(Temporal.YearMonth.from(t2)), [
+        deepEqual(at.formatToParts(Temporal.YearMonth.from({ ...fields, calendar: atCalendar })), [
           { type: 'month', value: '2' },
           { type: 'literal', value: '.' },
           { type: 'year', value: '2020' }
         ]);
       });
       it('should work for MonthDay', () => {
-        deepEqual(us.formatToParts(Temporal.MonthDay.from(t2)), [
+        const fields = Temporal.MonthDay.from(t2).getFields();
+        deepEqual(us.formatToParts(Temporal.MonthDay.from({ ...fields, calendar: usCalendar })), [
           { type: 'month', value: '2' },
           { type: 'literal', value: '/' },
           { type: 'day', value: '20' }
         ]);
-        deepEqual(at.formatToParts(Temporal.MonthDay.from(t2)), [
+        deepEqual(at.formatToParts(Temporal.MonthDay.from({ ...fields, calendar: atCalendar })), [
           { type: 'day', value: '20' },
           { type: 'literal', value: '.' },
           { type: 'month', value: '2' },
@@ -321,12 +386,40 @@ describe('Intl', () => {
         equal(at.formatRange(Temporal.Date.from(t1), Temporal.Date.from(t2)), '18.11.1976 – 20.02.2020');
       });
       it('should work for YearMonth', () => {
-        equal(us.formatRange(Temporal.YearMonth.from(t1), Temporal.YearMonth.from(t2)), '11/1976 – 2/2020');
-        equal(at.formatRange(Temporal.YearMonth.from(t1), Temporal.YearMonth.from(t2)), '11.1976 – 02.2020');
+        const fields1 = Temporal.YearMonth.from(t1).getFields();
+        const fields2 = Temporal.YearMonth.from(t2).getFields();
+        equal(
+          us.formatRange(
+            Temporal.YearMonth.from({ ...fields1, calendar: usCalendar }),
+            Temporal.YearMonth.from({ ...fields2, calendar: usCalendar })
+          ),
+          '11/1976 – 2/2020'
+        );
+        equal(
+          at.formatRange(
+            Temporal.YearMonth.from({ ...fields1, calendar: atCalendar }),
+            Temporal.YearMonth.from({ ...fields2, calendar: atCalendar })
+          ),
+          '11.1976 – 02.2020'
+        );
       });
       it('should work for MonthDay', () => {
-        equal(us.formatRange(Temporal.MonthDay.from(t2), Temporal.MonthDay.from(t1)), '2/20 – 11/18');
-        equal(at.formatRange(Temporal.MonthDay.from(t2), Temporal.MonthDay.from(t1)), '20.02. – 18.11.');
+        const fields1 = Temporal.MonthDay.from(t1).getFields();
+        const fields2 = Temporal.MonthDay.from(t2).getFields();
+        equal(
+          us.formatRange(
+            Temporal.MonthDay.from({ ...fields2, calendar: usCalendar }),
+            Temporal.MonthDay.from({ ...fields1, calendar: usCalendar })
+          ),
+          '2/20 – 11/18'
+        );
+        equal(
+          at.formatRange(
+            Temporal.MonthDay.from({ ...fields2, calendar: atCalendar }),
+            Temporal.MonthDay.from({ ...fields1, calendar: atCalendar })
+          ),
+          '20.02. – 18.11.'
+        );
       });
       it('should not break legacy Date', () => {
         equal(us.formatRange(start, end), '12/29/1922 – 12/25/1991');
@@ -519,45 +612,73 @@ describe('Intl', () => {
         ]);
       });
       it('should work for YearMonth', () => {
-        deepEqual(us.formatRangeToParts(Temporal.YearMonth.from(t1), Temporal.YearMonth.from(t2)), [
-          { type: 'month', value: '11', source: 'startRange' },
-          { type: 'literal', value: '/', source: 'startRange' },
-          { type: 'year', value: '1976', source: 'startRange' },
-          { type: 'literal', value: ' – ', source: 'shared' },
-          { type: 'month', value: '2', source: 'endRange' },
-          { type: 'literal', value: '/', source: 'endRange' },
-          { type: 'year', value: '2020', source: 'endRange' }
-        ]);
-        deepEqual(at.formatRangeToParts(Temporal.YearMonth.from(t1), Temporal.YearMonth.from(t2)), [
-          { type: 'month', value: '11', source: 'startRange' },
-          { type: 'literal', value: '.', source: 'startRange' },
-          { type: 'year', value: '1976', source: 'startRange' },
-          { type: 'literal', value: ' – ', source: 'shared' },
-          { type: 'month', value: '02', source: 'endRange' },
-          { type: 'literal', value: '.', source: 'endRange' },
-          { type: 'year', value: '2020', source: 'endRange' }
-        ]);
+        const fields1 = Temporal.YearMonth.from(t1).getFields();
+        const fields2 = Temporal.YearMonth.from(t2).getFields();
+        deepEqual(
+          us.formatRangeToParts(
+            Temporal.YearMonth.from({ ...fields1, calendar: usCalendar }),
+            Temporal.YearMonth.from({ ...fields2, calendar: usCalendar })
+          ),
+          [
+            { type: 'month', value: '11', source: 'startRange' },
+            { type: 'literal', value: '/', source: 'startRange' },
+            { type: 'year', value: '1976', source: 'startRange' },
+            { type: 'literal', value: ' – ', source: 'shared' },
+            { type: 'month', value: '2', source: 'endRange' },
+            { type: 'literal', value: '/', source: 'endRange' },
+            { type: 'year', value: '2020', source: 'endRange' }
+          ]
+        );
+        deepEqual(
+          at.formatRangeToParts(
+            Temporal.YearMonth.from({ ...fields1, calendar: atCalendar }),
+            Temporal.YearMonth.from({ ...fields2, calendar: atCalendar })
+          ),
+          [
+            { type: 'month', value: '11', source: 'startRange' },
+            { type: 'literal', value: '.', source: 'startRange' },
+            { type: 'year', value: '1976', source: 'startRange' },
+            { type: 'literal', value: ' – ', source: 'shared' },
+            { type: 'month', value: '02', source: 'endRange' },
+            { type: 'literal', value: '.', source: 'endRange' },
+            { type: 'year', value: '2020', source: 'endRange' }
+          ]
+        );
       });
       it('should work for MonthDay', () => {
-        deepEqual(us.formatRangeToParts(Temporal.MonthDay.from(t2), Temporal.MonthDay.from(t1)), [
-          { type: 'month', value: '2', source: 'startRange' },
-          { type: 'literal', value: '/', source: 'startRange' },
-          { type: 'day', value: '20', source: 'startRange' },
-          { type: 'literal', value: ' – ', source: 'shared' },
-          { type: 'month', value: '11', source: 'endRange' },
-          { type: 'literal', value: '/', source: 'endRange' },
-          { type: 'day', value: '18', source: 'endRange' }
-        ]);
-        deepEqual(at.formatRangeToParts(Temporal.MonthDay.from(t2), Temporal.MonthDay.from(t1)), [
-          { type: 'day', value: '20', source: 'startRange' },
-          { type: 'literal', value: '.', source: 'startRange' },
-          { type: 'month', value: '02', source: 'startRange' },
-          { type: 'literal', value: '. – ', source: 'shared' },
-          { type: 'day', value: '18', source: 'endRange' },
-          { type: 'literal', value: '.', source: 'endRange' },
-          { type: 'month', value: '11', source: 'endRange' },
-          { type: 'literal', value: '.', source: 'shared' }
-        ]);
+        const fields1 = Temporal.MonthDay.from(t1).getFields();
+        const fields2 = Temporal.MonthDay.from(t2).getFields();
+        deepEqual(
+          us.formatRangeToParts(
+            Temporal.MonthDay.from({ ...fields2, calendar: usCalendar }),
+            Temporal.MonthDay.from({ ...fields1, calendar: usCalendar })
+          ),
+          [
+            { type: 'month', value: '2', source: 'startRange' },
+            { type: 'literal', value: '/', source: 'startRange' },
+            { type: 'day', value: '20', source: 'startRange' },
+            { type: 'literal', value: ' – ', source: 'shared' },
+            { type: 'month', value: '11', source: 'endRange' },
+            { type: 'literal', value: '/', source: 'endRange' },
+            { type: 'day', value: '18', source: 'endRange' }
+          ]
+        );
+        deepEqual(
+          at.formatRangeToParts(
+            Temporal.MonthDay.from({ ...fields2, calendar: atCalendar }),
+            Temporal.MonthDay.from({ ...fields1, calendar: atCalendar })
+          ),
+          [
+            { type: 'day', value: '20', source: 'startRange' },
+            { type: 'literal', value: '.', source: 'startRange' },
+            { type: 'month', value: '02', source: 'startRange' },
+            { type: 'literal', value: '. – ', source: 'shared' },
+            { type: 'day', value: '18', source: 'endRange' },
+            { type: 'literal', value: '.', source: 'endRange' },
+            { type: 'month', value: '11', source: 'endRange' },
+            { type: 'literal', value: '.', source: 'shared' }
+          ]
+        );
       });
       it('should not break legacy Date', () => {
         deepEqual(us.formatRangeToParts(start, end), [

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -284,18 +284,30 @@
           1. <ins>Let _x_ be _date_.</ins>
           1. <mark>TODO: _era_, _dayPeriod_, _fractionalSecondDigits_.</mark>
           1. <ins>If _date_ has an [[InitializedTemporalDate]] internal slot, then</ins>
+            1. <ins>Let _calendar_ be ? CalendarToString(_x_).</ins>
+            1. <ins>If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then</ins>
+              1. <ins>Throw a *RangeError* exception.</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalDatePattern]].</ins>
             1. <ins>Let _tm_ be { [[weekday]]: ToDayOfWeek(_date_.[[Year]], _date_.[[Month]], _date_.[[Day]]), [[year]]: _date_.[[Year]], [[month]]: _date_.[[Month]], [[day]]: _date_.[[Day]] }.</ins>
           1. <ins>If _date_ has an [[InitializedTemporalYearMonth]] internal slot, then</ins>
+            1. <ins>Let _calendar_ be ? CalendarToString(_x_).</ins>
+            1. <ins>If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then</ins>
+              1. <ins>Throw a *RangeError* exception.</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalYearMonthPattern]].</ins>
             1. <ins>Let _tm_ be { [[year]]: _date_.[[Year]], [[month]]: _date_.[[Month]] }.</ins>
           1. <ins>If _date_ has an [[InitializedTemporalMonthDay]] internal slot, then</ins>
+            1. <ins>Let _calendar_ be ? CalendarToString(_x_).</ins>
+            1. <ins>If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then</ins>
+              1. <ins>Throw a *RangeError* exception.</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalMonthDayPattern]].</ins>
             1. <ins>Let _tm_ be { [[month]]: _date_.[[Month]], [[day]]: _date_.[[Day]] }.</ins>
           1. <ins>If _date_ has an [[InitializedTemporalTime]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalTimePattern]].</ins>
             1. <ins>Let _tm_ be { [[hour]]: _date_.[[Hour]], [[minute]]: _date_.[[Minute]], [[second]]: _date_.[[Second]] }.</ins>
           1. <ins>If _date_ has an [[InitializedTemporalDateTime]] or an [[InitializedTemporalInstant]] internal slot, then</ins>
+            1. <ins>Let _calendar_ be ? CalendarToString(_x_).</ins>
+            1. <ins>If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then</ins>
+              1. <ins>Throw a *RangeError* exception.</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalDateTimePattern]].</ins>
             1. <ins>Let _tm_ be { [[weekday]]: ToDayOfWeek(_date_.[[Year]], _date_.[[Month]], _date_.[[Day]]), [[year]]: _date_.[[Year]], [[month]]: _date_.[[Month]], [[day]]: _date_.[[Day]], [[hour]]: _date_.[[Hour]], [[minute]]: _date_.[[Minute]], [[second]]: _date_.[[Second]] }.</ins>
           1. <ins>If _pattern_ is *null*, throw a *TypeError* exception.</ins>


### PR DESCRIPTION
This ensures that the calendar of a Temporal object on which the
toLocaleString() method is called, must match the calendar of the locale
which is passed to toLocaleString().

In the case of DateTime and Date, if the object's calendar is the ISO
calendar, then the locale's calendar overrides it. In the case of
YearMonth and MonthDay, the calendars must match exactly, because there's
no way to implicitly convert MonthDay and YearMonth between calendars.

Closes: #262