### PR TITLE
Rename LocalDateTime docs to ZonedDateTime

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ A cookbook to help you get started and learn the ins and outs of Temporal is ava
 
 - `Temporal.now.instant()` - get the exact time since [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)
 - `Temporal.now.timeZone()` - get the current system time zone
-- `Temporal.now.localDateTime()` - get the current calendar date and wall-clock time in the system time zone
+- `Temporal.now.zonedDateTime()` - get the current calendar date and wall-clock time in the system time zone
 - `Temporal.now.date()` - get the current calendar date in the system time zone
 - `Temporal.now.time()` - get the current wall-clock time in the system time zone
 - `Temporal.now.dateTime()` - get the current system date/time in the system time zone, but return an object that doesn't remember its time zone so should NOT be used to derive other values (e.g. 12 hours later) in time zones that use Daylight Saving Time (DST).
@@ -40,19 +40,20 @@ See [Temporal.now Documentation](./now.md) for detailed documentation.
 ### **Temporal.Instant**
 
 A `Temporal.Instant` represents a fixed point in time, without regard to calendar or location.
-For a human-readable local calendar date or clock time, use a `Temporal.TimeZone` and `Temporal.Calendar` to obtain a `Temporal.LocalDateTime` or `Temporal.DateTime`.
+For a human-readable local calendar date or clock time, use a `Temporal.TimeZone` and `Temporal.Calendar` to obtain a `Temporal.ZonedDateTime` or `Temporal.DateTime`.
 
 See [Temporal.Instant Documentation](./instant.md) for detailed documentation.
 
-### **Temporal.LocalDateTime**
+### **Temporal.ZonedDateTime**
 
-_NOTE: this type is not checked into the polyfill yet, but is planned to land in early October 2020._
+_NOTE: this type is not checked into the polyfill yet, but is planned to land in late October 2020._
 
-A `Temporal.LocalDateTime` is a time-zone-aware, calendar-aware date/time type that represents a real event that has happened (or will happen) at a particular instant in a real place on Earth. This type is optimized for use cases that require a time zone, including DST-safe arithmetic and interoperability with RFC 5545 (iCalendar).
+A `Temporal.ZonedDateTime` is a timezone-aware, calendar-aware date/time type that represents a real event that has happened (or will happen) at a particular instant from the perspective of a particular region on Earth.
+This type is optimized for use cases that require a time zone, including DST-safe arithmetic and interoperability with RFC 5545 (iCalendar).
 
-As the broadest `Temporal` type, `Temporal.LocalDateTime` can be considered a combination of `Temporal.TimeZone`, `Temporal.Instant`, and `Temporal.DateTime` (which includes `Temporal.Calendar`).
+As the broadest `Temporal` type, `Temporal.ZonedDateTime` can be considered a combination of `Temporal.TimeZone`, `Temporal.Instant`, and `Temporal.DateTime` (which includes `Temporal.Calendar`).
 
-See [Temporal.LocalDateTime Documentation](./localdatetime.md) for detailed documentation.
+See [Temporal.ZonedDateTime Documentation](./zoneddatetime.md) for detailed documentation.
 
 ### **Temporal.Date**
 
@@ -64,7 +65,7 @@ See [Temporal.Date Documentation](./date.md) for detailed documentation.
 
 #### Time Zones and Resolving Ambiguity
 
-Converting between wall-clock/calendar-date types (like `Temporal.Date`, `Temporal.Time`, and `Temporal.DateTime`) and exact time types (`Temporal.Instant` and `Temporal.LocalDateTime`) can be ambiguous because of time zones and daylight saving time.
+Converting between wall-clock/calendar-date types (like `Temporal.Date`, `Temporal.Time`, and `Temporal.DateTime`) and exact time types (`Temporal.Instant` and `Temporal.ZonedDateTime`) can be ambiguous because of time zones and daylight saving time.
 
 Read more about [handling time zones, DST, and ambiguity in `Temporal`](./ambiguity.md).
 
@@ -76,8 +77,8 @@ See [Temporal.Time Documentation](./time.md) for detailed documentation.
 
 ### **Temporal.DateTime**
 
-A `Temporal.DateTime` represents a calendar date and wall-clock time that does not carry time zone information. It can be converted to a `Temporal.LocalDateTime` or a `Temporal.Instant` using a `Temporal.TimeZone`.
-For use cases that require a time zone, especially using arithmetic or other derived values, consider using `Temporal.LocalDateTime` instead because that type automatically adjusts for Daylight Saving Time.
+A `Temporal.DateTime` represents a calendar date and wall-clock time that does not carry time zone information. It can be converted to a `Temporal.ZonedDateTime` or a `Temporal.Instant` using a `Temporal.TimeZone`.
+For use cases that require a time zone, especially using arithmetic or other derived values, consider using `Temporal.ZonedDateTime` instead because that type automatically adjusts for Daylight Saving Time.
 
 See [Temporal.DateTime Documentation](./datetime.md) for detailed documentation.
 
@@ -143,8 +144,8 @@ See [Temporal.Calendar Documentation](./calendar.md) for detailed documentation.
 - [Parse Draft](./parse-draft.md) &mdash; Draft design document for a `Temporal.parse` API, which is not currently planned to be implemented.
 - [Calendar Draft](./calendar-draft.md) &mdash; Draft design document for calendar support in Temporal.
   Mostly superseded by the documentation of [Temporal.Calendar](./calendar.md), but also contains some discussion about whether to have a default calendar.
-- [Zoned Date/Time Type Draft](./localdatetime-draft.md) &mdash; Explanation of `Temporal.LocalDateTime` (not the final name) which is a new type combining an instant time with a time zone and calendar, and exposing a superset of the `Temporal.DateTime` API.
-  Superseded by the [documentation](./localdatetime.md), but contains background info about the reasons and goals behind this type.
+- [Zoned Date/Time Type Draft](./zoneddatetime-draft.md) &mdash; Explanation of `Temporal.ZonedDateTime` which is a new type combining an instant time with a time zone and calendar, and exposing a superset of the `Temporal.DateTime` API.
+  Superseded by the [documentation](./zoneddatetime.md), but contains background info about the reasons and goals behind this type.
 
 ## Object Relationship
 

--- a/docs/ambiguity.md
+++ b/docs/ambiguity.md
@@ -23,7 +23,7 @@ However the same calendar date and wall-clock time India would have an offset of
 
 [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) and [RFC 3339](https://tools.ietf.org/html/rfc3339) define standard representations for exact times as a date and time value, e.g. `2020-09-06T17:35:24.485Z`. The `Z` suffix indicates that this is an exact UTC time.
 
-Temporal has two types that store exact time: `Temporal.Instant` (which only stores exact time and no other information) and `Temporal.LocalDateTime` which stores exact time, a time zone, and a calendar system
+Temporal has two types that store exact time: `Temporal.Instant` (which only stores exact time and no other information) and `Temporal.ZonedDateTime` which stores exact time, a time zone, and a calendar system
 
 Another way to represent exact time is using a single number representing the amount of time after or before [Unix epoch](https://en.wikipedia.org/wiki/Unix_time) (midnight UTC on January 1, 1970).
 For example, `Temporal.Instant` (an exact-time type) can be constructed using only a `BigInt` value of nanoseconds since epoch.
@@ -52,12 +52,12 @@ In Temporal:
   These types all carry a calendar system, which by default is `'iso8601'` (the ISO 8601 calendar) but can be overridden for other [calendars](./calendar.md) like `'islamic'` or `'japanese'`.
 - The [`Temporal.TimeZone`](./timezone.md) represents a time zone function that converts between exact time and wall-clock time and vice-versa.
   It also includes helper functions, e.g. to fetch the current time zone offset for a particular exact time.
-- The [`Temporal.LocalDateTime`](./localdatetime.md) type encapsulates all of the types above: an exact time (like a [`Temporal.Instant`](./instant.md)), its wall-clock equivalent (like a [`Temporal.DateTime`](./datetime.md)), and the time zone that links the two (like a [`Temporal.TimeZone`](./timezone.md)).
+- The [`Temporal.ZonedDateTime`](./zoneddatetime.md) type encapsulates all of the types above: an exact time (like a [`Temporal.Instant`](./instant.md)), its wall-clock equivalent (like a [`Temporal.DateTime`](./datetime.md)), and the time zone that links the two (like a [`Temporal.TimeZone`](./timezone.md)).
 
 There are two ways to get a human-readable calendar date and clock time from a `Temporal` type that stores exact time.
 
-- If the exact time is already represented by a [`Temporal.LocalDateTime`](./localdatetime.md) instance then the wall-clock time values are trivially available using the properties and methods of that type, e.g. [`.year`](./localdatetime.md#year), [`.hour`](./localdatetime.md#hour), [`.getFields()`](./localdatetime.md#getFields), or [`.toLocaleString()`](./localdatetime.md#toLocaleString).
-- However, if the exact time is represented by a [`Temporal.Instant`](./instant.md), use a time zone and optional calendar to create a [`Temporal.LocalDateTime`](./localdatetime.md). Example:
+- If the exact time is already represented by a [`Temporal.ZonedDateTime`](./zoneddatetime.md) instance then the wall-clock time values are trivially available using the properties and methods of that type, e.g. [`.year`](./zoneddatetime.md#year), [`.hour`](./zoneddatetime.md#hour), [`.getFields()`](./zoneddatetime.md#getFields), or [`.toLocaleString()`](./zoneddatetime.md#toLocaleString).
+- However, if the exact time is represented by a [`Temporal.Instant`](./instant.md), use a time zone and optional calendar to create a [`Temporal.ZonedDateTime`](./zoneddatetime.md). Example:
 
 <!-- prettier-ignore-start -->
 ```javascript
@@ -72,21 +72,21 @@ formatOptions = {
   second: 'numeric'
 };
 
-ldt = instant.toLocalDateTime('Asia/Tokyo');
+zdt = instant.toZonedDateTime('Asia/Tokyo');
   // => 2019-09-03T17:34:05+09:00[Asia/Tokyo]
-ldt.toLocaleString('en-us', { ...formatOptions, calendar: ldt.calendar });
+zdt.toLocaleString('en-us', { ...formatOptions, calendar: zdt.calendar });
   // => "Sep 3, 2019 AD, 5:34:05 PM"
-ldt.year;
+zdt.year;
   // => 2019
-ldt = instant.toLocalDateTime('Asia/Tokyo', 'iso8601').toLocaleString('ja-jp', formatOptions);
+zdt = instant.toZonedDateTime('Asia/Tokyo', 'iso8601').toLocaleString('ja-jp', formatOptions);
   // => 2019-09-03T17:34:05+09:00[Asia/Tokyo]
-  // this is identical to the result of toLocalDateTime() above
+  // this is identical to the result of toZonedDateTime() above
 
-ldt = instant.toLocalDateTime('Asia/Tokyo', 'japanese');
+zdt = instant.toZonedDateTime('Asia/Tokyo', 'japanese');
   // => 2019-09-03T17:34:05+09:00[Asia/Tokyo][c=japanese]
-ldt.toLocaleString('en-us', { ...formatOptions, calendar: ldt.calendar });
+zdt.toLocaleString('en-us', { ...formatOptions, calendar: zdt.calendar });
   // => "Sep 3, 1 Reiwa, 5:34:05 PM"
-ldt.year;
+zdt.year;
   // => 1
 ```
 <!-- prettier-ignore-end -->
@@ -97,19 +97,19 @@ Conversions from calendar date and/or wall clock time to exact time are also sup
 ```javascript
 // Convert various local time types to an exact time type by providing a time zone
 date = Temporal.Date.from('2019-12-17');
-ldt = date.toLocalDateTime('Asia/Tokyo');
+zdt = date.toZonedDateTime('Asia/Tokyo');
   // => 2019-12-17T00:00+09:00[Asia/Tokyo]
-ldt = date.toLocalDateTime('Asia/Tokyo', Temporal.Time.from('10:00'));
+zdt = date.toZonedDateTime('Asia/Tokyo', Temporal.Time.from('10:00'));
   // => 2019-12-17T10:00+09:00[Asia/Tokyo]
 time = Temporal.Time.from('14:35');
-ldt = time.toLocalDateTime('Asia/Tokyo', Temporal.Date.from('2020-08-27'));
+zdt = time.toZonedDateTime('Asia/Tokyo', Temporal.Date.from('2020-08-27'));
   // => 020-08-27T14:35+09:00[Asia/Tokyo]
 dateTime = Temporal.DateTime.from('2019-12-17T07:48');
-ldt = dateTime.toLocalDateTime('Asia/Tokyo');
+zdt = dateTime.toZonedDateTime('Asia/Tokyo');
   // => 2019-12-17T07:48+09:00[Asia/Tokyo]
 
 // Get the exact time in seconds, milliseconds, or nanoseconds since the UNIX epoch.
-abs = ldt.toInstant();
+abs = zdt.toInstant();
 epochNano = abs.getEpochNanoseconds();
   // => 1576536480000000000n
 epochMicro = abs.getEpochMilliseconds();
@@ -150,36 +150,36 @@ abs = Temporal.Instant.from('2020-09-06T17:35:24.485Z');
 // An offset can make a local time "exact" with no ambiguity possible.
 abs = Temporal.Instant.from('2020-09-06T10:35:24.485-07:00');
   // => 2020-09-06T17:35:24.485Z
-ldt = Temporal.LocalDateTime.from('2020-09-06T10:35:24.485-07:00[America/Los_Angeles]');
+zdt = Temporal.ZonedDateTime.from('2020-09-06T10:35:24.485-07:00[America/Los_Angeles]');
   // => 2020-09-06T10:35:24.485-07:00[America/Los_Angeles]
 // if the source is an exact Temporal object, then no ambiguity is possible.
-ldt = abs.toLocalDateTime('America/Los_Angeles');
+zdt = abs.toZonedDateTime('America/Los_Angeles');
   // => 2020-09-06T10:35:24.485-07:00[America/Los_Angeles]
-abs2 = ldt.toInstant();
+abs2 = zdt.toInstant();
   // => 2020-09-06T17:35:24.485Z
 ```
 <!-- prettier-ignore-end -->
 
-However, opportunities for ambiguity are present when creating an exact-time type (`Temporal.LocalDateTime` or `Temporal.Instant`) from a non-exact source. For example:
+However, opportunities for ambiguity are present when creating an exact-time type (`Temporal.ZonedDateTime` or `Temporal.Instant`) from a non-exact source. For example:
 
 <!-- prettier-ignore-start -->
 ```javascript
 // Offset is not known. Ambiguity is possible!
-ldt = Temporal.Date('2019-02-19').toLocalDateTime('America/Sao_Paulo'); // can be ambiguous
-ldt = Temporal.DateTime('2019-02-19T00:00').toLocalDateTime('America/Sao_Paulo'); // can be ambiguous
+zdt = Temporal.Date('2019-02-19').toZonedDateTime('America/Sao_Paulo'); // can be ambiguous
+zdt = Temporal.DateTime('2019-02-19T00:00').toZonedDateTime('America/Sao_Paulo'); // can be ambiguous
 
 // Even if the offset is present in the source string, if the type (like DateTime)
 // isn't an exact type then the offset is ignored when parsing so ambiguity is possible.
 dt = Temporal.DateTime.from('2019-02-19T00:00-03:00');
-ldt = dt.toLocalDateTimeISO('America/Sao_Paulo'); // can be ambiguous
+zdt = dt.toZonedDateTimeISO('America/Sao_Paulo'); // can be ambiguous
 abs = dt.toInstantISO('America/Sao_Paulo'); // can be ambiguous
 
 // the offset is lost when converting from an exact type to a non-exact type
-ldt = Temporal.LocalDateTime.from('2020-11-01T01:30-08:00[America/Los_Angeles]');
+zdt = Temporal.ZonedDateTime.from('2020-11-01T01:30-08:00[America/Los_Angeles]');
   // => 2020-11-01T01:30-08:00[America/Los_Angeles]
-dt = ldt.toDateTime(); // offset is lost!
+dt = zdt.toDateTime(); // offset is lost!
   // => 2020-11-01T01:30
-ldtAmbiguous = dt.toLocalDateTime('America/Los_Angeles'); // can be ambiguous
+zdtAmbiguous = dt.toZonedDateTime('America/Los_Angeles'); // can be ambiguous
   // => 2020-11-01T01:30-07:00[America/Los_Angeles]
   // note that the offset is now -07:00 (Pacific Daylight Time) which is the "first" 1:30AM
   // not -08:00 (Pacific Standard Time) like the original time which was the "second" 1:30AM
@@ -198,13 +198,13 @@ This mode also matches the behavior of cross-platform standards like [RFC 5545 (
 
 Methods where this option is present include:
 
-- [`Temporal.Date.prototype.toLocalDateTime`](./date.md#toLocalDateTime)
-- [`Temporal.Time.prototype.toLocalDateTime`](./time.md#toLocalDateTime)
-- [`Temporal.DateTime.prototype.toLocalDateTime`](./datetime.md#toLocalDateTime)
+- [`Temporal.Date.prototype.toZonedDateTime`](./date.md#toZonedDateTime)
+- [`Temporal.Time.prototype.toZonedDateTime`](./time.md#toZonedDateTime)
+- [`Temporal.DateTime.prototype.toZonedDateTime`](./datetime.md#toZonedDateTime)
 - [`Temporal.DateTime.prototype.toInstant`](./datetime.md#toInstant)
-- [`Temporal.YearMonth.prototype.toLocalDateTime`](./yearmonth.md#toLocalDateTime)
-- [`Temporal.MonthDay.prototype.toLocalDateTime`](./monthday.md#toLocalDateTime)
-- [`Temporal.TimeZone.prototype.getLocalDateTimeFor`](./timezone.md#getLocalDateTimeFor).
+- [`Temporal.YearMonth.prototype.toZonedDateTime`](./yearmonth.md#toZonedDateTime)
+- [`Temporal.MonthDay.prototype.toZonedDateTime`](./monthday.md#toZonedDateTime)
+- [`Temporal.TimeZone.prototype.getZonedDateTimeFor`](./timezone.md#getZonedDateTimeFor).
 - [`Temporal.TimeZone.prototype.getInstantFor`](./timezone.md#getInstantFor).
 
 ## Examples: DST Disambiguation
@@ -234,13 +234,13 @@ In `'compatible'` mode, the same time is returned as `'later'` mode, which match
 // Different disambiguation modes for times in the skipped clock hour after DST starts in the Spring
 // Offset of -07:00 is Daylight Saving Time, while offset of -08:00 indicates Standard Time.
 props = { timeZone: 'America/Los_Angeles', year: 2020, month: 3, day: 8, hour: 2, minute: 30 };
-ldt = Temporal.LocalDateTime.from(props, { disambiguation: 'compatible' });
+zdt = Temporal.ZonedDateTime.from(props, { disambiguation: 'compatible' });
   // => 2020-03-08T03:30-07:00[America/Los_Angeles]
-ldt = Temporal.LocalDateTime.from(props);
+zdt = Temporal.ZonedDateTime.from(props);
   // => 2020-03-08T03:30-07:00[America/Los_Angeles] ('compatible' is the default)
-earlier = Temporal.LocalDateTime.from(props, { disambiguation: 'earlier' });
+earlier = Temporal.ZonedDateTime.from(props, { disambiguation: 'earlier' });
   // => 2020-03-08T01:30-08:00[America/Los_Angeles] (1:30 clock time; still in Standard Time)
-later = Temporal.LocalDateTime.from(props, { disambiguation: 'later' });
+later = Temporal.ZonedDateTime.from(props, { disambiguation: 'later' });
   // => 2020-03-08T03:30-07:00[America/Los_Angeles] ('later' is same as 'compatible' for backwards transitions)
 later.toDateTime().difference(earlier.toDateTime());
   // => PT2H  (2 hour difference in clock time...
@@ -260,15 +260,15 @@ In `'compatible'` mode, the same time is returned as `'earlier'` mode, which mat
 // Different disambiguation modes for times in the repeated clock hour after DST ends in the Fall
 // Offset of -07:00 is Daylight Saving Time, while offset of -08:00 indicates Standard Time.
 props = { timeZone: 'America/Los_Angeles', year: 2020, month: 11, day: 1, hour: 1, minute: 30 };
-ldt = Temporal.LocalDateTime.from(props, { disambiguation: 'compatible' });
+zdt = Temporal.ZonedDateTime.from(props, { disambiguation: 'compatible' });
   // => 2020-11-01T01:30-07:00[America/Los_Angeles]
-ldt = Temporal.LocalDateTime.from(props);
+zdt = Temporal.ZonedDateTime.from(props);
   // => 2020-11-01T01:30-07:00[America/Los_Angeles]
   // 'compatible' is the default.
-earlier = Temporal.LocalDateTime.from(props, { disambiguation: 'earlier' });
+earlier = Temporal.ZonedDateTime.from(props, { disambiguation: 'earlier' });
   // => 2020-11-01T01:30-07:00[America/Los_Angeles] 
   // 'earlier' is same as 'compatible' for backwards transitions.
-later = Temporal.LocalDateTime.from(props, { disambiguation: 'later' });
+later = Temporal.ZonedDateTime.from(props, { disambiguation: 'later' });
   // => 2020-11-01T01:30-08:00[America/Los_Angeles] 
   // Same clock time, but one hour later.
   // -08:00 offset indicates Standard Time.
@@ -289,7 +289,7 @@ But computers sometimes store data about the future!
 For example, a calendar app might record that a user wants to be reminded of a friend's birthday next year.
 
 When date/time data for future times is stored with both the offset and the time zone, and if the time zone definition changes, then it's possible that the new time zone definition may conflict with previously-stored data.
-In this case, then the `offset` option to [`Temporal.LocalDateTime.from`](./localdatetime.md#from) is used to resolve the conflict:
+In this case, then the `offset` option to [`Temporal.ZonedDateTime.from`](./zoneddatetime.md#from) is used to resolve the conflict:
 
 - `'use'`: Evaluate date/time values using the time zone offset if it's provided in the input.
   This will keep the exact time unchanged even if local time will be different than what was originally stored.
@@ -301,16 +301,16 @@ In this case, then the `offset` option to [`Temporal.LocalDateTime.from`](./loca
   See the documentation of `with()` for more details about why this option is used.
 - `'reject'`: Throw a `RangeError` if the offset is not valid for the provided date and time in the provided time zone.
 
-The default is `reject` for [`Temporal.LocalDateTime.from`](./localdatetime.md#from) because there is no obvious default solution.
+The default is `reject` for [`Temporal.ZonedDateTime.from`](./zoneddatetime.md#from) because there is no obvious default solution.
 Instead, the developer needs to decide how to fix the now-invalid data.
 
-For [`Temporal.LocalDateTime.with`](./localdatetime.md#with) the default is `'prefer'`.
+For [`Temporal.ZonedDateTime.with`](./zoneddatetime.md#with) the default is `'prefer'`.
 This default is helpful to prevent DST disambiguation from causing unexpected one-hour changes in exact time after making small changes to clock time fields.
-For example, if a [`Temporal.LocalDateTime`](./localdatetime.md) is set to the "second" 1:30AM on a day where the 1-2AM clock hour is repeated after a backwards DST transition, then calling `.with({minute: 45})` will result in an ambiguity which is resolved using the default `offset: 'prefer'` option.
+For example, if a [`Temporal.ZonedDateTime`](./zoneddatetime.md) is set to the "second" 1:30AM on a day where the 1-2AM clock hour is repeated after a backwards DST transition, then calling `.with({minute: 45})` will result in an ambiguity which is resolved using the default `offset: 'prefer'` option.
 Because the existing offset is valid for the new time, it will be retained so the result will be the "second" 1:45AM.
 However, if the existing offset is not valid for the new result (e.g. `.with({hour: 0})`), then the default behavior will change the offset to match the new local time in that time zone.
 
-Note that offset vs. timezone conflicts only matter for [`Temporal.LocalDateTime`](./localdatetime.md) because no other Temporal type accepts both an IANA time zone and a time zone offset as an input to any method.
+Note that offset vs. timezone conflicts only matter for [`Temporal.ZonedDateTime`](./zoneddatetime.md) because no other Temporal type accepts both an IANA time zone and a time zone offset as an input to any method.
 For example, [`Temporal.Instant.from`](./instant.md#from) will never run into conflicts because the [`Temporal.Instant`](./instant.md) type ignores the time sone in the input and only uses the offset.
 
 ## Examples: `offset` option
@@ -319,13 +319,13 @@ The primary reason to use the `offset` option is for parsing values which were s
 For example, Brazil stopped observing Daylight Saving Time in 2019, with the final transition out of DST on February 16, 2019.
 The change to stop DST permanently was announced in April 2019.
 Now imagine that an app running in 2018 (before these changes were announced) had saved a far-future time in a string format that contained both offset and IANA time zone.
-Such a format is used by [`Temporal.LocalDateTime.prototype.toString`](./localdatetime.md#toString) as well as other platforms and libraries that use the same format like [`Java.time.ZonedDateTime`](https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.md).
+Such a format is used by [`Temporal.ZonedDateTime.prototype.toString`](./zoneddatetime.md#toString) as well as other platforms and libraries that use the same format like [`Java.time.ZonedDateTime`](https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.md).
 Let's assume the stored future time was noon on January 15, 2020 in São Paulo:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from({ year: 2020, month: 1, day: 15, hour: 12, timeZone: 'America/Sao_Paulo' });
-ldt.toString();
+zdt = Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 15, hour: 12, timeZone: 'America/Sao_Paulo' });
+zdt.toString();
   // => "2020-01-15T12:00-02:00[America/Sao_Paulo]"
   // Assume this string is saved in an external database.
   // Note that the offset is `-02:00` which is Daylight Saving Time
@@ -345,18 +345,18 @@ The `offset` option helps deal with this case.
 <!-- prettier-ignore-start -->
 ```javascript
 savedUsingOldTzDefinition = '2020-01-01T12:00-02:00[America/Sao_Paulo]'; // string that was saved earlier
-ldt = Temporal.LocalDateTime.from(savedUsingOldTzDefinition);
+zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition);
   // => RangeError: Offset is invalid for '2020-01-01T12:00' in 'America/Sao_Paulo'. Provided: -02:00, expected: -03:00.
   // Default is to throw when the offset and time zone conflict.
-ldt = Temporal.LocalDateTime.from(savedUsingOldTzDefinition, { offset: 'reject' });
+zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition, { offset: 'reject' });
   // => RangeError: Offset is invalid for '2020-01-01T12:00' in 'America/Sao_Paulo'. Provided: -02:00, expected: -03:00.
-ldt = Temporal.LocalDateTime.from(savedUsingOldTzDefinition, { offset: 'use' });
+zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition, { offset: 'use' });
   // => 2020-01-15T11:00-03:00[America/Sao_Paulo]
   // Evaluate DateTime value using old offset, which keeps UTC time constant as local time changes to 11:00
-ldt = Temporal.LocalDateTime.from(savedUsingOldTzDefinition, { offset: 'ignore' });
+zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition, { offset: 'ignore' });
   // => 2020-01-15T12:00-03:00[America/Sao_Paulo]
   // Use current time zone rules to calculate offset, ignoring any saved offset
-ldt = Temporal.LocalDateTime.from(savedUsingOldTzDefinition, { offset: 'prefer' });
+zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition, { offset: 'prefer' });
   // => 2020-01-15T12:00-03:00[America/Sao_Paulo]
   // Saved offset is invalid for current time zone rules, so use time zone to to calculate offset.
 ```

--- a/docs/date.md
+++ b/docs/date.md
@@ -578,7 +578,7 @@ This method overrides `Object.prototype.valueOf()` and always throws an exceptio
 This is because it's not possible to compare `Temporal.Date` objects with the relational operators `<`, `<=`, `>`, or `>=`.
 Use `Temporal.Date.compare()` for this, or `date.equals()` for equality.
 
-### date.**toLocalDateTime**(_timeZone_: _timeZone_ : object | string, _time_?: Temporal.Time, _options_?: object) : Temporal.LocalDateTime
+### date.**toZonedDateTime**(_timeZone_: _timeZone_ : object | string, _time_?: Temporal.Time, _options_?: object) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -590,9 +590,9 @@ Use `Temporal.Date.compare()` for this, or `date.equals()` for equality.
     Allowed values are `'compatible'`, `'earlier'`, `'later'`, and `'reject'`.
     The default is `'compatible'`.
 
-**Returns:** a `Temporal.LocalDateTime` object that represents the wall-clock time `time` on the calendar date `date` projected into `timeZone`.
+**Returns:** a `Temporal.ZonedDateTime` object that represents the wall-clock time `time` on the calendar date `date` projected into `timeZone`.
 
-This method can be used to convert `Temporal.Date` into a `Temporal.LocalDateTime`, by supplying the time zone and time of day.
+This method can be used to convert `Temporal.Date` into a `Temporal.ZonedDateTime`, by supplying the time zone and time of day.
 The default `time`, if it's not provided, is the first valid local time in `timeZone` on the calendar date `date`.
 Usually this is midnight (`00:00`), but may be a different time in rare circumstances like DST starting at midnight or calendars like `ethiopic` where each day doesn't start at midnight.
 
@@ -600,7 +600,7 @@ For a list of IANA time zone names, see the current version of the [IANA time zo
 A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
 
 In addition to the `timeZone`, the converted object carries a copy of all the relevant fields of `date` and `time`.
-If `time` is given, this method is exactly equivalent to [`time.toLocalDateTime(date)`](./time.html#toLocalDateTime).
+If `time` is given, this method is exactly equivalent to [`time.toZonedDateTime(date)`](./time.html#toZonedDateTime).
 
 In the case of ambiguity caused by DST or other time zone changes, the `disambiguation` option controls how to resolve the ambiguity:
 
@@ -613,19 +613,19 @@ When interoperating with existing code or services, `'compatible'` mode matches 
 This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
 
 During "skipped" clock time like the hour after DST starts in the Spring, this method interprets invalid times using the pre-transition time zone offset if `'compatible'` or `'later'` is used or the post-transition time zone offset if `'earlier'` is used.
-This behavior avoids exceptions when converting non-existent date/time values to `Temporal.LocalDateTime`, but it also means that values during these periods will result in a different `Temporal.Date` value in "round-trip" conversions to `Temporal.LocalDateTime` and back again.
+This behavior avoids exceptions when converting non-existent date/time values to `Temporal.ZonedDateTime`, but it also means that values during these periods will result in a different `Temporal.Date` value in "round-trip" conversions to `Temporal.ZonedDateTime` and back again.
 
 For usage examples and a more complete explanation of how this disambiguation works and why it is necessary, see [Resolving ambiguity](./ambiguity.md).
 
-If the result is earlier or later than the range that `Temporal.LocalDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
+If the result is earlier or later than the range that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
 
 Usage example:
 
 ```javascript
 date = Temporal.Date.from('2006-08-24');
 time = Temporal.Time.from('15:23:30.003');
-date.toLocalDateTime('America/Los_Angeles', time); // => 2006-08-24T15:23:30.003-07:00[America/Los_Angeles]
-date.toLocalDateTime('America/Los_Angeles'); // => 2006-08-24T00:00-07:00[America/Los_Angeles]
+date.toZonedDateTime('America/Los_Angeles', time); // => 2006-08-24T15:23:30.003-07:00[America/Los_Angeles]
+date.toZonedDateTime('America/Los_Angeles'); // => 2006-08-24T00:00-07:00[America/Los_Angeles]
 ```
 
 ### date.**toDateTime**(_time_?: Temporal.Time) : Temporal.DateTime

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -677,7 +677,7 @@ The `locales` and `options` arguments are the same as in the constructor to [`In
 
 > **NOTE**: Unlike in [`Temporal.Instant.prototype.toLocaleString()`](./instant.html#toLocaleString), `options.timeZone` will have no effect, because `Temporal.DateTime` carries no time zone information.
 > It's not always possible to uniquely determine the localized time zone name using the `Temporal.DateTime` instance and the `options.timeZone`.
-> Therefore, to display a localized date and time including its time zone, convert the `Temporal.DateTime` to a `Temporal.LocalDateTime` or `Temporal.Instant` and then call the `toLocaleString()` method.
+> Therefore, to display a localized date and time including its time zone, convert the `Temporal.DateTime` to a `Temporal.ZonedDateTime` or `Temporal.Instant` and then call the `toLocaleString()` method.
 
 Example usage:
 
@@ -733,7 +733,7 @@ This method overrides `Object.prototype.valueOf()` and always throws an exceptio
 This is because it's not possible to compare `Temporal.DateTime` objects with the relational operators `<`, `<=`, `>`, or `>=`.
 Use `Temporal.DateTime.compare()` for this, or `datetime.equals()` for equality.
 
-### datetime.**toLocalDateTime**(_timeZone_ : object | string, _options_?: object) : Temporal.LocalDateTime
+### datetime.**toZonedDateTime**(_timeZone_ : object | string, _options_?: object) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -744,10 +744,10 @@ Use `Temporal.DateTime.compare()` for this, or `datetime.equals()` for equality.
     Allowed values are `'compatible'`, `'earlier'`, `'later'`, and `'reject'`.
     The default is `'compatible'`.
 
-**Returns:** A `Temporal.LocalDateTime` object representing the calendar date and wall-clock time from `dateTime` projected into `timeZone`.
+**Returns:** A `Temporal.ZonedDateTime` object representing the calendar date and wall-clock time from `dateTime` projected into `timeZone`.
 
-This method is one way to convert a `Temporal.DateTime` to a `Temporal.LocalDateTime`.
-It is identical to [`(Temporal.TimeZone.from(timeZone)).getLocalDateTimeFor(dateTime, disambiguation)`](./timezone.html#getLocalDateTimeFor).
+This method is one way to convert a `Temporal.DateTime` to a `Temporal.ZonedDateTime`.
+It is identical to [`(Temporal.TimeZone.from(timeZone)).getZonedDateTimeFor(dateTime, disambiguation)`](./timezone.html#getZonedDateTimeFor).
 
 For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
 A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
@@ -763,11 +763,11 @@ When interoperating with existing code or services, `'compatible'` mode matches 
 This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
 
 During "skipped" clock time like the hour after DST starts in the Spring, this method interprets invalid times using the pre-transition time zone offset if `'compatible'` or `'later'` is used or the post-transition time zone offset if `'earlier'` is used.
-This behavior avoids exceptions when converting non-existent `Temporal.DateTime` values to `Temporal.LocalDateTime`, but it also means that values during these periods will result in a different `Temporal.DateTime` in "round-trip" conversions to `Temporal.LocalDateTime` and back again.
+This behavior avoids exceptions when converting non-existent `Temporal.DateTime` values to `Temporal.ZonedDateTime`, but it also means that values during these periods will result in a different `Temporal.DateTime` in "round-trip" conversions to `Temporal.ZonedDateTime` and back again.
 
 For usage examples and a more complete explanation of how this disambiguation works and why it is necessary, see [Resolving ambiguity](./ambiguity.md).
 
-If the result is earlier or later than the range that `Temporal.LocalDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
+If the result is earlier or later than the range that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
 
 ### datetime.**toInstant**(_timeZone_ : object | string, _options_?: object) : Temporal.Instant
 

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -225,7 +225,7 @@ Same as `getEpochSeconds()`, but with nanosecond (10<sup>&minus;9</sup> second) 
 
 The value returned from this method is suitable to be passed to `new Temporal.Instant()`.
 
-### instant.**toLocalDateTime**(_timeZone_: object | string, _calendar_?: object | string) : Temporal.LocalDateTime
+### instant.**toZonedDateTime**(_timeZone_: object | string, _calendar_?: object | string) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -233,7 +233,7 @@ The value returned from this method is suitable to be passed to `new Temporal.In
 - `calendar` (optional object or string): A `Temporal.Calendar` object, or a plain object, or a calendar identifier.
   The default is to use the ISO 8601 calendar.
 
-**Returns:** a `Temporal.LocalDateTime` object representing the calendar date, wall-clock time, time zone offset, and `timeZone`, according to the reckoning of `calendar`, at the exact time indicated by `instant`.
+**Returns:** a `Temporal.ZonedDateTime` object representing the calendar date, wall-clock time, time zone offset, and `timeZone`, according to the reckoning of `calendar`, at the exact time indicated by `instant`.
 
 For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
 A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
@@ -252,7 +252,7 @@ timestamp.toDateTime('-08:00'); // => 2019-03-30T16:45-08:00[-08:00]
 // What time was the Unix epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA)?
 epoch = Temporal.Instant.fromEpochSeconds(0);
 tz = Temporal.TimeZone.from('America/New_York');
-epoch.toLocalDateTime(tz); // => 1969-12-31T19:00-05:00[America/New_York]
+epoch.toZonedDateTime(tz); // => 1969-12-31T19:00-05:00[America/New_York]
 ```
 
 ### instant.**toDateTime**(_timeZone_: object | string, _calendar_?: object | string) : Temporal.DateTime

--- a/docs/now.md
+++ b/docs/now.md
@@ -9,7 +9,7 @@ The `Temporal.now` object has several methods which give information about the c
 
 ## Methods
 
-### Temporal.now.**localDateTime**(_timeZone_: object | string = Temporal.now.timeZone(), _calendar_: object | string = 'iso8601') : Temporal.DateTime
+### Temporal.now.**zonedDateTime**(_timeZone_: object | string = Temporal.now.timeZone(), _calendar_: object | string = 'iso8601') : Temporal.DateTime
 
 **Parameters:**
 
@@ -18,7 +18,7 @@ The `Temporal.now` object has several methods which give information about the c
 - `calendar` (optional `Temporal.Calendar`, plain object, or string): The calendar system to get the current date and time in.
   If not given, the ISO 8601 calendar will be used.
 
-**Returns:** a `Temporal.LocalDateTime` object representing the current system date, time, time zone, and time zone offset.
+**Returns:** a `Temporal.ZonedDateTime` object representing the current system date, time, time zone, and time zone offset.
 
 This method gets the current date, time, time zone, and time zone offset according to the system settings.
 Optionally a time zone can be given in which the time is computed, and a calendar system in which the date is reckoned.
@@ -32,9 +32,9 @@ financialCentres = {
   London: 'Europe/London',
   Tokyo: 'Asia/Tokyo'
 };
-console.log(`Here: ${Temporal.now.localDateTime()}`);
+console.log(`Here: ${Temporal.now.zonedDateTime()}`);
 Object.entries(financialCentres).forEach(([name, timeZone]) => {
-  console.log(`${name}: ${Temporal.now.localDateTime(timeZone)}`);
+  console.log(`${name}: ${Temporal.now.zonedDateTime(timeZone)}`);
 });
 // example output:
 // Here: 2020-09-18T01:17:48.431957915-07:00[America/Los_Angeles]

--- a/docs/object-model.svg
+++ b/docs/object-model.svg
@@ -89,7 +89,7 @@
       d="M 30103 86120 C 30103 84458 31449 83112 33111 83112 L 216430 83112 C 217228 83112 217993 83428 218557 83993 219122 84557 219439 85322 219439 86120 L 219439 98152 C 219439 99813 218092 101160 216430 101160 L 33111 101160 C 31449 101160 30103 99813 30103 98151 Z"
     />
     <g transform="matrix(381,0,0,381,34641,87564)">
-      <text style="fill: #000" x="179" y="19.2">LocalDateTime</text>
+      <text style="fill: #000" x="179" y="19.2">ZonedDateTime</text>
     </g>
     <g transform="matrix(381,0,0,381,165750,175782)">
       <text style="fill: #737373" x="17" y="17.28">These types have a calendar &amp; know wall-clock time</text>

--- a/docs/time.md
+++ b/docs/time.md
@@ -463,27 +463,27 @@ This method overrides `Object.prototype.valueOf()` and always throws an exceptio
 This is because it's not possible to compare `Temporal.Time` objects with the relational operators `<`, `<=`, `>`, or `>=`.
 Use `Temporal.Time.compare()` for this, or `time.equals()` for equality.
 
-### time.**toLocalDateTime**(_timeZone_: _timeZone_ : object | string, date?: Temporal.Date) : Temporal.LocalDateTime
+### time.**toZonedDateTime**(_timeZone_: _timeZone_ : object | string, date?: Temporal.Date) : Temporal.ZonedDateTime
 
 **Parameters:**
 
 - `timeZone` (optional string or object): The time zone in which to interpret `time` and `date`, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
-- `date` (optional `Temporal.Date`): A date used to merge into a `Temporal.LocalDateTime` along with `time`.
+- `date` (optional `Temporal.Date`): A date used to merge into a `Temporal.ZonedDateTime` along with `time`.
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `disambiguation` (string): How to disambiguate if the date and time given by `time` and `date` does not exist in the time zone, or exists more than once.
     Allowed values are `'compatible'`, `'earlier'`, `'later'`, and `'reject'`.
     The default is `'compatible'`.
 
-**Returns:** a `Temporal.LocalDateTime` object that represents the clock `time` on the calendar `date` projected into `timeZone`.
+**Returns:** a `Temporal.ZonedDateTime` object that represents the clock `time` on the calendar `date` projected into `timeZone`.
 
-This method can be used to convert `Temporal.Time` into a `Temporal.LocalDateTime`, by supplying the time zone and date.
+This method can be used to convert `Temporal.Time` into a `Temporal.ZonedDateTime`, by supplying the time zone and date.
 
 For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
 A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
 
 In addition to the `timeZone`, the converted object carries a copy of all the relevant fields of `time` and `date`.
-This method produces identical results to [`date.toLocalDateTime(time)`](./date.html#toLocalDateTime).
+This method produces identical results to [`date.toZonedDateTime(time)`](./date.html#toZonedDateTime).
 
 In the case of ambiguity caused by DST or other time zone changes, the `disambiguation` option controls how to resolve the ambiguity:
 
@@ -496,18 +496,18 @@ When interoperating with existing code or services, `'compatible'` mode matches 
 This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
 
 During "skipped" clock time like the hour after DST starts in the Spring, this method interprets invalid times using the pre-transition time zone offset if `'compatible'` or `'later'` is used or the post-transition time zone offset if `'earlier'` is used.
-This behavior avoids exceptions when converting non-existent date/time values to `Temporal.LocalDateTime`, but it also means that values during these periods will result in a different `Temporal.Time` value in "round-trip" conversions to `Temporal.LocalDateTime` and back again.
+This behavior avoids exceptions when converting non-existent date/time values to `Temporal.ZonedDateTime`, but it also means that values during these periods will result in a different `Temporal.Time` value in "round-trip" conversions to `Temporal.ZonedDateTime` and back again.
 
 For usage examples and a more complete explanation of how this disambiguation works and why it is necessary, see [Resolving ambiguity](./ambiguity.md).
 
-If the result is earlier or later than the range that `Temporal.LocalDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
+If the result is earlier or later than the range that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
 
 Usage example:
 
 ```javascript
 time = Temporal.Time.from('15:23:30.003');
 date = Temporal.Date.from('2006-08-24');
-time.toLocalDateTime('America/Los_Angeles', date); // => 2006-08-24T15:23:30.003-07:00[America/Los_Angeles]
+time.toZonedDateTime('America/Los_Angeles', date); // => 2006-08-24T15:23:30.003-07:00[America/Los_Angeles]
 ```
 
 ### time.**toDateTime**(_date_: Temporal.Date) : Temporal.DateTime

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -182,7 +182,7 @@ tz = Temporal.TimeZone.from('-08:00');
 tz.getOffsetStringFor(timestamp); // => -08:00
 ```
 
-### timeZone.**getLocalDateTimeFor**(_instant_: Temporal.Instant, _calendar_?: object | string) : Temporal.LocalDateTime
+### timeZone.**getZonedDateTimeFor**(_instant_: Temporal.Instant, _calendar_?: object | string) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -190,9 +190,9 @@ tz.getOffsetStringFor(timestamp); // => -08:00
 - `calendar` (optional object or string): A `Temporal.Calendar` object, or a plain object, or a calendar identifier.
   The default is to use the ISO 8601 calendar.
 
-**Returns:** A `Temporal.LocalDateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the exact time indicated by `instant`.
+**Returns:** A `Temporal.ZonedDateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the exact time indicated by `instant`.
 
-This method is one way to convert a `Temporal.Instant` to a `Temporal.LocalDateTime`.
+This method is one way to convert a `Temporal.Instant` to a `Temporal.ZonedDateTime`.
 
 Example usage:
 
@@ -200,12 +200,12 @@ Example usage:
 // Converting a specific exact time to a calendar date / wall-clock time
 timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
 tz = Temporal.TimeZone.from('Europe/Berlin');
-tz.getLocalDateTimeFor(timestamp); // => 2019-03-31T01:45+02:00[Europe/Berlin]
+tz.getZonedDateTimeFor(timestamp); // => 2019-03-31T01:45+02:00[Europe/Berlin]
 
 // What time was the Unix Epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA)?
 epoch = Temporal.Instant.fromEpochSeconds(0);
 tz = Temporal.TimeZone.from('America/New_York');
-tz.getLocalDateTimeFor(epoch); // => 1969-12-31T19:00-05:00[America/New_York]
+tz.getZonedDateTimeFor(epoch); // => 1969-12-31T19:00-05:00[America/New_York]
 ```
 
 ### timeZone.**getDateTimeFor**(_instant_: Temporal.Instant, _calendar_?: object | string) : Temporal.DateTime

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -300,6 +300,43 @@ inIsoCalendar.withCalendar('japanese').year;
 
 > **NOTE**: The possible values for the `month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
+### zonedDateTime.**epochSeconds**: number
+
+### zonedDateTime.**epochMilliseconds**: number
+
+### zonedDateTime.**epochMicroseconds**: bigint
+
+### zonedDateTime.**epochNanoseconds**: bigint
+
+The above read-only properties return the integer number of full seconds, milliseconds, microseconds, or nanoseconds between `zonedDateTime` and 00:00 UTC on 1970-01-01, otherwise known as the [UNIX Epoch](https://en.wikipedia.org/wiki/Unix_time).
+
+These properties are equivalent to `zonedDateTime.toInstant().epochSeconds`, `zonedDateTime.toInstant().epochMilliseconds`, `zonedDateTime.toInstant().epochMicroseconds`, `zonedDateTime.toInstant().epochNanoseconds`, respectively.
+Any fractional remainders are truncated towards zero.
+The time zone is irrelevant to these properties because time because there is only one epoch, not one per time zone.
+
+Note that the `epochSeconds` and `epochMilliseconds` properties are of type `number` (although only integers are returned) while the `epochMicroseconds` and `epochNanoseconds` are of type `bigint`.
+
+The `epochMilliseconds` property is the easiest way to construct a legacy `Date` object from a `Temporal.ZonedDateTime` instance.
+
+<!-- prettier-ignore-start -->
+```javascript
+zdt = Temporal.ZonedDateTime.from('2020-02-01T12:30+09:00[Asia/Tokyo]');
+epochSecs = zdt.epochSeconds;
+  // => 1580527800
+epochMs = zdt.epochMilliseconds;
+  // => 1580527800000
+zdt.toInstant().epochMilliseconds;
+  // => 1580527800000
+legacyDate = new Date(epochMs);
+  // => Fri Jan 31 2020 19:30:00 GMT-0800 (Pacific Standard Time)
+  // (if the system time zone is America/Los_Angeles)
+epochMicros = zdt.epochMicroseconds;
+  // => 1580527800000000
+epochNanos = sdt.epochNanoseconds;
+  // => 1580527800000000000
+```
+<!-- prettier-ignore-end -->
+
 ### zonedDateTime.**calendar** : object
 
 The `calendar` read-only property gives the calendar used to calculate date/time field values.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -75,7 +75,7 @@ new Temporal.ZonedDateTime(0n, 'America/Los_Angeles')  // same, but shorter
 
 This static method creates a new `Temporal.ZonedDateTime` object from another value.
 If the value is another `Temporal.ZonedDateTime` object, a new but otherwise identical object will be returned.
-If the value is any other object, a `Temporal.ZonedDateTime` will be constructed from the values of any `timeZone`, `timeZoneOffsetNanoseconds`, `era`, `year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`, `microsecond`, `nanosecond`, and/or `calendar` properties that are present.
+If the value is any other object, a `Temporal.ZonedDateTime` will be constructed from the values of any `timeZone`, `offsetNanoseconds`, `era`, `year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`, `microsecond`, `nanosecond`, and/or `calendar` properties that are present.
 At least the `timeZone`, `year`, `month`, and `day` properties must be present. Other properties are optional.
 If `calendar` is missing, it will be assumed to be `Temporal.Calendar.from('iso8601')`.
 Any other missing properties will be assumed to be 0 (for time fields).
@@ -578,25 +578,25 @@ zdt = Temporal.ZonedDateTime.from('2018-11-04T12:00-02:00[America/Sao_Paulo]').s
 ```
 <!-- prettier-ignore-end -->
 
-### zonedDateTime.**isTimeZoneOffsetTransition** : boolean
+### zonedDateTime.**isOffsetTransition** : boolean
 
-The `isTimeZoneOffsetTransition` read-only property is `true` if this `Temporal.ZonedDateTime` instance is immediately after a DST transition or other change in time zone offset, `false` otherwise.
+The `isOffsetTransition` read-only property is `true` if this `Temporal.ZonedDateTime` instance is immediately after a DST transition or other change in time zone offset, `false` otherwise.
 
-"Immediately after" means that subtracting one nanosecond would yield a `Temporal.ZonedDateTime` instance that has a different value for `timeZoneOffsetNanoseconds`.
+"Immediately after" means that subtracting one nanosecond would yield a `Temporal.ZonedDateTime` instance that has a different value for `offsetNanoseconds`.
 In the ISO 8601 calendar, to calculate if a DST transition happens on the same day (but not necessarily at the same time), use `.hoursInDay() !== 24`.
 
 <!-- prettier-ignore-start -->
 ```javascript
-zdt = Temporal.ZonedDateTime.from('2020-11-01T01:00-07:00[America/Denver]').isTimeZoneOffsetTransition;
+zdt = Temporal.ZonedDateTime.from('2020-11-01T01:00-07:00[America/Denver]').isOffsetTransition;
   // => true (DST ended right before this time)
-zdt = Temporal.ZonedDateTime.from('2020-11-01T01:00-07:00[America/Phoenix]').isTimeZoneOffsetTransition;
+zdt = Temporal.ZonedDateTime.from('2020-11-01T01:00-07:00[America/Phoenix]').isOffsetTransition;
   // => false (Phoenix doesn't observe DST)
 ```
 <!-- prettier-ignore-end -->
 
-### zonedDateTime.**timeZoneOffsetNanoseconds** : number
+### zonedDateTime.**offsetNanoseconds** : number
 
-The `timeZoneOffsetNanoseconds` read-only property is the offset (in nanoseconds) relative to UTC of `zonedDateTime`.
+The `offsetNanoseconds` read-only property is the offset (in nanoseconds) relative to UTC of `zonedDateTime`.
 
 The value of this field will change after DST transitions or after political changes to a time zone, e.g. a country switching to a new time zone.
 
@@ -610,36 +610,36 @@ minus8Hours = -8 * 3600 * 1e9;
 daylightTime0130 = Temporal.ZonedDateTime.from('2020-11-01T01:30-07:00[America/Los_Angeles]');
   // => 2020-11-01T01:30-07:00[America/Los_Angeles]
   // This is Pacific Daylight Time 1:30AM
-repeated0130 = daylightTime0130.with({ timeZoneOffsetNanoseconds: minus8Hours });
+repeated0130 = daylightTime0130.with({ offsetNanoseconds: minus8Hours });
   // => 2020-11-01T01:30-08:00[America/Los_Angeles]
   // This is Pacific Standard Time 1:30AM
-const { timeZoneOffsetNanoseconds, ...otherFields } = repeated0130.getFields();
+const { offsetNanoseconds, ...otherFields } = repeated0130.getFields();
 zdt = Temporal.ZonedDateTime.from(otherFields, { disambiguation: 'earlier' });
   // => 2020-11-01T01:30-07:00[America/Los_Angeles]
-zdt = Temporal.ZonedDateTime.from({ ...otherFields, timeZoneOffsetNanoseconds }, { disambiguation: 'earlier' });
+zdt = Temporal.ZonedDateTime.from({ ...otherFields, offsetNanoseconds }, { disambiguation: 'earlier' });
   // => 2020-11-01T01:30-08:00[America/Los_Angeles]
-  // Note that the `{disambiguation: 'earlier'}` option is ignored because `timeZoneOffsetNanoseconds`
+  // Note that the `{disambiguation: 'earlier'}` option is ignored because `offsetNanoseconds`
   // is included in the input so the result is not ambiguous.
 ```
 <!-- prettier-ignore-end -->
 
-### zonedDateTime.**timeZoneOffsetString** : number
+### zonedDateTime.**offsetString** : number
 
-The `timeZoneOffsetString` read-only property is the offset (formatted as a string) relative to UTC of the current time zone and exact instant. Examples: `'-08:00'` or `'+05:30'`
+The `offsetString` read-only property is the offset (formatted as a string) relative to UTC of the current time zone and exact instant. Examples: `'-08:00'` or `'+05:30'`
 
 The format used is defined in the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) standard.
 
 The value of this field will change after DST transitions or after political changes to a time zone, e.g. a country switching to a new time zone.
 
-Note that when setting the offset using `with` (or `from` using an property bag object instead of a string), the only way to set the time zone offset is via the `timeZoneOffsetNanoseconds` field.
+Note that when setting the offset using `with` (or `from` using an property bag object instead of a string), the only way to set the time zone offset is via the `offsetNanoseconds` field.
 String values are not accepted for offsets in these cases, nor is this property emitted by `.getFields()`.
 
 <!-- prettier-ignore-start -->
 ```javascript
 zdt = Temporal.ZonedDateTime.from('2020-11-01T01:30-07:00[America/Los_Angeles]');
-zdt.timeZoneOffsetString;
+zdt.offsetString;
   // => "-07:00"
-zdt.with({ timeZone: 'Asia/Kolkata' }).timeZoneOffsetString;
+zdt.with({ timeZone: 'Asia/Kolkata' }).offsetString;
   // => "+05:30"
 ```
 <!-- prettier-ignore-end -->
@@ -654,7 +654,7 @@ zdt.with({ timeZone: 'Asia/Kolkata' }).timeZoneOffsetString;
   - All date/time fields
   - `calendar` as a calendar identifier string like `japanese` or `iso8601`, a `Temporal.Calendar` instance, or a `Temporal.CalendarProtocol` object
   - `timeZone` as a time zone identifier string like `Europe/Paris`, a `Temporal.TimeZone` instance, or a `Temporal.TimeZoneProtocol` object.
-  - `timezoneOffsetNanoseconds` to uniquely identify a time that's ambiguous or invalid due to DST.
+  - `offsetNanoseconds` to uniquely identify a time that's ambiguous or invalid due to DST.
 - `options` (optional object): An object which may have some or all of the following properties:
   - `overflow` (string): How to deal with out-of-range values.
     Allowed values are `'constrain'` and `'reject'`.
@@ -687,7 +687,7 @@ const sameInstantInOtherTz = zdt.with({ timeZone: 'Europe/London' });
 const newTzSameLocalTime = zdt.toDateTime().toZonedDateTime('Europe/London');
 ```
 
-Some input values can cause conflict between the `timezoneOffsetNanoseconds` field and the `timeZone` field.
+Some input values can cause conflict between the `offsetNanoseconds` field and the `timeZone` field.
 This can happen when either of these fields are included in the input, and can also happen when setting date/time values on the opposite side of a time zone offset transition like DST starting or ending.
 The `offset` option can resolve this offset vs. time zone conflict or ambiguity.
 
@@ -700,7 +700,7 @@ However, if the existing offset is not valid for the new result (e.g. `.with({ho
 Options on `with` behave identically to options on `from`, with only the following exceptions:
 
 - The default for `offset` is `'prefer'` to support the use case described above.
-- If the input's `timeZone` field is both provided and has a different ID than the current object, then the object's current `timeZoneOffsetNanoseconds` field will be ignored regardless of the `offset` option chosen.
+- If the input's `timeZone` field is both provided and has a different ID than the current object, then the object's current `offsetNanoseconds` field will be ignored regardless of the `offset` option chosen.
 
 Please see the documentation of `from` for more details on options behavior.
 
@@ -1028,7 +1028,7 @@ If you don't need to know the order in which two events occur, then this functio
 But both methods do the same thing, so a `0` returned from `compare` implies a `true` result from `equals`, and vice-versa.
 
 Note that two `Temporal.ZonedDateTime` instances can have the same clock time, time zone, and calendar but still be unequal, e.g. when a clock hour is repeated after DST ends in the Fall.
-In this case, the two instances will have different `timeZoneOffsetNanoseconds` field values.
+In this case, the two instances will have different `offsetNanoseconds` field values.
 
 To ignore calendars, convert both instances to use the ISO 8601 calendar:
 
@@ -1199,7 +1199,7 @@ zdt.toTime(); // => 03:24:30
 
 ### zonedDateTime.**getFields**() : { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: object, [propName: string]: unknown }
 
-**Returns:** a plain object with properties equal to the fields of `zonedDateTime`, including all date/time fields (expressed in the current calendar) as well as the `calendar`, `timeZone`, and `timeZoneOffsetNanoseconds` properties.
+**Returns:** a plain object with properties equal to the fields of `zonedDateTime`, including all date/time fields (expressed in the current calendar) as well as the `calendar`, `timeZone`, and `offsetNanoseconds` properties.
 
 This method can be used to convert a `Temporal.ZonedDateTime` into a record-like data structure.
 It returns a new plain JavaScript object, with all the fields as enumerable, writable, own data properties.
@@ -1228,7 +1228,7 @@ const thisWillWork = { ...zdt.getFields(), hour: 12 };
 JSON.stringify(thisWillWork, undefined, 2);
 // => "{
 //   "timeZone": "America/Los_Angeles",
-//   "timeZoneOffsetNanoseconds": -28800000000000,
+//   "offsetNanoseconds": -28800000000000,
 //   "day": 7,
 //   "hour": 12,    // note that `hour` has been updated
 //   "microsecond": 3,
@@ -1244,7 +1244,7 @@ JSON.stringify(thisWillWork, undefined, 2);
 
 ### zonedDateTime.**getISOFields**(): { isoYear: number, isoMonth: number, isoDay: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: object }
 
-**Returns:** a plain object with properties expressing `zonedDateTime` in the ISO 8601 calendar, including all date/time fields as well as the `calendar`, `timeZone`, and `timeZoneOffsetNanoseconds` properties.
+**Returns:** a plain object with properties expressing `zonedDateTime` in the ISO 8601 calendar, including all date/time fields as well as the `calendar`, `timeZone`, and `offsetNanoseconds` properties.
 Note that date/time properties have different names with an `iso` prefix to better differentiate from "normal" `getFields` results.
 
 This is an advanced method that's mainly useful if you are implementing a custom calendar.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1,18 +1,17 @@
-# Temporal.LocalDateTime
+# Temporal.ZonedDateTime
 
 <details>
   <summary><strong>Table of Contents</strong></summary>
 <!-- toc -->
 </details>
 
-> **NOTE**: This type has been approved and will be merged soon (probably early October 2020), but it's not in current builds yet.
-> Also, "LocalDateTime" is a placeholder name. Its final name is being discussed [here](https://github.com/tc39/proposal-temporal/issues/707).
+> **NOTE**: This type has been approved and will be merged soon (targeting late October 2020), but it's not in current builds yet.
 > If you have feedback about this new type, visit https://github.com/tc39/proposal-temporal/issues/700.
 
-A `Temporal.LocalDateTime` is a time-zone-aware, calendar-aware date/time type that represents a real event that has happened (or will happen) at a particular instant in a real place on Earth.
-As the broadest `Temporal` type, `Temporal.LocalDateTime` can be considered a combination of `Temporal.TimeZone`, `Temporal.Instant`, and `Temporal.DateTime` (which includes `Temporal.Calendar`).
+A `Temporal.ZonedDateTime` is a timezone-aware, calendar-aware date/time type that represents a real event that has happened (or will happen) at a particular instant from the perspective of a particular region on Earth.
+As the broadest `Temporal` type, `Temporal.ZonedDateTime` can be considered a combination of `Temporal.TimeZone`, `Temporal.Instant`, and `Temporal.DateTime` (which includes `Temporal.Calendar`).
 
-As the only `Temporal` type that persists a time zone, `Temporal.LocalDateTime` is optimized for use cases that require a time zone:
+As the only `Temporal` type that persists a time zone, `Temporal.ZonedDateTime` is optimized for use cases that require a time zone:
 
 - Arithmetic automatically adjusts for Daylight Saving Time, using the rules defined in [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545) and adopted in other libraries like moment.js.
 - Creating derived values (e.g. change time to 2:30AM) can avoid worrying that the result will be invalid due to the time zone's DST rules.
@@ -22,14 +21,14 @@ As the only `Temporal` type that persists a time zone, `Temporal.LocalDateTime` 
   This behavior is also be helpful for developers who are not sure which of those components will be needed by later readers of this data.
 - Multiple time-zone-sensitive operations can be performed in a chain without having to repeatedly provide the same time zone.
 
-A `Temporal.LocalDateTime` instance can be losslessly converted into every other `Temporal` type except `Temporal.Duration`.
+A `Temporal.ZonedDateTime` instance can be losslessly converted into every other `Temporal` type except `Temporal.Duration`.
 `Temporal.Instant`, `Temporal.DateTime`, `Temporal.Date`, `Temporal.Time`, `Temporal.YearMonth`, and `Temporal.MonthDay` all carry less information and can be used when complete information is not required.
 
-The `Temporal.LocalDateTime` API is a superset of `Temporal.DateTime`, which makes it easy to port code back and forth between the two types as needed. Because `Temporal.DateTime` is not aware of time zones, in use cases where the time zone is known it's recommended to use `Temporal.LocalDateTime` which will automatically adjust for DST and can convert easily to `Temporal.Instant` without having to re-specify the time zone.
+The `Temporal.ZonedDateTime` API is a superset of `Temporal.DateTime`, which makes it easy to port code back and forth between the two types as needed. Because `Temporal.DateTime` is not aware of time zones, in use cases where the time zone is known it's recommended to use `Temporal.ZonedDateTime` which will automatically adjust for DST and can convert easily to `Temporal.Instant` without having to re-specify the time zone.
 
 ## Constructor
 
-### **new Temporal.LocalDateTime**(_epochNanoseconds_: bigint, _timeZone_: string | object, _calendar_: string | object) : Temporal.LocalDateTime
+### **new Temporal.ZonedDateTime**(_epochNanoseconds_: bigint, _timeZone_: string | object, _calendar_: string | object) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -37,10 +36,10 @@ The `Temporal.LocalDateTime` API is a superset of `Temporal.DateTime`, which mak
 - `timeZone` (`Temporal.TimeZone` or plain object): The time zone in which the event takes place.
 - `calendar` (optional `Temporal.Calendar` or plain object): Calendar used to interpret dates and times. Usually set to `'iso8601'`.
 
-**Returns:** a new `Temporal.LocalDateTime` object.
+**Returns:** a new `Temporal.ZonedDateTime` object.
 
 Like all `Temporal` constructors, this constructor is an advanced API used to create instances for a narrow set of use cases.
-Instead of the constructor, `Temporal.LocalDateTime.from()` is preferred instead because it accepts more kinds of input and provides options for handling ambiguity and overflow.
+Instead of the constructor, `Temporal.ZonedDateTime.from()` is preferred instead because it accepts more kinds of input and provides options for handling ambiguity and overflow.
 
 The range of allowed values for this type is the same as the old-style JavaScript `Date`: 100 million (10<sup>8</sup>) days before or after the Unix epoch.
 This range covers approximately half a million years. If `epochNanoseconds` is outside of this range, a `RangeError` will be thrown.
@@ -49,14 +48,14 @@ Usage examples:
 
 ```javascript
 // UNIX epoch in California
-new Temporal.LocalDateTime(0n, Temporal.TimeZone.from('America/Los_Angeles), Temporal.Calendar.from('iso8601'))
+new Temporal.ZonedDateTime(0n, Temporal.TimeZone.from('America/Los_Angeles), Temporal.Calendar.from('iso8601'))
   // => 1969-12-31T16:00-08:00[America/Los_Angeles]
-new Temporal.LocalDateTime(0n, 'America/Los_Angeles')  // same, but shorter
+new Temporal.ZonedDateTime(0n, 'America/Los_Angeles')  // same, but shorter
 ```
 
 ## Static methods
 
-### Temporal.LocalDateTime.**from**(_thing_: any, _options_?: object) : Temporal.LocalDateTime
+### Temporal.ZonedDateTime.**from**(_thing_: any, _options_?: object) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -65,18 +64,18 @@ new Temporal.LocalDateTime(0n, 'America/Los_Angeles')  // same, but shorter
   - `overflow` (string): How to deal with out-of-range values in `thing`.
     Allowed values are `'constrain'` and `'reject'`.
     The default is `'constrain'`.
-  - `disambiguation` (string): How to disambiguate if the date and time given by `localDateTime` does not exist in the time zone, or exists more than once.
+  - `disambiguation` (string): How to disambiguate if the date and time given by `zonedDateTime` does not exist in the time zone, or exists more than once.
     Allowed values are `'compatible'`, `'earlier'`, `'later'`, and `'reject'`.
     The default is `'compatible'`.
   - `offset` (string): How to interpret a provided time zone offset (e.g. `-02:00`) if it conflicts with the provided time zone (e.g. `America/Sao_Paulo`).
     Allowed values are `'use'`, `'ignore'`, `'prefer'`, and `'reject'`.
     The default is `'reject'`.
 
-**Returns:** a new `Temporal.LocalDateTime` object.
+**Returns:** a new `Temporal.ZonedDateTime` object.
 
-This static method creates a new `Temporal.LocalDateTime` object from another value.
-If the value is another `Temporal.LocalDateTime` object, a new but otherwise identical object will be returned.
-If the value is any other object, a `Temporal.LocalDateTime` will be constructed from the values of any `timeZone`, `timeZoneOffsetNanoseconds`, `era`, `year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`, `microsecond`, `nanosecond`, and/or `calendar` properties that are present.
+This static method creates a new `Temporal.ZonedDateTime` object from another value.
+If the value is another `Temporal.ZonedDateTime` object, a new but otherwise identical object will be returned.
+If the value is any other object, a `Temporal.ZonedDateTime` will be constructed from the values of any `timeZone`, `timeZoneOffsetNanoseconds`, `era`, `year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`, `microsecond`, `nanosecond`, and/or `calendar` properties that are present.
 At least the `timeZone`, `year`, `month`, and `day` properties must be present. Other properties are optional.
 If `calendar` is missing, it will be assumed to be `Temporal.Calendar.from('iso8601')`.
 Any other missing properties will be assumed to be 0 (for time fields).
@@ -100,7 +99,7 @@ The time zone ID is always required.
 To parse these string formats, use `Temporal.Instant`:
 
 ```javascript
-Temporal.Instant.from('2020-08-05T20:06:13+0900').toLocalDateTime('Asia/Tokyo', 'iso8601');
+Temporal.Instant.from('2020-08-05T20:06:13+0900').toZonedDateTime('Asia/Tokyo', 'iso8601');
 ```
 
 Usually a named IANA time zone like `Europe/Paris` or `America/Los_Angeles` is used, but there are cases where adjusting for DST or other time zone offset changes is not desired.
@@ -112,12 +111,12 @@ If a non-whole-hour single-offset time zone is needed, the offset can be used as
 ```javascript
 Temporal.Instant.from('2020-08-05T20:06:13+05:45[+05:45]');
 // OR
-Temporal.Instant('2020-08-05T20:06:13+05:45').toLocalDateTime('+05:45', 'iso8601');
+Temporal.Instant('2020-08-05T20:06:13+05:45').toZonedDateTime('+05:45', 'iso8601');
 ```
 
-Note that using `Temporal.LocalDateTime` with a single-offset time zone will not adjust for Daylight Savings Time or other time zone changes.
-Therefore, using offset time zones with `Temporal.LocalDateTime` is relatively unusual.
-Instead of using `Temporal.LocalDateTime` with an offset time zone, it may be easier for most use cases to use `Temporal.DateTime` and/or `Temporal.Instant` instead.
+Note that using `Temporal.ZonedDateTime` with a single-offset time zone will not adjust for Daylight Savings Time or other time zone changes.
+Therefore, using offset time zones with `Temporal.ZonedDateTime` is relatively unusual.
+Instead of using `Temporal.ZonedDateTime` with an offset time zone, it may be easier for most use cases to use `Temporal.DateTime` and/or `Temporal.Instant` instead.
 
 The `overflow` option works as follows:
 
@@ -131,7 +130,7 @@ Additionally, if the result is earlier or later than the range of dates that `Te
 > In `'reject'` mode, this function will throw, so if you have to interoperate with times that may contain leap seconds, don't use `reject`.
 
 If the input contains a time zone offset, in rare cases it's possible for those values to conflict for a particular local date and time.
-For example, this could happen if the definition of a time zone is changed (e.g. to abolish DST) after storing a `Temporal.LocalDateTime` as a string representing a far-future event.
+For example, this could happen if the definition of a time zone is changed (e.g. to abolish DST) after storing a `Temporal.ZonedDateTime` as a string representing a far-future event.
 If the time zone and offset are in conflict, then the `offset` option is used to resolve the conflict:
 
 - `'use'`: Evaluate date/time values using the time zone offset if it's provided in the input.
@@ -162,7 +161,7 @@ When interoperating with existing code or services, `'compatible'` mode matches 
 This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
 
 During "skipped" clock time like the hour after DST starts, this method interprets invalid times using the pre-transition time zone offset if `'compatible'` or `'later'` is used or the post-transition time zone offset if `'earlier'` is used.
-This behavior avoids exceptions when converting non-existent local time values to `Temporal.LocalDateTime`.
+This behavior avoids exceptions when converting non-existent local time values to `Temporal.ZonedDateTime`.
 
 For usage examples and a more complete explanation of how this disambiguation works and why it is necessary, see [Resolving Ambiguity](./ambiguity.md).
 
@@ -174,16 +173,16 @@ If the offset in the input is used, then there is no ambiguity and the `disambig
 Example usage:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30+02:00[Africa/Cairo]');
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30+02:00[Africa/Cairo][c=islamic]');
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30');  // RangeError; time zone ID required
-ldt = Temporal.LocalDateTime.from('1995-12-07T01:24:30Z');  // RangeError; time zone ID required
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30+02:00');  // RangeError; time zone ID required
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30+02:00[+02:00]');  // OK (offset time zone) but rarely used
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30+03:00[Africa/Cairo]');
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00[Africa/Cairo]');
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00[Africa/Cairo][c=islamic]');
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30');  // RangeError; time zone ID required
+zdt = Temporal.ZonedDateTime.from('1995-12-07T01:24:30Z');  // RangeError; time zone ID required
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00');  // RangeError; time zone ID required
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00[+02:00]');  // OK (offset time zone) but rarely used
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+03:00[Africa/Cairo]');
 // => RangeError: Offset is invalid for '1995-12-07T03:24:30' in 'Africa/Cairo'. Provided: +03:00, expected: +02:00.
 
-ldt = Temporal.LocalDateTime.from({
+zdt = Temporal.ZonedDateTime.from({
     timeZone: 'America/Los_Angeles'
     year: 1995,
     month: 12,
@@ -197,22 +196,22 @@ ldt = Temporal.LocalDateTime.from({
 });  // => 1995-12-07T03:24:30.000003500+08:00[America/Los_Angeles]
 
 // Different overflow modes
-ldt = Temporal.LocalDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month: 13, day: 1 }, { overflow: 'constrain' })
+zdt = Temporal.ZonedDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month: 13, day: 1 }, { overflow: 'constrain' })
   // => 2001-12-01T00:00+01:00[Europe/Paris]
-ldt = Temporal.LocalDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month: -1, day: 1 }, { overflow: 'constrain' })
+zdt = Temporal.ZonedDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month: -1, day: 1 }, { overflow: 'constrain' })
   // => 2001-01-01T00:00+01:00[Europe/Paris]
-ldt = Temporal.LocalDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month: 13, day: 1 }, { overflow: 'reject' })
+zdt = Temporal.ZonedDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month: 13, day: 1 }, { overflow: 'reject' })
   // => throws RangeError
-ldt = Temporal.LocalDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month: -1, day: 1 }, { overflow: 'reject' })
+zdt = Temporal.ZonedDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month: -1, day: 1 }, { overflow: 'reject' })
   // => throws RangeError
 ```
 
-### Temporal.LocalDateTime.**compare**(_one_: Temporal.LocalDateTime, _two_: Temporal.LocalDateTime) : number
+### Temporal.ZonedDateTime.**compare**(_one_: Temporal.ZonedDateTime, _two_: Temporal.ZonedDateTime) : number
 
 **Parameters:**
 
-- `one` (`Temporal.LocalDateTime`): First value to compare.
-- `two` (`Temporal.LocalDateTime`): Second value to compare.
+- `one` (`Temporal.ZonedDateTime`): First value to compare.
+- `two` (`Temporal.ZonedDateTime`): Second value to compare.
 
 **Returns:** an integer indicating whether `one` comes before or after or is equal to `two`.
 
@@ -220,7 +219,7 @@ ldt = Temporal.LocalDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month:
 - &minus;1 if `one` is less than `two`
 - 1 if `one` is greater than `two`.
 
-This function can be used to sort arrays of `Temporal.LocalDateTime` objects.
+This function can be used to sort arrays of `Temporal.ZonedDateTime` objects.
 
 Comparison will use exact time, not clock time, because sorting is almost always based on when events happened in the real world.
 Note that during the hour before and after DST ends, sorting of clock time may not match the order the events actually occurred.
@@ -232,12 +231,12 @@ For example:
 
 ```javascript
 arr = [
-  Temporal.LocalDateTime.from('2020-02-01T12:30-05:00[America/Toronto]'),
-  Temporal.LocalDateTime.from('2020-02-01T12:30-05:00[America/New_York]'),
-  Temporal.LocalDateTime.from('2020-02-01T12:30+01:00[Europe/Brussels]'),
-  Temporal.LocalDateTime.from('2020-02-01T12:30+00:00[Europe/London]')
+  Temporal.ZonedDateTime.from('2020-02-01T12:30-05:00[America/Toronto]'),
+  Temporal.ZonedDateTime.from('2020-02-01T12:30-05:00[America/New_York]'),
+  Temporal.ZonedDateTime.from('2020-02-01T12:30+01:00[Europe/Brussels]'),
+  Temporal.ZonedDateTime.from('2020-02-01T12:30+00:00[Europe/London]')
 ];
-sorted = arr.sort(Temporal.LocalDateTime.compare);
+sorted = arr.sort(Temporal.ZonedDateTime.compare);
 JSON.stringify(sorted, undefined, 2);
 // => "[
 //   "2020-02-01T12:30+01:00[Europe/Brussels]",
@@ -248,41 +247,41 @@ JSON.stringify(sorted, undefined, 2);
 ```
 
 Note that in unusual cases like the repeated clock hour after DST ends, values that are later in the real world can be earlier in clock time, or vice versa.
-To sort `Temporal.LocalDateTime` values according to clock time only (which is a very rare use case), convert each value to `Temporal.DateTime`.
+To sort `Temporal.ZonedDateTime` values according to clock time only (which is a very rare use case), convert each value to `Temporal.DateTime`.
 For example:
 
 <!-- prettier-ignore-start -->
 ```javascript
-one = Temporal.LocalDateTime.from('2020-11-01T01:45-07:00[America/Los_Angeles]');
-two = Temporal.LocalDateTime.from('2020-11-01T01:15-08:00[America/Los_Angeles]');
-Temporal.LocalDateTime.compare(one, two);
+one = Temporal.ZonedDateTime.from('2020-11-01T01:45-07:00[America/Los_Angeles]');
+two = Temporal.ZonedDateTime.from('2020-11-01T01:15-08:00[America/Los_Angeles]');
+Temporal.ZonedDateTime.compare(one, two);
   // => -1, because `one` is earlier in the real world
 Temporal.DateTime.compare(one.toDateTime(), two.toDateTime());
   // => 1, because `one` is later in clock time
 Temporal.Instant.compare(one.toInstant(), two.toInstant());
-  // => -1, because `Temporal.Instant` and `Temporal.LocalDateTime` both compare real-world exact times
+  // => -1, because `Temporal.Instant` and `Temporal.ZonedDateTime` both compare real-world exact times
 ```
 <!-- prettier-ignore-end -->
 
 ## Properties
 
-### localDateTime.**year** : number
+### zonedDateTime.**year** : number
 
-### localDateTime.**month** : number
+### zonedDateTime.**month** : number
 
-### localDateTime.**day** : number
+### zonedDateTime.**day** : number
 
-### localDateTime.**hour**: number
+### zonedDateTime.**hour**: number
 
-### localDateTime.**minute**: number
+### zonedDateTime.**minute**: number
 
-### localDateTime.**second**: number
+### zonedDateTime.**second**: number
 
-### localDateTime.**millisecond**: number
+### zonedDateTime.**millisecond**: number
 
-### localDateTime.**microsecond**: number
+### zonedDateTime.**microsecond**: number
 
-### localDateTime.**nanosecond**: number
+### zonedDateTime.**nanosecond**: number
 
 The above read-only properties allow accessing each component of the date or time individually.
 Keep in mind that the values above are dependent on the calendar.
@@ -290,7 +289,7 @@ For example:
 
 <!-- prettier-ignore-start -->
 ```javascript
-inIsoCalendar = Temporal.LocalDateTime.from('2020-02-01T12:30+09:00[Asia/Tokyo]');
+inIsoCalendar = Temporal.ZonedDateTime.from('2020-02-01T12:30+09:00[Asia/Tokyo]');
   // => 2020-02-01T12:30+09:00[Asia/Tokyo]
 inIsoCalendar.year;
   // => 2020
@@ -301,7 +300,7 @@ inIsoCalendar.withCalendar('japanese').year;
 
 > **NOTE**: The possible values for the `month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
-### localDateTime.**calendar** : object
+### zonedDateTime.**calendar** : object
 
 The `calendar` read-only property gives the calendar used to calculate date/time field values.
 Calendar-sensitive values are used in most places, including:
@@ -317,17 +316,17 @@ Calendar-specific date/time values are NOT used in only a few places:
 
 - Extended ISO strings emitted by `.toString()`, because ISO-string date/time values are, by definition, using the ISO 8601 calendar
 - In the values returned by the `getISOFields()` method which is explicitly used to provide ISO 8601 calendar values
-- In arguments to the `Temporal.LocalDateTime` constructor which is used for advanced use cases only
+- In arguments to the `Temporal.ZonedDateTime` constructor which is used for advanced use cases only
 
-### localDateTime.**era** : unknown
+### zonedDateTime.**era** : unknown
 
 The `era` read-only property is `undefined` when using the ISO 8601 calendar.
 It's used for calendar systems like `japanese` that specify an era in addition to the year.
 
-### localDateTime.**timeZone** : Temporal.TimeZoneProtocol
+### zonedDateTime.**timeZone** : Temporal.TimeZoneProtocol
 
-The `timeZone` read-only property represents the persistent time zone of `localDateTime`.
-By storing its time zone, `Temporal.LocalDateTime` is able to use that time zone when deriving other values, e.g. to automatically perform DST adjustment when adding or subtracting time.
+The `timeZone` read-only property represents the persistent time zone of `zonedDateTime`.
+By storing its time zone, `Temporal.ZonedDateTime` is able to use that time zone when deriving other values, e.g. to automatically perform DST adjustment when adding or subtracting time.
 
 If a non-canonical time zone ID is used, it will be normalized by `Temporal` into its canonical name listed in the [IANA time zone database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
@@ -339,40 +338,40 @@ Therefore, using an IANA time zone is recommended wherever possible.
 
 In very rare cases, you may choose to use `UTC` as your time zone ID.
 This is generally not advised because no humans actually live in the UTC time zone; it's just for computers.
-Also, UTC has no DST and always has a zero offset, which means that any action you'd take with `Temporal.LocalDateTime` would return identical results to the same action on `Temporal.DateTime` or `Temporal.Instant`.
+Also, UTC has no DST and always has a zero offset, which means that any action you'd take with `Temporal.ZonedDateTime` would return identical results to the same action on `Temporal.DateTime` or `Temporal.Instant`.
 Therefore, you should almost always use `Temporal.Instant` to represent UTC times.
-When you want to convert UTC time to a real time zone, that's when `Temporal.LocalDateTime` will be useful.
+When you want to convert UTC time to a real time zone, that's when `Temporal.ZonedDateTime` will be useful.
 
 To change the time zone while keeping the exact time constant, use `.with({timeZone})`.
 
-The time zone is a required property when creating `Temporal.LocalDateTime` instances.
+The time zone is a required property when creating `Temporal.ZonedDateTime` instances.
 If you don't know the time zone of your underlying data, please use `Temporal.Instant` and/or `Temporal.DateTime`, neither of which have awareness of time zones.
 
-Although this property is a `Temporal.TimeZoneProtocol` object (which is usually a `Temporal.TimeZone` except custom timezones), it will be automatically coerced to its string form (e.g. `"Europe/Paris"`) when displayed by `console.log`, `JSON.stringify`, `${localDateTime.timeZone}`, or other similar APIs.
+Although this property is a `Temporal.TimeZoneProtocol` object (which is usually a `Temporal.TimeZone` except custom timezones), it will be automatically coerced to its string form (e.g. `"Europe/Paris"`) when displayed by `console.log`, `JSON.stringify`, `${zonedDateTime.timeZone}`, or other similar APIs.
 
 Usage example:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
-`Time zone is: ${ldt.timeZone}`;
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
+`Time zone is: ${zdt.timeZone}`;
   // => "Time zone is: America/Los_Angeles"
-ldt.with({ timeZone: 'Asia/Singapore' }).timeZone;
+zdt.with({ timeZone: 'Asia/Singapore' }).timeZone;
   // => Asia/Singapore
-ldt.with({ timeZone: 'Asia/Chongqing' }).timeZone;
+zdt.with({ timeZone: 'Asia/Chongqing' }).timeZone;
   // => Asia/Shanghai (time zone IDs are normalized, e.g. Asia/Chongqing -> Asia/Shanghai)
-ldt.with({ timeZone: '+05:00' }).timeZone;
+zdt.with({ timeZone: '+05:00' }).timeZone;
   // => +05:00
-ldt.with({ timeZone: '+05' }).timeZone;
+zdt.with({ timeZone: '+05' }).timeZone;
   // => +05:00 (normalized to canonical form)
-ldt.with({ timeZone: 'utc' }).timeZone;
+zdt.with({ timeZone: 'utc' }).timeZone;
   // => UTC (normalized to canonical form which is uppercase)
-ldt.with({ timeZone: 'GMT' }).timeZone;
+zdt.with({ timeZone: 'GMT' }).timeZone;
   // => UTC (normalized to canonical form)
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**dayOfWeek** : number
+### zonedDateTime.**dayOfWeek** : number
 
 The `dayOfWeek` read-only property gives the weekday number that the date falls on.
 For the ISO 8601 calendar, the weekday number is defined as in the ISO 8601 standard: a value between 1 and 7, inclusive, with Monday being 1, and Sunday 7.
@@ -381,11 +380,11 @@ For an overview, see [ISO 8601 on Wikipedia](https://en.wikipedia.org/wiki/ISO_8
 Usage example:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
-['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'][ldt.dayOfWeek - 1]; // => THU
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
+['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'][zdt.dayOfWeek - 1]; // => THU
 ```
 
-### localDateTime.**dayOfYear** : number
+### zonedDateTime.**dayOfYear** : number
 
 The `dayOfYear` read-only property gives the ordinal day of the year that the date falls on.
 For the ISO 8601 calendar, this is a value between 1 and 365, or 366 in a leap year.
@@ -393,12 +392,12 @@ For the ISO 8601 calendar, this is a value between 1 and 365, or 366 in a leap y
 Usage example:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
 // ISO ordinal date
-console.log(ldt.year, ldt.dayOfYear); // => 1995 341
+console.log(zdt.year, zdt.dayOfYear); // => 1995 341
 ```
 
-### localDateTime.**weekOfYear** : number
+### zonedDateTime.**weekOfYear** : number
 
 The `weekOfYear` read-only property gives the ISO week number of the date.
 For the ISO 8601 calendar, this is normally a value between 1 and 52, but in a few cases it can be 53 as well.
@@ -408,12 +407,12 @@ For more information on ISO week numbers, see for example the Wikipedia article 
 Usage example:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
 // ISO week date
-console.log(ldt.year, ldt.weekOfYear, ldt.dayOfWeek); // => 1995 49 4
+console.log(zdt.year, zdt.weekOfYear, zdt.dayOfWeek); // => 1995 49 4
 ```
 
-### localDateTime.**daysInWeek** : number
+### zonedDateTime.**daysInWeek** : number
 
 The `daysInWeek` read-only property gives the number of days in the week that the date falls in.
 For the ISO 8601 calendar, this is always 7, but in other calendar systems it may differ from week to week.
@@ -421,11 +420,11 @@ For the ISO 8601 calendar, this is always 7, but in other calendar systems it ma
 Usage example:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
-ldt.daysInWeek; // => 7
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
+zdt.daysInWeek; // => 7
 ```
 
-### localDateTime.**daysInMonth** : number
+### zonedDateTime.**daysInMonth** : number
 
 The `daysInMonth` read-only property gives the number of days in the month that the date falls in.
 For the ISO 8601 calendar, this is 28, 29, 30, or 31, depending on the month and whether the year is a leap year.
@@ -436,11 +435,11 @@ Usage example:
 // Attempt to write some mnemonic poetry
 const monthsByDays = {};
 for (let month = 1; month <= 12; month++) {
-  const ldt = Temporal.now.localDateTime().with({ month });
-  monthsByDays[ldt.daysInMonth] = (monthsByDays[ldt.daysInMonth] || []).concat(ldt);
+  const zdt = Temporal.now.zonedDateTime().with({ month });
+  monthsByDays[zdt.daysInMonth] = (monthsByDays[zdt.daysInMonth] || []).concat(zdt);
 }
 
-const strings = monthsByDays[30].map((ldt) => ldt.toLocaleString('en', { month: 'long' }));
+const strings = monthsByDays[30].map((zdt) => zdt.toLocaleString('en', { month: 'long' }));
 // Shuffle to improve poem as determined empirically
 strings.unshift(strings.pop());
 const format = new Intl.ListFormat('en');
@@ -449,7 +448,7 @@ const poem = `Thirty days hath ${format.format(strings)}`;
 console.log(poem);
 ```
 
-### localDateTime.**daysInYear** : number
+### zonedDateTime.**daysInYear** : number
 
 The `daysInYear` read-only property gives the number of days in the year that the date falls in.
 For the ISO 8601 calendar, this is 365 or 366, depending on whether the year is a leap year.
@@ -457,13 +456,13 @@ For the ISO 8601 calendar, this is 365 or 366, depending on whether the year is 
 Usage example:
 
 ```javascript
-ldt = Temporal.now.localDateTime();
-percent = ldt.dayOfYear / ldt.daysInYear;
+zdt = Temporal.now.zonedDateTime();
+percent = zdt.dayOfYear / zdt.daysInYear;
 `The year is ${percent.toLocaleString('en', { style: 'percent' })} over!`;
 // example output: "The year is 10% over!"
 ```
 
-### localDateTime.**monthsInYear**: number
+### zonedDateTime.**monthsInYear**: number
 
 The `monthsInYear` read-only property gives the number of months in the year that the date falls in.
 For the ISO 8601 calendar, this is always 12, but in other calendar systems it may differ from year to year.
@@ -471,13 +470,13 @@ For the ISO 8601 calendar, this is always 12, but in other calendar systems it m
 Usage example:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1900-01-01T12:00+09:00[Asia/Tokyo]');
-ldt.monthsInYear; // => 12
+zdt = Temporal.ZonedDateTime.from('1900-01-01T12:00+09:00[Asia/Tokyo]');
+zdt.monthsInYear; // => 12
 ```
 
-### localDateTime.**isLeapYear** : boolean
+### zonedDateTime.**isLeapYear** : boolean
 
-The `isLeapYear` read-only property tells whether the year of this `Temporal.LocalDateTime` is a leap year.
+The `isLeapYear` read-only property tells whether the year of this `Temporal.ZonedDateTime` is a leap year.
 Its value is `true` if the year is a leap year, and `false` if not.
 
 For the ISO calendar, leap years are years evenly divisible by 4, except years evenly divisible by 100 but not evenly divisible by 400.
@@ -487,15 +486,15 @@ Usage example:
 
 ```javascript
 // Is this year a leap year?
-ldt = Temporal.now.localDateTime();
-ldt.isLeapYear; // example output: true
+zdt = Temporal.now.zonedDateTime();
+zdt.isLeapYear; // example output: true
 // Is 2100 a leap year? (no, because it's divisible by 100 and not 400)
-ldt.with({ year: 2100 }).isLeapYear; // => false
+zdt.with({ year: 2100 }).isLeapYear; // => false
 ```
 
-### localDateTime.**hoursInDay** : number
+### zonedDateTime.**hoursInDay** : number
 
-The `hoursInDay` read-only property returns the number of real-world hours between the start of the current day (usually midnight) in `localDateTime.timeZone` to the start of the next calendar day in the same time zone.
+The `hoursInDay` read-only property returns the number of real-world hours between the start of the current day (usually midnight) in `zonedDateTime.timeZone` to the start of the next calendar day in the same time zone.
 Normally days will be 24 hours long, but on days where there are DST changes or other time zone transitions, this property may return 23 or 25.
 In rare cases, other integers or even non-integer values may be returned, e.g. when time zone definitions change by less than one hour.
 
@@ -507,24 +506,24 @@ Usage example:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from('2020-01-01T12:00-08:00[America/Los_Angeles]').hoursInDay;
+zdt = Temporal.ZonedDateTime.from('2020-01-01T12:00-08:00[America/Los_Angeles]').hoursInDay;
   // => 24 (normal day)
-ldt = Temporal.LocalDateTime.from('2020-03-08T12:00-07:00[America/Los_Angeles]').hoursInDay;
+zdt = Temporal.ZonedDateTime.from('2020-03-08T12:00-07:00[America/Los_Angeles]').hoursInDay;
   // => 23 (DST starts on this day)
-ldt = Temporal.LocalDateTime.from('2020-11-01T12:00-08:00[America/Los_Angeles]').hoursInDay;
+zdt = Temporal.ZonedDateTime.from('2020-11-01T12:00-08:00[America/Los_Angeles]').hoursInDay;
   // => 25 (DST ends on this day)
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**startOfDay** : Temporal.LocalDateTime
+### zonedDateTime.**startOfDay** : Temporal.ZonedDateTime
 
-The `startOfDay` read-only property returns a new `Temporal.LocalDateTime` instance representing the earliest valid local clock time during the current calendar day and time zone of `localDateTime`.
+The `startOfDay` read-only property returns a new `Temporal.ZonedDateTime` instance representing the earliest valid local clock time during the current calendar day and time zone of `zonedDateTime`.
 
 The local time of the result is almost always `00:00`, but in rare cases it could be a later time e.g. if DST starts at midnight in a time zone. For example:
 
 ```javascript
-const ldt = Temporal.LocalDateTime.from('2015-10-18T12:00-02:00[America/Sao_Paulo]');
-ldt.startOfDay; // => 2015-10-18T01:00-02:00[America/Sao_Paulo]
+const zdt = Temporal.ZonedDateTime.from('2015-10-18T12:00-02:00[America/Sao_Paulo]');
+zdt.startOfDay; // => 2015-10-18T01:00-02:00[America/Sao_Paulo]
 ```
 
 Also note that some calendar systems (e.g. `ethiopic`) may not start days at `00:00`.
@@ -533,61 +532,61 @@ Usage example:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from('2020-01-01T12:00-08:00[America/Los_Angeles]').startOfDay;
+zdt = Temporal.ZonedDateTime.from('2020-01-01T12:00-08:00[America/Los_Angeles]').startOfDay;
   // => 2020-01-01T00:00-08:00[America/Los_Angeles]
-ldt = Temporal.LocalDateTime.from('2018-11-04T12:00-02:00[America/Sao_Paulo]').startOfDay;
+zdt = Temporal.ZonedDateTime.from('2018-11-04T12:00-02:00[America/Sao_Paulo]').startOfDay;
   // => 2018-11-04T01:00-02:00[America/Sao_Paulo]
   // Note the 1:00AM start time because the first clock hour was skipped due to DST transition
   // that started at midnight.
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**isTimeZoneOffsetTransition** : boolean
+### zonedDateTime.**isTimeZoneOffsetTransition** : boolean
 
-The `isTimeZoneOffsetTransition` read-only property is `true` if this `Temporal.LocalDateTime` instance is immediately after a DST transition or other change in time zone offset, `false` otherwise.
+The `isTimeZoneOffsetTransition` read-only property is `true` if this `Temporal.ZonedDateTime` instance is immediately after a DST transition or other change in time zone offset, `false` otherwise.
 
-"Immediately after" means that subtracting one nanosecond would yield a `Temporal.LocalDateTime` instance that has a different value for `timeZoneOffsetNanoseconds`.
+"Immediately after" means that subtracting one nanosecond would yield a `Temporal.ZonedDateTime` instance that has a different value for `timeZoneOffsetNanoseconds`.
 In the ISO 8601 calendar, to calculate if a DST transition happens on the same day (but not necessarily at the same time), use `.hoursInDay() !== 24`.
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from('2020-11-01T01:00-07:00[America/Denver]').isTimeZoneOffsetTransition;
+zdt = Temporal.ZonedDateTime.from('2020-11-01T01:00-07:00[America/Denver]').isTimeZoneOffsetTransition;
   // => true (DST ended right before this time)
-ldt = Temporal.LocalDateTime.from('2020-11-01T01:00-07:00[America/Phoenix]').isTimeZoneOffsetTransition;
+zdt = Temporal.ZonedDateTime.from('2020-11-01T01:00-07:00[America/Phoenix]').isTimeZoneOffsetTransition;
   // => false (Phoenix doesn't observe DST)
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**timeZoneOffsetNanoseconds** : number
+### zonedDateTime.**timeZoneOffsetNanoseconds** : number
 
-The `timeZoneOffsetNanoseconds` read-only property is the offset (in nanoseconds) relative to UTC of `localDateTime`.
+The `timeZoneOffsetNanoseconds` read-only property is the offset (in nanoseconds) relative to UTC of `zonedDateTime`.
 
 The value of this field will change after DST transitions or after political changes to a time zone, e.g. a country switching to a new time zone.
 
 This field is used to uniquely map date/time fields to an exact date/time in cases where the calendar date and clock time are ambiguous due to time zone offset transitions.
 Therefore, this field is returned by `getFields()` and is accepted by `from` and `with`.
-The presence of this field means that `localDateTime.toInstant()` requires no parameters.
+The presence of this field means that `zonedDateTime.toInstant()` requires no parameters.
 
 <!-- prettier-ignore-start -->
 ```javascript
 minus8Hours = -8 * 3600 * 1e9;
-daylightTime0130 = Temporal.LocalDateTime.from('2020-11-01T01:30-07:00[America/Los_Angeles]');
+daylightTime0130 = Temporal.ZonedDateTime.from('2020-11-01T01:30-07:00[America/Los_Angeles]');
   // => 2020-11-01T01:30-07:00[America/Los_Angeles]
   // This is Pacific Daylight Time 1:30AM
 repeated0130 = daylightTime0130.with({ timeZoneOffsetNanoseconds: minus8Hours });
   // => 2020-11-01T01:30-08:00[America/Los_Angeles]
   // This is Pacific Standard Time 1:30AM
 const { timeZoneOffsetNanoseconds, ...otherFields } = repeated0130.getFields();
-ldt = Temporal.LocalDateTime.from(otherFields, { disambiguation: 'earlier' });
+zdt = Temporal.ZonedDateTime.from(otherFields, { disambiguation: 'earlier' });
   // => 2020-11-01T01:30-07:00[America/Los_Angeles]
-ldt = Temporal.LocalDateTime.from({ ...otherFields, timeZoneOffsetNanoseconds }, { disambiguation: 'earlier' });
+zdt = Temporal.ZonedDateTime.from({ ...otherFields, timeZoneOffsetNanoseconds }, { disambiguation: 'earlier' });
   // => 2020-11-01T01:30-08:00[America/Los_Angeles]
   // Note that the `{disambiguation: 'earlier'}` option is ignored because `timeZoneOffsetNanoseconds`
   // is included in the input so the result is not ambiguous.
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**timeZoneOffsetString** : number
+### zonedDateTime.**timeZoneOffsetString** : number
 
 The `timeZoneOffsetString` read-only property is the offset (formatted as a string) relative to UTC of the current time zone and exact instant. Examples: `'-08:00'` or `'+05:30'`
 
@@ -600,21 +599,21 @@ String values are not accepted for offsets in these cases, nor is this property 
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from('2020-11-01T01:30-07:00[America/Los_Angeles]');
-ldt.timeZoneOffsetString;
+zdt = Temporal.ZonedDateTime.from('2020-11-01T01:30-07:00[America/Los_Angeles]');
+zdt.timeZoneOffsetString;
   // => "-07:00"
-ldt.with({ timeZone: 'Asia/Kolkata' }).timeZoneOffsetString;
+zdt.with({ timeZone: 'Asia/Kolkata' }).timeZoneOffsetString;
   // => "+05:30"
 ```
 <!-- prettier-ignore-end -->
 
 ## Methods
 
-### localDateTime.**with**(_localDateTimeLike_: object, _options_?: object) : Temporal.LocalDateTime
+### zonedDateTime.**with**(_zonedDateTimeLike_: object, _options_?: object) : Temporal.ZonedDateTime
 
 **Parameters:**
 
-- `localDateTimeLike` (object): an object with some or all of the properties of a `Temporal.LocalDateTime`. Accepted fields include:
+- `zonedDateTimeLike` (object): an object with some or all of the properties of a `Temporal.ZonedDateTime`. Accepted fields include:
   - All date/time fields
   - `calendar` as a calendar identifier string like `japanese` or `iso8601`, a `Temporal.Calendar` instance, or a `Temporal.CalendarProtocol` object
   - `timeZone` as a time zone identifier string like `Europe/Paris`, a `Temporal.TimeZone` instance, or a `Temporal.TimeZoneProtocol` object.
@@ -630,15 +629,15 @@ ldt.with({ timeZone: 'Asia/Kolkata' }).timeZoneOffsetString;
     Allowed values are `'prefer'`, `'use'`, `'ignore'`, and `'reject'`.
     The default is `'prefer'`.
 
-**Returns:** a new `Temporal.LocalDateTime` object.
+**Returns:** a new `Temporal.ZonedDateTime` object.
 
-This method creates a new `Temporal.LocalDateTime` which is a copy of `localDateTime`, but any properties present on `localDateTimeLike` override the ones already present on `localDateTime`.
+This method creates a new `Temporal.ZonedDateTime` which is a copy of `zonedDateTime`, but any properties present on `zonedDateTimeLike` override the ones already present on `zonedDateTime`.
 
-Since `Temporal.LocalDateTime` objects are immutable, this method will create a new instance instead of modifying the existing instance.
+Since `Temporal.ZonedDateTime` objects are immutable, this method will create a new instance instead of modifying the existing instance.
 
-If the result is earlier or later than the range of dates that `Temporal.LocalDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
+If the result is earlier or later than the range of dates that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
 
-> **NOTE**: The allowed values for the `localDateTimeLike.month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
+> **NOTE**: The allowed values for the `zonedDateTimeLike.month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
 If a `timeZone` and/or `calendar` field is included with a different ID than the current object's fields, then `with` will first convert all existing fields to the new time zone and/or calendar and then fields in the input will be played on top of the new time zone or calendar.
 This makes `.with({timeZone})` is an easy way to convert to a new time zone while updating the clock time.
@@ -646,9 +645,9 @@ However, to keep clock time as-is while resetting the time zone, use the `.toDat
 
 ```javascript
 // update local time to match new time zone
-const sameInstantInOtherTz = ldt.with({ timeZone: 'Europe/London' });
+const sameInstantInOtherTz = zdt.with({ timeZone: 'Europe/London' });
 // create instance with same local time in a new time zone
-const newTzSameLocalTime = ldt.toDateTime().toLocalDateTime('Europe/London');
+const newTzSameLocalTime = zdt.toDateTime().toZonedDateTime('Europe/London');
 ```
 
 Some input values can cause conflict between the `timezoneOffsetNanoseconds` field and the `timeZone` field.
@@ -657,7 +656,7 @@ The `offset` option can resolve this offset vs. time zone conflict or ambiguity.
 
 Unlike the `from()` method where `offset` defaults to `'reject'`, the offset option in `with` defaults to `'prefer'`.
 This default prevents DST disambiguation from causing unexpected one-hour changes in exact time after making small changes to clock time fields.
-For example, if a `Temporal.LocalDateTime` is set to the "second" 1:30AM on a day where the 1-2AM clock hour is repeated after a backwards DST transition, then calling `.with({minute: 45})` will result in an ambiguity which is resolved using the default `offset: 'prefer'` option.
+For example, if a `Temporal.ZonedDateTime` is set to the "second" 1:30AM on a day where the 1-2AM clock hour is repeated after a backwards DST transition, then calling `.with({minute: 45})` will result in an ambiguity which is resolved using the default `offset: 'prefer'` option.
 Because the existing offset is valid for the new time, it will be retained so the result will be the "second" 1:45AM.
 However, if the existing offset is not valid for the new result (e.g. `.with({hour: 0})`), then the default behavior will change the offset to match the new local time in that time zone.
 
@@ -671,35 +670,35 @@ Please see the documentation of `from` for more details on options behavior.
 Usage example:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24-06:00[America/Chicago]');
-ldt.with({ year: 2015, minute: 31 }); // => 2015-12-07T03:31-06:00[America/Chicago]
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24-06:00[America/Chicago]');
+zdt.with({ year: 2015, minute: 31 }); // => 2015-12-07T03:31-06:00[America/Chicago]
 
 midnight = Temporal.Time.from({ hour: 0 });
-ldt.with(midnight); // => 1995-12-07T00:00-06:00[America/Chicago]
-// Note: not the same as ldt.with({ hour: 0 }), because all time units are set to zero.
+zdt.with(midnight); // => 1995-12-07T00:00-06:00[America/Chicago]
+// Note: not the same as zdt.with({ hour: 0 }), because all time units are set to zero.
 date = Temporal.Date.from('2015-05-31');
-ldt.with(date); // => 2015-05-31T03:24-05:00[America/Chicago] (automatically adjusted for DST)
+zdt.with(date); // => 2015-05-31T03:24-05:00[America/Chicago] (automatically adjusted for DST)
 yearMonth = Temporal.YearMonth.from('2018-04');
-ldt.with(yearMonth); // => 2018-04-07T03:24-05:00[America/Chicago]
+zdt.with(yearMonth); // => 2018-04-07T03:24-05:00[America/Chicago]
 ```
 
-### localDateTime.**withCalendar**(_calendar_: object | string) : Temporal.LocalDateTime
+### zonedDateTime.**withCalendar**(_calendar_: object | string) : Temporal.ZonedDateTime
 
 **Parameters:**
 
-- `calendar` (`Temporal.Calendar` or plain object or string): The calendar into which to project `localDateTime`.
+- `calendar` (`Temporal.Calendar` or plain object or string): The calendar into which to project `zonedDateTime`.
 
-**Returns:** a new `Temporal.LocalDateTime` object which is the date indicated by `localDateTime`, projected into `calendar`.
+**Returns:** a new `Temporal.ZonedDateTime` object which is the date indicated by `zonedDateTime`, projected into `calendar`.
 
 Usage example:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30.000003500+09:00[Asia/Tokyo][c=japanese]');
-`${ldt.era} ${ldt.year}`; // => "heisei 7"
-ldt.withCalendar('iso8601').year; // => 1995
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+09:00[Asia/Tokyo][c=japanese]');
+`${zdt.era} ${zdt.year}`; // => "heisei 7"
+zdt.withCalendar('iso8601').year; // => 1995
 ```
 
-### localDateTime.**plus**(_duration_: object, _options_?: object) : Temporal.LocalDateTime
+### zonedDateTime.**plus**(_duration_: object, _options_?: object) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -709,9 +708,9 @@ ldt.withCalendar('iso8601').year; // => 1995
     Allowed values are `constrain` and `reject`.
     The default is `constrain`.
 
-**Returns:** a new `Temporal.LocalDateTime` object representing the sum of `localDateTime` plus `duration`.
+**Returns:** a new `Temporal.ZonedDateTime` object representing the sum of `zonedDateTime` plus `duration`.
 
-This method adds `duration` to `localDateTime`.
+This method adds `duration` to `zonedDateTime`.
 
 The `duration` argument is an object with properties denoting a duration, such as `{ hours: 5, minutes: 30 }`, or a `Temporal.Duration` object. Adding a negative duration like `{ hours: -5, minutes: -30 }` is equivalent to subtracting the absolute value of that duration.
 
@@ -725,7 +724,7 @@ Addition and subtraction are performed according to rules defined in [RFC 5545 (
 - If a result is ambiguous or invalid due to a time zone offset transition, the later of the two possible instants will be used for time-skipped transitions and the earlier of the two possible instants will be used for time-repeated transitions.
   This behavior corresponds to the default `disambiguation: 'compatible'` option used in `from` and used by legacy `Date` and moment.js.
 
-These rules make arithmetic with `Temporal.LocalDateTime` "DST-safe", which means that the results most closely match the expectations of both real-world users and implementers of other standards-compliant calendar applications. These expectations include:
+These rules make arithmetic with `Temporal.ZonedDateTime` "DST-safe", which means that the results most closely match the expectations of both real-world users and implementers of other standards-compliant calendar applications. These expectations include:
 
 - Adding or subtracting days should keep clock time consistent across DST transitions.
   For example, if you have an appointment on Saturday at 1:00PM and you ask to reschedule it 1 day later, you would expect the reschedule appointment to still be at 1:00PM, even if there was a DST transition overnight.
@@ -741,29 +740,29 @@ For these cases, the `overflow` option tells what to do:
 - In `'constrain'` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `'reject'` mode, a result that would be out of range causes a `RangeError` to be thrown.
 
-Additionally, if the result is earlier or later than the range of dates that `Temporal.LocalDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
+Additionally, if the result is earlier or later than the range of dates that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
 
 Usage example:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from('2020-03-08T00:00-08:00[America/Los_Angeles]');
+zdt = Temporal.ZonedDateTime.from('2020-03-08T00:00-08:00[America/Los_Angeles]');
 // Add a day to get midnight on the day after DST starts
-laterDay = ldt.plus({ days: 1 });
+laterDay = zdt.plus({ days: 1 });
   // => 2020-03-09T00:00-07:00[America/Los_Angeles];
   // Note that the new offset is different, indicating the result is adjusted for DST.
-laterDay.difference(ldt, { largestUnit: 'hours' }).hours;
+laterDay.difference(zdt, { largestUnit: 'hours' }).hours;
   // => 23, because one clock hour lost to DST
 
-laterHours = ldt.plus({ hours: 24 });
+laterHours = zdt.plus({ hours: 24 });
   // => 2020-03-09T01:00-07:00[America/Los_Angeles]
   // Adding time units doesn't adjust for DST. Result is 1:00AM: 24 real-world
   // hours later because a clock hour was skipped by DST.
-laterHours.difference(ldt, { largestUnit: 'hours' }).hours; // => 24
+laterHours.difference(zdt, { largestUnit: 'hours' }).hours; // => 24
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**minus**(_duration_: object, _options_?: object) : Temporal.LocalDateTime
+### zonedDateTime.**minus**(_duration_: object, _options_?: object) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -773,9 +772,9 @@ laterHours.difference(ldt, { largestUnit: 'hours' }).hours; // => 24
     Allowed values are `constrain` and `reject`.
     The default is `constrain`.
 
-**Returns:** a new `Temporal.LocalDateTime` object representing the result of `localDateTime` minus `duration`.
+**Returns:** a new `Temporal.ZonedDateTime` object representing the result of `zonedDateTime` minus `duration`.
 
-This method subtracts a `duration` from `localDateTime`.
+This method subtracts a `duration` from `zonedDateTime`.
 
 The `duration` argument is an object with properties denoting a duration, such as `{ hours: 5, minutes: 30 }`, or a `Temporal.Duration` object. Subtracting a negative duration like `{ hours: -5, minutes: -30 }` is equivalent to adding the absolute value of that duration.
 
@@ -789,7 +788,7 @@ Addition and subtraction are performed according to rules defined in [RFC 5545 (
 - If a result is ambiguous or invalid due to a time zone offset transition, the later of the two possible instants will be used for time-skipped transitions and the earlier of the two possible instants will be used for time-repeated transitions.
   This behavior corresponds to the default `disambiguation: 'compatible'` option used in `from` and used by legacy `Date` and moment.js.
 
-These rules make arithmetic with `Temporal.LocalDateTime` "DST-safe", which means that the results most closely match the expectations of both real-world users and implementers of other standards-compliant calendar applications. These expectations include:
+These rules make arithmetic with `Temporal.ZonedDateTime` "DST-safe", which means that the results most closely match the expectations of both real-world users and implementers of other standards-compliant calendar applications. These expectations include:
 
 - Adding or subtracting days should keep clock time consistent across DST transitions.
   For example, if you have an appointment on Saturday at 1:00PM and you ask to reschedule it 1 day later, you would expect the reschedule appointment to still be at 1:00PM, even if there was a DST transition overnight.
@@ -805,33 +804,33 @@ For these cases, the `overflow` option tells what to do:
 - In `'constrain'` mode (the default), out-of-range values are clamped to the nearest in-range value.
 - In `'reject'` mode, a result that would be out of range causes a `RangeError` to be thrown.
 
-Additionally, if the result is earlier or later than the range of dates that `Temporal.LocalDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
+Additionally, if the result is earlier or later than the range of dates that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
 
 Usage example:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from('2020-03-09T00:00-07:00[America/Los_Angeles]');
+zdt = Temporal.ZonedDateTime.from('2020-03-09T00:00-07:00[America/Los_Angeles]');
 // Add a day to get midnight on the day after DST starts
-earlierDay = ldt.minus({ days: 1 });
+earlierDay = zdt.minus({ days: 1 });
   // => 2020-03-08T00:00-08:00[America/Los_Angeles]
   // Note that the new offset is different, indicating the result is adjusted for DST.
-earlierDay.difference(ldt, { largestUnit: 'hours' }).hours;
+earlierDay.difference(zdt, { largestUnit: 'hours' }).hours;
   // => -23, because one clock hour lost to DST
 
-earlierHours = ldt.minus({ hours: 24 });
+earlierHours = zdt.minus({ hours: 24 });
   // => 2020-03-07T23:00-08:00[America/Los_Angeles]
   // Subtracting time units doesn't adjust for DST. Result is 11:00PM: 24 real-world
   // hours earlier because a clock hour was skipped by DST.
-earlierHours.difference(ldt, { largestUnit: 'hours' }).hours; // => -24
+earlierHours.difference(zdt, { largestUnit: 'hours' }).hours; // => -24
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**difference**(_other_: Temporal.LocalDateTime, _options_?: object) : Temporal.Duration
+### zonedDateTime.**difference**(_other_: Temporal.ZonedDateTime, _options_?: object) : Temporal.Duration
 
 **Parameters:**
 
-- `other` (`Temporal.LocalLocalDateTime`): Another date/time with which to compute the difference.
+- `other` (`Temporal.LocalZonedDateTime`): Another date/time with which to compute the difference.
 - `options` (optional object): An object which may have some or all of the following properties:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
     Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
@@ -845,10 +844,10 @@ earlierHours.difference(ldt, { largestUnit: 'hours' }).hours; // => -24
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
-**Returns:** a `Temporal.Duration` representing the difference between `localDateTime` and `other`.
+**Returns:** a `Temporal.Duration` representing the difference between `zonedDateTime` and `other`.
 
-This method computes the difference between the two times represented by `localDateTime` and `other`, optionally rounds it, and returns it as a `Temporal.Duration` object.
-If `other` is later than `localDateTime` then the resulting duration will be negative.
+This method computes the difference between the two times represented by `zonedDateTime` and `other`, optionally rounds it, and returns it as a `Temporal.Duration` object.
+If `other` is later than `zonedDateTime` then the resulting duration will be negative.
 
 The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
@@ -857,7 +856,7 @@ However, a difference of 30 seconds will still be 30 seconds if `largestUnit` is
 
 You can round the result using the `smallestUnit`, `roundingIncrement`, and `roundingMode` options.
 These behave as in the `Temporal.Duration.round()` method, but increments of days and larger are allowed.
-Because rounding to an increment expressed in days or larger units requires a reference point, `localDateTime` is used as the reference point in that case.
+Because rounding to an increment expressed in days or larger units requires a reference point, `zonedDateTime` is used as the reference point in that case.
 The default is to do no rounding.
 
 The duration returned is a "hybrid" duration.
@@ -877,7 +876,7 @@ If both values have the same local time, then the result will be the same as if 
 To calculate the difference between calendar dates only, use `.toDate().difference(other.toDate())`.
 To calculate the difference between clock times only, use `.toTime().difference(other.toTime())`.
 
-If the other `Temporal.LocalDateTime` is in a different time zone, then the same days can be different lengths in each time zone, e.g. if only one of them observes DST.
+If the other `Temporal.ZonedDateTime` is in a different time zone, then the same days can be different lengths in each time zone, e.g. if only one of them observes DST.
 Therefore, a `RangeError` will be thrown if `largestUnit` is `'days'` or larger and the two instances' time zones have different `id` fields.
 To work around this limitation, transform one of the instances to the other's time zone using `.with({timeZone: other.timeZone})` and then calculate the same-timezone difference.
 Because of the complexity and ambiguity involved in cross-timezone calculations involving days or larger units, `'hours'` is the default for `largestUnit`.
@@ -887,30 +886,30 @@ For some durations, the resulting value may overflow `Number.MAX_SAFE_INTEGER` a
 Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.
 
 Computing the difference between two dates in different calendar systems is not supported.
-If you need to do this, choose the calendar in which the computation takes place by converting one of the dates with `localDateTime.withCalendar`.
+If you need to do this, choose the calendar in which the computation takes place by converting one of the dates with `zonedDateTime.withCalendar`.
 
 Usage example:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt1 = Temporal.LocalDateTime.from('1995-12-07T03:24:30.000003500+05:30[Asia/Kolkata]');
-ldt2 = Temporal.LocalDateTime.from('2019-01-31T15:30+05:30[Asia/Kolkata]');
-ldt2.difference(ldt1);
+zdt1 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+05:30[Asia/Kolkata]');
+zdt2 = Temporal.ZonedDateTime.from('2019-01-31T15:30+05:30[Asia/Kolkata]');
+zdt2.difference(zdt1);
   // =>      PT202956H5M29.999996500S
-ldt2.difference(ldt1, { largestUnit: 'years' });
+zdt2.difference(zdt1, { largestUnit: 'years' });
   // =>  P23Y1M24DT12H5M29.999996500S
-ldt1.difference(ldt2, { largestUnit: 'years' });
+zdt1.difference(zdt2, { largestUnit: 'years' });
   // => -P23Y1M24DT12H5M29.999996500S
-ldt2.difference(ldt1, { largestUnit: 'nanoseconds' });
+zdt2.difference(zdt1, { largestUnit: 'nanoseconds' });
   // =>       PT730641929.999996544S (precision lost)
 
 // Rounding, for example if you don't care about sub-seconds
-ldt2.difference(ldt1, { smallestUnit: 'seconds' });
+zdt2.difference(zdt1, { smallestUnit: 'seconds' });
   // => PT202956H5M30S
 
 // Months and years can be different lengths
 [jan1, feb1, mar1] = [1, 2, 3].map((month) =>
-  Temporal.LocalDateTime.from({ year: 2020, month, day: 1, timeZone: 'Asia/Seoul' })
+  Temporal.ZonedDateTime.from({ year: 2020, month, day: 1, timeZone: 'Asia/Seoul' })
 );
 feb1.difference(jan1, { largestUnit: 'days' }); // => P31D
 feb1.difference(jan1, { largestUnit: 'months' }); // => P1M
@@ -920,7 +919,7 @@ mar1.difference(jan1, { largestUnit: 'days' }); // => P60D
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**round**(_options_: object) : Temporal.LocalDateTime
+### zonedDateTime.**round**(_options_: object) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -933,9 +932,9 @@ mar1.difference(jan1, { largestUnit: 'days' }); // => P60D
     Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
     The default is `'nearest'`.
 
-**Returns:** a new `Temporal.LocalDateTime` object which is `localDateTime` rounded to `roundingIncrement` of `smallestUnit`.
+**Returns:** a new `Temporal.ZonedDateTime` object which is `zonedDateTime` rounded to `roundingIncrement` of `smallestUnit`.
 
-Rounds `localDateTime` to the given unit and increment, and returns the result as a new `Temporal.LocalDateTime` object.
+Rounds `zonedDateTime` to the given unit and increment, and returns the result as a new `Temporal.ZonedDateTime` object.
 
 The `smallestUnit` option determines the unit to round to.
 For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
@@ -963,59 +962,59 @@ Example usage:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30.000003500-08:00[America/Los_Angeles]');
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500-08:00[America/Los_Angeles]');
 
 // Round to a particular unit
-ldt.round({ smallestUnit: 'hour' }); // => 1995-12-07T03:00-08:00[America/Los_Angeles]
+zdt.round({ smallestUnit: 'hour' }); // => 1995-12-07T03:00-08:00[America/Los_Angeles]
 // Round to an increment of a unit, e.g. half an hour:
-ldt.round({ roundingIncrement: 30, smallestUnit: 'minute' });
+zdt.round({ roundingIncrement: 30, smallestUnit: 'minute' });
   // => 1995-12-07T03:30-08:00[America/Los_Angeles]
 // Round to the same increment but round down instead:
-ldt.round({ roundingIncrement: 30, smallestUnit: 'minute', roundingMode: 'floor' });
+zdt.round({ roundingIncrement: 30, smallestUnit: 'minute', roundingMode: 'floor' });
   // => 1995-12-07T03:00-08:00[America/Los_Angeles]
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**equals**(_other_: Temporal.LocalDateTime) : boolean
+### zonedDateTime.**equals**(_other_: Temporal.ZonedDateTime) : boolean
 
 **Parameters:**
 
-- `other` (`Temporal.LocalDateTime`): Another date/time to compare.
+- `other` (`Temporal.ZonedDateTime`): Another date/time to compare.
 
-**Returns:** `true` if `localDateTime` and `other` are have equivalent fields (date/time fields, offset, time zone ID, and calendar ID), or `false` if not.
+**Returns:** `true` if `zonedDateTime` and `other` are have equivalent fields (date/time fields, offset, time zone ID, and calendar ID), or `false` if not.
 
-Compares two `Temporal.LocalDateTime` objects for equality.
+Compares two `Temporal.ZonedDateTime` objects for equality.
 
-This function exists because it's not possible to compare using `localDateTime == other` or `localDateTime === other`, due to ambiguity in the primitive representation and between Temporal types.
+This function exists because it's not possible to compare using `zonedDateTime == other` or `zonedDateTime === other`, due to ambiguity in the primitive representation and between Temporal types.
 
-If you don't need to know the order in which two events occur, then this function is easier to use than `Temporal.LocalDateTime.compare`.
+If you don't need to know the order in which two events occur, then this function is easier to use than `Temporal.ZonedDateTime.compare`.
 But both methods do the same thing, so a `0` returned from `compare` implies a `true` result from `equals`, and vice-versa.
 
-Note that two `Temporal.LocalDateTime` instances can have the same clock time, time zone, and calendar but still be unequal, e.g. when a clock hour is repeated after DST ends in the Fall.
+Note that two `Temporal.ZonedDateTime` instances can have the same clock time, time zone, and calendar but still be unequal, e.g. when a clock hour is repeated after DST ends in the Fall.
 In this case, the two instances will have different `timeZoneOffsetNanoseconds` field values.
 
 To ignore calendars, convert both instances to use the ISO 8601 calendar:
 
 ```javascript
-ldt.withCalendar('iso8601').equals(other.withCalendar('iso8601'));
+zdt.withCalendar('iso8601').equals(other.withCalendar('iso8601'));
 ```
 
 To ignore both time zones and calendars, compare the instants of both:
 
 ```javascript
-ldt.toInstant().equals(other.toInstant()));
+zdt.toInstant().equals(other.toInstant()));
 ```
 
 Example usage:
 
 ```javascript
-ldt1 = Temporal.LocalDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Paris]');
-ldt2 = Temporal.LocalDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Brussels]');
-ldt1.equals(ldt2); // => false (same offset but different time zones)
-ldt1.equals(ldt1); // => true
+zdt1 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Paris]');
+zdt2 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Brussels]');
+zdt1.equals(zdt2); // => false (same offset but different time zones)
+zdt1.equals(zdt1); // => true
 ```
 
-### localDateTime.**toString**() : string
+### zonedDateTime.**toString**() : string
 
 **Returns:** a string containing an ISO 8601 date+time+offset format, a bracketed time zone suffix, and (if the calendar is not `iso8601`) a calendar suffix.
 
@@ -1024,9 +1023,9 @@ Examples:
 - `2011-12-03T10:15:30+01:00[Europe/Paris]`
 - `2011-12-03T10:15:30+09:00[Asia/Tokyo][c=japanese]`
 
-This method overrides the `Object.prototype.toString()` method and provides a convenient, unambiguous string representation of `localDateTime`.
+This method overrides the `Object.prototype.toString()` method and provides a convenient, unambiguous string representation of `zonedDateTime`.
 The string is "round-trippable".
-This means that it can be passed to `Temporal.LocalDateTime.from()` to create a new `Temporal.LocalDateTime` object with the same field values as the original.
+This means that it can be passed to `Temporal.ZonedDateTime.from()` to create a new `Temporal.ZonedDateTime` object with the same field values as the original.
 
 The string format output by this method can be parsed by [`java.time.ZonedDateTime`](https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html) as long as the calendar is `iso8601`.
 For more information on `Temporal`'s extensions to the ISO string format and the progress towards becoming a published standard, see [ISO standard extensions](./iso-string-ext.md).
@@ -1034,54 +1033,54 @@ For more information on `Temporal`'s extensions to the ISO string format and the
 Example usage:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from({ year: 2019, month: 12, day: 1, hour: 12, timeZone: 'Africa/Lagos' });
-ldt.toString(); // => 2019-12-01T12:00+01:00[Africa/Lagos]
-ldt.withCalendar('japanese');
-ldt.toString(); // => 2019-12-01T12:00+01:00[Africa/Lagos][c=japanese]
+zdt = Temporal.ZonedDateTime.from({ year: 2019, month: 12, day: 1, hour: 12, timeZone: 'Africa/Lagos' });
+zdt.toString(); // => 2019-12-01T12:00+01:00[Africa/Lagos]
+zdt.withCalendar('japanese');
+zdt.toString(); // => 2019-12-01T12:00+01:00[Africa/Lagos][c=japanese]
 ```
 
-### localDateTime.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
+### zonedDateTime.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
 
 **Parameters:**
 
 - `locales` (optional string or array of strings): A string with a BCP 47 language tag with an optional Unicode extension key, or an array of such strings.
 - `options` (optional object): An object with properties influencing the formatting.
 
-**Returns:** a language-sensitive representation of `localDateTime`.
+**Returns:** a language-sensitive representation of `zonedDateTime`.
 
-This method overrides `Object.prototype.toLocaleString()` to provide a human-readable, language-sensitive representation of `localDateTime`.
+This method overrides `Object.prototype.toLocaleString()` to provide a human-readable, language-sensitive representation of `zonedDateTime`.
 
-The `locales` and `options` arguments are the same as in the constructor to [`Intl.LocalDateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat).
+The `locales` and `options` arguments are the same as in the constructor to [`Intl.ZonedDateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat).
 
-`options.timeZone` will be automatically set from the time zone of of `localDateTime`.
+`options.timeZone` will be automatically set from the time zone of of `zonedDateTime`.
 If a different time zone ID is provided in `options.timeZone`, a RangeError will be thrown.
-To display a `Temporal.LocalDateTime` value in a different time zone, use `with({timeZone}).toLocaleString()`.
+To display a `Temporal.ZonedDateTime` value in a different time zone, use `with({timeZone}).toLocaleString()`.
 
 Example usage:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ldt = Temporal.LocalDateTime.from('2019-12-01T12:00+01:00[Europe/Berlin]');
-ldt.toLocaleString(); // => example output: 12/1/2019, 12:00:00 PM
-ldt.toLocaleString('de-DE'); // => 1.12.2019, 12:00:00
+zdt = Temporal.ZonedDateTime.from('2019-12-01T12:00+01:00[Europe/Berlin]');
+zdt.toLocaleString(); // => example output: 12/1/2019, 12:00:00 PM
+zdt.toLocaleString('de-DE'); // => 1.12.2019, 12:00:00
 options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-ldt.toLocaleString('de-DE', options); // => Sonntag, 1. Dezember 2019
-ldt.toLocaleString('de-DE', { timeZone: 'Pacific/Auckland' });
+zdt.toLocaleString('de-DE', options); // => Sonntag, 1. Dezember 2019
+zdt.toLocaleString('de-DE', { timeZone: 'Pacific/Auckland' });
   // => RangeError: Time zone option Pacific/Auckland does not match actual time zone Europe/Berlin
-ldt.with({ timeZone: 'Pacific/Auckland' }).toLocaleString('de-DE'); // => 2.12.2019, 00:00:00
-ldt.toLocaleString('en-US-u-nu-fullwide-hc-h12'); // => １２/１/２０１９, １２:００:００ PM
+zdt.with({ timeZone: 'Pacific/Auckland' }).toLocaleString('de-DE'); // => 2.12.2019, 00:00:00
+zdt.toLocaleString('en-US-u-nu-fullwide-hc-h12'); // => １２/１/２０１９, １２:００:００ PM
 ```
 <!-- prettier-ignore-end -->
 
-### localDateTime.**toJSON**() : string
+### zonedDateTime.**toJSON**() : string
 
-**Returns:** a string in the ISO 8601 date format representing `localDateTime`.
+**Returns:** a string in the ISO 8601 date format representing `zonedDateTime`.
 
-This method is the same as `localDateTime.toString()`.
+This method is the same as `zonedDateTime.toString()`.
 It is usually not called directly, but it can be called automatically by `JSON.stringify()`.
 
-The reverse operation, recovering a `Temporal.LocalDateTime` object from a string, is `Temporal.LocalDateTime.from()`, but it cannot be called automatically by `JSON.parse()`.
-If you need to rebuild a `Temporal.LocalDateTime` object from a JSON string, then you need to know the names of the keys that should be interpreted as `Temporal.LocalDateTime`s.
+The reverse operation, recovering a `Temporal.ZonedDateTime` object from a string, is `Temporal.ZonedDateTime.from()`, but it cannot be called automatically by `JSON.parse()`.
+If you need to rebuild a `Temporal.ZonedDateTime` object from a JSON string, then you need to know the names of the keys that should be interpreted as `Temporal.ZonedDateTime`s.
 In that case you can build a custom "reviver" function for your use case.
 
 Example usage:
@@ -1090,8 +1089,8 @@ Example usage:
 const event = {
   id: 311,
   name: 'FictionalConf 2018',
-  openingLocalDateTime: Temporal.LocalDateTime.from('2018-07-06T10:00+05:30[Asia/Kolkata]'),
-  closingLocalDateTime: Temporal.LocalDateTime.from('2018-07-08T18:15+05:30[Asia/Kolkata]')
+  openingZonedDateTime: Temporal.ZonedDateTime.from('2018-07-06T10:00+05:30[Asia/Kolkata]'),
+  closingZonedDateTime: Temporal.ZonedDateTime.from('2018-07-08T18:15+05:30[Asia/Kolkata]')
 };
 const str = JSON.stringify(event, null, 2);
 console.log(str);
@@ -1099,77 +1098,77 @@ console.log(str);
 // {
 //   "id": 311,
 //   "name": "FictionalConf 2018",
-//   "openingLocalDateTime": "2018-07-06T10:00+05:30[Asia/Calcutta]",
-//   "closingLocalDateTime": "2018-07-08T18:15+05:30[Asia/Calcutta]"
+//   "openingZonedDateTime": "2018-07-06T10:00+05:30[Asia/Calcutta]",
+//   "closingZonedDateTime": "2018-07-08T18:15+05:30[Asia/Calcutta]"
 // }
 
 // To rebuild from the string:
 function reviver(key, value) {
-  if (key.endsWith('LocalDateTime')) return Temporal.LocalDateTime.from(value);
+  if (key.endsWith('ZonedDateTime')) return Temporal.ZonedDateTime.from(value);
   return value;
 }
 JSON.parse(str, reviver);
 ```
 
-### localDateTime.**valueOf**()
+### zonedDateTime.**valueOf**()
 
 This method overrides `Object.prototype.valueOf()` and always throws an exception.
-This is because it's not possible to compare `Temporal.LocalDateTime` objects with the relational operators `<`, `<=`, `>`, or `>=`.
-Use `Temporal.LocalDateTime.compare()` for this, or `localDateTime.equals()` for equality.
+This is because it's not possible to compare `Temporal.ZonedDateTime` objects with the relational operators `<`, `<=`, `>`, or `>=`.
+Use `Temporal.ZonedDateTime.compare()` for this, or `zonedDateTime.equals()` for equality.
 
-### localDateTime.**toInstant**() : Temporal.Instant
+### zonedDateTime.**toInstant**() : Temporal.Instant
 
-**Returns:** A `Temporal.Instant` object that represents the same instant as `localDateTime`.
+**Returns:** A `Temporal.Instant` object that represents the same instant as `zonedDateTime`.
 
-### localDateTime.**toDate**() : Temporal.Date
+### zonedDateTime.**toDate**() : Temporal.Date
 
-**Returns:** a `Temporal.Date` object that is the same as the date portion of `localDateTime`.
+**Returns:** a `Temporal.Date` object that is the same as the date portion of `zonedDateTime`.
 
-### localDateTime.**toTime**() : Temporal.Time
+### zonedDateTime.**toTime**() : Temporal.Time
 
-**Returns:** a `Temporal.Time` object that is the same as the wall-clock time portion of `localDateTime`.
+**Returns:** a `Temporal.Time` object that is the same as the wall-clock time portion of `zonedDateTime`.
 
-### localDateTime.**toDateTime**() : Temporal.DateTime
+### zonedDateTime.**toDateTime**() : Temporal.DateTime
 
-**Returns:** a `Temporal.DateTime` object that is the same as the date and time portion of `localDateTime`.
+**Returns:** a `Temporal.DateTime` object that is the same as the date and time portion of `zonedDateTime`.
 
-> **NOTE**: After a `Temporal.LocalDateTime` is converted to `Temporal.DateTime`, it will no longer be aware of its time zone.
-> This means that subsequent operations like arithmetic or `with` will not adjust for DST and may not yield the same results as equivalent operations with `Temporal.LocalDateTime`.
+> **NOTE**: After a `Temporal.ZonedDateTime` is converted to `Temporal.DateTime`, it will no longer be aware of its time zone.
+> This means that subsequent operations like arithmetic or `with` will not adjust for DST and may not yield the same results as equivalent operations with `Temporal.ZonedDateTime`.
 > However, unless you perform those operations across a time zone offset transition, it's impossible to notice the difference.
 > Therefore, be very careful when performing this conversion because subsequent results may look correct most of the time while failing around time zone transitions like when DST starts or ends.
 
-### localDateTime.**toYearMonth**() : Temporal.YearMonth
+### zonedDateTime.**toYearMonth**() : Temporal.YearMonth
 
-**Returns:** a `Temporal.YearMonth` object that is the same as the year and month of `localDateTime`.
+**Returns:** a `Temporal.YearMonth` object that is the same as the year and month of `zonedDateTime`.
 
-### localDateTime.**toMonthDay**() : Temporal.MonthDay
+### zonedDateTime.**toMonthDay**() : Temporal.MonthDay
 
-**Returns:** a `Temporal.MonthDay` object that is the same as the month and day of `localDateTime`.
+**Returns:** a `Temporal.MonthDay` object that is the same as the month and day of `zonedDateTime`.
 
-The above six methods can be used to convert `Temporal.LocalDateTime` into a `Temporal.Instant`, `Temporal.Date`, `Temporal.Time`, `Temporal.DateTime`, `Temporal.YearMonth`, or `Temporal.MonthDay` respectively.
-The converted object carries a copy of all the relevant data of `localDateTime` (for example, in `toDate()`, the `year`, `month`, and `day` properties are the same.)
+The above six methods can be used to convert `Temporal.ZonedDateTime` into a `Temporal.Instant`, `Temporal.Date`, `Temporal.Time`, `Temporal.DateTime`, `Temporal.YearMonth`, or `Temporal.MonthDay` respectively.
+The converted object carries a copy of all the relevant data of `zonedDateTime` (for example, in `toDate()`, the `year`, `month`, and `day` properties are the same.)
 
 Usage example:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30+02:00[Africa/Johannesburg]');
-ldt.toInstant(); // => 1995-12-07T01:24:30Z
-ldt.toDateTime(); // => 1995-12-07T03:24:30
-ldt.toDate(); // => 1995-12-07
-ldt.toYearMonth(); // => 1995-12
-ldt.toMonthDay(); // => 12-07
-ldt.toTime(); // => 03:24:30
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00[Africa/Johannesburg]');
+zdt.toInstant(); // => 1995-12-07T01:24:30Z
+zdt.toDateTime(); // => 1995-12-07T03:24:30
+zdt.toDate(); // => 1995-12-07
+zdt.toYearMonth(); // => 1995-12
+zdt.toMonthDay(); // => 12-07
+zdt.toTime(); // => 03:24:30
 ```
 
-### localDateTime.**getFields**() : { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: object, [propName: string]: unknown }
+### zonedDateTime.**getFields**() : { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: object, [propName: string]: unknown }
 
-**Returns:** a plain object with properties equal to the fields of `localDateTime`, including all date/time fields (expressed in the current calendar) as well as the `calendar`, `timeZone`, and `timeZoneOffsetNanoseconds` properties.
+**Returns:** a plain object with properties equal to the fields of `zonedDateTime`, including all date/time fields (expressed in the current calendar) as well as the `calendar`, `timeZone`, and `timeZoneOffsetNanoseconds` properties.
 
-This method can be used to convert a `Temporal.LocalDateTime` into a record-like data structure.
+This method can be used to convert a `Temporal.ZonedDateTime` into a record-like data structure.
 It returns a new plain JavaScript object, with all the fields as enumerable, writable, own data properties.
 
-This method is helpful when you want to use the ES6 "object spread" (`...`) feature (or equivalent code like `Object.assign`) on a `Temporal.LocalDateTime` instance.  
-Because `Temporal.LocalDateTime` fields are not "own properties" according to JavaScript, they cannot be enumerated by `...` or `Object.assign`.
+This method is helpful when you want to use the ES6 "object spread" (`...`) feature (or equivalent code like `Object.assign`) on a `Temporal.ZonedDateTime` instance.  
+Because `Temporal.ZonedDateTime` fields are not "own properties" according to JavaScript, they cannot be enumerated by `...` or `Object.assign`.
 But calling `.getFields()` creates a new object whose properties can be enumerated by `...` or `Object.assign`.
 
 The `timeZone` and `calendar` properties are returned as objects, not as their string IDs.
@@ -1181,14 +1180,14 @@ Note that if using a different calendar from ISO 8601, these will be the calenda
 Usage example:
 
 ```javascript
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30.000003500-08:00[America/Los_Angeles]');
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500-08:00[America/Los_Angeles]');
 
-const thisWontWork = { ...ldt, hour: 12 };
+const thisWontWork = { ...zdt, hour: 12 };
 JSON.stringify(thisWontWork);
 // => { "hour": 12 }
-// There are no other properties because Temporal.LocalDateTime has no enumerable own properties
+// There are no other properties because Temporal.ZonedDateTime has no enumerable own properties
 
-const thisWillWork = { ...ldt.getFields(), hour: 12 };
+const thisWillWork = { ...zdt.getFields(), hour: 12 };
 JSON.stringify(thisWillWork, undefined, 2);
 // => "{
 //   "timeZone": "America/Los_Angeles",
@@ -1206,25 +1205,25 @@ JSON.stringify(thisWillWork, undefined, 2);
 // }"
 ```
 
-### localDateTime.**getISOFields**(): { isoYear: number, isoMonth: number, isoDay: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: object }
+### zonedDateTime.**getISOFields**(): { isoYear: number, isoMonth: number, isoDay: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: object }
 
-**Returns:** a plain object with properties expressing `localDateTime` in the ISO 8601 calendar, including all date/time fields as well as the `calendar`, `timeZone`, and `timeZoneOffsetNanoseconds` properties.
+**Returns:** a plain object with properties expressing `zonedDateTime` in the ISO 8601 calendar, including all date/time fields as well as the `calendar`, `timeZone`, and `timeZoneOffsetNanoseconds` properties.
 Note that date/time properties have different names with an `iso` prefix to better differentiate from "normal" `getFields` results.
 
 This is an advanced method that's mainly useful if you are implementing a custom calendar.
 Most developers will not need to use it.
-Instead, most applications will use `localDateTime.getFields()` (for fields in the current calendar) or `localDateTime.withCalendar('iso8601').getFields()` (for fields expressed using the ISO 8601 calendar).
+Instead, most applications will use `zonedDateTime.getFields()` (for fields in the current calendar) or `zonedDateTime.withCalendar('iso8601').getFields()` (for fields expressed using the ISO 8601 calendar).
 
 Usage example:
 
 ```javascript
-// get a Temporal.LocalDateTime in `japanese` calendar system
-ldt = Temporal.LocalDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Paris]').withCalendar('japanese');
+// get a Temporal.ZonedDateTime in `japanese` calendar system
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Paris]').withCalendar('japanese');
 
 // Year in japanese calendar is year 7 of Heisei era
-ldt.getFields().year; // => 7
-ldt.getISOFields().isoYear; // => 1995
+zdt.getFields().year; // => 7
+zdt.getISOFields().isoYear; // => 1995
 
 // Instead of calling getISOFields, the pattern below is recommended for most use cases
-ldt.withCalendar('iso8601').year; // => 1995
+zdt.withCalendar('iso8601').year; // => 1995
 ```


### PR DESCRIPTION
This PR renames LocalDateTime => ZonedDateTime in the docs.  While in the neighborhood, I also:
* added docs for `epochXxx` properties on ZDT (#932)
* renamed timeZoneOffsetXxx properties to offsetXxx. (#935)

I *didn't* rename plus/minus in this PR because I didn't want to conflict with @ptomato's PR in #975.