### PR TITLE
Avoid using Temporal constructors in documentation examples

### DIFF
--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -28,7 +28,7 @@ No balancing is ever performed between years, months, and days, because such con
 If you need such a conversion, you must implement it yourself, since the rules can depend on the start date and the calendar in use.
 
 `Temporal.Duration` fields are not allowed to have mixed signs.
-For example, passing one positive and one negative argument to `new Temporal.Duration()` or as properties in the object passed to `Temporal.Duration.from()` will always throw an exception, regardless of the overflow option.
+For example, `Temporal.Duration.from({ hours: 1, minutes: -30 })` will always throw an exception, regardless of the overflow option.
 
 Therefore, the only case where constrain and reject mode have any effect when creating a duration, is integer overflow.
 If one of the values overflows, constrain mode will cap it to `Number.MAX_VALUE` or `-Number.MAX_VALUE`.

--- a/docs/date.md
+++ b/docs/date.md
@@ -703,6 +703,7 @@ Usage example:
 date = Temporal.Date.from('2006-08-24');
 f = date.getISOFields();
 f.isoDay; // => 24
+// Fields correspond exactly to constructor arguments:
 date2 = new Temporal.Date(f.isoYear, f.isoMonth, f.isoDay, f.calendar);
 date.equals(date2); // => true
 

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -211,7 +211,7 @@ Usage examples:
 
 <!-- prettier-ignore-start -->
 ```javascript
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 dt.year;        // => 1995
 dt.month;       // => 12
 dt.day;         // => 7
@@ -242,7 +242,7 @@ For an overview, see [ISO 8601 on Wikipedia](https://en.wikipedia.org/wiki/ISO_8
 Usage example:
 
 ```javascript
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'][dt.dayOfWeek - 1]; // => THU
 ```
 
@@ -254,7 +254,7 @@ For the ISO 8601 calendar, this is a value between 1 and 365, or 366 in a leap y
 Usage example:
 
 ```javascript
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 // ISO ordinal date
 console.log(dt.year, dt.dayOfYear); // => 1995 341
 ```
@@ -269,7 +269,7 @@ For more information on ISO week numbers, see for example the Wikipedia article 
 Usage example:
 
 ```javascript
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 // ISO week date
 console.log(dt.year, dt.weekOfYear, dt.dayOfWeek); // => 1995 49 4
 ```
@@ -380,7 +380,7 @@ If the result is earlier or later than the range of dates that `Temporal.DateTim
 Usage example:
 
 ```javascript
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 dt.with({ year: 2015, second: 31 }); // => 2015-12-07T03:24:31.000003500
 
 // Temporal.Time, Temporal.Date, Temporal.YearMonth and
@@ -445,7 +445,7 @@ Adding a negative duration is equivalent to subtracting the absolute value of th
 Usage example:
 
 ```javascript
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 dt.plus({ years: 20, months: 4, nanoseconds: 500 }); // => 2016-04-07T03:24:30.000004
 
 dt = Temporal.DateTime.from('2019-01-31T15:30');
@@ -484,7 +484,7 @@ Subtracting a negative duration is equivalent to adding the absolute value of th
 Usage example:
 
 ```javascript
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 dt.minus({ years: 20, months: 4, nanoseconds: 500 }); // => 1975-08-07T03:24:30.000003
 
 dt = Temporal.DateTime.from('2019-03-31T15:30');
@@ -658,8 +658,8 @@ The string can be passed to `Temporal.DateTime.from()` to create a new `Temporal
 Example usage:
 
 ```js
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
-dt.toString(); // => 1995-12-07T03:24:30.000003500
+dt = Temporal.DateTime.from({ year: 1999, month: 12, day: 31 });
+dt.toString(); // => 1999-12-31T00:00
 ```
 
 ### datetime.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
@@ -682,7 +682,7 @@ The `locales` and `options` arguments are the same as in the constructor to [`In
 Example usage:
 
 ```js
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 dt.toLocaleString(); // => example output: 1995-12-07, 3:24:30 a.m.
 dt.toLocaleString('de-DE'); // => example output: 7.12.1995, 03:24:30
 dt.toLocaleString('de-DE', { timeZone: 'Europe/Berlin', weekday: 'long' }); // => Donnerstag, 7.12.1995, 03:24:30
@@ -824,7 +824,7 @@ The converted object carries a copy of all the relevant fields of `datetime` (fo
 Usage example:
 
 ```javascript
-dt = new Temporal.DateTime(1995, 12, 7, 3, 24, 30, 0, 3, 500);
+dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 dt.toDate(); // => 1995-12-07
 dt.toYearMonth(); // => 1995-12
 dt.toMonthDay(); // => 12-07
@@ -865,6 +865,7 @@ Usage example:
 dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
 f = dt.getISOFields();
 f.isoDay; // => 7
+// Fields correspond exactly to constructor arguments:
 dt2 = new Temporal.DateTime(f.isoYear, f.isoMonth, f.isoDay, f.hour, f.minute,
   f.second, f.millisecond, f.microsecond, f.nanosecond, f.calendar);
 dt.equals(dt2); // => true

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -151,7 +151,7 @@ The above read-only properties allow accessing each component of the duration in
 
 Usage examples:
 ```javascript
-d = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+d = Temporal.Duration.from('P1Y2M3W4DT5H6M7.987654321S');
 d.years         // => 1
 d.months        // => 2
 d.weeks         // => 3

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -244,14 +244,14 @@ Example usage:
 
 ```js
 // Converting a specific exact time to a calendar date / wall-clock time
-timestamp = new Temporal.Instant(1553993100000000000n);
+timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
 timestamp.toDateTime('Europe/Berlin'); // => 2019-03-31T01:45+02:00[Europe/Berlin]
 timestamp.toDateTime('UTC'); // => 2019-03-31T00:45+00:00[UTC]
 timestamp.toDateTime('-08:00'); // => 2019-03-30T16:45-08:00[-08:00]
 
 // What time was the Unix epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA)?
-epoch = new Temporal.Instant(0n);
-tz = new Temporal.TimeZone('America/New_York');
+epoch = Temporal.Instant.fromEpochSeconds(0);
+tz = Temporal.TimeZone.from('America/New_York');
 epoch.toLocalDateTime(tz); // => 1969-12-31T19:00-05:00[America/New_York]
 ```
 
@@ -276,14 +276,14 @@ Example usage:
 
 ```js
 // Converting a specific instant time to a calendar date / wall-clock time
-timestamp = new Temporal.Instant(1553993100000000000n);
+timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
 timestamp.toDateTime('Europe/Berlin'); // => 2019-03-31T01:45
 timestamp.toDateTime('UTC'); // => 2019-03-31T00:45
 timestamp.toDateTime('-08:00'); // => 2019-03-30T16:45
 
 // What time was the Unix epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA)?
-epoch = new Temporal.Instant(0n);
-tz = new Temporal.TimeZone('America/New_York');
+epoch = Temporal.Instant.fromEpochSeconds(0);
+tz = Temporal.TimeZone.from('America/New_York');
 epoch.toDateTime(tz); // => 1969-12-31T19:00
 ```
 
@@ -313,7 +313,7 @@ Example usage:
 ```js
 // Temporal.Instant representing five hours from now
 Temporal.now.instant().plus({ hours: 5 });
-fiveHours = new Temporal.Duration(0, 0, 0, 0, 5);
+fiveHours = Temporal.Duration.from({ hours: 5 });
 Temporal.now.instant().plus(fiveHours);
 ```
 
@@ -343,7 +343,7 @@ Example usage:
 ```js
 // Temporal.Instant representing this time an hour ago
 Temporal.now.instant().minus({ hours: 1 });
-oneHour = new Temporal.Duration(0, 0, 0, 0, 1);
+oneHour = Temporal.Duration.from({ hours: 1 });
 Temporal.now.instant().minus(oneHour);
 ```
 
@@ -414,7 +414,7 @@ approxMissionLength = endOfMoonMission.difference(startOfMoonMission, {
   // => P8DT3H
 
 // A billion (10^9) seconds since the epoch in different units
-epoch = new Temporal.Instant(0n);
+epoch = Temporal.Instant.fromEpochSeconds(0);
 billion = Temporal.Instant.fromEpochSeconds(1e9);
 billion.difference(epoch);
   // =>    PT1000000000S
@@ -525,7 +525,7 @@ The string can be passed to `Temporal.Instant.from()` to create a new `Temporal.
 Example usage:
 
 ```js
-instant = new Temporal.Instant(1574074321816000000n);
+instant = Temporal.Instant.fromEpochMilliseconds(1574074321816);
 instant.toString(); // => 2019-11-18T10:52:01.816Z
 instant.toString(Temporal.TimeZone.from('UTC')); // => 2019-11-18T10:52:01.816Z
 instant.toString('Asia/Seoul'); // => 2019-11-18T19:52:01.816+09:00[Asia/Seoul]

--- a/docs/localdatetime.md
+++ b/docs/localdatetime.md
@@ -671,7 +671,7 @@ Please see the documentation of `from` for more details on options behavior.
 Usage example:
 
 ```javascript
-ldt = new Temporal.LocalDateTime('1995-12-07T03:24-06:00[America/Chicago]');
+ldt = Temporal.LocalDateTime.from('1995-12-07T03:24-06:00[America/Chicago]');
 ldt.with({ year: 2015, minute: 31 }); // => 2015-12-07T03:31-06:00[America/Chicago]
 
 midnight = Temporal.Time.from({ hour: 0 });

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -173,12 +173,12 @@ Example usage:
 
 ```javascript
 // Getting the UTC offset for a time zone at a particular time
-timestamp = new Temporal.Instant(1553993100000000000n);
-tz = new Temporal.TimeZone('Europe/Berlin');
+timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
+tz = Temporal.TimeZone.from('Europe/Berlin');
 tz.getOffsetStringFor(timestamp); // => +01:00
 
 // TimeZone with a fixed UTC offset
-tz = new Temporal.TimeZone('-08:00');
+tz = Temporal.TimeZone.from('-08:00');
 tz.getOffsetStringFor(timestamp); // => -08:00
 ```
 
@@ -198,13 +198,13 @@ Example usage:
 
 ```javascript
 // Converting a specific exact time to a calendar date / wall-clock time
-timestamp = new Temporal.Instant(1553993100000000000n);
-tz = new Temporal.TimeZone('Europe/Berlin');
+timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
+tz = Temporal.TimeZone.from('Europe/Berlin');
 tz.getLocalDateTimeFor(timestamp); // => 2019-03-31T01:45+02:00[Europe/Berlin]
 
 // What time was the Unix Epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA)?
-epoch = new Temporal.Instant(0n);
-tz = new Temporal.TimeZone('America/New_York');
+epoch = Temporal.Instant.fromEpochSeconds(0);
+tz = Temporal.TimeZone.from('America/New_York');
 tz.getLocalDateTimeFor(epoch); // => 1969-12-31T19:00-05:00[America/New_York]
 ```
 
@@ -224,13 +224,13 @@ Example usage:
 
 ```javascript
 // Converting a specific instant time to a calendar date / wall-clock time
-timestamp = new Temporal.Instant(1553993100000000000n);
-tz = new Temporal.TimeZone('Europe/Berlin');
+timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
+tz = Temporal.TimeZone.from('Europe/Berlin');
 tz.getDateTimeFor(timestamp); // => 2019-03-31T01:45
 
 // What time was the Unix Epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA)?
-epoch = new Temporal.Instant(0n);
-tz = new Temporal.TimeZone('America/New_York');
+epoch = Temporal.Instant.fromEpochSeconds(0);
+tz = Temporal.TimeZone.from('America/New_York');
 tz.getDateTimeFor(epoch); // => 1969-12-31T19:00
 ```
 


### PR DESCRIPTION
In general, we want to encourage using from() instead of the constructors
directly, which are considered more low-level. This replaces direct usage
of the constructors with from() in the docs, except in the code examples
of the constructors themselves.

Closes: #914