### PR TITLE
Duration rounding part 3

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -265,13 +265,15 @@ date.toString()  // => 2020-06-28[c=islamic]
 - `options` (object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, and `'days'`.
-    The default is `days`.
+    Valid values are `'auto'`, `'years'`, `'months'`, and `'days'`.
+    The default is `'auto'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `larger` and `smaller`.
 
 This method does not need to be called directly except in specialized code.
 It is called indirectly when using the `difference()` methods of `Temporal.DateTime`, `Temporal.Date`, and `Temporal.YearMonth`.
+
+The default `largestUnit` value of `'auto'` is the same as `'days'`.
 
 For example:
 ```javascript

--- a/docs/date.md
+++ b/docs/date.md
@@ -434,8 +434,8 @@ date.subtract({ months: 1 }, { overflow: 'reject' }); // => throws
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, and `'days'`.
-    The default is `days`.
+    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, and `'days'`.
+    The default is `'auto'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `date` and `other`.
 
@@ -446,6 +446,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two years will become 24 months when `largestUnit` is `"months"`, for example.
 However, a difference of two months will still be two months even if `largestUnit` is `"years"`.
+A value of `'auto'` means `'days'`, unless `smallestUnit` is `'years'`, `'months'`, or `'weeks'`, in which case `largestUnit` is equal to `smallestUnit`.
 
 By default, the largest unit in the result is days.
 This is because months and years can be different lengths depending on which month is meant and whether the year is a leap year.

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -500,10 +500,10 @@ dt.subtract({ months: 1 }); // => throws
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `days`.
+    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are the same as for `largestUnit`.
+    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
     The default is `'nanoseconds'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
@@ -520,6 +520,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`, for example.
 However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `"hours"`.
+A value of `'auto'` means `'days'`, unless `smallestUnit` is `'years'`, `'months'`, or `'weeks'`, in which case `largestUnit` is equal to `smallestUnit`.
 
 By default, the largest unit in the result is days.
 This is because months and years can be different lengths depending on which month is meant and whether the year is a leap year.

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -100,6 +100,7 @@ Otherwise, the function will throw a `RangeError`.
 In the default ISO calendar, a year can be 365 or 366 days, and a month can be 28, 29, 30, or 31 days.
 Therefore, any `Duration` object with nonzero years or months can refer to a different length of time depending on when the start date is.
 No conversion is ever performed between years, months, weeks, and days, even in `balance` mode, because such conversion would be ambiguous.
+If you need to do this, use the `round()` method, and provide the start date using the `relativeTo` option.
 
 > **NOTE:** This function understands strings where weeks and other units are combined, and strings with a single sign character at the start, which are extensions to the ISO 8601 standard described in ISO 8601-2.
 > (For example, `P3W1D` is understood to mean three weeks and one day, `-P1Y1M` is a negative duration of one year and one month, and `+P1Y1M` is one year and one month.)
@@ -233,7 +234,7 @@ The `overflow` option tells what to do in this case:
 For usage examples and a more complete explanation of how balancing works and why it is necessary, see [Duration balancing](./balancing.md).
 
 No conversion is ever performed between years, months, days, and other units, as that could be ambiguous depending on the start date.
-If you need such a conversion, you must implement it yourself, since the rules can depend on the start date and the calendar in use.
+If you need such a conversion, use the `round()` method, and provide the start date using the `relativeTo` option.
 
 Adding a negative duration is equivalent to subtracting the absolute value of that duration.
 
@@ -348,6 +349,124 @@ Usage example:
 ```javascript
 d = Temporal.Duration.from('-PT8H30M');
 d.abs()  // PT8H30M
+```
+
+### duration.**round**(_options_: object) : Temporal.Duration
+
+**Parameters:**
+- `options` (object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
+    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    The default is `'auto'`.
+  - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
+    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    The default is `'nanoseconds'`, i.e. no rounding.
+  - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
+    The default is 1.
+  - `roundingMode` (string): How to handle the remainder, if rounding.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    The default is `'nearest'`.
+  - `relativeTo` (`Temporal.DateTime`): The starting point to use when converting between years, months, weeks, and days.
+    It must be a `Temporal.DateTime`, or a value that can be passed to `Temporal.DateTime.from()`.
+
+**Returns:** a new `Temporal.Duration` object which is `duration`, rounded and/or balanced.
+
+Rounds and/or balances `duration` to the given largest and smallest units and rounding increment, and returns the result as a new `Temporal.DateTime` object.
+
+The `largestUnit` determines the largest unit allowed in the result.
+It will cause units larger than `largestUnit` to be converted into smaller units, and units smaller than `largestUnit` to be converted into larger units as much as possible.
+For example, with `largestUnit: 'minutes'`, a duration of 1 hour and 125 seconds will be converted into a duration of 62 minutes and 5 seconds.
+These durations are equally long, so no rounding takes place, but they are expressed differently.
+
+A `largestUnit` value of `'auto'`, which is the default if only `smallestUnit` is given, means that `largestUnit` should be the largest nonzero unit in the duration that is larger than `smallestUnit`.
+(For example, in a duration of 3 days and 12 hours, `largestUnit: 'auto'` would mean the same as `largestUnit: 'days'`.)
+This means that the default is for the balancing behaviour of this method to not 'grow' the duration beyond its current largest unit unless needed for rounding.
+
+The `smallestUnit` option determines the unit to round to.
+For example, to round to the nearest minute, use `smallestUnit: 'minutes'`.
+The default, if only `largestUnit` is given, is to do no rounding.
+
+At least one of `largestUnit` or `smallestUnit` is required.
+
+Converting between years, months, weeks, and other units requires a reference point.
+If `largestUnit` or `smallestUnit` is years, months, or weeks, or the duration has nonzero years, months, or weeks, then the `relativeTo` option is required.
+
+The `roundingIncrement` option allows rounding to an integer number of units.
+For example, to round to increments of a half hour, use `smallestUnit: 'minutes', roundingIncrement: 30`.
+
+Unless `smallestUnit` is years, months, weeks, or days, the value given as `roundingIncrement` must divide evenly into the next highest unit after `smallestUnit`, and must not be equal to it.
+(For example, if `smallestUnit` is `'minutes'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
+The valid values in this case are 1 (default), 2, 3, 4, 5, 6, 10, 12, 15, 20, and 30.
+Instead of 60 minutes, use 1 hour.)
+
+The `roundingMode` option controls how the rounding is performed.
+  - `ceil`: Always round up, towards positive infinity.
+  - `floor`: Always round down, towards negative infinity.
+  - `trunc`: Always round towards zero, chopping off the part after the decimal point.
+  - `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+    When there is a tie, round up, like `ceil`.
+
+The `relativeTo` option gives the starting point used when converting between or rounding to years, months, weeks, or days.
+It is a `Temporal.DateTime` instance.
+If any other type of value is given, then it will be converted to a `Temporal.DateTime` as if it were passed to `Temporal.DateTime.from(.., { overflow: 'reject' })`.
+
+Example usage:
+```javascript
+// Balance a duration as far as possible without knowing a starting point
+d = Temporal.Duration.from({ minutes: 130 });
+d.round({ largestUnit: 'days' }); // => PT2H10M
+
+// Round to the nearest unit
+d = Temporal.Duration.from({ minutes: 10, seconds: 52 });
+d.round({ smallestUnit: 'minutes' }); // => PT11M
+d.round({ smallestUnit: 'minutes', roundingMode: 'trunc' }); // => PT10M
+
+// How many seconds in a multi-unit duration?
+d = Temporal.Duration.from('PT2H34M18S');
+d.round({ largestUnit: 'seconds' }).seconds; // => 9258
+
+// Normalize, with and without taking DST into account
+d = Temporal.Duration.from({ hours: 1756 });
+// FIXME: write this example after ZonedDateTime is added
+// d.round({
+//   relativeTo: '2020-01-01T00:00+01:00[Europe/Rome]',
+//   largestUnit: 'years'
+// }); // => ???
+d.round({
+  relativeTo: '2020-01-01',
+  largestUnit: 'years'
+}); // => P73DT4H
+
+// Normalize days into months or years
+d = Temporal.Duration.from({ days: 190 });
+refDate = Temporal.Date.from('2020-01-01');
+d.round({ relativeTo: refDate, largestUnit: 'years' });  // => P6M6D
+
+// Same, but in a different calendar system
+d.round({
+  relativeTo: refDate.withCalendar('hebrew'),
+  largestUnit: 'years'
+}); // => ???
+
+// Round a duration up to the next 5-minute billing period
+d = Temporal.Duration.from({ minutes: 6 });
+d.round({
+  smallestUnit: 'minutes',
+  roundingIncrement: 5,
+  roundingMode: 'ceil'
+}); // ==> P10M
+
+// How many full 3-month quarters of this year, are in this duration?
+d = Temporal.Duration.from({ months: 10, days: 15 });
+d = d.round({
+  smallestUnit: 'months',
+  roundingIncrement: 3,
+  roundingMode: 'trunc',
+  relativeTo: Temporal.now.date()
+});
+quarters = d.months / 3;
+quarters; // => 3
 ```
 
 ### duration.**getFields**() : { years: number, months: number, weeks: number, days: number, hours: number, minutes: number, seconds: number, milliseconds: number, microseconds: number, nanoseconds: number }

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -355,8 +355,8 @@ Temporal.now.instant().subtract(oneHour);
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `"seconds"`.
+    Valid values are `'auto'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
     Valid values are the same as for `largestUnit`.
     The default is `'nanoseconds'`, i.e., no rounding.
@@ -375,6 +375,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`, for example.
 However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `"hours"`.
+A value of `'auto'` means `'seconds'`, unless `smallestUnit` is `'hours'` or `'minutes'`, in which case `largestUnit` is equal to `smallestUnit`.
 
 By default, the largest unit in the result is seconds.
 Weeks, months, years, and days are not allowed, unlike the difference methods of the other Temporal types.

--- a/docs/time.md
+++ b/docs/time.md
@@ -263,10 +263,10 @@ time.subtract({ minutes: 5, nanoseconds: 800 }); // => 19:34:09.068345405
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `'hours'`.
+    Valid values are `'auto'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are the same as for `largestUnit`.
+    Valid values are `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
     The default is `'nanoseconds'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
@@ -283,6 +283,7 @@ The `largestUnit` parameter controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two hours will become 7200 seconds when `largestUnit` is `'seconds'`, for example.
 However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `'hours'`.
+A value of `'auto'` means `'hours'`.
 
 You can round the result using the `smallestUnit`, `roundingIncrement`, and `roundingMode` options.
 These behave as in the `Temporal.Duration.round()` method.

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -312,8 +312,8 @@ ym.subtract({years: 20, months: 4})  // => 1999-02
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'years'` and `'months'`.
-    The default is `years`.
+    Valid values are `'auto'`, `'years'` and `'months'`.
+    The default is `'auto'`.
 
 
 **Returns:** a `Temporal.Duration` representing the difference between `yearMonth` and `other`.
@@ -325,6 +325,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of one year and two months will become 14 months when `largestUnit` is `"months"`, for example.
 However, a difference of one month will still be one month even if `largestUnit` is `"years"`.
+A value of `'auto'` means `'years'`.
 
 Unlike other Temporal types, days and lower units are not allowed, because the data model of `Temporal.YearMonth` doesn't have that accuracy.
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -870,10 +870,10 @@ earlierHours.difference(zdt, { largestUnit: 'hours' }).hours; // => -24
 - `other` (`Temporal.LocalZonedDateTime`): Another date/time with which to compute the difference.
 - `options` (optional object): An object which may have some or all of the following properties:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `days`.
+    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are the same as for `largestUnit`.
+    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
     The default is `'nanoseconds'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
@@ -890,6 +890,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 For example, a difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`.
 However, a difference of 30 seconds will still be 30 seconds if `largestUnit` is `"hours"`.
+A value of `'auto'` means `'hours'`, unless `smallestUnit` is `'years'`, `'months'`, `'weeks'`, or `'days'`, in which case `largestUnit` is equal to `smallestUnit`.
 
 You can round the result using the `smallestUnit`, `roundingIncrement`, and `roundingMode` options.
 These behave as in the `Temporal.Duration.round()` method, but increments of days and larger are allowed.

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -169,6 +169,33 @@ export namespace Temporal {
     roundingMode?: 'nearest' | 'ceil' | 'floor' | 'trunc';
   }
 
+  export interface DurationRoundOptions {
+    largestUnit:
+      | 'auto'
+      | 'years'
+      | 'months'
+      | 'days'
+      | 'hours'
+      | 'minutes'
+      | 'seconds'
+      | 'milliseconds'
+      | 'microseconds'
+      | 'nanoseconds';
+    smallestUnit:
+      | 'years'
+      | 'months'
+      | 'days'
+      | 'hours'
+      | 'minutes'
+      | 'seconds'
+      | 'milliseconds'
+      | 'microseconds'
+      | 'nanoseconds';
+    roundingIncrement?: number;
+    roundingMode?: 'nearest' | 'ceil' | 'floor' | 'trunc';
+    relativeTo?: Temporal.DateTime | DateTimeLike | string;
+  }
+
   export type DurationLike = {
     years?: number;
     months?: number;
@@ -221,6 +248,7 @@ export namespace Temporal {
     with(durationLike: DurationLike, options?: DurationOptions): Temporal.Duration;
     add(other: Temporal.Duration | DurationLike, options?: DurationOptions): Temporal.Duration;
     subtract(other: Temporal.Duration | DurationLike, options?: DurationOptions): Temporal.Duration;
+    round(options: DurationRoundOptions): Temporal.Duration;
     getFields(): DurationFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -93,13 +93,15 @@ export namespace Temporal {
      * The largest unit to allow in the resulting `Temporal.Duration` object.
      *
      * Valid values may include `'years'`, `'months'`, `'days'`, `'hours'`,
-     * `'minutes'`, and `'seconds'`, although some types may throw an exception
+     * `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`,
+     * `'nanoseconds'` and `'auto'`, although some types may throw an exception
      * if a value is used that would produce an invalid result. For example,
      * `hours` is not accepted by `Date.prototype.difference()`.
      *
-     * The default depends on the type being used.
+     * The default is always `'auto'`, though the meaning of this depends on the
+     * type being used.
      */
-    largestUnit?: T;
+    largestUnit?: 'auto' | T;
 
     /**
      * The unit to round to. For example, to round to the nearest minute, use

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -391,7 +391,7 @@ export class DateTime {
       defaultLargestUnit = smallestUnit;
     }
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
-    ES.ValidateTemporalDifferenceUnits(largestUnit, smallestUnit);
+    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options);
     const maximumIncrements = {
       years: undefined,

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -386,10 +386,7 @@ export class DateTime {
     }
     options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
-    let defaultLargestUnit = 'days';
-    if (smallestUnit === 'years' || smallestUnit === 'months' || smallestUnit === 'weeks') {
-      defaultLargestUnit = smallestUnit;
-    }
+    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -650,27 +650,9 @@ export class DateTime {
         const fields = ES.ToTemporalDateTimeRecord(item);
         const TemporalDate = GetIntrinsic('%Temporal.Date%');
         const date = calendar.dateFromFields(fields, options, TemporalDate);
-        let year = GetSlot(date, ISO_YEAR);
-        let month = GetSlot(date, ISO_MONTH);
-        let day = GetSlot(date, ISO_DAY);
-
-        if (overflow === 'constrain') {
-          // Special case to determine if the date was clipped by dateFromFields
-          // and therefore the time possibly needs to be clipped too
-          try {
-            calendar.dateFromFields(fields, { overflow: 'reject' }, TemporalDate);
-          } catch {
-            // Date was clipped
-            if (year === 275760 && month === 9 && day === 13) {
-              // Clipped at end of range
-              day += 1;
-            } else if (year === -271821 && month === 4 && day === 19) {
-              // Clipped at beginning of range
-              day -= 1;
-            }
-            ({ year, month, day } = ES.BalanceDate(year, month, day));
-          }
-        }
+        const year = GetSlot(date, ISO_YEAR);
+        const month = GetSlot(date, ISO_MONTH);
+        const day = GetSlot(date, ISO_DAY);
 
         let { hour, minute, second, millisecond, microsecond, nanosecond } = fields;
         ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateTime(

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -566,6 +566,22 @@ export const ES = ObjectAssign({}, ES2019, {
       throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
     }
   },
+  LargerOfTwoTemporalDurationUnits: (unit1, unit2) => {
+    const validUnits = [
+      'years',
+      'months',
+      'weeks',
+      'days',
+      'hours',
+      'minutes',
+      'seconds',
+      'milliseconds',
+      'microseconds',
+      'nanoseconds'
+    ];
+    if (validUnits.indexOf(unit1) > validUnits.indexOf(unit2)) return unit2;
+    return unit1;
+  },
   ToPartialRecord: (bag, fields) => {
     if (!bag || 'object' !== typeof bag) return false;
     let any;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -483,7 +483,9 @@ export const ES = ObjectAssign({}, ES2019, {
     for (const s of disallowedStrings) {
       allowed.delete(s);
     }
-    return ES.GetOption(options, 'largestUnit', [...allowed], fallback);
+    const retval = ES.GetOption(options, 'largestUnit', ['auto', ...allowed], 'auto');
+    if (retval === 'auto') return fallback;
+    return retval;
   },
   ToSmallestTemporalUnit: (options, disallowedStrings = []) => {
     const singular = new Map([

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1739,7 +1739,7 @@ export const ES = ObjectAssign({}, ES2019, {
         if (!calendar) throw new RangeError('A starting point is required for years rounding');
 
         // convert months and weeks to days by calculating difference(
-        // relativeTo + years, relativeTo - { years, months, weeks })
+        // relativeTo - years, relativeTo - { years, months, weeks })
         const yearsBefore = calendar.dateSubtract(relativeTo, new TemporalDuration(years), {}, TemporalDate);
         const yearsMonthsWeeks = new TemporalDuration(years, months, weeks);
         const yearsMonthsWeeksBefore = calendar.dateSubtract(relativeTo, yearsMonthsWeeks, {}, TemporalDate);
@@ -1769,7 +1769,7 @@ export const ES = ObjectAssign({}, ES2019, {
       case 'months': {
         if (!calendar) throw new RangeError('A starting point is required for months rounding');
 
-        // convert weeks to days by calculating difference(relativeTo +
+        // convert weeks to days by calculating difference(relativeTo -
         //   { years, months }, relativeTo - { years, months, weeks })
         const yearsMonths = new TemporalDuration(years, months);
         const yearsMonthsBefore = calendar.dateSubtract(relativeTo, yearsMonths, {}, TemporalDate);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1759,9 +1759,21 @@ export const ES = ObjectAssign({}, ES2019, {
         days += monthsWeeksInDays.days;
         days += ((seconds / 60 + minutes) / 60 + hours) / 24;
 
+        // Years may be different lengths of days depending on the calendar, so
+        // we need to convert days to years in a loop. We get the number of days
+        // in the one-year period preceding the relativeTo date, and convert
+        // that number of days to one year, repeating until the number of days
+        // is less than a year.
         const oneYear = new TemporalDuration(1);
+        const sign = Math.sign(days);
         relativeTo = calendar.dateSubtract(relativeTo, oneYear, {}, TemporalDate);
-        const oneYearDays = calendar.daysInYear(relativeTo);
+        let oneYearDays = calendar.daysInYear(relativeTo);
+        while (Math.abs(days) > oneYearDays) {
+          years += sign;
+          days -= oneYearDays * sign;
+          relativeTo = calendar.dateSubtract(relativeTo, oneYear, {}, TemporalDate);
+          oneYearDays = calendar.daysInYear(relativeTo);
+        }
         years += days / oneYearDays;
 
         years = ES.RoundNumberToIncrement(years, increment, roundingMode);
@@ -1791,9 +1803,18 @@ export const ES = ObjectAssign({}, ES2019, {
         days += weeksInDays.days;
         days += ((seconds / 60 + minutes) / 60 + hours) / 24;
 
+        // Months may be different lengths of days depending on the calendar,
+        // convert days to months in a loop as described above under 'years'.
         const oneMonth = new TemporalDuration(0, 1);
+        const sign = Math.sign(days);
         relativeTo = calendar.dateSubtract(relativeTo, oneMonth, {}, TemporalDate);
-        const oneMonthDays = calendar.daysInMonth(relativeTo);
+        let oneMonthDays = calendar.daysInMonth(relativeTo);
+        while (Math.abs(days) > oneMonthDays) {
+          months += sign;
+          days -= oneMonthDays * sign;
+          relativeTo = calendar.dateSubtract(relativeTo, oneMonth, {}, TemporalDate);
+          oneMonthDays = calendar.daysInMonth(relativeTo);
+        }
         months += days / oneMonthDays;
 
         months = ES.RoundNumberToIncrement(months, increment, roundingMode);
@@ -1805,9 +1826,18 @@ export const ES = ObjectAssign({}, ES2019, {
         seconds += milliseconds * 1e-3 + microseconds * 1e-6 + nanoseconds * 1e-9;
         days += ((seconds / 60 + minutes) / 60 + hours) / 24;
 
+        // Weeks may be different lengths of days depending on the calendar,
+        // convert days to weeks in a loop as described above under 'years'.
         const oneWeek = new TemporalDuration(0, 0, 1);
+        const sign = Math.sign(days);
         relativeTo = calendar.dateSubtract(relativeTo, oneWeek, {}, TemporalDate);
-        const oneWeekDays = calendar.daysInWeek(relativeTo);
+        let oneWeekDays = calendar.daysInWeek(relativeTo);
+        while (Math.abs(days) > oneWeekDays) {
+          weeks += sign;
+          days -= oneWeekDays * sign;
+          relativeTo = calendar.dateSubtract(relativeTo, oneWeek, {}, TemporalDate);
+          oneWeekDays = calendar.daysInWeek(relativeTo);
+        }
         weeks += days / oneWeekDays;
 
         weeks = ES.RoundNumberToIncrement(weeks, increment, roundingMode);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -549,7 +549,7 @@ export const ES = ObjectAssign({}, ES2019, {
     }
     return value;
   },
-  ValidateTemporalDifferenceUnits: (largestUnit, smallestUnit) => {
+  ValidateTemporalUnitRange: (largestUnit, smallestUnit) => {
     const validUnits = [
       'years',
       'months',

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -106,8 +106,7 @@ export class Instant {
     const disallowedUnits = ['years', 'months', 'weeks', 'days'];
     options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds', disallowedUnits);
-    let defaultLargestUnit = 'seconds';
-    if (smallestUnit === 'hours' || smallestUnit === 'minutes') defaultLargestUnit = smallestUnit;
+    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('seconds', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit, disallowedUnits);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -109,7 +109,7 @@ export class Instant {
     let defaultLargestUnit = 'seconds';
     if (smallestUnit === 'hours' || smallestUnit === 'minutes') defaultLargestUnit = smallestUnit;
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit, disallowedUnits);
-    ES.ValidateTemporalDifferenceUnits(largestUnit, smallestUnit);
+    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options);
     const maximumIncrements = {
       hours: 24,

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -245,7 +245,7 @@ export class Time {
     options = ES.NormalizeOptionsObject(options);
     const largestUnit = ES.ToLargestTemporalUnit(options, 'hours', ['years', 'months', 'weeks', 'days']);
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
-    ES.ValidateTemporalDifferenceUnits(largestUnit, smallestUnit);
+    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options);
     const maximumIncrements = {
       hours: 24,

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -233,6 +233,7 @@ describe('Date', () => {
     const feb21 = Date.from('2021-02-01');
     it('defaults to returning days', () => {
       equal(`${feb21.difference(feb20)}`, 'P366D');
+      equal(`${feb21.difference(feb20, { largestUnit: 'auto' })}`, 'P366D');
       equal(`${feb21.difference(feb20, { largestUnit: 'days' })}`, 'P366D');
     });
     it('can return higher units', () => {

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -458,6 +458,7 @@ describe('DateTime', () => {
     const feb21 = DateTime.from('2021-02-01T00:00');
     it('defaults to returning days', () => {
       equal(`${feb21.difference(feb20)}`, 'P366D');
+      equal(`${feb21.difference(feb20, { largestUnit: 'auto' })}`, 'P366D');
       equal(`${feb21.difference(feb20, { largestUnit: 'days' })}`, 'P366D');
       equal(`${DateTime.from('2021-02-01T00:00:00.000000001').difference(feb20)}`, 'P366DT0.000000001S');
       equal(`${feb21.difference(DateTime.from('2020-02-01T00:00:00.000000001'))}`, 'P365DT23H59M59.999999999S');

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -456,6 +456,7 @@ describe('Instant', () => {
     const feb21 = Instant.from('2021-02-01T00:00Z');
     it('defaults to returning seconds', () => {
       equal(`${feb21.difference(feb20)}`, 'PT31622400S');
+      equal(`${feb21.difference(feb20, { largestUnit: 'auto' })}`, 'PT31622400S');
       equal(`${feb21.difference(feb20, { largestUnit: 'seconds' })}`, 'PT31622400S');
       equal(`${Instant.from('2021-02-01T00:00:00.000000001Z').difference(feb20)}`, 'PT31622400.000000001S');
       equal(`${feb21.difference(Instant.from('2020-02-01T00:00:00.000000001Z'))}`, 'PT31622399.999999999S');

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -235,6 +235,7 @@ describe('Time', () => {
       const time2 = Time.from('17:15:57');
       it('the default largest unit is at least hours', () => {
         equal(`${time2.difference(time1)}`, 'PT6H52M42S');
+        equal(`${time2.difference(time1, { largestUnit: 'auto' })}`, 'PT6H52M42S');
         equal(`${time2.difference(time1, { largestUnit: 'hours' })}`, 'PT6H52M42S');
       });
       it('higher units are not allowed', () => {

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -211,6 +211,7 @@ describe('YearMonth', () => {
     const feb21 = YearMonth.from('2021-02');
     it('defaults to returning years', () => {
       equal(`${feb21.difference(feb20)}`, 'P1Y');
+      equal(`${feb21.difference(feb20, { largestUnit: 'auto' })}`, 'P1Y');
       equal(`${feb21.difference(feb20, { largestUnit: 'years' })}`, 'P1Y');
     });
     it('can return months', () => {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -273,6 +273,21 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-sign" aoid="Sign">
+    <h1>Sign ( _n_ )</h1>
+    <p>
+      The abstract operation Sign takes argument _n_ and returns the mathematical sign of _n_.
+    </p>
+    <emu-note type="editor">
+      This operation is the same as Math.sign and should be used there as well when merged into ECMA-262.
+    </emu-note>
+    <emu-alg>
+      1. If _n_ is *NaN*, n is *+0*, or n is *−0*, return _n_.
+      1. If _n_ < 0, return *−1*.
+      1. Return *+1*.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-constraintorange" aoid="ConstrainToRange">
     <h1>ConstrainToRange ( _x_, _minimum_, _maximum_ )</h1>
     <emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -135,8 +135,10 @@
   <emu-clause id="sec-temporal-tolargesttemporalunit" aoid="ToLargestTemporalUnit">
     <h1>ToLargestTemporalUnit ( _normalizedOptions_, _disallowedUnits_, _defaultUnit_ )</h1>
     <emu-alg>
-      1. Assert: _disallowedUnits_ does not contain _defaultUnit_.
-      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, *"string"*, « *"years"*, *"months"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », _defaultUnit_).
+      1. Assert: _disallowedUnits_ does not contain _defaultUnit_ or *"auto"*.
+      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, *"string"*, « *"auto"*, *"years"*, *"months"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"auto"*).
+      1. If _largestUnit_ is *"auto"*, then
+        1. Return _defaultUnit_.
       1. If _disallowedUnits_ contains _largestUnit_, then
         1. Throw a *RangeError* exception.
       1. Return _largestUnit_.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -225,6 +225,25 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-largeroftwotemporaldurationunits" aoid="LargerOfTwoTemporalDurationUnits">
+    <h1>LargerOfTwoTemporalDurationUnits ( _u1_, _u2_ )</h1>
+    <p>
+      The abstract operation LargerOfTwoTemporalDurationUnits, given two strings representing the units of a Temporal.Duration, returns the string representing the larger of the two units.
+    </p>
+    <emu-alg>
+      1. If either _u1_ or _u2_ is *"years"*, then return *"years"*.
+      1. If either _u1_ or _u2_ is *"months"*, then return *"months"*.
+      1. If either _u1_ or _u2_ is *"weeks"*, then return *"weeks"*.
+      1. If either _u1_ or _u2_ is *"days"*, then return *"days"*.
+      1. If either _u1_ or _u2_ is *"hours"*, then return *"hours"*.
+      1. If either _u1_ or _u2_ is *"minutes"*, then return *"minutes"*.
+      1. If either _u1_ or _u2_ is *"seconds"*, then return *"seconds"*.
+      1. If either _u1_ or _u2_ is *"milliseconds"*, then return *"milliseconds"*.
+      1. If either _u1_ or _u2_ is *"microseconds"*, then return *"microseconds"*.
+      1. Return *"nanoseconds"*.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-maximumtemporaldurationroundingincrement" aoid="MaximumTemporalDurationRoundingIncrement">
     <h1>MaximumTemporalDurationRoundingIncrement ( _unit_ )</h1>
     <emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -201,6 +201,40 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-torelativetemporalobject" aoid="ToRelativeTemporalObject">
+    <h1>ToRelativeTemporalObject ( _options_ )</h1>
+    <p>
+      The abstract operation ToRelativeTemporalObject examines the value of the `relativeTo` property of its _options_ argument, and attempts to return a Temporal.ZonedDateTime instance <mark>(TODO)</mark>, Temporal.DateTime instance, or *undefined*, in order of preference.
+      If none of those are possible, the operation throws a *RangeError*.
+    </p>
+    <emu-alg>
+      1. Assert: Type(_options_) is Object.
+      1. Let _value_ be ? Get(_options_, *"relativeTo"*).
+      1. If _value_ is *undefined*, then
+        1. Return _value_.
+      1. If Type(_value_) is Object, then
+        1. If _value_ has an [[InitializedTemporalDateTime]] internal slot, then
+          1. Return _value_.
+        1. Let _calendar_ be ? Get(_value_, *"calendar"*).
+        1. If _calendar_ is *undefined*, then
+          1. Set _calendar_ to ! GetDefaultCalendar().
+        1. Else,
+          1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+        1. Let _fields_ be ? ToTemporalDateTimeRecord(_value_).
+        1. Let _dateFromFields_ be ? Get(_calendar_, *"dateFromFields"*).
+        1. Let _dateOptions_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _temporalDate_ be ? Call(_dateFromFields_, _calendar_, « _fields_, _dateOptions_, %Temporal.Date% »).
+        1. Return ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _fields_.[[Hour]], _fields_.[[Minute]], _fields_.[[Second]], _fields_.[[Millisecond]], _fields_.[[Microsecond]], _fields_.[[Nanosecond]], _calendar_).
+      1. Let _string_ be ? ToString(_value_).
+      1. Let _result_ be ? ParseTemporalDateTimeString(_string_).
+      1. Let _calendar_ be _result_.[[Calendar]].
+      1. If _calendar_ is *undefined*, then
+        1. Set _calendar_ to ! GetDefaultCalendar().
+      1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+      1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-validatetemporalunitrange" aoid="ValidateTemporalUnitRange">
     <h1>ValidateTemporalUnitRange ( _largestUnit_, _smallestUnit_ )</h1>
     <emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -201,8 +201,8 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-validatetemporaldifferenceunits" aoid="ValidateTemporalDifferenceUnits">
-    <h1>ValidateTemporalDifferenceUnits ( _largestUnit_, _smallestUnit_ )</h1>
+  <emu-clause id="sec-temporal-validatetemporalunitrange" aoid="ValidateTemporalUnitRange">
+    <h1>ValidateTemporalUnitRange ( _largestUnit_, _smallestUnit_ )</h1>
     <emu-alg>
       1. If _smallestUnit_ is *"years"* and _largestUnit_ is not *"years"*, then
         1. Throw a *RangeError* exception.

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -494,10 +494,7 @@
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalDateTime]]).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « », *"nanoseconds"*).
-        1. If _smallestUnit_ is *"years"*, *"months"*, or *"weeks"*, then
-          1. Let _defaultLargestUnit_ be _smallestUnit_.
-        1. Else,
-          1. Let _defaultLargestUnit_ be *"days"*.
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"days"*, _smallestUnit_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -499,7 +499,7 @@
         1. Else,
           1. Let _defaultLargestUnit_ be *"days"*.
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalDifferenceUnits(_largestUnit_, _smallestUnit_).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -387,6 +387,33 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.duration.prototype.round">
+      <h1>Temporal.Duration.prototype.round ( _options_ )</h1>
+      <p>
+        The `round` method takes one argument _options_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _duration_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"nanoseconds"*).
+        1. Let _defaultLargestUnit_ be ! DefaultTemporalLargestUnitForRounding(_duration_).
+        1. Set _default_largestUnit_ to ! LargerOfTwoTemporalDurationUnits(_defaultLargestUnit_, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _defaultLargestUnit_).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
+        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_options_).
+        1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_years_, _months_, _weeks_, days_, _largestUnit_, _relativeTo_).
+        1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
+        1. Let _balanceResult_ be ? BalanceDurationRelative(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _largestUnit_, _relativeTo_).
+        1. Let _result_ be ? BalanceDuration(_balanceResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult.[[Nanoseconds]]).
+        1. Return ? CreateTemporalDurationFromInstance(_duration_, _balanceResult_.[[Years]], _balanceResult_.[[Months]], _balanceResult_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.duration.prototype.getfields">
       <h1>Temporal.Duration.prototype.getFields ( )</h1>
       <p>
@@ -626,6 +653,26 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-defaulttemporallargestunitforrounding" aoid="DefaultTemporalLargestUnitForRounding">
+      <h1>DefaultTemporalLargestUnitForRounding ( _duration_ )</h1>
+      <p>
+        The abstract operation DefaultTemporalLargestUnitForRounding implements the logic used in the `Temporal.Duration.prototype.round()` method, where the `largestUnit` option, if not given explicitly, is set to the largest non-zero unit in the input Temporal.Duration.
+      </p>
+      <emu-alg>
+        1. Assert: _duration_ has an [[InitializedTemporalDuration]] internal slot.
+        1. If _duration_.[[Years]] is not zero, return *"years"*.
+        1. If _duration_.[[Months]] is not zero, return *"months"*.
+        1. If _duration_.[[Weeks]] is not zero, return *"weeks"*.
+        1. If _duration_.[[Days]] is not zero, return *"days"*.
+        1. If _duration_.[[Hours]] is not zero, return *"hours"*.
+        1. If _duration_.[[Minutes]] is not zero, return *"minutes"*.
+        1. If _duration_.[[Seconds]] is not zero, return *"seconds"*.
+        1. If _duration_.[[Milliseconds]] is not zero, return *"milliseconds"*.
+        1. If _duration_.[[Microseconds]] is not zero, return *"microseconds"*.
+        1. Return *"nanoseconds"*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-topartialduration" aoid="ToPartialDuration">
       <h1>ToPartialDuration ( _temporalDurationLike_ )</h1>
       <emu-alg>
@@ -740,6 +787,164 @@
           [[Milliseconds]]: _milliseconds_ &times; _sign_,
           [[Microseconds]]: _microseconds_ &times; _sign_,
           [[Nanoseconds]]: _nanoseconds_ &times; _sign_
+          }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-unbalancedurationrelative" aoid="UnbalanceDurationRelative">
+      <h1>UnbalanceDurationRelative ( _years_, _months_, _weeks_, _days_, _largestUnit_, _relativeTo_ )</h1>
+      <p>The abstract operation UnbalanceDurationRelative converts the calendar units of a Temporal.Duration into a form where no unit is larger than _largestUnit_.</p>
+      <emu-alg>
+        1. If _largestUnit_ is *"years"*, then
+          1. Return the new Record {
+            [[Years]]: _years_,
+            [[Months]]: _months_,
+            [[Weeks]]: _weeks_,
+            [[Days]]: _days_
+            }.
+        1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
+        1. Set _years_ to abs(_years_).
+        1. Set _months_ to abs(_months_).
+        1. Set _weeks_ to abs(_weeks_).
+        1. Set _days_ to abs(_days_).
+        1. Let _oneYear_ be ! CreateTemporalDuration(1, 0, 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Let _oneMonth_ be ! CreateTemporalDuration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, 1, 0, 0, 0, 0, 0, 0, 0).
+        1. Let _addOptions_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. If _relativeTo_ is not *undefined*, then
+          1. Assert: _relativeTo_ has a [[Calendar]] internal slot.
+          1. Let _calendar_ be _relativeTo_.[[Calendar]].
+        1. Else,
+          1. Let _calendar_ be *undefined*.
+        1. If _largestUnit_ is *"months"*, then
+          1. If _calendar_is *undefined*, then
+            1. Throw a *RangeError* exception.
+          1. Let _monthsInYear_ be ? Get(_calendar_, *"monthsInYear"*).
+          1. Let _datePlus_ be ? Get(_calendar_, *"datePlus"*).
+          1. Repeat, while _years_ &gt; 0,
+            1. Let _oneYearMonths_ be ? Call(_monthsInYear_, _calendar_, « _relativeTo_ »).
+            1. Set _years_ to _years_ − 1.
+            1. Set _months_ to _months_ + _oneYearMonths_.
+            1. Set _relativeTo_ to ? Call(_datePlus_, _calendar_, « _relativeTo_, _oneYear_, _addOptions_, %Temporal.Date%).
+        1. Else if _largestUnit_ is *"weeks"*, then
+          1. If _calendar_ is *undefined*, then
+            1. Throw a *RangeError* exception.
+          1. Let _daysInYear_ be ? Get(_calendar_, *"daysInYear"*).
+          1. Let _daysInMonth_ be ? Get(_calendar_, *"daysInMonth"*).
+          1. Let _datePlus_ be ? Get(_calendar_, *"datePlus"*).
+          1. Repeat, while _years_ &gt; 0,
+            1. Let _oneYearDays_ be ? Call(_daysInYear_, _calendar_, « _relativeTo_ »).
+            1. Set _years_ to _years_ − 1.
+            1. Set _days_ to _days_ + _oneYearDays_.
+            1. Set _relativeTo_ to ? Call(_datePlus_, _calendar_, « _relativeTo_, _oneYear_, _addOptions_, %Temporal.Date%).
+          1. Repeat, while _months_ &gt; 0,
+            1. Let _oneMonthDays_ be ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
+            1. Set _months_ to _months_ − 1.
+            1. Set _days_ to _days_ + _oneMonthDays_.
+            1. Set _relativeTo_ to ? Call(_datePlus_, _calendar_, « _relativeTo_, _oneMonth_, _addOptions_, %Temporal.Date%).
+        1. Else,
+          1. If any of _years_, _months_, and _days_ are not zero, then
+            1. If _calendar_ is *undefined*, then
+              1. Throw a *RangeError* exception.
+            1. Let _daysInYear_ be ? Get(_calendar_, *"daysInYear"*).
+            1. Let _daysInMonth_ be ? Get(_calendar_, *"daysInMonth"*).
+            1. Let _daysInWeek_ be ? Get(_calendar_, *"daysInWeek"*).
+            1. Let _datePlus_ be ? Get(_calendar_, *"datePlus"*).
+            1. Repeat, while _years_ &gt; 0,
+              1. Let _oneYearDays_ be ? Call(_daysInYear_, _calendar_, « _relativeTo_ »).
+              1. Set _years_ to _years_ − 1.
+              1. Set _days_ to _days_ + _oneYearDays_.
+              1. Set _relativeTo_ to ? Call(_datePlus_, _calendar_, « _relativeTo_, _oneYear_, _addOptions_, %Temporal.Date%).
+            1. Repeat, while _months_ &gt; 0,
+              1. Let _oneMonthDays_ be ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
+              1. Set _months_ to _months_ − 1.
+              1. Set _days_ to _days_ + _oneMonthDays_.
+              1. Set _relativeTo_ to ? Call(_datePlus_, _calendar_, « _relativeTo_, _oneMonth_, _addOptions_, %Temporal.Date%).
+            1. Repeat, while _weeks_ &gt; 0,
+              1. Let _oneWeekDays_ be ? Call(_daysInWeek_, _calendar_, « _relativeTo_ »).
+              1. Set _weeks_ to _weeks_ − 1.
+              1. Set _days_ to _days_ + _oneWeekDays_.
+              1. Set _relativeTo_ to ? Call(_datePlus_, _calendar_, « _relativeTo_, _oneWeek_, _addOptions_, %Temporal.Date%).
+        1. Return the new Record {
+          [[Years]]: _years_ × _sign_,
+          [[Months]]: _months_ × _sign_,
+          [[Weeks]]: _weeks_ × _sign,
+          [[Days]]: _days_ × _sign_
+          }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-balancedurationrelative" aoid="BalanceDurationRelative">
+      <h1>BalanceDurationRelative ( _years_, _months_, _weeks_, _days_, _largestUnit_, _relativeTo_ )</h1>
+      <p>The abstract operation BalanceDurationRelative converts the calendar units of a duration into a form where lower units are converted into higher units as much as possible, up to _largestUnit_.</p>
+      <emu-alg>
+        1. If _largestUnit_ is not one of *"years"*, *"months"*, or *"weeks"*, then
+          1. Return the new Record {
+            [[Years]]: _years_,
+            [[Months]]: _months_,
+            [[Weeks]]: _weeks_,
+            [[Days]]: _days_
+            }.
+        1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
+        1. Set _years_ to abs(_years_).
+        1. Set _months_ to abs(_months_).
+        1. Set _weeks_ to abs(_weeks_).
+        1. Set _days_ to abs(_days_).
+        1. Let _oneYear_ be ! CreateTemporalDuration(1, 0, 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Let _oneMonth_ be ! CreateTemporalDuration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, 1, 0, 0, 0, 0, 0, 0, 0).
+        1. Let _subtractOptions_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. If _relativeTo_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Assert: _relativeTo_ has a [[Calendar]] internal slot.
+        1. Let _calendar_ be _relativeTo_.[[Calendar]].
+        1. If _largestUnit_ is *"years"*, then
+          1. Let _daysInYear_ be ? Get(_calendar_, *"daysInYear"*).
+          1. Let _daysInMonth_ be ? Get(_calendar_, *"daysInMonth"*).
+          1. Let _monthsInYear_ be ? Get(_calendar_, *"monthsInYear"*).
+          1. Let _dateMinus_ be ? Get(_calendar_, *"dateMinus"*).
+          1. Let _oneYearDays_ be ? Call(_daysInYear_, _calendar_, « _relativeTo_ »).
+          1. Repeat, while _days_ &gt; _oneYearDays_,
+            1. Set _days_ to _days_ − _oneYearDays_.
+            1. Set _years_ to _years_ + 1.
+            1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneYear_, _subtractOptions_, %Temporal.Date%).
+            1. Set _oneYearDays_ to ? Call(_daysInYear_, _calendar_, « _relativeTo_ »).
+          1. Let _oneMonthDays_ be ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
+          1. Repeat, while _days_ &gt; _oneMonthDays_,
+            1. Set _days_ to _days_ − _oneMonthDays_.
+            1. Set _months_ to _months_ + 1.
+            1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneMonth_, _subtractOptions_, %Temporal.Date%).
+            1. Set _oneMonthDays_ to ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
+          1. Let _oneYearMonths_ be ? Call(_monthsInYear_, _calendar_, « _relativeTo_ »).
+          1. Repeat, while _months_ &gt; _oneYearMonths_,
+            1. Set _months_ to _months_ − _oneYearMonths_.
+            1. Set _years_ to _years_ + 1.
+            1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneYear_, _subtractOptions_, %Temporal.Date%).
+            1. Set _oneYearMonths_ to ? Call(_monthsInYear_, _calendar_, « _relativeTo_ »).
+        1. Else if _largestUnit_ is *"months"*, then
+          1. Let _daysInMonth_ be ? Get(_calendar_, *"daysInMonth"*).
+          1. Let _dateMinus_ be ? Get(_calendar_, *"dateMinus"*).
+          1. Let _oneMonthDays_ be ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
+          1. Repeat, while _days_ &gt; _oneMonthDays_,
+            1. Set _days_ to _days_ − _oneMonthDays_.
+            1. Set _months_ to _months_ + 1.
+            1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneMonth_, _subtractOptions_, %Temporal.Date%).
+            1. Set _oneMonthDays_ to ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
+        1. Else,
+          1. Assert: _largestUnit_ is *"weeks"*.
+          1. Let _daysInWeek_ be ? Get(_calendar_, *"daysInWeek"*).
+          1. Let _dateMinus_ be ? Get(_calendar_, *"dateMinus"*).
+          1. Let _oneWeekDays_ be ? Call(_daysInWeek_, _calendar_, « _relativeTo_ »).
+          1. Repeat, while _days_ &gt; _oneWeekDays_,
+            1. Set _days_ to _days_ − _oneWeekDays_.
+            1. Set _weeks_ to _weeks_ + 1.
+            1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneWeek_, _subtractOptions_, %Temporal.Date%).
+            1. Set _oneWeekDays_ to ? Call(_daysInWeek_, _calendar_, « _relativeTo_ »).
+        1. Return the new Record {
+          [[Years]]: _years_ × _sign_,
+          [[Months]]: _months_ × _sign_,
+          [[Weeks]]: _weeks_ × _sign_,
+          [[Days]]: _days_ × _sign_
           }.
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -859,10 +859,15 @@
           1. Let _monthsWeeksInDays_ be ? DifferenceDate(_yearsMonthsWeeksBefore_.[[ISOYear]], _yearsMonthsWeeksBefore_.[[ISOMonth]], _yearsMonthsWeeksBefore_.[[ISODay]], _yearsBefore_.[[ISOYear]], _yearsBefore_.[[ISOMonth]], _yearsBefore_.[[ISODay]], *"days"*).
           1. Let _days_ be _days_ + _monthsWeeksInDays_.[[Days]].
           1. Let _oneYear_ be ? CreateTemporalDuration(1, 0, 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Let _sign_ be ! Sign(_days_).
           1. Set _relativeTo_ to ? Call(_dateSubtract_, _calendar_, « _relativeTo_, _oneYear_, _options_, %Temporal.Date% »).
           1. Let _daysInYear_ be ? Get(_calendar_, *"daysInYear"*).
           1. Let _oneYearDays_ be ? Call(_daysInYear_, _calendar_, « _relativeTo_ »).
-          1. Assert: _days_ ≤ _oneYearDays_. <mark>Note this will not be true in Temporal.Duration.prototype.round, this will become a loop</mark>.
+          1. Repeat, while _days_ ≥ _oneYearDays_,
+            1. Set _years_ to _years_ + _sign_.
+            1. Set _days_ to _days_ − _oneYearDays_ × _sign_.
+            1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneYear_, _options_, %Temporal.Date% »).
+            1. Set _oneYearDays_ to ? Call(_daysInYear_, _calendar_, « _relativeTo_ »).
           1. Let _fractionalYears_ be _years_ + _days_ / _oneYearDays_.
           1. Set _years_ to ? RoundNumberToIncrement(_fractionalYears_, _increment_, _roundingMode_).
           1. Set _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
@@ -874,19 +879,29 @@
           1. Let _weeksInDays_ be ? DifferenceDate(_yearsMonthsWeeksBefore_.[[ISOYear]], _yearsMonthsWeeksBefore_.[[ISOMonth]], _yearsMonthsWeeksBefore_.[[ISODay]], _yearsMonthsBefore_.[[ISOYear]], _yearsMonthsBefore_.[[ISOMonth]], _yearsMonthsBefore_.[[ISODay]], *"days"*).
           1. Let _days_ be _days_ + _weeksInDays_.[[Days]].
           1. Let _oneMonth_ be ? CreateTemporalDuration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Let _sign_ be ! Sign(_days_).
           1. Set _relativeTo_ to ? Call(_dateSubtract_, _calendar_, « _relativeTo_, _oneMonth_, _options_, %Temporal.Date% »).
           1. Let _daysInMonth_ be ? Get(_calendar_, *"daysInMonth"*).
           1. Let _oneMonthDays_ be ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
-          1. Assert: _days_ ≤ _oneMonthDays_. <mark>Note this will not be true in Temporal.Duration.prototype.round, this will become a loop</mark>.
+          1. Repeat, while _days_ ≥ _oneMonthDays_,
+            1. Set _months_ to _months_ + _sign_.
+            1. Set _days_ to _days_ − _oneMonthDays_ × _sign_.
+            1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneMonth_, _options_, %Temporal.Date% »).
+            1. Set _oneMonthDays_ to ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
           1. Let _fractionalMonths_ be _months_ + _days_ / _oneMonthDays_.
           1. Set _months_ to ? RoundNumberToIncrement(_fractionalMonths_, _increment_, _roundingMode_).
           1. Set _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"weeks"*, then
           1. Let _oneWeek_ be ? CreateTemporalDuration(0, 0, 1, 0, 0, 0, 0, 0, 0, 0).
+          1. Let _sign_ be ! Sign(_days_).
           1. Set _relativeTo_ to ? Call(_dateSubtract_, _calendar_, « _relativeTo_, _oneWeek_, _options_, %Temporal.Date% »).
           1. Let _daysInWeek_ be ? Get(_calendar_, *"daysInWeek"*).
           1. Let _oneWeekDays_ be ? Call(_daysInWeek_, _calendar_, « _relativeTo_ »).
-          1. Assert: _days_ ≤ _oneWeekDays_. <mark>Note this will not be true in Temporal.Duration.prototype.round, this will become a loop</mark>.
+          1. Repeat, while _days_ ≥ _oneWeekDays_,
+            1. Set _weeks_ to _weeks_ + _sign_.
+            1. Set _days_ to _days_ − _oneWeekDays_ × _sign_.
+            1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneWeek_, _options_, %Temporal.Date% »).
+            1. Set _oneWeekDays_ to ? Call(_daysInWeek_, _calendar_, « _relativeTo_ »).
           1. Let _fractionalWeeks_ be _weeks_ + _fractionalDays_ / _oneWeekDays_.
           1. Set _weeks_ to ? RoundNumberToIncrement(_fractionalWeeks_, _increment_, _roundingMode_).
           1. Set _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -705,7 +705,6 @@
     <emu-clause id="sec-temporal-balanceduration" aoid="BalanceDuration">
       <h1>BalanceDuration ( _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_ )</h1>
       <emu-alg>
-        1. Assert: _largestUnit_ is one of *"days"*, *"hours"*, *"minutes"*, or *"seconds"*.
         1. Let _sign_ be ! DurationSign(0, 0, 0, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Let _bt_ be ? BalanceTime(abs(_hours_), abs(_minutes_), abs(_seconds_), abs(_milliseconds_), abs(_microseconds_), abs(_nanoseconds_)).
         1. Increment _days_ by _bt_.[[Days]].

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -292,7 +292,7 @@
         1. Else,
           1. Let _defaultLargestUnit_ be *"seconds"*.
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalDifferenceUnits(_largestUnit_, _smallestUnit_).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be the mathematical value of ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -287,10 +287,7 @@
         1. Perform ? RequireInternalSlot(_other_, [[InitializedTemporalInstant]]).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
-        1. If _smallestUnit_ is *"hours"* or *"minutes"*, then
-          1. Let _defaultLargestUnit_ be _smallestUnit_.
-        1. Else,
-          1. Let _defaultLargestUnit_ be *"seconds"*.
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"seconds"*, _smallestUnit_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).

--- a/spec/time.html
+++ b/spec/time.html
@@ -299,7 +299,7 @@
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"hours"*).
-        1. Perform ? ValidateTemporalDifferenceUnits(_largestUnit_, _smallestUnit_).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).


### PR DESCRIPTION
~~This doesn't yet implement Duration rounding, but I was starting to accumulate enough commits preparing for it that I thought it'd be best to start getting them reviewed.~~

This implements Duration.round(). Another pull request will still follow for rounding options in add() and subtract(), and the new compare() method.

To review this, I would recommend looking at the tests to see if you find any of the expected results surprising, and if there are any edge cases that are not tested but should be. Then I'd recommend looking at the algorithm in either the spec or the polyfill. (They are as alike as I could make them.)

See: #856