### PR TITLE
Move NormalizeOptionsObject outside of other abstract operations

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -129,6 +129,7 @@ class ISO8601Calendar extends Calendar {
   }
   dateFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     // Intentionally alphabetical
     let { year, month, day } = ES.ToTemporalDateRecord(fields);
@@ -137,6 +138,7 @@ class ISO8601Calendar extends Calendar {
   }
   yearMonthFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     // Intentionally alphabetical
     let { year, month } = ES.ToTemporalYearMonthRecord(fields);
@@ -145,6 +147,7 @@ class ISO8601Calendar extends Calendar {
   }
   monthDayFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     // Intentionally alphabetical
     let { month, day } = ES.ToTemporalMonthDayRecord(fields);
@@ -153,6 +156,7 @@ class ISO8601Calendar extends Calendar {
   }
   datePlus(date, duration, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const { years, months, weeks, days } = duration;
     ES.RejectDurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
@@ -169,6 +173,7 @@ class ISO8601Calendar extends Calendar {
   }
   dateMinus(date, duration, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const { years, months, weeks, days } = duration;
     ES.RejectDurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
@@ -185,6 +190,7 @@ class ISO8601Calendar extends Calendar {
   }
   dateDifference(one, two, options) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
     const largestUnit = ES.ToLargestTemporalUnit(options, 'days', [
       'hours',
       'minutes',

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -242,6 +242,7 @@ export class Date {
     };
   }
   static from(item, options = undefined) {
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
     let result;

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -148,6 +148,7 @@ export class DateTime {
   }
   with(temporalDateTimeLike, options = undefined) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     let source;
     let calendar = temporalDateTimeLike.calendar;
@@ -383,6 +384,7 @@ export class DateTime {
         `cannot compute difference between dates of ${calendar.id} and ${otherCalendar.id} calendars`
       );
     }
+    options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
     let defaultLargestUnit = 'days';
     if (smallestUnit === 'years' || smallestUnit === 'months' || smallestUnit === 'weeks') {
@@ -484,6 +486,7 @@ export class DateTime {
   round(options) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     if (options === undefined) throw new TypeError('options parameter is required');
+    options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalUnit(options);
     const roundingMode = ES.ToTemporalRoundingMode(options);
     const maximumIncrements = {
@@ -574,6 +577,7 @@ export class DateTime {
   toInstant(temporalTimeZoneLike, options = undefined) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+    options = ES.NormalizeOptionsObject(options);
     const disambiguation = ES.ToTemporalDisambiguation(options);
     return ES.GetTemporalInstantFor(timeZone, this, disambiguation);
   }
@@ -622,6 +626,7 @@ export class DateTime {
   }
 
   static from(item, options = undefined) {
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
     let result;

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -138,6 +138,7 @@ export class Duration {
   }
   with(durationLike, options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalDurationOverflow(options);
     const props = ES.ToPartialRecord(durationLike, [
       'days',
@@ -257,6 +258,7 @@ export class Duration {
       nanoseconds
     } = ES.ToLimitedTemporalDuration(other);
     ES.RejectDurationSign(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalDurationOverflow(options);
     ({
       years,
@@ -323,6 +325,7 @@ export class Duration {
       nanoseconds
     } = ES.ToLimitedTemporalDuration(other);
     ES.RejectDurationSign(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalDurationOverflow(options);
     ({
       years,
@@ -406,6 +409,7 @@ export class Duration {
     throw new TypeError('not possible to compare Temporal.Duration');
   }
   static from(item, options = undefined) {
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalDurationOverflow(options);
     let years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
     if (typeof item === 'object' && item) {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -446,23 +446,18 @@ export const ES = ObjectAssign({}, ES2019, {
     return duration;
   },
   ToTemporalDurationOverflow: (options) => {
-    options = ES.NormalizeOptionsObject(options);
     return ES.GetOption(options, 'overflow', ['constrain', 'balance'], 'constrain');
   },
   ToTemporalOverflow: (options) => {
-    options = ES.NormalizeOptionsObject(options);
     return ES.GetOption(options, 'overflow', ['constrain', 'reject'], 'constrain');
   },
   ToTemporalDisambiguation: (options) => {
-    options = ES.NormalizeOptionsObject(options);
     return ES.GetOption(options, 'disambiguation', ['compatible', 'earlier', 'later', 'reject'], 'compatible');
   },
   ToTemporalRoundingMode: (options) => {
-    options = ES.NormalizeOptionsObject(options);
     return ES.GetOption(options, 'roundingMode', ['ceil', 'floor', 'trunc', 'nearest'], 'nearest');
   },
   ToTemporalRoundingIncrement: (options, dividend, inclusive) => {
-    options = ES.NormalizeOptionsObject(options);
     let maximum = Infinity;
     if (dividend !== undefined) maximum = dividend;
     if (!inclusive && dividend !== undefined) maximum = dividend > 1 ? dividend - 1 : 1;
@@ -488,7 +483,6 @@ export const ES = ObjectAssign({}, ES2019, {
     for (const s of disallowedStrings) {
       allowed.delete(s);
     }
-    options = ES.NormalizeOptionsObject(options);
     return ES.GetOption(options, 'largestUnit', [...allowed], fallback);
   },
   ToSmallestTemporalUnit: (options, disallowedStrings = []) => {
@@ -506,7 +500,6 @@ export const ES = ObjectAssign({}, ES2019, {
       allowed.delete(s);
     }
     const allowedValues = [...allowed];
-    options = ES.NormalizeOptionsObject(options);
     let value = options.smallestUnit;
     if (value === undefined) throw new RangeError('smallestUnit option is required');
     value = ES.ToString(value);
@@ -545,7 +538,6 @@ export const ES = ObjectAssign({}, ES2019, {
       allowed.delete(s);
     }
     const allowedValues = [...allowed];
-    options = ES.NormalizeOptionsObject(options);
     let value = options.smallestUnit;
     if (value === undefined) return fallback;
     value = ES.ToString(value);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -104,6 +104,7 @@ export class Instant {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalInstant(other)) throw new TypeError('invalid Instant object');
     const disallowedUnits = ['years', 'months', 'weeks', 'days'];
+    options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds', disallowedUnits);
     let defaultLargestUnit = 'seconds';
     if (smallestUnit === 'hours' || smallestUnit === 'minutes') defaultLargestUnit = smallestUnit;
@@ -167,6 +168,7 @@ export class Instant {
   round(options) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     if (options === undefined) throw new TypeError('options parameter is required');
+    options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalUnit(options, ['day', 'hour']);
     const roundingMode = ES.ToTemporalRoundingMode(options);
     const maximumIncrements = {

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -121,6 +121,7 @@ export class MonthDay {
     };
   }
   static from(item, options = undefined) {
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
     let result;

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -74,6 +74,7 @@ export class Time {
 
   with(temporalTimeLike, options = undefined) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const props = ES.ToPartialRecord(temporalTimeLike, [
       'hour',
@@ -112,6 +113,7 @@ export class Time {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     let { hour, minute, second, millisecond, microsecond, nanosecond } = this;
     const duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     ES.RejectDurationSign(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
@@ -176,6 +178,7 @@ export class Time {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     let { hour, minute, second, millisecond, microsecond, nanosecond } = this;
     const duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     ES.RejectDurationSign(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
@@ -239,6 +242,7 @@ export class Time {
   difference(other, options = undefined) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     if (!ES.IsTemporalTime(other)) throw new TypeError('invalid Time object');
+    options = ES.NormalizeOptionsObject(options);
     const largestUnit = ES.ToLargestTemporalUnit(options, 'hours', ['years', 'months', 'weeks', 'days']);
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
     ES.ValidateTemporalDifferenceUnits(largestUnit, smallestUnit);
@@ -298,6 +302,7 @@ export class Time {
   round(options) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     if (options === undefined) throw new TypeError('options parameter is required');
+    options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalUnit(options, ['day']);
     const roundingMode = ES.ToTemporalRoundingMode(options);
     const maximumIncrements = {
@@ -388,6 +393,7 @@ export class Time {
   }
 
   static from(item, options = undefined) {
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     let hour, minute, second, millisecond, microsecond, nanosecond;
     if (typeof item === 'object' && item) {

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -90,6 +90,7 @@ export class TimeZone {
   }
   getInstantFor(dateTime, options = undefined) {
     if (!ES.IsTemporalDateTime(dateTime)) throw new TypeError('invalid DateTime object');
+    options = ES.NormalizeOptionsObject(options);
     const disambiguation = ES.ToTemporalDisambiguation(options);
 
     const Instant = GetIntrinsic('%Temporal.Instant%');

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -130,6 +130,7 @@ export class YearMonth {
         `cannot compute difference between months of ${calendar.id} and ${otherCalendar.id} calendars`
       );
     }
+    options = ES.NormalizeOptionsObject(options);
     const largestUnit = ES.ToLargestTemporalUnit(options, 'years', [
       'weeks',
       'days',
@@ -200,6 +201,7 @@ export class YearMonth {
     };
   }
   static from(item, options = undefined) {
+    options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
     let result;

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -87,41 +87,36 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-totemporaldurationoverflow" aoid="ToTemporalDurationOverflow">
-    <h1>ToTemporalDurationOverflow ( _options_ )</h1>
+    <h1>ToTemporalDurationOverflow ( _normalizedOptions_ )</h1>
     <emu-alg>
-      1. Set _options_ to ? NormalizeOptionsObject(_options_).
-      1. Return ? GetOption(_options_, *"overflow"*, « *"constrain"*, *"balance"* », *"constrain"*).
+      1. Return ? GetOption(_normalizedOptions_, *"overflow"*, « *"constrain"*, *"balance"* », *"constrain"*).
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-totemporaloverflow" aoid="ToTemporalOverflow">
-    <h1>ToTemporalOverflow ( _options_ )</h1>
+    <h1>ToTemporalOverflow ( _normalizedOptions_ )</h1>
     <emu-alg>
-      1. Set _options_ to ? NormalizeOptionsObject(_options_).
-      1. Return ? GetOption(_options_, *"overflow"*, « *"constrain"*, *"reject"* », *"constrain"*).
+      1. Return ? GetOption(_normalizedOptions_, *"overflow"*, « *"constrain"*, *"reject"* », *"constrain"*).
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-totemporaldisambiguation" aoid="ToTemporalDisambiguation">
-    <h1>ToTemporalDisambiguation ( _options_ )</h1>
+    <h1>ToTemporalDisambiguation ( _normalizedOptions_ )</h1>
     <emu-alg>
-      1. Set _options_ to ? NormalizeOptionsObject(_options_).
-      1. Return ? GetOption(_options_, *"disambiguation"*, *"string"*, « *"compatible"*, *"earlier"*, *"later"*, *"reject"* », *"compatible"*).
+      1. Return ? GetOption(_normalizedOptions_, *"disambiguation"*, *"string"*, « *"compatible"*, *"earlier"*, *"later"*, *"reject"* », *"compatible"*).
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-totemporalroundingmode" aoid="ToTemporalRoundingMode">
-    <h1>ToTemporalRoundingMode ( _options_ )</h1>
+    <h1>ToTemporalRoundingMode ( _normalizedOptions_ )</h1>
     <emu-alg>
-      1. Set _options_ to ? NormalizeOptionsObject(_options_).
-      1. Return ? GetOption(_options_, *"roundingMode"*, *"string"*, « *"ceil"*, *"floor"*, *"trunc"*, *"nearest"* », *"nearest"*).
+      1. Return ? GetOption(_normalizedOptions_, *"roundingMode"*, *"string"*, « *"ceil"*, *"floor"*, *"trunc"*, *"nearest"* », *"nearest"*).
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-totemporalroundingincrement" aoid="ToTemporalRoundingIncrement">
-    <h1>ToTemporalRoundingIncrement ( _options_, _dividend_, _inclusive_ )</h1>
+    <h1>ToTemporalRoundingIncrement ( _normalizedOptions_, _dividend_, _inclusive_ )</h1>
     <emu-alg>
-      1. Set _options_ to ? NormalizeOptionsObject(_options_).
       1. If _dividend_ is *undefined*, then
         1. Let _maximum_ be *+∞*.
       1. Else if _inclusive_ is *true*, then
@@ -130,7 +125,7 @@
         1. Let _maximum_ be _dividend_ − 1.
       1. Else,
         1. Let _maximum_ be 1.
-      1. Let _increment_ be ? GetNumberOption(_options_, *"roundingIncrement"*, 1, _maximum_, 1).
+      1. Let _increment_ be ? GetNumberOption(_normalizedOptions_, *"roundingIncrement"*, 1, _maximum_, 1).
       1. If _dividend_ is not *undefined* and _dividend_ modulo _increment_ is not zero, then
         1. Throw a *RangeError* exception.
       1. Return _increment_.
@@ -138,11 +133,10 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-tolargesttemporalunit" aoid="ToLargestTemporalUnit">
-    <h1>ToLargestTemporalUnit ( _options_, _disallowedUnits_, _defaultUnit_ )</h1>
+    <h1>ToLargestTemporalUnit ( _normalizedOptions_, _disallowedUnits_, _defaultUnit_ )</h1>
     <emu-alg>
       1. Assert: _disallowedUnits_ does not contain _defaultUnit_.
-      1. Set _options_ to ? NormalizeOptionsObject(_options_).
-      1. Let _largestUnit_ be ? GetOption(_options_, *"largestUnit"*, *"string"*, « *"years"*, *"months"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », _defaultUnit_).
+      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, *"string"*, « *"years"*, *"months"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », _defaultUnit_).
       1. If _disallowedUnits_ contains _largestUnit_, then
         1. Throw a *RangeError* exception.
       1. Return _largestUnit_.
@@ -150,10 +144,9 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-tosmallesttemporalunit" aoid="ToSmallestTemporalUnit">
-    <h1>ToSmallestTemporalUnit ( _options_, _disallowedUnits_ )</h1>
+    <h1>ToSmallestTemporalUnit ( _normalizedOptions_, _disallowedUnits_ )</h1>
     <emu-alg>
-      1. Set _options_ to ? NormalizeOptionsObject(_options_).
-      1. Let _smallestUnit_ be ? GetOption(_options_, *"smallestUnit"*, *"string"*, « *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *"not present"*).
+      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *"not present"*).
       1. If _smallestUnit_ is *"not present"*, then
         1. Throw a *RangeError* exception.
       1. If _smallestUnit_ is *"days"*, then
@@ -177,10 +170,9 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-tosmallesttemporaldurationunit" aoid="ToSmallestTemporalDurationUnit">
-    <h1>ToSmallestTemporalDurationUnit ( _options_, _fallback_, _disallowedUnits_ )</h1>
+    <h1>ToSmallestTemporalDurationUnit ( _normalizedOptions_, _fallback_, _disallowedUnits_ )</h1>
     <emu-alg>
-      1. Set _options_ to ? NormalizeOptionsObject(_options_).
-      1. Let _smallestUnit_ be ? GetOption(_options_, *"smallestUnit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
+      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
       1. If _smallestUnit_ is *"year"*, then
         1. Set _smallestUnit_ to *"years"*.
       1. Else if _smallestUnit_ is *"month"*, then

--- a/spec/date.html
+++ b/spec/date.html
@@ -65,6 +65,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _result_ be ? ToTemporalDateRecord(_item_).
@@ -365,6 +366,7 @@
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Let _result_ be ? AddDate(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_).
         1. Assert: ! ValidateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
@@ -384,6 +386,7 @@
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Let _result_ be ? SubtractDate(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_).
         1. Assert: ! ValidateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
@@ -401,6 +404,7 @@
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Let _partialDate_ be ? ToPartialDate(_temporalDateLike_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If _partialDate_.[[Year]] is not *undefined*, then
           1. Let _y_ be _partialDate_.[[Year]].
@@ -430,6 +434,7 @@
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalDate]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
         1. Let _result_ be ? DifferenceDate(_other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _largestUnit_).
         1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -76,6 +76,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _result_ be ? ToTemporalDateTimeRecord(_item_).
@@ -394,6 +395,7 @@
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _partialDateTime_ be ? ToPartialDateTime(_temporalDateTimeLike_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If _partialDateTime_.[[Year]] is not *undefined*, then
           1. Let _year_ be _partialDateTime_.[[Year]].
@@ -448,6 +450,7 @@
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Let _timePart_ be ? AddTime(_dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _datePart_ be ? AddDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _overflow_).
@@ -469,6 +472,7 @@
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Let _timePart_ be ? SubtractTime(_dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _datePart_ be ? SubtractDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]] - _timePart_.[[Day]], _overflow_).
@@ -488,6 +492,7 @@
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalDateTime]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « », *"nanoseconds"*).
         1. If _smallestUnit_ is *"years"*, *"months"*, or *"weeks"*, then
           1. Let _defaultLargestUnit_ be _smallestUnit_.
@@ -518,6 +523,7 @@
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. If _options_ is *undefined*, then
           1. Throw a *TypeError* exception.
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
         1. If _smallestUnit_ is *"day"*, then
@@ -618,6 +624,7 @@
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
         1. Return ? GetTemporalInstantFor(_timeZone_, _dateTime_, _disambiguation_).
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -88,6 +88,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalDurationOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _result_ be ? ToTemporalDurationRecord(_arg_).
@@ -277,6 +278,7 @@
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Let _temporalDurationLike_ be ? ToPartialDuration(_temporalDurationLike_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalDurationOverflow(_options_).
         1. If _temporalDurationLike_.[[Years]] is not *undefined*, then
           1. Let _years_ be _temporalDurationLike_.[[Years]].
@@ -360,6 +362,7 @@
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Set _other_ to ? ToLimitedTemporalDuration(_other_, « »).
         1. Perform ? RejectDurationSign (_other_.[[Years]], _other_.[[Months]], _other_.[[Weeks]], _other_.[[Days]], _other_.[[Hours]], _other_.[[Minutes]], _other_.[[Seconds]], _other_.[[Milliseconds]], _other_.[[Microseconds]], _other_.[[Nanoseconds]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalDurationOverflow(_options_).
         1. Let _result_ be ? DurationArithmetic(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _other_.[[Years]], _other_.[[Months]], _other_.[[Weeks]], _other_.[[Days]], _other_.[[Hours]], _other_.[[Minutes]], _other_.[[Seconds]], _other_.[[Milliseconds]], _other_.[[Microseconds]], _other_.[[Nanoseconds]], _overflow_).
         1. Return ? CreateTemporalDurationFromInstance(_duration_, _result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
@@ -377,6 +380,7 @@
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Set _other_ to ? ToLimitedTemporalDuration(_other_, « »).
         1. Perform ? RejectDurationSign (_other_.[[Years]], _other_.[[Months]], _other_.[[Weeks]], _other_.[[Days]], _other_.[[Hours]], _other_.[[Minutes]], _other_.[[Seconds]], _other_.[[Milliseconds]], _other_.[[Microseconds]], _other_.[[Nanoseconds]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalDurationOverflow(_options_).
         1. Let _result_ be ? DurationArithmetic(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], &minus;_other_.[[Years]], &minus;_other_.[[Months]], &minus;_other_.[[Weeks]], &minus;_other_.[[Days]], &minus;_other_.[[Hours]], &minus;_other_.[[Minutes]], &minus;_other_.[[Seconds]], &minus;_other_.[[Milliseconds]], &minus;_other_.[[Microseconds]], &minus;_other_.[[Nanoseconds]], _overflow_).
         1. Return ? CreateTemporalDurationFromInstance(_duration_, _result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -285,6 +285,7 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalInstant]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
         1. If _smallestUnit_ is *"hours"* or *"minutes"*, then
           1. Let _defaultLargestUnit_ be _smallestUnit_.
@@ -324,6 +325,7 @@
       <emu-alg>
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"*, *"hour"* »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
         1. If _smallestUnit_ is *"minute"*, then

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -65,6 +65,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _result_ be ? ToTemporalMonthDayRecord(_item_).
@@ -142,6 +143,7 @@
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Let _partialMonthDay_ be ? ToPartialMonthDay(_temporalMonthDayLike_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If _partialMonthDay_.[[Month]] is not *undefined*, then
           1. Let _m_ be _partialMonthDay_.[[Month]].
@@ -232,6 +234,7 @@
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _y_ be ? Get(_item_, *"year"*).

--- a/spec/time.html
+++ b/spec/time.html
@@ -70,6 +70,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _result_ be ? ToTemporalTimeRecord(_item_).
@@ -211,6 +212,7 @@
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Perform ? ToTemporalOverflow(_options_).
         1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. If _sign_ &lt; 0, then
@@ -232,6 +234,7 @@
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Perform ? ToTemporalOverflow(_options_).
         1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. If _sign_ &lt; 0, then
@@ -252,6 +255,7 @@
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Let _partialTime_ be ? ToPartialTime(_temporalTimeLike_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If _partialTime_.[[Hour]] is not *undefined*, then
           1. Let _hour_ be _partialTime_.[[Hour]].
@@ -292,6 +296,7 @@
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalTime]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"hours"*).
         1. Perform ? ValidateTemporalDifferenceUnits(_largestUnit_, _smallestUnit_).
@@ -316,6 +321,7 @@
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. If _options_ is *undefined*, then
           1. Throw a *TypeError* exception.
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"* »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
         1. If _smallestUnit_ is *"hour"*, then

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -208,6 +208,7 @@
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
         1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
         1. Let _n_ be _possibleInstants_'s length.

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -65,6 +65,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _result_ be ? ToTemporalYearMonthRecord(_item_).
@@ -208,6 +209,7 @@
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _partialYearMonth_ be ? ToPartialYearMonth(_temporalYearMonthLike_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If _partialYearMonth_.[[Year]] is not *undefined*, then
           1. Let _y_ be _partialYearMonth_.[[Year]].
@@ -234,6 +236,7 @@
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. If _sign_ &lt; 0, then
@@ -258,6 +261,7 @@
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. If _sign_ &lt; 0, then
@@ -280,6 +284,7 @@
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalYearMonth]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"weeks"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliesconds"*, *"microseconds"*, *"nanoseconds"* », *"years"*).
         1. Let _years_ be _yearMonth_.[[ISOYear]] - _other_.[[ISOYear]].
         1. Let _months_ be _yearMonth_.[[ISOMonth]] - _other_.[[ISOMonth]].


### PR DESCRIPTION
Previously, the abstract operation NormalizeOptionsObject was called more
than once on the same options object. This was not observable, but this
change makes the spec cleaner.

Closes: #899