### PR TITLE
Add Duration.isZero

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -351,6 +351,21 @@ d = Temporal.Duration.from('-PT8H30M');
 d.abs()  // PT8H30M
 ```
 
+### duration.**isZero**() : boolean
+
+**Returns:** `true` if `duration` has zero length, `false` otherwise.
+
+This is a convenience method that tells whether `duration` represents a zero length of time.
+
+Usage example:
+```javascript
+d = Temporal.Duration.from('PT0S');
+d.isZero(); // => true
+
+d = Temporal.Duration.from({ days: 0, hours: 0, minutes: 0 });
+d.isZero(); // => true
+```
+
 ### duration.**round**(_options_: object) : Temporal.Duration
 
 **Parameters:**

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -243,6 +243,23 @@ export class Duration {
     if (!ES.IsTemporalDuration(result)) throw new TypeError('invalid result');
     return result;
   }
+  isZero() {
+    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    return (
+      ES.DurationSign(
+        GetSlot(this, YEARS),
+        GetSlot(this, MONTHS),
+        GetSlot(this, WEEKS),
+        GetSlot(this, DAYS),
+        GetSlot(this, HOURS),
+        GetSlot(this, MINUTES),
+        GetSlot(this, SECONDS),
+        GetSlot(this, MILLISECONDS),
+        GetSlot(this, MICROSECONDS),
+        GetSlot(this, NANOSECONDS)
+      ) === 0
+    );
+  }
   add(other, options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
     let {

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -41,6 +41,9 @@ describe('Duration', () => {
       it('Duration.prototype.abs is a Function', () => {
         equal(typeof Duration.prototype.abs, 'function');
       });
+      it('Duration.prototype.isZero is a Function', () => {
+        equal(typeof Duration.prototype.isZero, 'function');
+      });
       it('Duration.prototype.round is a Function', () => {
         equal(typeof Duration.prototype.round, 'function');
       });
@@ -723,6 +726,28 @@ describe('Duration', () => {
       equal(`${zero}`, `${zero2}`);
       notEqual(zero, zero2);
       equal(zero2.sign, 0);
+    });
+  });
+  describe('Duration.isZero()', () => {
+    it('works', () => {
+      assert(!Duration.from('P3DT1H').isZero());
+      assert(!Duration.from('-PT2H20M30S').isZero());
+      assert(Duration.from('PT0S').isZero());
+    });
+    it('zero regardless of how many fields are in the duration', () => {
+      const zero = Duration.from({
+        years: 0,
+        months: 0,
+        weeks: 0,
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+        milliseconds: 0,
+        microseconds: 0,
+        nanoseconds: 0
+      });
+      assert(zero.isZero());
     });
   });
   describe('Duration.round()', () => {

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -351,6 +351,21 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.duration.prototype.iszero">
+      <h1>Temporal.Duration.prototype.isZero ( )</h1>
+      <p>
+        The `isZero` method takes no arguments.
+        It performs the following steps when called:
+      </p>
+      <emu-alg>
+        1. Let _duration_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
+        1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. If _sign_ = 0, return *true*.
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.duration.prototype.add">
       <h1>Temporal.Duration.prototype.add ( _other_ [ , _options_ ] )</h1>
       <p>


### PR DESCRIPTION
A convenience method that can be used instead of the less discoverable
duration.sign === 0.

Closes: #924