### PR TITLE
Initial implementation of ZonedDateTime

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -282,7 +282,7 @@ date.toString()  // => 2020-06-28[c=islamic]
 
 **Returns:** a `Temporal.Duration` representing the time elapsed after `one` and until `two`.
 
-If either of `smaller` or `larger` are not `Temporal.Date` objects, then they will be converted to one as if they were passed to `Temporal.Date.from()`.
+If either of `one` or `two` are not `Temporal.Date` objects, then they will be converted to one as if they were passed to `Temporal.Date.from()`.
 
 This method does not need to be called directly except in specialized code.
 It is called indirectly when using the `until()` and `since()` methods of `Temporal.DateTime`, `Temporal.Date`, and `Temporal.YearMonth`.

--- a/docs/time.md
+++ b/docs/time.md
@@ -536,7 +536,7 @@ This method overrides `Object.prototype.valueOf()` and always throws an exceptio
 This is because it's not possible to compare `Temporal.Time` objects with the relational operators `<`, `<=`, `>`, or `>=`.
 Use `Temporal.Time.compare()` for this, or `time.equals()` for equality.
 
-### time.**toZonedDateTime**(_timeZone_?: Temporal.TimeZone | object | string, _date_: Temporal.Date | object | string) : Temporal.ZonedDateTime
+### time.**toZonedDateTime**(_timeZone_?: Temporal.TimeZone | object | string, _date_: Temporal.Date | object | string, _options_?: object) : Temporal.ZonedDateTime
 
 **Parameters:**
 

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -649,7 +649,7 @@ export namespace Temporal {
         | /** @deprecated */ 'day'
       >
     ): Temporal.Duration;
-    toDateTime(temporalTime: Temporal.Time | TimeLike | string): Temporal.DateTime;
+    toDateTime(temporalTime?: Temporal.Time | TimeLike | string): Temporal.DateTime;
     toYearMonth(): Temporal.YearMonth;
     toMonthDay(): Temporal.MonthDay;
     getFields(): DateFields;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -70,6 +70,46 @@ export namespace Temporal {
     disambiguation: 'compatible' | 'earlier' | 'later' | 'reject';
   };
 
+  type OffsetDisambiguationOptions = {
+    /**
+     * Time zone definitions can change. If an application stores data about
+     * events in the future, then stored data about future events may become
+     * ambiguous, for example if a country permanently abolishes DST. The
+     * `offset` option controls this unusual case.
+     *
+     * - `'use'` always uses the offset (if it's provided) to calculate the
+     *   instant. This ensures that the result will match the instant that was
+     *   originally stored, even if local clock time is different.
+     * - `'prefer'` uses the offset if it's valid for the date/time in this time
+     *   zone, but if it's not valid then the time zone will be used as a
+     *   fallback to calculate the instant.
+     * - `'ignore'` will disregard any provided offset. Instead, the time zone
+     *    and date/time value are used to calculate the instant. This will keep
+     *    local clock time unchanged but may result in a different real-world
+     *    instant.
+     * - `'reject'` acts like `'prefer'`, except it will throw a RangeError if
+     *   the offset is not valid for the given time zone identifier and
+     *   date/time value.
+     *
+     * If the ISO string ends in 'Z' then this option is ignored because there
+     * is no possibility of ambiguity.
+     *
+     * If a time zone offset is not present in the input, then this option is
+     * ignored because the time zone will always be used to calculate the
+     * offset.
+     *
+     * If the offset is not used, and if the date/time and time zone don't
+     * uniquely identify a single instant, then the `disambiguation` option will
+     * be used to choose the correct instant. However, if the offset is used
+     * then the `disambiguation` option will be ignored.
+     */
+    offset: 'use' | 'prefer' | 'ignore' | 'reject';
+  };
+
+  export type ZonedDateTimeAssignmentOptions = Partial<
+    AssignmentOptions & ToInstantOptions & OffsetDisambiguationOptions
+  >;
+
   /**
    * Options for arithmetic operations like `add()` and `subtract()`
    * */
@@ -441,6 +481,8 @@ export namespace Temporal {
     ): Temporal.Instant;
     toDateTime(tzLike: TimeZoneProtocol | string, calendar: CalendarProtocol | string): Temporal.DateTime;
     toDateTimeISO(tzLike: TimeZoneProtocol | string): Temporal.DateTime;
+    toZonedDateTime(tzLike: TimeZoneProtocol | string, calendar: CalendarProtocol | string): Temporal.ZonedDateTime;
+    toZonedDateTimeISO(tzLike: TimeZoneProtocol | string): Temporal.ZonedDateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(tzLike?: TimeZoneProtocol | string, options?: ToStringOptions): string;
@@ -650,6 +692,11 @@ export namespace Temporal {
       >
     ): Temporal.Duration;
     toDateTime(temporalTime?: Temporal.Time | TimeLike | string): Temporal.DateTime;
+    toZonedDateTime(
+      timeZone: TimeZoneProtocol | string,
+      temporalTime?: Temporal.Time | TimeLike | string,
+      options?: ToInstantOptions
+    ): Temporal.ZonedDateTime;
     toYearMonth(): Temporal.YearMonth;
     toMonthDay(): Temporal.MonthDay;
     getFields(): DateFields;
@@ -817,6 +864,7 @@ export namespace Temporal {
       >
     ): Temporal.DateTime;
     toInstant(tzLike: TimeZoneProtocol | string, options?: ToInstantOptions): Temporal.Instant;
+    toZonedDateTime(tzLike: TimeZoneProtocol | string, options?: ToInstantOptions): Temporal.ZonedDateTime;
     toDate(): Temporal.Date;
     toYearMonth(): Temporal.YearMonth;
     toMonthDay(): Temporal.MonthDay;
@@ -976,6 +1024,11 @@ export namespace Temporal {
       >
     ): Temporal.Time;
     toDateTime(temporalDate: Temporal.Date | DateLike | string): Temporal.DateTime;
+    toZonedDateTime(
+      timeZoneLike: TimeZoneProtocol | string,
+      temporalDate: Temporal.Date | DateLike | string,
+      options?: ToInstantOptions
+    ): Temporal.ZonedDateTime;
     getFields(): TimeFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
@@ -1076,6 +1129,180 @@ export namespace Temporal {
     toDateOnDay(day: number): Temporal.Date;
     getFields(): YearMonthFields;
     getISOFields(): DateISOFields;
+    toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
+    toJSON(): string;
+    toString(): string;
+    valueOf(): never;
+  }
+
+  export type ZonedDateTimeLike = {
+    year?: number;
+    month?: number;
+    day?: number;
+    hour?: number;
+    minute?: number;
+    second?: number;
+    millisecond?: number;
+    microsecond?: number;
+    nanosecond?: number;
+    offset?: string;
+    timeZone?: TimeZoneProtocol | string;
+    calendar?: CalendarProtocol | string;
+  };
+
+  type ZonedDateTimeFields = {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+    millisecond: number;
+    microsecond: number;
+    nanosecond: number;
+    offset: string;
+    timeZone: TimeZoneProtocol;
+    calendar: CalendarProtocol;
+  };
+
+  type ZonedDateTimeISOFields = {
+    isoYear: number;
+    isoMonth: number;
+    isoDay: number;
+    hour: number;
+    minute: number;
+    second: number;
+    millisecond: number;
+    microsecond: number;
+    nanosecond: number;
+    offsetNanoseconds: number;
+    timeZone: TimeZoneProtocol;
+    calendar: CalendarProtocol;
+  };
+
+  export class ZonedDateTime {
+    static from(
+      item: Temporal.ZonedDateTime | ZonedDateTimeLike | string,
+      options?: ZonedDateTimeAssignmentOptions
+    ): ZonedDateTime;
+    static compare(
+      one: Temporal.ZonedDateTime | ZonedDateTimeLike | string,
+      two: Temporal.ZonedDateTime | ZonedDateTimeLike | string
+    ): ComparisonResult;
+    constructor(epochNanoseconds: bigint, timeZone: TimeZoneProtocol | string, calendar?: CalendarProtocol | string);
+    readonly year: number;
+    readonly month: number;
+    readonly day: number;
+    readonly hour: number;
+    readonly minute: number;
+    readonly second: number;
+    readonly millisecond: number;
+    readonly microsecond: number;
+    readonly nanosecond: number;
+    readonly timeZone: TimeZoneProtocol;
+    readonly calendar: CalendarProtocol;
+    readonly dayOfWeek: number;
+    readonly dayOfYear: number;
+    readonly weekOfYear: number;
+    readonly hoursInDay: number;
+    readonly daysInWeek: number;
+    readonly daysInMonth: number;
+    readonly daysInYear: number;
+    readonly monthsInYear: number;
+    readonly inLeapYear: boolean;
+    readonly startOfDay: Temporal.ZonedDateTime;
+    readonly offsetNanoseconds: number;
+    readonly offset: string;
+    readonly epochSeconds: number;
+    readonly epochMilliseconds: number;
+    readonly epochMicroseconds: bigint;
+    readonly epochNanoseconds: bigint;
+    equals(other: Temporal.ZonedDateTime | ZonedDateTimeLike | string): boolean;
+    with(
+      zonedDateTimeLike: ZonedDateTimeLike | string,
+      options?: ZonedDateTimeAssignmentOptions
+    ): Temporal.ZonedDateTime;
+    withCalendar(calendar: CalendarProtocol | string): Temporal.ZonedDateTime;
+    withTimeZone(timeZone: TimeZoneProtocol | string): Temporal.ZonedDateTime;
+    add(durationLike: Temporal.Duration | DurationLike | string, options?: ArithmeticOptions): Temporal.ZonedDateTime;
+    subtract(
+      durationLike: Temporal.Duration | DurationLike | string,
+      options?: ArithmeticOptions
+    ): Temporal.ZonedDateTime;
+    until(
+      other: Temporal.ZonedDateTime | ZonedDateTimeLike | string,
+      options?: Temporal.DifferenceOptions<
+        | 'years'
+        | 'months'
+        | 'weeks'
+        | 'days'
+        | 'hours'
+        | 'minutes'
+        | 'seconds'
+        | 'milliseconds'
+        | 'microseconds'
+        | 'nanoseconds'
+        | /** @deprecated */ 'year'
+        | /** @deprecated */ 'month'
+        | /** @deprecated */ 'day'
+        | /** @deprecated */ 'hour'
+        | /** @deprecated */ 'minute'
+        | /** @deprecated */ 'second'
+        | /** @deprecated */ 'millisecond'
+        | /** @deprecated */ 'microsecond'
+        | /** @deprecated */ 'nanosecond'
+      >
+    ): Temporal.Duration;
+    since(
+      other: Temporal.ZonedDateTime | ZonedDateTimeLike | string,
+      options?: Temporal.DifferenceOptions<
+        | 'years'
+        | 'months'
+        | 'weeks'
+        | 'days'
+        | 'hours'
+        | 'minutes'
+        | 'seconds'
+        | 'milliseconds'
+        | 'microseconds'
+        | 'nanoseconds'
+        | /** @deprecated */ 'year'
+        | /** @deprecated */ 'month'
+        | /** @deprecated */ 'day'
+        | /** @deprecated */ 'hour'
+        | /** @deprecated */ 'minute'
+        | /** @deprecated */ 'second'
+        | /** @deprecated */ 'millisecond'
+        | /** @deprecated */ 'microsecond'
+        | /** @deprecated */ 'nanosecond'
+      >
+    ): Temporal.Duration;
+    round(
+      options: Temporal.RoundOptions<
+        | 'day'
+        | 'hour'
+        | 'minute'
+        | 'second'
+        | 'millisecond'
+        | 'microsecond'
+        | 'nanosecond'
+        | /** @deprecated */ 'days'
+        | /** @deprecated */ 'hours'
+        | /** @deprecated */ 'minutes'
+        | /** @deprecated */ 'seconds'
+        | /** @deprecated */ 'milliseconds'
+        | /** @deprecated */ 'microseconds'
+        | /** @deprecated */ 'nanoseconds'
+      >
+    ): Temporal.ZonedDateTime;
+    toInstant(): Temporal.Instant;
+    toDateTime(): Temporal.DateTime;
+    toDate(): Temporal.Date;
+    toYearMonth(): Temporal.YearMonth;
+    toMonthDay(): Temporal.MonthDay;
+    toTime(): Temporal.Time;
+    getFields(): ZonedDateTimeFields;
+    getISOFields(): ZonedDateTimeISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(): string;

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -16,6 +16,7 @@ import {
   NANOSECOND,
   DATE_BRAND,
   CALENDAR,
+  EPOCHNANOSECONDS,
   CreateSlots,
   GetSlot,
   SetSlot
@@ -322,6 +323,39 @@ export class Date {
     const microsecond = GetSlot(temporalTime, MICROSECOND);
     const nanosecond = GetSlot(temporalTime, NANOSECOND);
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+  }
+  toZonedDateTime(timeZoneLike, temporalTime = undefined, options = undefined) {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    const timeZone = ES.ToTemporalTimeZone(timeZoneLike);
+    options = ES.NormalizeOptionsObject(options);
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+
+    const year = GetSlot(this, ISO_YEAR);
+    const month = GetSlot(this, ISO_MONTH);
+    const day = GetSlot(this, ISO_DAY);
+    const calendar = GetSlot(this, CALENDAR);
+    const DateTime = GetIntrinsic('%Temporal.DateTime%');
+
+    let hour = 0,
+      minute = 0,
+      second = 0,
+      millisecond = 0,
+      microsecond = 0,
+      nanosecond = 0;
+    if (temporalTime !== undefined) {
+      temporalTime = ES.ToTemporalTime(temporalTime, GetIntrinsic('%Temporal.Time%'));
+      hour = GetSlot(temporalTime, HOUR);
+      minute = GetSlot(temporalTime, MINUTE);
+      second = GetSlot(temporalTime, SECOND);
+      millisecond = GetSlot(temporalTime, MILLISECOND);
+      microsecond = GetSlot(temporalTime, MICROSECOND);
+      nanosecond = GetSlot(temporalTime, NANOSECOND);
+    }
+
+    const dt = new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+    const instant = ES.GetTemporalInstantFor(timeZone, dt, disambiguation);
+    const ZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
+    return new ZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
   toYearMonth() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -260,8 +260,7 @@ export class DateTime {
   }
   withCalendar(calendar) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
-    calendar = TemporalCalendar.from(calendar);
+    calendar = ES.ToTemporalCalendar(calendar);
     const Construct = ES.SpeciesConstructor(this, DateTime);
     const result = new Construct(
       GetSlot(this, ISO_YEAR),

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -16,6 +16,7 @@ import {
   MICROSECOND,
   NANOSECOND,
   CALENDAR,
+  EPOCHNANOSECONDS,
   CreateSlots,
   GetSlot,
   SetSlot
@@ -719,6 +720,15 @@ export class DateTime {
     options = ES.NormalizeOptionsObject(options);
     const disambiguation = ES.ToTemporalDisambiguation(options);
     return ES.GetTemporalInstantFor(timeZone, this, disambiguation);
+  }
+  toZonedDateTime(temporalTimeZoneLike, options = undefined) {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+    options = ES.NormalizeOptionsObject(options);
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    const instant = ES.GetTemporalInstantFor(timeZone, this, disambiguation);
+    const ZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
+    return new ZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, GetSlot(this, CALENDAR));
   }
   toDate() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -41,6 +41,7 @@ import {
   DATE_BRAND,
   YEAR_MONTH_BRAND,
   MONTH_DAY_BRAND,
+  TIME_ZONE,
   CALENDAR,
   YEARS,
   MONTHS,
@@ -96,7 +97,7 @@ const ES2020 = {
 };
 
 export const ES = ObjectAssign({}, ES2020, {
-  IsTemporalInstant: (item) => HasSlot(item, EPOCHNANOSECONDS),
+  IsTemporalInstant: (item) => HasSlot(item, EPOCHNANOSECONDS) && !HasSlot(item, TIME_ZONE, CALENDAR),
   IsTemporalTimeZone: (item) => HasSlot(item, TIMEZONE_ID),
   IsTemporalCalendar: (item) => HasSlot(item, CALENDAR_ID),
   IsTemporalDuration: (item) =>
@@ -109,6 +110,7 @@ export const ES = ObjectAssign({}, ES2020, {
     HasSlot(item, ISO_YEAR, ISO_MONTH, ISO_DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND),
   IsTemporalYearMonth: (item) => HasSlot(item, YEAR_MONTH_BRAND),
   IsTemporalMonthDay: (item) => HasSlot(item, MONTH_DAY_BRAND),
+  IsTemporalZonedDateTime: (item) => HasSlot(item, EPOCHNANOSECONDS, TIME_ZONE, CALENDAR),
   TemporalTimeZoneFromString: (stringIdent) => {
     const { ianaName, offset } = ES.ParseTemporalTimeZoneString(stringIdent);
     const result = ES.GetCanonicalTimeZoneIdentifier(ianaName || offset);
@@ -185,6 +187,9 @@ export const ES = ObjectAssign({}, ES2020, {
     };
   },
   ParseTemporalInstantString: (isoString) => {
+    return ES.ParseISODateTime(isoString, { zoneRequired: true });
+  },
+  ParseTemporalZonedDateTimeString: (isoString) => {
     return ES.ParseISODateTime(isoString, { zoneRequired: true });
   },
   ParseTemporalDateTimeString: (isoString) => {
@@ -517,6 +522,9 @@ export const ES = ObjectAssign({}, ES2020, {
       default:
         return roundingMode;
     }
+  },
+  ToTemporalOffset: (options, fallback) => {
+    return ES.GetOption(options, 'offset', ['prefer', 'use', 'ignore', 'reject'], fallback);
   },
   ToTemporalRoundingIncrement: (options, dividend, inclusive) => {
     let maximum = Infinity;
@@ -1044,6 +1052,61 @@ export const ES = ObjectAssign({}, ES2020, {
     if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
     return result;
   },
+  ToTemporalZonedDateTime: (
+    item,
+    constructor,
+    overflow = 'constrain',
+    disambiguation = 'compatible',
+    offsetOpt = 'reject'
+  ) => {
+    let year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, timeZone, offset, calendar;
+    if (ES.Type(item) === 'Object') {
+      if (ES.IsTemporalZonedDateTime(item)) return item;
+      calendar = item.calendar;
+      if (calendar === undefined) calendar = new (GetIntrinsic('%Temporal.ISO8601Calendar%'))();
+      calendar = ES.ToTemporalCalendar(calendar);
+      timeZone = ES.ToTemporalTimeZone(item.timeZone);
+      offset = item.offset;
+      if (offset !== undefined) offset = ES.ToString(offset);
+      const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'year']);
+      ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.ToTemporalDateTimeFields(
+        item,
+        fieldNames
+      ));
+    } else {
+      let ianaName;
+      ({
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        millisecond,
+        microsecond,
+        nanosecond,
+        ianaName,
+        offset,
+        calendar
+      } = ES.ParseTemporalZonedDateTimeString(ES.ToString(item)));
+      if (!ianaName) throw new RangeError('named time zone required');
+      timeZone = ES.TimeZoneFrom(ianaName);
+      if (!calendar) calendar = new (GetIntrinsic('%Temporal.ISO8601Calendar%'))();
+      calendar = ES.ToTemporalCalendar(calendar);
+    }
+    const DateTime = GetIntrinsic('%Temporal.DateTime%');
+    const dt = new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+
+    const instant = ES.GetTemporalInstantFor(timeZone, dt, disambiguation);
+    void overflow;
+    void offset;
+    void offsetOpt;
+    // TODO: implement overflow and offset options
+
+    const result = new constructor(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
+    if (!ES.IsTemporalZonedDateTime(result)) throw new TypeError('invalid result');
+    return result;
+  },
 
   CalendarFrom: (calendarLike) => {
     const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
@@ -1100,6 +1163,16 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     const identifier = ES.ToString(temporalTimeZoneLike);
     return ES.TimeZoneFrom(identifier);
+  },
+  TimeZoneCompare: (one, two) => {
+    const tz1 = ES.TimeZoneToString(one);
+    const tz2 = ES.TimeZoneToString(two);
+    return tz1 < tz2 ? -1 : tz1 > tz2 ? 1 : 0;
+  },
+  TimeZoneEquals: (one, two) => {
+    const tz1 = ES.TimeZoneToString(one);
+    const tz2 = ES.TimeZoneToString(two);
+    return tz1 === tz2;
   },
   TemporalDateTimeToDate: (dateTime) => {
     const Date = GetIntrinsic('%Temporal.Date%');

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -252,6 +252,20 @@ export class Instant {
     const calendar = GetISO8601Calendar();
     return ES.GetTemporalDateTimeFor(timeZone, this, calendar);
   }
+  toZonedDateTime(temporalTimeZoneLike, calendarLike) {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+    const calendar = ES.ToTemporalCalendar(calendarLike);
+    const TemporalZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
+    return new TemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, calendar);
+  }
+  toZonedDateTimeISO(temporalTimeZoneLike) {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+    const calendar = GetISO8601Calendar();
+    const TemporalZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
+    return new TemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, calendar);
+  }
 
   static fromEpochSeconds(epochSeconds) {
     epochSeconds = ES.ToNumber(epochSeconds);

--- a/polyfill/lib/slots.mjs
+++ b/polyfill/lib/slots.mjs
@@ -20,6 +20,10 @@ export const DATE_BRAND = 'slot-date-brand';
 export const YEAR_MONTH_BRAND = 'slot-year-month-brand';
 export const MONTH_DAY_BRAND = 'slot-month-day-brand';
 
+// ZonedDateTime
+export const INSTANT = 'slot-cached-instant';
+export const TIME_ZONE = 'slot-time-zone';
+
 // Duration
 export const YEARS = 'slot-years';
 export const MONTHS = 'slot-months';

--- a/polyfill/lib/temporal.mjs
+++ b/polyfill/lib/temporal.mjs
@@ -8,3 +8,4 @@ export { now } from './now.mjs';
 export { Time } from './time.mjs';
 export { TimeZone } from './timezone.mjs';
 export { YearMonth } from './yearmonth.mjs';
+export { ZonedDateTime } from './zoneddatetime.mjs';

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -15,6 +15,7 @@ import {
   MICROSECOND,
   NANOSECOND,
   CALENDAR,
+  EPOCHNANOSECONDS,
   CreateSlots,
   GetSlot,
   SetSlot
@@ -483,6 +484,30 @@ export class Time {
     const calendar = GetSlot(temporalDate, CALENDAR);
     const DateTime = GetIntrinsic('%Temporal.DateTime%');
     return new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+  }
+  toZonedDateTime(timeZoneLike, temporalDate, options = undefined) {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    const timeZone = ES.ToTemporalTimeZone(timeZoneLike);
+    temporalDate = ES.ToTemporalDate(temporalDate, GetIntrinsic('%Temporal.Date%'));
+    options = ES.NormalizeOptionsObject(options);
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+
+    const year = GetSlot(temporalDate, ISO_YEAR);
+    const month = GetSlot(temporalDate, ISO_MONTH);
+    const day = GetSlot(temporalDate, ISO_DAY);
+    const calendar = GetSlot(temporalDate, CALENDAR);
+    const hour = GetSlot(this, HOUR);
+    const minute = GetSlot(this, MINUTE);
+    const second = GetSlot(this, SECOND);
+    const millisecond = GetSlot(this, MILLISECOND);
+    const microsecond = GetSlot(this, MICROSECOND);
+    const nanosecond = GetSlot(this, NANOSECOND);
+    const DateTime = GetIntrinsic('%Temporal.DateTime%');
+
+    const dt = new DateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+    const instant = ES.GetTemporalInstantFor(timeZone, dt, disambiguation);
+    const ZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
+    return new ZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
   getFields() {
     const fields = ES.ToTemporalTimeRecord(this);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -1,0 +1,460 @@
+/* global __debug__ */
+
+import { GetISO8601Calendar } from './calendar.mjs';
+import { ES } from './ecmascript.mjs';
+import { DateTimeFormat } from './intl.mjs';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
+import {
+  CALENDAR,
+  EPOCHNANOSECONDS,
+  HOUR,
+  INSTANT,
+  ISO_DAY,
+  ISO_MONTH,
+  ISO_YEAR,
+  MICROSECOND,
+  MILLISECOND,
+  MINUTE,
+  NANOSECOND,
+  SECOND,
+  TIME_ZONE,
+  CreateSlots,
+  GetSlot,
+  SetSlot
+} from './slots.mjs';
+
+import bigInt from 'big-integer';
+
+export class ZonedDateTime {
+  constructor(epochNanoseconds, timeZone, calendar = GetISO8601Calendar()) {
+    epochNanoseconds = ES.ToBigInt(epochNanoseconds);
+    timeZone = ES.ToTemporalTimeZone(timeZone);
+    calendar = ES.ToTemporalCalendar(calendar);
+
+    ES.RejectInstantRange(epochNanoseconds);
+
+    CreateSlots(this);
+    SetSlot(this, EPOCHNANOSECONDS, epochNanoseconds);
+    SetSlot(this, TIME_ZONE, timeZone);
+    SetSlot(this, CALENDAR, calendar);
+
+    const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+    const instant = new TemporalInstant(GetSlot(this, EPOCHNANOSECONDS));
+    SetSlot(this, INSTANT, instant);
+
+    if (typeof __debug__ !== 'undefined' && __debug__) {
+      Object.defineProperty(this, '_repr_', {
+        value: `${this[Symbol.toStringTag]} <${zonedDateTimeToString(this)}>`,
+        writable: false,
+        enumerable: false,
+        configurable: false
+      });
+    }
+  }
+  get calendar() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR);
+  }
+  get timeZone() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, TIME_ZONE);
+  }
+  get year() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).year(dateTime(this));
+  }
+  get month() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).month(dateTime(this));
+  }
+  get day() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).day(dateTime(this));
+  }
+  get hour() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), HOUR);
+  }
+  get minute() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), MINUTE);
+  }
+  get second() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), SECOND);
+  }
+  get millisecond() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), MILLISECOND);
+  }
+  get microsecond() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), MICROSECOND);
+  }
+  get nanosecond() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(dateTime(this), NANOSECOND);
+  }
+  get epochSeconds() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const value = GetSlot(this, EPOCHNANOSECONDS);
+    return +value.divide(1e9);
+  }
+  get epochMilliseconds() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const value = GetSlot(this, EPOCHNANOSECONDS);
+    return +value.divide(1e6);
+  }
+  get epochMicroseconds() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const value = GetSlot(this, EPOCHNANOSECONDS);
+    return bigIntIfAvailable(value.divide(1e3));
+  }
+  get epochNanoseconds() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return bigIntIfAvailable(GetSlot(this, EPOCHNANOSECONDS));
+  }
+  get dayOfWeek() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).dayOfWeek(dateTime(this));
+  }
+  get dayOfYear() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).dayOfYear(dateTime(this));
+  }
+  get weekOfYear() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).weekOfYear(dateTime(this));
+  }
+  get hoursInDay() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    throw new Error('hoursInDay not implemented yet');
+  }
+  get daysInWeek() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).daysInWeek(dateTime(this));
+  }
+  get daysInMonth() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).daysInMonth(dateTime(this));
+  }
+  get daysInYear() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).daysInYear(dateTime(this));
+  }
+  get monthsInYear() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).monthsInYear(dateTime(this));
+  }
+  get inLeapYear() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return GetSlot(this, CALENDAR).inLeapYear(dateTime(this));
+  }
+  get startOfDay() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    throw new Error('startOfDay not implemented yet');
+  }
+  get offset() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.GetOffsetStringFor(GetSlot(this, TIME_ZONE), GetSlot(this, INSTANT));
+  }
+  with(temporalZonedDateTimeLike, options = undefined) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (ES.Type(temporalZonedDateTimeLike) !== 'Object') {
+      const str = ES.ToString(temporalZonedDateTimeLike);
+      temporalZonedDateTimeLike = ES.RelevantTemporalObjectFromString(str);
+    }
+    options = ES.NormalizeOptionsObject(options);
+    const overflow = ES.ToTemporalOverflow(options);
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    const offset = ES.ToTemporalOffset(options, 'prefer');
+
+    void overflow;
+    void disambiguation;
+    void offset;
+    throw new Error('with() not implemented yet');
+  }
+  withTimeZone(timeZone) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    timeZone = ES.ToTemporalTimeZone(timeZone);
+    const Construct = ES.SpeciesConstructor(this, ZonedDateTime);
+    const result = new Construct(GetSlot(this, EPOCHNANOSECONDS), timeZone, GetSlot(this, CALENDAR));
+    if (!ES.IsTemporalZonedDateTime(result)) throw new TypeError('invalid result');
+    return result;
+  }
+  withCalendar(calendar) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    calendar = ES.ToTemporalCalendar(calendar);
+    const Construct = ES.SpeciesConstructor(this, ZonedDateTime);
+    const result = new Construct(GetSlot(this, EPOCHNANOSECONDS), GetSlot(this, TIME_ZONE), calendar);
+    if (!ES.IsTemporalZonedDateTime(result)) throw new TypeError('invalid result');
+    return result;
+  }
+  add(temporalDurationLike, options = undefined) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
+    const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
+    ES.RejectDurationSign(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+    options = ES.NormalizeOptionsObject(options);
+    const overflow = ES.ToTemporalOverflow(options);
+    void overflow;
+    throw new Error('add() not implemented yet');
+  }
+  subtract(temporalDurationLike, options = undefined) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
+    const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
+    ES.RejectDurationSign(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+    options = ES.NormalizeOptionsObject(options);
+    const overflow = ES.ToTemporalOverflow(options);
+    void overflow;
+    throw new Error('subtract() not implemented yet');
+  }
+  until(other, options = undefined) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalZonedDateTime(other, ZonedDateTime);
+    const calendar = GetSlot(this, CALENDAR);
+    const otherCalendar = GetSlot(other, CALENDAR);
+    const calendarId = ES.CalendarToString(calendar);
+    const otherCalendarId = ES.CalendarToString(otherCalendar);
+    if (calendarId !== otherCalendarId) {
+      throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
+    }
+    options = ES.NormalizeOptionsObject(options);
+    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
+    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
+    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const maximumIncrements = {
+      years: undefined,
+      months: undefined,
+      weeks: undefined,
+      days: undefined,
+      hours: 24,
+      minutes: 60,
+      seconds: 60,
+      milliseconds: 1000,
+      microseconds: 1000,
+      nanoseconds: 1000
+    };
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+    void roundingMode;
+    void roundingIncrement;
+    throw new Error('until() not implemented yet');
+  }
+  since(other, options = undefined) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalZonedDateTime(other, ZonedDateTime);
+    const calendar = GetSlot(this, CALENDAR);
+    const otherCalendar = GetSlot(other, CALENDAR);
+    const calendarId = ES.CalendarToString(calendar);
+    const otherCalendarId = ES.CalendarToString(otherCalendar);
+    if (calendarId !== otherCalendarId) {
+      throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
+    }
+    options = ES.NormalizeOptionsObject(options);
+    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
+    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
+    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
+    let roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
+    const maximumIncrements = {
+      years: undefined,
+      months: undefined,
+      weeks: undefined,
+      days: undefined,
+      hours: 24,
+      minutes: 60,
+      seconds: 60,
+      milliseconds: 1000,
+      microseconds: 1000,
+      nanoseconds: 1000
+    };
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+    void roundingMode;
+    void roundingIncrement;
+    throw new Error('since() not implemented yet');
+  }
+  round(options) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (options === undefined) throw new TypeError('options parameter is required');
+    options = ES.NormalizeOptionsObject(options);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const maximumIncrements = {
+      day: 1,
+      hour: 24,
+      minute: 60,
+      second: 60,
+      millisecond: 1000,
+      microsecond: 1000,
+      nanosecond: 1000
+    };
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+    void roundingMode;
+    void roundingIncrement;
+    throw new Error('round() not implemented yet');
+  }
+  equals(other) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalZonedDateTime(other, ZonedDateTime);
+    const one = GetSlot(this, EPOCHNANOSECONDS);
+    const two = GetSlot(other, EPOCHNANOSECONDS);
+    if (!bigInt(one).equals(two)) return false;
+    if (!ES.TimeZoneEquals(GetSlot(this, TIME_ZONE), GetSlot(other, TIME_ZONE))) return false;
+    return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+  }
+  toString(options = undefined) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    options = ES.NormalizeOptionsObject(options);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
+    return zonedDateTimeToString(this, precision, { unit, increment, roundingMode });
+  }
+  toLocaleString(locales = undefined, options = undefined) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return new DateTimeFormat(locales, options).format(this);
+  }
+  toJSON() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return zonedDateTimeToString(this, 'auto');
+  }
+  valueOf() {
+    throw new TypeError('use compare() or equals() to compare Temporal.ZonedDateTime');
+  }
+  toInstant() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+    return new TemporalInstant(GetSlot(this, EPOCHNANOSECONDS));
+  }
+  toDate() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalDateTimeToDate(dateTime(this));
+  }
+  toTime() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.TemporalDateTimeToTime(dateTime(this));
+  }
+  toDateTime() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return dateTime(this);
+  }
+  toYearMonth() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'year']);
+    const fields = ES.ToTemporalDateFields(this, fieldNames);
+    return calendar.yearMonthFromFields(fields, {}, YearMonth);
+  }
+  toMonthDay() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const MonthDay = GetIntrinsic('%Temporal.MonthDay%');
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'year']);
+    const fields = ES.ToTemporalDateFields(this, fieldNames);
+    return calendar.monthDayFromFields(fields, {}, MonthDay);
+  }
+  getFields() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const calendar = GetSlot(this, CALENDAR);
+    const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'year']);
+    void fieldNames;
+    throw new Error('getFields() not implemented yet');
+  }
+  getISOFields() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const dt = dateTime(this);
+    const tz = GetSlot(this, TIME_ZONE);
+    return {
+      calendar: GetSlot(this, CALENDAR),
+      hour: GetSlot(dt, HOUR),
+      isoDay: GetSlot(dt, ISO_DAY),
+      isoMonth: GetSlot(dt, ISO_MONTH),
+      isoYear: GetSlot(dt, ISO_YEAR),
+      microsecond: GetSlot(dt, MICROSECOND),
+      millisecond: GetSlot(dt, MILLISECOND),
+      minute: GetSlot(dt, MINUTE),
+      nanosecond: GetSlot(dt, NANOSECOND),
+      offset: ES.GetOffsetStringFor(tz, GetSlot(this, INSTANT)),
+      second: GetSlot(dt, SECOND),
+      timeZone: tz
+    };
+  }
+  static from(item, options = undefined) {
+    options = ES.NormalizeOptionsObject(options);
+    const overflow = ES.ToTemporalOverflow(options);
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    const offset = ES.ToTemporalOffset(options, 'reject');
+    if (ES.IsTemporalZonedDateTime(item)) {
+      return new ZonedDateTime(GetSlot(item, EPOCHNANOSECONDS), GetSlot(item, TIME_ZONE), GetSlot(item, CALENDAR));
+    }
+    return ES.ToTemporalZonedDateTime(item, this, overflow, disambiguation, offset);
+  }
+  static compare(one, two) {
+    one = ES.ToTemporalZonedDateTime(one, ZonedDateTime);
+    two = ES.ToTemporalZonedDateTime(two, ZonedDateTime);
+    const ns1 = GetSlot(one, EPOCHNANOSECONDS);
+    const ns2 = GetSlot(two, EPOCHNANOSECONDS);
+    if (bigInt(ns1).lesser(ns2)) return -1;
+    if (bigInt(ns1).greater(ns2)) return 1;
+    const calendarResult = ES.CalendarCompare(GetSlot(one, CALENDAR), GetSlot(two, CALENDAR));
+    if (calendarResult) return calendarResult;
+    return ES.TimeZoneCompare(GetSlot(one, TIME_ZONE), GetSlot(two, TIME_ZONE));
+  }
+}
+
+MakeIntrinsicClass(ZonedDateTime, 'Temporal.ZonedDateTime');
+
+function bigIntIfAvailable(wrapper) {
+  return typeof BigInt === 'undefined' ? wrapper : wrapper.value;
+}
+
+function dateTime(zdt) {
+  return ES.GetTemporalDateTimeFor(GetSlot(zdt, TIME_ZONE), GetSlot(zdt, INSTANT), GetSlot(zdt, CALENDAR));
+}
+
+function zonedDateTimeToString(zdt, precision, options = undefined) {
+  const dt = dateTime(zdt);
+  let year = GetSlot(dt, ISO_YEAR);
+  let month = GetSlot(dt, ISO_MONTH);
+  let day = GetSlot(dt, ISO_DAY);
+  let hour = GetSlot(dt, HOUR);
+  let minute = GetSlot(dt, MINUTE);
+  let second = GetSlot(dt, SECOND);
+  let millisecond = GetSlot(dt, MILLISECOND);
+  let microsecond = GetSlot(dt, MICROSECOND);
+  let nanosecond = GetSlot(dt, NANOSECOND);
+
+  if (options) {
+    const { unit, increment, roundingMode } = options;
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      increment,
+      unit,
+      roundingMode
+    ));
+  }
+
+  year = ES.ISOYearString(year);
+  month = ES.ISODateTimePartString(month);
+  day = ES.ISODateTimePartString(day);
+  hour = ES.ISODateTimePartString(hour);
+  minute = ES.ISODateTimePartString(minute);
+  const seconds = ES.FormatSecondsStringPart(second, millisecond, microsecond, nanosecond, precision);
+  const tz = GetSlot(zdt, TIME_ZONE);
+  const offset = ES.GetOffsetStringFor(tz, GetSlot(zdt, INSTANT));
+  const zone = ES.TimeZoneToString(tz);
+  const calendar = ES.FormatCalendarAnnotation(GetSlot(zdt, CALENDAR));
+  return `${year}-${month}-${day}T${hour}:${minute}${seconds}${offset}[${zone}]${calendar}`;
+}

--- a/polyfill/test/all.mjs
+++ b/polyfill/test/all.mjs
@@ -20,6 +20,7 @@ import './exports.mjs';
 import './now.mjs';
 import './timezone.mjs';
 import './instant.mjs';
+import './zoneddatetime.mjs';
 import './date.mjs';
 import './time.mjs';
 import './datetime.mjs';

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -72,6 +72,9 @@ describe('Date', () => {
       it('Date.prototype.toDateTime is a Function', () => {
         equal(typeof Date.prototype.toDateTime, 'function');
       });
+      it('Date.prototype.toZonedDateTime is a Function', () => {
+        equal(typeof Date.prototype.toZonedDateTime, 'function');
+      });
       it('Date.prototype.toYearMonth is a Function', () => {
         equal(typeof Date.prototype.toYearMonth, 'function');
       });
@@ -198,6 +201,55 @@ describe('Date', () => {
     });
     it('optional argument defaults to midnight', () => {
       equal(`${date.toDateTime()}`, '1976-11-18T00:00:00');
+    });
+  });
+  describe('Date.toZonedDateTime()', function () {
+    it('works', () => {
+      const date = Date.from('2020-01-01');
+      const time = Temporal.Time.from('12:00');
+      const tz = Temporal.TimeZone.from('America/Los_Angeles');
+      equal(`${date.toZonedDateTime(tz, time)}`, '2020-01-01T12:00:00-08:00[America/Los_Angeles]');
+    });
+    it('works with time omitted', () => {
+      const date = Date.from('2020-01-01');
+      const tz = Temporal.TimeZone.from('America/Los_Angeles');
+      equal(`${date.toZonedDateTime(tz)}`, '2020-01-01T00:00:00-08:00[America/Los_Angeles]');
+    });
+    it('works with disambiguation option', () => {
+      const date = Date.from('2020-03-08');
+      const time = Temporal.Time.from('02:00');
+      const tz = Temporal.TimeZone.from('America/Los_Angeles');
+      const zdt = date.toZonedDateTime(tz, time, { disambiguation: 'earlier' });
+      equal(`${zdt}`, '2020-03-08T01:00:00-08:00[America/Los_Angeles]');
+    });
+    it('casts first argument', () => {
+      const date = Date.from('2020-07-08');
+      const time = Temporal.Time.from('12:00');
+      const zdt = date.toZonedDateTime('America/Los_Angeles', time);
+      equal(`${zdt}`, '2020-07-08T12:00:00-07:00[America/Los_Angeles]');
+    });
+    it('casts second argument', () => {
+      const date = Date.from('2020-07-08');
+      const tz = Temporal.TimeZone.from('America/Los_Angeles');
+      const zdt = date.toZonedDateTime(tz, '12:00');
+      equal(`${zdt}`, '2020-07-08T12:00:00-07:00[America/Los_Angeles]');
+    });
+    it('throws on bad disambiguation', () => {
+      ['', 'EARLIER', 'xyz', 3, null].forEach((disambiguation) =>
+        throws(() => Date.from('2019-10-29').toZonedDateTime('UTC', '12:00', { disambiguation }), RangeError)
+      );
+    });
+    it('options may only be an object or undefined', () => {
+      const date = Date.from('2019-10-29');
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => date.toZonedDateTime('America/Sao_Paulo', '10:46:38', badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) =>
+        equal(
+          `${date.toZonedDateTime('America/Sao_Paulo', '10:46:38', options)}`,
+          '2019-10-29T10:46:38-03:00[America/Sao_Paulo]'
+        )
+      );
     });
   });
   describe('date.until() works', () => {

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -93,6 +93,9 @@ describe('DateTime', () => {
       it('DateTime.prototype.toInstant is a Function', () => {
         equal(typeof DateTime.prototype.toInstant, 'function');
       });
+      it('DateTime.prototype.toZonedDateTime is a Function', () => {
+        equal(typeof DateTime.prototype.toZonedDateTime, 'function');
+      });
       it('DateTime.prototype.toDate is a Function', () => {
         equal(typeof DateTime.prototype.toDate, 'function');
       });
@@ -1411,6 +1414,73 @@ describe('DateTime', () => {
       );
       [{}, () => {}, undefined].forEach((options) =>
         equal(`${dt.toInstant('America/Sao_Paulo', options)}`, '2019-10-29T13:46:38.271986102Z')
+      );
+    });
+  });
+  describe('DateTime.toZonedDateTime()', () => {
+    it('works', () => {
+      const dt = Temporal.DateTime.from('2020-01-01T00:00');
+      const zdt = dt.toZonedDateTime('America/Los_Angeles');
+      equal(zdt.toString(), '2020-01-01T00:00:00-08:00[America/Los_Angeles]');
+    });
+    it('works with disambiguation option', () => {
+      const dt = Temporal.DateTime.from('2020-03-08T02:00');
+      const zdt = dt.toZonedDateTime('America/Los_Angeles', { disambiguation: 'earlier' });
+      equal(zdt.toString(), '2020-03-08T01:00:00-08:00[America/Los_Angeles]');
+    });
+    it('datetime with multiple instants - Fall DST in Brazil', () => {
+      const dt = DateTime.from('2019-02-16T23:45');
+      equal(`${dt.toZonedDateTime('America/Sao_Paulo')}`, '2019-02-16T23:45:00-02:00[America/Sao_Paulo]');
+      equal(
+        `${dt.toZonedDateTime('America/Sao_Paulo', { disambiguation: 'compatible' })}`,
+        '2019-02-16T23:45:00-02:00[America/Sao_Paulo]'
+      );
+      equal(
+        `${dt.toZonedDateTime('America/Sao_Paulo', { disambiguation: 'earlier' })}`,
+        '2019-02-16T23:45:00-02:00[America/Sao_Paulo]'
+      );
+      equal(
+        `${dt.toZonedDateTime('America/Sao_Paulo', { disambiguation: 'later' })}`,
+        '2019-02-16T23:45:00-03:00[America/Sao_Paulo]'
+      );
+      throws(() => dt.toZonedDateTime('America/Sao_Paulo', { disambiguation: 'reject' }), RangeError);
+    });
+    it('datetime with multiple instants - Spring DST in Los Angeles', () => {
+      const dt = DateTime.from('2020-03-08T02:30');
+      equal(`${dt.toZonedDateTime('America/Los_Angeles')}`, '2020-03-08T03:30:00-07:00[America/Los_Angeles]');
+      equal(
+        `${dt.toZonedDateTime('America/Los_Angeles', { disambiguation: 'compatible' })}`,
+        '2020-03-08T03:30:00-07:00[America/Los_Angeles]'
+      );
+      equal(
+        `${dt.toZonedDateTime('America/Los_Angeles', { disambiguation: 'earlier' })}`,
+        '2020-03-08T01:30:00-08:00[America/Los_Angeles]'
+      );
+      equal(
+        `${dt.toZonedDateTime('America/Los_Angeles', { disambiguation: 'later' })}`,
+        '2020-03-08T03:30:00-07:00[America/Los_Angeles]'
+      );
+      throws(() => dt.toZonedDateTime('America/Los_Angeles', { disambiguation: 'reject' }), RangeError);
+    });
+    it('outside of Instant range', () => {
+      const max = Temporal.DateTime.from('+275760-09-13T23:59:59.999999999');
+      throws(() => max.toZonedDateTime('America/Godthab'), RangeError);
+    });
+    it('throws on bad disambiguation', () => {
+      ['', 'EARLIER', 'xyz', 3, null].forEach((disambiguation) =>
+        throws(() => DateTime.from('2019-10-29T10:46').toZonedDateTime('UTC', { disambiguation }), RangeError)
+      );
+    });
+    it('options may only be an object or undefined', () => {
+      const dt = DateTime.from('2019-10-29T10:46:38.271986102');
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => dt.toZonedDateTime('America/Sao_Paulo', badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) =>
+        equal(
+          `${dt.toZonedDateTime('America/Sao_Paulo', options)}`,
+          '2019-10-29T10:46:38.271986102-03:00[America/Sao_Paulo]'
+        )
       );
     });
   });

--- a/polyfill/test/exports.mjs
+++ b/polyfill/test/exports.mjs
@@ -18,8 +18,8 @@ import * as Temporal from 'proposal-temporal';
 
 describe('Exports', () => {
   const named = Object.keys(Temporal);
-  it('should be 10 things', () => {
-    equal(named.length, 10);
+  it('should be 11 things', () => {
+    equal(named.length, 11);
   });
   it('should contain `Instant`', () => {
     assert(named.includes('Instant'));
@@ -35,6 +35,9 @@ describe('Exports', () => {
   });
   it('should contain `DateTime`', () => {
     assert(named.includes('DateTime'));
+  });
+  it('should contain `ZonedDateTime`', () => {
+    assert(named.includes('ZonedDateTime'));
   });
   it('should contain `YearMonth`', () => {
     assert(named.includes('YearMonth'));

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -45,6 +45,12 @@ describe('Instant', () => {
       it('Instant.prototype.toDateTime is a Function', () => {
         equal(typeof Instant.prototype.toDateTime, 'function');
       });
+      it('Instant.prototype.toZonedDateTimeISO is a Function', () => {
+        equal(typeof Instant.prototype.toZonedDateTimeISO, 'function');
+      });
+      it('Instant.prototype.toZonedDateTime is a Function', () => {
+        equal(typeof Instant.prototype.toZonedDateTime, 'function');
+      });
     });
     it('Instant.fromEpochSeconds is a Function', () => {
       equal(typeof Instant.fromEpochSeconds, 'function');
@@ -1341,6 +1347,45 @@ describe('Instant', () => {
       const dt = inst.toDateTime(tz, 'gregory');
       equal(inst.epochNanoseconds, dt.toInstant(tz).epochNanoseconds);
       equal(`${dt}`, '1976-11-18T09:23:30.123456789[c=gregory]');
+    });
+  });
+  describe('Instant.toZonedDateTimeISO() works', () => {
+    const inst = Instant.from('1976-11-18T14:23:30.123456789Z');
+    it('throws without parameter', () => {
+      throws(() => inst.toZonedDateTimeISO(), RangeError);
+    });
+    it('time zone parameter UTC', () => {
+      const tz = Temporal.TimeZone.from('UTC');
+      const zdt = inst.toZonedDateTimeISO(tz);
+      equal(inst.epochNanoseconds, zdt.epochNanoseconds);
+      equal(`${zdt}`, '1976-11-18T14:23:30.123456789+00:00[UTC]');
+    });
+    it('time zone parameter non-UTC', () => {
+      const tz = Temporal.TimeZone.from('America/New_York');
+      const zdt = inst.toZonedDateTimeISO(tz);
+      equal(inst.epochNanoseconds, zdt.epochNanoseconds);
+      equal(`${zdt}`, '1976-11-18T09:23:30.123456789-05:00[America/New_York]');
+    });
+  });
+  describe('Instant.toZonedDateTime() works', () => {
+    const inst = Instant.from('1976-11-18T14:23:30.123456789Z');
+    it('throws without parameter', () => {
+      throws(() => inst.toZonedDateTime(), RangeError);
+    });
+    it('throws with only one parameter', () => {
+      throws(() => inst.toZonedDateTime('Asia/Singapore'));
+    });
+    it('time zone parameter UTC', () => {
+      const tz = Temporal.TimeZone.from('UTC');
+      const zdt = inst.toZonedDateTime(tz, 'gregory');
+      equal(inst.epochNanoseconds, zdt.epochNanoseconds);
+      equal(`${zdt}`, '1976-11-18T14:23:30.123456789+00:00[UTC][c=gregory]');
+    });
+    it('time zone parameter non-UTC', () => {
+      const tz = Temporal.TimeZone.from('America/New_York');
+      const zdt = inst.toZonedDateTime(tz, 'gregory');
+      equal(inst.epochNanoseconds, zdt.epochNanoseconds);
+      equal(`${zdt}`, '1976-11-18T09:23:30.123456789-05:00[America/New_York][c=gregory]');
     });
   });
 });

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -69,6 +69,9 @@ describe('Time', () => {
       it('Time.prototype.toDateTime is a Function', () => {
         equal(typeof Time.prototype.toDateTime, 'function');
       });
+      it('Time.prototype.toZonedDateTime is a Function', () => {
+        equal(typeof Time.prototype.toZonedDateTime, 'function');
+      });
       it('Time.prototype.getFields is a Function', () => {
         equal(typeof Time.prototype.getFields, 'function');
       });
@@ -235,6 +238,50 @@ describe('Time', () => {
     });
     it('object must contain at least the required properties', () => {
       throws(() => time.toDateTime({ year: 1976 }), TypeError);
+    });
+  });
+  describe('time.toZonedDateTime()', function () {
+    it('works', () => {
+      const time = Time.from('12:00');
+      const date = Temporal.Date.from('2020-01-01');
+      const tz = Temporal.TimeZone.from('America/Los_Angeles');
+      equal(`${time.toZonedDateTime(tz, date)}`, '2020-01-01T12:00:00-08:00[America/Los_Angeles]');
+    });
+    it('works with disambiguation option', () => {
+      const time = Time.from('02:00');
+      const date = Temporal.Date.from('2020-03-08');
+      const tz = Temporal.TimeZone.from('America/Los_Angeles');
+      const zdt = time.toZonedDateTime(tz, date, { disambiguation: 'earlier' });
+      equal(`${zdt}`, '2020-03-08T01:00:00-08:00[America/Los_Angeles]');
+    });
+    it('casts first argument', () => {
+      const time = Time.from('12:00');
+      const date = Temporal.Date.from('2020-07-08');
+      const zdt = time.toZonedDateTime('America/Los_Angeles', date);
+      equal(`${zdt}`, '2020-07-08T12:00:00-07:00[America/Los_Angeles]');
+    });
+    it('casts second argument', () => {
+      const time = Time.from('12:00');
+      const tz = Temporal.TimeZone.from('America/Los_Angeles');
+      const zdt = time.toZonedDateTime(tz, '2020-07-08');
+      equal(`${zdt}`, '2020-07-08T12:00:00-07:00[America/Los_Angeles]');
+    });
+    it('throws on bad disambiguation', () => {
+      ['', 'EARLIER', 'xyz', 3, null].forEach((disambiguation) =>
+        throws(() => Time.from('12:00').toZonedDateTime('UTC', '2019-10-29', { disambiguation }), RangeError)
+      );
+    });
+    it('options may only be an object or undefined', () => {
+      const time = Time.from('10:46:38');
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => time.toZonedDateTime('America/Sao_Paulo', '2019-10-29', badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) =>
+        equal(
+          `${time.toZonedDateTime('America/Sao_Paulo', '2019-10-29', options)}`,
+          '2019-10-29T10:46:38-03:00[America/Sao_Paulo]'
+        )
+      );
     });
   });
   describe('time.until() works', () => {

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -1,0 +1,603 @@
+#! /usr/bin/env -S node --experimental-modules
+
+/*
+ ** Copyright (C) 2018-2019 Bloomberg LP. All rights reserved.
+ ** This code is governed by the license found in the LICENSE file.
+ */
+
+import Demitasse from '@pipobscure/demitasse';
+const { describe, it, report } = Demitasse;
+
+import Pretty from '@pipobscure/demitasse-pretty';
+const { reporter } = Pretty;
+
+import { strict as assert } from 'assert';
+const { equal, notEqual, throws } = assert;
+
+import * as Temporal from 'proposal-temporal';
+const { ZonedDateTime } = Temporal;
+
+describe('ZonedDateTime', () => {
+  const tz = new Temporal.TimeZone('America/Los_Angeles');
+
+  describe('Structure', () => {
+    it('ZonedDateTime is a Function', () => {
+      equal(typeof ZonedDateTime, 'function');
+    });
+    it('ZonedDateTime has a prototype', () => {
+      assert(ZonedDateTime.prototype);
+      equal(typeof ZonedDateTime.prototype, 'object');
+    });
+    describe('ZonedDateTime.prototype', () => {
+      it('ZonedDateTime.prototype has calendar', () => {
+        assert('calendar' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has timeZone', () => {
+        assert('timeZone' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has year', () => {
+        assert('year' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has month', () => {
+        assert('month' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has day', () => {
+        assert('day' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has hour', () => {
+        assert('hour' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has minute', () => {
+        assert('minute' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has second', () => {
+        assert('second' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has millisecond', () => {
+        assert('millisecond' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has microsecond', () => {
+        assert('microsecond' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has nanosecond', () => {
+        assert('nanosecond' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has epochSeconds', () => {
+        assert('epochSeconds' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has epochMilliseconds', () => {
+        assert('epochMilliseconds' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has epochMicroseconds', () => {
+        assert('epochMicroseconds' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has epochNanoseconds', () => {
+        assert('epochNanoseconds' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has dayOfWeek', () => {
+        assert('dayOfWeek' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has dayOfYear', () => {
+        assert('dayOfYear' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has weekOfYear', () => {
+        assert('weekOfYear' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has hoursInDay', () => {
+        assert('hoursInDay' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has daysInWeek', () => {
+        assert('daysInWeek' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has daysInMonth', () => {
+        assert('daysInMonth' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has daysInYear', () => {
+        assert('daysInYear' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has monthsInYear', () => {
+        assert('daysInWeek' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has inLeapYear', () => {
+        assert('daysInWeek' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has startOfDay', () => {
+        assert('daysInWeek' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype has offset', () => {
+        assert('daysInWeek' in ZonedDateTime.prototype);
+      });
+      it('ZonedDateTime.prototype.with is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.with, 'function');
+      });
+      it('ZonedDateTime.prototype.withTimeZone is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.withTimeZone, 'function');
+      });
+      it('ZonedDateTime.prototype.withCalendar is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.withCalendar, 'function');
+      });
+      it('ZonedDateTime.prototype.add is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.add, 'function');
+      });
+      it('ZonedDateTime.prototype.subtract is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.subtract, 'function');
+      });
+      it('ZonedDateTime.prototype.until is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.until, 'function');
+      });
+      it('ZonedDateTime.prototype.since is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.since, 'function');
+      });
+      it('ZonedDateTime.prototype.round is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.round, 'function');
+      });
+      it('ZonedDateTime.prototype.equals is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.equals, 'function');
+      });
+      it('ZonedDateTime.prototype.toString is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toString, 'function');
+      });
+      it('ZonedDateTime.prototype.toLocaleString is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toLocaleString, 'function');
+      });
+      it('ZonedDateTime.prototype.toJSON is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toJSON, 'function');
+      });
+      it('ZonedDateTime.prototype.valueOf is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.valueOf, 'function');
+      });
+      it('ZonedDateTime.prototype.toInstant is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toInstant, 'function');
+      });
+      it('ZonedDateTime.prototype.toDate is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toDate, 'function');
+      });
+      it('ZonedDateTime.prototype.toTime is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toTime, 'function');
+      });
+      it('ZonedDateTime.prototype.toDateTime is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toDateTime, 'function');
+      });
+      it('ZonedDateTime.prototype.toYearMonth is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toDateTime, 'function');
+      });
+      it('ZonedDateTime.prototype.toMonthDay is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toDateTime, 'function');
+      });
+      it('ZonedDateTime.prototype.getFields is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.getFields, 'function');
+      });
+      it('ZonedDateTime.prototype.getISOFields is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.getISOFields, 'function');
+      });
+    });
+    it('ZonedDateTime.from is a Function', () => {
+      equal(typeof ZonedDateTime.from, 'function');
+    });
+    it('ZonedDateTime.compare is a Function', () => {
+      equal(typeof ZonedDateTime.compare, 'function');
+    });
+  });
+
+  describe('Construction and properties', () => {
+    const epochMillis = Date.UTC(1976, 10, 18, 15, 23, 30, 123);
+    const epochNanos = BigInt(epochMillis) * BigInt(1e6) + BigInt(456789);
+    it('works', () => {
+      const zdt = new ZonedDateTime(epochNanos, tz);
+      assert(zdt);
+      equal(typeof zdt, 'object');
+      equal(zdt.toInstant().epochSeconds, Math.floor(Date.UTC(1976, 10, 18, 15, 23, 30, 123) / 1e3), 'epochSeconds');
+      equal(zdt.toInstant().epochMilliseconds, Date.UTC(1976, 10, 18, 15, 23, 30, 123), 'epochMilliseconds');
+    });
+
+    describe('ZonedDateTime for (1976, 11, 18, 15, 23, 30, 123, 456, 789)', () => {
+      it('can be constructed', () => {
+        const zdt = new ZonedDateTime(epochNanos, new Temporal.TimeZone('UTC'));
+        assert(zdt);
+        equal(typeof zdt, 'object');
+      });
+      const zdt = new ZonedDateTime(epochNanos, new Temporal.TimeZone('UTC'));
+      it('zdt.year is 1976', () => equal(zdt.year, 1976));
+      it('zdt.month is 11', () => equal(zdt.month, 11));
+      it('zdt.day is 18', () => equal(zdt.day, 18));
+      it('zdt.hour is 15', () => equal(zdt.hour, 15));
+      it('zdt.minute is 23', () => equal(zdt.minute, 23));
+      it('zdt.second is 30', () => equal(zdt.second, 30));
+      it('zdt.millisecond is 123', () => equal(zdt.millisecond, 123));
+      it('zdt.microsecond is 456', () => equal(zdt.microsecond, 456));
+      it('zdt.nanosecond is 789', () => equal(zdt.nanosecond, 789));
+      it('zdt.epochSeconds is 217178610', () => equal(zdt.epochSeconds, 217178610));
+      it('zdt.epochMilliseconds is 217178610123', () => equal(zdt.epochMilliseconds, 217178610123));
+      it('zdt.epochMicroseconds is 217178610123456n', () => equal(zdt.epochMicroseconds, 217178610123456n));
+      it('zdt.epochNanoseconds is 217178610123456789n', () => equal(zdt.epochNanoseconds, 217178610123456789n));
+      it('zdt.dayOfWeek is 4', () => equal(zdt.dayOfWeek, 4));
+      it('zdt.dayOfYear is 323', () => equal(zdt.dayOfYear, 323));
+      it('zdt.weekOfYear is 47', () => equal(zdt.weekOfYear, 47));
+      it('zdt.daysInWeek is 7', () => equal(zdt.daysInWeek, 7));
+      it('zdt.daysInMonth is 30', () => equal(zdt.daysInMonth, 30));
+      it('zdt.daysInYear is 366', () => equal(zdt.daysInYear, 366));
+      it('zdt.monthsInYear is 12', () => equal(zdt.monthsInYear, 12));
+      it('zdt.inLeapYear is true', () => equal(zdt.inLeapYear, true));
+      it('zdt.offset is +00:00', () => equal(zdt.offset, '+00:00'));
+      it('string output is 1976-11-18T15:23:30.123456789+00:00[UTC]', () =>
+        equal(`${zdt}`, '1976-11-18T15:23:30.123456789+00:00[UTC]'));
+    });
+
+    it('casts time zone', () => {
+      const zdt = new ZonedDateTime(epochNanos, 'Asia/Seoul');
+      equal(typeof zdt.timeZone, 'object');
+      assert(zdt.timeZone instanceof Temporal.TimeZone);
+      equal(zdt.timeZone.id, 'Asia/Seoul');
+    });
+    it('defaults to ISO calendar', () => {
+      const zdt = new ZonedDateTime(epochNanos, tz);
+      equal(typeof zdt.calendar, 'object');
+      assert(zdt.calendar instanceof Temporal.Calendar);
+      equal(zdt.calendar.id, 'iso8601');
+    });
+    it('casts calendar', () => {
+      const zdt = new ZonedDateTime(epochNanos, Temporal.TimeZone.from('Asia/Tokyo'), 'japanese');
+      equal(typeof zdt.calendar, 'object');
+      assert(zdt.calendar instanceof Temporal.Calendar);
+      equal(zdt.calendar.id, 'japanese');
+    });
+  });
+
+  describe('string parsing', () => {
+    it('parses with an IANA zone', () => {
+      const zdt = ZonedDateTime.from('2020-03-08T01:00-08:00[America/Los_Angeles]');
+      equal(zdt.toString(), '2020-03-08T01:00:00-08:00[America/Los_Angeles]');
+    });
+    it('parses with an IANA zone but no offset', () => {
+      const zdt = ZonedDateTime.from('2020-03-08T01:00[America/Los_Angeles]');
+      equal(zdt.toString(), '2020-03-08T01:00:00-08:00[America/Los_Angeles]');
+    });
+    it('parses with an IANA zone but no offset (with disambiguation)', () => {
+      const zdt = ZonedDateTime.from('2020-03-08T02:30[America/Los_Angeles]', { disambiguation: 'earlier' });
+      equal(zdt.toString(), '2020-03-08T01:30:00-08:00[America/Los_Angeles]');
+    });
+  });
+
+  describe('ZonedDateTime.withTimeZone()', () => {
+    const instant = Temporal.Instant.from('2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles]');
+    const zdt = instant.toZonedDateTimeISO('UTC');
+    it('zonedDateTime.withTimeZone(America/Los_Angeles) works', () => {
+      equal(`${zdt.withTimeZone(tz)}`, '2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles]');
+    });
+    it('casts its argument', () => {
+      equal(`${zdt.withTimeZone('America/Los_Angeles')}`, '2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles]');
+    });
+    it('keeps instant and calendar the same', () => {
+      const zdt = ZonedDateTime.from('2019-11-18T15:23:30.123456789+01:00[Europe/Madrid][c=gregory]');
+      const zdt2 = zdt.withTimeZone('America/Vancouver');
+      equal(zdt.epochNanoseconds, zdt2.epochNanoseconds);
+      equal(zdt2.calendar.id, 'gregory');
+      equal(zdt2.timeZone.id, 'America/Vancouver');
+      notEqual(`${zdt.toDateTime()}`, `${zdt2.toDateTime()}`);
+    });
+  });
+  describe('ZonedDateTime.withCalendar()', () => {
+    const zdt = ZonedDateTime.from('2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles]');
+    it('zonedDateTime.withCalendar(japanese) works', () => {
+      const cal = Temporal.Calendar.from('japanese');
+      equal(`${zdt.withCalendar(cal)}`, '2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles][c=japanese]');
+    });
+    it('casts its argument', () => {
+      equal(`${zdt.withCalendar('japanese')}`, '2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles][c=japanese]');
+    });
+    it('keeps instant and calendar the same', () => {
+      const zdt = ZonedDateTime.from('2019-11-18T15:23:30.123456789+01:00[Europe/Madrid][c=gregory]');
+      const zdt2 = zdt.withCalendar('japanese');
+      equal(zdt.epochNanoseconds, zdt2.epochNanoseconds);
+      equal(zdt2.calendar.id, 'japanese');
+      equal(zdt2.timeZone.id, 'Europe/Madrid');
+    });
+  });
+
+  describe('ZonedDateTime.equals()', () => {
+    const tz = Temporal.TimeZone.from('America/New_York');
+    const cal = Temporal.Calendar.from('gregory');
+    const zdt = new ZonedDateTime(0n, tz, cal);
+    it('constructed from equivalent parameters are equal', () => {
+      const zdt2 = ZonedDateTime.from('1969-12-31T19:00-05:00[America/New_York][c=gregory]');
+      assert(zdt.equals(zdt2));
+      assert(zdt2.equals(zdt));
+    });
+    it('different instant not equal', () => {
+      const zdt2 = new ZonedDateTime(1n, tz, cal);
+      assert(!zdt.equals(zdt2));
+    });
+    it('different time zone not equal', () => {
+      const zdt2 = new ZonedDateTime(0n, 'America/Chicago', cal);
+      assert(!zdt.equals(zdt2));
+    });
+    it('different calendar not equal', () => {
+      const zdt2 = new ZonedDateTime(0n, tz, 'iso8601');
+      assert(!zdt.equals(zdt2));
+    });
+    it('casts its argument', () => {
+      assert(zdt.equals('1969-12-31T19:00-05:00[America/New_York][c=gregory]'));
+      assert(
+        zdt.equals({
+          year: 1969,
+          month: 12,
+          day: 31,
+          hour: 19,
+          timeZone: 'America/New_York',
+          calendar: 'gregory'
+        })
+      );
+    });
+    it('at least the required properties must be present', () => {
+      throws(
+        () => zdt.equals({ years: 1969, months: 12, days: 31, timeZone: 'America/New_York', calendar: 'gregory' }),
+        TypeError
+      );
+    });
+  });
+  describe('ZonedDateTime.toString()', () => {
+    const zdt1 = ZonedDateTime.from('1976-11-18T15:23+01:00[Europe/Vienna]');
+    const zdt2 = ZonedDateTime.from('1976-11-18T15:23:30+01:00[Europe/Vienna]');
+    const zdt3 = ZonedDateTime.from('1976-11-18T15:23:30.1234+01:00[Europe/Vienna]');
+    it('default is to emit seconds and drop trailing zeros after the decimal', () => {
+      equal(zdt1.toString(), '1976-11-18T15:23:00+01:00[Europe/Vienna]');
+      equal(zdt2.toString(), '1976-11-18T15:23:30+01:00[Europe/Vienna]');
+      equal(zdt3.toString(), '1976-11-18T15:23:30.1234+01:00[Europe/Vienna]');
+    });
+    it('truncates to minute', () => {
+      [zdt1, zdt2, zdt3].forEach((zdt) =>
+        equal(zdt.toString({ smallestUnit: 'minute' }), '1976-11-18T15:23+01:00[Europe/Vienna]')
+      );
+    });
+    it('other smallestUnits are aliases for fractional digits', () => {
+      equal(zdt3.toString({ smallestUnit: 'second' }), zdt3.toString({ fractionalSecondDigits: 0 }));
+      equal(zdt3.toString({ smallestUnit: 'millisecond' }), zdt3.toString({ fractionalSecondDigits: 3 }));
+      equal(zdt3.toString({ smallestUnit: 'microsecond' }), zdt3.toString({ fractionalSecondDigits: 6 }));
+      equal(zdt3.toString({ smallestUnit: 'nanosecond' }), zdt3.toString({ fractionalSecondDigits: 9 }));
+    });
+    it('throws on invalid or disallowed smallestUnit', () => {
+      ['era', 'year', 'month', 'day', 'hour', 'nonsense'].forEach((smallestUnit) =>
+        throws(() => zdt1.toString({ smallestUnit }), RangeError)
+      );
+    });
+    it('accepts plural units', () => {
+      equal(zdt3.toString({ smallestUnit: 'minutes' }), zdt3.toString({ smallestUnit: 'minute' }));
+      equal(zdt3.toString({ smallestUnit: 'seconds' }), zdt3.toString({ smallestUnit: 'second' }));
+      equal(zdt3.toString({ smallestUnit: 'milliseconds' }), zdt3.toString({ smallestUnit: 'millisecond' }));
+      equal(zdt3.toString({ smallestUnit: 'microseconds' }), zdt3.toString({ smallestUnit: 'microsecond' }));
+      equal(zdt3.toString({ smallestUnit: 'nanoseconds' }), zdt3.toString({ smallestUnit: 'nanosecond' }));
+    });
+    it('truncates or pads to 2 places', () => {
+      const options = { fractionalSecondDigits: 2 };
+      equal(zdt1.toString(options), '1976-11-18T15:23:00.00+01:00[Europe/Vienna]');
+      equal(zdt2.toString(options), '1976-11-18T15:23:30.00+01:00[Europe/Vienna]');
+      equal(zdt3.toString(options), '1976-11-18T15:23:30.12+01:00[Europe/Vienna]');
+    });
+    it('pads to 7 places', () => {
+      const options = { fractionalSecondDigits: 7 };
+      equal(zdt1.toString(options), '1976-11-18T15:23:00.0000000+01:00[Europe/Vienna]');
+      equal(zdt2.toString(options), '1976-11-18T15:23:30.0000000+01:00[Europe/Vienna]');
+      equal(zdt3.toString(options), '1976-11-18T15:23:30.1234000+01:00[Europe/Vienna]');
+    });
+    it('auto is the default', () => {
+      [zdt1, zdt2, zdt3].forEach((zdt) => equal(zdt.toString({ fractionalSecondDigits: 'auto' }), zdt.toString()));
+    });
+    it('throws on out of range or invalid fractionalSecondDigits', () => {
+      [-1, 10, Infinity, NaN, 'not-auto'].forEach((fractionalSecondDigits) =>
+        throws(() => zdt1.toString({ fractionalSecondDigits }), RangeError)
+      );
+    });
+    it('accepts and truncates fractional fractionalSecondDigits', () => {
+      equal(zdt3.toString({ fractionalSecondDigits: 5.5 }), '1976-11-18T15:23:30.12340+01:00[Europe/Vienna]');
+    });
+    it('smallestUnit overrides fractionalSecondDigits', () => {
+      equal(
+        zdt3.toString({ smallestUnit: 'minute', fractionalSecondDigits: 9 }),
+        '1976-11-18T15:23+01:00[Europe/Vienna]'
+      );
+    });
+    it('throws on invalid roundingMode', () => {
+      throws(() => zdt1.toString({ roundingMode: 'cile' }), RangeError);
+    });
+    it('rounds to nearest', () => {
+      equal(
+        zdt2.toString({ smallestUnit: 'minute', roundingMode: 'nearest' }),
+        '1976-11-18T15:24+01:00[Europe/Vienna]'
+      );
+      equal(
+        zdt3.toString({ fractionalSecondDigits: 3, roundingMode: 'nearest' }),
+        '1976-11-18T15:23:30.123+01:00[Europe/Vienna]'
+      );
+    });
+    it('rounds up', () => {
+      equal(zdt2.toString({ smallestUnit: 'minute', roundingMode: 'ceil' }), '1976-11-18T15:24+01:00[Europe/Vienna]');
+      equal(
+        zdt3.toString({ fractionalSecondDigits: 3, roundingMode: 'ceil' }),
+        '1976-11-18T15:23:30.124+01:00[Europe/Vienna]'
+      );
+    });
+    it('rounds down', () => {
+      ['floor', 'trunc'].forEach((roundingMode) => {
+        equal(zdt2.toString({ smallestUnit: 'minute', roundingMode }), '1976-11-18T15:23+01:00[Europe/Vienna]');
+        equal(
+          zdt3.toString({ fractionalSecondDigits: 3, roundingMode }),
+          '1976-11-18T15:23:30.123+01:00[Europe/Vienna]'
+        );
+      });
+    });
+    it('rounding down is towards the Big Bang, not towards 1 BCE', () => {
+      const zdt4 = ZonedDateTime.from('-000099-12-15T12:00:00.5+00:00[UTC]');
+      equal(zdt4.toString({ smallestUnit: 'second', roundingMode: 'floor' }), '-000099-12-15T12:00:00+00:00[UTC]');
+    });
+    it('rounding can affect all units', () => {
+      const zdt5 = ZonedDateTime.from('1999-12-31T23:59:59.999999999+01:00[Europe/Berlin]');
+      equal(
+        zdt5.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' }),
+        '2000-01-01T00:00:00.00000000+01:00[Europe/Berlin]'
+      );
+    });
+    it('options may only be an object or undefined', () => {
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => zdt1.toString(badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) =>
+        equal(zdt1.toString(options), '1976-11-18T15:23:00+01:00[Europe/Vienna]')
+      );
+    });
+  });
+  describe('ZonedDateTime.toJSON()', () => {
+    it('does the default toString', () => {
+      const zdt1 = ZonedDateTime.from('1976-11-18T15:23+01:00[Europe/Vienna]');
+      const zdt2 = ZonedDateTime.from('1976-11-18T15:23:30+01:00[Europe/Vienna]');
+      const zdt3 = ZonedDateTime.from('1976-11-18T15:23:30.1234+01:00[Europe/Vienna]');
+      equal(zdt1.toJSON(), '1976-11-18T15:23:00+01:00[Europe/Vienna]');
+      equal(zdt2.toJSON(), '1976-11-18T15:23:30+01:00[Europe/Vienna]');
+      equal(zdt3.toJSON(), '1976-11-18T15:23:30.1234+01:00[Europe/Vienna]');
+    });
+  });
+  describe("Comparison operators don't work", () => {
+    const zdt1 = ZonedDateTime.from('1963-02-13T09:36:29.123456789+01:00[Europe/Vienna]');
+    const zdt1again = ZonedDateTime.from('1963-02-13T09:36:29.123456789+01:00[Europe/Vienna]');
+    const zdt2 = ZonedDateTime.from('1976-11-18T15:23:30.123456789+01:00[Europe/Vienna]');
+    it('=== is object equality', () => equal(zdt1, zdt1));
+    it('!== is object equality', () => notEqual(zdt1, zdt1again));
+    it('<', () => throws(() => zdt1 < zdt2));
+    it('>', () => throws(() => zdt1 > zdt2));
+    it('<=', () => throws(() => zdt1 <= zdt2));
+    it('>=', () => throws(() => zdt1 >= zdt2));
+  });
+
+  describe('ZonedDateTime.toInstant()', () => {
+    it('recent date', () => {
+      const zdt = ZonedDateTime.from('2019-10-29T10:46:38.271986102+01:00[Europe/Amsterdam]');
+      equal(`${zdt.toInstant()}`, '2019-10-29T09:46:38.271986102Z');
+    });
+    it('year ≤ 99', () => {
+      const zdt = ZonedDateTime.from('+000098-10-29T10:46:38.271986102+00:00[UTC]');
+      equal(`${zdt.toInstant()}`, '+000098-10-29T10:46:38.271986102Z');
+    });
+    it('year < 1', () => {
+      let zdt = ZonedDateTime.from('+000000-10-29T10:46:38.271986102+00:00[UTC]');
+      equal(`${zdt.toInstant()}`, '+000000-10-29T10:46:38.271986102Z');
+      zdt = ZonedDateTime.from('-001000-10-29T10:46:38.271986102+00:00[UTC]');
+      equal(`${zdt.toInstant()}`, '-001000-10-29T10:46:38.271986102Z');
+    });
+    it('year 0 leap day', () => {
+      const zdt = ZonedDateTime.from('+000000-02-29T00:00-00:01:15[Europe/London]');
+      equal(`${zdt.toInstant()}`, '+000000-02-29T00:01:15Z');
+    });
+  });
+  describe('ZonedDateTime.toDate()', () => {
+    it('works', () => {
+      const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTimeISO(tz);
+      equal(`${zdt.toDate()}`, '2019-10-29');
+    });
+    it('preserves the calendar', () => {
+      const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTime(tz, 'gregory');
+      equal(zdt.toDate().calendar.id, 'gregory');
+    });
+  });
+  describe('ZonedDateTime.toTime()', () => {
+    it('works', () => {
+      const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTimeISO(tz);
+      equal(`${zdt.toTime()}`, '02:46:38.271986102');
+    });
+  });
+  describe('ZonedDateTime.toYearMonth()', () => {
+    it('works', () => {
+      const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTimeISO(tz);
+      equal(`${zdt.toYearMonth()}`, '2019-10');
+    });
+    it('preserves the calendar', () => {
+      const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTime(tz, 'gregory');
+      equal(zdt.toYearMonth().calendar.id, 'gregory');
+    });
+  });
+  describe('ZonedDateTime.toMonthDay()', () => {
+    it('works', () => {
+      const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTimeISO(tz);
+      equal(`${zdt.toMonthDay()}`, '10-29');
+    });
+    it('preserves the calendar', () => {
+      const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTime(tz, 'gregory');
+      equal(zdt.toMonthDay().calendar.id, 'gregory');
+    });
+  });
+
+  describe('ZonedDateTime.getISOFields()', () => {
+    const zdt1 = ZonedDateTime.from('1976-11-18T15:23:30.123456789+08:00[Asia/Shanghai]');
+    const fields = zdt1.getISOFields();
+    it('fields', () => {
+      equal(fields.isoYear, 1976);
+      equal(fields.isoMonth, 11);
+      equal(fields.isoDay, 18);
+      equal(fields.hour, 15);
+      equal(fields.minute, 23);
+      equal(fields.second, 30);
+      equal(fields.millisecond, 123);
+      equal(fields.microsecond, 456);
+      equal(fields.nanosecond, 789);
+      equal(fields.offset, '+08:00');
+      equal(fields.timeZone.id, 'Asia/Shanghai');
+      equal(fields.calendar.id, 'iso8601');
+    });
+    it('enumerable', () => {
+      const fields2 = { ...fields };
+      equal(fields2.isoYear, 1976);
+      equal(fields2.isoMonth, 11);
+      equal(fields2.isoDay, 18);
+      equal(fields2.hour, 15);
+      equal(fields2.minute, 23);
+      equal(fields2.second, 30);
+      equal(fields2.millisecond, 123);
+      equal(fields2.microsecond, 456);
+      equal(fields2.nanosecond, 789);
+      equal(fields2.offset, '+08:00');
+      equal(fields2.timeZone, fields.timeZone);
+      equal(fields2.calendar, fields.calendar);
+    });
+  });
+
+  describe('ZonedDateTime.compare()', () => {
+    const zdt1 = ZonedDateTime.from('1976-11-18T15:23:30.123456789+01:00[Europe/Vienna]');
+    const zdt2 = ZonedDateTime.from('2019-10-29T10:46:38.271986102+01:00[Europe/Vienna]');
+    it('equal', () => equal(ZonedDateTime.compare(zdt1, zdt1), 0));
+    it('smaller/larger', () => equal(ZonedDateTime.compare(zdt1, zdt2), -1));
+    it('larger/smaller', () => equal(ZonedDateTime.compare(zdt2, zdt1), 1));
+    it('casts first argument', () => {
+      equal(ZonedDateTime.compare({ year: 1976, month: 11, day: 18, hour: 15, timeZone: 'Europe/Vienna' }, zdt2), -1);
+      equal(ZonedDateTime.compare('1976-11-18T15:23:30.123456789+01:00[Europe/Vienna]', zdt2), -1);
+    });
+    it('casts second argument', () => {
+      equal(ZonedDateTime.compare(zdt1, { year: 2019, month: 10, day: 29, hour: 10, timeZone: 'Europe/Vienna' }), -1);
+      equal(ZonedDateTime.compare(zdt1, '2019-10-29T10:46:38.271986102+01:00[Europe/Vienna]'), -1);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(
+        () => ZonedDateTime.compare({ years: 1976, months: 11, day: 19, hours: 15, timeZone: 'Europe/Vienna' }, zdt2),
+        TypeError
+      );
+      throws(
+        () => ZonedDateTime.compare(zdt1, { years: 2019, months: 10, days: 29, hours: 10, timeZone: 'Europe/Vienna' }),
+        TypeError
+      );
+    });
+    it('compares time zone IDs if exact times are equal', () => {
+      equal(ZonedDateTime.compare(zdt1, zdt1.withTimeZone('Asia/Kolkata')), 1);
+    });
+    it('compares calendar IDs if exact times and time zones are equal', () => {
+      equal(ZonedDateTime.compare(zdt1, zdt1.withCalendar('japanese')), -1);
+    });
+    it('compares exact time, not clock time', () => {
+      const clockBefore = ZonedDateTime.from('1999-12-31T23:30-08:00[America/Vancouver]');
+      const clockAfter = ZonedDateTime.from('2000-01-01T01:30-04:00[America/Halifax]');
+      equal(ZonedDateTime.compare(clockBefore, clockAfter), 1);
+      equal(Temporal.DateTime.compare(clockBefore.toDateTime(), clockAfter.toDateTime()), -1);
+    });
+  });
+});
+
+import { normalize } from 'path';
+if (normalize(import.meta.url.slice(8)) === normalize(process.argv[1])) {
+  report(reporter).then((failed) => process.exit(failed ? 1 : 0));
+}

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -191,6 +191,25 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-totemporaldatetimeroundingincrement" aoid="ToTemporalDateTimeRoundingIncrement">
+    <h1>ToTemporalDateTimeRoundingIncrement ( _normalizedOptions_, _smallestUnit_ )</h1>
+    <p>
+      The abstract operation ToTemporalDateTimeRoundingIncrement extracts the value of the property named *"roundingIncrement"* from _normalizedOptions_ and makes sure it is a valid value for the option, setting the correct maximum for rounding Temporal.ZonedDateTime and Temporal.DateTime.
+    </p>
+    <emu-alg>
+      1. If _smallestUnit_ is *"day"*, then
+        1. Let _maximum_ be 1.
+      1. Else if _smallestUnit_ is *"hour"*, then
+        1. Let _maximum_ be 24.
+      1. Else if _smallestUnit_ is *"minute"* or *"second"*, then
+        1. Let _maximum_ be 60.
+      1. Else,
+        1. Assert: _smallestUnit_ is *"millisecond"*, *"microsecond"*, or *"nanosecond"*.
+        1. Let _maximum_ be 1000.
+      1. Return ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-tosecondsstringprecision" aoid="ToSecondsStringPrecision">
     <h1>ToSecondsStringPrecision ( _normalizedOptions_ )</h1>
     <p>

--- a/spec/date.html
+++ b/spec/date.html
@@ -522,6 +522,28 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.date.prototype.tozoneddatetime">
+      <h1>Temporal.Date.prototype.toZonedDateTime ( _timeZoneLike_ [ , _temporalTime_ [ , _options_ ] ] )</h1>
+      <p>
+        The `toZonedDateTime` method takes three arguments, _timeZoneLike_, _temporalTime_, and _options_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _temporalDate_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
+        1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
+        1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
+        1. If _temporalTime_ is *undefined*, then
+          1. Let _temporalDateTime_ be ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], 0, 0, 0, 0, 0, 0, _temporalDate_.[[Calendar]]).
+        1. Else,
+          1. Set _temporalTime_ to ? ToTemporalTime(_temporalTime_).
+          1. Let _temporalDateTime_ be ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _temporalTime_.[[Hour]], _temporalTime_.[[Minute]], _temporalTime_.[[Second]], _temporalTime_.[[Millisecond]], _temporalTime_.[[Microsecond]], _temporalTime_.[[Nanosecond]], _temporalDate_.[[Calendar]]).
+        1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _temporalDateTime_, _disambiguation_).
+        1. Return ? CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _temporalDate_.[[Calendar]]).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.date.prototype.tostring">
       <h1>Temporal.Date.prototype.toString ( )</h1>
       <p>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -35,7 +35,10 @@
         1. Let _millisecond_ be ? ToInteger(_millisecond_).
         1. Let _microsecond_ be ? ToInteger(_microsecond_).
         1. Let _nanosecond_ be ? ToInteger(_nanosecond_).
-        1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
+        1. If _calendarLike_ is *undefined*, then
+          1. Set _calendar_ to ? GetISO8601Calendar().
+        1. Else,
+          1. Set _calendar_ to ? ToTemporalCalendar(_calendarLike_).
         1. Return ? CreateTemporalDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_, NewTarget).
       </emu-alg>
     </emu-clause>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -554,15 +554,7 @@
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
-        1. If _smallestUnit_ is *"day"*, then
-          1. Let _maximum_ be 1.
-        1. Else if _smallestUnit_ is *"hour"*, then
-          1. Let _maximum_ be 24.
-        1. Else if _smallestUnit_ is *"minute"* or *"second"*, then
-          1. Let _maximum_ be 60.
-        1. Else,
-          1. Let _maximum_ be 1000.
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _result_ be ? RoundDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -657,6 +657,23 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.datetime.prototype.tozoneddatetime">
+      <h1>Temporal.DateTime.prototype.toZonedDateTime ( _temporalTimeZoneLike_ [ , _options_ ] )</h1>
+      <p>
+        The `toZonedDateTime` method takes two arguments, _temporalTimeZoneLike_ and _options_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _dateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
+        1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
+        1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
+        1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _dateTime_, _disambiguation_).
+        1. Return ? CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _dateTime_.[[Calendar]]).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.datetime.prototype.todate">
       <h1>Temporal.DateTime.prototype.toDate ( )</h1>
       <p>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -493,6 +493,36 @@
         1. Return ? GetTemporalDateTimeFor(_timeZone_, _instant_, _calendar_).
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-temporal.instant.prototype.tozoneddatetime">
+      <h1>Temporal.Instant.prototype.toZonedDateTime ( _temporalTimeZoneLike_, _calendarLike_ )</h1>
+      <p>
+        The `toZonedDateTime` method takes two arguments, _temporalTimeZoneLike_ and _calendarLike_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _instant_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
+        1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
+        1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
+        1. Return ? CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _calendar_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.instant.prototype.tozoneddatetimeiso">
+      <h1>Temporal.Instant.prototype.toZonedDateTimeISO ( _temporalTimeZoneLike_ )</h1>
+      <p>
+        The `toZonedDateTimeISO` method takes one argument _temporalTimeZoneLike_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _instant_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
+        1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
+        1. Let _calendar_ be ! GetISO8601Calendar().
+        1. Return ? CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _calendar_).
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-properties-of-temporal-instant-instances">

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -181,8 +181,8 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Let _ns_ be _instant_.[[Nanoseconds]].
-        1. Let _s_ be RoundTowardsZero(_ns_ / 1,000,000,000<sub>ℝ</sub>).
-        1. Return the Number value for _s_.
+        1. Let _s_ be RoundTowardsZero(ℝ(_ns_) / 1,000,000,000<sub>ℝ</sub>).
+        1. Return 𝔽(_s_).
       </emu-alg>
     </emu-clause>
 
@@ -196,8 +196,8 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Let _ns_ be _instant_.[[Nanoseconds]].
-        1. Let _ms_ be RoundTowardsZero(_ns_ / 1,000,000<sub>ℝ</sub>).
-        1. Return the Number value for _ms_.
+        1. Let _ms_ be RoundTowardsZero(ℝ(_ns_) / 1,000,000<sub>ℝ</sub>).
+        1. Return 𝔽(_ms_).
       </emu-alg>
     </emu-clause>
 
@@ -211,8 +211,8 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Let _ns_ be _instant_.[[Nanoseconds]].
-        1. Let _mcs_ be RoundTowardsZero(_ns_ / 1,000<sub>ℝ</sub>).
-        1. Return _mcs_.
+        1. Let _µs_ be RoundTowardsZero(ℝ(_ns_) / 1,000<sub>ℝ</sub>).
+        1. Return ℤ(_µs_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/time.html
+++ b/spec/time.html
@@ -397,6 +397,25 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.time.prototype.tozoneddatetime">
+      <h1>Temporal.Time.prototype.toZonedDateTime ( _timeZoneLike_, _temporalDate_ [ , _options_ ] )</h1>
+      <p>
+        The `toZonedDateTime` method takes three arguments, _timeZoneLike_, _temporalDate_, and _options_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _temporalTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
+        1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
+        1. Set _temporalDate_ to ? ToTemporalTime(_temporalDate_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
+        1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
+        1. Let _temporalDateTime_ be ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _temporalTime_.[[Hour]], _temporalTime_.[[Minute]], _temporalTime_.[[Second]], _temporalTime_.[[Millisecond]], _temporalTime_.[[Microsecond]], _temporalTime_.[[Nanosecond]], _temporalDate_.[[Calendar]]).
+        1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _temporalDateTime_, _disambiguation_).
+        1. Return ? CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _temporalDate_.[[Calendar]]).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.time.prototype.getfields">
       <h1>Temporal.Time.prototype.getFields ( )</h1>
       <p>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -869,9 +869,22 @@
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Let _fields_ be ? ObjectCreate(%ObjectPrototype%).
-        1. <mark>TODO</mark>.
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"timeZone"*, _zonedDateTime_.[[TimeZone]]).
+        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _instant_ be ? CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
+        1. Let _temporalDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_).
+        1. Let _offset_ be ? GetOffsetStringFor(_timeZone_, _instant_).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"calendar"*, _zonedDateTime_.[[Calendar]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"hour"*, _dateTime_.[[Hour]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoDay"*, _dateTime_.[[ISODay]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMonth"*, _dateTime_.[[ISOMonth]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoYear"*, _dateTime_.[[ISOYear]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"microsecond"*, _dateTime_.[[Microsecond]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"millisecond"*, _dateTime_.[[Millisecond]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"minute"*, _dateTime_.[[Minute]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"nanosecond"*, _dateTime_.[[Nanosecond]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"offset"*, _offset_).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"second"*, _dateTime_.[[Second]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"timeZone"*, _timeZone_).
         1. Return _fields_.
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -691,15 +691,7 @@
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
-        1. If _smallestUnit_ is *"day"*, then
-          1. Let _maximum_ be 1.
-        1. Else if _smallestUnit_ is *"hour"*, then
-          1. Let _maximum_ be 24.
-        1. Else if _smallestUnit_ is *"minute"* or *"second"*, then
-          1. Let _maximum_ be 60.
-        1. Else,
-          1. Let _maximum_ be 1000.
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_options_, _maximum_, *false*).
         1. <mark>TODO</mark>.
         1. Return ? CreateTemporalZonedDateTimeFromInstance(_zonedDateTime_, _epochNanoseconds_, _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]]).
       </emu-alg>


### PR DESCRIPTION
This includes all the "trivial" methods of ZonedDateTime and their tests (spec text already exists), and all the conversion methods from other types to ZonedDateTime, and their tests and specification text.

Unimplemented methods (with, add, subtract, until, since, round, getFields, and anything dealing with DST) throw, for the time being. Some options (offset and overflow in from()) are also not implemented yet.
