### PR TITLE
Minor docs clarification about DateTime.toLocaleString(..., {timeZone})

### DIFF
--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -671,7 +671,9 @@ This method overrides `Object.prototype.toLocaleString()` to provide a human-rea
 
 The `locales` and `options` arguments are the same as in the constructor to [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat).
 
-> **NOTE**: Unlike in [`Temporal.Instant.prototype.toLocaleString()`](./instant.html#toLocaleString), `options.timeZone` will have no effect, because `Temporal.DateTime` carries no time zone information and is just a wall-clock time.
+> **NOTE**: Unlike in [`Temporal.Instant.prototype.toLocaleString()`](./instant.html#toLocaleString), `options.timeZone` will have no effect, because `Temporal.DateTime` carries no time zone information.
+> It's not always possible to uniquely determine the localized time zone name using the `Temporal.DateTime` instance and the `options.timeZone`.
+> Therefore, to display a localized date and time including its time zone, convert the `Temporal.DateTime` to a `Temporal.LocalDateTime` or `Temporal.Instant` and then call the `toLocaleString()` method.
 
 Example usage:
 


### PR DESCRIPTION
Closes: #577