### PR TITLE
Allow rounding to hours in Instant.round()

### DIFF
--- a/docs/instant.md
+++ b/docs/instant.md
@@ -441,7 +441,7 @@ billion.toDateTime(utc).difference(epoch.toDateTime(utc), { largestUnit: 'years'
 - `options` (object): An object with properties representing options for the operation.
   The following options are recognized:
   - `smallestUnit` (required string): The unit to round to.
-    Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    Valid values are `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder.
@@ -461,7 +461,7 @@ For example, to round to increments of a half hour, use `smallestUnit: 'minute',
 
 The combination of `roundingIncrement` and `smallestUnit` must make an increment that divides evenly into 86400 seconds (one 24-hour solar day).
 (For example, increments of 15 minutes and 45 seconds are both allowed.
-25 minutes, and 7 seconds are both not allowed.) Hour increments are not allowed either, since `Temporal.Instant` has no time zone and therefore it is not defined where the starting point of the hour is.
+25 minutes, and 7 seconds are both not allowed.)
 
 The `roundingMode` option controls how the rounding is performed.
 

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -168,9 +168,10 @@ export class Instant {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     if (options === undefined) throw new TypeError('options parameter is required');
     options = ES.NormalizeOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, ['day', 'hour']);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, ['day']);
     const roundingMode = ES.ToTemporalRoundingMode(options);
     const maximumIncrements = {
+      hour: 24,
       minute: 1440,
       second: 86400,
       millisecond: 86400e3,
@@ -181,6 +182,9 @@ export class Instant {
 
     let incrementNs = roundingIncrement;
     switch (smallestUnit) {
+      case 'hour':
+        incrementNs *= 60;
+      // fall through
       case 'minute':
         incrementNs *= 60;
       // fall through

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -727,7 +727,7 @@ describe('Instant', () => {
       throws(() => abs.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
     });
     it('throws on disallowed or invalid smallestUnit', () => {
-      ['era', 'year', 'month', 'week', 'day', 'hour', 'years', 'months', 'weeks', 'days', 'hours', 'nonsense'].forEach(
+      ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
         (smallestUnit) => {
           throws(() => abs.round({ smallestUnit }), RangeError);
         }
@@ -737,6 +737,7 @@ describe('Instant', () => {
       throws(() => abs.round({ smallestUnit: 'second', roundingMode: 'cile' }), RangeError);
     });
     const incrementOneNearest = [
+      ['hour', '1976-11-18T14:00Z'],
       ['minute', '1976-11-18T14:24Z'],
       ['second', '1976-11-18T14:23:30Z'],
       ['millisecond', '1976-11-18T14:23:30.123Z'],
@@ -748,6 +749,7 @@ describe('Instant', () => {
         equal(`${abs.round({ smallestUnit, roundingMode: 'nearest' })}`, expected));
     });
     const incrementOneCeil = [
+      ['hour', '1976-11-18T15:00Z'],
       ['minute', '1976-11-18T14:24Z'],
       ['second', '1976-11-18T14:23:31Z'],
       ['millisecond', '1976-11-18T14:23:30.124Z'],
@@ -758,6 +760,7 @@ describe('Instant', () => {
       it(`rounds up to ${smallestUnit}`, () => equal(`${abs.round({ smallestUnit, roundingMode: 'ceil' })}`, expected));
     });
     const incrementOneFloor = [
+      ['hour', '1976-11-18T14:00Z'],
       ['minute', '1976-11-18T14:23Z'],
       ['second', '1976-11-18T14:23:30Z'],
       ['millisecond', '1976-11-18T14:23:30.123Z'],
@@ -782,6 +785,9 @@ describe('Instant', () => {
       equal(`${abs2.round({ smallestUnit, roundingMode: 'trunc' })}`, '1969-12-15T12:00Z');
       equal(`${abs2.round({ smallestUnit, roundingMode: 'nearest' })}`, '1969-12-15T12:00:01Z');
     });
+    it('rounds to an increment of hours', () => {
+      equal(`${abs.round({ smallestUnit: 'hour', roundingIncrement: 4 })}`, '1976-11-18T16:00Z');
+    });
     it('rounds to an increment of minutes', () => {
       equal(`${abs.round({ smallestUnit: 'minute', roundingIncrement: 15 })}`, '1976-11-18T14:30Z');
     });
@@ -799,6 +805,7 @@ describe('Instant', () => {
     });
     it('rounds to days by specifying increment of 86400 seconds in various units', () => {
       const expected = '1976-11-19T00:00Z';
+      equal(`${abs.round({ smallestUnit: 'hour', roundingIncrement: 24 })}`, expected);
       equal(`${abs.round({ smallestUnit: 'minute', roundingIncrement: 1440 })}`, expected);
       equal(`${abs.round({ smallestUnit: 'second', roundingIncrement: 86400 })}`, expected);
       equal(`${abs.round({ smallestUnit: 'millisecond', roundingIncrement: 86400e3 })}`, expected);
@@ -809,6 +816,7 @@ describe('Instant', () => {
       assert(abs.round({ smallestUnit: 'second', roundingIncrement: 864 }) instanceof Instant);
     });
     it('throws on increments that do not divide evenly into solar days', () => {
+      throws(() => abs.round({ smallestUnit: 'hour', roundingIncrement: 7 }), RangeError);
       throws(() => abs.round({ smallestUnit: 'minute', roundingIncrement: 29 }), RangeError);
       throws(() => abs.round({ smallestUnit: 'second', roundingIncrement: 29 }), RangeError);
       throws(() => abs.round({ smallestUnit: 'millisecond', roundingIncrement: 29 }), RangeError);
@@ -816,6 +824,7 @@ describe('Instant', () => {
       throws(() => abs.round({ smallestUnit: 'nanosecond', roundingIncrement: 29 }), RangeError);
     });
     it('accepts plural units', () => {
+      assert(abs.round({ smallestUnit: 'hours' }).equals(abs.round({ smallestUnit: 'hour' })));
       assert(abs.round({ smallestUnit: 'minutes' }).equals(abs.round({ smallestUnit: 'minute' })));
       assert(abs.round({ smallestUnit: 'seconds' }).equals(abs.round({ smallestUnit: 'second' })));
       assert(abs.round({ smallestUnit: 'milliseconds' }).equals(abs.round({ smallestUnit: 'millisecond' })));

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -323,9 +323,11 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"*, *"hour"* »).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"* »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
-        1. If _smallestUnit_ is *"minute"*, then
+        1. If _smallestUnit_ is *"hour"*, then
+          1. Let _maximum_ be 24.
+        1. Else if _smallestUnit_ is *"minute"*, then
           1. Let _maximum_ be 1440.
         1. Else if _smallestUnit_ is *"second"*, then
           1. Let _maximum_ be 86400.
@@ -337,7 +339,9 @@
           1. Assert: _smallestUnit_ is *"nanosecond"*.
           1. Let _maximum_ be 8.64 × 10<sup>13</sup>.
         1. Let _roundingIncrement_ be the mathematical value of ? ToTemporalRoundingIncrement(_options_, _maximum_, *true*).
-        1. If _smallestUnit_ is *"minute"*, then
+        1. If _smallestUnit_ is *"hour"*, then
+          1. Let _incrementNs_ be _roundingIncrement_ × 3.6 × 10<sup>12</sup>.
+        1. Else if _smallestUnit_ is *"minute"*, then
           1. Let _incrementNs_ be _roundingIncrement_ × 6 × 10<sup>10</sup>.
         1. Else if _smallestUnit_ is *"second"*, then
           1. Let _incrementNs_ be _roundingIncrement_ × 10<sup>9</sup>.


### PR DESCRIPTION
The rationale for not allowing this was that the starting point of the
hour was not well-defined, due to Instant not having a time zone. However,
this applies to minutes as well, and so hours and minutes should either be
both allowed or both disallowed. We decide to allow them for convenience.

See: #908