### PR TITLE
Consistent handling of singular and plural field names

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -174,23 +174,43 @@ export namespace Temporal {
       | 'auto'
       | 'years'
       | 'months'
+      | 'weeks'
       | 'days'
       | 'hours'
       | 'minutes'
       | 'seconds'
       | 'milliseconds'
       | 'microseconds'
-      | 'nanoseconds';
+      | 'nanoseconds'
+      | /** @deprecated */ 'year'
+      | /** @deprecated */ 'month'
+      | /** @deprecated */ 'day'
+      | /** @deprecated */ 'hour'
+      | /** @deprecated */ 'minute'
+      | /** @deprecated */ 'second'
+      | /** @deprecated */ 'millisecond'
+      | /** @deprecated */ 'microsecond'
+      | /** @deprecated */ 'nanosecond';
     smallestUnit:
       | 'years'
       | 'months'
+      | 'weeks'
       | 'days'
       | 'hours'
       | 'minutes'
       | 'seconds'
       | 'milliseconds'
       | 'microseconds'
-      | 'nanoseconds';
+      | 'nanoseconds'
+      | /** @deprecated */ 'year'
+      | /** @deprecated */ 'month'
+      | /** @deprecated */ 'day'
+      | /** @deprecated */ 'hour'
+      | /** @deprecated */ 'minute'
+      | /** @deprecated */ 'second'
+      | /** @deprecated */ 'millisecond'
+      | /** @deprecated */ 'microsecond'
+      | /** @deprecated */ 'nanosecond';
     roundingIncrement?: number;
     roundingMode?: 'nearest' | 'ceil' | 'floor' | 'trunc';
     relativeTo?: Temporal.DateTime | DateTimeLike | string;
@@ -287,10 +307,36 @@ export namespace Temporal {
     subtract(durationLike: Temporal.Duration | DurationLike): Temporal.Instant;
     difference(
       other: Temporal.Instant,
-      options?: DifferenceOptions<'hours' | 'minutes' | 'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds'>
+      options?: DifferenceOptions<
+        | 'hours'
+        | 'minutes'
+        | 'seconds'
+        | 'milliseconds'
+        | 'microseconds'
+        | 'nanoseconds'
+        | /** @deprecated */ 'hour'
+        | /** @deprecated */ 'minute'
+        | /** @deprecated */ 'second'
+        | /** @deprecated */ 'millisecond'
+        | /** @deprecated */ 'microsecond'
+        | /** @deprecated */ 'nanosecond'
+      >
     ): Temporal.Duration;
     round(
-      options: RoundOptions<'hour' | 'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>
+      options: RoundOptions<
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+        | /** @deprecated */ 'hours'
+        | /** @deprecated */ 'minutes'
+        | /** @deprecated */ 'seconds'
+        | /** @deprecated */ 'milliseconds'
+        | /** @deprecated */ 'microseconds'
+        | /** @deprecated */ 'nanoseconds'
+      >
     ): Temporal.Instant;
     toDateTime(tzLike: TimeZoneProtocol | string, calendar: CalendarProtocol | string): Temporal.DateTime;
     toDateTimeISO(tzLike: TimeZoneProtocol | string): Temporal.DateTime;
@@ -343,7 +389,15 @@ export namespace Temporal {
     dateDifference?(
       smaller: Temporal.Date,
       larger: Temporal.Date,
-      options: DifferenceOptions<'years' | 'months' | 'weeks' | 'days'>
+      options: DifferenceOptions<
+        | 'years'
+        | 'months'
+        | 'weeks'
+        | 'days'
+        | /** @deprecated */ 'year'
+        | /** @deprecated */ 'month'
+        | /** @deprecated */ 'day'
+      >
     ): Temporal.Duration;
   }
 
@@ -401,7 +455,15 @@ export namespace Temporal {
     dateDifference(
       smaller: Temporal.Date,
       larger: Temporal.Date,
-      options?: DifferenceOptions<'years' | 'months' | 'weeks' | 'days'>
+      options?: DifferenceOptions<
+        | 'years'
+        | 'months'
+        | 'weeks'
+        | 'days'
+        | /** @deprecated */ 'year'
+        | /** @deprecated */ 'month'
+        | /** @deprecated */ 'day'
+      >
     ): Temporal.Duration;
     toString(): string;
   }
@@ -462,7 +524,15 @@ export namespace Temporal {
     subtract(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.Date;
     difference(
       other: Temporal.Date,
-      options?: DifferenceOptions<'years' | 'months' | 'weeks' | 'days'>
+      options?: DifferenceOptions<
+        | 'years'
+        | 'months'
+        | 'weeks'
+        | 'days'
+        | /** @deprecated */ 'year'
+        | /** @deprecated */ 'month'
+        | /** @deprecated */ 'day'
+      >
     ): Temporal.Duration;
     toDateTime(temporalTime: Temporal.Time): Temporal.DateTime;
     toYearMonth(): Temporal.YearMonth;
@@ -577,10 +647,34 @@ export namespace Temporal {
         | 'milliseconds'
         | 'microseconds'
         | 'nanoseconds'
+        | /** @deprecated */ 'year'
+        | /** @deprecated */ 'month'
+        | /** @deprecated */ 'day'
+        | /** @deprecated */ 'hour'
+        | /** @deprecated */ 'minute'
+        | /** @deprecated */ 'second'
+        | /** @deprecated */ 'millisecond'
+        | /** @deprecated */ 'microsecond'
+        | /** @deprecated */ 'nanosecond'
       >
     ): Temporal.Duration;
     round(
-      options: RoundOptions<'day' | 'hour' | 'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>
+      options: RoundOptions<
+        | 'day'
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+        | /** @deprecated */ 'days'
+        | /** @deprecated */ 'hours'
+        | /** @deprecated */ 'minutes'
+        | /** @deprecated */ 'seconds'
+        | /** @deprecated */ 'milliseconds'
+        | /** @deprecated */ 'microseconds'
+        | /** @deprecated */ 'nanoseconds'
+      >
     ): Temporal.DateTime;
     toInstant(tzLike: TimeZoneProtocol | string, options?: ToInstantOptions): Temporal.Instant;
     toDate(): Temporal.Date;
@@ -677,10 +771,36 @@ export namespace Temporal {
     subtract(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.Time;
     difference(
       other: Temporal.Time,
-      options?: DifferenceOptions<'hours' | 'minutes' | 'seconds' | 'milliseconds' | 'microseconds' | 'nanoseconds'>
+      options?: DifferenceOptions<
+        | 'hours'
+        | 'minutes'
+        | 'seconds'
+        | 'milliseconds'
+        | 'microseconds'
+        | 'nanoseconds'
+        | /** @deprecated */ 'hours'
+        | /** @deprecated */ 'minutes'
+        | /** @deprecated */ 'seconds'
+        | /** @deprecated */ 'milliseconds'
+        | /** @deprecated */ 'microseconds'
+        | /** @deprecated */ 'nanoseconds'
+      >
     ): Temporal.Duration;
     round(
-      options: RoundOptions<'hour' | 'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>
+      options: RoundOptions<
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+        | /** @deprecated */ 'hours'
+        | /** @deprecated */ 'minutes'
+        | /** @deprecated */ 'seconds'
+        | /** @deprecated */ 'milliseconds'
+        | /** @deprecated */ 'microseconds'
+        | /** @deprecated */ 'nanoseconds'
+      >
     ): Temporal.Time;
     toDateTime(temporalDate: Temporal.Date): Temporal.DateTime;
     getFields(): TimeFields;
@@ -769,7 +889,10 @@ export namespace Temporal {
     with(yearMonthLike: YearMonthLike, options?: AssignmentOptions): Temporal.YearMonth;
     add(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.YearMonth;
     subtract(durationLike: Temporal.Duration | DurationLike, options?: ArithmeticOptions): Temporal.YearMonth;
-    difference(other: Temporal.YearMonth, options?: DifferenceOptions<'years' | 'months'>): Temporal.Duration;
+    difference(
+      other: Temporal.YearMonth,
+      options?: DifferenceOptions<'years' | 'months' | /** @deprecated */ 'year' | /** @deprecated */ 'month'>
+    ): Temporal.Duration;
     toDateOnDay(day: number): Temporal.Date;
     getFields(): YearMonthFields;
     getISOFields(): DateISOFields;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -227,9 +227,29 @@ export namespace Temporal {
     milliseconds?: number;
     microseconds?: number;
     nanoseconds?: number;
+    /** @deprecated */ year?: number;
+    /** @deprecated */ month?: number;
+    /** @deprecated */ day?: number;
+    /** @deprecated */ hour?: number;
+    /** @deprecated */ minute?: number;
+    /** @deprecated */ second?: number;
+    /** @deprecated */ millisecond?: number;
+    /** @deprecated */ microsecond?: number;
+    /** @deprecated */ nanosecond?: number;
   };
 
-  type DurationFields = Required<DurationLike>;
+  type DurationFields = {
+    years: number;
+    months: number;
+    weeks: number;
+    days: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+    milliseconds: number;
+    microseconds: number;
+    nanoseconds: number;
+  };
 
   /**
    *
@@ -473,6 +493,9 @@ export namespace Temporal {
     year?: number;
     month?: number;
     day?: number;
+    /** @deprecated */ years?: number;
+    /** @deprecated */ months?: number;
+    /** @deprecated */ days?: number;
     calendar?: CalendarProtocol | string;
   };
 
@@ -556,6 +579,15 @@ export namespace Temporal {
     microsecond?: number;
     nanosecond?: number;
     calendar?: CalendarProtocol | string;
+    /** @deprecated */ years?: number;
+    /** @deprecated */ months?: number;
+    /** @deprecated */ days?: number;
+    /** @deprecated */ hours?: number;
+    /** @deprecated */ minutes?: number;
+    /** @deprecated */ seconds?: number;
+    /** @deprecated */ milliseconds?: number;
+    /** @deprecated */ microseconds?: number;
+    /** @deprecated */ nanoseconds?: number;
   };
 
   type DateTimeFields = {
@@ -691,6 +723,8 @@ export namespace Temporal {
   export type MonthDayLike = {
     month?: number;
     day?: number;
+    /** @deprecated */ months?: number;
+    /** @deprecated */ days?: number;
   };
 
   type MonthDayFields = {
@@ -729,9 +763,22 @@ export namespace Temporal {
     millisecond?: number;
     microsecond?: number;
     nanosecond?: number;
+    /** @deprecated */ hours?: number;
+    /** @deprecated */ minutes?: number;
+    /** @deprecated */ seconds?: number;
+    /** @deprecated */ milliseconds?: number;
+    /** @deprecated */ microseconds?: number;
+    /** @deprecated */ nanoseconds?: number;
   };
 
-  type TimeFields = Required<TimeLike>;
+  type TimeFields = {
+    hour: number;
+    minute: number;
+    second: number;
+    millisecond: number;
+    microsecond: number;
+    nanosecond: number;
+  };
 
   /**
    * A `Temporal.Time` represents a wall-clock time, with a precision in
@@ -857,6 +904,8 @@ export namespace Temporal {
     era?: string | undefined;
     year?: number;
     month?: number;
+    /** @deprecated */ years?: number;
+    /** @deprecated */ months?: number;
   };
 
   type YearMonthFields = {

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -113,7 +113,7 @@ export class Date {
     }
     const props = ES.ToPartialRecord(temporalDateLike, ['day', 'era', 'month', 'year']);
     if (!props) {
-      throw new RangeError('invalid date-like');
+      throw new TypeError('invalid date-like');
     }
     const fields = ES.ToTemporalDateRecord(source);
     ObjectAssign(fields, props);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -184,7 +184,7 @@ export class DateTime {
       'year'
     ]);
     if (!props) {
-      throw new RangeError('invalid date-time-like');
+      throw new TypeError('invalid date-time-like');
     }
     const fields = ES.ToTemporalDateTimeRecord(source);
     ObjectAssign(fields, props);

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -151,7 +151,7 @@ export class Duration {
       'years'
     ]);
     if (!props) {
-      throw new RangeError('invalid duration-like');
+      throw new TypeError('invalid duration-like');
     }
     let {
       years = GetSlot(this, YEARS),

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -351,18 +351,32 @@ export const ES = ObjectAssign({}, ES2019, {
         nanoseconds: GetSlot(item, NANOSECONDS)
       };
     }
-    return ES.ToRecord(item, [
-      ['days', 0],
-      ['hours', 0],
-      ['microseconds', 0],
-      ['milliseconds', 0],
-      ['minutes', 0],
-      ['months', 0],
-      ['nanoseconds', 0],
-      ['seconds', 0],
-      ['weeks', 0],
-      ['years', 0]
+    const props = ES.ToPartialRecord(item, [
+      'days',
+      'hours',
+      'microseconds',
+      'milliseconds',
+      'minutes',
+      'months',
+      'nanoseconds',
+      'seconds',
+      'weeks',
+      'years'
     ]);
+    if (!props) throw new TypeError('invalid duration-like');
+    const {
+      years = 0,
+      months = 0,
+      weeks = 0,
+      days = 0,
+      hours = 0,
+      minutes = 0,
+      seconds = 0,
+      milliseconds = 0,
+      microseconds = 0,
+      nanoseconds = 0
+    } = props;
+    return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
   },
   RegulateDuration: (
     years,
@@ -685,14 +699,10 @@ export const ES = ObjectAssign({}, ES2019, {
     return ES.ToRecord(bag, [['day'], ['month']]);
   },
   ToTemporalTimeRecord: (bag) => {
-    return ES.ToRecord(bag, [
-      ['hour', 0],
-      ['microsecond', 0],
-      ['millisecond', 0],
-      ['minute', 0],
-      ['nanosecond', 0],
-      ['second', 0]
-    ]);
+    const props = ES.ToPartialRecord(bag, ['hour', 'microsecond', 'millisecond', 'minute', 'nanosecond', 'second']);
+    if (!props) throw new TypeError('invalid time-like');
+    const { hour = 0, minute = 0, second = 0, millisecond = 0, microsecond = 0, nanosecond = 0 } = props;
+    return { hour, minute, second, millisecond, microsecond, nanosecond };
   },
   ToTemporalYearMonthRecord: (bag) => {
     return ES.ToRecord(bag, [['era', undefined], ['month'], ['year']]);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -469,6 +469,19 @@ export const ES = ObjectAssign({}, ES2019, {
     return increment;
   },
   ToLargestTemporalUnit: (options, fallback, disallowedStrings = []) => {
+    const plural = new Map(
+      [
+        ['year', 'years'],
+        ['month', 'months'],
+        ['day', 'days'],
+        ['hour', 'hours'],
+        ['minute', 'minutes'],
+        ['second', 'seconds'],
+        ['millisecond', 'milliseconds'],
+        ['microsecond', 'microseconds'],
+        ['nanosecond', 'nanoseconds']
+      ].filter(([, pl]) => !disallowedStrings.includes(pl))
+    );
     const allowed = new Set([
       'years',
       'months',
@@ -484,47 +497,46 @@ export const ES = ObjectAssign({}, ES2019, {
     for (const s of disallowedStrings) {
       allowed.delete(s);
     }
-    const retval = ES.GetOption(options, 'largestUnit', ['auto', ...allowed], 'auto');
+    const retval = ES.GetOption(options, 'largestUnit', ['auto', ...allowed, ...plural.keys()], 'auto');
     if (retval === 'auto') return fallback;
+    if (plural.has(retval)) return plural.get(retval);
     return retval;
   },
   ToSmallestTemporalUnit: (options, disallowedStrings = []) => {
-    const singular = new Map([
-      ['days', 'day'],
-      ['hours', 'hour'],
-      ['minutes', 'minute'],
-      ['seconds', 'second'],
-      ['milliseconds', 'millisecond'],
-      ['microseconds', 'microsecond'],
-      ['nanoseconds', 'nanosecond']
-    ]);
+    const singular = new Map(
+      [
+        ['days', 'day'],
+        ['hours', 'hour'],
+        ['minutes', 'minute'],
+        ['seconds', 'second'],
+        ['milliseconds', 'millisecond'],
+        ['microseconds', 'microsecond'],
+        ['nanoseconds', 'nanosecond']
+      ].filter(([, sing]) => !disallowedStrings.includes(sing))
+    );
     const allowed = new Set(['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond']);
     for (const s of disallowedStrings) {
       allowed.delete(s);
     }
-    const allowedValues = [...allowed];
-    let value = options.smallestUnit;
+    const value = ES.GetOption(options, 'smallestUnit', [...allowed, ...singular.keys()], undefined);
     if (value === undefined) throw new RangeError('smallestUnit option is required');
-    value = ES.ToString(value);
-    if (singular.has(value)) value = singular.get(value);
-    if (!allowedValues.includes(value)) {
-      throw new RangeError(`smallestUnit must be one of ${allowedValues.join(', ')}, not ${value}`);
-    }
+    if (singular.has(value)) return singular.get(value);
     return value;
   },
   ToSmallestTemporalDurationUnit: (options, fallback, disallowedStrings = []) => {
-    const plural = new Map([
-      ['year', 'years'],
-      ['month', 'months'],
-      ['week', 'weeks'],
-      ['day', 'days'],
-      ['hour', 'hours'],
-      ['minute', 'minutes'],
-      ['second', 'seconds'],
-      ['millisecond', 'milliseconds'],
-      ['microsecond', 'microseconds'],
-      ['nanosecond', 'nanoseconds']
-    ]);
+    const plural = new Map(
+      [
+        ['year', 'years'],
+        ['month', 'months'],
+        ['day', 'days'],
+        ['hour', 'hours'],
+        ['minute', 'minutes'],
+        ['second', 'seconds'],
+        ['millisecond', 'milliseconds'],
+        ['microsecond', 'microseconds'],
+        ['nanosecond', 'nanoseconds']
+      ].filter(([, pl]) => !disallowedStrings.includes(pl))
+    );
     const allowed = new Set([
       'years',
       'months',
@@ -540,14 +552,8 @@ export const ES = ObjectAssign({}, ES2019, {
     for (const s of disallowedStrings) {
       allowed.delete(s);
     }
-    const allowedValues = [...allowed];
-    let value = options.smallestUnit;
-    if (value === undefined) return fallback;
-    value = ES.ToString(value);
-    if (plural.has(value)) value = plural.get(value);
-    if (!allowedValues.includes(value)) {
-      throw new RangeError(`smallestUnit must be one of ${allowedValues.join(', ')}, not ${value}`);
-    }
+    const value = ES.GetOption(options, 'smallestUnit', [...allowed, ...plural.keys()], fallback);
+    if (plural.has(value)) return plural.get(value);
     return value;
   },
   ToRelativeTemporalObject: (options) => {

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -54,7 +54,7 @@ export class MonthDay {
     }
     const props = ES.ToPartialRecord(temporalMonthDayLike, ['day', 'month']);
     if (!props) {
-      throw new RangeError('invalid month-day-like');
+      throw new TypeError('invalid month-day-like');
     }
     const fields = ES.ToTemporalMonthDayRecord(this);
     ObjectAssign(fields, props);

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -85,7 +85,7 @@ export class Time {
       'second'
     ]);
     if (!props) {
-      throw new RangeError('invalid time-like');
+      throw new TypeError('invalid time-like');
     }
     let {
       hour = GetSlot(this, HOUR),

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -71,7 +71,7 @@ export class YearMonth {
     }
     const props = ES.ToPartialRecord(temporalYearMonthLike, ['era', 'month', 'year']);
     if (!props) {
-      throw new RangeError('invalid year-month-like');
+      throw new TypeError('invalid year-month-like');
     }
     const fields = ES.ToTemporalYearMonthRecord(this);
     ObjectAssign(fields, props);

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -158,6 +158,13 @@ describe('Date', () => {
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${original.with({ day: 17 }, options)}`, '1976-11-17'));
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => original.with({}), TypeError);
+      throws(() => original.with({ months: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${original.with({ months: 12, day: 15 })}`, '1976-11-15');
+    });
   });
   describe('Date.toDateTime() works', () => {
     const date = Date.from('1976-11-18');
@@ -464,6 +471,13 @@ describe('Date', () => {
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${date.add({ months: 1 }, options)}`, '1976-12-18'));
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => date.add({}), TypeError);
+      throws(() => date.add({ month: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${date.add({ month: 1, days: 1 })}`, '1976-11-19');
+    });
   });
   describe('date.subtract() works', () => {
     const date = Date.from('2019-11-18');
@@ -531,6 +545,13 @@ describe('Date', () => {
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${date.subtract({ months: 1 }, options)}`, '2019-10-18'));
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => date.subtract({}), TypeError);
+      throws(() => date.subtract({ month: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${date.subtract({ month: 1, days: 1 })}`, '2019-11-17');
+    });
   });
   describe('date.toString() works', () => {
     it('new Date(1976, 11, 18).toString()', () => {
@@ -586,7 +607,13 @@ describe('Date', () => {
       equal(`${Date.from({ year: 1976, month: 11, day: 18 })}`, '1976-11-18'));
     it('Date.from({ year: 2019, day: 15 }) throws', () => throws(() => Date.from({ year: 2019, day: 15 }), TypeError));
     it('Date.from({ month: 12 }) throws', () => throws(() => Date.from({ month: 12 }), TypeError));
-    it('Date.from({}) throws', () => throws(() => Date.from({}), TypeError));
+    it('object must contain at least the required correctly-spelled properties', () => {
+      throws(() => Date.from({}), TypeError);
+      throws(() => Date.from({ year: 1976, months: 11, day: 18 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${Date.from({ year: 1976, month: 11, day: 18, days: 15 })}`, '1976-11-18');
+    });
     it('Date.from(required prop undefined) throws', () =>
       throws(() => Date.from({ year: undefined, month: 11, day: 18 }), TypeError));
     it('Date.from(number) is converted to string', () => Date.from(19761118).equals(Date.from('19761118')));

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -373,16 +373,24 @@ describe('Date', () => {
     });
     it('accepts singular units', () => {
       equal(
+        `${later.difference(earlier, { largestUnit: 'year' })}`,
+        `${later.difference(earlier, { largestUnit: 'years' })}`
+      );
+      equal(
         `${later.difference(earlier, { smallestUnit: 'year' })}`,
         `${later.difference(earlier, { smallestUnit: 'years' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'month' })}`,
+        `${later.difference(earlier, { largestUnit: 'months' })}`
       );
       equal(
         `${later.difference(earlier, { smallestUnit: 'month' })}`,
         `${later.difference(earlier, { smallestUnit: 'months' })}`
       );
       equal(
-        `${later.difference(earlier, { smallestUnit: 'week' })}`,
-        `${later.difference(earlier, { smallestUnit: 'weeks' })}`
+        `${later.difference(earlier, { largestUnit: 'day' })}`,
+        `${later.difference(earlier, { largestUnit: 'days' })}`
       );
       equal(
         `${later.difference(earlier, { smallestUnit: 'day' })}`,

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -698,40 +698,72 @@ describe('DateTime', () => {
     });
     it('accepts singular units', () => {
       equal(
+        `${later.difference(earlier, { largestUnit: 'year' })}`,
+        `${later.difference(earlier, { largestUnit: 'years' })}`
+      );
+      equal(
         `${later.difference(earlier, { smallestUnit: 'year' })}`,
         `${later.difference(earlier, { smallestUnit: 'years' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'month' })}`,
+        `${later.difference(earlier, { largestUnit: 'months' })}`
       );
       equal(
         `${later.difference(earlier, { smallestUnit: 'month' })}`,
         `${later.difference(earlier, { smallestUnit: 'months' })}`
       );
       equal(
-        `${later.difference(earlier, { smallestUnit: 'week' })}`,
-        `${later.difference(earlier, { smallestUnit: 'weeks' })}`
+        `${later.difference(earlier, { largestUnit: 'day' })}`,
+        `${later.difference(earlier, { largestUnit: 'days' })}`
       );
       equal(
         `${later.difference(earlier, { smallestUnit: 'day' })}`,
         `${later.difference(earlier, { smallestUnit: 'days' })}`
       );
       equal(
+        `${later.difference(earlier, { largestUnit: 'hour' })}`,
+        `${later.difference(earlier, { largestUnit: 'hours' })}`
+      );
+      equal(
         `${later.difference(earlier, { smallestUnit: 'hour' })}`,
         `${later.difference(earlier, { smallestUnit: 'hours' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'minute' })}`,
+        `${later.difference(earlier, { largestUnit: 'minutes' })}`
       );
       equal(
         `${later.difference(earlier, { smallestUnit: 'minute' })}`,
         `${later.difference(earlier, { smallestUnit: 'minutes' })}`
       );
       equal(
+        `${later.difference(earlier, { largestUnit: 'second' })}`,
+        `${later.difference(earlier, { largestUnit: 'seconds' })}`
+      );
+      equal(
         `${later.difference(earlier, { smallestUnit: 'second' })}`,
         `${later.difference(earlier, { smallestUnit: 'seconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'millisecond' })}`,
+        `${later.difference(earlier, { largestUnit: 'milliseconds' })}`
       );
       equal(
         `${later.difference(earlier, { smallestUnit: 'millisecond' })}`,
         `${later.difference(earlier, { smallestUnit: 'milliseconds' })}`
       );
       equal(
+        `${later.difference(earlier, { largestUnit: 'microsecond' })}`,
+        `${later.difference(earlier, { largestUnit: 'microseconds' })}`
+      );
+      equal(
         `${later.difference(earlier, { smallestUnit: 'microsecond' })}`,
         `${later.difference(earlier, { smallestUnit: 'microseconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'nanosecond' })}`,
+        `${later.difference(earlier, { largestUnit: 'nanoseconds' })}`
       );
       equal(
         `${later.difference(earlier, { smallestUnit: 'nanosecond' })}`,

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -315,6 +315,13 @@ describe('DateTime', () => {
         equal(`${datetime.with({ day: 5 }, options)}`, '1976-11-05T15:23:30.123456789')
       );
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => datetime.with({}), TypeError);
+      throws(() => datetime.with({ months: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${datetime.with({ month: 12, days: 15 })}`, '1976-12-18T15:23:30.123456789');
+    });
   });
   describe('DateTime.compare() works', () => {
     const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
@@ -415,6 +422,13 @@ describe('DateTime', () => {
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${jan31.add({ years: 1 }, options)}`, '2021-01-31T15:00'));
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => jan31.add({}), TypeError);
+      throws(() => jan31.add({ month: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${jan31.add({ month: 1, days: 1 })}`, '2020-02-01T15:00');
+    });
   });
   describe('date.subtract() works', () => {
     const mar31 = DateTime.from('2020-03-31T15:00');
@@ -446,6 +460,13 @@ describe('DateTime', () => {
       [{}, () => {}, undefined].forEach((options) =>
         equal(`${mar31.subtract({ years: 1 }, options)}`, '2019-03-31T15:00')
       );
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => mar31.subtract({}), TypeError);
+      throws(() => mar31.subtract({ month: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${mar31.subtract({ month: 1, days: 1 })}`, '2020-03-30T15:00');
     });
   });
   describe('DateTime.difference()', () => {
@@ -1012,6 +1033,13 @@ describe('DateTime', () => {
       [{}, () => {}, undefined].forEach((options) =>
         equal(`${DateTime.from({ year: 1976, month: 11, day: 18 }, options)}`, '1976-11-18T00:00')
       );
+    });
+    it('object must contain at least the required correctly-spelled properties', () => {
+      throws(() => DateTime.from({}), TypeError);
+      throws(() => DateTime.from({ year: 1976, months: 11, day: 18 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${DateTime.from({ year: 1976, month: 11, day: 18, hours: 12 })}`, '1976-11-18T00:00');
     });
   });
   describe('DateTime.toInstant() works', () => {

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -972,26 +972,43 @@ describe('Duration', () => {
       throws(() => d.round({ relativeTo, smallestUnit: 'nanoseconds', roundingIncrement: 1000 }), RangeError);
     });
     it('accepts singular units', () => {
+      equal(`${d.round({ largestUnit: 'year', relativeTo })}`, `${d.round({ largestUnit: 'years', relativeTo })}`);
       equal(`${d.round({ smallestUnit: 'year', relativeTo })}`, `${d.round({ smallestUnit: 'years', relativeTo })}`);
+      equal(`${d.round({ largestUnit: 'month', relativeTo })}`, `${d.round({ largestUnit: 'months', relativeTo })}`);
       equal(`${d.round({ smallestUnit: 'month', relativeTo })}`, `${d.round({ smallestUnit: 'months', relativeTo })}`);
-      equal(`${d.round({ smallestUnit: 'week', relativeTo })}`, `${d.round({ smallestUnit: 'weeks', relativeTo })}`);
+      equal(`${d.round({ largestUnit: 'day', relativeTo })}`, `${d.round({ largestUnit: 'days', relativeTo })}`);
       equal(`${d.round({ smallestUnit: 'day', relativeTo })}`, `${d.round({ smallestUnit: 'days', relativeTo })}`);
+      equal(`${d.round({ largestUnit: 'hour', relativeTo })}`, `${d.round({ largestUnit: 'hours', relativeTo })}`);
       equal(`${d.round({ smallestUnit: 'hour', relativeTo })}`, `${d.round({ smallestUnit: 'hours', relativeTo })}`);
+      equal(`${d.round({ largestUnit: 'minute', relativeTo })}`, `${d.round({ largestUnit: 'minutes', relativeTo })}`);
       equal(
         `${d.round({ smallestUnit: 'minute', relativeTo })}`,
         `${d.round({ smallestUnit: 'minutes', relativeTo })}`
       );
+      equal(`${d.round({ largestUnit: 'second', relativeTo })}`, `${d.round({ largestUnit: 'seconds', relativeTo })}`);
       equal(
         `${d.round({ smallestUnit: 'second', relativeTo })}`,
         `${d.round({ smallestUnit: 'seconds', relativeTo })}`
+      );
+      equal(
+        `${d.round({ largestUnit: 'millisecond', relativeTo })}`,
+        `${d.round({ largestUnit: 'milliseconds', relativeTo })}`
       );
       equal(
         `${d.round({ smallestUnit: 'millisecond', relativeTo })}`,
         `${d.round({ smallestUnit: 'milliseconds', relativeTo })}`
       );
       equal(
+        `${d.round({ largestUnit: 'microsecond', relativeTo })}`,
+        `${d.round({ largestUnit: 'microseconds', relativeTo })}`
+      );
+      equal(
         `${d.round({ smallestUnit: 'microsecond', relativeTo })}`,
         `${d.round({ smallestUnit: 'microseconds', relativeTo })}`
+      );
+      equal(
+        `${d.round({ largestUnit: 'nanosecond', relativeTo })}`,
+        `${d.round({ largestUnit: 'nanoseconds', relativeTo })}`
       );
       equal(
         `${d.round({ smallestUnit: 'nanosecond', relativeTo })}`,

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -699,24 +699,48 @@ describe('Instant', () => {
     });
     it('accepts singular units', () => {
       equal(
+        `${later.difference(earlier, { largestUnit: 'hour' })}`,
+        `${later.difference(earlier, { largestUnit: 'hours' })}`
+      );
+      equal(
         `${later.difference(earlier, { largestUnit, smallestUnit: 'hour' })}`,
         `${later.difference(earlier, { largestUnit, smallestUnit: 'hours' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'minute' })}`,
+        `${later.difference(earlier, { largestUnit: 'minutes' })}`
       );
       equal(
         `${later.difference(earlier, { largestUnit, smallestUnit: 'minute' })}`,
         `${later.difference(earlier, { largestUnit, smallestUnit: 'minutes' })}`
       );
       equal(
+        `${later.difference(earlier, { largestUnit: 'second' })}`,
+        `${later.difference(earlier, { largestUnit: 'seconds' })}`
+      );
+      equal(
         `${later.difference(earlier, { largestUnit, smallestUnit: 'second' })}`,
         `${later.difference(earlier, { largestUnit, smallestUnit: 'seconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'millisecond' })}`,
+        `${later.difference(earlier, { largestUnit: 'milliseconds' })}`
       );
       equal(
         `${later.difference(earlier, { largestUnit, smallestUnit: 'millisecond' })}`,
         `${later.difference(earlier, { largestUnit, smallestUnit: 'milliseconds' })}`
       );
       equal(
+        `${later.difference(earlier, { largestUnit: 'microsecond' })}`,
+        `${later.difference(earlier, { largestUnit: 'microseconds' })}`
+      );
+      equal(
         `${later.difference(earlier, { largestUnit, smallestUnit: 'microsecond' })}`,
         `${later.difference(earlier, { largestUnit, smallestUnit: 'microseconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'nanosecond' })}`,
+        `${later.difference(earlier, { largestUnit: 'nanoseconds' })}`
       );
       equal(
         `${later.difference(earlier, { largestUnit, smallestUnit: 'nanosecond' })}`,

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -386,6 +386,13 @@ describe('Instant', () => {
     it('mixed positive and negative values always throw', () => {
       throws(() => abs.add({ hours: 1, minutes: -30 }), RangeError);
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => abs.add({}), TypeError);
+      throws(() => abs.add({ hour: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${abs.add({ hour: 1, minutes: 1 })}`, '1969-12-25T12:24:45.678901234Z');
+    });
   });
   describe('Instant.subtract works', () => {
     const abs = Instant.from('1969-12-25T12:23:45.678901234Z');
@@ -401,6 +408,13 @@ describe('Instant', () => {
     });
     it('mixed positive and negative values always throw', () => {
       throws(() => abs.subtract({ hours: 1, minutes: -30 }), RangeError);
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => abs.subtract({}), TypeError);
+      throws(() => abs.subtract({ hour: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${abs.subtract({ hour: 1, minutes: 1 })}`, '1969-12-25T12:22:45.678901234Z');
     });
   });
   describe('Instant.compare works', () => {

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -110,6 +110,13 @@ describe('MonthDay', () => {
           it(overflow, () => equal(`${MonthDay.from({ month: 2, day: 29 }, { overflow })}`, '02-29'))
         );
       });
+      it('object must contain at least the required correctly-spelled properties', () => {
+        throws(() => MonthDay.from({}), TypeError);
+        throws(() => MonthDay.from({ months: 12, day: 31 }), TypeError);
+      });
+      it('incorrectly-spelled properties are ignored', () => {
+        equal(`${MonthDay.from({ month: 12, day: 1, days: 31 })}`, '12-01');
+      });
     });
     describe('getters', () => {
       let md = new MonthDay(1, 15);
@@ -141,6 +148,13 @@ describe('MonthDay', () => {
         throws(() => md.with({ day: 1 }, badOptions), TypeError)
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${md.with({ day: 1 }, options)}`, '01-01'));
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => md.with({}), TypeError);
+      throws(() => md.with({ months: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${md.with({ month: 12, days: 1 })}`, '12-15');
     });
   });
   describe('MonthDay.equals()', () => {

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -202,6 +202,13 @@ describe('Time', () => {
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${time.with({ hour: 3 }, options)}`, '03:23:30.123456789'));
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => time.with({}), TypeError);
+      throws(() => time.with({ minutes: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${time.with({ minutes: 1, hour: 1 })}`, '01:23:30.123456789');
+    });
   });
   describe('time.toDateTime() works', () => {
     const time = Time.from('11:30:23.123456789');
@@ -675,6 +682,13 @@ describe('Time', () => {
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${time.add({ hours: 1 }, options)}`, '16:23:30.123456789'));
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => time.add({}), TypeError);
+      throws(() => time.add({ minute: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${time.add({ minute: 1, hours: 1 })}`, '16:23:30.123456789');
+    });
   });
   describe('time.subtract() works', () => {
     const time = Time.from('15:23:30.123456789');
@@ -721,6 +735,13 @@ describe('Time', () => {
         equal(`${time.subtract({ hours: 1 }, options)}`, '14:23:30.123456789')
       );
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => time.subtract({}), TypeError);
+      throws(() => time.subtract({ minute: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${time.subtract({ minute: 1, hours: 1 })}`, '14:23:30.123456789');
+    });
   });
   describe('time.toString() works', () => {
     it('new Time(15, 23).toString()', () => {
@@ -758,7 +779,6 @@ describe('Time', () => {
     it('Time.from({ hour: 15, minute: 23 })', () => equal(`${Time.from({ hour: 15, minute: 23 })}`, '15:23'));
     it('Time.from({ minute: 30, microsecond: 555 })', () =>
       equal(`${Time.from({ minute: 30, microsecond: 555 })}`, '00:30:00.000555'));
-    it('Time.from({})', () => equal(`${Time.from({})}`, `${new Time()}`));
     it('Time.from(ISO string leap second) is constrained', () => {
       equal(`${Time.from('23:59:60')}`, '23:59:59');
       equal(`${Time.from('23:59:60', { overflow: 'reject' })}`, '23:59:59');
@@ -844,6 +864,13 @@ describe('Time', () => {
       const leap = { hour: 23, minute: 59, second: 60 };
       it('reject leap second', () => throws(() => Time.from(leap, { overflow: 'reject' }), RangeError));
       it('constrain leap second', () => equal(`${Time.from(leap)}`, '23:59:59'));
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => Time.from({}), TypeError);
+      throws(() => Time.from({ minutes: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${Time.from({ minutes: 1, hour: 1 })}`, '01:00');
     });
   });
   describe('constructor treats -0 as 0', () => {

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -167,698 +167,694 @@ describe('Time', () => {
       const time = new Time();
       it('`${time}` is 00:00', () => equal(`${time}`, '00:00'));
     });
-    describe('.with manipulation', () => {
-      const time = new Time(15, 23, 30, 123, 456, 789);
-      it('time.with({ hour: 3 } works', () => {
-        equal(`${time.with({ hour: 3 })}`, '03:23:30.123456789');
-      });
-      it('time.with({ minute: 3 } works', () => {
-        equal(`${time.with({ minute: 3 })}`, '15:03:30.123456789');
-      });
-      it('time.with({ second: 3 } works', () => {
-        equal(`${time.with({ second: 3 })}`, '15:23:03.123456789');
-      });
-      it('time.with({ millisecond: 3 } works', () => {
-        equal(`${time.with({ millisecond: 3 })}`, '15:23:30.003456789');
-      });
-      it('time.with({ microsecond: 3 } works', () => {
-        equal(`${time.with({ microsecond: 3 })}`, '15:23:30.123003789');
-      });
-      it('time.with({ nanosecond: 3 } works', () => {
-        equal(`${time.with({ nanosecond: 3 })}`, '15:23:30.123456003');
-      });
-      it('time.with({ minute: 8, nanosecond: 3 } works', () => {
-        equal(`${time.with({ minute: 8, nanosecond: 3 })}`, '15:08:30.123456003');
-      });
-      it('invalid overflow', () => {
-        ['', 'CONSTRAIN', 'balance', 3, null].forEach((overflow) =>
-          throws(() => time.with({ hour: 3 }, { overflow }), RangeError)
-        );
-      });
-      it('options may only be an object or undefined', () => {
-        [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
-          throws(() => time.with({ hour: 3 }, badOptions), TypeError)
-        );
-        [{}, () => {}, undefined].forEach((options) =>
-          equal(`${time.with({ hour: 3 }, options)}`, '03:23:30.123456789')
-        );
-      });
+  });
+  describe('.with manipulation', () => {
+    const time = new Time(15, 23, 30, 123, 456, 789);
+    it('time.with({ hour: 3 } works', () => {
+      equal(`${time.with({ hour: 3 })}`, '03:23:30.123456789');
     });
-    describe('time.toDateTime() works', () => {
-      const time = Time.from('11:30:23.123456789');
-      const dt = time.toDateTime(Temporal.Date.from('1976-11-18'));
-      it('returns a Temporal.DateTime', () => assert(dt instanceof Temporal.DateTime));
-      it('combines the date and time', () => equal(`${dt}`, '1976-11-18T11:30:23.123456789'));
-      it("doesn't cast argument", () => {
-        throws(() => time.toDateTime({ year: 1976, month: 11, day: 18 }), TypeError);
-        throws(() => time.toDateTime('1976-11-18'), TypeError);
-      });
+    it('time.with({ minute: 3 } works', () => {
+      equal(`${time.with({ minute: 3 })}`, '15:03:30.123456789');
     });
-    describe('time.difference() works', () => {
-      const time = new Time(15, 23, 30, 123, 456, 789);
-      const one = new Time(14, 23, 30, 123, 456, 789);
-      it(`(${time}).difference(${one}) => PT1H`, () => {
-        const duration = time.difference(one);
-        equal(`${duration}`, 'PT1H');
-      });
-      const two = new Time(13, 30, 30, 123, 456, 789);
-      it(`(${time}).difference(${two}) => PT1H53M`, () => {
-        const duration = time.difference(two);
-        equal(`${duration}`, 'PT1H53M');
-      });
-      it(`(${two}).difference(${time}) => -PT1H53M`, () => equal(`${two.difference(time)}`, '-PT1H53M'));
-      it("doesn't cast argument", () => {
-        throws(() => time.difference({ hour: 16, minute: 34 }), TypeError);
-        throws(() => time.difference('16:34'), TypeError);
-      });
-      const time1 = Time.from('10:23:15');
-      const time2 = Time.from('17:15:57');
-      it('the default largest unit is at least hours', () => {
-        equal(`${time2.difference(time1)}`, 'PT6H52M42S');
-        equal(`${time2.difference(time1, { largestUnit: 'auto' })}`, 'PT6H52M42S');
-        equal(`${time2.difference(time1, { largestUnit: 'hours' })}`, 'PT6H52M42S');
-      });
-      it('higher units are not allowed', () => {
-        throws(() => time2.difference(time1, { largestUnit: 'days' }), RangeError);
-        throws(() => time2.difference(time1, { largestUnit: 'weeks' }), RangeError);
-        throws(() => time2.difference(time1, { largestUnit: 'months' }), RangeError);
-        throws(() => time2.difference(time1, { largestUnit: 'years' }), RangeError);
-      });
-      it('can return lower units', () => {
-        equal(`${time2.difference(time1, { largestUnit: 'minutes' })}`, 'PT412M42S');
-        equal(`${time2.difference(time1, { largestUnit: 'seconds' })}`, 'PT24762S');
-      });
-      it('can return subseconds', () => {
-        const time3 = time2.add({ milliseconds: 250, microseconds: 250, nanoseconds: 250 });
+    it('time.with({ second: 3 } works', () => {
+      equal(`${time.with({ second: 3 })}`, '15:23:03.123456789');
+    });
+    it('time.with({ millisecond: 3 } works', () => {
+      equal(`${time.with({ millisecond: 3 })}`, '15:23:30.003456789');
+    });
+    it('time.with({ microsecond: 3 } works', () => {
+      equal(`${time.with({ microsecond: 3 })}`, '15:23:30.123003789');
+    });
+    it('time.with({ nanosecond: 3 } works', () => {
+      equal(`${time.with({ nanosecond: 3 })}`, '15:23:30.123456003');
+    });
+    it('time.with({ minute: 8, nanosecond: 3 } works', () => {
+      equal(`${time.with({ minute: 8, nanosecond: 3 })}`, '15:08:30.123456003');
+    });
+    it('invalid overflow', () => {
+      ['', 'CONSTRAIN', 'balance', 3, null].forEach((overflow) =>
+        throws(() => time.with({ hour: 3 }, { overflow }), RangeError)
+      );
+    });
+    it('options may only be an object or undefined', () => {
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => time.with({ hour: 3 }, badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) => equal(`${time.with({ hour: 3 }, options)}`, '03:23:30.123456789'));
+    });
+  });
+  describe('time.toDateTime() works', () => {
+    const time = Time.from('11:30:23.123456789');
+    const dt = time.toDateTime(Temporal.Date.from('1976-11-18'));
+    it('returns a Temporal.DateTime', () => assert(dt instanceof Temporal.DateTime));
+    it('combines the date and time', () => equal(`${dt}`, '1976-11-18T11:30:23.123456789'));
+    it("doesn't cast argument", () => {
+      throws(() => time.toDateTime({ year: 1976, month: 11, day: 18 }), TypeError);
+      throws(() => time.toDateTime('1976-11-18'), TypeError);
+    });
+  });
+  describe('time.difference() works', () => {
+    const time = new Time(15, 23, 30, 123, 456, 789);
+    const one = new Time(14, 23, 30, 123, 456, 789);
+    it(`(${time}).difference(${one}) => PT1H`, () => {
+      const duration = time.difference(one);
+      equal(`${duration}`, 'PT1H');
+    });
+    const two = new Time(13, 30, 30, 123, 456, 789);
+    it(`(${time}).difference(${two}) => PT1H53M`, () => {
+      const duration = time.difference(two);
+      equal(`${duration}`, 'PT1H53M');
+    });
+    it(`(${two}).difference(${time}) => -PT1H53M`, () => equal(`${two.difference(time)}`, '-PT1H53M'));
+    it("doesn't cast argument", () => {
+      throws(() => time.difference({ hour: 16, minute: 34 }), TypeError);
+      throws(() => time.difference('16:34'), TypeError);
+    });
+    const time1 = Time.from('10:23:15');
+    const time2 = Time.from('17:15:57');
+    it('the default largest unit is at least hours', () => {
+      equal(`${time2.difference(time1)}`, 'PT6H52M42S');
+      equal(`${time2.difference(time1, { largestUnit: 'auto' })}`, 'PT6H52M42S');
+      equal(`${time2.difference(time1, { largestUnit: 'hours' })}`, 'PT6H52M42S');
+    });
+    it('higher units are not allowed', () => {
+      throws(() => time2.difference(time1, { largestUnit: 'days' }), RangeError);
+      throws(() => time2.difference(time1, { largestUnit: 'weeks' }), RangeError);
+      throws(() => time2.difference(time1, { largestUnit: 'months' }), RangeError);
+      throws(() => time2.difference(time1, { largestUnit: 'years' }), RangeError);
+    });
+    it('can return lower units', () => {
+      equal(`${time2.difference(time1, { largestUnit: 'minutes' })}`, 'PT412M42S');
+      equal(`${time2.difference(time1, { largestUnit: 'seconds' })}`, 'PT24762S');
+    });
+    it('can return subseconds', () => {
+      const time3 = time2.add({ milliseconds: 250, microseconds: 250, nanoseconds: 250 });
 
-        const msDiff = time3.difference(time1, { largestUnit: 'milliseconds' });
-        equal(msDiff.seconds, 0);
-        equal(msDiff.milliseconds, 24762250);
-        equal(msDiff.microseconds, 250);
-        equal(msDiff.nanoseconds, 250);
+      const msDiff = time3.difference(time1, { largestUnit: 'milliseconds' });
+      equal(msDiff.seconds, 0);
+      equal(msDiff.milliseconds, 24762250);
+      equal(msDiff.microseconds, 250);
+      equal(msDiff.nanoseconds, 250);
 
-        const µsDiff = time3.difference(time1, { largestUnit: 'microseconds' });
-        equal(µsDiff.milliseconds, 0);
-        equal(µsDiff.microseconds, 24762250250);
-        equal(µsDiff.nanoseconds, 250);
+      const µsDiff = time3.difference(time1, { largestUnit: 'microseconds' });
+      equal(µsDiff.milliseconds, 0);
+      equal(µsDiff.microseconds, 24762250250);
+      equal(µsDiff.nanoseconds, 250);
 
-        const nsDiff = time3.difference(time1, { largestUnit: 'nanoseconds' });
-        equal(nsDiff.microseconds, 0);
-        equal(nsDiff.nanoseconds, 24762250250250);
-      });
-      it('options may only be an object or undefined', () => {
-        [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
-          throws(() => time.difference(one, badOptions), TypeError)
-        );
-        [{}, () => {}, undefined].forEach((options) => equal(`${time.difference(one, options)}`, 'PT1H'));
-      });
-      const earlier = Time.from('08:22:36.123456789');
-      const later = Time.from('12:39:40.987654321');
-      it('throws on disallowed or invalid smallestUnit', () => {
-        ['era', 'years', 'months', 'weeks', 'days', 'year', 'month', 'week', 'day', 'nonsense'].forEach(
-          (smallestUnit) => {
-            throws(() => later.difference(earlier, { smallestUnit }), RangeError);
-          }
-        );
-      });
-      it('throws if smallestUnit is larger than largestUnit', () => {
-        const units = ['hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
-        for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
-          for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
-            const largestUnit = units[largestIdx];
-            const smallestUnit = units[smallestIdx];
-            throws(() => later.difference(earlier, { largestUnit, smallestUnit }), RangeError);
-          }
+      const nsDiff = time3.difference(time1, { largestUnit: 'nanoseconds' });
+      equal(nsDiff.microseconds, 0);
+      equal(nsDiff.nanoseconds, 24762250250250);
+    });
+    it('options may only be an object or undefined', () => {
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => time.difference(one, badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) => equal(`${time.difference(one, options)}`, 'PT1H'));
+    });
+    const earlier = Time.from('08:22:36.123456789');
+    const later = Time.from('12:39:40.987654321');
+    it('throws on disallowed or invalid smallestUnit', () => {
+      ['era', 'years', 'months', 'weeks', 'days', 'year', 'month', 'week', 'day', 'nonsense'].forEach(
+        (smallestUnit) => {
+          throws(() => later.difference(earlier, { smallestUnit }), RangeError);
         }
+      );
+    });
+    it('throws if smallestUnit is larger than largestUnit', () => {
+      const units = ['hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
+      for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
+        for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
+          const largestUnit = units[largestIdx];
+          const smallestUnit = units[smallestIdx];
+          throws(() => later.difference(earlier, { largestUnit, smallestUnit }), RangeError);
+        }
+      }
+    });
+    it('throws on invalid roundingMode', () => {
+      throws(() => later.difference(earlier, { roundingMode: 'cile' }), RangeError);
+    });
+    const incrementOneNearest = [
+      ['hours', 'PT4H'],
+      ['minutes', 'PT4H17M'],
+      ['seconds', 'PT4H17M5S'],
+      ['milliseconds', 'PT4H17M4.864S'],
+      ['microseconds', 'PT4H17M4.864198S'],
+      ['nanoseconds', 'PT4H17M4.864197532S']
+    ];
+    incrementOneNearest.forEach(([smallestUnit, expected]) => {
+      const roundingMode = 'nearest';
+      it(`rounds to nearest ${smallestUnit}`, () => {
+        equal(`${later.difference(earlier, { smallestUnit, roundingMode })}`, expected);
+        equal(`${earlier.difference(later, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
-      it('throws on invalid roundingMode', () => {
-        throws(() => later.difference(earlier, { roundingMode: 'cile' }), RangeError);
+    });
+    const incrementOneCeil = [
+      ['hours', 'PT5H', '-PT4H'],
+      ['minutes', 'PT4H18M', '-PT4H17M'],
+      ['seconds', 'PT4H17M5S', '-PT4H17M4S'],
+      ['milliseconds', 'PT4H17M4.865S', '-PT4H17M4.864S'],
+      ['microseconds', 'PT4H17M4.864198S', '-PT4H17M4.864197S'],
+      ['nanoseconds', 'PT4H17M4.864197532S', '-PT4H17M4.864197532S']
+    ];
+    incrementOneCeil.forEach(([smallestUnit, expectedPositive, expectedNegative]) => {
+      const roundingMode = 'ceil';
+      it(`rounds up to ${smallestUnit}`, () => {
+        equal(`${later.difference(earlier, { smallestUnit, roundingMode })}`, expectedPositive);
+        equal(`${earlier.difference(later, { smallestUnit, roundingMode })}`, expectedNegative);
       });
-      const incrementOneNearest = [
-        ['hours', 'PT4H'],
-        ['minutes', 'PT4H17M'],
-        ['seconds', 'PT4H17M5S'],
-        ['milliseconds', 'PT4H17M4.864S'],
-        ['microseconds', 'PT4H17M4.864198S'],
-        ['nanoseconds', 'PT4H17M4.864197532S']
-      ];
-      incrementOneNearest.forEach(([smallestUnit, expected]) => {
-        const roundingMode = 'nearest';
-        it(`rounds to nearest ${smallestUnit}`, () => {
-          equal(`${later.difference(earlier, { smallestUnit, roundingMode })}`, expected);
-          equal(`${earlier.difference(later, { smallestUnit, roundingMode })}`, `-${expected}`);
-        });
+    });
+    const incrementOneFloor = [
+      ['hours', 'PT4H', '-PT5H'],
+      ['minutes', 'PT4H17M', '-PT4H18M'],
+      ['seconds', 'PT4H17M4S', '-PT4H17M5S'],
+      ['milliseconds', 'PT4H17M4.864S', '-PT4H17M4.865S'],
+      ['microseconds', 'PT4H17M4.864197S', '-PT4H17M4.864198S'],
+      ['nanoseconds', 'PT4H17M4.864197532S', '-PT4H17M4.864197532S']
+    ];
+    incrementOneFloor.forEach(([smallestUnit, expectedPositive, expectedNegative]) => {
+      const roundingMode = 'floor';
+      it(`rounds down to ${smallestUnit}`, () => {
+        equal(`${later.difference(earlier, { smallestUnit, roundingMode })}`, expectedPositive);
+        equal(`${earlier.difference(later, { smallestUnit, roundingMode })}`, expectedNegative);
       });
-      const incrementOneCeil = [
-        ['hours', 'PT5H', '-PT4H'],
-        ['minutes', 'PT4H18M', '-PT4H17M'],
-        ['seconds', 'PT4H17M5S', '-PT4H17M4S'],
-        ['milliseconds', 'PT4H17M4.865S', '-PT4H17M4.864S'],
-        ['microseconds', 'PT4H17M4.864198S', '-PT4H17M4.864197S'],
-        ['nanoseconds', 'PT4H17M4.864197532S', '-PT4H17M4.864197532S']
-      ];
-      incrementOneCeil.forEach(([smallestUnit, expectedPositive, expectedNegative]) => {
-        const roundingMode = 'ceil';
-        it(`rounds up to ${smallestUnit}`, () => {
-          equal(`${later.difference(earlier, { smallestUnit, roundingMode })}`, expectedPositive);
-          equal(`${earlier.difference(later, { smallestUnit, roundingMode })}`, expectedNegative);
-        });
+    });
+    const incrementOneTrunc = [
+      ['hours', 'PT4H'],
+      ['minutes', 'PT4H17M'],
+      ['seconds', 'PT4H17M4S'],
+      ['milliseconds', 'PT4H17M4.864S'],
+      ['microseconds', 'PT4H17M4.864197S'],
+      ['nanoseconds', 'PT4H17M4.864197532S']
+    ];
+    incrementOneTrunc.forEach(([smallestUnit, expected]) => {
+      const roundingMode = 'trunc';
+      it(`truncates to ${smallestUnit}`, () => {
+        equal(`${later.difference(earlier, { smallestUnit, roundingMode })}`, expected);
+        equal(`${earlier.difference(later, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
-      const incrementOneFloor = [
-        ['hours', 'PT4H', '-PT5H'],
-        ['minutes', 'PT4H17M', '-PT4H18M'],
-        ['seconds', 'PT4H17M4S', '-PT4H17M5S'],
-        ['milliseconds', 'PT4H17M4.864S', '-PT4H17M4.865S'],
-        ['microseconds', 'PT4H17M4.864197S', '-PT4H17M4.864198S'],
-        ['nanoseconds', 'PT4H17M4.864197532S', '-PT4H17M4.864197532S']
-      ];
-      incrementOneFloor.forEach(([smallestUnit, expectedPositive, expectedNegative]) => {
-        const roundingMode = 'floor';
-        it(`rounds down to ${smallestUnit}`, () => {
-          equal(`${later.difference(earlier, { smallestUnit, roundingMode })}`, expectedPositive);
-          equal(`${earlier.difference(later, { smallestUnit, roundingMode })}`, expectedNegative);
-        });
+    });
+    it('nearest is the default', () => {
+      equal(`${later.difference(earlier, { smallestUnit: 'minutes' })}`, 'PT4H17M');
+      equal(`${later.difference(earlier, { smallestUnit: 'seconds' })}`, 'PT4H17M5S');
+    });
+    it('rounds to an increment of hours', () => {
+      equal(`${later.difference(earlier, { smallestUnit: 'hours', roundingIncrement: 3 })}`, 'PT3H');
+    });
+    it('rounds to an increment of minutes', () => {
+      equal(`${later.difference(earlier, { smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'PT4H30M');
+    });
+    it('rounds to an increment of seconds', () => {
+      equal(`${later.difference(earlier, { smallestUnit: 'seconds', roundingIncrement: 15 })}`, 'PT4H17M');
+    });
+    it('rounds to an increment of milliseconds', () => {
+      equal(`${later.difference(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10 })}`, 'PT4H17M4.860S');
+    });
+    it('rounds to an increment of microseconds', () => {
+      equal(
+        `${later.difference(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10 })}`,
+        'PT4H17M4.864200S'
+      );
+    });
+    it('rounds to an increment of nanoseconds', () => {
+      equal(
+        `${later.difference(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`,
+        'PT4H17M4.864197530S'
+      );
+    });
+    it('valid hour increments divide into 24', () => {
+      [1, 2, 3, 4, 6, 8, 12].forEach((roundingIncrement) => {
+        const options = { smallestUnit: 'hours', roundingIncrement };
+        assert(later.difference(earlier, options) instanceof Temporal.Duration);
       });
-      const incrementOneTrunc = [
-        ['hours', 'PT4H'],
-        ['minutes', 'PT4H17M'],
-        ['seconds', 'PT4H17M4S'],
-        ['milliseconds', 'PT4H17M4.864S'],
-        ['microseconds', 'PT4H17M4.864197S'],
-        ['nanoseconds', 'PT4H17M4.864197532S']
-      ];
-      incrementOneTrunc.forEach(([smallestUnit, expected]) => {
-        const roundingMode = 'trunc';
-        it(`truncates to ${smallestUnit}`, () => {
-          equal(`${later.difference(earlier, { smallestUnit, roundingMode })}`, expected);
-          equal(`${earlier.difference(later, { smallestUnit, roundingMode })}`, `-${expected}`);
-        });
-      });
-      it('nearest is the default', () => {
-        equal(`${later.difference(earlier, { smallestUnit: 'minutes' })}`, 'PT4H17M');
-        equal(`${later.difference(earlier, { smallestUnit: 'seconds' })}`, 'PT4H17M5S');
-      });
-      it('rounds to an increment of hours', () => {
-        equal(`${later.difference(earlier, { smallestUnit: 'hours', roundingIncrement: 3 })}`, 'PT3H');
-      });
-      it('rounds to an increment of minutes', () => {
-        equal(`${later.difference(earlier, { smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'PT4H30M');
-      });
-      it('rounds to an increment of seconds', () => {
-        equal(`${later.difference(earlier, { smallestUnit: 'seconds', roundingIncrement: 15 })}`, 'PT4H17M');
-      });
-      it('rounds to an increment of milliseconds', () => {
-        equal(`${later.difference(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10 })}`, 'PT4H17M4.860S');
-      });
-      it('rounds to an increment of microseconds', () => {
-        equal(
-          `${later.difference(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10 })}`,
-          'PT4H17M4.864200S'
-        );
-      });
-      it('rounds to an increment of nanoseconds', () => {
-        equal(
-          `${later.difference(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`,
-          'PT4H17M4.864197530S'
-        );
-      });
-      it('valid hour increments divide into 24', () => {
-        [1, 2, 3, 4, 6, 8, 12].forEach((roundingIncrement) => {
-          const options = { smallestUnit: 'hours', roundingIncrement };
+    });
+    ['minutes', 'seconds'].forEach((smallestUnit) => {
+      it(`valid ${smallestUnit} increments divide into 60`, () => {
+        [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30].forEach((roundingIncrement) => {
+          const options = { smallestUnit, roundingIncrement };
           assert(later.difference(earlier, options) instanceof Temporal.Duration);
         });
       });
-      ['minutes', 'seconds'].forEach((smallestUnit) => {
-        it(`valid ${smallestUnit} increments divide into 60`, () => {
-          [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30].forEach((roundingIncrement) => {
-            const options = { smallestUnit, roundingIncrement };
-            assert(later.difference(earlier, options) instanceof Temporal.Duration);
-          });
+    });
+    ['milliseconds', 'microseconds', 'nanoseconds'].forEach((smallestUnit) => {
+      it(`valid ${smallestUnit} increments divide into 1000`, () => {
+        [1, 2, 4, 5, 8, 10, 20, 25, 40, 50, 100, 125, 200, 250, 500].forEach((roundingIncrement) => {
+          const options = { smallestUnit, roundingIncrement };
+          assert(later.difference(earlier, options) instanceof Temporal.Duration);
         });
-      });
-      ['milliseconds', 'microseconds', 'nanoseconds'].forEach((smallestUnit) => {
-        it(`valid ${smallestUnit} increments divide into 1000`, () => {
-          [1, 2, 4, 5, 8, 10, 20, 25, 40, 50, 100, 125, 200, 250, 500].forEach((roundingIncrement) => {
-            const options = { smallestUnit, roundingIncrement };
-            assert(later.difference(earlier, options) instanceof Temporal.Duration);
-          });
-        });
-      });
-      it('throws on increments that do not divide evenly into the next highest', () => {
-        throws(() => later.difference(earlier, { smallestUnit: 'hours', roundingIncrement: 11 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'minutes', roundingIncrement: 29 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'seconds', roundingIncrement: 29 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 29 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'microseconds', roundingIncrement: 29 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 29 }), RangeError);
-      });
-      it('throws on increments that are equal to the next highest', () => {
-        throws(() => later.difference(earlier, { smallestUnit: 'hours', roundingIncrement: 24 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'minutes', roundingIncrement: 60 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'seconds', roundingIncrement: 60 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 1000 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'microseconds', roundingIncrement: 1000 }), RangeError);
-        throws(() => later.difference(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 1000 }), RangeError);
-      });
-      it('accepts singular units', () => {
-        equal(
-          `${later.difference(earlier, { largestUnit: 'hour' })}`,
-          `${later.difference(earlier, { largestUnit: 'hours' })}`
-        );
-        equal(
-          `${later.difference(earlier, { smallestUnit: 'hour' })}`,
-          `${later.difference(earlier, { smallestUnit: 'hours' })}`
-        );
-        equal(
-          `${later.difference(earlier, { largestUnit: 'minute' })}`,
-          `${later.difference(earlier, { largestUnit: 'minutes' })}`
-        );
-        equal(
-          `${later.difference(earlier, { smallestUnit: 'minute' })}`,
-          `${later.difference(earlier, { smallestUnit: 'minutes' })}`
-        );
-        equal(
-          `${later.difference(earlier, { largestUnit: 'second' })}`,
-          `${later.difference(earlier, { largestUnit: 'seconds' })}`
-        );
-        equal(
-          `${later.difference(earlier, { smallestUnit: 'second' })}`,
-          `${later.difference(earlier, { smallestUnit: 'seconds' })}`
-        );
-        equal(
-          `${later.difference(earlier, { largestUnit: 'millisecond' })}`,
-          `${later.difference(earlier, { largestUnit: 'milliseconds' })}`
-        );
-        equal(
-          `${later.difference(earlier, { smallestUnit: 'millisecond' })}`,
-          `${later.difference(earlier, { smallestUnit: 'milliseconds' })}`
-        );
-        equal(
-          `${later.difference(earlier, { largestUnit: 'microsecond' })}`,
-          `${later.difference(earlier, { largestUnit: 'microseconds' })}`
-        );
-        equal(
-          `${later.difference(earlier, { smallestUnit: 'microsecond' })}`,
-          `${later.difference(earlier, { smallestUnit: 'microseconds' })}`
-        );
-        equal(
-          `${later.difference(earlier, { largestUnit: 'nanosecond' })}`,
-          `${later.difference(earlier, { largestUnit: 'nanoseconds' })}`
-        );
-        equal(
-          `${later.difference(earlier, { smallestUnit: 'nanosecond' })}`,
-          `${later.difference(earlier, { smallestUnit: 'nanoseconds' })}`
-        );
       });
     });
-    describe('Time.round works', () => {
-      const time = Time.from('13:46:23.123456789');
-      it('throws without parameter', () => {
-        throws(() => time.round(), TypeError);
+    it('throws on increments that do not divide evenly into the next highest', () => {
+      throws(() => later.difference(earlier, { smallestUnit: 'hours', roundingIncrement: 11 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'minutes', roundingIncrement: 29 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'seconds', roundingIncrement: 29 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 29 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'microseconds', roundingIncrement: 29 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 29 }), RangeError);
+    });
+    it('throws on increments that are equal to the next highest', () => {
+      throws(() => later.difference(earlier, { smallestUnit: 'hours', roundingIncrement: 24 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'minutes', roundingIncrement: 60 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'seconds', roundingIncrement: 60 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 1000 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'microseconds', roundingIncrement: 1000 }), RangeError);
+      throws(() => later.difference(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 1000 }), RangeError);
+    });
+    it('accepts singular units', () => {
+      equal(
+        `${later.difference(earlier, { largestUnit: 'hour' })}`,
+        `${later.difference(earlier, { largestUnit: 'hours' })}`
+      );
+      equal(
+        `${later.difference(earlier, { smallestUnit: 'hour' })}`,
+        `${later.difference(earlier, { smallestUnit: 'hours' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'minute' })}`,
+        `${later.difference(earlier, { largestUnit: 'minutes' })}`
+      );
+      equal(
+        `${later.difference(earlier, { smallestUnit: 'minute' })}`,
+        `${later.difference(earlier, { smallestUnit: 'minutes' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'second' })}`,
+        `${later.difference(earlier, { largestUnit: 'seconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { smallestUnit: 'second' })}`,
+        `${later.difference(earlier, { smallestUnit: 'seconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'millisecond' })}`,
+        `${later.difference(earlier, { largestUnit: 'milliseconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { smallestUnit: 'millisecond' })}`,
+        `${later.difference(earlier, { smallestUnit: 'milliseconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'microsecond' })}`,
+        `${later.difference(earlier, { largestUnit: 'microseconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { smallestUnit: 'microsecond' })}`,
+        `${later.difference(earlier, { smallestUnit: 'microseconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'nanosecond' })}`,
+        `${later.difference(earlier, { largestUnit: 'nanoseconds' })}`
+      );
+      equal(
+        `${later.difference(earlier, { smallestUnit: 'nanosecond' })}`,
+        `${later.difference(earlier, { smallestUnit: 'nanoseconds' })}`
+      );
+    });
+  });
+  describe('Time.round works', () => {
+    const time = Time.from('13:46:23.123456789');
+    it('throws without parameter', () => {
+      throws(() => time.round(), TypeError);
+    });
+    it('throws without required smallestUnit parameter', () => {
+      throws(() => time.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
+    });
+    it('throws on disallowed or invalid smallestUnit', () => {
+      ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
+        (smallestUnit) => {
+          throws(() => time.round({ smallestUnit }), RangeError);
+        }
+      );
+    });
+    it('throws on invalid roundingMode', () => {
+      throws(() => time.round({ smallestUnit: 'second', roundingMode: 'cile' }), RangeError);
+    });
+    const incrementOneNearest = [
+      ['hour', '14:00'],
+      ['minute', '13:46'],
+      ['second', '13:46:23'],
+      ['millisecond', '13:46:23.123'],
+      ['microsecond', '13:46:23.123457'],
+      ['nanosecond', '13:46:23.123456789']
+    ];
+    incrementOneNearest.forEach(([smallestUnit, expected]) => {
+      it(`rounds to nearest ${smallestUnit}`, () =>
+        equal(`${time.round({ smallestUnit, roundingMode: 'nearest' })}`, expected));
+    });
+    const incrementOneCeil = [
+      ['hour', '14:00'],
+      ['minute', '13:47'],
+      ['second', '13:46:24'],
+      ['millisecond', '13:46:23.124'],
+      ['microsecond', '13:46:23.123457'],
+      ['nanosecond', '13:46:23.123456789']
+    ];
+    incrementOneCeil.forEach(([smallestUnit, expected]) => {
+      it(`rounds up to ${smallestUnit}`, () =>
+        equal(`${time.round({ smallestUnit, roundingMode: 'ceil' })}`, expected));
+    });
+    const incrementOneFloor = [
+      ['hour', '13:00'],
+      ['minute', '13:46'],
+      ['second', '13:46:23'],
+      ['millisecond', '13:46:23.123'],
+      ['microsecond', '13:46:23.123456'],
+      ['nanosecond', '13:46:23.123456789']
+    ];
+    incrementOneFloor.forEach(([smallestUnit, expected]) => {
+      it(`rounds down to ${smallestUnit}`, () =>
+        equal(`${time.round({ smallestUnit, roundingMode: 'floor' })}`, expected));
+      it(`truncates to ${smallestUnit}`, () =>
+        equal(`${time.round({ smallestUnit, roundingMode: 'trunc' })}`, expected));
+    });
+    it('nearest is the default', () => {
+      equal(`${time.round({ smallestUnit: 'hour' })}`, '14:00');
+      equal(`${time.round({ smallestUnit: 'minute' })}`, '13:46');
+    });
+    it('rounds to an increment of hours', () => {
+      equal(`${time.round({ smallestUnit: 'hour', roundingIncrement: 3 })}`, '15:00');
+    });
+    it('rounds to an increment of minutes', () => {
+      equal(`${time.round({ smallestUnit: 'minute', roundingIncrement: 15 })}`, '13:45');
+    });
+    it('rounds to an increment of seconds', () => {
+      equal(`${time.round({ smallestUnit: 'second', roundingIncrement: 30 })}`, '13:46:30');
+    });
+    it('rounds to an increment of milliseconds', () => {
+      equal(`${time.round({ smallestUnit: 'millisecond', roundingIncrement: 10 })}`, '13:46:23.120');
+    });
+    it('rounds to an increment of microseconds', () => {
+      equal(`${time.round({ smallestUnit: 'microsecond', roundingIncrement: 10 })}`, '13:46:23.123460');
+    });
+    it('rounds to an increment of nanoseconds', () => {
+      equal(`${time.round({ smallestUnit: 'nanosecond', roundingIncrement: 10 })}`, '13:46:23.123456790');
+    });
+    it('valid hour increments divide into 24', () => {
+      const smallestUnit = 'hour';
+      [1, 2, 3, 4, 6, 8, 12].forEach((roundingIncrement) => {
+        assert(time.round({ smallestUnit, roundingIncrement }) instanceof Time);
       });
-      it('throws without required smallestUnit parameter', () => {
-        throws(() => time.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
-      });
-      it('throws on disallowed or invalid smallestUnit', () => {
-        ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
-          (smallestUnit) => {
-            throws(() => time.round({ smallestUnit }), RangeError);
-          }
-        );
-      });
-      it('throws on invalid roundingMode', () => {
-        throws(() => time.round({ smallestUnit: 'second', roundingMode: 'cile' }), RangeError);
-      });
-      const incrementOneNearest = [
-        ['hour', '14:00'],
-        ['minute', '13:46'],
-        ['second', '13:46:23'],
-        ['millisecond', '13:46:23.123'],
-        ['microsecond', '13:46:23.123457'],
-        ['nanosecond', '13:46:23.123456789']
-      ];
-      incrementOneNearest.forEach(([smallestUnit, expected]) => {
-        it(`rounds to nearest ${smallestUnit}`, () =>
-          equal(`${time.round({ smallestUnit, roundingMode: 'nearest' })}`, expected));
-      });
-      const incrementOneCeil = [
-        ['hour', '14:00'],
-        ['minute', '13:47'],
-        ['second', '13:46:24'],
-        ['millisecond', '13:46:23.124'],
-        ['microsecond', '13:46:23.123457'],
-        ['nanosecond', '13:46:23.123456789']
-      ];
-      incrementOneCeil.forEach(([smallestUnit, expected]) => {
-        it(`rounds up to ${smallestUnit}`, () =>
-          equal(`${time.round({ smallestUnit, roundingMode: 'ceil' })}`, expected));
-      });
-      const incrementOneFloor = [
-        ['hour', '13:00'],
-        ['minute', '13:46'],
-        ['second', '13:46:23'],
-        ['millisecond', '13:46:23.123'],
-        ['microsecond', '13:46:23.123456'],
-        ['nanosecond', '13:46:23.123456789']
-      ];
-      incrementOneFloor.forEach(([smallestUnit, expected]) => {
-        it(`rounds down to ${smallestUnit}`, () =>
-          equal(`${time.round({ smallestUnit, roundingMode: 'floor' })}`, expected));
-        it(`truncates to ${smallestUnit}`, () =>
-          equal(`${time.round({ smallestUnit, roundingMode: 'trunc' })}`, expected));
-      });
-      it('nearest is the default', () => {
-        equal(`${time.round({ smallestUnit: 'hour' })}`, '14:00');
-        equal(`${time.round({ smallestUnit: 'minute' })}`, '13:46');
-      });
-      it('rounds to an increment of hours', () => {
-        equal(`${time.round({ smallestUnit: 'hour', roundingIncrement: 3 })}`, '15:00');
-      });
-      it('rounds to an increment of minutes', () => {
-        equal(`${time.round({ smallestUnit: 'minute', roundingIncrement: 15 })}`, '13:45');
-      });
-      it('rounds to an increment of seconds', () => {
-        equal(`${time.round({ smallestUnit: 'second', roundingIncrement: 30 })}`, '13:46:30');
-      });
-      it('rounds to an increment of milliseconds', () => {
-        equal(`${time.round({ smallestUnit: 'millisecond', roundingIncrement: 10 })}`, '13:46:23.120');
-      });
-      it('rounds to an increment of microseconds', () => {
-        equal(`${time.round({ smallestUnit: 'microsecond', roundingIncrement: 10 })}`, '13:46:23.123460');
-      });
-      it('rounds to an increment of nanoseconds', () => {
-        equal(`${time.round({ smallestUnit: 'nanosecond', roundingIncrement: 10 })}`, '13:46:23.123456790');
-      });
-      it('valid hour increments divide into 24', () => {
-        const smallestUnit = 'hour';
-        [1, 2, 3, 4, 6, 8, 12].forEach((roundingIncrement) => {
+    });
+    ['minute', 'second'].forEach((smallestUnit) => {
+      it(`valid ${smallestUnit} increments divide into 60`, () => {
+        [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30].forEach((roundingIncrement) => {
           assert(time.round({ smallestUnit, roundingIncrement }) instanceof Time);
         });
       });
-      ['minute', 'second'].forEach((smallestUnit) => {
-        it(`valid ${smallestUnit} increments divide into 60`, () => {
-          [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30].forEach((roundingIncrement) => {
-            assert(time.round({ smallestUnit, roundingIncrement }) instanceof Time);
-          });
+    });
+    ['millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+      it(`valid ${smallestUnit} increments divide into 1000`, () => {
+        [1, 2, 4, 5, 8, 10, 20, 25, 40, 50, 100, 125, 200, 250, 500].forEach((roundingIncrement) => {
+          assert(time.round({ smallestUnit, roundingIncrement }) instanceof Time);
         });
       });
-      ['millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
-        it(`valid ${smallestUnit} increments divide into 1000`, () => {
-          [1, 2, 4, 5, 8, 10, 20, 25, 40, 50, 100, 125, 200, 250, 500].forEach((roundingIncrement) => {
-            assert(time.round({ smallestUnit, roundingIncrement }) instanceof Time);
-          });
+    });
+    it('throws on increments that do not divide evenly into the next highest', () => {
+      throws(() => time.round({ smallestUnit: 'hour', roundingIncrement: 29 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'minute', roundingIncrement: 29 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'second', roundingIncrement: 29 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'millisecond', roundingIncrement: 29 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'microsecond', roundingIncrement: 29 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'nanosecond', roundingIncrement: 29 }), RangeError);
+    });
+    it('throws on increments that are equal to the next highest', () => {
+      throws(() => time.round({ smallestUnit: 'hour', roundingIncrement: 24 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'minute', roundingIncrement: 60 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'second', roundingIncrement: 60 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'millisecond', roundingIncrement: 1000 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'microsecond', roundingIncrement: 1000 }), RangeError);
+      throws(() => time.round({ smallestUnit: 'nanosecond', roundingIncrement: 1000 }), RangeError);
+    });
+    const bal = Time.from('23:59:59.999999999');
+    ['hour', 'minute', 'second', 'millisecond', 'microsecond'].forEach((smallestUnit) => {
+      it(`balances to next ${smallestUnit}`, () => {
+        equal(`${bal.round({ smallestUnit })}`, '00:00');
+      });
+    });
+    it('accepts plural units', () => {
+      assert(time.round({ smallestUnit: 'hours' }).equals(time.round({ smallestUnit: 'hour' })));
+      assert(time.round({ smallestUnit: 'minutes' }).equals(time.round({ smallestUnit: 'minute' })));
+      assert(time.round({ smallestUnit: 'seconds' }).equals(time.round({ smallestUnit: 'second' })));
+      assert(time.round({ smallestUnit: 'milliseconds' }).equals(time.round({ smallestUnit: 'millisecond' })));
+      assert(time.round({ smallestUnit: 'microseconds' }).equals(time.round({ smallestUnit: 'microsecond' })));
+      assert(time.round({ smallestUnit: 'nanoseconds' }).equals(time.round({ smallestUnit: 'nanosecond' })));
+    });
+  });
+  describe('Time.compare() works', () => {
+    const t1 = Time.from('08:44:15.321');
+    const t2 = Time.from('14:23:30.123');
+    it('equal', () => equal(Time.compare(t1, t1), 0));
+    it('smaller/larger', () => equal(Time.compare(t1, t2), -1));
+    it('larger/smaller', () => equal(Time.compare(t2, t1), 1));
+    it("doesn't cast first argument", () => {
+      throws(() => Time.compare({ hour: 16, minute: 34 }, t2), TypeError);
+      throws(() => Time.compare('16:34', t2), TypeError);
+    });
+    it("doesn't cast second argument", () => {
+      throws(() => Time.compare(t1, { hour: 16, minute: 34 }), TypeError);
+      throws(() => Time.compare(t1, '16:34'), TypeError);
+    });
+  });
+  describe('time.equals() works', () => {
+    const t1 = Time.from('08:44:15.321');
+    const t2 = Time.from('14:23:30.123');
+    it('equal', () => assert(t1.equals(t1)));
+    it('unequal', () => assert(!t1.equals(t2)));
+    it("doesn't cast argument", () => {
+      throws(() => t1.equals('08:44:15.321'), TypeError);
+      throws(() => t1.equals({ hour: 8, minute: 44, second: 15, millisecond: 321 }), TypeError);
+    });
+  });
+  describe("Comparison operators don't work", () => {
+    const t1 = Time.from('09:36:29.123456789');
+    const t1again = Time.from('09:36:29.123456789');
+    const t2 = Time.from('15:23:30.123456789');
+    it('=== is object equality', () => equal(t1, t1));
+    it('!== is object equality', () => notEqual(t1, t1again));
+    it('<', () => throws(() => t1 < t2));
+    it('>', () => throws(() => t1 > t2));
+    it('<=', () => throws(() => t1 <= t2));
+    it('>=', () => throws(() => t1 >= t2));
+  });
+  describe('time.add() works', () => {
+    const time = new Time(15, 23, 30, 123, 456, 789);
+    it(`(${time}).add({ hours: 16 })`, () => {
+      equal(`${time.add({ hours: 16 })}`, '07:23:30.123456789');
+    });
+    it(`(${time}).add({ minutes: 45 })`, () => {
+      equal(`${time.add({ minutes: 45 })}`, '16:08:30.123456789');
+    });
+    it(`(${time}).add({ nanoseconds: 300 })`, () => {
+      equal(`${time.add({ nanoseconds: 300 })}`, '15:23:30.123457089');
+    });
+    it('symmetric with regard to negative durations', () => {
+      equal(`${Time.from('07:23:30.123456789').add({ hours: -16 })}`, '15:23:30.123456789');
+      equal(`${Time.from('16:08:30.123456789').add({ minutes: -45 })}`, '15:23:30.123456789');
+      equal(`${Time.from('15:23:30.123457089').add({ nanoseconds: -300 })}`, '15:23:30.123456789');
+    });
+    it('time.add(durationObj)', () => {
+      equal(`${time.add(Temporal.Duration.from('PT16H'))}`, '07:23:30.123456789');
+    });
+    it('ignores higher units', () => {
+      equal(`${time.add({ days: 1 })}`, '15:23:30.123456789');
+      equal(`${time.add({ months: 1 })}`, '15:23:30.123456789');
+      equal(`${time.add({ years: 1 })}`, '15:23:30.123456789');
+    });
+    it('invalid overflow', () => {
+      ['', 'CONSTRAIN', 'balance', 3, null].forEach((overflow) =>
+        throws(() => time.add({ hours: 1 }, { overflow }), RangeError)
+      );
+    });
+    it('mixed positive and negative values always throw', () => {
+      ['constrain', 'reject'].forEach((overflow) =>
+        throws(() => time.add({ hours: 1, minutes: -30 }, { overflow }), RangeError)
+      );
+    });
+    it('options may only be an object or undefined', () => {
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => time.add({ hours: 1 }, badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) => equal(`${time.add({ hours: 1 }, options)}`, '16:23:30.123456789'));
+    });
+  });
+  describe('time.subtract() works', () => {
+    const time = Time.from('15:23:30.123456789');
+    it(`(${time}).subtract({ hours: 16 })`, () => equal(`${time.subtract({ hours: 16 })}`, '23:23:30.123456789'));
+    it(`(${time}).subtract({ minutes: 45 })`, () => equal(`${time.subtract({ minutes: 45 })}`, '14:38:30.123456789'));
+    it(`(${time}).subtract({ seconds: 45 })`, () => equal(`${time.subtract({ seconds: 45 })}`, '15:22:45.123456789'));
+    it(`(${time}).subtract({ milliseconds: 800 })`, () =>
+      equal(`${time.subtract({ milliseconds: 800 })}`, '15:23:29.323456789'));
+    it(`(${time}).subtract({ microseconds: 800 })`, () =>
+      equal(`${time.subtract({ microseconds: 800 })}`, '15:23:30.122656789'));
+    it(`(${time}).subtract({ nanoseconds: 800 })`, () =>
+      equal(`${time.subtract({ nanoseconds: 800 })}`, '15:23:30.123455989'));
+    it('symmetric with regard to negative durations', () => {
+      equal(`${Time.from('23:23:30.123456789').subtract({ hours: -16 })}`, '15:23:30.123456789');
+      equal(`${Time.from('14:38:30.123456789').subtract({ minutes: -45 })}`, '15:23:30.123456789');
+      equal(`${Time.from('15:22:45.123456789').subtract({ seconds: -45 })}`, '15:23:30.123456789');
+      equal(`${Time.from('15:23:29.323456789').subtract({ milliseconds: -800 })}`, '15:23:30.123456789');
+      equal(`${Time.from('15:23:30.122656789').subtract({ microseconds: -800 })}`, '15:23:30.123456789');
+      equal(`${Time.from('15:23:30.123455989').subtract({ nanoseconds: -800 })}`, '15:23:30.123456789');
+    });
+    it('time.subtract(durationObj)', () => {
+      equal(`${time.subtract(Temporal.Duration.from('PT16H'))}`, '23:23:30.123456789');
+    });
+    it('ignores higher units', () => {
+      equal(`${time.subtract({ days: 1 })}`, '15:23:30.123456789');
+      equal(`${time.subtract({ months: 1 })}`, '15:23:30.123456789');
+      equal(`${time.subtract({ years: 1 })}`, '15:23:30.123456789');
+    });
+    it('invalid overflow', () => {
+      ['', 'CONSTRAIN', 'balance', 3, null].forEach((overflow) =>
+        throws(() => time.subtract({ hours: 1 }, { overflow }), RangeError)
+      );
+    });
+    it('mixed positive and negative values always throw', () => {
+      ['constrain', 'reject'].forEach((overflow) =>
+        throws(() => time.subtract({ hours: 1, minutes: -30 }, { overflow }), RangeError)
+      );
+    });
+    it('options may only be an object or undefined', () => {
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => time.subtract({ hours: 1 }, badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) =>
+        equal(`${time.subtract({ hours: 1 }, options)}`, '14:23:30.123456789')
+      );
+    });
+  });
+  describe('time.toString() works', () => {
+    it('new Time(15, 23).toString()', () => {
+      equal(new Time(15, 23).toString(), '15:23');
+    });
+    it('new Time(15, 23, 30).toString()', () => {
+      equal(new Time(15, 23, 30).toString(), '15:23:30');
+    });
+    it('new Time(15, 23, 30, 123).toString()', () => {
+      equal(new Time(15, 23, 30, 123).toString(), '15:23:30.123');
+    });
+    it('new Time(15, 23, 30, 123, 456).toString()', () => {
+      equal(new Time(15, 23, 30, 123, 456).toString(), '15:23:30.123456');
+    });
+    it('new Time(15, 23, 30, 123, 456, 789).toString()', () => {
+      equal(new Time(15, 23, 30, 123, 456, 789).toString(), '15:23:30.123456789');
+    });
+  });
+  describe('Time.from() works', () => {
+    it('Time.from("15:23")', () => {
+      equal(`${Time.from('15:23')}`, '15:23');
+    });
+    it('Time.from("15:23:30")', () => {
+      equal(`${Time.from('15:23:30')}`, '15:23:30');
+    });
+    it('Time.from("15:23:30.123")', () => {
+      equal(`${Time.from('15:23:30.123')}`, '15:23:30.123');
+    });
+    it('Time.from("15:23:30.123456")', () => {
+      equal(`${Time.from('15:23:30.123456')}`, '15:23:30.123456');
+    });
+    it('Time.from("15:23:30.123456789")', () => {
+      equal(`${Time.from('15:23:30.123456789')}`, '15:23:30.123456789');
+    });
+    it('Time.from({ hour: 15, minute: 23 })', () => equal(`${Time.from({ hour: 15, minute: 23 })}`, '15:23'));
+    it('Time.from({ minute: 30, microsecond: 555 })', () =>
+      equal(`${Time.from({ minute: 30, microsecond: 555 })}`, '00:30:00.000555'));
+    it('Time.from({})', () => equal(`${Time.from({})}`, `${new Time()}`));
+    it('Time.from(ISO string leap second) is constrained', () => {
+      equal(`${Time.from('23:59:60')}`, '23:59:59');
+      equal(`${Time.from('23:59:60', { overflow: 'reject' })}`, '23:59:59');
+    });
+    it('Time.from(number) is converted to string', () => equal(`${Time.from(1523)}`, `${Time.from('1523')}`));
+    it('Time.from(time) returns the same properties', () => {
+      const t = Time.from('2020-02-12T11:42+01:00[Europe/Amsterdam]');
+      deepEqual(Time.from(t).getFields(), t.getFields());
+    });
+    it('Time.from(dateTime) returns the same time properties', () => {
+      const dt = DateTime.from('2020-02-12T11:42+01:00[Europe/Amsterdam]');
+      deepEqual(Time.from(dt).getFields(), dt.toTime().getFields());
+    });
+    it('Time.from(time) is not the same object', () => {
+      const t = Time.from('2020-02-12T11:42+01:00[Europe/Amsterdam]');
+      notEqual(Time.from(t), t);
+    });
+    it('any number of decimal places', () => {
+      equal(`${Time.from('1976-11-18T15:23:30.1Z')}`, '15:23:30.100');
+      equal(`${Time.from('1976-11-18T15:23:30.12Z')}`, '15:23:30.120');
+      equal(`${Time.from('1976-11-18T15:23:30.123Z')}`, '15:23:30.123');
+      equal(`${Time.from('1976-11-18T15:23:30.1234Z')}`, '15:23:30.123400');
+      equal(`${Time.from('1976-11-18T15:23:30.12345Z')}`, '15:23:30.123450');
+      equal(`${Time.from('1976-11-18T15:23:30.123456Z')}`, '15:23:30.123456');
+      equal(`${Time.from('1976-11-18T15:23:30.1234567Z')}`, '15:23:30.123456700');
+      equal(`${Time.from('1976-11-18T15:23:30.12345678Z')}`, '15:23:30.123456780');
+      equal(`${Time.from('1976-11-18T15:23:30.123456789Z')}`, '15:23:30.123456789');
+    });
+    it('variant decimal separator', () => {
+      equal(`${Time.from('1976-11-18T15:23:30,12Z')}`, '15:23:30.120');
+    });
+    it('variant minus sign', () => {
+      equal(`${Time.from('1976-11-18T15:23:30.12\u221202:00')}`, '15:23:30.120');
+    });
+    it('basic format', () => {
+      equal(`${Time.from('152330')}`, '15:23:30');
+      equal(`${Time.from('152330.1')}`, '15:23:30.100');
+      equal(`${Time.from('152330-08')}`, '15:23:30');
+      equal(`${Time.from('152330.1-08')}`, '15:23:30.100');
+      equal(`${Time.from('152330-0800')}`, '15:23:30');
+      equal(`${Time.from('152330.1-0800')}`, '15:23:30.100');
+    });
+    it('mixture of basic and extended format', () => {
+      equal(`${Time.from('1976-11-18T152330.1+00:00')}`, '15:23:30.100');
+      equal(`${Time.from('19761118T15:23:30.1+00:00')}`, '15:23:30.100');
+      equal(`${Time.from('1976-11-18T15:23:30.1+0000')}`, '15:23:30.100');
+      equal(`${Time.from('1976-11-18T152330.1+0000')}`, '15:23:30.100');
+      equal(`${Time.from('19761118T15:23:30.1+0000')}`, '15:23:30.100');
+      equal(`${Time.from('19761118T152330.1+00:00')}`, '15:23:30.100');
+      equal(`${Time.from('19761118T152330.1+0000')}`, '15:23:30.100');
+      equal(`${Time.from('+001976-11-18T152330.1+00:00')}`, '15:23:30.100');
+      equal(`${Time.from('+0019761118T15:23:30.1+00:00')}`, '15:23:30.100');
+      equal(`${Time.from('+001976-11-18T15:23:30.1+0000')}`, '15:23:30.100');
+      equal(`${Time.from('+001976-11-18T152330.1+0000')}`, '15:23:30.100');
+      equal(`${Time.from('+0019761118T15:23:30.1+0000')}`, '15:23:30.100');
+      equal(`${Time.from('+0019761118T152330.1+00:00')}`, '15:23:30.100');
+      equal(`${Time.from('+0019761118T152330.1+0000')}`, '15:23:30.100');
+    });
+    it('optional parts', () => {
+      equal(`${Time.from('15')}`, '15:00');
+    });
+    it('no junk at end of string', () => throws(() => Time.from('15:23:30.100junk'), RangeError));
+    it('options may only be an object or undefined', () => {
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => Time.from({ hour: 12 }, badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) => equal(`${Time.from({ hour: 12 }, options)}`, '12:00'));
+    });
+    describe('Overflow', () => {
+      const bad = { nanosecond: 1000 };
+      it('reject', () => throws(() => Time.from(bad, { overflow: 'reject' }), RangeError));
+      it('constrain', () => {
+        equal(`${Time.from(bad)}`, '00:00:00.000000999');
+        equal(`${Time.from(bad, { overflow: 'constrain' })}`, '00:00:00.000000999');
+      });
+      it('throw on bad overflow', () => {
+        [new Time(15), { hour: 15 }, '15:00'].forEach((input) => {
+          ['', 'CONSTRAIN', 'balance', 3, null].forEach((overflow) =>
+            throws(() => Time.from(input, { overflow }), RangeError)
+          );
         });
       });
-      it('throws on increments that do not divide evenly into the next highest', () => {
-        throws(() => time.round({ smallestUnit: 'hour', roundingIncrement: 29 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'minute', roundingIncrement: 29 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'second', roundingIncrement: 29 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'millisecond', roundingIncrement: 29 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'microsecond', roundingIncrement: 29 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'nanosecond', roundingIncrement: 29 }), RangeError);
-      });
-      it('throws on increments that are equal to the next highest', () => {
-        throws(() => time.round({ smallestUnit: 'hour', roundingIncrement: 24 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'minute', roundingIncrement: 60 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'second', roundingIncrement: 60 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'millisecond', roundingIncrement: 1000 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'microsecond', roundingIncrement: 1000 }), RangeError);
-        throws(() => time.round({ smallestUnit: 'nanosecond', roundingIncrement: 1000 }), RangeError);
-      });
-      const bal = Time.from('23:59:59.999999999');
-      ['hour', 'minute', 'second', 'millisecond', 'microsecond'].forEach((smallestUnit) => {
-        it(`balances to next ${smallestUnit}`, () => {
-          equal(`${bal.round({ smallestUnit })}`, '00:00');
-        });
-      });
-      it('accepts plural units', () => {
-        assert(time.round({ smallestUnit: 'hours' }).equals(time.round({ smallestUnit: 'hour' })));
-        assert(time.round({ smallestUnit: 'minutes' }).equals(time.round({ smallestUnit: 'minute' })));
-        assert(time.round({ smallestUnit: 'seconds' }).equals(time.round({ smallestUnit: 'second' })));
-        assert(time.round({ smallestUnit: 'milliseconds' }).equals(time.round({ smallestUnit: 'millisecond' })));
-        assert(time.round({ smallestUnit: 'microseconds' }).equals(time.round({ smallestUnit: 'microsecond' })));
-        assert(time.round({ smallestUnit: 'nanoseconds' }).equals(time.round({ smallestUnit: 'nanosecond' })));
-      });
+      const leap = { hour: 23, minute: 59, second: 60 };
+      it('reject leap second', () => throws(() => Time.from(leap, { overflow: 'reject' }), RangeError));
+      it('constrain leap second', () => equal(`${Time.from(leap)}`, '23:59:59'));
     });
-    describe('Time.compare() works', () => {
-      const t1 = Time.from('08:44:15.321');
-      const t2 = Time.from('14:23:30.123');
-      it('equal', () => equal(Time.compare(t1, t1), 0));
-      it('smaller/larger', () => equal(Time.compare(t1, t2), -1));
-      it('larger/smaller', () => equal(Time.compare(t2, t1), 1));
-      it("doesn't cast first argument", () => {
-        throws(() => Time.compare({ hour: 16, minute: 34 }, t2), TypeError);
-        throws(() => Time.compare('16:34', t2), TypeError);
-      });
-      it("doesn't cast second argument", () => {
-        throws(() => Time.compare(t1, { hour: 16, minute: 34 }), TypeError);
-        throws(() => Time.compare(t1, '16:34'), TypeError);
-      });
-    });
-    describe('time.equals() works', () => {
-      const t1 = Time.from('08:44:15.321');
-      const t2 = Time.from('14:23:30.123');
-      it('equal', () => assert(t1.equals(t1)));
-      it('unequal', () => assert(!t1.equals(t2)));
-      it("doesn't cast argument", () => {
-        throws(() => t1.equals('08:44:15.321'), TypeError);
-        throws(() => t1.equals({ hour: 8, minute: 44, second: 15, millisecond: 321 }), TypeError);
-      });
-    });
-    describe("Comparison operators don't work", () => {
-      const t1 = Time.from('09:36:29.123456789');
-      const t1again = Time.from('09:36:29.123456789');
-      const t2 = Time.from('15:23:30.123456789');
-      it('=== is object equality', () => equal(t1, t1));
-      it('!== is object equality', () => notEqual(t1, t1again));
-      it('<', () => throws(() => t1 < t2));
-      it('>', () => throws(() => t1 > t2));
-      it('<=', () => throws(() => t1 <= t2));
-      it('>=', () => throws(() => t1 >= t2));
-    });
-    describe('time.add() works', () => {
-      const time = new Time(15, 23, 30, 123, 456, 789);
-      it(`(${time}).add({ hours: 16 })`, () => {
-        equal(`${time.add({ hours: 16 })}`, '07:23:30.123456789');
-      });
-      it(`(${time}).add({ minutes: 45 })`, () => {
-        equal(`${time.add({ minutes: 45 })}`, '16:08:30.123456789');
-      });
-      it(`(${time}).add({ nanoseconds: 300 })`, () => {
-        equal(`${time.add({ nanoseconds: 300 })}`, '15:23:30.123457089');
-      });
-      it('symmetric with regard to negative durations', () => {
-        equal(`${Time.from('07:23:30.123456789').add({ hours: -16 })}`, '15:23:30.123456789');
-        equal(`${Time.from('16:08:30.123456789').add({ minutes: -45 })}`, '15:23:30.123456789');
-        equal(`${Time.from('15:23:30.123457089').add({ nanoseconds: -300 })}`, '15:23:30.123456789');
-      });
-      it('time.add(durationObj)', () => {
-        equal(`${time.add(Temporal.Duration.from('PT16H'))}`, '07:23:30.123456789');
-      });
-      it('ignores higher units', () => {
-        equal(`${time.add({ days: 1 })}`, '15:23:30.123456789');
-        equal(`${time.add({ months: 1 })}`, '15:23:30.123456789');
-        equal(`${time.add({ years: 1 })}`, '15:23:30.123456789');
-      });
-      it('invalid overflow', () => {
-        ['', 'CONSTRAIN', 'balance', 3, null].forEach((overflow) =>
-          throws(() => time.add({ hours: 1 }, { overflow }), RangeError)
-        );
-      });
-      it('mixed positive and negative values always throw', () => {
-        ['constrain', 'reject'].forEach((overflow) =>
-          throws(() => time.add({ hours: 1, minutes: -30 }, { overflow }), RangeError)
-        );
-      });
-      it('options may only be an object or undefined', () => {
-        [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
-          throws(() => time.add({ hours: 1 }, badOptions), TypeError)
-        );
-        [{}, () => {}, undefined].forEach((options) =>
-          equal(`${time.add({ hours: 1 }, options)}`, '16:23:30.123456789')
-        );
-      });
-    });
-    describe('time.subtract() works', () => {
-      const time = Time.from('15:23:30.123456789');
-      it(`(${time}).subtract({ hours: 16 })`, () => equal(`${time.subtract({ hours: 16 })}`, '23:23:30.123456789'));
-      it(`(${time}).subtract({ minutes: 45 })`, () => equal(`${time.subtract({ minutes: 45 })}`, '14:38:30.123456789'));
-      it(`(${time}).subtract({ seconds: 45 })`, () => equal(`${time.subtract({ seconds: 45 })}`, '15:22:45.123456789'));
-      it(`(${time}).subtract({ milliseconds: 800 })`, () =>
-        equal(`${time.subtract({ milliseconds: 800 })}`, '15:23:29.323456789'));
-      it(`(${time}).subtract({ microseconds: 800 })`, () =>
-        equal(`${time.subtract({ microseconds: 800 })}`, '15:23:30.122656789'));
-      it(`(${time}).subtract({ nanoseconds: 800 })`, () =>
-        equal(`${time.subtract({ nanoseconds: 800 })}`, '15:23:30.123455989'));
-      it('symmetric with regard to negative durations', () => {
-        equal(`${Time.from('23:23:30.123456789').subtract({ hours: -16 })}`, '15:23:30.123456789');
-        equal(`${Time.from('14:38:30.123456789').subtract({ minutes: -45 })}`, '15:23:30.123456789');
-        equal(`${Time.from('15:22:45.123456789').subtract({ seconds: -45 })}`, '15:23:30.123456789');
-        equal(`${Time.from('15:23:29.323456789').subtract({ milliseconds: -800 })}`, '15:23:30.123456789');
-        equal(`${Time.from('15:23:30.122656789').subtract({ microseconds: -800 })}`, '15:23:30.123456789');
-        equal(`${Time.from('15:23:30.123455989').subtract({ nanoseconds: -800 })}`, '15:23:30.123456789');
-      });
-      it('time.subtract(durationObj)', () => {
-        equal(`${time.subtract(Temporal.Duration.from('PT16H'))}`, '23:23:30.123456789');
-      });
-      it('ignores higher units', () => {
-        equal(`${time.subtract({ days: 1 })}`, '15:23:30.123456789');
-        equal(`${time.subtract({ months: 1 })}`, '15:23:30.123456789');
-        equal(`${time.subtract({ years: 1 })}`, '15:23:30.123456789');
-      });
-      it('invalid overflow', () => {
-        ['', 'CONSTRAIN', 'balance', 3, null].forEach((overflow) =>
-          throws(() => time.subtract({ hours: 1 }, { overflow }), RangeError)
-        );
-      });
-      it('mixed positive and negative values always throw', () => {
-        ['constrain', 'reject'].forEach((overflow) =>
-          throws(() => time.subtract({ hours: 1, minutes: -30 }, { overflow }), RangeError)
-        );
-      });
-      it('options may only be an object or undefined', () => {
-        [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
-          throws(() => time.subtract({ hours: 1 }, badOptions), TypeError)
-        );
-        [{}, () => {}, undefined].forEach((options) =>
-          equal(`${time.subtract({ hours: 1 }, options)}`, '14:23:30.123456789')
-        );
-      });
-    });
-    describe('time.toString() works', () => {
-      it('new Time(15, 23).toString()', () => {
-        equal(new Time(15, 23).toString(), '15:23');
-      });
-      it('new Time(15, 23, 30).toString()', () => {
-        equal(new Time(15, 23, 30).toString(), '15:23:30');
-      });
-      it('new Time(15, 23, 30, 123).toString()', () => {
-        equal(new Time(15, 23, 30, 123).toString(), '15:23:30.123');
-      });
-      it('new Time(15, 23, 30, 123, 456).toString()', () => {
-        equal(new Time(15, 23, 30, 123, 456).toString(), '15:23:30.123456');
-      });
-      it('new Time(15, 23, 30, 123, 456, 789).toString()', () => {
-        equal(new Time(15, 23, 30, 123, 456, 789).toString(), '15:23:30.123456789');
-      });
-    });
-    describe('Time.from() works', () => {
-      it('Time.from("15:23")', () => {
-        equal(`${Time.from('15:23')}`, '15:23');
-      });
-      it('Time.from("15:23:30")', () => {
-        equal(`${Time.from('15:23:30')}`, '15:23:30');
-      });
-      it('Time.from("15:23:30.123")', () => {
-        equal(`${Time.from('15:23:30.123')}`, '15:23:30.123');
-      });
-      it('Time.from("15:23:30.123456")', () => {
-        equal(`${Time.from('15:23:30.123456')}`, '15:23:30.123456');
-      });
-      it('Time.from("15:23:30.123456789")', () => {
-        equal(`${Time.from('15:23:30.123456789')}`, '15:23:30.123456789');
-      });
-      it('Time.from({ hour: 15, minute: 23 })', () => equal(`${Time.from({ hour: 15, minute: 23 })}`, '15:23'));
-      it('Time.from({ minute: 30, microsecond: 555 })', () =>
-        equal(`${Time.from({ minute: 30, microsecond: 555 })}`, '00:30:00.000555'));
-      it('Time.from({})', () => equal(`${Time.from({})}`, `${new Time()}`));
-      it('Time.from(ISO string leap second) is constrained', () => {
-        equal(`${Time.from('23:59:60')}`, '23:59:59');
-        equal(`${Time.from('23:59:60', { overflow: 'reject' })}`, '23:59:59');
-      });
-      it('Time.from(number) is converted to string', () => equal(`${Time.from(1523)}`, `${Time.from('1523')}`));
-      it('Time.from(time) returns the same properties', () => {
-        const t = Time.from('2020-02-12T11:42+01:00[Europe/Amsterdam]');
-        deepEqual(Time.from(t).getFields(), t.getFields());
-      });
-      it('Time.from(dateTime) returns the same time properties', () => {
-        const dt = DateTime.from('2020-02-12T11:42+01:00[Europe/Amsterdam]');
-        deepEqual(Time.from(dt).getFields(), dt.toTime().getFields());
-      });
-      it('Time.from(time) is not the same object', () => {
-        const t = Time.from('2020-02-12T11:42+01:00[Europe/Amsterdam]');
-        notEqual(Time.from(t), t);
-      });
-      it('any number of decimal places', () => {
-        equal(`${Time.from('1976-11-18T15:23:30.1Z')}`, '15:23:30.100');
-        equal(`${Time.from('1976-11-18T15:23:30.12Z')}`, '15:23:30.120');
-        equal(`${Time.from('1976-11-18T15:23:30.123Z')}`, '15:23:30.123');
-        equal(`${Time.from('1976-11-18T15:23:30.1234Z')}`, '15:23:30.123400');
-        equal(`${Time.from('1976-11-18T15:23:30.12345Z')}`, '15:23:30.123450');
-        equal(`${Time.from('1976-11-18T15:23:30.123456Z')}`, '15:23:30.123456');
-        equal(`${Time.from('1976-11-18T15:23:30.1234567Z')}`, '15:23:30.123456700');
-        equal(`${Time.from('1976-11-18T15:23:30.12345678Z')}`, '15:23:30.123456780');
-        equal(`${Time.from('1976-11-18T15:23:30.123456789Z')}`, '15:23:30.123456789');
-      });
-      it('variant decimal separator', () => {
-        equal(`${Time.from('1976-11-18T15:23:30,12Z')}`, '15:23:30.120');
-      });
-      it('variant minus sign', () => {
-        equal(`${Time.from('1976-11-18T15:23:30.12\u221202:00')}`, '15:23:30.120');
-      });
-      it('basic format', () => {
-        equal(`${Time.from('152330')}`, '15:23:30');
-        equal(`${Time.from('152330.1')}`, '15:23:30.100');
-        equal(`${Time.from('152330-08')}`, '15:23:30');
-        equal(`${Time.from('152330.1-08')}`, '15:23:30.100');
-        equal(`${Time.from('152330-0800')}`, '15:23:30');
-        equal(`${Time.from('152330.1-0800')}`, '15:23:30.100');
-      });
-      it('mixture of basic and extended format', () => {
-        equal(`${Time.from('1976-11-18T152330.1+00:00')}`, '15:23:30.100');
-        equal(`${Time.from('19761118T15:23:30.1+00:00')}`, '15:23:30.100');
-        equal(`${Time.from('1976-11-18T15:23:30.1+0000')}`, '15:23:30.100');
-        equal(`${Time.from('1976-11-18T152330.1+0000')}`, '15:23:30.100');
-        equal(`${Time.from('19761118T15:23:30.1+0000')}`, '15:23:30.100');
-        equal(`${Time.from('19761118T152330.1+00:00')}`, '15:23:30.100');
-        equal(`${Time.from('19761118T152330.1+0000')}`, '15:23:30.100');
-        equal(`${Time.from('+001976-11-18T152330.1+00:00')}`, '15:23:30.100');
-        equal(`${Time.from('+0019761118T15:23:30.1+00:00')}`, '15:23:30.100');
-        equal(`${Time.from('+001976-11-18T15:23:30.1+0000')}`, '15:23:30.100');
-        equal(`${Time.from('+001976-11-18T152330.1+0000')}`, '15:23:30.100');
-        equal(`${Time.from('+0019761118T15:23:30.1+0000')}`, '15:23:30.100');
-        equal(`${Time.from('+0019761118T152330.1+00:00')}`, '15:23:30.100');
-        equal(`${Time.from('+0019761118T152330.1+0000')}`, '15:23:30.100');
-      });
-      it('optional parts', () => {
-        equal(`${Time.from('15')}`, '15:00');
-      });
-      it('no junk at end of string', () => throws(() => Time.from('15:23:30.100junk'), RangeError));
-      it('options may only be an object or undefined', () => {
-        [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
-          throws(() => Time.from({ hour: 12 }, badOptions), TypeError)
-        );
-        [{}, () => {}, undefined].forEach((options) => equal(`${Time.from({ hour: 12 }, options)}`, '12:00'));
-      });
-      describe('Overflow', () => {
-        const bad = { nanosecond: 1000 };
-        it('reject', () => throws(() => Time.from(bad, { overflow: 'reject' }), RangeError));
-        it('constrain', () => {
-          equal(`${Time.from(bad)}`, '00:00:00.000000999');
-          equal(`${Time.from(bad, { overflow: 'constrain' })}`, '00:00:00.000000999');
-        });
-        it('throw on bad overflow', () => {
-          [new Time(15), { hour: 15 }, '15:00'].forEach((input) => {
-            ['', 'CONSTRAIN', 'balance', 3, null].forEach((overflow) =>
-              throws(() => Time.from(input, { overflow }), RangeError)
-            );
-          });
-        });
-        const leap = { hour: 23, minute: 59, second: 60 };
-        it('reject leap second', () => throws(() => Time.from(leap, { overflow: 'reject' }), RangeError));
-        it('constrain leap second', () => equal(`${Time.from(leap)}`, '23:59:59'));
-      });
-    });
-    describe('constructor treats -0 as 0', () => {
-      it('ignores the sign of -0', () => {
-        const datetime = new Time(-0, -0, -0, -0, -0);
-        equal(datetime.hour, 0);
-        equal(datetime.minute, 0);
-        equal(datetime.second, 0);
-        equal(datetime.millisecond, 0);
-        equal(datetime.microsecond, 0);
-        equal(datetime.nanosecond, 0);
-      });
+  });
+  describe('constructor treats -0 as 0', () => {
+    it('ignores the sign of -0', () => {
+      const datetime = new Time(-0, -0, -0, -0, -0);
+      equal(datetime.hour, 0);
+      equal(datetime.minute, 0);
+      equal(datetime.second, 0);
+      equal(datetime.millisecond, 0);
+      equal(datetime.microsecond, 0);
+      equal(datetime.nanosecond, 0);
     });
   });
   describe('time operations', () => {

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -422,24 +422,48 @@ describe('Time', () => {
       });
       it('accepts singular units', () => {
         equal(
+          `${later.difference(earlier, { largestUnit: 'hour' })}`,
+          `${later.difference(earlier, { largestUnit: 'hours' })}`
+        );
+        equal(
           `${later.difference(earlier, { smallestUnit: 'hour' })}`,
           `${later.difference(earlier, { smallestUnit: 'hours' })}`
+        );
+        equal(
+          `${later.difference(earlier, { largestUnit: 'minute' })}`,
+          `${later.difference(earlier, { largestUnit: 'minutes' })}`
         );
         equal(
           `${later.difference(earlier, { smallestUnit: 'minute' })}`,
           `${later.difference(earlier, { smallestUnit: 'minutes' })}`
         );
         equal(
+          `${later.difference(earlier, { largestUnit: 'second' })}`,
+          `${later.difference(earlier, { largestUnit: 'seconds' })}`
+        );
+        equal(
           `${later.difference(earlier, { smallestUnit: 'second' })}`,
           `${later.difference(earlier, { smallestUnit: 'seconds' })}`
+        );
+        equal(
+          `${later.difference(earlier, { largestUnit: 'millisecond' })}`,
+          `${later.difference(earlier, { largestUnit: 'milliseconds' })}`
         );
         equal(
           `${later.difference(earlier, { smallestUnit: 'millisecond' })}`,
           `${later.difference(earlier, { smallestUnit: 'milliseconds' })}`
         );
         equal(
+          `${later.difference(earlier, { largestUnit: 'microsecond' })}`,
+          `${later.difference(earlier, { largestUnit: 'microseconds' })}`
+        );
+        equal(
           `${later.difference(earlier, { smallestUnit: 'microsecond' })}`,
           `${later.difference(earlier, { smallestUnit: 'microseconds' })}`
+        );
+        equal(
+          `${later.difference(earlier, { largestUnit: 'nanosecond' })}`,
+          `${later.difference(earlier, { largestUnit: 'nanoseconds' })}`
         );
         equal(
           `${later.difference(earlier, { smallestUnit: 'nanosecond' })}`,

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -322,8 +322,16 @@ describe('YearMonth', () => {
     });
     it('accepts singular units', () => {
       equal(
+        `${later.difference(earlier, { largestUnit: 'year' })}`,
+        `${later.difference(earlier, { largestUnit: 'years' })}`
+      );
+      equal(
         `${later.difference(earlier, { smallestUnit: 'year' })}`,
         `${later.difference(earlier, { smallestUnit: 'years' })}`
+      );
+      equal(
+        `${later.difference(earlier, { largestUnit: 'month' })}`,
+        `${later.difference(earlier, { largestUnit: 'months' })}`
       );
       equal(
         `${later.difference(earlier, { smallestUnit: 'month' })}`,

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -128,6 +128,13 @@ describe('YearMonth', () => {
           });
         });
       });
+      it('object must contain at least the required correctly-spelled properties', () => {
+        throws(() => YearMonth.from({}), TypeError);
+        throws(() => YearMonth.from({ year: 1976, months: 11 }), TypeError);
+      });
+      it('incorrectly-spelled properties are ignored', () => {
+        equal(`${YearMonth.from({ year: 1976, month: 11, months: 12 })}`, '1976-11');
+      });
     });
     describe('.with()', () => {
       const ym = YearMonth.from('2019-10');
@@ -145,6 +152,13 @@ describe('YearMonth', () => {
         throws(() => ym.with({ year: 2020 }, badOptions), TypeError)
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${ym.with({ year: 2020 }, options)}`, '2020-10'));
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => ym.with({}), TypeError);
+      throws(() => ym.with({ months: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${ym.with({ month: 1, years: 2020 })}`, '2019-01');
     });
   });
   describe('YearMonth.compare() works', () => {
@@ -406,6 +420,13 @@ describe('YearMonth', () => {
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${ym.add({ months: 1 }, options)}`, '2019-12'));
     });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => ym.add({}), TypeError);
+      throws(() => ym.add({ month: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${ym.add({ month: 1, years: 1 })}`, '2020-11');
+    });
   });
   describe('YearMonth.subtract() works', () => {
     const ym = YearMonth.from('2019-11');
@@ -472,6 +493,13 @@ describe('YearMonth', () => {
         throws(() => ym.subtract({ months: 1 }, badOptions), TypeError)
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${ym.subtract({ months: 1 }, options)}`, '2019-10'));
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => ym.subtract({}), TypeError);
+      throws(() => ym.subtract({ month: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${ym.subtract({ month: 1, years: 1 })}`, '2018-11');
     });
   });
   describe('Min/max range', () => {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -146,9 +146,11 @@
     <h1>ToLargestTemporalUnit ( _normalizedOptions_, _disallowedUnits_, _defaultUnit_ )</h1>
     <emu-alg>
       1. Assert: _disallowedUnits_ does not contain _defaultUnit_ or *"auto"*.
-      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, *"string"*, « *"auto"*, *"years"*, *"months"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"auto"*).
+      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, *"string"*, « *"auto"*, *"year"*, *"years"*, *"month"*, *"months"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *"auto"*).
       1. If _largestUnit_ is *"auto"*, then
         1. Return _defaultUnit_.
+      1. If the value of _largestUnit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
+        1. Set _largestUnit_ to the corresponding Plural value of the same row.
       1. If _disallowedUnits_ contains _largestUnit_, then
         1. Throw a *RangeError* exception.
       1. Return _largestUnit_.
@@ -161,20 +163,8 @@
       1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *"not present"*).
       1. If _smallestUnit_ is *"not present"*, then
         1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"days"*, then
-        1. Set _smallestUnit_ to *"day"*.
-      1. Else if _smallestUnit_ is *"hours"*, then
-        1. Set _smallestUnit_ to *"hour"*.
-      1. Else if _smallestUnit_ is *"minutes"*, then
-        1. Set _smallestUnit_ to *"minute"*.
-      1. Else if _smallestUnit_ is *"seconds"*, then
-        1. Set _smallestUnit_ to *"second"*.
-      1. Else if _smallestUnit_ is *"milliseconds"*, then
-        1. Set _smallestUnit_ to *"millisecond"*.
-      1. Else if _smallestUnit_ is *"microseconds"*, then
-        1. Set _smallestUnit_ to *"microsecond"*.
-      1. Else if _smallestUnit_ is *"nanoseconds"*, then
-        1. Set _smallestUnit_ to *"nanosecond"*.
+      1. If the value of _smallestUnit_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
+        1. Set _smallestUnit_ to the corresponding Singular value of the same row.
       1. If _disallowedUnits_ contains _smallestUnit_, then
         1. Throw a *RangeError* exception.
       1. Return _smallestUnit_.
@@ -184,31 +174,78 @@
   <emu-clause id="sec-temporal-tosmallesttemporaldurationunit" aoid="ToSmallestTemporalDurationUnit">
     <h1>ToSmallestTemporalDurationUnit ( _normalizedOptions_, _fallback_, _disallowedUnits_ )</h1>
     <emu-alg>
-      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
-      1. If _smallestUnit_ is *"year"*, then
-        1. Set _smallestUnit_ to *"years"*.
-      1. Else if _smallestUnit_ is *"month"*, then
-        1. Set _smallestUnit_ to *"months"*.
-      1. Else if _smallestUnit_ is *"week"*, then
-        1. Set _smallestUnit_ to *"weeks"*.
-      1. Else if _smallestUnit_ is *"day"*, then
-        1. Set _smallestUnit_ to *"days"*.
-      1. Else if _smallestUnit_ is *"hour"*, then
-        1. Set _smallestUnit_ to *"hours"*.
-      1. Else if _smallestUnit_ is *"minute"*, then
-        1. Set _smallestUnit_ to *"minutes"*.
-      1. Else if _smallestUnit_ is *"second"*, then
-        1. Set _smallestUnit_ to *"seconds"*.
-      1. Else if _smallestUnit_ is *"millisecond"*, then
-        1. Set _smallestUnit_ to *"milliseconds"*.
-      1. Else if _smallestUnit_ is *"microsecond"*, then
-        1. Set _smallestUnit_ to *"microseconds"*.
-      1. Else if _smallestUnit_ is *"nanosecond"*, then
-        1. Set _smallestUnit_ to *"nanoseconds"*.
+      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
+      1. If the value of _smallestUnit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
+        1. Set _smallestUnit_ to the corresponding Plural value of the same row.
       1. If _disallowedUnits_ contains _smallestUnit_, then
         1. Throw a *RangeError* exception.
       1. Return _smallestUnit_.
     </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-singular-and-plural-units">
+    <h1>Singular and plural units</h1>
+    <p>
+      Where possible, the `smallestUnit` and `largestUnit` options accept both singular and plural forms.
+      As an exception, *"week"* is not accepted, because there is no property named that on any Temporal object.
+    </p>
+    <emu-table id="table-temporal-singular-and-plural-units">
+      <emu-caption>Singular and plural units</emu-caption>
+      <table class="real-table">
+        <thead>
+          <tr>
+            <th>Singular</th>
+            <th>Plural</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>*"year"*</td>
+            <td>*"years"*</td>
+          </tr>
+
+          <tr>
+            <td>*"month"*</td>
+            <td>*"months"*</td>
+          </tr>
+
+          <tr>
+            <td>*"day"*</td>
+            <td>*"days"*</td>
+          </tr>
+
+          <tr>
+            <td>*"hour"*</td>
+            <td>*"hours"*</td>
+          </tr>
+
+          <tr>
+            <td>*"minute"*</td>
+            <td>*"minutes"*</td>
+          </tr>
+
+          <tr>
+            <td>*"second"*</td>
+            <td>*"seconds"*</td>
+          </tr>
+
+          <tr>
+            <td>*"millisecond"*</td>
+            <td>*"milliseconds"*</td>
+          </tr>
+
+          <tr>
+            <td>*"microsecond"*</td>
+            <td>*"microseconds"*</td>
+          </tr>
+
+          <tr>
+            <td>*"nanosecond"*</td>
+            <td>*"nanoseconds"*</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
   </emu-clause>
 
   <emu-clause id="sec-temporal-torelativetemporalobject" aoid="ToRelativeTemporalObject">

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -618,11 +618,16 @@
               [[Nanoseconds]]: _temporalDurationLike_.[[Nanoseconds]]
             }.
         1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-temporaldurationlike-properties"></emu-xref>.
+        1. Let _any_ be *false*.
         1. For each row of <emu-xref href="#table-temporal-temporaldurationlike-properties"></emu-xref>, except the header row, in table order, do
           1. Let _prop_ be the Property value of the current row.
           1. Let _val_ be ? Get(_temporalDurationLike_, _prop_).
+          1. If _val_ is not *undefined*, then
+            1. Set _any_ to *true*.
           1. Let _val_ be ? ToInteger(_val_).
           1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _val_.
+        1. If _any_ is *false*, then
+          1. Throw a *TypeError* exception.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/time.html
+++ b/spec/time.html
@@ -762,11 +762,16 @@
               [[Nanosecond]]: _temporalTimeLike_.[[Nanosecond]]
             }.
         1. Let _result_ be a new Record with all the internal slots given in the Internal Slot column in <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>.
+        1. Let _any_ be *false*.
         1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
           1. Let _property_ be the Property value of the current row.
           1. Let _value_ be ? Get(_temporalTimeLike_, _property_).
+          1. If _value_ is not *undefined*, then
+            1. Set _any_ to *true*.
           1. Let _value_ be ? ToInteger(_value_).
           1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. If _any_ is *false*, then
+          1. Throw a *TypeError* exception.
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
For values of largestUnit and smallestUnit options, accept both singular and plural everywhere (except "week"), but describe only the "correct" ones in documentation, and mark the "wrong" ones as deprecated in TypeScript.

For names of properties, accept only the correct ones. Property bags must include at least one correctly-spelled property or throw a TypeError.

Closes: #325