### PR TITLE
Don't convert custom calendar fields to integers

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -60,6 +60,27 @@ const NS_MAX = bigInt(86400).multiply(1e17);
 const YEAR_MIN = -271821;
 const YEAR_MAX = 275760;
 const BEFORE_FIRST_DST = bigInt(-388152).multiply(1e13); // 1847-01-01T00:00:00Z
+const BUILTIN_FIELDS = new Set([
+  'year',
+  'month',
+  'day',
+  'hour',
+  'minute',
+  'second',
+  'millisecond',
+  'microsecond',
+  'nanosecond',
+  'years',
+  'months',
+  'weeks',
+  'days',
+  'hours',
+  'minutes',
+  'seconds',
+  'milliseconds',
+  'microseconds',
+  'nanoseconds'
+]);
 
 import * as PARSE from './regex.mjs';
 
@@ -735,11 +756,10 @@ export const ES = ObjectAssign({}, ES2020, {
       const value = bag[property];
       if (value !== undefined) {
         any = any || {};
-        if (property === 'era') {
-          // FIXME: this is terrible
-          any.era = value;
-        } else {
+        if (BUILTIN_FIELDS.has(property)) {
           any[property] = ES.ToInteger(value);
+        } else {
+          any[property] = value;
         }
       }
     }
@@ -757,11 +777,10 @@ export const ES = ObjectAssign({}, ES2020, {
         }
         value = defaultValue;
       }
-      if (property === 'era') {
-        // FIXME: this is terrible
-        result.era = value;
-      } else {
+      if (BUILTIN_FIELDS.has(property)) {
         result[property] = ES.ToInteger(value);
+      } else {
+        result[property] = value;
       }
     }
     return result;

--- a/spec/date.html
+++ b/spec/date.html
@@ -742,10 +742,9 @@
         1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
         1. For each value _property_ of _fieldNames_, do
           1. Let _value_ be ? Get(_temporalDateLike_, _property_).
-          1. If _property_ is one of *"day"*, *"month"*, or *"year"*, and _value_ is *undefined*, then
-            1. Throw a *TypeError* exception.
-          1. If _property_ is not *"era"*, then
-            1. Let _value_ be ? ToInteger(_value_).
+          1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
+            1. If _value_ is *undefined*, throw a *TypeError* exception.
+            1. Set _value_ to ? ToInteger(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. Return _result_.
       </emu-alg>
@@ -762,7 +761,7 @@
           1. Let _value_ be ? Get(_temporalDateLike_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
-            1. If _property_ is not *"era"*, then
+            1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
               1. Set _value_ to ? ToInteger(_value_).
             1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. If _any_ is *false*, then

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -910,7 +910,7 @@
           1. Let _value_ be ? Get(_temporalDateTimeLike_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
-            1. If _property_ is not *"era"*, then
+            1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
               1. Set _value_ to ? ToInteger(_value_).
             1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
@@ -1059,10 +1059,9 @@
         1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
         1. For each value _property_ of _fieldNames_, do
           1. Let _value_ be ? Get(_temporalDateLike_, _property_).
-          1. If _property_ is one of *"day"*, *"month"*, or *"year"*, and _value_ is *undefined*, then
-            1. Throw a *TypeError* exception.
-          1. If _property_ is not *"era"*, then
-            1. Let _value_ be ? ToInteger(_value_).
+          1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
+            1. If _value_ is *undefined*, throw a *TypeError* exception.
+            1. Set _value_ to ? ToInteger(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
           1. Let _property_ be the Property value of the current row.

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -389,7 +389,8 @@
           1. Let _value_ be ? Get(_temporalMonthDayLike_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
-            1. Set _value_ to ? ToInteger(_value_).
+            1. If _property_ is either *"month"* or *"day"*, then
+              1. Set _value_ to ? ToInteger(_value_).
             1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. If _any_ is *false*, then
           1. Throw a *TypeError* exception.
@@ -494,9 +495,9 @@
         1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
         1. For each value _property_ of _fieldNames_, do
           1. Let _value_ be ? Get(_temporalDateLike_, _property_).
-          1. If _property_ is one of *"month"* or *"year"*, and _value_ is *undefined*, then
-            1. Throw a *TypeError* exception.
-          1. Let _value_ be ? ToInteger(_value_).
+          1. If _property_ is one of *"month"* or *"year"*, then
+            1. If _value_ is *undefined*, throw a *TypeError* exception.
+            1. Set _value_ to ? ToInteger(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. Let _year_ be the first leap year after the Unix epoch (1972).
         1. Perform ! CreateDataPropertyOrThrow(_result_, *"year"*, _year_).

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -530,7 +530,7 @@
           1. Let _value_ be ? Get(_temporalYearMonthLike_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
-            1. If _property_ is not *"era"*, then
+            1. If _property_ is either *"month"* or *"year"*, then
               1. Set _value_ to ? ToInteger(_value_).
             1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. If _any_ is *false*, then
@@ -655,10 +655,9 @@
         1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
         1. For each value _property_ of _fieldNames_, do
           1. Let _value_ be ? Get(_temporalDateLike_, _property_).
-          1. If _property_ is one of *"day"*, *"month"*, or *"year"*, and _value_ is *undefined*, then
-            1. Throw a *TypeError* exception.
-          1. If _property_ is not *"era"*, then
-            1. Let _value_ be ? ToInteger(_value_).
+          1. If _property_ is either *"month"*, or *"year"*, then
+            1. If _value_ is *undefined*, throw a *TypeError* exception.
+            1. Set _value_ to ? ToInteger(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. Perform ! CreateDataPropertyOrThrow(_result_, *"day"*, 1).
         1. Return _result_.


### PR DESCRIPTION
Only the built-in fields (year through nanosecond, and the plural names
for Duration) should be converted to integers. Custom calendar fields
should not have any type conversion performed on them.

Closes: #1045