### PR TITLE
Convenience comparison methods: lessThan(), greaterThan(), lessEquals(), greaterEquals()

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -555,6 +555,118 @@ date.equals(other); // => false
 date.equals(date); // => true
 ```
 
+### date.**lessThan**(_other_: Temporal.Date | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Date` or value convertible to one): Another date to compare.
+
+**Returns:** `true` if `date` is earlier than `other`, or `false` if not.
+
+Compares two `Temporal.Date` objects to check if `date` is earlier than `other`.
+
+This function exists because it's not possible to compare using `date < other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Date.compare(date, other) < 0` but is easier to understand and shorter to type.
+
+Note that this function ignores calendar systems by converting both values to the ISO 8601 calendar before comparing.
+
+If `other` is not a `Temporal.Date` object, then it will be converted to one as if it were passed to `Temporal.Date.from()`.
+
+Example usage:
+
+```javascript
+date = Temporal.Date.from('2006-08-24');
+other = Temporal.Date.from('2019-01-31');
+date.lessThan(other); // => true
+date.lessThan('2000-01-01'); // => false
+date.lessThan(date); // => false
+```
+
+### date.**greaterThan**(_other_: Temporal.Date | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Date` or value convertible to one): Another date to compare.
+
+**Returns:** `true` if `date` is later than `other`, or `false` if not.
+
+Compares two `Temporal.Date` objects to check if `date` is later than `other`.
+
+This function exists because it's not possible to compare using `date > other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Date.compare(date, other) > 0` but is easier to understand and shorter to type.
+
+Note that this function ignores calendar systems by converting both values to the ISO 8601 calendar before comparing.
+
+If `other` is not a `Temporal.Date` object, then it will be converted to one as if it were passed to `Temporal.Date.from()`.
+
+Example usage:
+
+```javascript
+date = Temporal.Date.from('2006-08-24');
+other = Temporal.Date.from('2019-01-31');
+date.greaterThan(other); // => false
+date.greaterThan('2000-01-01'); // => true
+date.greaterThan(date); // => false
+```
+
+### date.**lessEquals**(_other_: Temporal.Date | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Date` or value convertible to one): Another date to compare.
+
+**Returns:** `true` if `date` is earlier than or equal to `other`, or `false` if not.
+
+Compares two `Temporal.Date` objects to check if `date` is earlier than or equal to `other`.
+
+This function exists because it's not possible to compare using `date <= other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Date.compare(date, other) <= 0` but is easier to understand and shorter to type.
+
+Note that this function ignores calendar systems by converting both values to the ISO 8601 calendar before comparing.
+
+If `other` is not a `Temporal.Date` object, then it will be converted to one as if it were passed to `Temporal.Date.from()`.
+
+Example usage:
+
+```javascript
+date = Temporal.Date.from('2006-08-24');
+other = Temporal.Date.from('2019-01-31');
+date.lessEquals(other); // => true
+date.lessEquals('2000-01-01'); // => false
+date.lessEquals(date); // => true
+```
+
+### date.**greaterEquals**(_other_: Temporal.Date | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Date` or value convertible to one): Another date to compare.
+
+**Returns:** `true` if `date` is later than or equal to `other`, or `false` if not.
+
+Compares two `Temporal.Date` objects to check if `date` is later than or equal to `other`.
+
+This function exists because it's not possible to compare using `date >= other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Date.compare(date, other) >= 0` but is easier to understand and shorter to type.
+
+Note that this function ignores calendar systems by converting both values to the ISO 8601 calendar before comparing.
+
+If `other` is not a `Temporal.Date` object, then it will be converted to one as if it were passed to `Temporal.Date.from()`.
+
+Example usage:
+
+```javascript
+date = Temporal.Date.from('2006-08-24');
+other = Temporal.Date.from('2019-01-31');
+date.greaterThan(other); // => false
+date.greaterThan('2000-01-01'); // => true
+date.greaterThan(date); // => true
+```
+
 ### date.**toString**() : string
 
 **Returns:** a string in the ISO 8601 date format representing `date`.

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -693,6 +693,118 @@ dt1.equals(dt2); // => false
 dt1.equals(dt1); // => true
 ```
 
+### datetime.**lessThan**(_other_: Temporal.DateTime | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.DateTime`): Another date/time to compare.
+
+**Returns:** `true` if `datetime` is earlier than `other`, or `false` if not.
+
+Compares two `Temporal.DateTime` objects to check if `datetime` is earlier than `other`.
+
+This function exists because it's not possible to compare using `datetime < other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.DateTime.compare(datetime, other) < 0` but is easier to understand and shorter to type.
+
+Note that this function ignores calendar systems by converting both values to the ISO 8601 calendar before comparing.
+
+If `other` is not a `Temporal.DateTime` object, then it will be converted to one as if it were passed to `Temporal.DateTime.from()`.
+
+Example usage:
+
+```javascript
+dt1 = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
+dt2 = Temporal.DateTime.from('2019-01-31T15:30');
+dt1.lessThan(dt2); // => true
+dt1.lessThan('1999-12-31'); // => false
+dt1.lessThan(dt1); // => false
+```
+
+### datetime.**greaterThan**(_other_: Temporal.DateTime | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.DateTime`): Another date/time to compare.
+
+**Returns:** `true` if `datetime` is later than `other`, or `false` if not.
+
+Compares two `Temporal.DateTime` objects to check if `datetime` is later than `other`.
+
+This function exists because it's not possible to compare using `datetime > other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.DateTime.compare(datetime, other) > 0` but is easier to understand and shorter to type.
+
+Note that this function ignores calendar systems by converting both values to the ISO 8601 calendar before comparing.
+
+If `other` is not a `Temporal.DateTime` object, then it will be converted to one as if it were passed to `Temporal.DateTime.from()`.
+
+Example usage:
+
+```javascript
+dt1 = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
+dt2 = Temporal.DateTime.from('2019-01-31T15:30');
+dt1.greaterThan(dt2); // => false
+dt1.greaterThan('1999-12-31'); // => true
+dt1.greaterThan(dt1); // => false
+```
+
+### datetime.**lessEquals**(_other_: Temporal.DateTime | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.DateTime`): Another date/time to compare.
+
+**Returns:** `true` if `datetime` is earlier than or equal to`other`, or `false` if not.
+
+Compares two `Temporal.DateTime` objects to check if `datetime` is earlier than or equal to `other`.
+
+This function exists because it's not possible to compare using `datetime <= other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.DateTime.compare(datetime, other) <= 0` but is easier to understand and shorter to type.
+
+Note that this function ignores calendar systems by converting both values to the ISO 8601 calendar before comparing.
+
+If `other` is not a `Temporal.DateTime` object, then it will be converted to one as if it were passed to `Temporal.DateTime.from()`.
+
+Example usage:
+
+```javascript
+dt1 = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
+dt2 = Temporal.DateTime.from('2019-01-31T15:30');
+dt1.lessEquals(dt2); // => true
+dt1.lessEquals('1999-12-31'); // => false
+dt1.lessEquals(dt1); // => true
+```
+
+### datetime.**greaterEquals**(_other_: Temporal.DateTime | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.DateTime`): Another date/time to compare.
+
+**Returns:** `true` if `datetime` is later than or equal to `other`, or `false` if not.
+
+Compares two `Temporal.DateTime` objects to check if `datetime` is later than or equal to `other`.
+
+This function exists because it's not possible to compare using `datetime >= other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.DateTime.compare(datetime, other) >= 0` but is easier to understand and shorter to type.
+
+Note that this function ignores calendar systems by converting both values to the ISO 8601 calendar before comparing.
+
+If `other` is not a `Temporal.DateTime` object, then it will be converted to one as if it were passed to `Temporal.DateTime.from()`.
+
+Example usage:
+
+```javascript
+dt1 = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
+dt2 = Temporal.DateTime.from('2019-01-31T15:30');
+dt1.greaterEquals(dt2); // => false
+dt1.greaterEquals('1999-12-31'); // => true
+dt1.greaterEquals(dt1); // => true
+```
+
 ### datetime.**toString**(_options_?: object) : string
 
 **Parameters:**
@@ -722,6 +834,7 @@ Note that rounding may change the value of other units as well.
 
 Example usage:
 
+<!-- prettier-ignore-start -->
 ```js
 dt = Temporal.DateTime.from({
   year: 1999,
@@ -742,6 +855,7 @@ dt.toString({ fractionalSecondDigits: 4 }); // => 1999-12-31T23:59:59.9999
 dt.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' });
   // => 2000-01-01T00:00:00.00000000
 ```
+<!-- prettier-ignore-end -->
 
 ### datetime.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
 

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -611,6 +611,110 @@ one.equals(two); // => false
 one.equals(one); // => true
 ```
 
+### instant.**lessThan**(_other_: Temporal.Instant | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Instant` or value convertible to one): Another exact time to compare.
+
+**Returns:** `true` if `instant` is earlier than `other`, or `false` if not.
+
+Compares two `Temporal.Instant` objects to check if `instant` is earlier than `other`.
+
+This function exists because it's not possible to compare using `instant < other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Instant.compare(instant, other) < 0` but is easier to understand and shorter to type.
+
+If `other` is not a `Temporal.Instant` object, then it will be converted to one as if it were passed to `Temporal.Instant.from()`.
+
+Example usage:
+
+```javascript
+one = Temporal.Instant.fromEpochSeconds(1.0e9);
+two = Temporal.Instant.fromEpochSeconds(1.1e9);
+one.lessThan(two); // => true
+two.lessThan(one); // => false
+one.lessThan(one); // => false
+```
+
+### instant.**greaterThan**(_other_: Temporal.Instant | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Instant` or value convertible to one): Another exact time to compare.
+
+**Returns:** `true` if `instant` is later than `other`, or `false` if not.
+
+Compares two `Temporal.Instant` objects to check if `instant` is later than `other`.
+
+This function exists because it's not possible to compare using `instant > other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Instant.compare(instant, other) > 0` but is easier to understand and shorter to type.
+
+If `other` is not a `Temporal.Instant` object, then it will be converted to one as if it were passed to `Temporal.Instant.from()`.
+
+Example usage:
+
+```javascript
+one = Temporal.Instant.fromEpochSeconds(1.0e9);
+two = Temporal.Instant.fromEpochSeconds(1.1e9);
+one.greaterThan(two); // => false
+two.greaterThan(one); // => true
+one.greaterThan(one); // => false
+```
+
+### instant.**lessEquals**(_other_: Temporal.Instant | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Instant` or value convertible to one): Another exact time to compare.
+
+**Returns:** `true` if `instant` is earlier than or equal to `other`, or `false` if not.
+
+Compares two `Temporal.Instant` objects to check if `instant` is earlier than or equal to `other`.
+
+This function exists because it's not possible to compare using `instant <= other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Instant.compare(instant, other) <= 0` but is easier to understand and shorter to type.
+
+If `other` is not a `Temporal.Instant` object, then it will be converted to one as if it were passed to `Temporal.Instant.from()`.
+
+Example usage:
+
+```javascript
+one = Temporal.Instant.fromEpochSeconds(1.0e9);
+two = Temporal.Instant.fromEpochSeconds(1.1e9);
+one.lessEquals(two); // => true
+two.lessEquals(one); // => false
+one.lessEquals(one); // => true
+```
+
+### instant.**greaterEquals**(_other_: Temporal.Instant | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Instant` or value convertible to one): Another exact time to compare.
+
+**Returns:** `true` if `instant` is later than or equal to `other`, or `false` if not.
+
+Compares two `Temporal.Instant` objects to check if `instant` is later than or equal to `other`.
+
+This function exists because it's not possible to compare using `instant >= other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Instant.compare(instant, other) >= 0` but is easier to understand and shorter to type.
+
+If `other` is not a `Temporal.Instant` object, then it will be converted to one as if it were passed to `Temporal.Instant.from()`.
+
+Example usage:
+
+```javascript
+one = Temporal.Instant.fromEpochSeconds(1.0e9);
+two = Temporal.Instant.fromEpochSeconds(1.1e9);
+one.greaterEquals(two); // => false
+two.greaterEquals(one); // => true
+one.greaterEquals(one); // => true
+```
+
 ### instant.**toString**(_timeZone_?: object | string, _options_?: object) : string
 
 **Parameters:**
@@ -642,6 +746,7 @@ Note that rounding may change the value of other units as well.
 
 Example usage:
 
+<!-- prettier-ignore-start -->
 ```js
 instant = Temporal.Instant.fromEpochMilliseconds(1574074321816);
 instant.toString(); // => 2019-11-18T10:52:01.816Z
@@ -657,6 +762,7 @@ instant.toString(undefined, { fractionalSecondDigits: 4 });
 instant.toString(undefined, { smallestUnit: 'second', roundingMode: 'nearest' });
   // => 2019-11-18T10:52:02Z
 ```
+<!-- prettier-ignore-end -->
 
 ### instant.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
 

--- a/docs/time.md
+++ b/docs/time.md
@@ -414,7 +414,7 @@ Compares two `Temporal.Time` objects for equality.
 
 This function exists because it's not possible to compare using `time == other` or `time === other`, due to ambiguity in the primitive representation and between Temporal types.
 
-If you don't need to know the order in which the two dates occur, then this function may be less typing and more efficient than `Temporal.Time.compare`.
+If you don't need to know the order in which the two times occur, then this function may be less typing and more efficient than `Temporal.Time.compare`.
 
 If `other` is not a `Temporal.Time` object, then it will be converted to one as if it were passed to `Temporal.Time.from()`.
 
@@ -425,6 +425,110 @@ time = Temporal.Time.from('19:39:09.068346205');
 other = Temporal.Time.from('20:13:20.971398099');
 time.equals(other); // => false
 time.equals(time); // => true
+```
+
+### time.**lessThan**(_other_: Temporal.Time | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Time` or value convertible to one): Another time to compare.
+
+**Returns:** `true` if `time` is earlier than `other`, or `false` if not.
+
+Compares two `Temporal.Time` objects to check if `time` is earlier than `other`.
+
+This function exists because it's not possible to compare using `time < other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Time.compare(time, other) < 0` but is easier to understand and shorter to type.
+
+If `other` is not a `Temporal.Time` object, then it will be converted to one as if it were passed to `Temporal.Time.from()`.
+
+Example usage:
+
+```javascript
+time = Temporal.Time.from('19:39:09.068346205');
+other = Temporal.Time.from('20:13:20.971398099');
+time.lessThan(other); // => true
+time.lessThan('08:00'); // => false
+time.lessThan(time); // => false
+```
+
+### time.**greaterThan**(_other_: Temporal.Time | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Time` or value convertible to one): Another time to compare.
+
+**Returns:** `true` if `time` is later than `other`, or `false` if not.
+
+Compares two `Temporal.Time` objects to check if `time` is later than `other`.
+
+This function exists because it's not possible to compare using `time > other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Time.compare(time, other) > 0` but is easier to understand and shorter to type.
+
+If `other` is not a `Temporal.Time` object, then it will be converted to one as if it were passed to `Temporal.Time.from()`.
+
+Example usage:
+
+```javascript
+time = Temporal.Time.from('19:39:09.068346205');
+other = Temporal.Time.from('20:13:20.971398099');
+time.greaterThan(other); // => false
+time.greaterThan('02:00'); // => true
+time.greaterThan(time); // => false
+```
+
+### time.**lessEquals**(_other_: Temporal.Time | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Time` or value convertible to one): Another time to compare.
+
+**Returns:** `true` if `time` is earlier than or equal to `other`, or `false` if not.
+
+Compares two `Temporal.Time` objects to check if `time` is earlier than or equal to `other`.
+
+This function exists because it's not possible to compare using `time <= other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Time.compare(time, other) <= 0` but is easier to understand and shorter to type.
+
+If `other` is not a `Temporal.Time` object, then it will be converted to one as if it were passed to `Temporal.Time.from()`.
+
+Example usage:
+
+```javascript
+time = Temporal.Time.from('19:39:09.068346205');
+other = Temporal.Time.from('20:13:20.971398099');
+time.lessEquals(other); // => true
+time.lessEquals('08:00'); // => false
+time.lessEquals(time); // => true
+```
+
+### time.**greaterEquals**(_other_: Temporal.Time | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.Time` or value convertible to one): Another time to compare.
+
+**Returns:** `true` if `time` is later than or equal to `other`, or `false` if not.
+
+Compares two `Temporal.Time` objects to check if `time` is later than or equal to `other`.
+
+This function exists because it's not possible to compare using `time >= other` due to ambiguity in the primitive representation and between Temporal types.
+
+This function returns the same result as `Temporal.Time.compare(time, other) >= 0` but is easier to understand and shorter to type.
+
+If `other` is not a `Temporal.Time` object, then it will be converted to one as if it were passed to `Temporal.Time.from()`.
+
+Example usage:
+
+```javascript
+time = Temporal.Time.from('19:39:09.068346205');
+other = Temporal.Time.from('20:13:20.971398099');
+time.greaterEquals(other); // => false
+time.greaterEquals('02:00'); // => true
+time.greaterEquals(time); // => true
 ```
 
 ### time.**toString**(_options_?: object) : string
@@ -456,6 +560,7 @@ Note that rounding may change the value of other units as well.
 
 Example usage:
 
+<!-- prettier-ignore-start -->
 ```js
 time = Temporal.Time.from('19:39:09.068346205');
 time.toString(); // => 19:39:09.068346205
@@ -463,9 +568,10 @@ time.toString(); // => 19:39:09.068346205
 time.toString({ smallestUnit: 'minute' }); // => 19:39
 time.toString({ fractionalSecondDigits: 0 }); // => 19:39:09
 time.toString({ fractionalSecondDigits: 4 }); // => 19:39:09.0683
-time.toString({ fractionalSecondDigits: 5, roundingMode: 'nearest' })
+time.toString({ fractionalSecondDigits: 5, roundingMode: 'nearest' });
   // => 19:39:09.06835
 ```
+<!-- prettier-ignore-end -->
 
 ### time.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
 

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -436,7 +436,7 @@ This function exists because it's not possible to compare using `yearMonth == ot
 
 If `other` is not a `Temporal.YearMonth` object, then it will be converted to one as if it were passed to `Temporal.YearMonth.from()`.
 
-Note that equality of two months from different calendar systems only makes sense in a few cases, such as when the two calendar systems both use the Gregorian year.
+Note that equality of two `Temporal.YearMonth` objects in different calendar systems only makes sense when the definitions of months and years are the same in both calendars, such as when both calendars use Gregorian years and months.
 
 Even if you are using the same calendar system, if you don't need to know the order in which the two months occur, then this function may be less typing and more efficient than `Temporal.YearMonth.compare`.
 
@@ -447,6 +447,118 @@ ym = Temporal.YearMonth.from('2019-06');
 other = Temporal.YearMonth.from('2006-08');
 ym.equals(other); // => false
 ym.equals(ym); // => true
+```
+
+### yearMonth.**lessThan**(_other_: Temporal.YearMonth | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.YearMonth` or value convertible to one): Another month to compare.
+
+**Returns:** `true` if `yearMonth` is earlier than `other`, or `false` if not.
+
+Compares two `Temporal.YearMonth` objects to check if `yearMonth` is earlier than `other`.
+
+This function exists because it's not possible to compare using `yearMonth < other` due to ambiguity in the primitive representation and between Temporal types.
+
+If `other` is not a `Temporal.YearMonth` object, then it will be converted to one as if it were passed to `Temporal.YearMonth.from()`.
+
+Note that comparison of two `Temporal.YearMonth` objects in different calendar systems only makes sense when the definitions of months and years are the same in both calendars, such as when both calendars use Gregorian years and months.
+
+This function returns the same result as `Temporal.YearMonth.compare(date, other) < 0` but is easier to understand and shorter to type.
+
+Example usage:
+
+```javascript
+ym = Temporal.YearMonth.from('2019-06');
+other = Temporal.YearMonth.from('2006-08');
+ym.lessThan(other); // => false
+ym.lessThan('2020-03'); // => true
+ym.lessThan(ym); // => false
+```
+
+### yearMonth.**greaterThan**(_other_: Temporal.YearMonth | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.YearMonth` or value convertible to one): Another month to compare.
+
+**Returns:** `true` if `yearMonth` is later than `other`, or `false` if not.
+
+Compares two `Temporal.YearMonth` objects to check if `yearMonth` is later than `other`.
+
+This function exists because it's not possible to compare using `yearMonth > other` due to ambiguity in the primitive representation and between Temporal types.
+
+If `other` is not a `Temporal.YearMonth` object, then it will be converted to one as if it were passed to `Temporal.YearMonth.from()`.
+
+Note that comparison of two `Temporal.YearMonth` objects in different calendar systems only makes sense when the definitions of months and years are the same in both calendars, such as when both calendars use Gregorian years and months.
+
+This function returns the same result as `Temporal.YearMonth.compare(date, other) > 0` but is easier to understand and shorter to type.
+
+Example usage:
+
+```javascript
+ym = Temporal.YearMonth.from('2019-06');
+other = Temporal.YearMonth.from('2006-08');
+ym.greaterThan(other); // => true
+ym.greaterThan('2020-03'); // => false
+ym.greaterThan(ym); // => false
+```
+
+### yearMonth.**lessEquals**(_other_: Temporal.YearMonth | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.YearMonth` or value convertible to one): Another month to compare.
+
+**Returns:** `true` if `yearMonth` is earlier than or equal to `other`, or `false` if not.
+
+Compares two `Temporal.YearMonth` objects to check if `yearMonth` is earlier than or equal to `other`.
+
+This function exists because it's not possible to compare using `yearMonth <= other` due to ambiguity in the primitive representation and between Temporal types.
+
+If `other` is not a `Temporal.YearMonth` object, then it will be converted to one as if it were passed to `Temporal.YearMonth.from()`.
+
+Note that comparison of two `Temporal.YearMonth` objects in different calendar systems only makes sense when the definitions of months and years are the same in both calendars, such as when both calendars use Gregorian years and months.
+
+This function returns the same result as `Temporal.YearMonth.compare(date, other) <= 0` but is easier to understand and shorter to type.
+
+Example usage:
+
+```javascript
+ym = Temporal.YearMonth.from('2019-06');
+other = Temporal.YearMonth.from('2006-08');
+ym.lessEquals(other); // => false
+ym.lessEquals('2020-03'); // => true
+ym.lessEquals(ym); // => true
+```
+
+### yearMonth.**greaterEquals**(_other_: Temporal.YearMonth | object | string) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.YearMonth` or value convertible to one): Another month to compare.
+
+**Returns:** `true` if `yearMonth` is later than or equal to `other`, or `false` if not.
+
+Compares two `Temporal.YearMonth` objects to check if `yearMonth` is later than or equal to `other`.
+
+This function exists because it's not possible to compare using `yearMonth >= other` due to ambiguity in the primitive representation and between Temporal types.
+
+If `other` is not a `Temporal.YearMonth` object, then it will be converted to one as if it were passed to `Temporal.YearMonth.from()`.
+
+Note that comparison of two `Temporal.YearMonth` objects in different calendar systems only makes sense when the definitions of months and years are the same in both calendars, such as when both calendars use Gregorian years and months.
+
+This function returns the same result as `Temporal.YearMonth.compare(date, other) >= 0` but is easier to understand and shorter to type.
+
+Example usage:
+
+```javascript
+ym = Temporal.YearMonth.from('2019-06');
+other = Temporal.YearMonth.from('2006-08');
+ym.greaterEquals(other); // => true
+ym.greaterEquals('2020-03'); // => false
+ym.greaterEquals(ym); // => true
 ```
 
 ### yearMonth.**toString**() : string

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1049,7 +1049,7 @@ If you don't need to know the order in which two events occur, then this functio
 But both methods do the same thing, so a `0` returned from `compare` implies a `true` result from `equals`, and vice-versa.
 
 Note that two `Temporal.ZonedDateTime` instances can have the same clock time, time zone, and calendar but still be unequal, e.g. when a clock hour is repeated after DST ends in the Fall.
-In this case, the two instances will have different `offsetNanoseconds` field values.
+In this case, the two instances will have different `offset` and `offsetNanoseconds` field values.
 
 To ignore calendars, convert both instances to use the ISO 8601 calendar:
 
@@ -1060,7 +1060,7 @@ zdt.withCalendar('iso8601').equals(other.withCalendar('iso8601'));
 To ignore both time zones and calendars, compare the instants of both:
 
 ```javascript
-zdt.toInstant().equals(other.toInstant()));
+zdt.toInstant().equals(other.toInstant());
 ```
 
 Example usage:
@@ -1070,6 +1070,186 @@ zdt1 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/P
 zdt2 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Brussels]');
 zdt1.equals(zdt2); // => false (same offset but different time zones)
 zdt1.equals(zdt1); // => true
+```
+
+### zonedDateTime.**lessThan**(_other_: Temporal.ZonedDateTime) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.ZonedDateTime`): Another date/time to compare.
+
+**Returns:** `true` if `zonedDateTime` is earlier than `other` (using calendar ID and time zone ID as tie-breakers if the two objects represent the same instant), or `false` otherwise.
+
+Compares two `Temporal.ZonedDateTime` objects to check if `zonedDateTime` is earlier than `other`.
+
+This function exists because it's not possible to compare using `zonedDateTime < other` due to ambiguity in the primitive representation and between Temporal types.
+
+Comparison will use exact time, not clock time, because sorting is almost always based on when events happened in the real world.
+Note that during the hour before and after DST ends, sorting of clock time may not match the order the events actually occurred.
+
+If exact timestamps are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
+If those are equal too, then `.timeZone.id` will be compared lexicographically.
+
+This function returns the same result as `Temporal.ZonedDateTime.compare(date, other) < 0` but is easier to understand and shorter to type.
+
+Note that two `Temporal.ZonedDateTime` instances can have the same clock time, time zone, and calendar but still be unequal, e.g. when a clock hour is repeated after DST ends in the Fall.
+In this case, the two instances will have different `offset` and `offsetNanoseconds` field values.
+
+To ignore calendars, convert both instances to use the ISO 8601 calendar:
+
+```javascript
+zdt.withCalendar('iso8601').lessThan(other.withCalendar('iso8601'));
+```
+
+To ignore both time zones and calendars, compare the instants of both:
+
+```javascript
+zdt.toInstant().lessThan(other.toInstant());
+```
+
+Example usage:
+
+```javascript
+zdt1 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Paris]');
+zdt1.lessThan('2000-01-01T00:00-08:00[America/Los_Angeles]'); // => true
+zdt2 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Brussels]');
+zdt2.lessThan(zdt1); // => true (same instant but "Europe/Brussels" < "Europe/Paris" as text)
+zdt1.lessThan(zdt1); // => false
+```
+
+### zonedDateTime.**greaterThan**(_other_: Temporal.ZonedDateTime) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.ZonedDateTime`): Another date/time to compare.
+
+**Returns:** `true` if `zonedDateTime` is earlier than `other` (using calendar ID and time zone ID as tie-breakers if the two objects represent the same instant), or `false` otherwise.
+
+Compares two `Temporal.ZonedDateTime` objects to check if `zonedDateTime` is earlier than `other`.
+
+This function exists because it's not possible to compare using `zonedDateTime < other` due to ambiguity in the primitive representation and between Temporal types.
+
+Comparison will use exact time, not clock time, because sorting is almost always based on when events happened in the real world.
+Note that during the hour before and after DST ends, sorting of clock time may not match the order the events actually occurred.
+
+If exact timestamps are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
+If those are equal too, then `.timeZone.id` will be compared lexicographically.
+
+This function returns the same result as `Temporal.ZonedDateTime.compare(date, other) < 0` but is easier to understand and shorter to type.
+
+Note that two `Temporal.ZonedDateTime` instances can have the same clock time, time zone, and calendar but still be unequal, e.g. when a clock hour is repeated after DST ends in the Fall.
+In this case, the two instances will have different `offset` and `offsetNanoseconds` field values.
+
+To ignore calendars, convert both instances to use the ISO 8601 calendar:
+
+```javascript
+zdt.withCalendar('iso8601').greaterThan(other.withCalendar('iso8601'));
+```
+
+To ignore both time zones and calendars, compare the instants of both:
+
+```javascript
+zdt.toInstant().greaterThan(other.toInstant());
+```
+
+Example usage:
+
+```javascript
+zdt1 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Paris]');
+zdt1.greaterThan('2000-01-01T00:00-08:00[America/Los_Angeles]'); // => false
+zdt2 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Brussels]');
+zdt1.greaterThan(zdt2); // => true (same instant but "Europe/Paris" > "Europe/Brussels" as text)
+zdt1.greaterThan(zdt1); // => false
+```
+
+### zonedDateTime.**lessEquals**(_other_: Temporal.ZonedDateTime) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.ZonedDateTime`): Another date/time to compare.
+
+**Returns:** `true` if `zonedDateTime` is earlier than or equal to `other` (using calendar ID and time zone ID as tie-breakers if the two objects represent the same instant), or `false` otherwise.
+
+Compares two `Temporal.ZonedDateTime` objects to check if `zonedDateTime` is earlier than or equal to `other`.
+
+This function exists because it's not possible to compare using `zonedDateTime <= other` due to ambiguity in the primitive representation and between Temporal types.
+
+Comparison will use exact time, not clock time, because sorting is almost always based on when events happened in the real world.
+Note that during the hour before and after DST ends, sorting of clock time may not match the order the events actually occurred.
+
+If exact timestamps are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
+If those are equal too, then `.timeZone.id` will be compared lexicographically.
+
+This function returns the same result as `Temporal.ZonedDateTime.compare(date, other) <= 0` but is easier to understand and shorter to type.
+
+Note that two `Temporal.ZonedDateTime` instances can have the same clock time, time zone, and calendar but still be unequal, e.g. when a clock hour is repeated after DST ends in the Fall.
+In this case, the two instances will have different `offset` and `offsetNanoseconds` field values.
+
+To ignore calendars, convert both instances to use the ISO 8601 calendar:
+
+```javascript
+zdt.withCalendar('iso8601').lessEquals(other.withCalendar('iso8601'));
+```
+
+To ignore both time zones and calendars, compare the instants of both:
+
+```javascript
+zdt.toInstant().lessEquals(other.toInstant());
+```
+
+Example usage:
+
+```javascript
+zdt1 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Paris]');
+zdt1.lessEquals('2000-01-01T00:00-08:00[America/Los_Angeles]'); // => true
+zdt2 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Brussels]');
+zdt2.lessEquals(zdt1); // => true (same instant but "Europe/Brussels" < "Europe/Paris" as text)
+zdt1.lessEquals(zdt1); // => true
+```
+
+### zonedDateTime.**greaterEquals**(_other_: Temporal.ZonedDateTime) : boolean
+
+**Parameters:**
+
+- `other` (`Temporal.ZonedDateTime`): Another date/time to compare.
+
+**Returns:** `true` if `zonedDateTime` is earlier than or equal to `other` (using calendar ID and time zone ID as tie-breakers if the two objects represent the same instant), or `false` otherwise.
+
+Compares two `Temporal.ZonedDateTime` objects to check if `zonedDateTime` is earlier than or equal to `other`.
+
+This function exists because it's not possible to compare using `zonedDateTime <= other` due to ambiguity in the primitive representation and between Temporal types.
+
+Comparison will use exact time, not clock time, because sorting is almost always based on when events happened in the real world.
+Note that during the hour before and after DST ends, sorting of clock time may not match the order the events actually occurred.
+
+If exact timestamps are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
+If those are equal too, then `.timeZone.id` will be compared lexicographically.
+
+This function returns the same result as `Temporal.ZonedDateTime.compare(date, other) <= 0` but is easier to understand and shorter to type.
+
+Note that two `Temporal.ZonedDateTime` instances can have the same clock time, time zone, and calendar but still be unequal, e.g. when a clock hour is repeated after DST ends in the Fall.
+In this case, the two instances will have different `offset` and `offsetNanoseconds` field values.
+
+To ignore calendars, convert both instances to use the ISO 8601 calendar:
+
+```javascript
+zdt.withCalendar('iso8601').greaterThan(other.withCalendar('iso8601'));
+```
+
+To ignore both time zones and calendars, compare the instants of both:
+
+```javascript
+zdt.toInstant().greaterThan(other.toInstant());
+```
+
+Example usage:
+
+```javascript
+zdt1 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Paris]');
+zdt1.greaterThan('2000-01-01T00:00-08:00[America/Los_Angeles]'); // => false
+zdt2 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Brussels]');
+zdt1.greaterThan(zdt2); // => true (same instant but "Europe/Paris" > "Europe/Brussels" as text)
+zdt1.greaterThan(zdt1); // => true
 ```
 
 ### zonedDateTime.**toString**() : string

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -289,6 +289,62 @@ export class Date {
     }
     return ES.CalendarEquals(this, other);
   }
+  lessThan(other) {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalDate(other, Date);
+    let result = ES.CompareTemporalDate(
+      GetSlot(this, ISO_YEAR),
+      GetSlot(this, ISO_MONTH),
+      GetSlot(this, ISO_DAY),
+      GetSlot(other, ISO_YEAR),
+      GetSlot(other, ISO_MONTH),
+      GetSlot(other, ISO_DAY)
+    );
+    if (!result) result = ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+    return result < 0;
+  }
+  greaterThan(other) {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalDate(other, Date);
+    let result = ES.CompareTemporalDate(
+      GetSlot(this, ISO_YEAR),
+      GetSlot(this, ISO_MONTH),
+      GetSlot(this, ISO_DAY),
+      GetSlot(other, ISO_YEAR),
+      GetSlot(other, ISO_MONTH),
+      GetSlot(other, ISO_DAY)
+    );
+    if (!result) result = ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+    return result > 0;
+  }
+  lessEquals(other) {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalDate(other, Date);
+    let result = ES.CompareTemporalDate(
+      GetSlot(this, ISO_YEAR),
+      GetSlot(this, ISO_MONTH),
+      GetSlot(this, ISO_DAY),
+      GetSlot(other, ISO_YEAR),
+      GetSlot(other, ISO_MONTH),
+      GetSlot(other, ISO_DAY)
+    );
+    if (!result) result = ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+    return result <= 0;
+  }
+  greaterEquals(other) {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalDate(other, Date);
+    let result = ES.CompareTemporalDate(
+      GetSlot(this, ISO_YEAR),
+      GetSlot(this, ISO_MONTH),
+      GetSlot(this, ISO_DAY),
+      GetSlot(other, ISO_YEAR),
+      GetSlot(other, ISO_MONTH),
+      GetSlot(other, ISO_DAY)
+    );
+    if (!result) result = ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
+    return result >= 0;
+  }
   toString() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     return TemporalDateToString(this);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -695,6 +695,46 @@ export class DateTime {
     }
     return ES.CalendarEquals(this, other);
   }
+  lessThan(other) {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalDateTime(other, DateTime);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 < val2;
+    }
+    return ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR)) < 0;
+  }
+  greaterThan(other) {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalDateTime(other, DateTime);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 > val2;
+    }
+    return ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR)) > 0;
+  }
+  lessEquals(other) {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalDateTime(other, DateTime);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 < val2;
+    }
+    return ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR)) <= 0;
+  }
+  greaterEquals(other) {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalDateTime(other, DateTime);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY, HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 > val2;
+    }
+    return ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR)) >= 0;
+  }
   toString(options = undefined) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     options = ES.NormalizeOptionsObject(options);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -216,6 +216,34 @@ export class Instant {
     const two = GetSlot(other, EPOCHNANOSECONDS);
     return bigInt(one).equals(two);
   }
+  lessThan(other) {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalInstant(other, Instant);
+    const one = GetSlot(this, EPOCHNANOSECONDS);
+    const two = GetSlot(other, EPOCHNANOSECONDS);
+    return bigInt(one).lesser(two);
+  }
+  greaterThan(other) {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalInstant(other, Instant);
+    const one = GetSlot(this, EPOCHNANOSECONDS);
+    const two = GetSlot(other, EPOCHNANOSECONDS);
+    return bigInt(one).greater(two);
+  }
+  lessEquals(other) {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalInstant(other, Instant);
+    const one = GetSlot(this, EPOCHNANOSECONDS);
+    const two = GetSlot(other, EPOCHNANOSECONDS);
+    return bigInt(one).lesserOrEquals(two);
+  }
+  greaterEquals(other) {
+    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalInstant(other, Instant);
+    const one = GetSlot(this, EPOCHNANOSECONDS);
+    const two = GetSlot(other, EPOCHNANOSECONDS);
+    return bigInt(one).greaterOrEquals(two);
+  }
   toString(temporalTimeZoneLike = 'UTC', options = undefined) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -448,6 +448,46 @@ export class Time {
     }
     return true;
   }
+  lessThan(other) {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalTime(other, Time);
+    for (const slot of [HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 < val2;
+    }
+    return false;
+  }
+  greaterThan(other) {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalTime(other, Time);
+    for (const slot of [HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 > val2;
+    }
+    return false;
+  }
+  lessEquals(other) {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalTime(other, Time);
+    for (const slot of [HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 < val2;
+    }
+    return true;
+  }
+  greaterEquals(other) {
+    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalTime(other, Time);
+    for (const slot of [HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 > val2;
+    }
+    return true;
+  }
 
   toString(options = undefined) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -288,6 +288,46 @@ export class YearMonth {
     }
     return ES.CalendarEquals(this, other);
   }
+  lessThan(other) {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalYearMonth(other, YearMonth);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 < val2;
+    }
+    return ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR)) < 0;
+  }
+  greaterThan(other) {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalYearMonth(other, YearMonth);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 > val2;
+    }
+    return ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR)) > 0;
+  }
+  lessEquals(other) {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalYearMonth(other, YearMonth);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 < val2;
+    }
+    return ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR)) <= 0;
+  }
+  greaterEquals(other) {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    other = ES.ToTemporalYearMonth(other, YearMonth);
+    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
+      const val1 = GetSlot(this, slot);
+      const val2 = GetSlot(other, slot);
+      if (val1 !== val2) return val1 > val2;
+    }
+    return ES.CalendarCompare(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR)) >= 0;
+  }
   toString() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     return YearMonthToString(this);

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -909,6 +909,70 @@ describe('Date', () => {
       throws(() => Date.compare(d1, { year: 2019 }), TypeError);
     });
   });
+  describe('Date.lessThan works', () => {
+    const d1 = Date.from('1976-11-18');
+    const d2 = Date.from('2019-06-30');
+    it('equal', () => equal(d1.lessThan(d1), false));
+    it('smaller/larger', () => equal(d1.lessThan(d2), true));
+    it('larger/smaller', () => equal(d2.lessThan(d1), false));
+    it('compares calendars lexically', () => {
+      equal(d1.withCalendar('japanese').lessThan(d1), false);
+    });
+    it('casts argument', () => {
+      equal(d2.lessThan({ year: 1976, month: 11, day: 18 }), false);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => d1.lessThan({ year: 2019 }), TypeError);
+    });
+  });
+  describe('Date.greaterThan works', () => {
+    const d1 = Date.from('1976-11-18');
+    const d2 = Date.from('2019-06-30');
+    it('equal', () => equal(d1.greaterThan(d1), false));
+    it('smaller/larger', () => equal(d1.greaterThan(d2), false));
+    it('larger/smaller', () => equal(d2.greaterThan(d1), true));
+    it('compares calendars lexically', () => {
+      equal(d1.withCalendar('japanese').greaterThan(d1), true);
+    });
+    it('casts argument', () => {
+      equal(d2.greaterThan({ year: 1976, month: 11, day: 18 }), true);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => d1.greaterThan({ year: 2019 }), TypeError);
+    });
+  });
+  describe('Date.lessEquals works', () => {
+    const d1 = Date.from('1976-11-18');
+    const d2 = Date.from('2019-06-30');
+    it('equal', () => equal(d1.lessEquals(d1), true));
+    it('smaller/larger', () => equal(d1.lessEquals(d2), true));
+    it('larger/smaller', () => equal(d2.lessEquals(d1), false));
+    it('compares calendars lexically', () => {
+      equal(d1.withCalendar('japanese').lessEquals(d1), false);
+    });
+    it('casts argument', () => {
+      equal(d2.lessEquals({ year: 1976, month: 11, day: 18 }), false);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => d1.lessEquals({ year: 2019 }), TypeError);
+    });
+  });
+  describe('Date.greaterEquals works', () => {
+    const d1 = Date.from('1976-11-18');
+    const d2 = Date.from('2019-06-30');
+    it('equal', () => equal(d1.greaterEquals(d1), true));
+    it('smaller/larger', () => equal(d1.greaterEquals(d2), false));
+    it('larger/smaller', () => equal(d2.greaterEquals(d1), true));
+    it('compares calendars lexically', () => {
+      equal(d1.withCalendar('japanese').greaterEquals(d1), true);
+    });
+    it('casts argument', () => {
+      equal(d2.greaterEquals({ year: 1976, month: 11, day: 18 }), true);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => d1.greaterEquals({ year: 2019 }), TypeError);
+    });
+  });
   describe('Date.equal works', () => {
     const d1 = Date.from('1976-11-18');
     const d2 = Date.from('2019-06-30');

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -360,6 +360,70 @@ describe('DateTime', () => {
       throws(() => DateTime.compare(dt1, { year: 2019 }), TypeError);
     });
   });
+  describe('DateTime.lessThan works', () => {
+    const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
+    const dt2 = DateTime.from('2019-10-29T10:46:38.271986102');
+    it('equal', () => equal(dt1.lessThan(dt1), false));
+    it('smaller/larger', () => equal(dt1.lessThan(dt2), true));
+    it('larger/smaller', () => equal(dt2.lessThan(dt1), false));
+    it('compares calendars lexically', () => {
+      equal(dt1.withCalendar('japanese').lessThan(dt1), false);
+    });
+    it('casts argument', () => {
+      equal(dt2.lessThan({ year: 1976, month: 11, day: 18, hour: 15 }), false);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => dt1.lessThan({ year: 2019 }), TypeError);
+    });
+  });
+  describe('DateTime.greaterThan works', () => {
+    const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
+    const dt2 = DateTime.from('2019-10-29T10:46:38.271986102');
+    it('equal', () => equal(dt1.greaterThan(dt1), false));
+    it('smaller/larger', () => equal(dt1.greaterThan(dt2), false));
+    it('larger/smaller', () => equal(dt2.greaterThan(dt1), true));
+    it('compares calendars lexically', () => {
+      equal(dt1.withCalendar('japanese').greaterThan(dt1), true);
+    });
+    it('casts argument', () => {
+      equal(dt2.greaterThan({ year: 1976, month: 11, day: 18, hour: 15 }), true);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => dt1.greaterThan({ year: 2019 }), TypeError);
+    });
+  });
+  describe('DateTime.lessEquals works', () => {
+    const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
+    const dt2 = DateTime.from('2019-10-29T10:46:38.271986102');
+    it('equal', () => equal(dt1.lessEquals(dt1), true));
+    it('smaller/larger', () => equal(dt1.lessEquals(dt2), true));
+    it('larger/smaller', () => equal(dt2.lessEquals(dt1), false));
+    it('compares calendars lexically', () => {
+      equal(dt1.withCalendar('japanese').lessEquals(dt1), false);
+    });
+    it('casts argument', () => {
+      equal(dt2.lessEquals({ year: 1976, month: 11, day: 18, hour: 15 }), false);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => dt1.lessEquals({ year: 2019 }), TypeError);
+    });
+  });
+  describe('DateTime.greaterEquals works', () => {
+    const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
+    const dt2 = DateTime.from('2019-10-29T10:46:38.271986102');
+    it('equal', () => equal(dt1.greaterEquals(dt1), true));
+    it('smaller/larger', () => equal(dt1.greaterEquals(dt2), false));
+    it('larger/smaller', () => equal(dt2.greaterEquals(dt1), true));
+    it('compares calendars lexically', () => {
+      equal(dt1.withCalendar('japanese').greaterEquals(dt1), true);
+    });
+    it('casts argument', () => {
+      equal(dt2.greaterEquals({ year: 1976, month: 11, day: 18, hour: 15 }), true);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => dt1.greaterEquals({ year: 2019 }), TypeError);
+    });
+  });
   describe('DateTime.equals() works', () => {
     const dt1 = DateTime.from('1976-11-18T15:23:30.123456789');
     const dt2 = DateTime.from('2019-10-29T10:46:38.271986102');

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -564,6 +564,70 @@ describe('Instant', () => {
       throws(() => Instant.compare({}, i2), RangeError);
     });
   });
+  describe('Instant.lessThan works', () => {
+    const i1 = Instant.from('1963-02-13T09:36:29.123456789Z');
+    const i2 = Instant.from('1976-11-18T15:23:30.123456789Z');
+    const i3 = Instant.from('1981-12-15T14:34:31.987654321Z');
+    it('pre epoch equal', () => equal(i1.lessThan(Instant.from(i1)), false));
+    it('epoch equal', () => equal(i2.lessThan(Instant.from(i2)), false));
+    it('cross epoch smaller/larger', () => equal(i1.lessThan(i2), true));
+    it('cross epoch larger/smaller', () => equal(i2.lessThan(i1), false));
+    it('epoch smaller/larger', () => equal(i2.lessThan(i3), true));
+    it('epoch larger/smaller', () => equal(i3.lessThan(i2), false));
+    it('casts argument', () => equal(i2.lessThan(i3.toString()), true));
+    it('only casts from a string', () => {
+      throws(() => i1.lessThan(i2.epochNanoseconds), RangeError);
+      throws(() => i1.lessThan({}), RangeError);
+    });
+  });
+  describe('Instant.greaterThan works', () => {
+    const i1 = Instant.from('1963-02-13T09:36:29.123456789Z');
+    const i2 = Instant.from('1976-11-18T15:23:30.123456789Z');
+    const i3 = Instant.from('1981-12-15T14:34:31.987654321Z');
+    it('pre epoch equal', () => equal(i1.greaterThan(Instant.from(i1)), false));
+    it('epoch equal', () => equal(i2.greaterThan(Instant.from(i2)), false));
+    it('cross epoch smaller/larger', () => equal(i1.greaterThan(i2), false));
+    it('cross epoch larger/smaller', () => equal(i2.greaterThan(i1), true));
+    it('epoch smaller/larger', () => equal(i2.greaterThan(i3), false));
+    it('epoch larger/smaller', () => equal(i3.greaterThan(i2), true));
+    it('casts argument', () => equal(i3.greaterThan(i2.toString()), true));
+    it('only casts from a string', () => {
+      throws(() => i1.greaterThan(i2.epochNanoseconds), RangeError);
+      throws(() => i1.greaterThan({}), RangeError);
+    });
+  });
+  describe('Instant.lessEquals works', () => {
+    const i1 = Instant.from('1963-02-13T09:36:29.123456789Z');
+    const i2 = Instant.from('1976-11-18T15:23:30.123456789Z');
+    const i3 = Instant.from('1981-12-15T14:34:31.987654321Z');
+    it('pre epoch equal', () => equal(i1.lessEquals(Instant.from(i1)), true));
+    it('epoch equal', () => equal(i2.lessEquals(Instant.from(i2)), true));
+    it('cross epoch smaller/larger', () => equal(i1.lessEquals(i2), true));
+    it('cross epoch larger/smaller', () => equal(i2.lessEquals(i1), false));
+    it('epoch smaller/larger', () => equal(i2.lessEquals(i3), true));
+    it('epoch larger/smaller', () => equal(i3.lessEquals(i2), false));
+    it('casts argument', () => equal(i2.lessEquals(i3.toString()), true));
+    it('only casts from a string', () => {
+      throws(() => i1.lessEquals(i2.epochNanoseconds), RangeError);
+      throws(() => i1.lessEquals({}), RangeError);
+    });
+  });
+  describe('Instant.greaterEquals works', () => {
+    const i1 = Instant.from('1963-02-13T09:36:29.123456789Z');
+    const i2 = Instant.from('1976-11-18T15:23:30.123456789Z');
+    const i3 = Instant.from('1981-12-15T14:34:31.987654321Z');
+    it('pre epoch equal', () => equal(i1.greaterEquals(Instant.from(i1)), true));
+    it('epoch equal', () => equal(i2.greaterEquals(Instant.from(i2)), true));
+    it('cross epoch smaller/larger', () => equal(i1.greaterEquals(i2), false));
+    it('cross epoch larger/smaller', () => equal(i2.greaterEquals(i1), true));
+    it('epoch smaller/larger', () => equal(i2.greaterEquals(i3), false));
+    it('epoch larger/smaller', () => equal(i3.greaterEquals(i2), true));
+    it('casts argument', () => equal(i3.greaterEquals(i2.toString()), true));
+    it('only casts from a string', () => {
+      throws(() => i1.greaterEquals(i2.epochNanoseconds), RangeError);
+      throws(() => i1.greaterEquals({}), RangeError);
+    });
+  });
   describe('Instant.equals works', () => {
     const i1 = Instant.from('1963-02-13T09:36:29.123456789Z');
     const i2 = Instant.from('1976-11-18T15:23:30.123456789Z');

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -885,6 +885,62 @@ describe('Time', () => {
       throws(() => Time.compare(t1, { hours: 16 }), TypeError);
     });
   });
+  describe('Time.lessThan() works', () => {
+    const t1 = Time.from('08:44:15.321');
+    const t2 = Time.from('14:23:30.123');
+    it('equal', () => equal(t1.lessThan(t1), false));
+    it('smaller/larger', () => equal(t1.lessThan(t2), true));
+    it('larger/smaller', () => equal(t2.lessThan(t1), false));
+    it('casts argument', () => {
+      equal(t1.lessThan({ hour: 16, minute: 34 }), true);
+      equal(t1.lessThan('16:34'), true);
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => t1.lessThan({ hours: 16 }), TypeError);
+    });
+  });
+  describe('Time.greaterThan() works', () => {
+    const t1 = Time.from('08:44:15.321');
+    const t2 = Time.from('14:23:30.123');
+    it('equal', () => equal(t1.greaterThan(t1), false));
+    it('smaller/larger', () => equal(t1.greaterThan(t2), false));
+    it('larger/smaller', () => equal(t2.greaterThan(t1), true));
+    it('casts argument', () => {
+      equal(t1.greaterThan({ hour: 16, minute: 34 }), false);
+      equal(t1.greaterThan('16:34'), false);
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => t1.greaterThan({ hours: 16 }), TypeError);
+    });
+  });
+  describe('Time.lessEquals() works', () => {
+    const t1 = Time.from('08:44:15.321');
+    const t2 = Time.from('14:23:30.123');
+    it('equal', () => equal(t1.lessEquals(t1), true));
+    it('smaller/larger', () => equal(t1.lessEquals(t2), true));
+    it('larger/smaller', () => equal(t2.lessEquals(t1), false));
+    it('casts argument', () => {
+      equal(t1.lessEquals({ hour: 16, minute: 34 }), true);
+      equal(t1.lessEquals('16:34'), true);
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => t1.lessEquals({ hours: 16 }), TypeError);
+    });
+  });
+  describe('Time.greaterEquals() works', () => {
+    const t1 = Time.from('08:44:15.321');
+    const t2 = Time.from('14:23:30.123');
+    it('equal', () => equal(t1.greaterEquals(t1), true));
+    it('smaller/larger', () => equal(t1.greaterEquals(t2), false));
+    it('larger/smaller', () => equal(t2.greaterEquals(t1), true));
+    it('casts argument', () => {
+      equal(t1.greaterEquals({ hour: 16, minute: 34 }), false);
+      equal(t1.greaterEquals('16:34'), false);
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => t1.greaterEquals({ hours: 16 }), TypeError);
+    });
+  });
   describe('time.equals() works', () => {
     const t1 = Time.from('08:44:15.321');
     const t2 = Time.from('14:23:30.123');

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -189,6 +189,44 @@ describe('YearMonth', () => {
       equal(YearMonth.compare(ym1, ym2), -1);
     });
   });
+  describe('YearMonth.lessThan() works', () => {
+    const nov94 = YearMonth.from('1994-11');
+    const jun13 = YearMonth.from('2013-06');
+    it('equal', () => equal(nov94.lessThan(nov94), false));
+    it('smaller/larger', () => equal(nov94.lessThan(jun13), true));
+    it('larger/smaller', () => equal(jun13.lessThan(nov94), false));
+    it('casts argument', () => {
+      equal(jun13.lessThan('1994-11'), false);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => nov94.lessThan({ year: 2013 }), TypeError);
+    });
+    it('takes [[ISODay]] into account', () => {
+      const iso = Temporal.Calendar.from('iso8601');
+      const ym1 = new YearMonth(2000, 1, iso, 1);
+      const ym2 = new YearMonth(2000, 1, iso, 2);
+      equal(ym1.lessThan(ym2), true);
+    });
+  });
+  describe('YearMonth.greaterThan() works', () => {
+    const nov94 = YearMonth.from('1994-11');
+    const jun13 = YearMonth.from('2013-06');
+    it('equal', () => equal(nov94.greaterThan(nov94), false));
+    it('smaller/larger', () => equal(nov94.greaterThan(jun13), false));
+    it('larger/smaller', () => equal(jun13.greaterThan(nov94), true));
+    it('casts argument', () => {
+      equal(jun13.greaterThan('1994-11'), true);
+    });
+    it('object must contain at least the required properties', () => {
+      throws(() => nov94.greaterThan({ year: 2013 }), TypeError);
+    });
+    it('takes [[ISODay]] into account', () => {
+      const iso = Temporal.Calendar.from('iso8601');
+      const ym1 = new YearMonth(2000, 1, iso, 1);
+      const ym2 = new YearMonth(2000, 1, iso, 2);
+      equal(ym1.greaterThan(ym2), false);
+    });
+  });
   describe('YearMonth.equals() works', () => {
     const nov94 = YearMonth.from('1994-11');
     const jun13 = YearMonth.from('2013-06');

--- a/spec/date.html
+++ b/spec/date.html
@@ -503,6 +503,66 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.date.prototype.lessthan">
+      <h1>Temporal.Date.prototype.lessThan ( _other_ )</h1>
+      <p>
+        The `lessThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDate]]).
+        1. Set _two_ to ? ToTemporalDate(_other_).
+        1. Let _comparison_ be ? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]]).
+        1. If _comparison_ &lt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.date.prototype.greaterthan">
+      <h1>Temporal.Date.prototype.greaterThan ( _other_ )</h1>
+      <p>
+        The `greaterThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDate]]).
+        1. Set _two_ to ? ToTemporalDate(_other_).
+        1. Let _comparison_ be ? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]]).
+        1. If _comparison_ &gt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.date.prototype.lessequals">
+      <h1>Temporal.Date.prototype.lessEquals ( _other_ )</h1>
+      <p>
+        The `lessEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDate]]).
+        1. Set _two_ to ? ToTemporalDate(_other_).
+        1. Let _comparison_ be ? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]]).
+        1. If _comparison_ ≤ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.date.prototype.greaterequals">
+      <h1>Temporal.Date.prototype.greaterEquals ( _other_ )</h1>
+      <p>
+        The `greaterEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDate]]).
+        1. Set _two_ to ? ToTemporalDate(_other_).
+        1. Let _comparison_ be ? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]]).
+        1. If _comparison_ ≥ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.date.prototype.todatetime">
       <h1>Temporal.Date.prototype.toDateTime ( [ _temporalTime_ ] )</h1>
       <p>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -591,6 +591,78 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.datetime.prototype.lessthan">
+      <h1>Temporal.DateTime.prototype.lessThan ( _other_ )</h1>
+      <p>
+        The `lessThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDateTime]]).
+        1. Set _two_ to ? ToTemporalDateTime(_other_).
+        1. Let _comparison_ be ! CompareTemporalDateTime(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ &lt; *+0* return *true* else return *false*..
+        1. Set _comparison_ to ? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]]).
+        1. If _comparison_ &lt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.datetime.prototype.greaterthan">
+      <h1>Temporal.DateTime.prototype.greaterThan ( _other_ )</h1>
+      <p>
+        The `greaterThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDateTime]]).
+        1. Set _two_ to ? ToTemporalDateTime(_other_).
+        1. Let _comparison_ be ! CompareTemporalDateTime(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ &gt; *+0* return *true* else return *false*..
+        1. Set _comparison_ to ? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]]).
+        1. If _comparison_ &gt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.datetime.prototype.lessequals">
+      <h1>Temporal.DateTime.prototype.lessEquals ( _other_ )</h1>
+      <p>
+        The `lessEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDateTime]]).
+        1. Set _two_ to ? ToTemporalDateTime(_other_).
+        1. Let _comparison_ be ! CompareTemporalDateTime(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ ≤ *+0* return *true* else return *false*..
+        1. Set _comparison_ to ? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]]).
+        1. If _comparison_ ≤ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.datetime.prototype.greaterequals">
+      <h1>Temporal.Date.prototype.greaterEquals ( _other_ )</h1>
+      <p>
+        The `greaterEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalDateTime]]).
+        1. Set _two_ to ? ToTemporalDateTime(_other_).
+        1. Let _comparison_ be ! CompareTemporalDateTime(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ ≥ *+0* return *true* else return *false*..
+        1. Set _comparison_ to ? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]]).
+        1. If _comparison_ ≥ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.datetime.prototype.tostring">
       <h1>Temporal.DateTime.prototype.toString ( [ _options_ ] )</h1>
       <p>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -399,6 +399,66 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.instant.prototype.lessthan">
+      <h1>Temporal.Instant.prototype.lessThan ( _other_ )</h1>
+      <p>
+        The `lessThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalInstant]]).
+        1. Set _two_ to ? ToTemporalInstant(_other_).
+        1. Let _comparison_ be ? CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]].
+        1. If _comparison_ &lt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.instant.prototype.greaterthan">
+      <h1>Temporal.Instant.prototype.greaterThan ( _other_ )</h1>
+      <p>
+        The `greaterThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalInstant]]).
+        1. Set _two_ to ? ToTemporalInstant(_other_).
+        1. Let _comparison_ be ? CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]].
+        1. If _comparison_ &gt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.instant.prototype.lessequals">
+      <h1>Temporal.Instant.prototype.lessEquals ( _other_ )</h1>
+      <p>
+        The `lessEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalInstant]]).
+        1. Set _two_ to ? ToTemporalInstant(_other_).
+        1. Let _comparison_ be ? CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]].
+        1. If _comparison_ ≤ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.instant.prototype.greaterequals">
+      <h1>Temporal.Instant.prototype.greaterEquals ( _other_ )</h1>
+      <p>
+        The `greaterEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalInstant]]).
+        1. Set _two_ to ? ToTemporalInstant(_other_).
+        1. Let _comparison_ be ? CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]].
+        1. If _comparison_ ≥ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.instant.prototype.tostring">
       <h1>Temporal.Instant.prototype.toString ( [ _temporalTimeZoneLike_ [ , _options_ ] ] )</h1>
       <p>

--- a/spec/time.html
+++ b/spec/time.html
@@ -380,6 +380,66 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.time.prototype.lessthan">
+      <h1>Temporal.Time.prototype.lessThan ( _other_ )</h1>
+      <p>
+        The `lessThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalTime]]).
+        1. Set _two_ to ? ToTemporalTime(_other_).
+        1. Let _comparison_ be ? CompareTemporalTime(_one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
+        1. If _comparison_ &lt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.time.prototype.greaterthan">
+      <h1>Temporal.Time.prototype.greaterThan ( _other_ )</h1>
+      <p>
+        The `greaterThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalTime]]).
+        1. Set _two_ to ? ToTemporalTime(_other_).
+        1. Let _comparison_ be ? CompareTemporalTime(_one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
+        1. If _comparison_ &gt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.time.prototype.lessequals">
+      <h1>Temporal.Time.prototype.lessEquals ( _other_ )</h1>
+      <p>
+        The `lessEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalTime]]).
+        1. Set _two_ to ? ToTemporalTime(_other_).
+        1. Let _comparison_ be ? CompareTemporalTime(_one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
+        1. If _comparison_ ≤ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.time.prototype.greaterequals">
+      <h1>Temporal.Time.prototype.greaterEquals ( _other_ )</h1>
+      <p>
+        The `greaterEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalTime]]).
+        1. Set _two_ to ? ToTemporalTime(_other_).
+        1. Let _comparison_ be ? CompareTemporalTime(_one_.[[Hour]], _one_.[[Minute]], _one_.[[Second]], _one_.[[Millisecond]], _one_.[[Microsecond]], _one_.[[Nanosecond]], _two_.[[Hour]], _two_.[[Minute]], _two_.[[Second]], _two_.[[Millisecond]], _two_.[[Microsecond]], _two_.[[Nanosecond]]).
+        1. If _comparison_ ≥ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.time.prototype.todatetime">
       <h1>Temporal.Time.prototype.toDateTime ( _temporalDate_ )</h1>
       <p>

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -355,6 +355,66 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.yearmonth.prototype.lessthan">
+      <h1>Temporal.YearMonth.prototype.lessThan ( _other_ )</h1>
+      <p>
+        The `lessThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalYearMonth]]).
+        1. Set _two_ to ? ToTemporalYearMonth(_other_).
+        1. Let _comparison_ be ? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]]).
+        1. If _comparison_ &lt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.yearmonth.prototype.greaterthan">
+      <h1>Temporal.YearMonth.prototype.greaterThan ( _other_ )</h1>
+      <p>
+        The `greaterThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalYearMonth]]).
+        1. Set _two_ to ? ToTemporalYearMonth(_other_).
+        1. Let _comparison_ be ? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]]).
+        1. If _comparison_ &gt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.yearmonth.prototype.lessequals">
+      <h1>Temporal.YearMonth.prototype.lessEquals ( _other_ )</h1>
+      <p>
+        The `lessEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalYearMonth]]).
+        1. Set _two_ to ? ToTemporalYearMonth(_other_).
+        1. Let _comparison_ be ? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]]).
+        1. If _comparison_ ≤ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.yearmonth.prototype.greaterequals">
+      <h1>Temporal.YearMonth.prototype.greaterEquals ( _other_ )</h1>
+      <p>
+        The `greaterEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalYearMonth]]).
+        1. Set _two_ to ? ToTemporalYearMonth(_other_).
+        1. Let _comparison_ be ? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]]).
+        1. If _comparison_ ≥ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.yearmonth.prototype.tostring">
       <h1>Temporal.YearMonth.prototype.toString ( )</h1>
       <p>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -721,6 +721,90 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.lessthan">
+      <h1>Temporal.ZonedDateTime.prototype.lessThan ( _other_ )</h1>
+      <p>
+        The `lessThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalZonedDateTime]]).
+        1. Set _two_ to ? ToTemporalZonedDateTime(_other_).
+        1. Let _comparison_ be ! CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ &lt; *+0* then return *true* else return *false*.
+        1. Set _comparison_ to ? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ &lt; *+0* then return *true* else return *false*.
+        1. Set _comparison_ to ? CompareTimeZone(_one_.[[TimeZone]], _two_.[[TimeZone]]).
+        1. If _comparison_ &lt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.greaterthan">
+      <h1>Temporal.ZonedDateTime.prototype.greaterThan ( _other_ )</h1>
+      <p>
+        The `greaterThan` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalZonedDateTime]]).
+        1. Set _two_ to ? ToTemporalZonedDateTime(_other_).
+        1. Let _comparison_ be ! CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ &gt; *+0* then return *true* else return *false*.
+        1. Set _comparison_ to ? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ &gt; *+0* then return *true* else return *false*.
+        1. Set _comparison_ to ? CompareTimeZone(_one_.[[TimeZone]], _two_.[[TimeZone]]).
+        1. If _comparison_ &gt; *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.lessequals">
+      <h1>Temporal.ZonedDateTime.prototype.lessEquals ( _other_ )</h1>
+      <p>
+        The `lessEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalZonedDateTime]]).
+        1. Set _two_ to ? ToTemporalZonedDateTime(_other_).
+        1. Let _comparison_ be ! CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ ≤ *+0* then return *true* else return *false*.
+        1. Set _comparison_ to ? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ ≤ *+0* then return *true* else return *false*.
+        1. Set _comparison_ to ? CompareTimeZone(_one_.[[TimeZone]], _two_.[[TimeZone]]).
+        1. If _comparison_ ≤ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.greaterequals">
+      <h1>Temporal.ZonedDateTime.prototype.greaterEquals ( _other_ )</h1>
+      <p>
+        The `greaterEquals` method takes one argument _other_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _one_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_one_, [[InitializedTemporalZonedDateTime]]).
+        1. Set _two_ to ? ToTemporalZonedDateTime(_other_).
+        1. Let _comparison_ be ! CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ ≥ *+0* then return *true* else return *false*.
+        1. Set _comparison_ to ? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]]).
+        1. If _comparison_ ≠ 0, then
+          1. If _comparison_ ≥ *+0* then return *true* else return *false*.
+        1. Set _comparison_ to ? CompareTimeZone(_one_.[[TimeZone]], _two_.[[TimeZone]]).
+        1. If _comparison_ ≥ *+0* then return *true* else return *false*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.zoneddatetime.prototype.tostring">
       <h1>Temporal.ZonedDateTime.prototype.toString ( )</h1>
       <p>


### PR DESCRIPTION
After a few days of using `since` and `until`, I'm now 100% converted to @gibson042's position that confusingly-ordered parameters are evil. While discussing `difference` last week before we decided to rename it to `since` and `until`, we also discussed how `compare` also has confusing parameter order.  The other thing that's annoying about `compare` is that it's not "chainable", so you can't read it left to right. Instead you have to wrap the `compare` call around your code which makes it harder to read. 

If it's not too late, I got inspired today and built (polyfill, tests, docs, spec) convenience comparison methods, tentatively named `greaterThan()`, `lessThan()`, `greaterEquals()`, and `lessEquals()`.  I don't have a strong opinion about the names other than wanting to not make them any longer.

Here's an example.  It's 13-24 fewer characters per call. Also IMHO it's easier to understand what the code is doing.  

```js
// proposed
function afterKidsBedtime(time) {
  return time.greaterThan('20:30');
}
// current
function afterKidsBedtime(time) {
  return Temporal.Time.compare(time, '20:30') > 0;
}
```

Here's another sample from the docs: 

```js
dt1 = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
dt2 = Temporal.DateTime.from('2019-01-31T15:30');
dt1.lessThan(dt2); // => true
dt1.lessThan('1999-12-31'); // => false
dt1.lessThan(dt1); // => false
```

I wasn't sure about how to encode a simple if/else statement in the spec syntax. Is this valid?
```
1. If _comparison_ ≥ *+0* then return *true* else return *false*.
```
If not, what's the right spec syntax to express this?