### PR TITLE
Add Duration.prototype.total method

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -486,6 +486,58 @@ quarters = d.months / 3;
 quarters; // => 3
 ```
 
+### duration.**total**(_options_: object) : number
+
+**Parameters:**
+
+- `options` (object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `unit` (string): The unit of time that will be returned.
+    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    There is no default; `unit` is required.
+  - `relativeTo` (`Temporal.DateTime`): The starting point to use when converting between years, months, weeks, and days.
+    It must be a `Temporal.DateTime`, or a value that can be passed to `Temporal.DateTime.from()`.
+
+**Returns:** a floating-point number representing the number of desired units in the `Temporal.Duration`.
+
+Calculates the number of units of time that can fit in a particular `Temporal.Duration`.
+If the duration is not evenly divisible by the desired unit, then a fractional remainder will be included.
+If not, then the result is an integer.
+In that case, the integer result will be the same unit value returned from `round()` when `smallestUnit` and `largestUnit` are identical.
+
+Interpreting years, months, or weeks requires a reference point.
+Therefore, `unit` is `'years'`, `'months'`, or `'weeks'`, or the duration has nonzero 'years', 'months', or 'weeks', then the `relativeTo` option is required.
+
+The `relativeTo` option gives the starting point used when converting between or rounding to years, months, weeks, or days.
+It is a `Temporal.DateTime` instance.
+If any other type is provided, then it will be converted to a `Temporal.DateTime` as if it were passed to `Temporal.DateTime.from(..., { overflow: 'reject' })`.
+A `Temporal.Date` or a date string like `2020-01-01` is also accepted because time is optional when creating a `Temporal.DateTime`.
+
+Example usage:
+
+```javascript
+// How many seconds in 18 hours and 20 minutes?
+d = Temporal.Duration.from({ hours: 130, minutes: 20 });
+d.total({ largestUnit: 'minutes' }); // => 469200
+
+// How many 24-hour days is 123456789 seconds?
+d = Temporal.Duration.from('PT123456789S');
+d.total({ unit: 'days' }); // 1428.8980208333332
+
+// Find totals in days, with and without taking DST into account
+d = Temporal.Duration.from({ hours: 1756 });
+// FIXME: write this example after ZonedDateTime is added
+// d.round({
+//   relativeTo: '2020-01-01T00:00+01:00[Europe/Rome]',
+//   largestUnit: 'years'
+// }); // => ???
+d.total({
+  unit: 'months',
+  relativeTo: '2020-01-01'
+}); // => 2.39247311827957
+// FIXME: update the result above after duration rounding is fixed
+```
+
 ### duration.**getFields**() : { years: number, months: number, weeks: number, days: number, hours: number, minutes: number, seconds: number, milliseconds: number, microseconds: number, nanoseconds: number }
 
 **Returns:** a plain object with properties equal to the fields of `duration`.

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -501,9 +501,8 @@ quarters; // => 3
 **Returns:** a floating-point number representing the number of desired units in the `Temporal.Duration`.
 
 Calculates the number of units of time that can fit in a particular `Temporal.Duration`.
-If the duration is not evenly divisible by the desired unit, then a fractional remainder will be included.
-If not, then the result is an integer.
-In that case, the integer result will be the same unit value returned from `round()` when `smallestUnit` and `largestUnit` are identical.
+If the duration IS NOT evenly divisible by the desired unit, then a fractional remainder will be present in the result.
+If the duration IS evenly divisible by the desired unit, then the integer result will be identical to `duration.round({ smallestUnit: unit, largestUnit: unit, relativeTo })[unit]`.
 
 Interpreting years, months, or weeks requires a reference point.
 Therefore, `unit` is `'years'`, `'months'`, or `'weeks'`, or the duration has nonzero 'years', 'months', or 'weeks', then the `relativeTo` option is required.
@@ -524,12 +523,12 @@ d.total({ largestUnit: 'minutes' }); // => 469200
 d = Temporal.Duration.from('PT123456789S');
 d.total({ unit: 'days' }); // 1428.8980208333332
 
-// Find totals in days, with and without taking DST into account
+// Find totals in months, with and without taking DST into account
 d = Temporal.Duration.from({ hours: 1756 });
 // FIXME: write this example after ZonedDateTime is added
 // d.round({
 //   relativeTo: '2020-01-01T00:00+01:00[Europe/Rome]',
-//   largestUnit: 'years'
+//   largestUnit: 'months'
 // }); // => ???
 d.total({
   unit: 'months',

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -290,9 +290,79 @@ export namespace Temporal {
     roundingMode?: 'nearest' | 'ceil' | 'trunc' | 'floor';
 
     /**
-     * The starting point to use when converting between or rounding to years,
-     * months, weeks, and days. It must be a Temporal.DateTime, or a value that
-     * can be passed to Temporal.DateTime.from(), like a `Temporal.Date`.
+     * The starting point to use for rounding and conversions when
+     * variable-length units (years, months, weeks depending on the calendar)
+     * are involved. This option is required if any of the following are true:
+     * - `unit` is `'weeks'` or larger units
+     * - `this` has a nonzero value for `weeks` or larger units
+     *
+     * This value must be either a `Temporal.DateTime`, a
+     * `Temporal.ZonedDateTime`, or a string or object value that can be passed
+     * to `from()` of those types. Examples:
+     * - `'2020-01'01T00:00-08:00[America/Los_Angeles]'`
+     * - `'2020-01'01'`
+     * - `Temporal.Date.from('2020-01-01')`
+     *
+     * `Temporal.ZonedDateTime` will be tried first because it's more
+     * specific, with `Temporal.DateTime` as a fallback.
+     *
+     * If the value resolves to a `Temporal.ZonedDateTime`, then operation will
+     * adjust for DST and other time zone transitions. Otherwise (including if
+     * this option is omitted), then the operation will ignore time zone
+     * transitions and all days will be assumed to be 24 hours long.
+     */
+    relativeTo?: Temporal.DateTime | DateTimeLike | string;
+  }
+
+  /**
+   * Options to control behavior of `Duration.prototype.total()`
+   */
+  export interface DurationTotalOptions {
+    /**
+     * The unit to convert the duration to. This option is required.
+     */
+    unit:
+      | 'years'
+      | 'months'
+      | 'weeks'
+      | 'days'
+      | 'hours'
+      | 'minutes'
+      | 'seconds'
+      | 'milliseconds'
+      | 'microseconds'
+      | 'nanoseconds'
+      | /** @deprecated */ 'year'
+      | /** @deprecated */ 'month'
+      | /** @deprecated */ 'day'
+      | /** @deprecated */ 'hour'
+      | /** @deprecated */ 'minute'
+      | /** @deprecated */ 'second'
+      | /** @deprecated */ 'millisecond'
+      | /** @deprecated */ 'microsecond'
+      | /** @deprecated */ 'nanosecond';
+
+    /**
+     * The starting point to use when variable-length units (years, months,
+     * weeks depending on the calendar) are involved. This option is required if
+     * any of the following are true:
+     * - `unit` is `'weeks'` or larger units
+     * - `this` has a nonzero value for `weeks` or larger units
+     *
+     * This value must be either a `Temporal.DateTime`, a
+     * `Temporal.ZonedDateTime`, or a string or object value that can be passed
+     * to `from()` of those types. Examples:
+     * - `'2020-01'01T00:00-08:00[America/Los_Angeles]'`
+     * - `'2020-01'01'`
+     * - `Temporal.Date.from('2020-01-01')`
+     *
+     * `Temporal.ZonedDateTime` will be tried first because it's more
+     * specific, with `Temporal.DateTime` as a fallback.
+     *
+     * If the value resolves to a `Temporal.ZonedDateTime`, then operation will
+     * adjust for DST and other time zone transitions. Otherwise (including if
+     * this option is omitted), then the operation will ignore time zone
+     * transitions and all days will be assumed to be 24 hours long.
      */
     relativeTo?: Temporal.DateTime | DateTimeLike | string;
   }
@@ -351,6 +421,7 @@ export namespace Temporal {
     add(other: Temporal.Duration | DurationLike | string, options?: DurationOptions): Temporal.Duration;
     subtract(other: Temporal.Duration | DurationLike | string, options?: DurationOptions): Temporal.Duration;
     round(options: DurationRoundOptions): Temporal.Duration;
+    total(options: DurationTotalOptions): number;
     getFields(): DurationFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -654,6 +654,27 @@ export const ES = ObjectAssign({}, ES2020, {
     if (plural.has(value)) return plural.get(value);
     return value;
   },
+  ToTemporalDurationTotalUnit: (options) => {
+    // This AO is identical to ToSmallestTemporalDurationUnit, except:
+    // - default is always `undefined` (caller will throw if omitted)
+    // - option is named `unit` (not `smallestUnit`)
+    // - all units are valid (no `disallowedStrings`)
+    const plural = new Map([
+      ['year', 'years'],
+      ['month', 'months'],
+      ['day', 'days'],
+      ['hour', 'hours'],
+      ['minute', 'minutes'],
+      ['second', 'seconds'],
+      ['millisecond', 'milliseconds'],
+      ['microsecond', 'microseconds'],
+      ['nanosecond', 'nanoseconds']
+    ]);
+    // "week" doesn't exist in Temporal as a non-plural unit, so don't allow it
+    const value = ES.GetOption(options, 'unit', [...plural.values(), ...plural.keys(), 'weeks'], undefined);
+    if (plural.has(value)) return plural.get(value);
+    return value;
+  },
   ToRelativeTemporalObject: (options) => {
     const relativeTo = options.relativeTo;
     if (relativeTo === undefined) return relativeTo;
@@ -2445,9 +2466,10 @@ export const ES = ObjectAssign({}, ES2020, {
           oneYearDays = calendar.daysInYear(relativeTo);
         }
         years += days / oneYearDays;
-        remainder = years % 1;
 
+        remainder = years;
         years = ES.RoundNumberToIncrement(years, increment, roundingMode);
+        remainder -= years;
         months = weeks = days = hours = minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
         break;
       }
@@ -2487,9 +2509,10 @@ export const ES = ObjectAssign({}, ES2020, {
           oneMonthDays = calendar.daysInMonth(relativeTo);
         }
         months += days / oneMonthDays;
-        remainder = months % 1;
 
+        remainder = months;
         months = ES.RoundNumberToIncrement(months, increment, roundingMode);
+        remainder -= months;
         weeks = days = hours = minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
         break;
       }
@@ -2511,49 +2534,56 @@ export const ES = ObjectAssign({}, ES2020, {
           oneWeekDays = calendar.daysInWeek(relativeTo);
         }
         weeks += days / oneWeekDays;
-        remainder = weeks % 1;
 
+        remainder = weeks;
         weeks = ES.RoundNumberToIncrement(weeks, increment, roundingMode);
+        remainder -= weeks;
         days = hours = minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
         break;
       }
       case 'days':
         seconds += milliseconds * 1e-3 + microseconds * 1e-6 + nanoseconds * 1e-9;
         days += ((seconds / 60 + minutes) / 60 + hours) / 24;
-        remainder = days % 1;
+        remainder = days;
         days = ES.RoundNumberToIncrement(days, increment, roundingMode);
+        remainder -= days;
         hours = minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
         break;
       case 'hours':
         seconds += milliseconds * 1e-3 + microseconds * 1e-6 + nanoseconds * 1e-9;
         hours += (minutes + seconds / 60) / 60;
-        remainder = hours % 1;
+        remainder = hours;
         hours = ES.RoundNumberToIncrement(hours, increment, roundingMode);
+        remainder -= hours;
         minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
         break;
       case 'minutes':
         seconds += milliseconds * 1e-3 + microseconds * 1e-6 + nanoseconds * 1e-9;
         minutes += seconds / 60;
-        remainder = minutes % 1;
+        remainder = minutes;
         minutes = ES.RoundNumberToIncrement(minutes, increment, roundingMode);
+        remainder -= minutes;
         seconds = milliseconds = microseconds = nanoseconds = 0;
         break;
       case 'seconds':
         seconds += milliseconds * 1e-3 + microseconds * 1e-6 + nanoseconds * 1e-9;
-        remainder = seconds % 1;
+        remainder = seconds;
         seconds = ES.RoundNumberToIncrement(seconds, increment, roundingMode);
+        remainder -= seconds;
         milliseconds = microseconds = nanoseconds = 0;
         break;
       case 'milliseconds':
         milliseconds += microseconds * 1e-3 + nanoseconds * 1e-6;
-        remainder = milliseconds % 1;
+        remainder = milliseconds;
         milliseconds = ES.RoundNumberToIncrement(milliseconds, increment, roundingMode);
+        remainder -= milliseconds;
         microseconds = nanoseconds = 0;
         break;
       case 'microseconds':
         microseconds += nanoseconds * 1e-3;
-        remainder = microseconds % 1;
+        remainder = microseconds;
         microseconds = ES.RoundNumberToIncrement(microseconds, increment, roundingMode);
+        remainder -= microseconds;
         nanoseconds = 0;
         break;
       case 'nanoseconds':

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2405,6 +2405,7 @@ export const ES = ObjectAssign({}, ES2020, {
       if (!ES.IsTemporalDateTime(relativeTo)) throw new TypeError('starting point must be DateTime');
       calendar = GetSlot(relativeTo, CALENDAR);
     }
+    let remainder;
     switch (unit) {
       case 'years': {
         if (!calendar) throw new RangeError('A starting point is required for years rounding');
@@ -2444,6 +2445,7 @@ export const ES = ObjectAssign({}, ES2020, {
           oneYearDays = calendar.daysInYear(relativeTo);
         }
         years += days / oneYearDays;
+        remainder = years % 1;
 
         years = ES.RoundNumberToIncrement(years, increment, roundingMode);
         months = weeks = days = hours = minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
@@ -2485,6 +2487,7 @@ export const ES = ObjectAssign({}, ES2020, {
           oneMonthDays = calendar.daysInMonth(relativeTo);
         }
         months += days / oneMonthDays;
+        remainder = months % 1;
 
         months = ES.RoundNumberToIncrement(months, increment, roundingMode);
         weeks = days = hours = minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
@@ -2508,6 +2511,7 @@ export const ES = ObjectAssign({}, ES2020, {
           oneWeekDays = calendar.daysInWeek(relativeTo);
         }
         weeks += days / oneWeekDays;
+        remainder = weeks % 1;
 
         weeks = ES.RoundNumberToIncrement(weeks, increment, roundingMode);
         days = hours = minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
@@ -2516,41 +2520,48 @@ export const ES = ObjectAssign({}, ES2020, {
       case 'days':
         seconds += milliseconds * 1e-3 + microseconds * 1e-6 + nanoseconds * 1e-9;
         days += ((seconds / 60 + minutes) / 60 + hours) / 24;
+        remainder = days % 1;
         days = ES.RoundNumberToIncrement(days, increment, roundingMode);
         hours = minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
         break;
       case 'hours':
         seconds += milliseconds * 1e-3 + microseconds * 1e-6 + nanoseconds * 1e-9;
         hours += (minutes + seconds / 60) / 60;
+        remainder = hours % 1;
         hours = ES.RoundNumberToIncrement(hours, increment, roundingMode);
         minutes = seconds = milliseconds = microseconds = nanoseconds = 0;
         break;
       case 'minutes':
         seconds += milliseconds * 1e-3 + microseconds * 1e-6 + nanoseconds * 1e-9;
         minutes += seconds / 60;
+        remainder = minutes % 1;
         minutes = ES.RoundNumberToIncrement(minutes, increment, roundingMode);
         seconds = milliseconds = microseconds = nanoseconds = 0;
         break;
       case 'seconds':
         seconds += milliseconds * 1e-3 + microseconds * 1e-6 + nanoseconds * 1e-9;
+        remainder = seconds % 1;
         seconds = ES.RoundNumberToIncrement(seconds, increment, roundingMode);
         milliseconds = microseconds = nanoseconds = 0;
         break;
       case 'milliseconds':
         milliseconds += microseconds * 1e-3 + nanoseconds * 1e-6;
+        remainder = milliseconds % 1;
         milliseconds = ES.RoundNumberToIncrement(milliseconds, increment, roundingMode);
         microseconds = nanoseconds = 0;
         break;
       case 'microseconds':
         microseconds += nanoseconds * 1e-3;
+        remainder = microseconds % 1;
         microseconds = ES.RoundNumberToIncrement(microseconds, increment, roundingMode);
         nanoseconds = 0;
         break;
       case 'nanoseconds':
+        remainder = 0;
         nanoseconds = ES.RoundNumberToIncrement(nanoseconds, increment, roundingMode);
         break;
     }
-    return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
+    return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, remainder };
   },
 
   CompareTemporalDate: (y1, m1, d1, y2, m2, d2) => {

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -1065,6 +1065,147 @@ describe('Duration', () => {
       );
     });
   });
+  describe('Duration.total()', () => {
+    const d = new Duration(5, 5, 5, 5, 5, 5, 5, 5, 5, 5);
+    const d2 = new Duration(0, 0, 0, 5, 5, 5, 5, 5, 5, 5);
+    const relativeTo = Temporal.DateTime.from('2020-01-01T00:00');
+    it('options may only be an object', () => {
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) => throws(() => d.total(badOptions), TypeError));
+    });
+    it('throws on disallowed or invalid smallestUnit', () => {
+      ['era', 'nonsense'].forEach((unit) => {
+        throws(() => d.total({ unit }), RangeError);
+      });
+    });
+    it('accepts datetime string equivalents or fields for relativeTo', () => {
+      ['2020-01-01', '2020-01-01T00:00:00.000000000', 20200101, 20200101n, { year: 2020, month: 1, day: 1 }].forEach(
+        (relativeTo) => {
+          const end = Temporal.DateTime.from(relativeTo).add(d);
+          const { year, month, daysInMonth } = end;
+          const endMonth = Temporal.DateTime.from({ year, month, day: 1 });
+          const remainderNanos = end.since(endMonth, { largestUnit: 'nanoseconds' }).nanoseconds;
+          const partialMonth = remainderNanos / (3.6e12 * 24 * daysInMonth);
+          const total = d.total({ unit: 'months', relativeTo });
+          equal(total, 66 + partialMonth);
+        }
+      );
+    });
+    it("throws on relativeTo that can't be converted to datetime string", () => {
+      throws(() => d.total({ unit: 'months', relativeTo: Symbol('foo') }), TypeError);
+    });
+    it('throws on relativeTo that converts to an invalid datetime string', () => {
+      [3.14, true, null, 'hello', 1n].forEach((relativeTo) => {
+        throws(() => d.total({ unit: 'months', relativeTo }), RangeError);
+      });
+    });
+    it('relativeTo object must contain at least the required correctly-spelled properties', () => {
+      throws(() => d.total({ unit: 'months', relativeTo: {} }), TypeError);
+      throws(() => d.total({ unit: 'months', relativeTo: { years: 2020, month: 1, day: 1 } }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored in relativeTo', () => {
+      const oneMonth = Duration.from({ months: 1 });
+      equal(oneMonth.total({ unit: 'months', relativeTo: { year: 2020, month: 1, day: 1, months: 2 } }), 1);
+    });
+    it('throws if unit is missing', () => {
+      [undefined, {}, () => {}, { roundingMode: 'ceil' }].forEach((options) =>
+        throws(() => d.total(options), RangeError)
+      );
+    });
+    it('relativeTo is required for rounding calendar units even in durations without calendar units', () => {
+      throws(() => d2.total({ unit: 'years' }), RangeError);
+      throws(() => d2.total({ unit: 'months' }), RangeError);
+      throws(() => d2.total({ unit: 'weeks' }), RangeError);
+    });
+    it('relativeTo is required for rounding durations with calendar units', () => {
+      throws(() => d.total({ unit: 'years' }), RangeError);
+      throws(() => d.total({ unit: 'months' }), RangeError);
+      throws(() => d.total({ unit: 'weeks' }), RangeError);
+      throws(() => d.total({ unit: 'days' }), RangeError);
+      throws(() => d.total({ unit: 'hours' }), RangeError);
+      throws(() => d.total({ unit: 'minutes' }), RangeError);
+      throws(() => d.total({ unit: 'seconds' }), RangeError);
+      throws(() => d.total({ unit: 'milliseconds' }), RangeError);
+      throws(() => d.total({ unit: 'microseconds' }), RangeError);
+      throws(() => d.total({ unit: 'nanoseconds' }), RangeError);
+    });
+    const d2Nanoseconds = d2.round({ largestUnit: 'nanoseconds', smallestUnit: 'nanoseconds' }).nanoseconds;
+    const totalD2 = {
+      days: d2Nanoseconds / (24 * 3.6e12),
+      hours: d2Nanoseconds / 3.6e12,
+      minutes: d2Nanoseconds / 6e10,
+      seconds: d2Nanoseconds / 1e9,
+      milliseconds: d2Nanoseconds / 1e6,
+      microseconds: d2Nanoseconds / 1e3,
+      nanoseconds: d2Nanoseconds
+    };
+    it('relativeTo is not required for rounding non-calendar units in durations without calendar units', () => {
+      equal(d2.total({ unit: 'days' }), totalD2.days);
+      equal(d2.total({ unit: 'hours' }), totalD2.hours);
+      equal(d2.total({ unit: 'minutes' }), totalD2.minutes);
+      equal(d2.total({ unit: 'seconds' }), totalD2.seconds);
+      equal(d2.total({ unit: 'milliseconds' }), totalD2.milliseconds);
+      equal(d2.total({ unit: 'microseconds' }), totalD2.microseconds);
+      equal(d2.total({ unit: 'nanoseconds' }), totalD2.nanoseconds);
+    });
+    const endpoint = relativeTo.add(d);
+    const options = (unit) => ({ largestUnit: unit, smallestUnit: unit, roundingMode: 'trunc' });
+    const fullYears = 6;
+    const fullDays = endpoint.since(relativeTo, options('days')).days;
+    const fullMilliseconds = endpoint.since(relativeTo, options('milliseconds')).milliseconds;
+    const partialDayMilliseconds = fullMilliseconds - fullDays * 24 * 3.6e6 + 0.005005;
+    const fractionalDay = partialDayMilliseconds / (24 * 3.6e6);
+    const partialYearDays = fullDays - fullYears * 365 + 2;
+    const fractionalYear = partialYearDays / 365 + fractionalDay / 365;
+    const fractionalMonths = ((endpoint.day - 1) * (24 * 3.6e6) + partialDayMilliseconds) / (31 * 24 * 3.6e6);
+
+    const totalResults = {
+      years: fullYears + fractionalYear,
+      months: 66 + fractionalMonths,
+      weeks: (fullDays + fractionalDay) / 7,
+      days: fullDays + fractionalDay,
+      hours: fullDays * 24 + partialDayMilliseconds / 3.6e6,
+      minutes: fullDays * 24 * 60 + partialDayMilliseconds / 60000,
+      seconds: fullDays * 24 * 60 * 60 + partialDayMilliseconds / 1000,
+      milliseconds: fullMilliseconds + 0.005005,
+      microseconds: fullMilliseconds * 1000 + 5.005,
+      nanoseconds: fullMilliseconds * 1e6 + 5005
+    };
+    for (const [unit, expected] of Object.entries(totalResults)) {
+      it(`total(${unit}) = ${expected}`, () => {
+        equal(d.total({ unit, relativeTo }), expected);
+      });
+    }
+    for (const unit of ['microseconds', 'nanoseconds']) {
+      it(`total(${unit}) may lose precision below ms`, () => {
+        assert(d.total({ unit, relativeTo }).toString().startsWith('174373505005'));
+      });
+    }
+    it('balances differently depending on relativeTo', () => {
+      const fortyDays = Duration.from({ days: 40 });
+      equal(fortyDays.total({ unit: 'months', relativeTo: '2020-01-01' }), 1 + 9 / 29);
+      equal(fortyDays.total({ unit: 'months', relativeTo: '2020-02-01' }), 1 + 9 / 31);
+    });
+    it('balances up to the next unit after rounding', () => {
+      const almostWeek = Duration.from({ days: 6, hours: 20 });
+      equal(almostWeek.total({ unit: 'weeks', relativeTo: '2020-01-01' }), (6 + 20 / 24) / 7);
+    });
+    it('balances days up to both years and months', () => {
+      const twoYears = Duration.from({ months: 11, days: 396 });
+      equal(twoYears.total({ unit: 'years', relativeTo: '2017-01-01' }), 2);
+    });
+    it('accepts singular units', () => {
+      equal(d.total({ unit: 'year', relativeTo }), d.total({ unit: 'years', relativeTo }));
+      equal(d.total({ unit: 'month', relativeTo }), d.total({ unit: 'months', relativeTo }));
+      equal(d.total({ unit: 'day', relativeTo }), d.total({ unit: 'days', relativeTo }));
+      equal(d.total({ unit: 'hour', relativeTo }), d.total({ unit: 'hours', relativeTo }));
+      equal(d.total({ unit: 'minute', relativeTo }), d.total({ unit: 'minutes', relativeTo }));
+      equal(d.total({ unit: 'second', relativeTo }), d.total({ unit: 'seconds', relativeTo }));
+      equal(d.total({ unit: 'second', relativeTo }), d.total({ unit: 'seconds', relativeTo }));
+      equal(d.total({ unit: 'millisecond', relativeTo }), d.total({ unit: 'milliseconds', relativeTo }));
+      equal(d.total({ unit: 'microsecond', relativeTo }), d.total({ unit: 'microseconds', relativeTo }));
+      equal(d.total({ unit: 'nanosecond', relativeTo }), d.total({ unit: 'nanoseconds', relativeTo }));
+    });
+  });
 });
 
 import { normalize } from 'path';

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -294,6 +294,16 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-totemporaldurationtotalunit" aoid="ToTemporalDurationTotalUnit">
+    <h1>ToTemporalDurationTotalUnit ( _normalizedOptions_ )</h1>
+    <emu-alg>
+      1. Let _unit_ be ? GetOption(_normalizedOptions_, *"unit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *undefined*).
+      1. If the value of _unit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref> ("weeks" has no singular equivalent), then
+        1. Set _unit_ to the corresponding Plural value of the same row.
+      1. Return _unit_.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-singular-and-plural-units">
     <h1>Singular and plural units</h1>
     <p>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -431,34 +431,28 @@
         1. If _unit_ is not given, then
           1. Throw a *RangeError* exception.
         1. Else,
-          1. TODO: Let _revisedOptions_ be { smallestUnit: options.unit }.
-          1. Let _unit_ be ? ToSmallestTemporalDurationUnit(_revisedOptions_, *undefined*).
+          1. Let _unit_ be ? ToTemporalDurationTotalUnit(_revisedOptions_).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_years_, _months_, _weeks_, _days_, _unit_, _relativeTo_).
-        1. If _unit_ is "hours", "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
-          1. Set _hours_ to _hours_ + _days_ * 24.
-          1. Set _days_ to 0.
-        1. If _unit_ is "hours", "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
-          1. Set _hours_ to _hours_ + _days_ * 24.
-          1. Set _days_ to 0.
-        1. If _unit_ is "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
-          1. Set _minutes_ to _minutes_ + _hours_ * 60.
-          1. Set _hours_ to 0.
-        1. If _unit_ is "seconds", "milliseconds", "microseconds", or "nanoseconds", then
-          1. Set _seconds_ to _seconds_ + _minutes_ * 60.
-          1. Set _minutes_ to 0.
-        1. If _unit_ is "milliseconds", "microseconds", or "nanoseconds", then
-          1. Set _milliseconds_ to _milliseconds_ + _seconds_ * 1000.
-          1. Set _seconds_ to 0.
-        1. If _unit_ is "microseconds" or "nanoseconds", then
-          1. Set _microseconds_ to _microseconds_ + _milliseconds_ * 1000.
-          1. Set _milliseconds_ to 0.
-        1. If _unit_ is "nanoseconds", then
-          1. Set _nanoseconds_ to _nanoseconds_ + _microseconds_ * 1000.
-          1. Return _nanoseconds_.
-        1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]],
-        _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _hours_, _minutes_, _seconds_, _milliseconds_,
-        _microseconds_, _nanoseconds_, _roundingIncrement_, _unit_, _roundingMode_, _relativeTo_).
-        1. Let _whole_ be ? Get(_roundResult_, _unit_).
+        1. Let _balanceResult_ be ? BalanceDuration(_unbalanceResult_.[[Days]], _unbalanceResult_.[[Hours]], _unbalanceResult_.[[Minutes]], _unbalanceResult_.[[Seconds]], _unbalanceResult_.[[Milliseconds]], _unbalanceResult_.[[Microseconds]], _unbalanceResult_.[[Nanoseconds]], _unit_).
+        1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], *1*, _unit_, *"trunc"*, _relativeTo_).
+        1. If _unit_ is *"years"*, then
+          1. Let _whole_ be _roundResult_.[[Years]].
+        1. If _unit_ is *"months"*, then
+          1. Let _whole_ be _roundResult_.[[Months]].
+        1. If _unit_ is *"weeks"*, then
+          1. Let _whole_ be _roundResult_.[[Weeks]].
+        1. If _unit_ is *"days"*, then
+          1. Let _whole_ be _roundResult_.[[Days]].
+        1. If _unit_ is *"hours"*, then
+          1. Let _whole_ be _roundResult_.[[Hours]].
+        1. If _unit_ is *"minutes"*, then
+          1. Let _whole_ be _roundResult_.[[Minutes]].
+        1. If _unit_ is *"seconds"*, then
+          1. Let _whole_ be _roundResult_.[[Seconds]].
+        1. If _unit_ is *"milliseconds"*, then
+          1. Let _whole_ be _roundResult_.[[Milliseconds]].
+        1. If _unit_ is *"microseconds"*, then
+          1. Let _whole_ be _roundResult_.[[Microseconds]].
         1. Return _whole_ + _roundResult_.[[Remainder]].
       </emu-alg>
     </emu-clause>
@@ -1152,8 +1146,8 @@
             1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneYear_, _options_, %Temporal.Date% »).
             1. Set _oneYearDays_ to ? Call(_daysInYear_, _calendar_, « _relativeTo_ »).
           1. Let _fractionalYears_ be _years_ + _days_ / _oneYearDays_.
-          1. Set _remainder_ to _fractionalYears_ % 1.
           1. Set _years_ to ? RoundNumberToIncrement(_fractionalYears_, _increment_, _roundingMode_).
+          1. Set _remainder_ to _fractionalYears_ - _years_.
           1. Set _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"months"*, then
           1. Let _yearsMonths_ be ? CreateTemporalDuration(_years_, _months_, 0, 0, 0, 0, 0, 0, 0, 0).
@@ -1173,8 +1167,8 @@
             1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneMonth_, _options_, %Temporal.Date% »).
             1. Set _oneMonthDays_ to ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
           1. Let _fractionalMonths_ be _months_ + _days_ / _oneMonthDays_.
-          1. Set _remainder_ to _fractionalMonths_ % 1.
           1. Set _months_ to ? RoundNumberToIncrement(_fractionalMonths_, _increment_, _roundingMode_).
+          1. Set _remainder_ to _fractionalMonths_ - _months_.
           1. Set _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"weeks"*, then
           1. Let _oneWeek_ be ? CreateTemporalDuration(0, 0, 1, 0, 0, 0, 0, 0, 0, 0).
@@ -1188,35 +1182,36 @@
             1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneWeek_, _options_, %Temporal.Date% »).
             1. Set _oneWeekDays_ to ? Call(_daysInWeek_, _calendar_, « _relativeTo_ »).
           1. Let _fractionalWeeks_ be _weeks_ + _fractionalDays_ / _oneWeekDays_.
-          1. Set _remainder_ to _fractionalWeeks_ % 1.
           1. Set _weeks_ to ? RoundNumberToIncrement(_fractionalWeeks_, _increment_, _roundingMode_).
+          1. Set _remainder_ to _fractionalWeeks_ - _weeks_.
           1. Set _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"days"*, then
-          1. Set _remainder_ to _fractionalDays_ % 1.
           1. Set _days_ to ? RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
+          1. Set _remainder_ to _fractionalDays_ - _days_.
           1. Set _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"hours"*, then
           1. Let _fractionalHours_ be (_fractionalSeconds_ / 60 + _minutes_) / 60 + _hours_.
-          1. Set _remainder_ to _fractionalHours_ % 1.
           1. Set _hours_ to ? RoundNumberToIncrement(_fractionalHours_, _increment_, _roundingMode_).
+          1. Set _remainder_ to _fractionalHours_ - _hours_.
           1. Set _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"minutes"*, then
           1. Let _fractionalMinutes_ be _fractionalSeconds_ / 60 + _minutes_.
-          1. Set _remainder_ to _fractionalMinutes_ % 1.
           1. Set _minutes_ to ? RoundNumberToIncrement(_fractionalMinutes_, _increment_, _roundingMode_).
+          1. Set _remainder_ to _fractionalMinutes_ - _minutes_.
           1. Set _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"seconds"*, then
           1. Set _seconds_ to ? RoundNumberToIncrement(_fractionalSeconds_, _increment_, _roundingMode_).
+          1. Set _remainder_ to _fractionalSeconds_ - _seconds_.
           1. Set _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"milliseconds"*, then
           1. Let _fractionalMilliseconds_ be _nanoseconds_ × 10<sup>−6</sup> + _microseconds_ × 10<sup>−3</sup> + _milliseconds_.
-          1. Set _remainder_ to _fractionalMilliseconds_ % 1.
           1. Set _milliseconds_ to ? RoundNumberToIncrement(_fractionalMilliseconds_, _increment_, _roundingMode_).
+          1. Set _remainder_ to _fractionalMilliseconds_ - _milliseconds_.
           1. Set _microseconds_ and _nanoseconds_ to 0.
         1. Else if _unit_ is *"microseconds"*, then
           1. Let _fractionalMicroseconds_ be _nanoseconds_ × 10<sup>−3</sup> + _microseconds_.
-          1. Set _remainder_ to _fractionalMicroseconds_ % 1.
           1. Set _microseconds_ to ? RoundNumberToIncrement(_fractionalMicroseconds_, _increment_, _roundingMode_).
+          1. Set _remainder_ to _fractionalMicroseconds_ - _microseconds_.
           1. Set _nanoseconds_ to 0.
         1. Else,
           1. Assert: _unit_ is *"nanoseconds"*.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -417,6 +417,52 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.duration.prototype.total">
+      <h1>Temporal.Duration.prototype.total ( _options_ )</h1>
+      <p>
+        The `total` method takes one argument _options_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _duration_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
+        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_options_).
+        1. If _unit_ is not given, then
+          1. Throw a *RangeError* exception.
+        1. Else,
+          1. TODO: Let _revisedOptions_ be { smallestUnit: options.unit }.
+          1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_revisedOptions_, *undefined*).
+        1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_years_, _months_, _weeks_, _days_, _unit_, _relativeTo_).
+        1. If 'unit' is "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", then
+          1. Set _hours_ to _hours_ + _days_ * 24.
+          1. Set _days_ to 0.
+        1. If 'unit' is "hours", "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
+          1. Set _hours_ to _hours_ + _days_ * 24.
+          1. Set _days_ to 0.
+        1. If 'unit' is "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
+          1. Set _minutes_ to _minutes_ + _hours_ * 60.
+          1. Set _hours_ to 0.
+        1. If 'unit' is "seconds", "milliseconds", "microseconds", or "nanoseconds", then
+          1. Set _seconds_ to _seconds_ + _minutes_ * 60.
+          1. Set _minutes_ to 0.
+        1. If 'unit' is "milliseconds", "microseconds", or "nanoseconds", then
+          1. Set _milliseconds_ to _milliseconds_ + _seconds_ * 1000.
+          1. Set _seconds_ to 0.
+        1. If 'unit' is "microseconds" or "nanoseconds", then
+          1. Set _microseconds_ to _microseconds_ + _milliseconds_ * 1000.
+          1. Set _milliseconds_ to 0.
+        1. If 'unit' is "nanoseconds", then
+          1. Set _nanoseconds_ to _nanoseconds_ + _microseconds_ * 1000.
+          1. Return _nanoseconds_.
+        1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]],
+        _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _hours_, _minutes_, _seconds_, _milliseconds_,
+        _microseconds_, _nanoseconds_, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
+        1. Let _whole_ be ? Get(_roundResult_, _unit_).
+        1. Return _whole_ + _roundResult_.[[Remainder]].
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.duration.prototype.getfields">
       <h1>Temporal.Duration.prototype.getFields ( )</h1>
       <p>
@@ -1087,6 +1133,7 @@
             1. Let _options_ be ? ObjectCreate(%Object.prototype%).
         1. Let _fractionalSeconds_ be _nanoseconds_ × 10<sup>−9</sup> + _microseconds_ × 10<sup>−6</sup> + _milliseconds_ × 10<sup>−3</sup> + _seconds_.
         1. Let _fractionalDays_ be ((_fractionalSeconds_ / 60 + _minutes_) / 60 + _hours_) / 24 + _days_.
+        1. Let _remainder_ be *undefined*.
         1. If _unit_ is *"years"*, then
           1. Let _yearsDuration_ be ? CreateTemporalDuration(_years_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _yearsBefore_ be ? Call(_dateSubtract_, _calendar_, « _relativeTo_, _yearsDuration_, _options_, %Temporal.Date%).
@@ -1105,6 +1152,7 @@
             1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneYear_, _options_, %Temporal.Date% »).
             1. Set _oneYearDays_ to ? Call(_daysInYear_, _calendar_, « _relativeTo_ »).
           1. Let _fractionalYears_ be _years_ + _days_ / _oneYearDays_.
+          1. Set _remainder_ to _fractionalYears_ % 1.
           1. Set _years_ to ? RoundNumberToIncrement(_fractionalYears_, _increment_, _roundingMode_).
           1. Set _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"months"*, then
@@ -1125,6 +1173,7 @@
             1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneMonth_, _options_, %Temporal.Date% »).
             1. Set _oneMonthDays_ to ? Call(_daysInMonth_, _calendar_, « _relativeTo_ »).
           1. Let _fractionalMonths_ be _months_ + _days_ / _oneMonthDays_.
+          1. Set _remainder_ to _fractionalMonths_ % 1.
           1. Set _months_ to ? RoundNumberToIncrement(_fractionalMonths_, _increment_, _roundingMode_).
           1. Set _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"weeks"*, then
@@ -1139,17 +1188,21 @@
             1. Set _relativeTo_ to ? Call(_dateMinus_, _calendar_, « _relativeTo_, _oneWeek_, _options_, %Temporal.Date% »).
             1. Set _oneWeekDays_ to ? Call(_daysInWeek_, _calendar_, « _relativeTo_ »).
           1. Let _fractionalWeeks_ be _weeks_ + _fractionalDays_ / _oneWeekDays_.
+          1. Set _remainder_ to _fractionalWeeks_ % 1.
           1. Set _weeks_ to ? RoundNumberToIncrement(_fractionalWeeks_, _increment_, _roundingMode_).
           1. Set _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"days"*, then
+          1. Set _remainder_ to _fractionalDays_ % 1.
           1. Set _days_ to ? RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
           1. Set _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"hours"*, then
           1. Let _fractionalHours_ be (_fractionalSeconds_ / 60 + _minutes_) / 60 + _hours_.
+          1. Set _remainder_ to _fractionalHours_ % 1.
           1. Set _hours_ to ? RoundNumberToIncrement(_fractionalHours_, _increment_, _roundingMode_).
           1. Set _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"minutes"*, then
           1. Let _fractionalMinutes_ be _fractionalSeconds_ / 60 + _minutes_.
+          1. Set _remainder_ to _fractionalMinutes_ % 1.
           1. Set _minutes_ to ? RoundNumberToIncrement(_fractionalMinutes_, _increment_, _roundingMode_).
           1. Set _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"seconds"*, then
@@ -1157,14 +1210,17 @@
           1. Set _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"milliseconds"*, then
           1. Let _fractionalMilliseconds_ be _nanoseconds_ × 10<sup>−6</sup> + _microseconds_ × 10<sup>−3</sup> + _milliseconds_.
+          1. Set _remainder_ to _fractionalMilliseconds_ % 1.
           1. Set _milliseconds_ to ? RoundNumberToIncrement(_fractionalMilliseconds_, _increment_, _roundingMode_).
           1. Set _microseconds_ and _nanoseconds_ to 0.
         1. Else if _unit_ is *"microseconds"*, then
           1. Let _fractionalMicroseconds_ be _nanoseconds_ × 10<sup>−3</sup> + _microseconds_.
+          1. Set _remainder_ to _fractionalMicroseconds_ % 1.
           1. Set _microseconds_ to ? RoundNumberToIncrement(_fractionalMicroseconds_, _increment_, _roundingMode_).
           1. Set _nanoseconds_ to 0.
         1. Else,
           1. Assert: _unit_ is *"nanoseconds"*.
+          1. Set _remainder_ to 0.
           1. Set _nanoseconds_ to ? RoundNumberToIncrement(_nanoseconds_, _increment_, _roundingMode_).
         1. Return the new Record {
           [[Years]]: _years_,
@@ -1176,7 +1232,8 @@
           [[Seconds]]: _seconds_,
           [[Milliseconds]]: _milliseconds_,
           [[Microseconds]]: _microseconds_,
-          [[Nanoseconds]]: _nanoseconds_
+          [[Nanoseconds]]: _nanoseconds_,
+          [[Remainder]]: _remainder_
           }.
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -432,32 +432,32 @@
           1. Throw a *RangeError* exception.
         1. Else,
           1. TODO: Let _revisedOptions_ be { smallestUnit: options.unit }.
-          1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_revisedOptions_, *undefined*).
+          1. Let _unit_ be ? ToSmallestTemporalDurationUnit(_revisedOptions_, *undefined*).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_years_, _months_, _weeks_, _days_, _unit_, _relativeTo_).
-        1. If 'unit' is "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds", then
+        1. If _unit_ is "hours", "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
           1. Set _hours_ to _hours_ + _days_ * 24.
           1. Set _days_ to 0.
-        1. If 'unit' is "hours", "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
+        1. If _unit_ is "hours", "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
           1. Set _hours_ to _hours_ + _days_ * 24.
           1. Set _days_ to 0.
-        1. If 'unit' is "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
+        1. If _unit_ is "minutes", "seconds", "milliseconds", "microseconds", or "nanoseconds", then
           1. Set _minutes_ to _minutes_ + _hours_ * 60.
           1. Set _hours_ to 0.
-        1. If 'unit' is "seconds", "milliseconds", "microseconds", or "nanoseconds", then
+        1. If _unit_ is "seconds", "milliseconds", "microseconds", or "nanoseconds", then
           1. Set _seconds_ to _seconds_ + _minutes_ * 60.
           1. Set _minutes_ to 0.
-        1. If 'unit' is "milliseconds", "microseconds", or "nanoseconds", then
+        1. If _unit_ is "milliseconds", "microseconds", or "nanoseconds", then
           1. Set _milliseconds_ to _milliseconds_ + _seconds_ * 1000.
           1. Set _seconds_ to 0.
-        1. If 'unit' is "microseconds" or "nanoseconds", then
+        1. If _unit_ is "microseconds" or "nanoseconds", then
           1. Set _microseconds_ to _microseconds_ + _milliseconds_ * 1000.
           1. Set _milliseconds_ to 0.
-        1. If 'unit' is "nanoseconds", then
+        1. If _unit_ is "nanoseconds", then
           1. Set _nanoseconds_ to _nanoseconds_ + _microseconds_ * 1000.
           1. Return _nanoseconds_.
         1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]],
         _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _hours_, _minutes_, _seconds_, _milliseconds_,
-        _microseconds_, _nanoseconds_, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
+        _microseconds_, _nanoseconds_, _roundingIncrement_, _unit_, _roundingMode_, _relativeTo_).
         1. Let _whole_ be ? Get(_roundResult_, _unit_).
         1. Return _whole_ + _roundResult_.[[Remainder]].
       </emu-alg>


### PR DESCRIPTION
This PR fixes #584 by:
* Adding a new `total()` method on the Duration type
* Updating the `RoundDuration` abstract operation to return a remainder, which is used to calculate the fractional value returned by `total`. Other uses of `RoundDuration` will ignore the remainder.

BTW, this PR encountered problems with `RoundDuration` that I expect will be fixed by the fix to #1059. Therefore, a few of the tests in this PR are failing, but I expect them to pass after #1059's fix lands. See https://github.com/tc39/proposal-temporal/issues/1059#issuecomment-717448093 for more info on the failing tests. 

I'm very new to writing spec text so I assume I made a few mistakes in the spec. 

Questions / Open Issues: 
1. The changes to RoundDuration noted above are only one possible way to solve this problem. Would any of the alternatives below be better?
   * 1.1 Only return the remainder if an optional boolean parameter is `true`, thereby removing the need for any floating-point math in cases where rounding is being used outside of `total`.
   * 1.2 Add a boolean parameter, but if it's true then simply return a primitive floating-point value with the whole+fractional value. An advantage of doing this would be to remove some processing in cases where the resulting Duration object is not needed. I opted against this choice because I wasn't sure if it'd be weird if an abstract operation sometimes returned an object and sometimes returned a primitive. We'd never do this for a public-facing API, but I wasn't sure if it matters as much for AOs.  Also, I wasn't sure if there would be cases in the future where code would want *both* the fractional remainder *and* the Duration result. 

2. I re-used the `ToSmallestTemporalDurationUnit` and simply created a new `options` object: `{ smallestUnit: unit}`. This seems a little hacky. Is there a better way to do it?  Should this AO be renamed to  `ToTemporalDurationRoundingUnit` and accept a parameter to determine whether the name of the option is `smallestUnit` or `unit`?  And if so, should the parameter be a boolean or the string name of the unit?  Alternatively, if the current approach is correct, then how should "created a new `options` object: `{ smallestUnit: unit}`"  be expressed in spec text?  I put in a placeholder with a TODO. 

3. `UnbalanceDurationRelative` only goes down to days. If the unit is smaller, then I needed to convert days down to that unit before rounding the result. Is there already an abstract operation that does this that could be used instead of one-off code in this PR?