### PR TITLE
Pass calendars when constructing objects.

### DIFF
--- a/spec/date.html
+++ b/spec/date.html
@@ -513,11 +513,12 @@
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. If _temporalTime_ is *undefined*, then
-          1. Return ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], 0, 0, 0, 0, 0, 0).
+          1. Return ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], 0, 0, 0, 0, 0, 0, _temporalDate_.[[Calendar]]).
         1. Set _temporalTime_ to ? ToTemporalTime(_temporalTime_).
         1. Return ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]],
           _temporalTime_.[[Hour]], _temporalTime_.[[Minute]], _temporalTime_.[[Second]],
-          _temporalTime_.[[Millisecond]], _temporalTime_.[[Microsecond]], _temporalTime_.[[Nanosecond]]).
+          _temporalTime_.[[Millisecond]], _temporalTime_.[[Microsecond]], _temporalTime_.[[Nanosecond]],
+          _temporalDate_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -660,12 +661,12 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporaldatefrominstance" aoid="CreateTemporalDateFromInstance">
-      <h1>CreateTemporalDateFromInstance ( _temporalDate_, _isoYear_, _isoMonth_, _isoDay_ )</h1>
+      <h1>CreateTemporalDateFromInstance ( _temporalDate_, _isoYear_, _isoMonth_, _isoDay_, _calendar_ )</h1>
       <emu-alg>
         1. Assert: Type(_temporalDate_) is Object and _temporalDate_ has an [[InitializedTemporalDate]] internal slot.
         1. Assert: ! ValidateDate(_isoYear_, _isoMonth_, _isoDay_) is *true*.
         1. Let _constructor_ be ? SpeciesConstructor(_temporalDate_, %Temporal.Date%).
-        1. Let _result_ be ? Construct(_constructor_, « _isoYear_, _isoMonth_, _isoDay_ »).
+        1. Let _result_ be ? Construct(_constructor_, « _isoYear_, _isoMonth_, _isoDay_, _calendar_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalDate]]).
         1. Return _result_.
       </emu-alg>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -450,7 +450,7 @@
         1. Let _datePart_ be ? BalanceDate(_datePart_.[[Year]], _datePart_.[[Month]], _datePart_.[[Day]] + _timePart_.[[Day]]).
         1. Let _result_ be ? RegulateDateTime(_datePart_.[[Year]], _datePart_.[[Month]], _datePart_.[[Day]], _timePart_.[[Hour]], _timePart_.[[Minute]], _timePart_.[[Second]], _timePart_.[[Millisecond]], _timePart_.[[Microsecond]], _timePart_.[[Nanosecond]], _overflow_).
         1. Assert: ! ValidateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
-        1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+        1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -471,7 +471,7 @@
         1. Let _datePart_ be ? SubtractDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]] - _timePart_.[[Day]], _overflow_).
         1. Let _result_ be ? RegulateDateTime(_datePart_.[[Year]], _datePart_.[[Month]], _datePart_.[[Day]], _timePart_.[[Hour]], _timePart_.[[Minute]], _timePart_.[[Second]], _timePart_.[[Millisecond]], _timePart_.[[Microsecond]], _timePart_.[[Nanosecond]], _overflow_).
         1. Assert: ! ValidateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
-        1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+        1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -564,7 +564,7 @@
           1. Let _maximum_ be 1000.
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _result_ be ? RoundDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+        1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -670,7 +670,7 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]]).
+        1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -1038,7 +1038,7 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporaldatetime" aoid="CreateTemporalDateTime">
-      <h1>CreateTemporalDateTime ( _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ [ , _newTarget_ ] )</h1>
+      <h1>CreateTemporalDateTime ( _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ [ , _newTarget_ ] )</h1>
       <emu-alg>
         1. If ! ValidateDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *false*, then
           1. Throw a *RangeError* exception.
@@ -1055,30 +1055,30 @@
         1. Set _object_.[[Millisecond]] to _millisecond_.
         1. Set _object_.[[Microsecond]] to _microsecond_.
         1. Set _object_.[[Nanosecond]] to _nanosecond_.
-        1. <mark>TODO: Set it to the correct calendar.</mark> Set _object_.[[Calendar]] to ! GetISO8601Calendar().
+        1. Set _object_.[[Calendar]] to _calendar_.
         1. Return _object_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporaldatetimefrominstance" aoid="CreateTemporalDateTimeFromInstance">
-      <h1>CreateTemporalDateTimeFromInstance ( _dateTime_, _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
+      <h1>CreateTemporalDateTimeFromInstance ( _dateTime_, _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ )</h1>
       <emu-alg>
         1. Assert: Type(_dateTime_) is Object and _dateTime_ has an [[InitializedTemporalDateTime]] internal slot.
         1. Assert: ! ValidateDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
         1. Let _constructor_ be ? SpeciesConstructor(_dateTime_, %Temporal.DateTime%).
-        1. Let _result_ be ? Construct(_constructor_, « _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ »).
+        1. Let _result_ be ? Construct(_constructor_, « _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalDateTime]]).
         1. Return _result_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporaldatetimefromstatic" aoid="CreateTemporalDateTimeFromStatic">
-      <h1>CreateTemporalDateTimeFromStatic ( _constructor_, _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
+      <h1>CreateTemporalDateTimeFromStatic ( _constructor_, _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ )</h1>
       <emu-alg>
         1. Assert: ! ValidateDateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
         1. If ! IsConstructor(_constructor_) is *false*, then
           1. Throw a *TypeError* exception.
-        1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ »).
+        1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalDateTime]]).
         1. Return _result_.
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -613,7 +613,8 @@
       <emu-alg>
         1. Assert: Type(_isoString_) is String.
         1. Let _result_ be ? ParseTemporalInstantString(_isoString_).
-        1. Let _dateTime_ be ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[microsecond]], _result_.[[Nanosecond]]).
+        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Let _dateTime_ be ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[microsecond]], _result_.[[Nanosecond]], _calendar_).
         1. Let _timeZone_ be ? TimeZoneFrom(_result_.[[TimeZoneName]]).
         1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
         1. If _possibleInstants_'s length is 1, then

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -124,7 +124,7 @@
       </p>
       <emu-alg>
         1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
-        1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]]).
+        1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -136,7 +136,7 @@
       </p>
       <emu-alg>
         1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_).
-        1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]]).
+        1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/time.html
+++ b/spec/time.html
@@ -392,7 +392,8 @@
         1. Set _temporalDate_ to ? ToTemporalDate(_temporalDate_).
         1. Return ? CreateTemporalDateTime(_temporalDate_.[[Year]], _temporalDate_.[[Month]], _temporalDate_.[[Day]],
           _temporalTime_.[[Hour]], _temporalTime_.[[Minute]], _temporalTime_.[[Second]],
-          _temporalTime_.[[Millisecond]], _temporalTime_.[[Microsecond]], _temporalTime_.[[Nanosecond]]).
+          _temporalTime_.[[Millisecond]], _temporalTime_.[[Microsecond]], _temporalTime_.[[Nanosecond]],
+          _temporalDate_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -192,8 +192,7 @@
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
         1. <mark>TODO:</mark> Let _result_ be the moment _instant_.[[Nanosecond]] nanoseconds from the epoch, in the UTC time zone.
         1. Set _result_ to ? BalanceDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).
-        1. <mark>TODO:</mark> pass _calendar_ along.
-        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
       </emu-alg>
       <p>
         This function is the <dfn>%Temporal.TimeZone.prototype.getDateTimeFor%</dfn> intrinsic object.

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -74,7 +74,7 @@
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If Type(_item_) is Object and _item_ has an [[InitializedTemporalYearMonth]] internal slot, then
-          1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[Calendar]]).
+          1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[Calendar]], _item_.[[ISODay]]).
         1. Return ? ToTemporalYearMonth(_item_, _constructor_, _overflow_).
       </emu-alg>
     </emu-clause>
@@ -550,7 +550,7 @@
         1. If _calendar_ is *undefined*, set _calendar_ to ! GetISO8601Calendar().
         1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
         1. Set _result_ to ? RegulateYearMonth(_result_.[[Year]], _result_.[[Month]], _overflow_).
-        1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _referenceISODay_, _calendar_).
+        1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _calendar_, _referenceISODay_).
       </emu-alg>
     </emu-clause>
 
@@ -660,24 +660,24 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporalyearmonthfrominstance" aoid="CreateTemporalYearMonthFromInstance">
-      <h1>CreateTemporalYearMonthFromInstance ( _yearMonth_, _isoYear_, _isoMonth_ )</h1>
+      <h1>CreateTemporalYearMonthFromInstance ( _yearMonth_, _isoYear_, _isoMonth_, _calendar_, _refISODay_ )</h1>
       <emu-alg>
         1. Assert: Type(_yearMonth_) is Object and _yearMonth_ has an [[InitializedTemporalYearMonth]] internal slot.
         1. Assert: ! ValidateYearMonth(_isoYear_, _isoMonth_) is *true*.
         1. Let _constructor_ be ? SpeciesConstructor(_yearMonth_, %Temporal.YearMonth%).
-        1. Let _result_ be ? Construct(_constructor_, « _isoYear_, _isoMonth_ »).
+        1. Let _result_ be ? Construct(_constructor_, « _isoYear_, _isoMonth_, _calendar_, _refISODay_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalYearMonth]]).
         1. Return _result_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporalyearmonthfromstatic" aoid="CreateTemporalYearMonthFromStatic">
-      <h1>CreateTemporalYearMonthFromStatic ( _constructor_, _year_, _month_, _referenceISODay_ )</h1>
+      <h1>CreateTemporalYearMonthFromStatic ( _constructor_, _year_, _month_, _calendar_, _referenceISODay_ )</h1>
       <emu-alg>
         1. Assert: ! ValidateDate(_year_, _month_, _referenceISODay_) is *true*.
         1. If ! IsConstructor(_constructor_) is *false*, then
           1. Throw a *TypeError* exception.
-        1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _referenceISODay_ »).
+        1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _calendar_, _refISODay_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalYearMonth]]).
         1. Return _result_.
       </emu-alg>


### PR DESCRIPTION
This ignores the cases that need to go through the calendar anyway (dateFromFields, etc.).