### PR TITLE
Rename TimeZone.name to TimeZone.id

### DIFF
--- a/docs/cookbook/getTimeZoneObjectFromIanaName.mjs
+++ b/docs/cookbook/getTimeZoneObjectFromIanaName.mjs
@@ -3,4 +3,4 @@ const tz = Temporal.TimeZone.from('Europe/London');
 
 // Cast the timezone back to an IANA name, two ways:
 tz.toString(); // Europe/London
-tz.name; // Europe/London
+tz.id; // Europe/London

--- a/docs/timezone-draft.md
+++ b/docs/timezone-draft.md
@@ -40,7 +40,7 @@ const originalTemporalTimeZoneFrom = Temporal.TimeZone.from;
 Temporal.TimeZone.from = function (item) {
   let id;
   if (item instanceof Temporal.TimeZone) {
-    id = item.name;
+    id = item.id;
   } else {
     const string = `${item}`;
     try {
@@ -71,7 +71,7 @@ const originalTemporalTimeZoneFrom = Temporal.TimeZone.from;
 Temporal.TimeZone.from = function (item) {
   let id;
   if (item instanceof Temporal.TimeZone) {
-    id = item.name;
+    id = item.id;
   } else {
     const string = `${item}`;
     try {
@@ -123,7 +123,7 @@ class Temporal.TimeZone {
 
   // API methods that a subclassed custom time zone doesn't need to touch
 
-  get name() : string;
+  get id() : string;
   getDateTimeFor(instant : Temporal.Instant) : Temporal.DateTime;
   getInstantFor(
       dateTime : Temporal.DateTime,
@@ -157,8 +157,8 @@ class OffsetTimeZone extends Temporal.TimeZone {
     if (sign === -1 && offsetNs === 0) sign = 1;  // "-00:00" is "+00:00"
     const hourString = `${h}`.padStart(2, '0');
     const minuteString = `${min}`.padStart(2, '0');
-    const name = `${sign < 0 ? '-' : '+'}${hourString}:${minuteString}`;
-    super(name);
+    const id = `${sign < 0 ? '-' : '+'}${hourString}:${minuteString}`;
+    super(id);
     this.#offsetNs = sign * offsetNs;
   }
 

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -109,16 +109,15 @@ tz = Temporal.TimeZone.from('2020-01-13T16:31:00.065858086-08:00[America/Vancouv
 tz2 = Temporal.TimeZone.from(tz);
 
 /* WRONG */ tz = Temporal.TimeZone.from('local'); // not a time zone, throws
-/* WRONG */ tz = Temporal.TimeZone.from({ name: 'UTC' }); // not a TimeZone object, throws
 /* WRONG */ tz = Temporal.TimeZone.from('2020-01-14T00:31:00'); // ISO 8601 string without time zone offset part, throws
 /* WRONG */ tz = Temporal.TimeZone.from('-08:00[America/Vancouver]'); // ISO 8601 string without date-time part, throws
 ```
 
 ## Properties
 
-### timeZone.**name** : string
+### timeZone.**id** : string
 
-The `name` property gives an unambiguous identifier for the time zone.
+The `id` property gives an unambiguous identifier for the time zone.
 Effectively, this is the canonicalized version of whatever `timeZoneIdentifier` was passed as a parameter to the constructor.
 
 ## Methods
@@ -167,7 +166,7 @@ tz.getOffsetNanosecondsFor(Temporal.Instant.from('2020-11-06T01:00Z')); // => 0
 
 This method is similar to `timeZone.getOffsetNanosecondsFor()`, but returns the offset formatted as a string, with sign, hours, and minutes.
 
-If `timeZone` is a UTC offset time zone, the return value of this method is effectively the same as `timeZone.name`.
+If `timeZone` is a UTC offset time zone, the return value of this method is effectively the same as `timeZone.id`.
 
 Example usage:
 
@@ -333,13 +332,13 @@ duration.toLocaleString(); // output will vary
 
 ### timeZone.**toString**() : string
 
-**Returns:** The string given by `timeZone.name`.
+**Returns:** The string given by `timeZone.id`.
 
-This method overrides `Object.prototype.toString()` and provides the time zone's `name` property as a human-readable description.
+This method overrides `Object.prototype.toString()` and provides the time zone's `id` property as a human-readable description.
 
 ### timeZone.**toJSON**() : string
 
-**Returns:** the string given by `timeZone.name`.
+**Returns:** the string given by `timeZone.id`.
 
 This method is the same as `timeZone.toString()`.
 It is usually not called directly, but it can be called automatically by `JSON.stringify()`.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -225,7 +225,7 @@ Comparison will use exact time, not clock time, because sorting is almost always
 Note that during the hour before and after DST ends, sorting of clock time may not match the order the events actually occurred.
 
 If exact timestamps are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
-If those are equal too, then `.timeZone.name` will be compared lexicographically.
+If those are equal too, then `.timeZone.id` will be compared lexicographically.
 
 For example:
 

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -49,7 +49,7 @@ export class TimeZone {
       });
     }
   }
-  get name() {
+  get id() {
     return ES.TimeZoneToString(this);
   }
   getOffsetNanosecondsFor(absolute) {

--- a/polyfill/test/TimeZone/constructor/from/argument-valid.js
+++ b/polyfill/test/TimeZone/constructor/from/argument-valid.js
@@ -24,7 +24,7 @@ for (const [thisValue, constructor = thisValue] of thisValues) {
   for (const [valid, canonical = valid] of valids) {
     const result = Temporal.TimeZone.from.call(thisValue, valid);
     assert.sameValue(result.constructor, constructor);
-    assert.sameValue(result.name, canonical);
+    assert.sameValue(result.id, canonical);
     assert.sameValue(result.toString(), canonical);
   }
 }

--- a/polyfill/test/TimeZone/prototype/id/no-toString.js
+++ b/polyfill/test/TimeZone/prototype/id/no-toString.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-get-temporal.timezone.prototype.name
+esid: sec-get-temporal.timezone.prototype.id
 includes: [compareArray.js]
 ---*/
 
@@ -19,7 +19,7 @@ Object.defineProperty(timeZone, "toString", {
   },
 });
 
-const descriptor = Object.getOwnPropertyDescriptor(Temporal.TimeZone.prototype, "name");
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.TimeZone.prototype, "id");
 const result = descriptor.get.call(timeZone);
 assert.sameValue(result, "UTC");
 

--- a/polyfill/test/TimeZone/prototype/id/plain-custom-timezone.js
+++ b/polyfill/test/TimeZone/prototype/id/plain-custom-timezone.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-get-temporal.timezone.prototype.name
+esid: sec-get-temporal.timezone.prototype.id
 includes: [compareArray.js]
 ---*/
 
@@ -28,7 +28,7 @@ const timeZone = new Proxy({
   },
 });
 
-const descriptor = Object.getOwnPropertyDescriptor(Temporal.TimeZone.prototype, "name");
+const descriptor = Object.getOwnPropertyDescriptor(Temporal.TimeZone.prototype, "id");
 const result = descriptor.get.call(timeZone);
 assert.sameValue(result, "time zone");
 

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -388,7 +388,7 @@ describe('fromString regex', () => {
     function test(offsetString, expectedName) {
       it(offsetString, () => {
         const timeZone = Temporal.TimeZone.from(offsetString);
-        equal(timeZone.name, expectedName);
+        equal(timeZone.id, expectedName);
       });
     }
     function generateTest(dateTimeString, zoneString, expectedName) {

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -21,7 +21,7 @@ describe('TimeZone', () => {
     it('Temporal.TimeZone is a function', () => equal(typeof Temporal.TimeZone, 'function'));
     it('Temporal.TimeZone has prototype', () => equal(typeof Temporal.TimeZone.prototype, 'object'));
     describe('Temporal.TimeZone.prototype', () => {
-      it('Temporal.TimeZone.prototype has name', () => assert('name' in Temporal.TimeZone.prototype));
+      it('Temporal.TimeZone.prototype has id', () => assert('id' in Temporal.TimeZone.prototype));
       it('Temporal.TimeZone.prototype has getOffsetNanosecondsFor', () =>
         equal(typeof Temporal.TimeZone.prototype.getOffsetNanosecondsFor, 'function'));
       it('Temporal.TimeZone.prototype has getOffsetStringFor', () =>
@@ -60,7 +60,7 @@ describe('TimeZone', () => {
       it(`${zone} is a zone`, () => equal(typeof new Temporal.TimeZone(zone), 'object'));
     }
   });
-  describe('.name property', () => {
+  describe('.id property', () => {
     test('+01:00');
     test('-01:00');
     test('+0330', '+03:30');
@@ -75,8 +75,8 @@ describe('TimeZone', () => {
     test('Asia/Ulan_Bator', 'Asia/Ulaanbaatar');
     test('UTC');
     test('GMT', 'UTC');
-    function test(zone, name = zone) {
-      it(`${zone} has name ${name}`, () => equal(new Temporal.TimeZone(zone).name, name));
+    function test(zone, id = zone) {
+      it(`${zone} has ID ${id}`, () => equal(new Temporal.TimeZone(zone).id, id));
     }
   });
   describe('TimeZone.from(identifier)', () => {
@@ -99,7 +99,7 @@ describe('TimeZone', () => {
       const timezoneObj = new Temporal.TimeZone(zone);
       it(`TimeZone.from(${zone}) is a time zone`, () => equal(typeof timezoneFrom, 'object'));
       it(`TimeZone.from(${zone}) does the same thing as new TimeZone(${zone})`, () =>
-        equal(timezoneFrom.name, timezoneObj.name));
+        equal(timezoneFrom.id, timezoneObj.id));
     }
     it('TimeZone.from throws with bad identifier', () => {
       throws(() => Temporal.TimeZone.from('local'));
@@ -115,10 +115,10 @@ describe('TimeZone', () => {
     test('1994-11-05T08:15:30\u221205:00[America/New_York]', 'America/New_York');
     test('1994-11-05T08:15:30\u221205[America/New_York]', 'America/New_York');
     test('1994-11-05T13:15:30Z', 'UTC');
-    function test(isoString, name) {
+    function test(isoString, id) {
       const tz = Temporal.TimeZone.from(isoString);
       it(`TimeZone.from(${isoString}) is a time zone`, () => equal(typeof tz, 'object'));
-      it(`TimeZone.from(${isoString}) has name ${name}`, () => equal(tz.name, name));
+      it(`TimeZone.from(${isoString}) has ID ${id}`, () => equal(tz.id, id));
     }
     it('offset disagreeing with IANA name throws', () => {
       throws(() => Temporal.TimeZone.from('1994-11-05T08:15:30-05:00[UTC]'), RangeError);
@@ -130,7 +130,7 @@ describe('TimeZone', () => {
     const zone = new Temporal.TimeZone('+01:00');
     const abs = Temporal.Instant.fromEpochSeconds(Math.floor(Math.random() * 1e9));
     const dtm = new Temporal.DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
-    it(`${zone} has name ${zone}`, () => equal(zone.name, `${zone}`));
+    it(`${zone} has ID ${zone}`, () => equal(zone.id, `${zone}`));
     it(`${zone} has offset +01:00 in ns`, () => equal(zone.getOffsetNanosecondsFor(abs), 3600e9));
     it(`${zone} has offset +01:00`, () => equal(zone.getOffsetStringFor(abs), '+01:00'));
     it(`(${zone}).getDateTimeFor(${abs})`, () => assert(zone.getDateTimeFor(abs) instanceof Temporal.DateTime));
@@ -144,7 +144,7 @@ describe('TimeZone', () => {
     const zone = new Temporal.TimeZone('UTC');
     const abs = Temporal.Instant.fromEpochSeconds(Math.floor(Math.random() * 1e9));
     const dtm = new Temporal.DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
-    it(`${zone} has name ${zone}`, () => equal(zone.name, `${zone}`));
+    it(`${zone} has ID ${zone}`, () => equal(zone.id, `${zone}`));
     it(`${zone} has offset +00:00 in ns`, () => equal(zone.getOffsetNanosecondsFor(abs), 0));
     it(`${zone} has offset +00:00`, () => equal(zone.getOffsetStringFor(abs), '+00:00'));
     it(`(${zone}).getDateTimeFor(${abs})`, () => assert(zone.getDateTimeFor(abs) instanceof Temporal.DateTime));
@@ -156,7 +156,7 @@ describe('TimeZone', () => {
     const zone = new Temporal.TimeZone('America/Los_Angeles');
     const abs = Temporal.Instant.fromEpochSeconds(0n);
     const dtm = new Temporal.DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
-    it(`${zone} has name ${zone}`, () => equal(zone.name, `${zone}`));
+    it(`${zone} has ID ${zone}`, () => equal(zone.id, `${zone}`));
     it(`${zone} has offset -08:00 in ns`, () => equal(zone.getOffsetNanosecondsFor(abs), -8 * 3600e9));
     it(`${zone} has offset -08:00`, () => equal(zone.getOffsetStringFor(abs), '-08:00'));
     it(`(${zone}).getDateTimeFor(${abs})`, () => assert(zone.getDateTimeFor(abs) instanceof Temporal.DateTime));

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -43,9 +43,9 @@ describe('Userland time zone', () => {
     const dt = new Temporal.DateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
 
     it('is a time zone', () => equal(typeof obj, 'object'));
-    it('.name property', () => equal(obj.name, 'Etc/Custom_UTC_Subclass'));
+    it('.id property', () => equal(obj.id, 'Etc/Custom_UTC_Subclass'));
     // FIXME: what should happen in Temporal.TimeZone.from(obj)?
-    it('.name is not available in from()', () => {
+    it('.id is not available in from()', () => {
       throws(() => Temporal.TimeZone.from('Etc/Custom_UTC_Subclass'), RangeError);
       throws(() => Temporal.TimeZone.from('2020-05-26T16:02:46.251163036+00:00[Etc/Custom_UTC_Subclass]'), RangeError);
     });
@@ -58,7 +58,7 @@ describe('Userland time zone', () => {
       equal(`${obj.getInstantFor(dt)}`, '1976-11-18T15:23:30.123456789Z');
       equal(`${dt.toInstant(obj)}`, '1976-11-18T15:23:30.123456789Z');
     });
-    it('converts to string', () => equal(`${obj}`, obj.name));
+    it('converts to string', () => equal(`${obj}`, obj.id));
     it('prints in absolute.toString', () =>
       equal(abs.toString(obj), '1970-01-01T00:00+00:00[Etc/Custom_UTC_Subclass]'));
     it('has no next transitions', () => assert.equal(obj.getNextTransition(), null));
@@ -74,7 +74,7 @@ describe('Userland time zone', () => {
         Temporal.TimeZone.from = function (item) {
           let id;
           if (item instanceof Temporal.TimeZone) {
-            id = item.name;
+            id = item.id;
           } else {
             id = `${item}`;
             // TODO: Use Temporal.parse here to extract the ID from an ISO string
@@ -160,7 +160,7 @@ describe('Userland time zone', () => {
         Temporal.TimeZone.from = function (item) {
           let id;
           if (item instanceof Temporal.TimeZone) {
-            id = item.name;
+            id = item.id;
           } else {
             id = `${item}`;
             // TODO: Use Temporal.parse here to extract the ID from an ISO string

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -28,7 +28,7 @@
         1. Let _identifier_ be ? ToString(_identifier_).
         1. If _identifier_ does not satisfy the syntax of a |TemporalTimeZoneIdentifier| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
           1. Throw a *TypeError* exception.
-        1. Let _sign_, _hour_, _minute_, and _name_ be the parts of _identifier_ produced respectively by the |TimeZoneUTCOffsetSign|, |TimeZoneUTCOffsetHour|, |TimeZoneUTCOffsetMinute| and |TimeZoneIANAName| productions, or *undefined* if not present.
+        1. Let _sign_, _hour_, _minute_, and _id_ be the parts of _identifier_ produced respectively by the |TimeZoneUTCOffsetSign|, |TimeZoneUTCOffsetHour|, |TimeZoneUTCOffsetMinute| and |TimeZoneIANAName| productions, or *undefined* if not present.
         1. If _hour_ is not *undefined*, then
           1. Assert: _sign_ is not *undefined*.
           1. Set _hour_ to ! ToInteger(_hour_).
@@ -37,7 +37,7 @@
           1. If _minute_ is not *undefined*, then
             1. Set _minute_ to ! ToInteger(_minute_).
           1. <mark>Do something with the offset.</mark>
-        1. If ! IsValidTimeZoneName(_name_) is *false*, then
+        1. If ! IsValidTimeZoneName(_id_) is *false*, then
           1. Throw a *TypeError* exception.
         1. Let _canonical_ be ! CanonicalizeTimeZoneName(_identifier_).
         1. Return ? CreateTemporalTimeZone(_canonical_, NewTarget).
@@ -115,10 +115,10 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-get-temporal.timezone.prototype.name">
-      <h1>get Temporal.TimeZone.prototype.name</h1>
+    <emu-clause id="sec-get-temporal.timezone.prototype.id">
+      <h1>get Temporal.TimeZone.prototype.id</h1>
       <p>
-        `Temporal.TimeZone.prototype.name` is an accessor property whose set accessor function is undefined.
+        `Temporal.TimeZone.prototype.id` is an accessor property whose set accessor function is undefined.
         Its get accessor function performs the following steps:
       </p>
       <emu-alg>


### PR DESCRIPTION
This is in order to be consistent with Calendar.id.

Closes: #920