### PR TITLE
Allow property bags and strings in Calendar methods

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -127,40 +127,42 @@ When subclassing `Temporal.Calendar`, this property doesn't need to be overridde
 
 ## Methods
 
-### calendar.**year**(_date_: Temporal.Date) : number
+### calendar.**year**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | Temporal.YearMonth | object | string) : number
 
-### calendar.**month**(_date_: Temporal.Date) : number
+### calendar.**month**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | Temporal.YearMonth | Temporal.MonthDay | object | string) : number
 
-### calendar.**day**(_date_: Temporal.Date) : number
+### calendar.**day**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | Temporal.MonthDay | object | string) : number
 
-### calendar.**era**(_date_: Temporal.Date) : unknown
+### calendar.**era**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | Temporal.YearMonth | object | string) : string | undefined
 
-### calendar.**dayOfWeek**(_date_: Temporal.Date): number
+### calendar.**dayOfWeek**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | object | string): number
 
-### calendar.**dayOfYear**(_date_: Temporal.Date): number
+### calendar.**dayOfYear**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | object | string): number
 
-### calendar.**weekOfYear**(_date_: Temporal.Date): number
+### calendar.**weekOfYear**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | object | string): number
 
-### calendar.**daysInWeek**(_date_: Temporal.Date): number
+### calendar.**daysInWeek**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | object | string): number
 
-### calendar.**daysInMonth**(_date_: Temporal.Date): number
+### calendar.**daysInMonth**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | Temporal.YearMonth | object | string): number
 
-### calendar.**daysInYear**(_date_: Temporal.Date): number
+### calendar.**daysInYear**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | Temporal.YearMonth | object | string): number
 
-### calendar.**monthsInYear**(_date_: Temporal.Date): number
+### calendar.**monthsInYear**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | Temporal.YearMonth | object | string): number
 
-### calendar.**inLeapYear**(_date_: Temporal.Date): boolean
+### calendar.**inLeapYear**(_date_: Temporal.Date | Temporal.DateTime | Temporal.ZonedDateTime | Temporal.YearMonth | object | string): boolean
 
 The above methods are all similar.
 They provide a way to query properties of a particular date in the calendar's date reckoning.
 
 **Parameters:**
-- `date` (`Temporal.Date`): A date.
+- `date` (`Temporal.Date`, or value convertible to one): A date.
 
 **Returns:** some piece of data (year, month, day, etc., depending on the method) associated with `date`, in `calendar`'s calendar system.
 
+If `date` is not one of the appropriate Temporal objects, then it will be converted to a `Temporal.Date` as if it were passed to `Temporal.Date.from()`.
+
 None of the above methods need to be called directly except in specialized code.
-They are called indirectly when reading the various properties of `Temporal.DateTime`, `Temporal.Date`, or `Temporal.YearMonth`.
+They are called indirectly when reading the various properties of `Temporal.ZonedDateTime`, `Temporal.DateTime`, `Temporal.Date`, `Temporal.MonthDay`, or `Temporal.YearMonth`.
 
 For example:
 ```javascript
@@ -218,16 +220,16 @@ date.day         // => 6
 date.toString()  // => 2020-05-29[c=hebrew]
 ```
 
-### calendar.**dateAdd**(_date_: Temporal.Date, _duration_: Temporal.Duration, _options_: object, _constructor_: function) : Temporal.Date
+### calendar.**dateAdd**(_date_: Temporal.Date | object | string, _duration_: Temporal.Duration | object | string, _options_: object, _constructor_: function) : Temporal.Date
 
-### calendar.**dateSubtract**(_date_: Temporal.Date, _duration_: Temporal.Duration, _options_: object, _constructor_: function) : Temporal.Date
+### calendar.**dateSubtract**(_date_: Temporal.Date | object | string, _duration_: Temporal.Duration | object | string, _options_: object, _constructor_: function) : Temporal.Date
 
 The above two methods are similar.
 They provide a way to do date arithmetic in the calendar's date reckoning.
 
 **Parameters:**
-- `date` (`Temporal.Date`): A date.
-- `duration` (`Temporal.Duration`): A duration to add or subtract from `date`.
+- `date` (`Temporal.Date`, or value convertible to one): A date.
+- `duration` (`Temporal.Duration`, or value convertible to one): A duration to add or subtract from `date`.
 - `options` (object): An object with properties representing options for performing the addition or subtraction.
   The following options are recognized:
   - `overflow` (string): How to deal with out-of-range values in the result of the addition or subtraction.
@@ -237,6 +239,8 @@ They provide a way to do date arithmetic in the calendar's date reckoning.
   This is used when subclassing Temporal objects.
 
 **Returns:** a new object of the type of `constructor`.
+
+If `date` is not a `Temporal.Date` object, or `duration` not a `Temporal.Duration` object, then they will be converted to one as if they were passed to `Temporal.Date.from()` or `Temporal.Duration.from()`, respectively.
 
 Neither of the above methods need to be called directly except in specialized code.
 They are called indirectly when using the `add()` and `subtract()` methods, respectively, of `Temporal.DateTime`, `Temporal.Date`, and `Temporal.YearMonth`.
@@ -265,11 +269,11 @@ date.day         // => 7
 date.toString()  // => 2020-06-28[c=islamic]
 ```
 
-### calendar.**dateDifference**(_smaller_: Temporal.Date, _larger_: Temporal.Date, _options_: object) : Temporal.Duration
+### calendar.**dateDifference**(_smaller_: Temporal.Date | object | string, _larger_: Temporal.Date | object | string, _options_: object) : Temporal.Duration
 
 **Parameters:**
-- `smaller` (`Temporal.Date`): A date.
-- `larger` (`Temporal.Date`): A date, which must be later than `smaller`.
+- `smaller` (`Temporal.Date`, or value convertible to one): A date.
+- `larger` (`Temporal.Date`, or value convertible to one): A date, which must be later than `smaller`.
 - `options` (object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
@@ -277,6 +281,8 @@ date.toString()  // => 2020-06-28[c=islamic]
     The default is `'auto'`.
 
 **Returns:** a `Temporal.Duration` representing the difference between `larger` and `smaller`.
+
+If either of `smaller` or `larger` are not `Temporal.Date` objects, then they will be converted to one as if they were passed to `Temporal.Date.from()`.
 
 This method does not need to be called directly except in specialized code.
 It is called indirectly when using the `since()` methods of `Temporal.DateTime`, `Temporal.Date`, and `Temporal.YearMonth`.

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -429,17 +429,18 @@ export namespace Temporal {
   export interface CalendarProtocol {
     id?: string;
     calendar?: never;
-    year(date: Temporal.Date): number;
-    month(date: Temporal.Date): number;
-    day(date: Temporal.Date): number;
-    dayOfWeek?(date: Temporal.Date): number;
-    dayOfYear?(date: Temporal.Date): number;
-    weekOfYear?(date: Temporal.Date): number;
-    daysInWeek?(date: Temporal.Date): number;
-    daysInMonth?(date: Temporal.Date): number;
-    daysInYear?(date: Temporal.Date): number;
-    monthsInYear?(date: Temporal.Date): number;
-    inLeapYear?(date: Temporal.Date): boolean;
+    year(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): number;
+    month(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | Temporal.MonthDay | DateLike | string): number;
+    day(date: Temporal.Date | Temporal.DateTime | Temporal.MonthDay | DateLike | string): number;
+    era(date: Temporal.Date | Temporal.DateTime | DateLike | string): string | undefined;
+    dayOfWeek?(date: Temporal.Date | Temporal.DateTime | DateLike | string): number;
+    dayOfYear?(date: Temporal.Date | Temporal.DateTime | DateLike | string): number;
+    weekOfYear?(date: Temporal.Date | Temporal.DateTime | DateLike | string): number;
+    daysInWeek?(date: Temporal.Date | Temporal.DateTime | DateLike | string): number;
+    daysInMonth?(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): number;
+    daysInYear?(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): number;
+    monthsInYear?(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): number;
+    inLeapYear?(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): boolean;
     dateFromFields(
       fields: { year: number; month: number; day: number },
       options: AssignmentOptions,
@@ -456,20 +457,20 @@ export namespace Temporal {
       constructor: ConstructorOf<Temporal.MonthDay>
     ): Temporal.MonthDay;
     dateAdd?(
-      date: Temporal.Date,
-      duration: Temporal.Duration,
+      date: Temporal.Date | DateLike | string,
+      duration: Temporal.Duration | DurationLike | string,
       options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
     dateSubtract?(
-      date: Temporal.Date,
-      duration: Temporal.Duration,
+      date: Temporal.Date | DateLike | string,
+      duration: Temporal.Duration | DurationLike | string,
       options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
     dateDifference?(
-      smaller: Temporal.Date,
-      larger: Temporal.Date,
+      smaller: Temporal.Date | DateLike | string,
+      larger: Temporal.Date | DateLike | string,
       options: DifferenceOptions<
         | 'years'
         | 'months'
@@ -496,17 +497,18 @@ export namespace Temporal {
     static from(item: CalendarProtocol | string): Temporal.Calendar;
     constructor(calendarIdentifier: string);
     readonly id: string;
-    year(date: Temporal.Date): number;
-    month(date: Temporal.Date): number;
-    day(date: Temporal.Date): number;
-    dayOfWeek(date: Temporal.Date): number;
-    dayOfYear(date: Temporal.Date): number;
-    weekOfYear(date: Temporal.Date): number;
-    daysInWeek(date: Temporal.Date): number;
-    daysInMonth(date: Temporal.Date): number;
-    daysInYear(date: Temporal.Date): number;
-    monthsInYear(date: Temporal.Date): number;
-    inLeapYear(date: Temporal.Date): boolean;
+    year(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): number;
+    month(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | Temporal.MonthDay | DateLike | string): number;
+    day(date: Temporal.Date | Temporal.DateTime | Temporal.MonthDay | DateLike | string): number;
+    era(date: Temporal.Date | Temporal.DateTime | DateLike | string): string | undefined;
+    dayOfWeek(date: Temporal.Date | Temporal.DateTime | DateLike | string): number;
+    dayOfYear(date: Temporal.Date | Temporal.DateTime | DateLike | string): number;
+    weekOfYear(date: Temporal.Date | Temporal.DateTime | DateLike | string): number;
+    daysInWeek(date: Temporal.Date | Temporal.DateTime | DateLike | string): number;
+    daysInMonth(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): number;
+    daysInYear(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): number;
+    monthsInYear(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): number;
+    inLeapYear(date: Temporal.Date | Temporal.DateTime | Temporal.YearMonth | DateLike | string): boolean;
     dateFromFields(
       fields: { year: number; month: number; day: number },
       options: AssignmentOptions,
@@ -523,20 +525,20 @@ export namespace Temporal {
       constructor: ConstructorOf<Temporal.MonthDay>
     ): Temporal.MonthDay;
     dateAdd(
-      date: Temporal.Date,
-      duration: Temporal.Duration,
+      date: Temporal.Date | DateLike | string,
+      duration: Temporal.Duration | DurationLike | string,
       options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
     dateSubtract(
-      date: Temporal.Date,
-      duration: Temporal.Duration,
+      date: Temporal.Date | DateLike | string,
+      duration: Temporal.Duration | DurationLike | string,
       options: ArithmeticOptions,
       constructor: ConstructorOf<Temporal.Date>
     ): Temporal.Date;
     dateDifference(
-      smaller: Temporal.Date,
-      larger: Temporal.Date,
+      smaller: Temporal.Date | DateLike | string,
+      larger: Temporal.Date | DateLike | string,
       options?: DifferenceOptions<
         | 'years'
         | 'months'

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -3,7 +3,7 @@
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass.mjs';
 import * as REGEX from './regex.mjs';
-import { CALENDAR_ID, ISO_YEAR, ISO_MONTH, ISO_DAY, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
+import { CALENDAR_ID, ISO_YEAR, ISO_MONTH, ISO_DAY, CreateSlots, GetSlot, HasSlot, SetSlot } from './slots.mjs';
 
 const ID_REGEX = new RegExp(`^${REGEX.calendarID.source}$`);
 
@@ -176,6 +176,8 @@ class ISO8601Calendar extends Calendar {
   }
   dateAdd(date, duration, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
+    duration = ES.ToTemporalDuration(duration, GetIntrinsic('%Temporal.Duration%'));
     options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const { years, months, weeks, days } = duration;
@@ -193,6 +195,8 @@ class ISO8601Calendar extends Calendar {
   }
   dateSubtract(date, duration, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
+    duration = ES.ToTemporalDuration(duration, GetIntrinsic('%Temporal.Duration%'));
     options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
     const { years, months, weeks, days } = duration;
@@ -210,6 +214,8 @@ class ISO8601Calendar extends Calendar {
   }
   dateDifference(one, two, options) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    one = ES.ToTemporalDate(one, GetIntrinsic('%Temporal.Date%'));
+    two = ES.ToTemporalDate(two, GetIntrinsic('%Temporal.Date%'));
     options = ES.NormalizeOptionsObject(options);
     const largestUnit = ES.ToLargestTemporalUnit(options, 'days', [
       'hours',
@@ -233,50 +239,61 @@ class ISO8601Calendar extends Calendar {
   }
   year(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return GetSlot(date, ISO_YEAR);
   }
   month(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_MONTH)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return GetSlot(date, ISO_MONTH);
   }
   day(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_DAY)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return GetSlot(date, ISO_DAY);
   }
   era(date) {
-    void date;
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return undefined;
   }
   dayOfWeek(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return ES.DayOfWeek(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
   }
   dayOfYear(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return ES.DayOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
   }
   weekOfYear(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return ES.WeekOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
   }
   daysInWeek(date) {
-    void date;
+    ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return 7;
   }
   daysInMonth(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH)) {
+      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
+    }
     return ES.DaysInMonth(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH));
   }
   daysInYear(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return ES.LeapYear(GetSlot(date, ISO_YEAR)) ? 366 : 365;
   }
   monthsInYear(date) {
-    void date;
+    if (!HasSlot(date, ISO_YEAR)) ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return 12;
   }
   inLeapYear(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return ES.LeapYear(GetSlot(date, ISO_YEAR));
   }
 }
@@ -303,9 +320,11 @@ class Gregorian extends ISO8601Calendar {
   }
 
   era(date) {
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     return GetSlot(date, ISO_YEAR) < 1 ? 'bc' : 'ad';
   }
   year(date) {
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
     const isoYear = GetSlot(date, ISO_YEAR);
     return isoYear < 1 ? -isoYear + 1 : isoYear;
   }
@@ -398,9 +417,15 @@ class Japanese extends ISO8601Calendar {
   }
 
   era(date) {
+    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
+      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
+    }
     return jpn.eraNames[jpn.findEra(date)];
   }
   year(date) {
+    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
+      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.Date%'));
+    }
     const eraIdx = jpn.findEra(date);
     return GetSlot(date, ISO_YEAR) - jpn.eraAddends[eraIdx];
   }

--- a/polyfill/test/calendar.mjs
+++ b/polyfill/test/calendar.mjs
@@ -90,6 +90,7 @@ describe('Calendar', () => {
       equal(typeof Calendar.from, 'function');
     });
   });
+  const iso = Calendar.from('iso8601');
   describe('Calendar.from()', () => {
     describe('from identifier', () => {
       test('iso8601');
@@ -147,6 +148,205 @@ describe('Calendar', () => {
         it(`Calendar.from(${isoString}) is a calendar`, () => assert(calendar instanceof Calendar));
         it(`Calendar.from(${isoString}) has ID ${id}`, () => equal(calendar.id, id));
       }
+    });
+  });
+  describe('Calendar.year()', () => {
+    const res = 1994;
+    it('accepts Date', () => equal(iso.year(Temporal.Date.from('1994-11-05')), res));
+    it('accepts DateTime', () => equal(iso.year(Temporal.DateTime.from('1994-11-05T08:15:30')), res));
+    it('accepts YearMonth', () => equal(iso.year(Temporal.YearMonth.from('1994-11')), res));
+    it('casts argument', () => {
+      equal(iso.year({ year: 1994, month: 11, day: 5 }), res);
+      equal(iso.year('1994-11-05'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.year({ month: 5 }), TypeError);
+    });
+  });
+  describe('Calendar.month()', () => {
+    const res = 11;
+    it('accepts Date', () => equal(iso.month(Temporal.Date.from('1994-11-05')), res));
+    it('accepts DateTime', () => equal(iso.month(Temporal.DateTime.from('1994-11-05T08:15:30')), res));
+    it('accepts YearMonth', () => equal(iso.month(Temporal.YearMonth.from('1994-11')), res));
+    it('accepts MonthDay', () => equal(iso.month(Temporal.MonthDay.from('11-05')), res));
+    it('casts argument', () => {
+      equal(iso.month({ year: 1994, month: 11, day: 5 }), res);
+      equal(iso.month('1994-11-05'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.month({ year: 2000 }), TypeError);
+    });
+  });
+  describe('Calendar.day()', () => {
+    const res = 5;
+    it('accepts Date', () => equal(iso.day(Temporal.Date.from('1994-11-05')), res));
+    it('accepts DateTime', () => equal(iso.day(Temporal.DateTime.from('1994-11-05T08:15:30')), res));
+    it('accepts MonthDay', () => equal(iso.day(Temporal.MonthDay.from('11-05')), res));
+    it('casts argument', () => {
+      equal(iso.day({ year: 1994, month: 11, day: 5 }), res);
+      equal(iso.day('1994-11-05'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.day({ year: 2000 }), TypeError);
+    });
+  });
+  describe('Calendar.dayOfWeek()', () => {
+    const res = 5;
+    it('accepts Date', () => equal(iso.dayOfWeek(Temporal.Date.from('2020-10-23')), res));
+    it('accepts DateTime', () => equal(iso.dayOfWeek(Temporal.DateTime.from('2020-10-23T08:15:30')), res));
+    it('casts argument', () => {
+      equal(iso.dayOfWeek({ year: 2020, month: 10, day: 23 }), res);
+      equal(iso.dayOfWeek('2020-10-23'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.dayOfWeek({ year: 2000 }), TypeError);
+    });
+  });
+  describe('Calendar.dayOfYear()', () => {
+    const res = 32;
+    it('accepts Date', () => equal(iso.dayOfYear(Temporal.Date.from('1994-02-01')), res));
+    it('accepts DateTime', () => equal(iso.dayOfYear(Temporal.DateTime.from('1994-02-01T08:15:30')), res));
+    it('casts argument', () => {
+      equal(iso.dayOfYear({ year: 1994, month: 2, day: 1 }), res);
+      equal(iso.dayOfYear('1994-02-01'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.dayOfYear({ year: 2000 }), TypeError);
+    });
+  });
+  describe('Calendar.weekOfYear()', () => {
+    const res = 44;
+    it('accepts Date', () => equal(iso.weekOfYear(Temporal.Date.from('1994-11-05')), res));
+    it('accepts DateTime', () => equal(iso.weekOfYear(Temporal.DateTime.from('1994-11-05T08:15:30')), res));
+    it('casts argument', () => {
+      equal(iso.weekOfYear({ year: 1994, month: 11, day: 5 }), res);
+      equal(iso.weekOfYear('1994-11-05'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.weekOfYear({ year: 2000 }), TypeError);
+    });
+  });
+  describe('Calendar.daysInWeek()', () => {
+    const res = 7;
+    it('accepts Date', () => equal(iso.daysInWeek(Temporal.Date.from('1994-11-05')), res));
+    it('accepts DateTime', () => equal(iso.daysInWeek(Temporal.DateTime.from('1994-11-05T08:15:30')), res));
+    it('casts argument', () => {
+      equal(iso.daysInWeek({ year: 1994, month: 11, day: 5 }), res);
+      equal(iso.daysInWeek('1994-11-05'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.daysInWeek({ year: 2000 }), TypeError);
+    });
+  });
+  describe('Calendar.daysInMonth()', () => {
+    const res = 30;
+    it('accepts Date', () => equal(iso.daysInMonth(Temporal.Date.from('1994-11-05')), res));
+    it('accepts DateTime', () => equal(iso.daysInMonth(Temporal.DateTime.from('1994-11-05T08:15:30')), res));
+    it('accepts YearMonth', () => equal(iso.daysInMonth(Temporal.YearMonth.from('1994-11')), res));
+    it('casts argument', () => {
+      equal(iso.daysInMonth({ year: 1994, month: 11, day: 5 }), res);
+      equal(iso.daysInMonth('1994-11-05'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.daysInMonth({ year: 2000 }), TypeError);
+    });
+  });
+  describe('Calendar.daysInYear()', () => {
+    const res = 365;
+    it('accepts Date', () => equal(iso.daysInYear(Temporal.Date.from('1994-11-05')), res));
+    it('accepts DateTime', () => equal(iso.daysInYear(Temporal.DateTime.from('1994-11-05T08:15:30')), res));
+    it('accepts YearMonth', () => equal(iso.daysInYear(Temporal.YearMonth.from('1994-11')), res));
+    it('casts argument', () => {
+      equal(iso.daysInYear({ year: 1994, month: 11, day: 5 }), res);
+      equal(iso.daysInYear('1994-11-05'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.daysInYear({ month: 11 }), TypeError);
+    });
+  });
+  describe('Calendar.monthsInYear()', () => {
+    const res = 12;
+    it('accepts Date', () => equal(iso.monthsInYear(Temporal.Date.from('1994-11-05')), res));
+    it('accepts DateTime', () => equal(iso.monthsInYear(Temporal.DateTime.from('1994-11-05T08:15:30')), res));
+    it('accepts YearMonth', () => equal(iso.monthsInYear(Temporal.YearMonth.from('1994-11')), res));
+    it('casts argument', () => {
+      equal(iso.monthsInYear({ year: 1994, month: 11, day: 5 }), res);
+      equal(iso.monthsInYear('1994-11-05'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.monthsInYear({ month: 11 }), TypeError);
+    });
+  });
+  describe('Calendar.inLeapYear()', () => {
+    const res = false;
+    it('accepts Date', () => equal(iso.inLeapYear(Temporal.Date.from('1994-11-05')), res));
+    it('accepts DateTime', () => equal(iso.inLeapYear(Temporal.DateTime.from('1994-11-05T08:15:30')), res));
+    it('accepts YearMonth', () => equal(iso.inLeapYear(Temporal.YearMonth.from('1994-11')), res));
+    it('casts argument', () => {
+      equal(iso.inLeapYear({ year: 1994, month: 11, day: 5 }), res);
+      equal(iso.inLeapYear('1994-11-05'), res);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => iso.inLeapYear({ month: 11 }), TypeError);
+    });
+  });
+  describe('Calendar.dateAdd()', () => {
+    const date = Temporal.Date.from('1994-11-05');
+    const duration = Temporal.Duration.from({ months: 1, weeks: 1 });
+    it('casts date argument', () => {
+      equal(`${iso.dateAdd(Temporal.DateTime.from('1994-11-05T08:15:30'), duration, {}, Temporal.Date)}`, '1994-12-12');
+      equal(`${iso.dateAdd({ year: 1994, month: 11, day: 5 }, duration, {}, Temporal.Date)}`, '1994-12-12');
+      equal(`${iso.dateAdd('1994-11-05', duration, {}, Temporal.Date)}`, '1994-12-12');
+    });
+    it('date object must contain at least the required properties', () => {
+      throws(() => iso.dateAdd({ month: 11 }, duration, {}, Temporal.Date), TypeError);
+    });
+    it('casts duration argument', () => {
+      equal(`${iso.dateAdd(date, { months: 1, weeks: 1 }, {}, Temporal.Date)}`, '1994-12-12');
+      equal(`${iso.dateAdd(date, 'P1M1W', {}, Temporal.Date)}`, '1994-12-12');
+    });
+    it('duration object must contain at least one correctly-spelled property', () => {
+      throws(() => iso.dateAdd(date, { month: 1 }, {}, Temporal.Date), TypeError);
+    });
+  });
+  describe('Calendar.dateSubtract()', () => {
+    const date = Temporal.Date.from('1994-11-05');
+    const duration = Temporal.Duration.from({ months: 1, weeks: 1 });
+    it('casts date argument', () => {
+      equal(
+        `${iso.dateSubtract(Temporal.DateTime.from('1994-11-05T08:15:30'), duration, {}, Temporal.Date)}`,
+        '1994-09-29'
+      );
+      equal(`${iso.dateSubtract({ year: 1994, month: 11, day: 5 }, duration, {}, Temporal.Date)}`, '1994-09-29');
+      equal(`${iso.dateSubtract('1994-11-05', duration, {}, Temporal.Date)}`, '1994-09-29');
+    });
+    it('date object must contain at least the required properties', () => {
+      throws(() => iso.dateSubtract({ month: 11 }, duration, {}, Temporal.Date), TypeError);
+    });
+    it('casts duration argument', () => {
+      equal(`${iso.dateSubtract(date, { months: 1, weeks: 1 }, {}, Temporal.Date)}`, '1994-09-29');
+      equal(`${iso.dateSubtract(date, 'P1M1W', {}, Temporal.Date)}`, '1994-09-29');
+    });
+    it('duration object must contain at least one correctly-spelled property', () => {
+      throws(() => iso.dateSubtract(date, { month: 1 }, {}, Temporal.Date), TypeError);
+    });
+  });
+  describe('Calendar.dateDifference()', () => {
+    const date1 = Temporal.Date.from('1999-09-03');
+    const date2 = Temporal.Date.from('2000-01-01');
+    it('casts first argument', () => {
+      equal(`${iso.dateDifference(Temporal.DateTime.from('1999-09-03T08:15:30'), date2, {})}`, 'P120D');
+      equal(`${iso.dateDifference({ year: 1999, month: 9, day: 3 }, date2, {})}`, 'P120D');
+      equal(`${iso.dateDifference('1999-09-03', date2, {})}`, 'P120D');
+    });
+    it('casts second argument', () => {
+      equal(`${iso.dateDifference(date1, Temporal.DateTime.from('2000-01-01T08:15:30'), {})}`, 'P120D');
+      equal(`${iso.dateDifference(date1, { year: 2000, month: 1, day: 1 }, {})}`, 'P120D');
+      equal(`${iso.dateDifference(date1, '2000-01-01', {})}`, 'P120D');
+    });
+    it('objects must contain at least the required properties', () => {
+      throws(() => iso.dateDifference({ month: 11 }, date2, {}), TypeError);
+      throws(() => iso.dateDifference(date1, { month: 11 }, {}), TypeError);
     });
   });
 });

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -41,21 +41,6 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-requireoneofinternalslots" aoid="RequireOneOfInternalSlots">
-    <h1>RequireOneOfInternalSlots ( _value_, _internalSlots_ )</h1>
-    <p>
-      The abstract operation RequireOneOfInternalSlots takes arguments _value_ and _internalSlots_.
-      It throws an exception unless _value_ is an Object and has one of the given internal slots.
-      It performs the following steps when called:
-    </p>
-    <emu-alg>
-      1. If Type(_value_) is not Object, throw a *TypeError* exception.
-      1. For each element _slot_ of _internalSlots_, do
-        1. If O has a _slot_ internal slot, return.
-      1. Throw a *TypeError* exception.
-    </emu-alg>
-  </emu-clause>
-
   <!-- Copied from ECMA-402 9.2.12 -->
   <emu-clause id="sec-defaultnumberoption" aoid="DefaultNumberOption">
     <h1>DefaultNumberOption ( _value_, _minimum_, _maximum_, _fallback_ )</h1>

--- a/spec/isocalendar.html
+++ b/spec/isocalendar.html
@@ -125,6 +125,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
+        1. Set _date_ to ? ToTemporalDate(_date_).
+        1. Set _duration_ to ? ToTemporalDuration(_duration_).
         1. <mark>TODO.</mark>
       </emu-alg>
     </emu-clause>
@@ -136,6 +138,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
+        1. Set _date_ to ? ToTemporalDate(_date_).
+        1. Set _duration_ to ? ToTemporalDuration(_duration_).
         1. <mark>TODO.</mark>
       </emu-alg>
     </emu-clause>
@@ -147,6 +151,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
+        1. Set _one_ to ? ToTemporalDate(_one_).
+        1. Set _two_ to ? ToTemporalDate(_two_).
         1. <mark>TODO.</mark>
       </emu-alg>
     </emu-clause>
@@ -158,7 +164,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. If _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+          1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(_dateOrDateTime_.[[ISOYear]]).
       </emu-alg>
     </emu-clause>
@@ -170,7 +177,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. If _dateOrDateTime_ does not have an [[ISOMonth]] internal slot, then
+          1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(_dateOrDateTime_.[[ISOMonth]]).
       </emu-alg>
     </emu-clause>
@@ -182,7 +190,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. If _dateOrDateTime_ does not have an [[ISODay]] internal slot, then
+          1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(_dateOrDateTime_.[[ISODay]]).
       </emu-alg>
     </emu-clause>
@@ -194,7 +203,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. Perform ? ToTemporalDate(_dateOrDateTime_).
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>
@@ -206,7 +215,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. Set _date_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(! ToDayOfWeek(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]], _dateOrDateTime_.[[ISODay]])).
       </emu-alg>
     </emu-clause>
@@ -218,7 +227,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. Set _date_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(! ToDayOfYear(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]], _dateOrDateTime_.[[ISODay]])).
       </emu-alg>
     </emu-clause>
@@ -230,7 +239,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. Set _date_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(! ToWeekOfYear(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]], _dateOrDateTime_.[[ISODay]])).
       </emu-alg>
     </emu-clause>
@@ -242,7 +251,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. Perform ? ToTemporalDate(_dateOrDateTime_).
         1. Return *7*<sub>𝔽</sub>.
       </emu-alg>
     </emu-clause>
@@ -254,7 +263,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. If _dateOrDateTime_ does not have [[ISOYear]] and [[ISOMonth]] internal slots, then
+          1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(! DaysInMonth(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]])).
       </emu-alg>
     </emu-clause>
@@ -266,7 +276,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. If _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+          1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(! DaysInYear(_dateOrDateTime_.[[ISOYear]])).
       </emu-alg>
     </emu-clause>
@@ -278,7 +289,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. Perform ? ToTemporalDateTime(_dateOrDateTime_).
         1. Return *12*<sub>𝔽</sub>.
       </emu-alg>
     </emu-clause>
@@ -290,7 +301,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Perform ? RequireOneOfInternalSlots(_dateOrDateTime_, « [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] »).
+        1. If _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+          1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return ! IsLeapYear(_dateOrDateTime_.[[ISOYear]]).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
This also clarifies which Temporal objects are accepted by which Calendar
methods.

Closes: #1030