### PR TITLE
Remove balancing from Duration.from() and Duration.with()

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -219,7 +219,7 @@ export namespace Temporal {
    * See https://tc39.es/proposal-temporal/docs/duration.html for more details.
    */
   export class Duration implements DurationFields {
-    static from(item: Temporal.Duration | DurationLike | string, options?: DurationOptions): Temporal.Duration;
+    static from(item: Temporal.Duration | DurationLike | string): Temporal.Duration;
     constructor(
       years?: number,
       months?: number,
@@ -245,7 +245,7 @@ export namespace Temporal {
     readonly nanoseconds: number;
     negated(): Temporal.Duration;
     abs(): Temporal.Duration;
-    with(durationLike: DurationLike, options?: DurationOptions): Temporal.Duration;
+    with(durationLike: DurationLike): Temporal.Duration;
     add(other: Temporal.Duration | DurationLike, options?: DurationOptions): Temporal.Duration;
     subtract(other: Temporal.Duration | DurationLike, options?: DurationOptions): Temporal.Duration;
     round(options: DurationRoundOptions): Temporal.Duration;

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -136,10 +136,8 @@ export class Duration {
       GetSlot(this, NANOSECONDS)
     );
   }
-  with(durationLike, options = undefined) {
+  with(durationLike) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    options = ES.NormalizeOptionsObject(options);
-    const overflow = ES.ToTemporalDurationOverflow(options);
     const props = ES.ToPartialRecord(durationLike, [
       'days',
       'hours',
@@ -167,30 +165,6 @@ export class Duration {
       microseconds = GetSlot(this, MICROSECONDS),
       nanoseconds = GetSlot(this, NANOSECONDS)
     } = props;
-    ({
-      years,
-      months,
-      weeks,
-      days,
-      hours,
-      minutes,
-      seconds,
-      milliseconds,
-      microseconds,
-      nanoseconds
-    } = ES.RegulateDuration(
-      years,
-      months,
-      weeks,
-      days,
-      hours,
-      minutes,
-      seconds,
-      milliseconds,
-      microseconds,
-      nanoseconds,
-      overflow
-    ));
     const Construct = ES.SpeciesConstructor(this, Duration);
     const result = new Construct(
       years,
@@ -540,9 +514,7 @@ export class Duration {
   valueOf() {
     throw new TypeError('not possible to compare Temporal.Duration');
   }
-  static from(item, options = undefined) {
-    options = ES.NormalizeOptionsObject(options);
-    const overflow = ES.ToTemporalDurationOverflow(options);
+  static from(item) {
     let years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
     if (typeof item === 'object' && item) {
       ({
@@ -571,30 +543,6 @@ export class Duration {
         nanoseconds
       } = ES.ParseTemporalDurationString(ES.ToString(item)));
     }
-    ({
-      years,
-      months,
-      weeks,
-      days,
-      hours,
-      minutes,
-      seconds,
-      milliseconds,
-      microseconds,
-      nanoseconds
-    } = ES.RegulateDuration(
-      years,
-      months,
-      weeks,
-      days,
-      hours,
-      minutes,
-      seconds,
-      milliseconds,
-      microseconds,
-      nanoseconds,
-      overflow
-    ));
     const result = new this(
       years,
       months,

--- a/polyfill/test/Duration/constructor/from/argument-existing-object.js
+++ b/polyfill/test/Duration/constructor/from/argument-existing-object.js
@@ -5,13 +5,13 @@
 esid: sec-temporal.duration.from
 ---*/
 
-const unbalanced = Temporal.Duration.from({ milliseconds: 1000 });
-assert.sameValue(unbalanced.seconds, 0);
-assert.sameValue(unbalanced.milliseconds, 1000);
+const d1 = Temporal.Duration.from({ milliseconds: 1000 });
+assert.sameValue(d1.seconds, 0);
+assert.sameValue(d1.milliseconds, 1000);
 
-const balanced = Temporal.Duration.from(unbalanced, { overflow: "balance" });
-assert.notSameValue(balanced, unbalanced);
-assert.sameValue(unbalanced.seconds, 0);
-assert.sameValue(unbalanced.milliseconds, 1000);
-assert.sameValue(balanced.seconds, 1);
-assert.sameValue(balanced.milliseconds, 0);
+const d2 = Temporal.Duration.from(d1);
+assert.notSameValue(d1, d2);
+assert.sameValue(d1.seconds, 0);
+assert.sameValue(d1.milliseconds, 1000);
+assert.sameValue(d2.seconds, 0);
+assert.sameValue(d2.milliseconds, 1000);

--- a/polyfill/test/Duration/constructor/from/infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/constructor/from/infinity-throws-rangeerror.js
@@ -6,13 +6,10 @@ description: Temporal.Duration.from handles a property bag if any value is Infin
 esid: sec-temporal.duration.from
 ---*/
 
-const overflows = ['constrain', 'balance'];
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    assert.throws(RangeError, () => Temporal.Duration.from({ [field]: Infinity }, { overflow }));
-  });
+fields.forEach((field) => {
+  assert.throws(RangeError, () => Temporal.Duration.from({ [field]: Infinity }));
 });
 
 let calls = 0;
@@ -23,10 +20,8 @@ const obj = {
   }
 };
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    calls = 0;
-    assert.throws(RangeError, () => Temporal.Duration.from({ [field]: obj }, { overflow }));
-    assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-  });
+fields.forEach((field) => {
+  calls = 0;
+  assert.throws(RangeError, () => Temporal.Duration.from({ [field]: obj }));
+  assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/constructor/from/negative-inifinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/constructor/from/negative-inifinity-throws-rangeerror.js
@@ -6,13 +6,10 @@ description: Temporal.Duration.from handles a property bag if any value is -Infi
 esid: sec-temporal.duration.from
 ---*/
 
-const overflows = ['constrain', 'balance'];
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    assert.throws(RangeError, () => Temporal.Duration.from({ [field]: -Infinity }, { overflow }));
-  });
+fields.forEach((field) => {
+  assert.throws(RangeError, () => Temporal.Duration.from({ [field]: -Infinity }));
 });
 
 let calls = 0;
@@ -23,10 +20,8 @@ const obj = {
   }
 };
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    calls = 0;
-    assert.throws(RangeError, () => Temporal.Duration.from({ [field]: obj }, { overflow }));
-    assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-  });
+fields.forEach((field) => {
+  calls = 0;
+  assert.throws(RangeError, () => Temporal.Duration.from({ [field]: obj }));
+  assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/constructor/from/subclass-invalid-arg.js
+++ b/polyfill/test/Duration/constructor/from/subclass-invalid-arg.js
@@ -5,15 +5,16 @@
 esid: sec-temporal.duration.from
 ---*/
 
-let called = false;
+let called = 0;
 
 class MyDuration extends Temporal.Duration {
   constructor(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds) {
-    called = true;
+    ++called;
     super(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
 }
 
-assert.throws(RangeError, () => MyDuration.from({ years: Infinity }, { overflow: "reject" }));
-assert.throws(RangeError, () => MyDuration.from({ days: -Infinity }, { overflow: "reject" }));
-assert.sameValue(called, false);
+assert.throws(RangeError, () => MyDuration.from({ years: Infinity }));
+assert.sameValue(called, 1);
+assert.throws(RangeError, () => MyDuration.from({ days: -Infinity }));
+assert.sameValue(called, 2);

--- a/polyfill/test/Duration/prototype/with/infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/with/infinity-throws-rangeerror.js
@@ -6,15 +6,12 @@ description: Temporal.Duration.prototype.with handles a property bag if any valu
 esid: sec-temporal.duration.prototype.with
 ---*/
 
-const overflows = ['constrain', 'balance'];
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    assert.throws(RangeError, () => instance.with({ [field]: Infinity }, { overflow }));
-  });
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.with({ [field]: Infinity }));
 });
 
 let calls = 0;
@@ -25,10 +22,8 @@ const obj = {
   }
 };
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    calls = 0;
-    assert.throws(RangeError, () => instance.with({ [field]: obj }, { overflow }));
-    assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-  });
+fields.forEach((field) => {
+  calls = 0;
+  assert.throws(RangeError, () => instance.with({ [field]: obj }));
+  assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/with/negative-infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/with/negative-infinity-throws-rangeerror.js
@@ -6,15 +6,12 @@ description: Temporal.Duration.prototype.with throws a RangeError if any value i
 esid: sec-temporal.duration.prototype.with
 ---*/
 
-const overflows = ['constrain', 'balance'];
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    assert.throws(RangeError, () => instance.with({ [field]: -Infinity }, { overflow }));
-  });
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.with({ [field]: -Infinity }));
 });
 
 let calls = 0;
@@ -25,10 +22,8 @@ const obj = {
   }
 };
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    calls = 0;
-    assert.throws(RangeError, () => instance.with({ [field]: obj }, { overflow }));
-    assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-  });
+fields.forEach((field) => {
+  calls = 0;
+  assert.throws(RangeError, () => instance.with({ [field]: obj }));
+  assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/with/subclass-out-of-range.js
+++ b/polyfill/test/Duration/prototype/with/subclass-out-of-range.js
@@ -10,7 +10,7 @@ let called = 0;
 
 const constructorArguments = [
   Array(10).fill(0),
-  [0, 0, 0, Number.MAX_VALUE, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, Infinity, 0, 0, 0, 0, 0, 0],
 ];
 
 class MyDuration extends Temporal.Duration {
@@ -25,7 +25,4 @@ const instance = MyDuration.from("PT0S");
 assert.sameValue(called, 1);
 
 assert.throws(RangeError, () => instance.with({ days: Infinity }));
-assert.sameValue(called, 1);
-
-assert.throws(RangeError, () => instance.with({ days: Infinity }, { overflow: "balance" }));
-assert.sameValue(called, 1);
+assert.sameValue(called, 2);

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -188,44 +188,11 @@ describe('Duration', () => {
       throws(() => Duration.from('P-1Y1M'), RangeError);
       throws(() => Duration.from('P1Y-1M'), RangeError);
     });
-    it('options may only be an object or undefined', () => {
-      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
-        throws(() => Duration.from({ hours: 1 }, badOptions), TypeError)
-      );
-      [{}, () => {}, undefined].forEach((options) => equal(Duration.from({ hours: 1 }, options).hours, 1));
+    it('mixed positive and negative values throw', () => {
+      throws(() => Duration.from({ hours: 1, minutes: -30 }), RangeError);
     });
-    describe('Overflow', () => {
-      it('mixed positive and negative values always throw', () => {
-        ['constrain', 'balance'].forEach((overflow) =>
-          throws(() => Duration.from({ hours: 1, minutes: -30 }, { overflow }), RangeError)
-        );
-      });
-      it('excessive values unchanged when "constrain"', () => {
-        equal(`${Duration.from({ minutes: 100 }, { overflow: 'constrain' })}`, 'PT100M');
-      });
-      it('excessive time units balance when "balance"', () => {
-        equal(`${Duration.from({ nanoseconds: 1000 }, { overflow: 'balance' })}`, 'PT0.000001S');
-        equal(`${Duration.from({ microseconds: 1000 }, { overflow: 'balance' })}`, 'PT0.001S');
-        equal(`${Duration.from({ milliseconds: 1000 }, { overflow: 'balance' })}`, 'PT1S');
-        equal(`${Duration.from({ seconds: 100 }, { overflow: 'balance' })}`, 'PT1M40S');
-        equal(`${Duration.from({ minutes: 100 }, { overflow: 'balance' })}`, 'PT1H40M');
-        equal(`${Duration.from({ hours: 100 }, { overflow: 'balance' })}`, 'P4DT4H');
-      });
-      it('excessive date units do not balance when "balance"', () => {
-        equal(`${Duration.from({ months: 12 }, { overflow: 'balance' })}`, 'P12M');
-        equal(`${Duration.from({ months: 12, seconds: 3600 }, { overflow: 'balance' })}`, 'P12MT1H');
-        equal(`${Duration.from({ weeks: 6 }, { overflow: 'balance' })}`, 'P6W');
-        equal(`${Duration.from({ weeks: 6, seconds: 3600 }, { overflow: 'balance' })}`, 'P6WT1H');
-        equal(`${Duration.from({ days: 31 }, { overflow: 'balance' })}`, 'P31D');
-        equal(`${Duration.from({ days: 31, seconds: 3600 }, { overflow: 'balance' })}`, 'P31DT1H');
-      });
-      it('throw on bad overflow', () => {
-        [new Duration(3), { days: 0 }, 'P5Y'].forEach((input) => {
-          ['', 'CONSTRAIN', 'reject', 'xyz', 3, null].forEach((overflow) =>
-            throws(() => Duration.from(input, { overflow }), RangeError)
-          );
-        });
-      });
+    it('excessive values unchanged', () => {
+      equal(`${Duration.from({ minutes: 100 })}`, 'PT100M');
     });
   });
   describe('toString()', () => {
@@ -378,32 +345,8 @@ describe('Duration', () => {
     it('duration.with({ months: 1, seconds: 15 } works', () => {
       equal(`${duration.with({ months: 1, seconds: 15 })}`, 'P5Y1M5W5DT5H5M15.005005005S');
     });
-    it('balance balances all values up to days', () => {
-      const result = duration.with(
-        {
-          hours: 100,
-          minutes: 100,
-          seconds: 100,
-          milliseconds: 3000,
-          microseconds: 3000,
-          nanoseconds: 3001
-        },
-        { overflow: 'balance' }
-      );
-      equal(result.years, 5);
-      equal(result.months, 5);
-      equal(result.days, 9);
-      equal(result.hours, 5);
-      equal(result.minutes, 41);
-      equal(result.seconds, 43);
-      equal(result.milliseconds, 3);
-      equal(result.microseconds, 3);
-      equal(result.nanoseconds, 1);
-    });
-    it('mixed positive and negative values always throw', () => {
-      ['constrain', 'balance'].forEach((overflow) =>
-        throws(() => duration.with({ hours: 1, minutes: -1 }, { overflow }), RangeError)
-      );
+    it('mixed positive and negative values throw', () => {
+      throws(() => duration.with({ hours: 1, minutes: -1 }), RangeError);
     });
     it('can reverse the sign if all the fields are replaced', () => {
       const d = Duration.from({ years: 5, days: 1 });
@@ -415,19 +358,8 @@ describe('Duration', () => {
       const d = Duration.from({ years: 5, days: 1 });
       throws(() => d.with({ months: -5, minutes: 0 }), RangeError);
     });
-    it('invalid overflow', () => {
-      ['', 'CONSTRAIN', 'reject', 'xyz', 3, null].forEach((overflow) =>
-        throws(() => duration.with({ days: 5 }, { overflow }), RangeError)
-      );
-    });
     it('sign cannot be manipulated independently', () => {
       throws(() => duration.with({ sign: -1 }), RangeError);
-    });
-    it('options may only be an object or undefined', () => {
-      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
-        throws(() => duration.with({ days: 5 }, badOptions), TypeError)
-      );
-      [{}, () => {}, undefined].forEach((options) => equal(duration.with({ days: 5 }, options).days, 5));
     });
   });
   describe('Duration.add()', () => {

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -82,21 +82,18 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.duration.from">
-      <h1>Temporal.Duration.from ( _item_ [ , _options_ ] )</h1>
+      <h1>Temporal.Duration.from ( _item_ )</h1>
       <p>
-        The `from` method takes two arguments, _item_ and _options_.
+        The `from` method takes one argument _item_.
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Set _options_ to ? NormalizeOptionsObject(_options_).
-        1. Let _overflow_ be ? ToTemporalDurationOverflow(_options_).
         1. If Type(_item_) is Object, then
           1. Let _result_ be ? ToTemporalDurationRecord(_arg_).
         1. Else,
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalDurationString(_string_).
         1. Let _constructor_ be the *this* value.
-        1. Set _result_ to ? RegulateDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _overflow_).
         1. Return ? CreateTemporalDurationFromStatic(_constructor_, _result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]],
         _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
@@ -271,15 +268,13 @@
     <emu-clause id="sec-temporal.duration.prototype.with">
       <h1>Temporal.Duration.prototype.with ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _temporalDurationLike_ and _options_.
+        The `with` method takes one argument _temporalDurationLike_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Let _temporalDurationLike_ be ? ToPartialDuration(_temporalDurationLike_).
-        1. Set _options_ to ? NormalizeOptionsObject(_options_).
-        1. Let _overflow_ be ? ToTemporalDurationOverflow(_options_).
         1. If _temporalDurationLike_.[[Years]] is not *undefined*, then
           1. Let _years_ be _temporalDurationLike_.[[Years]].
         1. Else,
@@ -320,8 +315,7 @@
           1. Let _nanoseconds_ be _temporalDurationLike_.[[Nanoseconds]].
         1. Else,
           1. Let _nanoseconds_ be _duration_.[[Nanoseconds]].
-        1. Let _result_ be ? RegulateDuration(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _overflow_).
-        1. Return ? CreateTemporalDurationFromInstance(_duration_, _result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Return ? CreateTemporalDurationFromInstance(_duration_, _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
There is now a more complete way to balance in Duration.round(), so remove
the incomplete balancing from Duration.from() and Duration.with(). The way
to balance a duration is now to use round() (or, as an option to add() or
subtract()).

Closes: #974