### PR TITLE
Use 'exact time' consistently in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ See [Temporal.now Documentation](./now.md) for detailed documentation.
 
 ### **Temporal.Instant**
 
-A `Temporal.Instant` represents a fixed point in time, without regard to calendar or location.
+A `Temporal.Instant` represents a fixed point in time (called **"exact time"**), without regard to calendar or location.
 For a human-readable local calendar date or clock time, use a `Temporal.TimeZone` and `Temporal.Calendar` to obtain a `Temporal.ZonedDateTime` or `Temporal.DateTime`.
 
 See [Temporal.Instant Documentation](./instant.md) for detailed documentation.
@@ -48,7 +48,7 @@ See [Temporal.Instant Documentation](./instant.md) for detailed documentation.
 
 _NOTE: this type is not checked into the polyfill yet, but is planned to land in late October 2020._
 
-A `Temporal.ZonedDateTime` is a timezone-aware, calendar-aware date/time type that represents a real event that has happened (or will happen) at a particular instant from the perspective of a particular region on Earth.
+A `Temporal.ZonedDateTime` is a timezone-aware, calendar-aware date/time type that represents a real event that has happened (or will happen) at a particular exact time from the perspective of a particular region on Earth.
 This type is optimized for use cases that require a time zone, including DST-safe arithmetic and interoperability with RFC 5545 (iCalendar).
 
 As the broadest `Temporal` type, `Temporal.ZonedDateTime` can be considered a combination of `Temporal.TimeZone`, `Temporal.Instant`, and `Temporal.DateTime` (which includes `Temporal.Calendar`).
@@ -144,7 +144,7 @@ See [Temporal.Calendar Documentation](./calendar.md) for detailed documentation.
 - [Parse Draft](./parse-draft.md) &mdash; Draft design document for a `Temporal.parse` API, which is not currently planned to be implemented.
 - [Calendar Draft](./calendar-draft.md) &mdash; Draft design document for calendar support in Temporal.
   Mostly superseded by the documentation of [Temporal.Calendar](./calendar.md), but also contains some discussion about whether to have a default calendar.
-- [Zoned Date/Time Type Draft](./zoneddatetime-draft.md) &mdash; Explanation of `Temporal.ZonedDateTime` which is a new type combining an instant time with a time zone and calendar, and exposing a superset of the `Temporal.DateTime` API.
+- [Zoned Date/Time Type Draft](./zoneddatetime-draft.md) &mdash; Explanation of `Temporal.ZonedDateTime` which is a new type combining an exact time with a time zone and calendar, and exposing a superset of the `Temporal.DateTime` API.
   Superseded by the [documentation](./zoneddatetime.md), but contains background info about the reasons and goals behind this type.
 
 ## Object Relationship

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -36,7 +36,7 @@ How to get a Unix timestamp?
 
 ### Instant from legacy Date
 
-Map a legacy ECMAScript Date instance into a Temporal.Instant instance corresponding to the same instant in instant time.
+Map a legacy ECMAScript Date instance into a Temporal.Instant instance corresponding to the same instant in exact time.
 
 ```javascript
 {{cookbook/instantFromLegacyDate.mjs}}
@@ -89,7 +89,7 @@ An example of combining a day on the calendar (`Temporal.MonthDay`) and a year i
 
 ### Zoned instant from instant and time zone
 
-Use the optional parameter of `Temporal.Instant.prototype.toString()` to map a Temporal.Instant instance and a time zone name into a string serialization of the local time in that zone corresponding to the instant in instant time.
+Use the optional parameter of `Temporal.Instant.prototype.toString()` to map an exact-time Temporal.Instant instance and a time zone name, into a string serialization of the wall-clock time in that time zone corresponding to the exact time.
 
 Without the parameter, `Temporal.Instant.prototype.toString()` gives a serialization in UTC time.
 Using the parameter is useful if you need your serialized strings to be in a specific time zone.
@@ -116,7 +116,7 @@ Sorting other Temporal types would work exactly the same way as this.
 Sort a list of ISO 8601 date/time strings, for example to place log entries in order.
 
 ```javascript
-{{cookbook/sortAbsoluteInstants.mjs}}
+{{cookbook/sortExactTimeStrings.mjs}}
 ```
 
 ## Rounding
@@ -154,9 +154,9 @@ This is easily done with `dateTime.toInstant()`, but here is an example of imple
 {{cookbook/getInstantWithLocalTimeInZone.mjs}}
 ```
 
-### Preserving absolute instant
+### Preserving exact time
 
-Map a zoned date and time of day into a string serialization of the local time in a target zone at the corresponding instant in instant time.
+Map a zoned date and time of day into a string serialization of the local time in a target time zone at the corresponding exact time.
 This could be used when converting user-input date-time values between time zones.
 
 ```javascript
@@ -165,8 +165,8 @@ This could be used when converting user-input date-time values between time zone
 
 Here is another example similar to the previous one, using the time zone for future events.
 The times and locations of a series of future meetings are stored as a pair of strings: one for the calendar date and wall-clock time, and one for the time zone.
-They cannot be stored as an absolute point in UTC because between now and the time when the event happens, the time zone rules for daylight saving time could change &mdash; for example, Brazil abolished daylight saving time in 2019 &mdash; but the meeting would still be held at the same wall-clock time on that date.
-So if the time zone rules changed, the event's absolute point in time would change.
+They cannot be stored as an exact time because between now and the time when the event happens, the time zone rules for daylight saving time could change &mdash; for example, Brazil abolished daylight saving time in 2019 &mdash; but the meeting would still be held at the same wall-clock time on that date.
+So if the time zone rules changed, the event's exact time would change.
 
 This example calculates the starting times of all the Ecma TC39 meetings in 2019, in local time in Tokyo.
 
@@ -176,7 +176,7 @@ This example calculates the starting times of all the Ecma TC39 meetings in 2019
 
 ### Daily occurrence in local time
 
-Similar to the previous recipe, calculate the instant times of a daily occurrence that happens at a particular local time in a particular time zone.
+Similar to the previous recipe, calculate the exact times of a daily occurrence that happens at a particular local time in a particular time zone.
 
 ```javascript
 {{cookbook/calculateDailyOccurrence.mjs}}
@@ -184,7 +184,7 @@ Similar to the previous recipe, calculate the instant times of a daily occurrenc
 
 ### UTC offset for a zoned event, as a string
 
-Use `Temporal.TimeZone.getOffsetStringFor()` to map a `Temporal.Instant` instance and a time zone into the UTC offset at that instant in that time zone, as a string.
+Use `Temporal.TimeZone.getOffsetStringFor()` to map a `Temporal.Instant` instance and a time zone into the UTC offset at that exact time in that time zone, as a string.
 
 ```javascript
 {{cookbook/getUtcOffsetStringAtInstant.mjs}}
@@ -199,9 +199,9 @@ Similarly, use `Temporal.TimeZone.getOffsetNanosecondsFor()` to do the same thin
 {{cookbook/getUtcOffsetSecondsAtInstant.mjs}}
 ```
 
-### Offset between two time zones at an instant
+### Offset between two time zones at an exact time
 
-Also using `Temporal.TimeZone.getOffsetNanosecondsFor()`, we can map a `Temporal.Instant` instance and two time zones into the signed difference of UTC offsets between those time zones at that instant, as a number of seconds.
+Also using `Temporal.TimeZone.getOffsetNanosecondsFor()`, we can map a `Temporal.Instant` instance and two time zones into the signed difference of UTC offsets between those time zones at that exact time, as a number of seconds.
 
 ```javascript
 {{cookbook/getUtcOffsetDifferenceSecondsAtInstant.mjs}}
@@ -340,15 +340,15 @@ Take the difference between two Temporal.Instant instances as a Temporal.Duratio
 
 ### Nearest offset transition in a time zone
 
-Map a Temporal.Instant instance and a Temporal.TimeZone object into a Temporal.Instant instance representing the nearest following instant at which there is an offset transition in the time zone (e.g., for setting reminders).
+Map a Temporal.Instant instance and a Temporal.TimeZone object into a Temporal.Instant instance representing the nearest following exact time at which there is an offset transition in the time zone (e.g., for setting reminders).
 
 ```javascript
 {{cookbook/getInstantOfNearestOffsetTransitionToInstant.mjs}}
 ```
 
-### Comparison of an instant to business hours
+### Comparison of an exact time to business hours
 
-This example takes a roster of opening and closing times for a business, and maps a localized date and time of day into a time-sensitive state indicator ("opening soon" vs. "open" vs. "closing soon" vs. "closed").
+This example takes a roster of wall-clock opening and closing times for a business, and maps an exact time into a time-sensitive state indicator ("opening soon" vs. "open" vs. "closing soon" vs. "closed").
 
 ```javascript
 {{cookbook/getBusinessOpenStateText.mjs}}
@@ -379,8 +379,8 @@ Add the number of days it took to get an approval, and advance to the start of t
 ### Schedule a reminder ahead of matching a record-setting duration
 
 When considering a record (for example, a personal-best time in a sport), you might want to receive an alert just before the record is about to be broken.
-This example takes a record as a `Temporal.Duration`, the starting instant of the current attempt as a `Temporal.Instant`, and another `Temporal.Duration` indicating how long before the potentially record-setting instant you would like to receive an alert.
-It returns the instant at which a notification could be sent, for example "Keep going! 5 more minutes and it will be your personal best!"
+This example takes a record as a `Temporal.Duration`, the starting exact time of the current attempt as a `Temporal.Instant`, and another `Temporal.Duration` indicating how long before the potentially record-setting exact time you would like to receive an alert.
+It returns the exact time at which a notification could be sent, for example "Keep going! 5 more minutes and it will be your personal best!"
 
 This could be used for workout tracking, racing (including _long_ and potentially time-zone-crossing races like the Bullrun Rally, Iditarod, Self-Transcendence 3100, and Clipper Round The World), or even open-ended analogs like event-every-day "streaks".
 

--- a/docs/cookbook/all.mjs
+++ b/docs/cookbook/all.mjs
@@ -30,4 +30,4 @@ import './nextWeeklyOccurrence.mjs';
 import './noonOnDate.mjs';
 import './plusAndRoundToMonthStart.mjs';
 import './roundDownToWholeHours.mjs';
-import './sortAbsoluteInstants.mjs';
+import './sortExactTimeStrings.mjs';

--- a/docs/cookbook/calculateDailyOccurrence.mjs
+++ b/docs/cookbook/calculateDailyOccurrence.mjs
@@ -1,5 +1,5 @@
 /**
- * Returns an iterator of the instant times corresponding to a daily occurrence
+ * Returns an iterator of the exact times corresponding to a daily occurrence
  * starting on a particular date, and happening at a particular local time in a
  * particular time zone.
  *

--- a/docs/cookbook/getBusinessOpenStateText.mjs
+++ b/docs/cookbook/getBusinessOpenStateText.mjs
@@ -1,10 +1,10 @@
 /**
- * Compare the given time to the business hours of a business located in a
- * particular time zone, and return a string indicating whether the business is
- * open, closed, opening soon, or closing soon. The length of "soon" can be
+ * Compare the given exact time to the business hours of a business located in
+ * a particular time zone, and return a string indicating whether the business
+ * is open, closed, opening soon, or closing soon. The length of "soon" can be
  * controlled using the `soonWindow` parameter.
  *
- * @param {Temporal.Instant} now - Time at which to consider whether the
+ * @param {Temporal.Instant} now - Exact time at which to consider whether the
  *  business is open
  * @param {Temporal.TimeZone} timeZone - Time zone in which the business is
  *  located
@@ -14,14 +14,14 @@
  *  opens
  * @param {Temporal.Time} businessHours[].close - Time at which the business
  *  closes
- * @param {Temporal.Duration} soonWindow - Length of time before the opening or
- *  closing time during which the business should be considered "opening soon"
- *  or "closing soon"
+ * @param {Temporal.Duration} soonWindow - Length of time before the opening
+ *  or closing time during which the business should be considered "opening
+ *  soon" or "closing soon"
  * @returns {string} "open", "closed", "opening soon", or "closing soon"
  */
 function getBusinessOpenStateText(now, timeZone, businessHours, soonWindow) {
-  function inRange(abs, start, end) {
-    return Temporal.Instant.compare(abs, start) >= 0 && Temporal.Instant.compare(abs, end) < 0;
+  function inRange(i, start, end) {
+    return Temporal.Instant.compare(i, start) >= 0 && Temporal.Instant.compare(i, end) < 0;
   }
 
   const dateTime = now.toDateTimeISO(timeZone);

--- a/docs/cookbook/getInstantBeforeOldRecord.mjs
+++ b/docs/cookbook/getInstantBeforeOldRecord.mjs
@@ -1,12 +1,12 @@
 /**
- * Retrieve a time at which to give advance notice of a record that is
- * potentially about to be broken.
+ * Retrieve an exact time at which to give advance notice of a record that
+ * is potentially about to be broken.
  *
- * @param {Temporal.Instant} start - Start time of the event
+ * @param {Temporal.Instant} start - Starting exact time of the event
  * @param {Temporal.Duration} previousRecord - Existing record to be broken
  * @param {Temporal.Duration} noticeWindow - Advance notice time
- * @returns {Temporal.Instant} Time at which to give advance notice of breaking
- *  the record
+ * @returns {Temporal.Instant} Exact time at which to give advance notice of
+ *  breaking the record
  */
 function getInstantBeforeOldRecord(start, previousRecord, noticeWindow) {
   return start.add(previousRecord).subtract(noticeWindow);

--- a/docs/cookbook/getInstantOfNearestOffsetTransitionToInstant.mjs
+++ b/docs/cookbook/getInstantOfNearestOffsetTransitionToInstant.mjs
@@ -1,8 +1,8 @@
 /**
- * Get the nearest following instant that the given time zone transitions to
- * another UTC offset, inclusive or exclusive.
+ * Get the nearest following exact time that the given time zone transitions
+ * to another UTC offset, inclusive or exclusive.
  *
- * @param {Temporal.Instant} instant - Start time to consider
+ * @param {Temporal.Instant} instant - Starting exact time to consider
  * @param {Temporal.TimeZone} timeZone - Time zone to consider
  * @param {boolean} inclusive - Include the start time, or not
  * @returns {(Temporal.Instant|null)} - Next UTC offset transition, or null if
@@ -11,7 +11,7 @@
 function getInstantOfNearestOffsetTransitionToInstant(instant, timeZone, inclusive) {
   let nearest;
   if (inclusive) {
-    // In case instant itself is the moment of a transition:
+    // In case instant itself is the exact time of a transition:
     nearest = timeZone.getNextTransition(instant.subtract({ nanoseconds: 1 }));
   } else {
     nearest = timeZone.getNextTransition(instant);

--- a/docs/cookbook/getInstantWithLocalTimeInZone.mjs
+++ b/docs/cookbook/getInstantWithLocalTimeInZone.mjs
@@ -1,6 +1,6 @@
 /**
- * Get an instant time corresponding with a calendar date / wall-clock time in
- * a particular time zone, the same as Temporal.TimeZone.getInstantFor() or
+ * Get an exact time corresponding with a calendar date / wall-clock time in a
+ * particular time zone, the same as Temporal.TimeZone.getInstantFor() or
  * Temporal.DateTime.toInstant(), but with more disambiguation options.
  *
  * As well as the default Temporal disambiguation options 'compatible',

--- a/docs/cookbook/getParseableZonedStringAtInstant.mjs
+++ b/docs/cookbook/getParseableZonedStringAtInstant.mjs
@@ -1,19 +1,19 @@
-const instantTime = Temporal.Instant.from('2020-01-03T10:41:51Z');
+const instant = Temporal.Instant.from('2020-01-03T10:41:51Z');
 
-const result = instantTime.toString('Europe/Paris');
+const result = instant.toString('Europe/Paris');
 
 assert.equal(result, '2020-01-03T11:41:51+01:00[Europe/Paris]');
-assert.equal(Temporal.Instant.compare(instantTime, Temporal.Instant.from(result)), 0);
+assert(instant.equals(Temporal.Instant.from(result)));
 
 // With an offset:
 
-const result2 = instantTime.toString('-07:00');
+const result2 = instant.toString('-07:00');
 
 assert.equal(result2, '2020-01-03T03:41:51-07:00');
 
 // With a Temporal.TimeZone object:
 
 const timeZone = Temporal.TimeZone.from('Asia/Seoul');
-const result3 = instantTime.toString(timeZone);
+const result3 = instant.toString(timeZone);
 
 assert.equal(result3, '2020-01-03T19:41:51+09:00[Asia/Seoul]');

--- a/docs/cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs
+++ b/docs/cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs
@@ -1,6 +1,7 @@
 /**
  * Takes a local date and time in one time zone, and serializes it to a string
- * expressing the local date and time in another time zone.
+ * expressing the local date and time in another time zone at the same exact
+ * time.
  *
  * If `sourceDateTime` doesn't exist in `sourceTimeZone`, or exists twice, then
  * an error will be thrown by default.

--- a/docs/cookbook/getUtcOffsetDifferenceSecondsAtInstant.mjs
+++ b/docs/cookbook/getUtcOffsetDifferenceSecondsAtInstant.mjs
@@ -1,8 +1,8 @@
 /**
- * Returns the number of seconds' difference between the UTC offsets of two time
- * zones, at a particular moment in time.
+ * Returns the number of seconds' difference between the UTC offsets of two
+ * time zones, at an exact time
  *
- * @param {Temporal.Instant} instant - A moment in time
+ * @param {Temporal.Instant} instant - An exact time
  * @param {Temporal.TimeZone} sourceTimeZone - A time zone to examine
  * @param {Temporal.TimeZone} targetTimeZone - A second time zone to examine
  * @returns {number} The number of seconds difference between the time zones'
@@ -18,5 +18,5 @@ const instant = Temporal.Instant.from('2020-01-09T00:00Z');
 const nyc = Temporal.TimeZone.from('America/New_York');
 const chicago = Temporal.TimeZone.from('America/Chicago');
 
-// At this instant, Chicago is 3600 seconds earlier than New York
+// At this exact time, Chicago is 3600 seconds earlier than New York
 assert.equal(getUtcOffsetDifferenceSecondsAtInstant(instant, nyc, chicago), -3600);

--- a/docs/cookbook/sortExactTimeStrings.mjs
+++ b/docs/cookbook/sortExactTimeStrings.mjs
@@ -1,20 +1,20 @@
 /**
- * getSortedInstants will sort an array of strings (each of which is parseable
- * as a Temporal.Instant and may or may not include an IANA time zone name)
- * by the corresponding instant time (e.g., for presenting global log events
- * sequentially).
+ * sortInstantStrings will sort an array of strings (each of which is
+ * parseable as a Temporal.Instant and may or may not include an IANA time
+ * zone name) by the corresponding exact time (e.g., for presenting global
+ * log events sequentially).
  *
- * @param {string[]} parseableInstantStrings - a group of ISO Strings
+ * @param {string[]} strings - an array of ISO strings
  * @param {boolean} [reverse=false] - ascending or descending order
- * @returns {string[]} the array from parseableInstantStrings, sorted
+ * @returns {string[]} the array from strings, sorted
  */
-function getSortedInstants(parseableInstantStrings, reverse = false) {
-  const sortedInstantTimes = parseableInstantStrings
+function sortInstantStrings(strings, reverse = false) {
+  const sortedInstants = strings
     .map((v) => [v, Temporal.Instant.from(v)])
-    .sort(([, abs1], [, abs2]) => Temporal.Instant.compare(abs1, abs2))
+    .sort(([, i1], [, i2]) => Temporal.Instant.compare(i1, i2))
     .map(([str]) => str);
 
-  return reverse ? sortedInstantTimes.reverse() : sortedInstantTimes;
+  return reverse ? sortedInstants.reverse() : sortedInstants;
 }
 
 // simple string comparison order would not be correct here:
@@ -24,7 +24,7 @@ const c = '2020-04-01T05:01:00-05:00[America/New_York]';
 const d = '2020-04-01T10:00:00+01:00[Europe/London]';
 const e = '2020-04-01T11:02:00+02:00[Europe/Berlin]';
 
-const results = getSortedInstants([a, b, c, d, e]);
+const results = sortInstantStrings([a, b, c, d, e]);
 
 // results will have correct order
 assert.deepEqual(results, [

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -781,16 +781,16 @@ If the result is earlier or later than the range that `Temporal.ZonedDateTime` c
     Allowed values are `'compatible'`, `'earlier'`, `'later'`, and `'reject'`.
     The default is `'compatible'`.
 
-**Returns:** A `Temporal.Instant` object indicating the instant time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
+**Returns:** A `Temporal.Instant` object indicating the exact time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
 
 This method is one way to convert a `Temporal.DateTime` to a `Temporal.Instant`.
 It is identical to [`(Temporal.TimeZone.from(timeZone || 'UTC')).getInstantFor(dateTime, disambiguation)`](./timezone.html#getInstantFor).
 
-In the case of ambiguity, the `disambiguation` option controls what instant time to return:
+In the case of ambiguity, the `disambiguation` option controls what exact time to return:
 
 - `'compatible'` (the default): Acts like `'earlier'` for backward transitions and `'later'` for forward transitions.
-- `'earlier'`: The earlier of two possible times.
-- `'later'`: The later of two possible times.
+- `'earlier'`: The earlier of two possible exact times.
+- `'later'`: The later of two possible exact times.
 - `'reject'`: Throw a `RangeError` instead.
 
 When interoperating with existing code or services, `'compatible'` mode matches the behavior of legacy `Date` as well as libraries like moment.js, Luxon, and date-fns.

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -5,12 +5,12 @@
 <!-- toc -->
 </details>
 
-A `Temporal.Instant` is an instant point in time, with a precision in nanoseconds.
+A `Temporal.Instant` is a single point in time (called **"exact time"**), with a precision in nanoseconds.
 No time zone or calendar information is present.
 As such `Temporal.Instant` has no concept of days, months or even hours.
 
 For convenience of interoperability, it internally uses nanoseconds since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time) (midnight UTC on January 1, 1970).
-However, a `Temporal.Instant` can be created from any of several expressions that refer to a single point in time, including an ISO 8601 string with a time zone such as `'2020-01-23T17:04:36.491865121-08:00'`.
+However, a `Temporal.Instant` can be created from any of several expressions that refer to an exact time, including an ISO 8601 string with a time zone such as `'2020-01-23T17:04:36.491865121-08:00'`.
 
 If you have a legacy `Date` instance, you can use its `toTemporalInstant()` method to convert to a `Temporal.Instant`.
 
@@ -28,9 +28,9 @@ Like Unix time, `Temporal.Instant` ignores leap seconds.
 
 **Returns:** a new `Temporal.Instant` object.
 
-Creates a new `Temporal.Instant` object that represents a single point in time.
+Creates a new `Temporal.Instant` object that represents an exact time.
 
-`epochNanoseconds` is the number of nanoseconds (10<sup>&minus;9</sup> seconds) between the Unix epoch (midnight UTC on January 1, 1970) and the desired point in time.
+`epochNanoseconds` is the number of nanoseconds (10<sup>&minus;9</sup> seconds) between the Unix epoch (midnight UTC on January 1, 1970) and the desired exact time.
 
 Use this constructor directly if you know the precise number of nanoseconds already and have it in bigint form, for example from a database.
 Otherwise, `Temporal.Instant.from()`, which accepts more kinds of input, is probably more convenient.
@@ -54,15 +54,15 @@ turnOfTheCentury = new Temporal.Instant(-2208988800000000000n); // => 1900-01-01
 
 **Parameters:**
 
-- `thing`: The value representing the desired point in time.
+- `thing`: The value representing the desired exact time.
 
 **Returns:** a new `Temporal.Instant` object.
 
 This static method creates a new `Temporal.Instant` object from another value.
-If the value is another `Temporal.Instant` object, a new object representing the same point in time is returned.
+If the value is another `Temporal.Instant` object, a new object representing the same exact time is returned.
 
 Any other value is converted to a string, which is expected to be in ISO 8601 format, including a date, a time, and a time zone.
-If the point in time cannot be uniquely determined from the string, then this function throws an exception.
+If the exact time cannot be uniquely determined from the string, then this function throws an exception.
 This includes the case when `thing` is a validly-formatted ISO 8601 string denoting a time that doesn't exist, for example because it was skipped in a daylight saving time transition.
 
 Example usage:
@@ -74,7 +74,7 @@ instant = Temporal.Instant.from('2019-03-30T01:45+01:00');
 instant = Temporal.Instant.from('2019-03-30T00:45Z');
 instant === Temporal.Instant.from(instant); // => true
 
-// Not enough information to denote a single point in time:
+// Not enough information to denote an exact time:
 /* WRONG */ instant = Temporal.Instant.from('2019-03-30'); // no time; throws
 /* WRONG */ instant = Temporal.Instant.from('2019-03-30T01:45'); // no time zone; throws
 /* WRONG */ instant = Temporal.Instant.from('2019-03031T02:45+01:00[Europe/Berlin]');
@@ -91,9 +91,9 @@ instant === Temporal.Instant.from(instant); // => true
 **Returns:** a new `Temporal.Instant` object.
 
 This static method creates a new `Temporal.Instant` object with seconds precision.
-`epochSeconds` is the number of seconds between the Unix epoch (midnight UTC on January 1, 1970) and the desired point in time.
+`epochSeconds` is the number of seconds between the Unix epoch (midnight UTC on January 1, 1970) and the desired exact time.
 
-The number of seconds since the Unix epoch is a common measure of time in many computer systems.
+The number of seconds since the Unix epoch is a common measure of exact time in many computer systems.
 Use this method if you need to interface with such a system.
 
 Example usage:
@@ -300,7 +300,7 @@ Use this method if you are not doing computations in other calendars.
 
 Example usage:
 ```js
-// Converting a specific instant time to a calendar date / wall-clock time
+// Converting an exact time to a calendar date / wall-clock time
 timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
 timestamp.toDateTime('Europe/Berlin'); // => 2019-03-31T01:45
 timestamp.toDateTime('UTC'); // => 2019-03-31T00:45
@@ -349,9 +349,9 @@ console.log(dt.year, dt.era);
 
 - `duration` (object): A `Temporal.Duration` object or a duration-like object.
 
-**Returns:** a new `Temporal.Instant` object which is the time indicated by `instant` plus `duration`.
+**Returns:** a new `Temporal.Instant` object which is the exact time indicated by `instant` plus `duration`.
 
-This method adds `duration` to `instant`, returning a point in time that is in the future relative to `instant`.
+This method adds `duration` to `instant`.
 
 The `duration` argument is an object with properties denoting a duration, such as `{ hours: 5, minutes: 30 }`, or a `Temporal.Duration` object.
 
@@ -362,7 +362,7 @@ If you need to do this, convert the `Temporal.Instant` to a `Temporal.DateTime` 
 
 If the result is earlier or later than the range that `Temporal.Instant` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), a `RangeError` will be thrown.
 
-Adding a negative duration is equivalent to subtracting the instant value of that duration.
+Adding a negative duration is equivalent to subtracting the absolute value of that duration.
 
 Example usage:
 
@@ -379,9 +379,9 @@ Temporal.now.instant().add(fiveHours);
 
 - `duration` (object): A `Temporal.Duration` object or a duration-like object.
 
-**Returns:** a new `Temporal.Instant` object which is the time indicated by `instant` minus `duration`.
+**Returns:** a new `Temporal.Instant` object which is the exact time indicated by `instant` minus `duration`.
 
-This method subtracts `duration` from `instant`, returning a point in time that is in the past relative to `instant`.
+This method subtracts `duration` from `instant`.
 
 The `duration` argument is an object with properties denoting a duration, such as `{ hours: 5, minutes: 30 }`, or a `Temporal.Duration` object.
 
@@ -392,7 +392,7 @@ If you need to do this, convert the `Temporal.Instant` to a `Temporal.DateTime` 
 
 If the result is earlier or later than the range that `Temporal.Instant` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), a `RangeError` will be thrown.
 
-Subtracting a negative duration is equivalent to adding the instant value of that duration.
+Subtracting a negative duration is equivalent to adding the absolute value of that duration.
 
 Example usage:
 
@@ -407,7 +407,7 @@ Temporal.now.instant().subtract(oneHour);
 
 **Parameters:**
 
-- `other` (`Temporal.Instant`): Another time with which to compute the difference.
+- `other` (`Temporal.Instant`): Another exact time with which to compute the difference.
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
@@ -424,7 +424,7 @@ Temporal.now.instant().subtract(oneHour);
 
 **Returns:** a `Temporal.Duration` representing the difference between `instant` and `other`.
 
-This method computes the difference between the two times represented by `instant` and `other`, optionally rounds it, and returns it as a `Temporal.Duration` object.
+This method computes the difference between the two exact times represented by `instant` and `other`, optionally rounds it, and returns it as a `Temporal.Duration` object.
 If `other` is later than `instant` then the resulting duration will be negative.
 
 The `largestUnit` option controls how the resulting duration is expressed.
@@ -548,7 +548,7 @@ instant.round({ roundingIncrement: 60, smallestUnit: 'minute', roundingMode: 'fl
 
 **Parameters:**
 
-- `other` (`Temporal.Instant`): Another time to compare.
+- `other` (`Temporal.Instant`): Another exact time to compare.
 
 **Returns:** `true` if `instant` and `other` are equal, or `false` if not.
 

--- a/docs/now.md
+++ b/docs/now.md
@@ -61,7 +61,7 @@ If you only want to use the ISO 8601 calendar, use `Temporal.now.zonedDateTimeIS
 
 **Returns:** a `Temporal.Instant` object representing the current system time.
 
-This method gets the current absolute system time, without regard to calendar or time zone.
+This method gets the current exact system time, without regard to calendar or time zone.
 This is a good way to get a timestamp for an event, for example.
 It works like the old-style JavaScript `Date.now()`, but with nanosecond accuracy instead of milliseconds.
 

--- a/docs/timezone-draft.md
+++ b/docs/timezone-draft.md
@@ -110,9 +110,9 @@ class Temporal.TimeZone {
 
   /** Given the calendar/wall-clock time, returns an array of 0, 1, or
    * 2 (or theoretically more, but not in any currently known time zone)
-   * instant times, that are possible points on the timeline
-   * corresponding to it. In getInstantFor(), one of these will be
-   * selected, depending on the disambiguation option. */
+   * exact times, that are possible points on the timeline corresponding
+   * to it. In getInstantFor(), one of these will be selected, depending
+   * on the disambiguation option. */
   getPossibleInstantsFor(dateTime : Temporal.DateTime) : array<Temporal.Instant>;
 
   /** Return the next time zone transition after `startingPoint`. */

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -211,18 +211,18 @@ tz.getZonedDateTimeFor(epoch); // => 1969-12-31T19:00-05:00[America/New_York]
 
 **Parameters:**
 
-- `instant` (`Temporal.Instant`): An instant time to convert.
+- `instant` (`Temporal.Instant`): An exact time to convert.
 - `calendar` (optional object or string): A `Temporal.Calendar` object, or a plain object, or a calendar identifier.
   The default is to use the ISO 8601 calendar.
 
-**Returns:** A `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the instant time indicated by `instant`.
+**Returns:** A `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the exact time indicated by `instant`.
 
 This method is one way to convert a `Temporal.Instant` to a `Temporal.DateTime`.
 
 Example usage:
 
 ```javascript
-// Converting a specific instant time to a calendar date / wall-clock time
+// Converting an exact time to a calendar date / wall-clock time
 timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
 tz = Temporal.TimeZone.from('Europe/Berlin');
 tz.getDateTimeFor(timestamp); // => 2019-03-31T01:45
@@ -244,7 +244,7 @@ tz.getDateTimeFor(epoch); // => 1969-12-31T19:00
     Allowed values are `'compatible'`, `'earlier'`, `'later'`, and `'reject'`.
     The default is `'compatible'`.
 
-**Returns:** A `Temporal.Instant` object indicating the instant time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
+**Returns:** A `Temporal.Instant` object indicating the exact time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
 
 This method is one way to convert a `Temporal.DateTime` to a `Temporal.Instant`.
 It is identical to [`dateTime.toInstant(timeZone, disambiguation)`](./datetime.html#toInstant).
@@ -274,9 +274,9 @@ If the result is earlier or later than the range that `Temporal.Instant` can rep
 
 **Returns:** An array of `Temporal.Instant` objects, which may be empty.
 
-This method returns an array of all the possible instant times that could correspond to the calendar date and wall-clock time indicated by `dateTime`.
+This method returns an array of all the possible exact times that could correspond to the calendar date and wall-clock time indicated by `dateTime`.
 
-Normally there is only one possible instant time corresponding to a wall-clock time, but around a daylight saving change, a wall-clock time may not exist, or the same wall-clock time may exist twice in a row.
+Normally there is only one possible exact time corresponding to a wall-clock time, but around a daylight saving change, a wall-clock time may not exist, or the same wall-clock time may exist twice in a row.
 See [Resolving ambiguity](./ambiguity.md) for usage examples and a more complete explanation.
 
 Although this method is useful for implementing a custom time zone or custom disambiguation behaviour, usually you won't have to use this method; `Temporal.TimeZone.prototype.getInstantFor()` will be more convenient for most use cases.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -17,7 +17,7 @@ As the only `Temporal` type that persists a time zone, `Temporal.ZonedDateTime` 
 - Creating derived values (e.g. change time to 2:30AM) can avoid worrying that the result will be invalid due to the time zone's DST rules.
 - Properties are available to easily measure attributes like "length of day" or "starting time of day" which may not be the same on all days in all time zones due to DST transitions or political changes to the definitions of time zones.
 - It's easy to flip back and forth between a human-readable representation (like `Temporal.DateTime`) and the UTC timeline (like `Temporal.Instant`) without having to do any work to keep the two in sync.
-- A date/time, an offset, a time zone, and an optional calendar can be persisted in a single string that can be sorted alphabetically by when instants happened in the real world.
+- A date/time, an offset, a time zone, and an optional calendar can be persisted in a single string that can be sorted alphabetically by the exact time they happened.
   This behavior is also be helpful for developers who are not sure which of those components will be needed by later readers of this data.
 - Multiple time-zone-sensitive operations can be performed in a chain without having to repeatedly provide the same time zone.
 


### PR DESCRIPTION
Closes: #926