### PR TITLE
Rename RefISODay and RefISOYear slots

### DIFF
--- a/docs/calendar-draft.md
+++ b/docs/calendar-draft.md
@@ -31,23 +31,9 @@ As with Temporal.Date, all of these types will gain a `[[Calendar]]` slot, and y
 
 Main issue: https://github.com/tc39/proposal-temporal/issues/391
 
-For reasons explained above, using the ISO calendar as the internal data model has many advantages.  However, there are several challenges for these two "incomplete" types: lunar months don't line up with solar months, and not every lunar month occurs in every solar year.  After discussing several data model alternatives, we reached the conclusion that the simplest data model for Temporal.YearMonth and Temporal.MonthDay is to make it share the same data model as Temporal.Date, with the following slots:
+For reasons explained above, using the ISO calendar as the internal data model has many advantages.  However, there are several challenges for these two "incomplete" types: lunar months don't line up with solar months, and not every lunar month occurs in every solar year.  After discussing several data model alternatives, we reached the conclusion that the simplest data model for Temporal.YearMonth and Temporal.MonthDay is to make it share the same data model as Temporal.Date, with the same slots.
 
-Temporal.YearMonth:
-
-- `[[ISOYear]]`
-- `[[ISOMonth]]`
-- `[[Calendar]]`
-- `[[RefISODay]]`
-
-Temporal.MonthDay:
-
-- `[[ISOMonth]]`
-- `[[ISODay]]`
-- `[[Calendar]]`
-- `[[RefISOYear]]`
-
-For calendars that use ISO-style months, such as Gregorian, Solar Buddhist, and Japanese, "RefIsoDay" and "RefIsoYear" can be ignored.  However, for lunar and lunisolar calendars, such as Hebrew, Saudi Arabian Islamic, and Chinese, these additional fields allow those calendars to disambiguate which YearMonth and MonthDay are being represented.  The fields are called "Ref", or "reference", because they are only used in calendars that need them.
+For calendars that use ISO-style months, such as Gregorian, Solar Buddhist, and Japanese, "ISODay" and "ISOYear" can be ignored for YearMonth and MonthDay respectively.  However, for lunar and lunisolar calendars, such as Hebrew, Saudi Arabian Islamic, and Chinese, these fields allow those calendars to disambiguate which YearMonth and MonthDay are being represented.
 
 ## Temporal.Calendar interface
 

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -325,7 +325,7 @@ Object.assign({}, md).day  // => undefined
 Object.assign({}, md.getFields()).day  // => 24
 ```
 
-### monthDay.**getISOFields**(): { refISOYear: number, isoMonth: number, isoDay: number }
+### monthDay.**getISOFields**(): { isoYear: number, isoMonth: number, isoDay: number, calendar: object }
 
 **Returns:** a plain object with properties expressing `monthDay` in the ISO 8601 calendar, as well as the value of `monthDay.calendar`.
 
@@ -333,7 +333,7 @@ This method is mainly useful if you are implementing a custom calendar.
 Most code will not need to use it.
 Use `monthDay.getFields()` instead.
 
-The value of the `refISOYear` property will be equal to the `refISOYear` constructor argument passed when `monthDay` was constructed.
+The value of the `isoYear` property will be equal to the `refISOYear` constructor argument passed when `monthDay` was constructed.
 
 Usage example:
 ```javascript

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -13,13 +13,13 @@ A `Temporal.MonthDay` can be converted into a `Temporal.Date` by combining it wi
 
 ## Constructor
 
-### **new Temporal.MonthDay**(_isoMonth_: number, _isoDay_: number, _calendar_?: object, _refISOYear_?: number) : Temporal.MonthDay
+### **new Temporal.MonthDay**(_isoMonth_: number, _isoDay_: number, _calendar_?: object, _referenceISOYear_?: number) : Temporal.MonthDay
 
 **Parameters:**
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
 - `isoDay` (number): A day of the month, ranging between 1 and 31 inclusive.
 - `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the date into.
-- `refISOYear` (optional number): A reference year, used for disambiguation when implementing other calendar systems.
+- `referenceISOYear` (optional number): A reference year, used for disambiguation when implementing other calendar systems.
   The default is the first leap year after the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
   You can omit this parameter unless using a non-ISO-8601 calendar.
 
@@ -29,8 +29,8 @@ Use this constructor if you have the correct parameters for the date already as 
 Otherwise, `Temporal.MonthDay.from()`, which accepts more kinds of input, allows inputting dates in different calendar reckonings, and allows controlling the overflow behaviour, is probably more convenient.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
-Together, `refISOYear`, `isoMonth` and `isoDay` must represent a valid date in that calendar.
-For example, February 29 (Leap day in the ISO 8601 calendar) is a valid value for `Temporal.MonthDay`, even though that date does not occur every year, because the default value of `refISOYear` is a leap year.
+Together, `referenceISOYear`, `isoMonth` and `isoDay` must represent a valid date in that calendar.
+For example, February 29 (Leap day in the ISO 8601 calendar) is a valid value for `Temporal.MonthDay`, even though that date does not occur every year, because the default value of `referenceISOYear` is a leap year.
 
 > **NOTE**: The `isoMonth` argument ranges from 1 to 12, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
@@ -333,7 +333,7 @@ This method is mainly useful if you are implementing a custom calendar.
 Most code will not need to use it.
 Use `monthDay.getFields()` instead.
 
-The value of the `isoYear` property will be equal to the `refISOYear` constructor argument passed when `monthDay` was constructed.
+The value of the `isoYear` property will be equal to the `referenceISOYear` constructor argument passed when `monthDay` was constructed.
 
 Usage example:
 ```javascript

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -497,7 +497,7 @@ Object.assign({}, ym).year  // => undefined
 Object.assign({}, ym.getFields()).year  // => 2019
 ```
 
-### yearMonth.**getISOFields**(): { isoYear: number, isoMonth: number, refISODay: number }
+### yearMonth.**getISOFields**(): { isoYear: number, isoMonth: number, isoDay: number, calendar: object }
 
 **Returns:** a plain object with properties expressing `yearMonth` in the ISO 8601 calendar, as well as the value of `yearMonth.calendar`.
 
@@ -505,7 +505,7 @@ This method is mainly useful if you are implementing a custom calendar.
 Most code will not need to use it.
 Use `yearMonth.getFields()` instead.
 
-The value of the `refISODay` property will be equal to the `refISODay` constructor argument passed when `yearMonth` was constructed.
+The value of the `isoDay` property will be equal to the `refISODay` constructor argument passed when `yearMonth` was constructed.
 
 Usage example:
 ```javascript

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -13,13 +13,13 @@ A `Temporal.YearMonth` can be converted into a `Temporal.Date` by combining it w
 
 ## Constructor
 
-### **new Temporal.YearMonth**(_isoYear_: number, _isoMonth_: number, _calendar_?: object, _refISODay_: number = 1) : Temporal.YearMonth
+### **new Temporal.YearMonth**(_isoYear_: number, _isoMonth_: number, _calendar_?: object, _referenceISODay_: number = 1) : Temporal.YearMonth
 
 **Parameters:**
 - `isoYear` (number): A year.
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
 - `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the month into.
-- `refISODay` (optional number): A reference day, used for disambiguation when implementing other calendar systems.
+- `referenceISODay` (optional number): A reference day, used for disambiguation when implementing other calendar systems.
   You can omit this parameter unless using a non-ISO-8601 calendar.
 
 **Returns:** a new `Temporal.YearMonth` object.
@@ -28,7 +28,7 @@ Use this constructor if you have the correct parameters already as individual nu
 Otherwise, `Temporal.YearMonth.from()`, which accepts more kinds of input, allows months in other calendar systems, and allows controlling the overflow behaviour, is probably more convenient.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
-Together, `isoYear`, `isoMonth`, and `refISODay` must represent a valid date in that calendar, even if you are passing a different calendar as the `calendar` parameter.
+Together, `isoYear`, `isoMonth`, and `referenceISODay` must represent a valid date in that calendar, even if you are passing a different calendar as the `calendar` parameter.
 
 The range of allowed values for this type is exactly enough that calling [`toYearMonth()`](./date.html#toYearMonth) on any valid `Temporal.Date` will succeed.
 If `isoYear` and `isoMonth` are outside of this range, then this function will throw a `RangeError`.
@@ -505,7 +505,7 @@ This method is mainly useful if you are implementing a custom calendar.
 Most code will not need to use it.
 Use `yearMonth.getFields()` instead.
 
-The value of the `isoDay` property will be equal to the `refISODay` constructor argument passed when `yearMonth` was constructed.
+The value of the `isoDay` property will be equal to the `referenceISODay` constructor argument passed when `yearMonth` was constructed.
 
 Usage example:
 ```javascript

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -571,13 +571,6 @@ export namespace Temporal {
     calendar: CalendarProtocol;
   };
 
-  type MonthDayISOFields = {
-    refISOYear: number;
-    isoMonth: number;
-    isoDay: number;
-    calendar: CalendarProtocol;
-  };
-
   /**
    * A `Temporal.MonthDay` represents a particular day on the calendar, but
    * without a year. For example, it could be used to represent a yearly
@@ -595,7 +588,7 @@ export namespace Temporal {
     with(monthDayLike: MonthDayLike, options?: AssignmentOptions): Temporal.MonthDay;
     toDateInYear(year: number | { era?: string | undefined; year: number }, options?: AssignmentOptions): Temporal.Date;
     getFields(): MonthDayFields;
-    getISOFields(): MonthDayISOFields;
+    getISOFields(): DateISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(): string;
@@ -719,13 +712,6 @@ export namespace Temporal {
     calendar: CalendarProtocol;
   };
 
-  type YearMonthISOFields = {
-    isoYear: number;
-    isoMonth: number;
-    refISODay: number;
-    calendar: CalendarProtocol;
-  };
-
   /**
    * A `Temporal.YearMonth` represents a particular month on the calendar. For
    * example, it could be used to represent a particular instance of a monthly
@@ -752,7 +738,7 @@ export namespace Temporal {
     difference(other: Temporal.YearMonth, options?: DifferenceOptions<'years' | 'months'>): Temporal.Duration;
     toDateOnDay(day: number): Temporal.Date;
     getFields(): YearMonthFields;
-    getISOFields(): YearMonthISOFields;
+    getISOFields(): DateISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(): string;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -580,7 +580,7 @@ export namespace Temporal {
    */
   export class MonthDay implements MonthDayFields {
     static from(item: Temporal.MonthDay | MonthDayLike | string, options?: AssignmentOptions): Temporal.MonthDay;
-    constructor(isoMonth: number, isoDay: number, calendar?: CalendarProtocol, refISOYear?: number);
+    constructor(isoMonth: number, isoDay: number, calendar?: CalendarProtocol, referenceISOYear?: number);
     readonly month: number;
     readonly day: number;
     readonly calendar: CalendarProtocol;
@@ -722,7 +722,7 @@ export namespace Temporal {
   export class YearMonth implements YearMonthFields {
     static from(item: Temporal.YearMonth | YearMonthLike | string, options?: AssignmentOptions): Temporal.YearMonth;
     static compare(one: Temporal.YearMonth, two: Temporal.YearMonth): ComparisonResult;
-    constructor(isoYear: number, isoMonth: number, calendar?: CalendarProtocol, refISODay?: number);
+    constructor(isoYear: number, isoMonth: number, calendar?: CalendarProtocol, referenceISODay?: number);
     readonly year: number;
     readonly month: number;
     readonly calendar: CalendarProtocol;

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -141,7 +141,7 @@ class ISO8601Calendar extends Calendar {
     // Intentionally alphabetical
     let { year, month } = ES.ToTemporalYearMonthRecord(fields);
     ({ year, month } = ES.RegulateYearMonth(year, month, overflow));
-    return new constructor(year, month, this, /* refISODay = */ 1);
+    return new constructor(year, month, this, /* referenceISODay = */ 1);
   }
   monthDayFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
@@ -149,7 +149,7 @@ class ISO8601Calendar extends Calendar {
     // Intentionally alphabetical
     let { month, day } = ES.ToTemporalMonthDayRecord(fields);
     ({ month, day } = ES.RegulateMonthDay(month, day, overflow));
-    return new constructor(month, day, this, /* refISOYear = */ 1972);
+    return new constructor(month, day, this, /* referenceISOYear = */ 1972);
   }
   datePlus(date, duration, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -141,7 +141,7 @@ class ISO8601Calendar extends Calendar {
     // Intentionally alphabetical
     let { year, month } = ES.ToTemporalYearMonthRecord(fields);
     ({ year, month } = ES.RegulateYearMonth(year, month, overflow));
-    return new constructor(year, month, this, /* refIsoDay = */ 1);
+    return new constructor(year, month, this, /* refISODay = */ 1);
   }
   monthDayFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
@@ -149,7 +149,7 @@ class ISO8601Calendar extends Calendar {
     // Intentionally alphabetical
     let { month, day } = ES.ToTemporalMonthDayRecord(fields);
     ({ month, day } = ES.RegulateMonthDay(month, day, overflow));
-    return new constructor(month, day, this, /* refIsoYear = */ 1972);
+    return new constructor(month, day, this, /* refISOYear = */ 1972);
   }
   datePlus(date, duration, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -13,6 +13,7 @@ import {
   MILLISECOND,
   MICROSECOND,
   NANOSECOND,
+  DATE_BRAND,
   CALENDAR,
   CreateSlots,
   GetSlot,
@@ -35,6 +36,7 @@ export class Date {
     SetSlot(this, ISO_MONTH, isoMonth);
     SetSlot(this, ISO_DAY, isoDay);
     SetSlot(this, CALENDAR, calendar);
+    SetSlot(this, DATE_BRAND, true);
 
     if (typeof __debug__ !== 'undefined' && __debug__) {
       Object.defineProperty(this, '_repr_', {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -33,8 +33,9 @@ import {
   MILLISECOND,
   MICROSECOND,
   NANOSECOND,
-  REF_ISO_YEAR,
-  REF_ISO_DAY,
+  DATE_BRAND,
+  YEAR_MONTH_BRAND,
+  MONTH_DAY_BRAND,
   CALENDAR,
   YEARS,
   MONTHS,
@@ -73,16 +74,14 @@ export const ES = ObjectAssign({}, ES2019, {
   IsTemporalCalendar: (item) => HasSlot(item, CALENDAR_ID),
   IsTemporalDuration: (item) =>
     HasSlot(item, YEARS, MONTHS, DAYS, HOURS, MINUTES, SECONDS, MILLISECONDS, MICROSECONDS, NANOSECONDS),
-  IsTemporalDate: (item) =>
-    HasSlot(item, ISO_YEAR, ISO_MONTH, ISO_DAY) &&
-    !HasSlot(item, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND),
+  IsTemporalDate: (item) => HasSlot(item, DATE_BRAND),
   IsTemporalTime: (item) =>
     HasSlot(item, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND) &&
     !HasSlot(item, ISO_YEAR, ISO_MONTH, ISO_DAY),
   IsTemporalDateTime: (item) =>
     HasSlot(item, ISO_YEAR, ISO_MONTH, ISO_DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND),
-  IsTemporalYearMonth: (item) => HasSlot(item, ISO_YEAR, ISO_MONTH, REF_ISO_DAY),
-  IsTemporalMonthDay: (item) => HasSlot(item, ISO_MONTH, ISO_DAY, REF_ISO_YEAR),
+  IsTemporalYearMonth: (item) => HasSlot(item, YEAR_MONTH_BRAND),
+  IsTemporalMonthDay: (item) => HasSlot(item, MONTH_DAY_BRAND),
   TemporalTimeZoneFromString: (stringIdent) => {
     const { zone, ianaName, offset } = ES.ParseTemporalTimeZoneString(stringIdent);
     const result = ES.GetCanonicalTimeZoneIdentifier(zone);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -174,7 +174,7 @@ export const ES = ObjectAssign({}, ES2019, {
   },
   ParseTemporalYearMonthString: (isoString) => {
     const match = PARSE.yearmonth.exec(isoString);
-    let year, month, calendar, refISODay;
+    let year, month, calendar, referenceISODay;
     if (match) {
       let yearString = match[1];
       if (yearString[0] === '\u2212') yearString = `-${yearString.slice(1)}`;
@@ -182,22 +182,22 @@ export const ES = ObjectAssign({}, ES2019, {
       month = ES.ToInteger(match[2]);
       calendar = match[3] || null;
     } else {
-      ({ year, month, calendar, day: refISODay } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
-      if (!calendar) refISODay = undefined;
+      ({ year, month, calendar, day: referenceISODay } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
+      if (!calendar) referenceISODay = undefined;
     }
-    return { year, month, calendar, refISODay };
+    return { year, month, calendar, referenceISODay };
   },
   ParseTemporalMonthDayString: (isoString) => {
     const match = PARSE.monthday.exec(isoString);
-    let month, day, calendar, refISOYear;
+    let month, day, calendar, referenceISOYear;
     if (match) {
       month = ES.ToInteger(match[1]);
       day = ES.ToInteger(match[2]);
     } else {
-      ({ month, day, calendar, year: refISOYear } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
-      if (!calendar) refISOYear = undefined;
+      ({ month, day, calendar, year: referenceISOYear } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
+      if (!calendar) referenceISOYear = undefined;
     }
-    return { month, day, calendar, refISOYear };
+    return { month, day, calendar, referenceISOYear };
   },
   ParseTemporalTimeZoneString: (stringIdent) => {
     try {
@@ -312,10 +312,10 @@ export const ES = ObjectAssign({}, ES2019, {
     return { hour, minute, second, millisecond, microsecond, nanosecond };
   },
   RegulateYearMonth: (year, month, overflow) => {
-    const refISODay = 1;
+    const referenceISODay = 1;
     switch (overflow) {
       case 'reject':
-        ES.RejectDate(year, month, refISODay);
+        ES.RejectDate(year, month, referenceISODay);
         break;
       case 'constrain':
         ({ year, month } = ES.ConstrainDate(year, month));
@@ -324,13 +324,13 @@ export const ES = ObjectAssign({}, ES2019, {
     return { year, month };
   },
   RegulateMonthDay: (month, day, overflow) => {
-    const refISOYear = 1972;
+    const referenceISOYear = 1972;
     switch (overflow) {
       case 'reject':
-        ES.RejectDate(refISOYear, month, day);
+        ES.RejectDate(referenceISOYear, month, day);
         break;
       case 'constrain':
-        ({ month, day } = ES.ConstrainDate(refISOYear, month, day));
+        ({ month, day } = ES.ConstrainDate(referenceISOYear, month, day));
         break;
     }
     return { month, day };

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -11,8 +11,6 @@ import {
   MILLISECOND,
   MICROSECOND,
   NANOSECOND,
-  REF_ISO_YEAR,
-  REF_ISO_DAY,
   CALENDAR
 } from './slots.mjs';
 import { TimeZone } from './timezone.mjs';
@@ -225,7 +223,7 @@ function extractOverrides(temporalObj, main) {
   if (ES.IsTemporalYearMonth(temporalObj)) {
     const isoYear = GetSlot(temporalObj, ISO_YEAR);
     const isoMonth = GetSlot(temporalObj, ISO_MONTH);
-    const refISODay = GetSlot(temporalObj, REF_ISO_DAY);
+    const refISODay = GetSlot(temporalObj, ISO_DAY);
     const calendar = GetSlot(temporalObj, CALENDAR);
     if (calendar.id !== main[CAL_ID]) {
       throw new RangeError(
@@ -240,7 +238,7 @@ function extractOverrides(temporalObj, main) {
   }
 
   if (ES.IsTemporalMonthDay(temporalObj)) {
-    const refISOYear = GetSlot(temporalObj, REF_ISO_YEAR);
+    const refISOYear = GetSlot(temporalObj, ISO_YEAR);
     const isoMonth = GetSlot(temporalObj, ISO_MONTH);
     const isoDay = GetSlot(temporalObj, ISO_DAY);
     const calendar = GetSlot(temporalObj, CALENDAR);

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -223,14 +223,14 @@ function extractOverrides(temporalObj, main) {
   if (ES.IsTemporalYearMonth(temporalObj)) {
     const isoYear = GetSlot(temporalObj, ISO_YEAR);
     const isoMonth = GetSlot(temporalObj, ISO_MONTH);
-    const refISODay = GetSlot(temporalObj, ISO_DAY);
+    const referenceISODay = GetSlot(temporalObj, ISO_DAY);
     const calendar = GetSlot(temporalObj, CALENDAR);
     if (calendar.id !== main[CAL_ID]) {
       throw new RangeError(
         `cannot format YearMonth with calendar ${calendar.id} in locale with calendar ${main[CAL_ID]}`
       );
     }
-    const datetime = new DateTime(isoYear, isoMonth, refISODay, 12, 0, 0, 0, 0, 0, calendar);
+    const datetime = new DateTime(isoYear, isoMonth, referenceISODay, 12, 0, 0, 0, 0, 0, calendar);
     return {
       instant: main[TIMEZONE].getInstantFor(datetime),
       formatter: main[YM]
@@ -238,7 +238,7 @@ function extractOverrides(temporalObj, main) {
   }
 
   if (ES.IsTemporalMonthDay(temporalObj)) {
-    const refISOYear = GetSlot(temporalObj, ISO_YEAR);
+    const referenceISOYear = GetSlot(temporalObj, ISO_YEAR);
     const isoMonth = GetSlot(temporalObj, ISO_MONTH);
     const isoDay = GetSlot(temporalObj, ISO_DAY);
     const calendar = GetSlot(temporalObj, CALENDAR);
@@ -247,7 +247,7 @@ function extractOverrides(temporalObj, main) {
         `cannot format MonthDay with calendar ${calendar.id} in locale with calendar ${main[CAL_ID]}`
       );
     }
-    const datetime = new DateTime(refISOYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, calendar);
+    const datetime = new DateTime(referenceISOYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, calendar);
     return {
       instant: main[TIMEZONE].getInstantFor(datetime),
       formatter: main[MD]

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -8,19 +8,19 @@ import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, MONTH_DAY_BRAND, CreateSlots, G
 const ObjectAssign = Object.assign;
 
 export class MonthDay {
-  constructor(isoMonth, isoDay, calendar = undefined, refISOYear = 1972) {
+  constructor(isoMonth, isoDay, calendar = undefined, referenceISOYear = 1972) {
     isoMonth = ES.ToInteger(isoMonth);
     isoDay = ES.ToInteger(isoDay);
     if (calendar === undefined) calendar = GetDefaultCalendar();
-    refISOYear = ES.ToInteger(refISOYear);
-    ES.RejectDate(refISOYear, isoMonth, isoDay);
-    ES.RejectDateRange(refISOYear, isoMonth, isoDay);
+    referenceISOYear = ES.ToInteger(referenceISOYear);
+    ES.RejectDate(referenceISOYear, isoMonth, isoDay);
+    ES.RejectDateRange(referenceISOYear, isoMonth, isoDay);
     if (!calendar || typeof calendar !== 'object') throw new RangeError('invalid calendar');
 
     CreateSlots(this);
     SetSlot(this, ISO_MONTH, isoMonth);
     SetSlot(this, ISO_DAY, isoDay);
-    SetSlot(this, ISO_YEAR, refISOYear);
+    SetSlot(this, ISO_YEAR, referenceISOYear);
     SetSlot(this, CALENDAR, calendar);
     SetSlot(this, MONTH_DAY_BRAND, true);
 
@@ -129,8 +129,8 @@ export class MonthDay {
         const month = GetSlot(item, ISO_MONTH);
         const day = GetSlot(item, ISO_DAY);
         const calendar = GetSlot(item, CALENDAR);
-        const refISOYear = GetSlot(item, ISO_YEAR);
-        result = new this(month, day, calendar, refISOYear);
+        const referenceISOYear = GetSlot(item, ISO_YEAR);
+        result = new this(month, day, calendar, referenceISOYear);
       } else {
         let calendar = item.calendar;
         if (calendar === undefined) calendar = GetDefaultCalendar();
@@ -138,12 +138,12 @@ export class MonthDay {
         result = calendar.monthDayFromFields(item, options, this);
       }
     } else {
-      let { month, day, refISOYear, calendar } = ES.ParseTemporalMonthDayString(ES.ToString(item));
+      let { month, day, referenceISOYear, calendar } = ES.ParseTemporalMonthDayString(ES.ToString(item));
       ({ month, day } = ES.RegulateMonthDay(month, day, overflow));
       if (!calendar) calendar = GetDefaultCalendar();
       calendar = TemporalCalendar.from(calendar);
-      if (refISOYear === undefined) refISOYear = 1972;
-      result = new this(month, day, calendar, refISOYear);
+      if (referenceISOYear === undefined) referenceISOYear = 1972;
+      result = new this(month, day, calendar, referenceISOYear);
     }
     if (!ES.IsTemporalMonthDay(result)) throw new TypeError('invalid result');
     return result;

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -3,7 +3,7 @@
 import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
-import { ISO_MONTH, ISO_DAY, REF_ISO_YEAR, CALENDAR, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
+import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, MONTH_DAY_BRAND, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
 
 const ObjectAssign = Object.assign;
 
@@ -20,8 +20,9 @@ export class MonthDay {
     CreateSlots(this);
     SetSlot(this, ISO_MONTH, isoMonth);
     SetSlot(this, ISO_DAY, isoDay);
-    SetSlot(this, REF_ISO_YEAR, refISOYear);
+    SetSlot(this, ISO_YEAR, refISOYear);
     SetSlot(this, CALENDAR, calendar);
+    SetSlot(this, MONTH_DAY_BRAND, true);
 
     if (typeof __debug__ !== 'undefined' && __debug__) {
       Object.defineProperty(this, '_repr_', {
@@ -65,7 +66,7 @@ export class MonthDay {
   equals(other) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalMonthDay(other)) throw new TypeError('invalid MonthDay object');
-    for (const slot of [ISO_MONTH, ISO_DAY, REF_ISO_YEAR]) {
+    for (const slot of [ISO_MONTH, ISO_DAY, ISO_YEAR]) {
       const val1 = GetSlot(this, slot);
       const val2 = GetSlot(other, slot);
       if (val1 !== val2) return false;
@@ -79,7 +80,7 @@ export class MonthDay {
     let resultString = `${month}-${day}`;
     const calendar = ES.FormatCalendarAnnotation(GetSlot(this, CALENDAR));
     if (calendar) {
-      const year = ES.ISOYearString(GetSlot(this, REF_ISO_YEAR));
+      const year = ES.ISOYearString(GetSlot(this, ISO_YEAR));
       resultString = `${year}-${resultString}${calendar}`;
     }
     return resultString;
@@ -113,7 +114,7 @@ export class MonthDay {
   getISOFields() {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
     return {
-      refISOYear: GetSlot(this, REF_ISO_YEAR),
+      isoYear: GetSlot(this, ISO_YEAR),
       isoMonth: GetSlot(this, ISO_MONTH),
       isoDay: GetSlot(this, ISO_DAY),
       calendar: GetSlot(this, CALENDAR)
@@ -128,7 +129,7 @@ export class MonthDay {
         const month = GetSlot(item, ISO_MONTH);
         const day = GetSlot(item, ISO_DAY);
         const calendar = GetSlot(item, CALENDAR);
-        const refISOYear = GetSlot(item, REF_ISO_YEAR);
+        const refISOYear = GetSlot(item, ISO_YEAR);
         result = new this(month, day, calendar, refISOYear);
       } else {
         let calendar = item.calendar;

--- a/polyfill/lib/slots.mjs
+++ b/polyfill/lib/slots.mjs
@@ -14,9 +14,11 @@ export const SECOND = 'slot-second';
 export const MILLISECOND = 'slot-millisecond';
 export const MICROSECOND = 'slot-microsecond';
 export const NANOSECOND = 'slot-nanosecond';
-export const REF_ISO_YEAR = 'slot-ref-iso-year';
-export const REF_ISO_DAY = 'slot-ref-iso-day';
 export const CALENDAR = 'slot-calendar';
+// Date, YearMonth, and MonthDay all have the same slots, disambiguation needed:
+export const DATE_BRAND = 'slot-date-brand';
+export const YEAR_MONTH_BRAND = 'slot-year-month-brand';
+export const MONTH_DAY_BRAND = 'slot-month-day-brand';
 
 // Duration
 export const YEARS = 'slot-years';

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -8,18 +8,18 @@ import { ISO_YEAR, ISO_MONTH, ISO_DAY, YEAR_MONTH_BRAND, CALENDAR, CreateSlots, 
 const ObjectAssign = Object.assign;
 
 export class YearMonth {
-  constructor(isoYear, isoMonth, calendar = undefined, refISODay = 1) {
+  constructor(isoYear, isoMonth, calendar = undefined, referenceISODay = 1) {
     isoYear = ES.ToInteger(isoYear);
     isoMonth = ES.ToInteger(isoMonth);
     if (calendar === undefined) calendar = GetDefaultCalendar();
-    refISODay = ES.ToInteger(refISODay);
-    ES.RejectDate(isoYear, isoMonth, refISODay);
+    referenceISODay = ES.ToInteger(referenceISODay);
+    ES.RejectDate(isoYear, isoMonth, referenceISODay);
     ES.RejectYearMonthRange(isoYear, isoMonth);
     if (!calendar || typeof calendar !== 'object') throw new RangeError('invalid calendar');
     CreateSlots(this);
     SetSlot(this, ISO_YEAR, isoYear);
     SetSlot(this, ISO_MONTH, isoMonth);
-    SetSlot(this, ISO_DAY, refISODay);
+    SetSlot(this, ISO_DAY, referenceISODay);
     SetSlot(this, CALENDAR, calendar);
     SetSlot(this, YEAR_MONTH_BRAND, true);
 
@@ -208,8 +208,8 @@ export class YearMonth {
         const year = GetSlot(item, ISO_YEAR);
         const month = GetSlot(item, ISO_MONTH);
         const calendar = GetSlot(item, CALENDAR);
-        const refISODay = GetSlot(item, ISO_DAY);
-        result = new this(year, month, calendar, refISODay);
+        const referenceISODay = GetSlot(item, ISO_DAY);
+        result = new this(year, month, calendar, referenceISODay);
       } else {
         let calendar = item.calendar;
         if (calendar === undefined) calendar = GetDefaultCalendar();
@@ -217,12 +217,12 @@ export class YearMonth {
         result = calendar.yearMonthFromFields(item, options, this);
       }
     } else {
-      let { year, month, refISODay, calendar } = ES.ParseTemporalYearMonthString(ES.ToString(item));
+      let { year, month, referenceISODay, calendar } = ES.ParseTemporalYearMonthString(ES.ToString(item));
       ({ year, month } = ES.RegulateYearMonth(year, month, overflow));
       if (!calendar) calendar = GetDefaultCalendar();
       calendar = TemporalCalendar.from(calendar);
-      if (refISODay === undefined) refISODay = 1;
-      result = new this(year, month, calendar, refISODay);
+      if (referenceISODay === undefined) referenceISODay = 1;
+      result = new this(year, month, calendar, referenceISODay);
     }
     if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
     return result;

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -3,7 +3,7 @@
 import { GetDefaultCalendar } from './calendar.mjs';
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
-import { ISO_YEAR, ISO_MONTH, REF_ISO_DAY, CALENDAR, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
+import { ISO_YEAR, ISO_MONTH, ISO_DAY, YEAR_MONTH_BRAND, CALENDAR, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
 
 const ObjectAssign = Object.assign;
 
@@ -19,8 +19,9 @@ export class YearMonth {
     CreateSlots(this);
     SetSlot(this, ISO_YEAR, isoYear);
     SetSlot(this, ISO_MONTH, isoMonth);
-    SetSlot(this, REF_ISO_DAY, refISODay);
+    SetSlot(this, ISO_DAY, refISODay);
     SetSlot(this, CALENDAR, calendar);
+    SetSlot(this, YEAR_MONTH_BRAND, true);
 
     if (typeof __debug__ !== 'undefined' && __debug__) {
       Object.defineProperty(this, '_repr_', {
@@ -150,7 +151,7 @@ export class YearMonth {
   equals(other) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalYearMonth(other)) throw new TypeError('invalid YearMonth object');
-    for (const slot of [ISO_YEAR, ISO_MONTH, REF_ISO_DAY]) {
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
       const val1 = GetSlot(this, slot);
       const val2 = GetSlot(other, slot);
       if (val1 !== val2) return false;
@@ -164,7 +165,7 @@ export class YearMonth {
     let resultString = `${year}-${month}`;
     const calendar = ES.FormatCalendarAnnotation(GetSlot(this, CALENDAR));
     if (calendar) {
-      const day = ES.ISODateTimePartString(GetSlot(this, REF_ISO_DAY));
+      const day = ES.ISODateTimePartString(GetSlot(this, ISO_DAY));
       resultString = `${resultString}-${day}${calendar}`;
     }
     return resultString;
@@ -194,7 +195,7 @@ export class YearMonth {
     return {
       isoYear: GetSlot(this, ISO_YEAR),
       isoMonth: GetSlot(this, ISO_MONTH),
-      refISODay: GetSlot(this, REF_ISO_DAY),
+      isoDay: GetSlot(this, ISO_DAY),
       calendar: GetSlot(this, CALENDAR)
     };
   }
@@ -207,7 +208,7 @@ export class YearMonth {
         const year = GetSlot(item, ISO_YEAR);
         const month = GetSlot(item, ISO_MONTH);
         const calendar = GetSlot(item, CALENDAR);
-        const refISODay = GetSlot(item, REF_ISO_DAY);
+        const refISODay = GetSlot(item, ISO_DAY);
         result = new this(year, month, calendar, refISODay);
       } else {
         let calendar = item.calendar;
@@ -228,7 +229,7 @@ export class YearMonth {
   }
   static compare(one, two) {
     if (!ES.IsTemporalYearMonth(one) || !ES.IsTemporalYearMonth(two)) throw new TypeError('invalid YearMonth object');
-    for (const slot of [ISO_YEAR, ISO_MONTH, REF_ISO_DAY]) {
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
       const val1 = GetSlot(one, slot);
       const val2 = GetSlot(two, slot);
       if (val1 !== val2) return ES.ComparisonResult(val1 - val2);

--- a/polyfill/test/MonthDay/prototype/getISOFields/subclass.js
+++ b/polyfill/test/MonthDay/prototype/getISOFields/subclass.js
@@ -27,6 +27,6 @@ const result = instance.getISOFields();
 assert.sameValue(result.isoMonth, 5, "month result");
 assert.sameValue(result.isoDay, 2, "day result");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
-assert.sameValue(result.refISOYear, 1972, "ref year result");
+assert.sameValue(result.isoYear, 1972, "ref year result");
 assert.sameValue(called, 1);
 assert.sameValue(Object.getPrototypeOf(result), Object.prototype);

--- a/polyfill/test/YearMonth/prototype/getISOFields/subclass.js
+++ b/polyfill/test/YearMonth/prototype/getISOFields/subclass.js
@@ -27,6 +27,6 @@ const result = instance.getISOFields();
 assert.sameValue(result.isoYear, 2000, "year result");
 assert.sameValue(result.isoMonth, 5, "month result");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
-assert.sameValue(result.refISODay, 1, "ref day result");
+assert.sameValue(result.isoDay, 1, "ref day result");
 assert.sameValue(called, 1);
 assert.sameValue(Object.getPrototypeOf(result), Object.prototype);

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -152,7 +152,7 @@ describe('MonthDay', () => {
       throws(() => md1.equals('01-22'), TypeError);
       throws(() => md1.equals({ month: 1, day: 22 }), TypeError);
     });
-    it('takes [[RefISOYear]] into account', () => {
+    it('takes [[ISOYear]] into account', () => {
       const iso = Temporal.Calendar.from('iso8601');
       const md1 = new MonthDay(1, 1, iso, 1972);
       const md2 = new MonthDay(1, 1, iso, 2000);
@@ -222,17 +222,17 @@ describe('MonthDay', () => {
       equal(fields.isoMonth, 11);
       equal(fields.isoDay, 18);
       equal(fields.calendar.id, 'iso8601');
-      equal(typeof fields.refISOYear, 'number');
+      equal(typeof fields.isoYear, 'number');
     });
     it('enumerable', () => {
       const fields2 = { ...fields };
       equal(fields2.isoMonth, 11);
       equal(fields2.isoDay, 18);
       equal(fields2.calendar, fields.calendar);
-      equal(typeof fields2.refISOYear, 'number');
+      equal(typeof fields2.isoYear, 'number');
     });
     it('as input to constructor', () => {
-      const md2 = new MonthDay(fields.isoMonth, fields.isoDay, fields.calendar, fields.refISOYear);
+      const md2 = new MonthDay(fields.isoMonth, fields.isoDay, fields.calendar, fields.isoYear);
       assert(md2.equals(md1));
     });
   });

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -240,11 +240,11 @@ describe('Userland calendar', () => {
       return new Temporal.Date(1970, 1, 1).plus({ days });
     }
     function isoToDecimal(date) {
-      const iso = date.getISOFields();
-      const isoDate = new Temporal.Date(iso.isoYear || iso.refISOYear, iso.isoMonth, iso.isoDay || iso.refISODay);
+      const { isoYear, isoMonth, isoDay } = date.getISOFields();
+      const isoDate = new Temporal.Date(isoYear, isoMonth, isoDay);
       let { days } = isoDate.difference(new Temporal.Date(1970, 1, 1), { largestUnit: 'days' });
       let year = Math.floor(days / 100);
-      if (iso.isoYear < 1970) year *= -1;
+      if (isoYear < 1970) year *= -1;
       days %= 100;
       return { year, days };
     }

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -161,7 +161,7 @@ describe('YearMonth', () => {
       throws(() => YearMonth.compare(nov94, { year: 2013, month: 6 }), TypeError);
       throws(() => YearMonth.compare(nov94, '2013-06'), TypeError);
     });
-    it('takes [[RefISODay]] into account', () => {
+    it('takes [[ISODay]] into account', () => {
       const iso = Temporal.Calendar.from('iso8601');
       const ym1 = new YearMonth(2000, 1, iso, 1);
       const ym2 = new YearMonth(2000, 1, iso, 2);
@@ -177,7 +177,7 @@ describe('YearMonth', () => {
       throws(() => nov94.equals({ year: 1994, month: 11 }), TypeError);
       throws(() => nov94.equals('1994-11'), TypeError);
     });
-    it('takes [[RefISODay]] into account', () => {
+    it('takes [[ISODay]] into account', () => {
       const iso = Temporal.Calendar.from('iso8601');
       const ym1 = new YearMonth(2000, 1, iso, 1);
       const ym2 = new YearMonth(2000, 1, iso, 2);
@@ -449,17 +449,17 @@ describe('YearMonth', () => {
       equal(fields.isoYear, 1976);
       equal(fields.isoMonth, 11);
       equal(fields.calendar.id, 'iso8601');
-      equal(typeof fields.refISODay, 'number');
+      equal(typeof fields.isoDay, 'number');
     });
     it('enumerable', () => {
       const fields2 = { ...fields };
       equal(fields2.isoYear, 1976);
       equal(fields2.isoMonth, 11);
       equal(fields2.calendar, fields.calendar);
-      equal(typeof fields2.refISODay, 'number');
+      equal(typeof fields2.isoDay, 'number');
     });
     it('as input to constructor', () => {
-      const ym2 = new YearMonth(fields.isoYear, fields.isoMonth, fields.calendar, fields.refISODay);
+      const ym2 = new YearMonth(fields.isoYear, fields.isoMonth, fields.calendar, fields.isoDay);
       assert(ym2.equals(ym1));
     });
   });

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -168,7 +168,7 @@
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalMonthDay]]).
         1. If _monthDay_.[[ISOMonth]] ≠ _other_.[[ISOMonth]], return *false*.
         1. If _monthDay_.[[ISODay]] ≠ _other_.[[ISODay]], return *false*.
-        1. If _monthDay_.[[RefISOYear]] ≠ _other_.[[RefISOYear]], return *false*.
+        1. If _monthDay_.[[ISOYear]] ≠ _other_.[[ISOYear]], return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>
@@ -271,7 +271,7 @@
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Let _fields_ be ? ObjectCreate(%ObjectPrototype%).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"refISOYear"*, _monthDay_.[[RefISOYear]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoYear"*, _monthDay_.[[ISOYear]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMonth"*, _monthDay_.[[ISOMonth]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoDay"*, _monthDay_.[[ISODay]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"calendar"*, _monthDay_.[[Calendar]]).
@@ -385,10 +385,10 @@
         1. If ! ValidateDate(_refISOYear_, _month_, _day_) is *false*, then
           1. Throw a *RangeError* exception.
         1. If _newTarget_ is not given, set it to %Temporal.MonthDay%.
-        1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Temporal.MonthDay.prototype%"`, « [[InitializedTemporalMonthDay]], [[ISOMonth]], [[ISODay]], [[RefISOYear]] »).
+        1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Temporal.MonthDay.prototype%"`, « [[InitializedTemporalMonthDay]], [[ISOMonth]], [[ISODay]], [[ISOYear]] »).
         1. Set _object_.[[ISOMonth]] to _month_.
         1. Set _object_.[[ISODay]] to _day_.
-        1. Set _object_.[[RefISOYear]] to _refISOYear_.
+        1. Set _object_.[[ISOYear]] to _refISOYear_.
         1. Return _object_.
       </emu-alg>
     </emu-clause>
@@ -425,7 +425,7 @@
           1. Return the Record {
               [[Month]]: _temporalMonthDayLike_.[[ISOMonth]],
               [[Day]]: _temporalMonthDayLike_.[[ISODay]],
-              [[Year]]: _temporalMonthDayLike_.[[RefISOYear]]
+              [[Year]]: _temporalMonthDayLike_.[[ISOYear]]
             }.
         1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-temporalmonthdaylike-properties"></emu-xref>, as well as a [[Year]] slot.
         1. For each row of <emu-xref href="#table-temporal-temporalmonthdaylike-properties"></emu-xref>, except the header row, in table order, do

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -18,17 +18,17 @@
     </p>
 
     <emu-clause id="sec-temporal.monthday">
-      <h1>Temporal.MonthDay ( _isoMonth_, _isoDay_ [ , _refISOYear_ ] )</h1>
+      <h1>Temporal.MonthDay ( _isoMonth_, _isoDay_ [ , _referenceISOYear_ ] )</h1>
       <p>
         When the `Temporal.MonthDay` function is called, the following steps are taken:
       </p>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. If _refISOYear_ is not given, set it to the first leap year after the Unix epoch (1972).
+        1. If _referenceISOYear_ is not given, set it to the first leap year after the Unix epoch (1972).
         1. Let _m_ be ? ToInteger(_isoMonth_).
         1. Let _d_ be ? ToInteger(_isoDay_).
-        1. Let _ref_ be ? ToInteger(_refISOYear_).
+        1. Let _ref_ be ? ToInteger(_referenceISOYear_).
         1. Return ? CreateTemporalMonthDay(_m_, _d_, _ref_, NewTarget).
       </emu-alg>
     </emu-clause>
@@ -68,14 +68,14 @@
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _result_ be ? ToTemporalMonthDayRecord(_item_).
-          1. Let _refISOYear_ be _result_.[[Year]].
+          1. Let _referenceISOYear_ be _result_.[[Year]].
         1. Else,
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalMonthDayString(_string_).
-          1. Let _refISOYear_ be the first leap year after the Unix epoch (1972).
+          1. Let _referenceISOYear_ be the first leap year after the Unix epoch (1972).
         1. Let _constructor_ be the *this* value.
         1. Set _result_ to ? RegulateMonthDay(_result_.[[Month]], _result_.[[Day]], _overflow_).
-        1. Return ? CreateTemporalMonthDayFromStatic(_constructor_, _result_.[[Month]], _result_.[[Day]], _refISOYear_).
+        1. Return ? CreateTemporalMonthDayFromStatic(_constructor_, _result_.[[Month]], _result_.[[Day]], _referenceISOYear_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -380,15 +380,15 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporalmonthday" aoid="CreateTemporalMonthDay">
-      <h1>CreateTemporalMonthDay ( _isoMonth_, _isoDay_, _refISOYear_ [ , _newTarget_ ] )</h1>
+      <h1>CreateTemporalMonthDay ( _isoMonth_, _isoDay_, _referenceISOYear_ [ , _newTarget_ ] )</h1>
       <emu-alg>
-        1. If ! ValidateDate(_refISOYear_, _month_, _day_) is *false*, then
+        1. If ! ValidateDate(_referenceISOYear_, _month_, _day_) is *false*, then
           1. Throw a *RangeError* exception.
         1. If _newTarget_ is not given, set it to %Temporal.MonthDay%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Temporal.MonthDay.prototype%"`, « [[InitializedTemporalMonthDay]], [[ISOMonth]], [[ISODay]], [[ISOYear]] »).
         1. Set _object_.[[ISOMonth]] to _month_.
         1. Set _object_.[[ISODay]] to _day_.
-        1. Set _object_.[[ISOYear]] to _refISOYear_.
+        1. Set _object_.[[ISOYear]] to _referenceISOYear_.
         1. Return _object_.
       </emu-alg>
     </emu-clause>
@@ -406,12 +406,12 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporalmonthdayfromstatic" aoid="CreateTemporalMonthDayFromStatic">
-      <h1>CreateTemporalMonthDayFromStatic ( _constructor_, _month_, _day_, _refISOYear_ )</h1>
+      <h1>CreateTemporalMonthDayFromStatic ( _constructor_, _month_, _day_, _referenceISOYear_ )</h1>
       <emu-alg>
-        1. Assert: ! ValidateDate(_refISOYear_, _month_, _day_) is *true*.
+        1. Assert: ! ValidateDate(_referenceISOYear_, _month_, _day_) is *true*.
         1. If ! IsConstructor(_constructor_) is *false*, then
           1. Throw a *TypeError* exception.
-        1. Let _result_ be ? Construct(_constructor_, « _month_, _day_, _refISOYear_ »).
+        1. Let _result_ be ? Construct(_constructor_, « _month_, _day_, _referenceISOYear_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalMonthDay]]).
         1. Return _result_.
       </emu-alg>

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -88,7 +88,7 @@
       <emu-alg>
         1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalYearMonth]]).
         1. Perform ? RequireInternalSlot(_two_, [[InitializedTemporalYearMonth]]).
-        1. Return ! CompareTemporalDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[RefISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[RefISODay]]).
+        1. Return ! CompareTemporalDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -306,7 +306,7 @@
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalYearMonth]]).
         1. If _yearMonth_.[[ISOYear]] ≠ _other_.[[ISOYear]], return *false*.
         1. If _yearMonth_.[[ISOMonth]] ≠ _other_.[[ISOMonth]], return *false*.
-        1. If _yearMonth_.[[RefISODay]] ≠ _other_.[[RefISODay]], return *false*.
+        1. If _yearMonth_.[[ISODay]] ≠ _other_.[[ISODay]], return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>
@@ -403,7 +403,7 @@
         1. Let _fields_ be ? ObjectCreate(%ObjectPrototype%).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoYear"*, _yearMonth_.[[ISOYear]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMonth"*, _yearMonth_.[[ISOMonth]]).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"refISODay"*, _yearMonth_.[[RefISODay]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoDay"*, _yearMonth_.[[ISODay]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"calendar"*, _yearMonth_.[[Calendar]]).
         1. Return _fields_.
       </emu-alg>
@@ -533,10 +533,10 @@
         1. If ! ValidateYearMonthRange(_isoYear_, _isoMonth_) is *false*, then
           1. Throw a *RangeError* exception.
         1. If _newTarget_ is not given, set it to %Temporal.YearMonth%.
-        1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Temporal.YearMonth.prototype%"`, « [[InitializedTemporalYearMonth]], [[ISOYear]], [[ISOMonth]], [[RefISODay]] »).
+        1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Temporal.YearMonth.prototype%"`, « [[InitializedTemporalYearMonth]], [[ISOYear]], [[ISOMonth]], [[ISODay]] »).
         1. Set _object_.[[ISOYear]] to _isoYear_.
         1. Set _object_.[[ISOMonth]] to _isoMonth_.
-        1. Set _object_.[[RefISODay]] to _refISODay_.
+        1. Set _object_.[[ISODay]] to _refISODay_.
         1. Return _object_.
       </emu-alg>
     </emu-clause>
@@ -571,9 +571,9 @@
         1. Assert: Type(_temporalYearMonthLike_) is Object.
         1. If _temporalYearMonthLike_ has an [[InitializedTemporalYearMonth]] internal slot, then
           1. Return the Record {
-              [[Year]]: _temporalYearMonthLike_.[[Year]],
-              [[Month]]: _temporalYearMonthLike_.[[Month]],
-              [[Day]]: _temporalYearMonthLike_.[[RefISODay]]
+              [[Year]]: _temporalYearMonthLike_.[[ISOYear]],
+              [[Month]]: _temporalYearMonthLike_.[[ISOMonth]],
+              [[Day]]: _temporalYearMonthLike_.[[ISODay]]
             }.
         1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-temporalyearmonthlike-properties"></emu-xref>, as well as a [[Day]] slot.
         1. For each row of <emu-xref href="#table-temporal-temporalyearmonthlike-properties"></emu-xref>, except the header row, in table order, do

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -18,17 +18,17 @@
     </p>
 
     <emu-clause id="sec-temporal.yearmonth">
-      <h1>Temporal.YearMonth ( _isoYear_, _isoMonth_ [ , _refISODay_ ] )</h1>
+      <h1>Temporal.YearMonth ( _isoYear_, _isoMonth_ [ , _referenceISODay_ ] )</h1>
       <p>
         When the `Temporal.YearMonth` function is called, the following steps are taken:
       </p>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. If _refISODay_ is not given, set it to 1.
+        1. If _referenceISODay_ is not given, set it to 1.
         1. Let _y_ be ? ToInteger(_isoYear_).
         1. Let _m_ be ? ToInteger(_isoMonth_).
-        1. Let _ref_ be ? ToInteger(_refISODay_).
+        1. Let _ref_ be ? ToInteger(_referenceISODay_).
         1. Return ? CreateTemporalYearMonth(_y_, _m_, _ref_, NewTarget).
       </emu-alg>
     </emu-clause>
@@ -68,14 +68,14 @@
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _result_ be ? ToTemporalYearMonthRecord(_item_).
-          1. Let _refISODay_ be _result_.[[Day]].
+          1. Let _referenceISODay_ be _result_.[[Day]].
         1. Else,
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalYearMonthString(_string_).
-          1. Let _refISODay_ be 1.
+          1. Let _referenceISODay_ be 1.
         1. Let _constructor_ be the *this* value.
         1. Set _result_ to ? RegulateYearMonth(_result_.[[Year]], _result_.[[Month]], _overflow_).
-        1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _refISODay_).
+        1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _referenceISODay_).
       </emu-alg>
     </emu-clause>
 
@@ -526,9 +526,9 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporalyearmonth" aoid="CreateTemporalYearMonth">
-      <h1>CreateTemporalYearMonth ( _isoYear_, _isoMonth_, _refISODay_ [ , _newTarget_ ] )</h1>
+      <h1>CreateTemporalYearMonth ( _isoYear_, _isoMonth_, _referenceISODay_ [ , _newTarget_ ] )</h1>
       <emu-alg>
-        1. If ! ValidateDate(_isoYear_, _isoMonth_, _refISODay_) is *false*, then
+        1. If ! ValidateDate(_isoYear_, _isoMonth_, _referenceISODay_) is *false*, then
           1. Throw a *RangeError* exception.
         1. If ! ValidateYearMonthRange(_isoYear_, _isoMonth_) is *false*, then
           1. Throw a *RangeError* exception.
@@ -536,7 +536,7 @@
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%Temporal.YearMonth.prototype%"`, « [[InitializedTemporalYearMonth]], [[ISOYear]], [[ISOMonth]], [[ISODay]] »).
         1. Set _object_.[[ISOYear]] to _isoYear_.
         1. Set _object_.[[ISOMonth]] to _isoMonth_.
-        1. Set _object_.[[ISODay]] to _refISODay_.
+        1. Set _object_.[[ISODay]] to _referenceISODay_.
         1. Return _object_.
       </emu-alg>
     </emu-clause>
@@ -554,12 +554,12 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporalyearmonthfromstatic" aoid="CreateTemporalYearMonthFromStatic">
-      <h1>CreateTemporalYearMonthFromStatic ( _constructor_, _year_, _month_, _refISODay_ )</h1>
+      <h1>CreateTemporalYearMonthFromStatic ( _constructor_, _year_, _month_, _referenceISODay_ )</h1>
       <emu-alg>
-        1. Assert: ! ValidateDate(_year_, _month_, _refISODay_) is *true*.
+        1. Assert: ! ValidateDate(_year_, _month_, _referenceISODay_) is *true*.
         1. If ! IsConstructor(_constructor_) is *false*, then
           1. Throw a *TypeError* exception.
-        1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _refISODay_ »).
+        1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _referenceISODay_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalYearMonth]]).
         1. Return _result_.
       </emu-alg>


### PR DESCRIPTION
This renames YearMonth's [[RefISODay]] slot to [[ISODay]], MonthDay's
[[RefISOYear]] slot to [[ISOYear]], changes the `refISOYear` property on
the returned object from MonthDay.getISOFields() to `isoYear`, and changes
the `refISODay` property on the returned object from
YearMonth.getISOFields() to `isoDay`.

Fixes a few inconsistencies with the capitalization of ISO, and also adds
extra slots to Temporal.Date, YearMonth, and MonthDay for brand checks
(since they all otherwise have the same slots now.)

Closes: #896