### PR TITLE
Add "properties of instances" sections to spec

### DIFF
--- a/spec/date.html
+++ b/spec/date.html
@@ -524,14 +524,64 @@
 
   <emu-clause id="sec-properties-of-temporal-date-instances">
     <h1>Properties of Temporal.Date Instances</h1>
-    <p>Temporal.Date instances are ordinary objects that inherit properties from the %Temporal.Date.prototype%.</p>
-    <p>Temporal.Date instances have the following internal slots:
-    <ul>
-      <li>[[ISOYear]], representing the year. The value is an integer Number.</li>
-      <li>[[ISOMonth]], representing the month within the year. The value is an integer Number between 1 and 12, inclusive.</li>
-      <li>[[ISODay]], representing the day within the month. The value is an integer Number between 1 and DaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive.</li>
-      <li>[[Calendar]], representing the calendar. The value is an Object.</li>
-    </ul>
+    <p>
+      Temporal.Date instances are ordinary objects that inherit properties from the %Temporal.Date.prototype% intrinsic object.
+      Temporal.Date instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-temporaldate-instances"></emu-xref>.
+    </p>
+    <emu-table id="table-internal-slots-of-temporaldate-instances" caption="Internal Slots of Temporal.Date Instances">
+      <table>
+        <tbody>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[InitializedTemporalDate]]
+            </td>
+            <td>
+              The only specified use of this slot is for distinguishing Temporal.Date instances from other objects.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISOYear]]
+            </td>
+            <td>
+              An integer Number value representing the year in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISOMonth]]
+            </td>
+            <td>
+              An integer Number value between 1 and 12, inclusive, representing the month of the year in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISODay]]
+            </td>
+            <td>
+              An integer Number value between 1 and DaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing the day of the month in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Calendar]]
+            </td>
+            <td>
+              An Object representing the calendar.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
   </emu-clause>
 
   <emu-clause id="sec-temporal-date-abstract-ops">

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -712,6 +712,116 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-properties-of-temporal-datetime-instances">
+    <h1>Properties of Temporal.DateTime Instances</h1>
+    <p>
+      Temporal.DateTime instances are ordinary objects that inherit properties from the %Temporal.DateTime.prototype% intrinsic object.
+      Temporal.DateTime instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-temporaldatetime-instances"></emu-xref>.
+    </p>
+    <emu-table id="table-internal-slots-of-temporaldatetime-instances" caption="Internal Slots of Temporal.DateTime Instances">
+      <table>
+        <tbody>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[InitializedTemporalDateTime]]
+            </td>
+            <td>
+              The only specified use of this slot is for distinguishing Temporal.DateTime instances from other objects.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISOYear]]
+            </td>
+            <td>
+              An integer Number value representing the year in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISOMonth]]
+            </td>
+            <td>
+              An integer Number value between 1 and 12, inclusive, representing the month of the year in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISODay]]
+            </td>
+            <td>
+              An integer Number value between 1 and DaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing the day of the month in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Hour]]
+            </td>
+            <td>
+              An integer Number value between 0 and 23, inclusive, representing the hour of the day.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Minute]]
+            </td>
+            <td>
+              An integer Number value between 0 and 59, inclusive, representing the minute of the hour.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Second]]
+            </td>
+            <td>
+              An integer Number value between 0 and 59, inclusive, representing the second within the minute.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Millisecond]]
+            </td>
+            <td>
+              An integer Number value between 0 and 999, inclusive, representing the millisecond within the second.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Microsecond]]
+            </td>
+            <td>
+              An integer Number value between 0 and 999, inclusive, representing the microsecond within the millisecond.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Nanosecond]]
+            </td>
+            <td>
+              An integer Number value between 0 and 999, inclusive, representing the nanosecond within the microsecond.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Calendar]]
+            </td>
+            <td>
+              An Object representing the calendar.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-datetime-abstract-ops">
     <h1>Abstract operations</h1>
 

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -448,6 +448,116 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-properties-of-temporal-duration-instances">
+    <h1>Properties of Temporal.Duration Instances</h1>
+    <p>
+      Temporal.Duration instances are ordinary objects that inherit properties from the %Temporal.Duration.prototype% intrinsic object.
+      Temporal.Duration instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-temporalduration-instances"></emu-xref>.
+    </p>
+    <emu-table id="table-internal-slots-of-temporalduration-instances" caption="Internal Slots of Temporal.Duration Instances">
+      <table>
+        <tbody>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[InitializedTemporalDuration]]
+            </td>
+            <td>
+              The only specified use of this slot is for distinguishing Temporal.Duration instances from other objects.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Years]]
+            </td>
+            <td>
+              An integer Number value representing the number of years in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Months]]
+            </td>
+            <td>
+              An integer Number value representing the number of months in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Weeks]]
+            </td>
+            <td>
+              An integer Number value representing the number of weeks in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Days]]
+            </td>
+            <td>
+              An integer Number value representing the number of days in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Hours]]
+            </td>
+            <td>
+              An integer Number value representing the number of hours in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Minutes]]
+            </td>
+            <td>
+              An integer Number value representing the number of minutes in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Seconds]]
+            </td>
+            <td>
+              An integer Number value representing the number of seconds in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Milliseconds]]
+            </td>
+            <td>
+              An integer Number value representing the number of milliseconds in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Microseconds]]
+            </td>
+            <td>
+              An integer Number value representing the number of microseconds in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Nanoseconds]]
+            </td>
+            <td>
+              An integer Number value representing the number of nanoseconds in the duration.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-duration-abstract-ops">
     <h1>Abstract Operations</h1>
 

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -444,6 +444,45 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-properties-of-temporal-instant-instances">
+    <h1>Properties of Temporal.Instant Instances</h1>
+
+    <p>
+      Temporal.Instant instances are ordinary objects that inherit properties from the %Temporal.Instant.prototype% intrinsic object.
+      Temporal.Instant instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-temporalinstant-instances"></emu-xref>.
+    </p>
+    <emu-table id="table-internal-slots-of-temporalinstant-instances" caption="Internal Slots of Temporal.Instant Instances">
+      <table>
+        <tbody>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[InitializedTemporalInstant]]
+            </td>
+            <td>
+              The only specified use of this slot is for distinguishing Temporal.Instant instances from other objects.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Nanoseconds]]
+            </td>
+            <td>
+              A BigInt value representing the number of nanoseconds since the Unix epoch.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-instant-abstract-ops">
     <h1>Abstract operations</h1>
 

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -280,6 +280,69 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-properties-of-temporal-monthday-instances">
+    <h1>Properties of Temporal.MonthDay Instances</h1>
+    <p>
+      Temporal.MonthDay instances are ordinary objects that inherit properties from the %Temporal.MonthDay.prototype% intrinsic object.
+      Temporal.MonthDay instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-temporalmonthday-instances"></emu-xref>.
+    </p>
+    <emu-table id="table-internal-slots-of-temporalmonthday-instances" caption="Internal Slots of Temporal.MonthDay Instances">
+      <table>
+        <tbody>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[InitializedTemporalMonthDay]]
+            </td>
+            <td>
+              The only specified use of this slot is for distinguishing Temporal.MonthDay instances from other objects.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISOYear]]
+            </td>
+            <td>
+              An integer Number value representing the year in the ISO 8601 calendar.
+              This slot is used by the calendar object in the [[Calendar]] slot to disambiguate if the [[ISOMonth]] and [[ISODay]] slots are not enough to uniquely identify a month and day in that calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISOMonth]]
+            </td>
+            <td>
+              An integer Number value between 1 and 12, inclusive, representing the month of the year in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISODay]]
+            </td>
+            <td>
+              An integer Number value between 1 and DaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing the day of the month in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Calendar]]
+            </td>
+            <td>
+              An Object representing the calendar.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-monthday-abstract-ops">
     <h1>Abstract operations</h1>
 

--- a/spec/time.html
+++ b/spec/time.html
@@ -434,6 +434,84 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-properties-of-temporal-time-instances">
+    <h1>Properties of Temporal.Time Instances</h1>
+    <p>
+      Temporal.Time instances are ordinary objects that inherit properties from the %Temporal.Time.prototype% intrinsic object.
+      Temporal.Time instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-temporaltime-instances"></emu-xref>.
+    </p>
+    <emu-table id="table-internal-slots-of-temporaltime-instances" caption="Internal Slots of Temporal.Time Instances">
+      <table>
+        <tbody>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[InitializedTemporalTime]]
+            </td>
+            <td>
+              The only specified use of this slot is for distinguishing Temporal.Time instances from other objects.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Hour]]
+            </td>
+            <td>
+              An integer Number value between 0 and 23, inclusive, representing the hour of the day.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Minute]]
+            </td>
+            <td>
+              An integer Number value between 0 and 59, inclusive, representing the minute of the hour.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Second]]
+            </td>
+            <td>
+              An integer Number value between 0 and 59, inclusive, representing the second within the minute.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Millisecond]]
+            </td>
+            <td>
+              An integer Number value between 0 and 999, inclusive, representing the millisecond within the second.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Microsecond]]
+            </td>
+            <td>
+              An integer Number value between 0 and 999, inclusive, representing the microsecond within the millisecond.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Nanosecond]]
+            </td>
+            <td>
+              An integer Number value between 0 and 999, inclusive, representing the nanosecond within the microsecond.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-time-abstract-ops">
     <h1>Abstract operations</h1>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -299,6 +299,45 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-properties-of-temporal-timezone-instances">
+    <h1>Properties of Temporal.TimeZone Instances</h1>
+
+    <p>
+      Temporal.TimeZone instances are ordinary objects that inherit properties from the %Temporal.TimeZone.prototype% intrinsic object.
+      Temporal.TimeZone instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-temporaltimezone-instances"></emu-xref>.
+    </p>
+    <emu-table id="table-internal-slots-of-temporaltimezone-instances" caption="Internal Slots of Temporal.TimeZone Instances">
+      <table>
+        <tbody>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[InitializedTemporalTimeZone]]
+            </td>
+            <td>
+              The only specified use of this slot is for distinguishing Temporal.TimeZone instances from other objects.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Identifier]]
+            </td>
+            <td>
+              A String value.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-timezone-abstract-ops">
     <h1>Abstract operations</h1>
 

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -410,6 +410,69 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-properties-of-temporal-yearmonth-instances">
+    <h1>Properties of Temporal.YearMonth Instances</h1>
+    <p>
+      Temporal.YearMonth instances are ordinary objects that inherit properties from the %Temporal.YearMonth.prototype% intrinsic object.
+      Temporal.YearMonth instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-temporalyearmonth-instances"></emu-xref>.
+    </p>
+    <emu-table id="table-internal-slots-of-temporalyearmonth-instances" caption="Internal Slots of Temporal.YearMonth Instances">
+      <table>
+        <tbody>
+          <tr>
+            <th>
+              Internal Slot
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              [[InitializedTemporalYearMonth]]
+            </td>
+            <td>
+              The only specified use of this slot is for distinguishing Temporal.YearMonth instances from other objects.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISOYear]]
+            </td>
+            <td>
+              An integer Number value representing the year in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISOMonth]]
+            </td>
+            <td>
+              An integer Number value between 1 and 12, inclusive, representing the month of the year in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[ISODay]]
+            </td>
+            <td>
+              An integer Number value between 1 and DaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing a reference day of the month in the ISO 8601 calendar.
+              This slot is used by the calendar object in the [[Calendar]] slot to disambiguate if the [[ISOYear]] and [[ISOMonth]] slots are not enough to uniquely identify a year and month in that calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Calendar]]
+            </td>
+            <td>
+              An Object representing the calendar.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-yearmonth-abstract-ops">
     <h1>Abstract operations</h1>
 


### PR DESCRIPTION
This adds a section to each of the Temporal types with details about the
internal slots. It also makes the existing Temporal.Date section conform
to the way that many such sections are written in the ECMA-262 spec.

I've left the existing sections in Temporal.Calendar and
Temporal.ISO8601Calendar as they are, since it's not yet clear where we're
going with the subclassing scheme there.

Closes: #898