### PR TITLE
Misc documentation and JSDoc updates

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -449,7 +449,7 @@ date.subtract({ months: 1 }, { overflow: 'reject' }); // => throws
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `date` and `other`.

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -518,7 +518,7 @@ dt.subtract({ months: 1 }); // => throws
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `datetime` and `other`.
@@ -590,7 +590,7 @@ mar1.difference(jan1);                            // => P121D
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
 **Returns:** a new `Temporal.DateTime` object which is `datetime` rounded to `roundingIncrement` of `smallestUnit`.

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -17,18 +17,18 @@ Briefly, the ISO 8601 notation consists of a `P` character, followed by years, m
 Any zero components may be omitted.
 For more detailed information, see the ISO 8601 standard or the [Wikipedia page](https://en.wikipedia.org/wiki/ISO_8601#Durations).
 
-| ISO 8601             | Meaning |
-| -------------------- | ------- |
+| ISO 8601             | Meaning                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------ |
 | **P1Y1M1DT1H1M1.1S** | One year, one month, one day, one hour, one minute, one second, and 100 milliseconds |
-| **P40D**             | Forty days |
-| **P1Y1D**            | A year and a day |
-| **P3DT4H59M**        | Three days, four hours and 59 minutes |
-| **PT2H30M**          | Two and a half hours |
-| **P1M**              | One month |
-| **PT1M**             | One minute |
-| **PT0.0021S**        | 2.1 milliseconds (two milliseconds and 100 microseconds) |
-| **PT0S**             | Zero |
-| **P0D**              | Zero |
+| **P40D**             | Forty days                                                                           |
+| **P1Y1D**            | A year and a day                                                                     |
+| **P3DT4H59M**        | Three days, four hours and 59 minutes                                                |
+| **PT2H30M**          | Two and a half hours                                                                 |
+| **P1M**              | One month                                                                            |
+| **PT1M**             | One minute                                                                           |
+| **PT0.0021S**        | 2.1 milliseconds (two milliseconds and 100 microseconds)                             |
+| **PT0S**             | Zero                                                                                 |
+| **P0D**              | Zero                                                                                 |
 
 > **NOTE:** According to the ISO 8601-1 standard, weeks are not allowed to appear together with any other units, and durations can only be positive.
 > As extensions to the standard, ISO 8601-2 allows a sign character at the start of the string, and allows combining weeks with other units.
@@ -39,6 +39,7 @@ For more detailed information, see the ISO 8601 standard or the [Wikipedia page]
 ### **new Temporal.Duration**(_years_?: number, _months_?: number, _days_?: number, _hours_?: number, _minutes_?: number, _seconds_?: number, _milliseconds_?: number, _microseconds_?: number, _nanoseconds_?: number) : Temporal.Duration
 
 **Parameters:**
+
 - `years` (optional number): A number of years.
 - `months` (optional number): A number of months.
 - `weeks` (optional number): A number of weeks.
@@ -60,11 +61,12 @@ Use this constructor directly if you have the correct parameters already as nume
 Otherwise `Temporal.Duration.from()` is probably more convenient because it accepts more kinds of input and allows controlling the overflow behaviour.
 
 Usage examples:
+
 ```javascript
-new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321)  // => P1Y2M3W4DT5H6M7.987654321S
-new Temporal.Duration(0, 0, 0, 40)  // => P40D
-new Temporal.Duration(undefined, undefined, undefined, 40)  // => P40D
-new Temporal.Duration()  // => PT0S
+new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321); // => P1Y2M3W4DT5H6M7.987654321S
+new Temporal.Duration(0, 0, 0, 40); // => P40D
+new Temporal.Duration(undefined, undefined, undefined, 40); // => P40D
+new Temporal.Duration(); // => PT0S
 ```
 
 ## Static methods
@@ -72,6 +74,7 @@ new Temporal.Duration()  // => PT0S
 ### Temporal.Duration.**from**(_thing_: any, _options_?: object) : Temporal.Duration
 
 **Parameters:**
+
 - `thing`: A `Duration`-like object or a string from which to create a `Temporal.Duration`.
 
 **Returns:** a new `Temporal.Duration` object.
@@ -91,18 +94,19 @@ Any non-object value is converted to a string, which is expected to be in ISO 86
 > If no sign character is present, then the sign is assumed to be positive.
 
 Usage examples:
+
 ```javascript
-d = Temporal.Duration.from({ years: 1, days: 1 })  // => P1Y1D
-d = Temporal.Duration.from({ days: -2, hours: -12 })  // => -P2DT12H
+d = Temporal.Duration.from({ years: 1, days: 1 }); // => P1Y1D
+d = Temporal.Duration.from({ days: -2, hours: -12 }); // => -P2DT12H
 
-Temporal.Duration.from(d) === d  // => true
+Temporal.Duration.from(d) === d; // => true
 
-d = Temporal.Duration.from('P1Y1D')  // => P1Y1D
-d = Temporal.Duration.from('-P2DT12H')  // => -P2DT12H
-d = Temporal.Duration.from('P0D')  // => PT0S
+d = Temporal.Duration.from('P1Y1D'); // => P1Y1D
+d = Temporal.Duration.from('-P2DT12H'); // => -P2DT12H
+d = Temporal.Duration.from('P0D'); // => PT0S
 
 // Mixed-sign values are never allowed, even if overall positive:
-d = Temporal.Duration.from({ hours: 1, minutes: -30 })  // throws
+d = Temporal.Duration.from({ hours: 1, minutes: -30 }); // throws
 ```
 
 ## Properties
@@ -130,6 +134,8 @@ d = Temporal.Duration.from({ hours: 1, minutes: -30 })  // throws
 The above read-only properties allow accessing each component of the duration individually.
 
 Usage examples:
+
+<!-- prettier-ignore-start -->
 ```javascript
 d = Temporal.Duration.from('P1Y2M3W4DT5H6M7.987654321S');
 d.years         // => 1
@@ -143,6 +149,7 @@ d.milliseconds  // => 987
 d.microseconds  // => 654
 d.nanoseconds   // => 321
 ```
+<!-- prettier-ignore-end -->
 
 ### duration.**sign** : number
 
@@ -153,6 +160,7 @@ The read-only `sign` property has the value –1, 0, or 1, depending on whether 
 ### duration.**with**(_durationLike_: object, _options_?: object) : Temporal.Duration
 
 **Parameters:**
+
 - `durationLike` (object): an object with some or all of the properties of a `Temporal.Duration`.
 
 **Returns:** a new `Temporal.Duration` object.
@@ -165,6 +173,8 @@ All non-zero properties of `durationLike` must have the same sign, and they must
 If a property of `durationLike` is infinity, then this function will throw a `RangeError`.
 
 Usage example:
+
+<!-- prettier-ignore-start -->
 ```javascript
 duration = Temporal.Duration.from({ months: 50, days: 50, hours: 50, minutes: 100 });
 // Perform a balance operation using additional ISO calendar rules:
@@ -174,10 +184,12 @@ months %= 12;
 duration = duration.with({ years, months });
   // => P4Y2M50DT50H100M
 ```
+<!-- prettier-ignore-end -->
 
 ### duration.**add**(_other_: Temporal.Duration | object | string, _options_?: object) : Temporal.Duration
 
 **Parameters:**
+
 - `other` (`Temporal.Duration` or value convertible to one): The duration to add.
 - `options` (optional object): An object with properties representing options for the addition.
   The following options are recognized:
@@ -196,6 +208,7 @@ In order to be valid, the resulting duration must not have fields with mixed sig
 However, before the result is balanced, it's possible that the intermediate result will have one or more negative fields while the overall duration is positive, or vice versa.
 For example, "4 hours and 15 minutes" minus "2 hours and 30 minutes" results in "2 hours and &minus;15 minutes".
 The `overflow` option tells what to do in this case:
+
 - In `constrain` mode (the default), additions that result in mixed-sign fields will balance those fields with the next-highest field so that all the fields of the result are constrained to have the same sign.
 - In `balance` mode, all fields are balanced with the next highest field, no matter if they have mixed signs or not.
 
@@ -207,39 +220,44 @@ If you need such a conversion, use the `round()` method, and provide the start d
 Adding a negative duration is equivalent to subtracting the absolute value of that duration.
 
 Usage example:
+
+<!-- prettier-ignore-start -->
+
 ```javascript
 hour = Temporal.Duration.from('PT1H');
-hour.add({ minutes: 30 })  // => PT1H30M
+hour.add({ minutes: 30 }); // => PT1H30M
 
 // Examples of balancing:
 one = Temporal.Duration.from({ hours: 1, minutes: 30 });
 two = Temporal.Duration.from({ hours: 2, minutes: 45 });
-result = one.add(two)  // => PT3H75M
-result.with(result, { overflow: 'balance' })  // => PT4H15M
+result = one.add(two); // => PT3H75M
+result.with(result, { overflow: 'balance' }); // => PT4H15M
 
 fifty = Temporal.Duration.from('P50Y50M50DT50H50M50.500500500S');
-result = fifty.add(fifty)  // => P100Y100M100DT100H100M101.001001S'
-Temporal.Duration.from(result, { overflow: 'balance' })
-  // => P100Y100M104DT5H41M41.001001S
+result = fifty.add(fifty); // => P100Y100M100DT100H100M101.001001S'
+Temporal.Duration.from(result, { overflow: 'balance' });
+// => P100Y100M104DT5H41M41.001001S
 
 // Example of not balancing:
 oneAndAHalfYear = Temporal.Duration.from({ years: 1, months: 6 });
-result = oneAndAHalfYear.add(oneAndAHalfYear)  // => P2Y12M
-Temporal.Duration.from(result, { overflow: 'balance' }) // => P2Y12M
+result = oneAndAHalfYear.add(oneAndAHalfYear); // => P2Y12M
+Temporal.Duration.from(result, { overflow: 'balance' }); // => P2Y12M
 // Example of custom conversion using ISO calendar rules:
 function monthsToYears(duration) {
-    let { years, months } = duration;
-    years += Math.floor(months / 12);
-    months %= 12;
-    return duration.with({ years, months });
+  let { years, months } = duration;
+  years += Math.floor(months / 12);
+  months %= 12;
+  return duration.with({ years, months });
 }
-monthsToYears(result)  // => P3Y
-
+monthsToYears(result); // => P3Y
 ```
+
+<!-- prettier-ignore-start -->
 
 ### duration.**subtract**(_other_: Temporal.Duration | object | string, _options_?: object) : Temporal.Duration
 
 **Parameters:**
+
 - `other` (`Temporal.Duration` or value convertible to one): The duration to subtract.
 - `options` (optional object): An object with properties representing options for the subtraction.
   The following options are recognized:
@@ -260,6 +278,7 @@ In order to be valid, the resulting duration must not have fields with mixed sig
 However, before the result is balanced, it's possible that the intermediate result will have one or more negative fields while the overall duration is positive, or vice versa.
 For example, "4 hours and 15 minutes" minus "2 hours and 30 minutes" results in "2 hours and &minus;15 minutes".
 The `overflow` argument tells what to do in this case:
+
 - In `constrain` mode (the default), subtractions that result in mixed-sign fields will balance those fields with the next-highest field so that all the fields of the result are constrained to have the same sign.
 - In `balance` mode, all fields are balanced with the next highest field, no matter if they have mixed signs or not.
 
@@ -268,26 +287,27 @@ For usage examples and a more complete explanation of how balancing works and wh
 Subtracting a negative duration is equivalent to adding the absolute value of that duration.
 
 Usage example:
+
 ```javascript
 hourAndAHalf = Temporal.Duration.from('PT1H30M');
-hourAndAHalf.subtract({ hours: 1 })  // => PT30M
+hourAndAHalf.subtract({ hours: 1 }); // => PT30M
 
 one = Temporal.Duration.from({ minutes: 180 });
 two = Temporal.Duration.from({ seconds: 30 });
-one.subtract(two);  // => PT179M30S
-one.subtract(two, { overflow: 'balance' });  // => PT2H59M30S
+one.subtract(two); // => PT179M30S
+one.subtract(two, { overflow: 'balance' }); // => PT2H59M30S
 
 // Example of not balancing:
 threeYears = Temporal.Duration.from({ years: 3 });
 oneAndAHalfYear = Temporal.Duration.from({ years: 1, months: 6 });
-threeYears.subtract(oneAndAHalfYear)  // throws; mixed months and years signs cannot be balanced
+threeYears.subtract(oneAndAHalfYear); // throws; mixed months and years signs cannot be balanced
 // Example of a custom conversion using ISO calendar rules:
 function yearsToMonths(duration) {
-    let { years, months } = duration;
-    months += years * 12;
-    return duration.with({ years: 0, months });
+  let { years, months } = duration;
+  months += years * 12;
+  return duration.with({ years: 0, months });
 }
-yearsToMonths(threeYears).subtract(yearsToMonths(oneAndAHalfYear))  // => P18M
+yearsToMonths(threeYears).subtract(yearsToMonths(oneAndAHalfYear)); // => P18M
 ```
 
 ### duration.**negated**() : Temporal.Duration
@@ -299,11 +319,12 @@ It returns a newly constructed `Temporal.Duration` with all the fields having th
 If `duration` is zero, then the returned object is a copy of `duration`.
 
 Usage example:
+
 ```javascript
 d = Temporal.Duration.from('P1Y2M3DT4H5M6.987654321S');
-d.sign  // 1
-d.negated()  // -P1Y2M3DT4H5M6.987654321S
-d.negated().sign  // -1
+d.sign; // 1
+d.negated(); // -P1Y2M3DT4H5M6.987654321S
+d.negated().sign; // -1
 ```
 
 ### duration.**abs**() : Temporal.Duration
@@ -315,9 +336,10 @@ It returns a newly constructed `Temporal.Duration` with all the fields having th
 If `duration` is already positive or zero, then the returned object is a copy of `duration`.
 
 Usage example:
+
 ```javascript
 d = Temporal.Duration.from('-PT8H30M');
-d.abs()  // PT8H30M
+d.abs(); // PT8H30M
 ```
 
 ### duration.**isZero**() : boolean
@@ -327,6 +349,7 @@ d.abs()  // PT8H30M
 This is a convenience method that tells whether `duration` represents a zero length of time.
 
 Usage example:
+
 ```javascript
 d = Temporal.Duration.from('PT0S');
 d.isZero(); // => true
@@ -338,6 +361,7 @@ d.isZero(); // => true
 ### duration.**round**(_options_: object) : Temporal.Duration
 
 **Parameters:**
+
 - `options` (object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
@@ -349,7 +373,7 @@ d.isZero(); // => true
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
   - `relativeTo` (`Temporal.DateTime`): The starting point to use when converting between years, months, weeks, and days.
     It must be a `Temporal.DateTime`, or a value that can be passed to `Temporal.DateTime.from()`.
@@ -388,17 +412,24 @@ The valid values in this case are 1 (default), 2, 3, 4, 5, 6, 10, 12, 15, 20, an
 Instead of 60 minutes, use 1 hour.)
 
 The `roundingMode` option controls how the rounding is performed.
-  - `ceil`: Always round up, towards positive infinity.
-  - `floor`: Always round down, towards negative infinity.
-  - `trunc`: Always round towards zero, chopping off the part after the decimal point.
-  - `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
-    When there is a tie, round up, like `ceil`.
+
+- `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+  When there is a tie, round away from zero like `ceil` for positive durations and like `floor` for negative durations.
+- `ceil`: Always round towards positive infinity.
+  For negative durations this option will decrease the absolute value of the duration which may be unexpected.
+  To round away from zero, use `ceil` for positive durations and `floor` for negative durations.
+- `trunc`: Always round towards zero, chopping off the part after the decimal point.
+- `floor`: Always round down, towards negative infinity.
+  This mode acts the same as `trunc` for positive durations but for negative durations it will increase the absolute value of the result which may be unexpected.
+  For this reason, `trunc` is recommended for most "round down" use cases.
 
 The `relativeTo` option gives the starting point used when converting between or rounding to years, months, weeks, or days.
 It is a `Temporal.DateTime` instance.
-If any other type of value is given, then it will be converted to a `Temporal.DateTime` as if it were passed to `Temporal.DateTime.from(.., { overflow: 'reject' })`.
+If any other type of value is given, then it will be converted to a `Temporal.DateTime` as if it were passed to `Temporal.DateTime.from(..., { overflow: 'reject' })`.
+A `Temporal.Date` or a date string like `2020-01-01` is also accepted because time is optional when creating a `Temporal.DateTime`.
 
 Example usage:
+
 ```javascript
 // Balance a duration as far as possible without knowing a starting point
 d = Temporal.Duration.from({ minutes: 130 });
@@ -428,7 +459,7 @@ d.round({
 // Normalize days into months or years
 d = Temporal.Duration.from({ days: 190 });
 refDate = Temporal.Date.from('2020-01-01');
-d.round({ relativeTo: refDate, largestUnit: 'years' });  // => P6M6D
+d.round({ relativeTo: refDate, largestUnit: 'years' }); // => P6M6D
 
 // Same, but in a different calendar system
 d.round({
@@ -464,10 +495,11 @@ This method can be used to convert a `Temporal.Duration` into a record-like data
 It returns a new plain JavaScript object, with all the fields as enumerable, writable, own data properties.
 
 Usage example:
+
 ```javascript
 d = Temporal.Duration.from('P1Y2M3DT4H5M6.987654321S');
-Object.assign({}, d).days  // => undefined
-Object.assign({}, d.getFields()).days  // => 3
+Object.assign({}, d).days; // => undefined
+Object.assign({}, d.getFields()).days; // => 3
 ```
 
 ### duration.**toString**() : string
@@ -480,20 +512,21 @@ This method overrides `Object.prototype.toString()` and provides the ISO 8601 de
 > See [Duration balancing](./balancing.md#serialization) for more information.
 
 Usage examples:
+
 ```javascript
 d = Temporal.Duration.from({ years: 1, days: 1 });
-d.toString();  // => P1Y1D
+d.toString(); // => P1Y1D
 d = Temporal.Duration.from({ years: -1, days: -1 });
-d.toString();  // => -P1Y1D
+d.toString(); // => -P1Y1D
 d = Temporal.Duration.from({ milliseconds: 1000 });
-d.toString();  // => PT1S
+d.toString(); // => PT1S
 
 // The output format always balances units under 1 s, even if the
 // underlying Temporal.Duration object doesn't.
 nobal = Temporal.Duration.from({ milliseconds: 3500 });
-console.log(`${nobal}`, nobal.seconds, nobal.milliseconds);  // => PT3.500S 0 3500
-bal = Temporal.Duration.from({ milliseconds: 3500 }, { overflow: 'balance'});
-console.log(`${bal}`, bal.seconds, bal.milliseconds);  // => PT3.500S 3 500
+console.log(`${nobal}`, nobal.seconds, nobal.milliseconds); // => PT3.500S 0 3500
+bal = Temporal.Duration.from({ milliseconds: 3500 }, { overflow: 'balance' });
+console.log(`${bal}`, bal.seconds, bal.milliseconds); // => PT3.500S 3 500
 ```
 
 ### duration.**toJSON**() : string
@@ -510,10 +543,11 @@ If you need to rebuild a `Temporal.Duration` object from a JSON string, then you
 In that case you can build a custom "reviver" function for your use case.
 
 Example usage:
+
 ```js
 const ban = {
   reason: 'cooldown',
-  banDuration: Temporal.Duration.from({ hours: 48 }),
+  banDuration: Temporal.Duration.from({ hours: 48 })
 };
 const str = JSON.stringify(ban, null, 2);
 console.log(str);
@@ -525,8 +559,7 @@ console.log(str);
 
 // To rebuild from the string:
 function reviver(key, value) {
-  if (key.endsWith('Duration'))
-    return Temporal.Duration.from(value);
+  if (key.endsWith('Duration')) return Temporal.Duration.from(value);
   return value;
 }
 JSON.parse(str, reviver);
@@ -535,6 +568,7 @@ JSON.parse(str, reviver);
 ### duration.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
 
 **Parameters:**
+
 - `locales` (optional string or array of strings): A string with a BCP 47 language tag with an optional Unicode extension key, or an array of such strings.
 - `options` (optional object): An object with properties influencing the formatting.
 
@@ -549,11 +583,12 @@ The `locales` and `options` arguments are the same as in the constructor to [`In
 > If `Intl.DurationFormat` is not available, then the output of this method is the same as that of `duration.toString()`, and the `locales` and `options` arguments are ignored.
 
 Usage examples:
+
 ```javascript
-d = Temporal.Duration.from('P1DT6H30M')
-d.toLocaleString()  // => 1 day 6 hours 30 minutes
-d.toLocaleString('de-DE')  // => 1 Tag 6 Stunden 30 Minuten
-d.toLocaleString('en-US', {day: 'numeric', hour: 'numeric'})  // => 1 day 6 hours
+d = Temporal.Duration.from('P1DT6H30M');
+d.toLocaleString(); // => 1 day 6 hours 30 minutes
+d.toLocaleString('de-DE'); // => 1 Tag 6 Stunden 30 Minuten
+d.toLocaleString('en-US', { day: 'numeric', hour: 'numeric' }); // => 1 day 6 hours
 ```
 
 ### duration.**valueOf**()

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -239,6 +239,7 @@ It is the same as `toZonedDateTime()`, but always uses the ISO 8601 calendar.
 Use this method if you are not doing computations in other calendars.
 
 Example usage:
+
 ```js
 // Converting a specific exact time to a calendar date / wall-clock time
 timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
@@ -265,6 +266,7 @@ If you only want to use the ISO 8601 calendar, use `toDateTimeISO()`.
 
 Example usage:
 
+<!-- prettier-ignore-start -->
 ```js
 // What time was the Unix epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA) in the Gregorian calendar?
 epoch = Temporal.Instant.fromEpochSeconds(0);
@@ -280,6 +282,7 @@ zdt = epoch.toZonedDateTime(tz, cal);
 console.log(zdt.year, zdt.era);
   // => 45 showa
 ```
+<!-- prettier-ignore-end -->
 
 ### instant.**toDateTimeISO**(_timeZone_: object | string) : Temporal.DateTime
 
@@ -297,6 +300,7 @@ It is the same as `toDateTime()`, but always uses the ISO 8601 calendar.
 Use this method if you are not doing computations in other calendars.
 
 Example usage:
+
 ```js
 // Converting an exact time to a calendar date / wall-clock time
 timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
@@ -325,6 +329,7 @@ If you only want to use the ISO 8601 calendar, use `toDateTimeISO()`.
 
 Example usage:
 
+<!-- prettier-ignore-start -->
 ```js
 // What time was the Unix epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA) in the Gregorian calendar?
 epoch = Temporal.Instant.fromEpochSeconds(0);
@@ -340,6 +345,7 @@ dt = epoch.toDateTime(tz, cal);
 console.log(dt.year, dt.era);
   // => 45 showa
 ```
+<!-- prettier-ignore-end -->
 
 ### instant.**add**(_duration_: Temporal.Duration | object | string) : Temporal.Instant
 
@@ -419,7 +425,7 @@ Temporal.now.instant().subtract(oneHour);
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `instant` and `other`.
@@ -503,7 +509,7 @@ billion.toDateTime(utc).difference(epoch.toDateTime(utc), { largestUnit: 'years'
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
 **Returns:** a new `Temporal.Instant` object which is `instant` rounded to `roundingIncrement` of `smallestUnit`.

--- a/docs/time.md
+++ b/docs/time.md
@@ -278,7 +278,7 @@ time.subtract({ minutes: 5, nanoseconds: 800 }); // => 19:34:09.068345405
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `time` and `other`.
@@ -323,7 +323,7 @@ time.difference(Temporal.Time.from('19:39:09.068346205'), { smallestUnit: 'secon
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
 **Returns:** a new `Temporal.Time` object which is `time` rounded to `roundingIncrement` of `smallestUnit`.

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -16,6 +16,7 @@ A `Temporal.YearMonth` can be converted into a `Temporal.Date` by combining it w
 ### **new Temporal.YearMonth**(_isoYear_: number, _isoMonth_: number, _calendar_?: object, _referenceISODay_: number = 1) : Temporal.YearMonth
 
 **Parameters:**
+
 - `isoYear` (number): A year.
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
 - `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the month into.
@@ -36,9 +37,10 @@ If `isoYear` and `isoMonth` are outside of this range, then this function will t
 > **NOTE**: The `isoMonth` argument ranges from 1 to 12, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
 Usage examples:
+
 ```javascript
 // The June 2019 meeting
-ym = new Temporal.YearMonth(2019, 6)  // => 2019-06
+ym = new Temporal.YearMonth(2019, 6); // => 2019-06
 ```
 
 ## Static methods
@@ -46,6 +48,7 @@ ym = new Temporal.YearMonth(2019, 6)  // => 2019-06
 ### Temporal.YearMonth.**from**(_thing_: any, _options_?: object) : Temporal.YearMonth
 
 **Parameters:**
+
 - `thing`: The value representing the desired month.
 - `options` (optional object): An object with properties representing options for constructing the date.
   The following options are recognized:
@@ -59,7 +62,7 @@ This static method creates a new `Temporal.YearMonth` object from another value.
 If the value is another `Temporal.YearMonth` object, a new object representing the same month is returned.
 If the value is any other object, it must have `year` and `month` properties, and optionally `era` and `calendar` properties.
 If `calendar` is a calendar that requires `era` (such as the Japanese calendar), then the `era` property must also be present.
-A `Temporal.YearMonth` will be constructed from these properies.
+A `Temporal.YearMonth` will be constructed from these properties.
 
 If the `calendar` property is not present, it will be assumed to be `Temporal.Calendar.from('iso8601')`, the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 In this calendar, `era` is ignored.
@@ -69,6 +72,7 @@ Any parts of the string other than the year and the month are optional and will 
 If the string isn't valid according to ISO 8601, then a `RangeError` will be thrown regardless of the value of `overflow`.
 
 The `overflow` option works as follows:
+
 - In `constrain` mode (the default), any out-of-range values are clamped to the nearest in-range value.
 - In `reject` mode, the presence of out-of-range values will cause the function to throw a `RangeError`.
 
@@ -77,33 +81,37 @@ Additionally, if the result is earlier or later than the range of dates that `Te
 > **NOTE**: The allowed values for the `thing.month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
 Example usage:
+
+<!-- prettier-ignore-start -->
 ```javascript
-ym = Temporal.YearMonth.from('2019-06');  // => 2019-06
-ym = Temporal.YearMonth.from('2019-06-24');  // => 2019-06
-ym = Temporal.YearMonth.from('2019-06-24T15:43:27');  // => 2019-06
-ym = Temporal.YearMonth.from('2019-06-24T15:43:27Z');  // => 2019-06
+ym = Temporal.YearMonth.from('2019-06'); // => 2019-06
+ym = Temporal.YearMonth.from('2019-06-24'); // => 2019-06
+ym = Temporal.YearMonth.from('2019-06-24T15:43:27'); // => 2019-06
+ym = Temporal.YearMonth.from('2019-06-24T15:43:27Z'); // => 2019-06
 ym = Temporal.YearMonth.from('2019-06-24T15:43:27+01:00[Europe/Brussels]');
   // => 2019-06
-ym === Temporal.YearMonth.from(ym)  // => true
+ym === Temporal.YearMonth.from(ym); // => true
 
-ym = Temporal.YearMonth.from({year: 2019, month: 6});  // => 2019-06
+ym = Temporal.YearMonth.from({ year: 2019, month: 6 }); // => 2019-06
 ym = Temporal.YearMonth.from(Temporal.Date.from('2019-06-24'));
   // => same as above; Temporal.Date has year and month properties
 
 // Different overflow modes
-ym = Temporal.YearMonth.from({ year: 2001, month: 13 }, { overflow: 'constrain' })
+ym = Temporal.YearMonth.from({ year: 2001, month: 13 }, { overflow: 'constrain' });
   // => 2001-12
-ym = Temporal.YearMonth.from({ year: 2001, month: -1 }, { overflow: 'constrain' })
+ym = Temporal.YearMonth.from({ year: 2001, month: -1 }, { overflow: 'constrain' });
   // => 2001-01
-ym = Temporal.YearMonth.from({ year: 2001, month: 13 }, { overflow: 'reject' })
+ym = Temporal.YearMonth.from({ year: 2001, month: 13 }, { overflow: 'reject' });
   // throws
-ym = Temporal.YearMonth.from({ year: 2001, month: -1 }, { overflow: 'reject' })
+ym = Temporal.YearMonth.from({ year: 2001, month: -1 }, { overflow: 'reject' });
   // throws
 ```
+<!-- prettier-ignore-end -->
 
 ### Temporal.YearMonth.**compare**(_one_: Temporal.YearMonth | object | string, _two_: Temporal.YearMonth | object | string) : number
 
 **Parameters:**
+
 - `one` (`Temporal.YearMonth` or value convertible to one): First month to compare.
 - `two` (`Temporal.YearMonth` or value convertible to one): Second month to compare.
 
@@ -111,6 +119,7 @@ ym = Temporal.YearMonth.from({ year: 2001, month: -1 }, { overflow: 'reject' })
 
 Compares two `Temporal.YearMonth` objects.
 Returns an integer indicating whether `one` comes before or after or is equal to `two`.
+
 - &minus;1 if `one` comes before `two`;
 - 0 if `one` and `two` are the same;
 - 1 if `one` comes after `two`.
@@ -119,12 +128,13 @@ If `one` and `two` are not `Temporal.YearMonth` objects, then they will be conve
 
 This function can be used to sort arrays of `Temporal.YearMonth` objects.
 For example:
+
 ```javascript
 one = Temporal.YearMonth.from('2006-08');
 two = Temporal.YearMonth.from('2015-07');
 three = Temporal.YearMonth.from('1930-02');
 sorted = [one, two, three].sort(Temporal.YearMonth.compare);
-sorted.join(' ');  // => 1930-02 2006-08 2015-07
+sorted.join(' '); // => 1930-02 2006-08 2015-07
 ```
 
 ## Properties
@@ -138,10 +148,11 @@ The above read-only properties allow accessing the year and month individually.
 > **NOTE**: The possible values for the `month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
 Usage examples:
+
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
-ym.year   // => 2019
-ym.month  // => 6
+ym.year; // => 2019
+ym.month; // => 6
 ```
 
 ### yearMonth.**calendar** : object
@@ -159,15 +170,16 @@ The `daysInMonth` read-only property gives the number of days in the month.
 This is 28, 29, 30, or 31, depending on the month and whether the year is a leap year.
 
 Usage example:
+
 ```javascript
 // Attempt to write some mnemonic poetry
 const monthsByDays = {};
 for (let month = 1; month <= 12; month++) {
-    const ym = Temporal.YearMonth.from({year: 2020, month});
-    monthsByDays[ym.daysInMonth] = (monthsByDays[ym.daysInMonth] || []).concat(ym);
+  const ym = Temporal.YearMonth.from({ year: 2020, month });
+  monthsByDays[ym.daysInMonth] = (monthsByDays[ym.daysInMonth] || []).concat(ym);
 }
 
-const strings = monthsByDays[30].map(ym => ym.toLocaleString('en', {month: 'long'}));
+const strings = monthsByDays[30].map((ym) => ym.toLocaleString('en', { month: 'long' }));
 // Shuffle to improve poem as determined empirically
 strings.unshift(strings.pop());
 const format = new Intl.ListFormat('en');
@@ -182,12 +194,15 @@ The `daysInYear` read-only property gives the number of days in the year that th
 This is 365 or 366, depending on whether the year is a leap year.
 
 Usage example:
+
+<!-- prettier-ignore-start -->
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
 percent = ym.daysInMonth / ym.daysInYear;
 `${ym.toLocaleString('en', {month: 'long', year: 'numeric'})} was ${percent.toLocaleString('en', {style: 'percent'})} of the year!`
   // => example output: "June 2019 was 8% of the year!"
 ```
+<!-- prettier-ignore-end -->
 
 ### yearMonth.**monthsInYear**: number
 
@@ -195,9 +210,10 @@ The `monthsInYear` read-only property gives the number of months in the year tha
 For the ISO 8601 calendar, this is always 12, but in other calendar systems it may differ from year to year.
 
 Usage example:
+
 ```javascript
 ym = Temporal.Date.from('1900-01');
-ym.monthsInYear  // => 12
+ym.monthsInYear; // => 12
 ```
 
 ### yearMonth.**isLeapYear** : boolean
@@ -206,12 +222,13 @@ The `isLeapYear` read-only property tells whether the year that the date falls i
 Its value is `true` if the year is a leap year, and `false` if not.
 
 Usage example:
+
 ```javascript
 // Was June 2019 in a leap year?
 ym = Temporal.YearMonth.from('2019-06');
-ym.isLeapYear  // => false
+ym.isLeapYear; // => false
 // Is 2100 a leap year? (no, because it's divisible by 100 and not 400)
-ym.with({year: 2100}).isLeapYear  // => false
+ym.with({ year: 2100 }).isLeapYear; // => false
 ```
 
 ## Methods
@@ -219,6 +236,7 @@ ym.with({year: 2100}).isLeapYear  // => false
 ### yearMonth.**with**(_yearMonthLike_: object, _options_?: object) : Temporal.YearMonth
 
 **Parameters:**
+
 - `yearMonthLike` (object): an object with some or all of the properties of a `Temporal.YearMonth`.
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
@@ -241,15 +259,17 @@ If the result is earlier or later than the range of dates that `Temporal.YearMon
 > If you need to do this, use `yearMonth.toDateOnDay(day).withCalendar(calendar).toYearMonth()`.
 
 Usage example:
+
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
 // Get December of that year
-ym.with({month: 12})  // => 2019-12
+ym.with({ month: 12 }); // => 2019-12
 ```
 
 ### yearMonth.**add**(_duration_: Temporal.Duration | object | string, _options_?: object) : Temporal.YearMonth
 
 **Parameters:**
+
 - `duration` (`Temporal.Duration` or value convertible to one): The duration to add.
 - `options` (optional object): An object with properties representing options for the addition.
   The following options are recognized:
@@ -273,14 +293,16 @@ However, `overflow` may have an effect in other calendars where years can be dif
 Adding a negative duration is equivalent to subtracting the absolute value of that duration.
 
 Usage example:
+
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
-ym.add({years: 20, months: 4})  // => 2039-10
+ym.add({ years: 20, months: 4 }); // => 2039-10
 ```
 
 ### yearMonth.**subtract**(_duration_: Temporal.Duration | object | string, _options_?: object) : Temporal.YearMonth
 
 **Parameters:**
+
 - `duration` (`Temporal.Duration` or value convertible to one): The duration to subtract.
 - `options` (optional object): An object with properties representing options for the subtraction.
   The following options are recognized:
@@ -304,14 +326,16 @@ However, `overflow` may have an effect in other calendars where years can be dif
 Subtracting a negative duration is equivalent to adding the absolute value of that duration.
 
 Usage example:
+
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
-ym.subtract({years: 20, months: 4})  // => 1999-02
+ym.subtract({ years: 20, months: 4 }); // => 1999-02
 ```
 
 ### yearMonth.**difference**(_other_: Temporal.YearMonth | object | string, _options_?: object) : Temporal.Duration
 
 **Parameters:**
+
 - `other` (`Temporal.YearMonth` or value convertible to one): Another month with which to compute the difference.
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
@@ -324,7 +348,7 @@ ym.subtract({years: 20, months: 4})  // => 1999-02
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `yearMonth` and `other`.
@@ -350,24 +374,28 @@ Unlike other Temporal types, weeks and lower are not allowed for either `largest
 Computing the difference between two months in different calendar systems is not supported.
 
 Usage example:
+
+<!-- prettier-ignore-start -->
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
 other = Temporal.YearMonth.from('2006-08');
-ym.difference(other)                             // => P12Y10M
-ym.difference(other, { largestUnit: 'months' })  // => P154M
-other.difference(ym, { largestUnit: 'months' })  // => -P154M
+ym.difference(other);                            // => P12Y10M
+ym.difference(other, { largestUnit: 'months' }); // => P154M
+other.difference(ym, { largestUnit: 'months' }); // => -P154M
 
 // If you really need to calculate the difference between two YearMonths
 // in days, you can eliminate the ambiguity by explicitly choosing the
 // day of the month (and if applicable, the time of that day) from which
 // you want to reckon the difference. For example, using the first of
 // the month to calculate a number of days:
-ym.toDateOnDay(1).difference(other.toDateOnDay(1), { largestUnit: 'days' });  // => P4687D
+ym.toDateOnDay(1).difference(other.toDateOnDay(1), { largestUnit: 'days' }); // => P4687D
 ```
+<!-- prettier-ignore-end -->
 
 ### yearMonth.**equals**(_other_: Temporal.YearMonth | object | string) : boolean
 
 **Parameters:**
+
 - `other` (`Temporal.YearMonth` or value convertible to one): Another month to compare.
 
 **Returns:** `true` if `yearMonth` and `other` are equal, or `false` if not.
@@ -383,11 +411,12 @@ Note that equality of two months from different calendar systems only makes sens
 Even if you are using the same calendar system, if you don't need to know the order in which the two months occur, then this function may be less typing and more efficient than `Temporal.YearMonth.compare`.
 
 Example usage:
+
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
 other = Temporal.YearMonth.from('2006-08');
-ym.equals(other)  // => false
-ym.equals(ym)  // => true
+ym.equals(other); // => false
+ym.equals(ym); // => true
 ```
 
 ### yearMonth.**toString**() : string
@@ -398,14 +427,16 @@ This method overrides the `Object.prototype.toString()` method and provides a co
 The string can be passed to `Temporal.YearMonth.from()` to create a new `Temporal.YearMonth` object.
 
 Example usage:
+
 ```js
 ym = Temporal.YearMonth.from('2019-06');
-ym.toString();  // => 2019-06
+ym.toString(); // => 2019-06
 ```
 
 ### yearMonth.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
 
 **Parameters:**
+
 - `locales` (optional string or array of strings): A string with a BCP 47 language tag with an optional Unicode extension key, or an array of such strings.
 - `options` (optional object): An object with properties influencing the formatting.
 
@@ -429,16 +460,17 @@ yearMonth.toLocaleString();
 ```
 
 Example usage:
+
 ```js
 ({ calendar } = new Intl.DateTimeFormat().resolvedOptions());
 ym = Temporal.YearMonth.from({ year: 2019, month: 6, calendar });
-ym.toLocaleString();  // => example output: 2019-06
+ym.toLocaleString(); // => example output: 2019-06
 // Same as above, but explicitly specifying the calendar:
 ym.toLocaleString(undefined, { calendar });
 
-ym.toLocaleString('de-DE', { calendar });  // => example output: 6.2019
-ym.toLocaleString('de-DE', { month: 'long', year: 'numeric', calendar });  // => Juni 2019
-ym.toLocaleString(`en-US-u-nu-fullwide-u-ca-${calendar}`);  // => ６/２０１９
+ym.toLocaleString('de-DE', { calendar }); // => example output: 6.2019
+ym.toLocaleString('de-DE', { month: 'long', year: 'numeric', calendar }); // => Juni 2019
+ym.toLocaleString(`en-US-u-nu-fullwide-u-ca-${calendar}`); // => ６/２０１９
 ```
 
 ### yearMonth.**toJSON**() : string
@@ -453,14 +485,12 @@ If you need to rebuild a `Temporal.YearMonth` object from a JSON string, then yo
 In that case you can build a custom "reviver" function for your use case.
 
 Example usage:
+
 ```js
 const boardMeeting = {
   id: 4,
-  agenda: [
-    'Roll call',
-    'Budget',
-  ],
-  meetingYearMonth: Temporal.YearMonth.from({ year: 2019, month: 3 }),
+  agenda: ['Roll call', 'Budget'],
+  meetingYearMonth: Temporal.YearMonth.from({ year: 2019, month: 3 })
 };
 const str = JSON.stringify(boardMeeting, null, 2);
 console.log(str);
@@ -476,8 +506,7 @@ console.log(str);
 
 // To rebuild from the string:
 function reviver(key, value) {
-  if (key.endsWith('YearMonth'))
-    return Temporal.YearMonth.from(value);
+  if (key.endsWith('YearMonth')) return Temporal.YearMonth.from(value);
   return value;
 }
 JSON.parse(str, reviver);
@@ -492,6 +521,7 @@ Use `Temporal.YearMonth.compare()` for this, or `yearMonth.equals()` for equalit
 ### yearMonth.**toDateOnDay**(_day_: number) : Temporal.Date
 
 **Parameters:**
+
 - `day` (number): A day of the month, which must be a valid day of `yearMonth`.
 
 **Returns:** a `Temporal.Date` object that represents the calendar date of `day` in `yearMonth`.
@@ -500,9 +530,10 @@ This method can be used to convert `Temporal.YearMonth` into a `Temporal.Date`, 
 The converted object carries a copy of all the relevant fields of `yearMonth`.
 
 Usage example:
+
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
-ym.toDateOnDay(24)  // => 2019-06-24
+ym.toDateOnDay(24); // => 2019-06-24
 ```
 
 ### yearMonth.**getFields**() : { year: number, month: number, calendar: object, [propName: string]: unknown }
@@ -517,10 +548,11 @@ Note that if using a different calendar from ISO 8601, these will be the calenda
 > **NOTE**: The possible values for the `month` property of the returned object start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
 Usage example:
+
 ```javascript
 ym = Temporal.DateTime.from('2019-06');
-Object.assign({}, ym).year  // => undefined
-Object.assign({}, ym.getFields()).year  // => 2019
+Object.assign({}, ym).year; // => undefined
+Object.assign({}, ym.getFields()).year; // => 2019
 ```
 
 ### yearMonth.**getISOFields**(): { isoYear: number, isoMonth: number, isoDay: number, calendar: object }
@@ -534,7 +566,8 @@ Use `yearMonth.getFields()` instead.
 The value of the `isoDay` property will be equal to the `referenceISODay` constructor argument passed when `yearMonth` was constructed.
 
 Usage example:
+
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
-ym.getISOFields().isoYear  // => 2019
+ym.getISOFields().isoYear; // => 2019
 ```

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -623,9 +623,9 @@ zdt = Temporal.ZonedDateTime.from({ ...otherFields, offsetNanoseconds }, { disam
 ```
 <!-- prettier-ignore-end -->
 
-### zonedDateTime.**offsetString** : number
+### zonedDateTime.**offset** : number
 
-The `offsetString` read-only property is the offset (formatted as a string) relative to UTC of the current time zone and exact instant. Examples: `'-08:00'` or `'+05:30'`
+The `offset` read-only property is the offset (formatted as a string) relative to UTC of the current time zone and exact instant. Examples: `'-08:00'` or `'+05:30'`
 
 The format used is defined in the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) standard.
 
@@ -637,9 +637,9 @@ String values are not accepted for offsets in these cases, nor is this property 
 <!-- prettier-ignore-start -->
 ```javascript
 zdt = Temporal.ZonedDateTime.from('2020-11-01T01:30-07:00[America/Los_Angeles]');
-zdt.offsetString;
+zdt.offset;
   // => "-07:00"
-zdt.with({ timeZone: 'Asia/Kolkata' }).offsetString;
+zdt.with({ timeZone: 'Asia/Kolkata' }).offset;
   // => "+05:30"
 ```
 <!-- prettier-ignore-end -->
@@ -969,7 +969,7 @@ mar1.difference(jan1, { largestUnit: 'days' }); // => P60D
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'nearest'`.
 
 **Returns:** a new `Temporal.ZonedDateTime` object which is `zonedDateTime` rounded to `roundingIncrement` of `smallestUnit`.


### PR DESCRIPTION
* Clarify roundingMode docs (fixes #1028)
* Consistent order for roundingMode options
* Clarify that `relativeTo` can also accept a Date
* Added JSDoc content to index.d.ts to mirror the docs changes above.
* Added JSDoc content for new xxxISO methods of Temporal.now
* Added JSDoc content for duration rounding options
* Renamed `offsetString` to `offset` in ZonedDateTime docs
* Ran prettier for the first time on duration.md and yearmonth.md, so many whitespace changes, code semicolons, etc. I also added prettier-ignore comments where needed to retain code formatting.