### PR TITLE
Remove Instant.toDateTime{,ISO}(), DateTime.toInstant()

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -92,6 +92,7 @@ overrides:
       - polyfill/test/Time/**/*.js
       - polyfill/test/TimeZone/**/*.js
       - polyfill/test/YearMonth/**/*.js
+      - polyfill/test/ZonedDateTime/**/*.js
       - polyfill/test/now/**/*.js
     globals:
       Temporal: readonly

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -362,7 +362,7 @@ Map localized trip departure and arrival times into trip duration in units no la
 {{cookbook/getTripDurationInHrMinSec.mjs}}
 ```
 
-Map localized departure time and duration into localized arrival time.
+Given a departure time with time zone and a flight duration, get an arrival time in the destination time zone, using time zone-aware math.
 
 ```javascript
 {{cookbook/getLocalizedArrival.mjs}}

--- a/docs/cookbook/calculateDailyOccurrence.mjs
+++ b/docs/cookbook/calculateDailyOccurrence.mjs
@@ -9,7 +9,7 @@
  */
 function* calculateDailyOccurrence(startDate, time, timeZone) {
   for (let date = startDate; ; date = date.add({ days: 1 })) {
-    yield date.toDateTime(time).toInstant(timeZone);
+    yield date.toDateTime(time).toZonedDateTime(timeZone);
   }
 }
 

--- a/docs/cookbook/getInstantWithLocalTimeInZone.mjs
+++ b/docs/cookbook/getInstantWithLocalTimeInZone.mjs
@@ -34,13 +34,13 @@ function getInstantWithLocalTimeInZone(dateTime, timeZone, disambiguation = 'ear
   switch (disambiguation) {
     case 'clipEarlier':
       if (possible.length === 0) {
-        const before = dateTime.toInstant(timeZone, { disambiguation: 'earlier' });
+        const before = timeZone.getInstantFor(dateTime, { disambiguation: 'earlier' });
         return timeZone.getNextTransition(before).subtract({ nanoseconds: 1 });
       }
       return possible[0];
     case 'clipLater':
       if (possible.length === 0) {
-        const before = dateTime.toInstant(timeZone, { disambiguation: 'earlier' });
+        const before = timeZone.getInstantFor(dateTime, { disambiguation: 'earlier' });
         return timeZone.getNextTransition(before);
       }
       return possible[possible.length - 1];

--- a/docs/cookbook/getLocalizedArrival.mjs
+++ b/docs/cookbook/getLocalizedArrival.mjs
@@ -2,23 +2,26 @@
  * Given a localized departure time and a flight duration, get a local arrival
  * time in the destination time zone.
  *
- * @param {string} parseableDeparture - Departure time with time zone
+ * FIXME: This becomes a one-liner when Temporal.ZonedDateTime.add() is
+ * implemented.
+ *
+ * @param {string} departure - Departure time with time zone
  * @param {Temporal.Duration} flightTime - Duration of the flight
  * @param {Temporal.TimeZone} destinationTimeZone - Time zone in which the
  *  flight's destination is located
  * @param {Temporal.Calendar|string} calendar - Calendar system used for output
  * @returns {Temporal.DateTime} Local arrival time
  */
-function getLocalizedArrival(parseableDeparture, flightTime, destinationTimeZone, calendar) {
-  const departure = Temporal.Instant.from(parseableDeparture);
-  const arrival = departure.add(flightTime);
-  return arrival.toDateTime(destinationTimeZone, calendar);
+function getLocalizedArrival(departure, flightTime, destinationTimeZone, calendar) {
+  const instant = departure.toInstant();
+  const arrival = instant.add(flightTime);
+  return destinationTimeZone.getDateTimeFor(arrival, calendar);
 }
 
 const arrival = getLocalizedArrival(
-  '2020-03-08T11:55:00+08:00[Asia/Hong_Kong]',
+  Temporal.ZonedDateTime.from('2020-03-08T11:55:00+08:00[Asia/Hong_Kong]'),
   Temporal.Duration.from({ minutes: 775 }),
-  'America/Los_Angeles',
+  Temporal.TimeZone.from('America/Los_Angeles'),
   'iso8601'
 );
 assert.equal(arrival.toString(), '2020-03-08T09:50:00');

--- a/docs/cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs
+++ b/docs/cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs
@@ -23,7 +23,10 @@ function getParseableZonedStringWithLocalTimeInOtherZone(
   targetTimeZone,
   sourceDisambiguationPolicy = 'reject'
 ) {
-  const zonedDateTime = sourceDateTime.toZonedDateTime(sourceTimeZone, { disambiguation: sourceDisambiguationPolicy });
+  return sourceDateTime
+    .toZonedDateTime(sourceTimeZone, { disambiguation: sourceDisambiguationPolicy })
+    .withTimeZone(targetTimeZone)
+    .toString();
   return zonedDateTime.withTimeZone(targetTimeZone).toString();
 }
 

--- a/docs/cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs
+++ b/docs/cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs
@@ -27,7 +27,6 @@ function getParseableZonedStringWithLocalTimeInOtherZone(
     .toZonedDateTime(sourceTimeZone, { disambiguation: sourceDisambiguationPolicy })
     .withTimeZone(targetTimeZone)
     .toString();
-  return zonedDateTime.withTimeZone(targetTimeZone).toString();
 }
 
 const result = getParseableZonedStringWithLocalTimeInOtherZone(

--- a/docs/cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs
+++ b/docs/cookbook/getParseableZonedStringWithLocalTimeInOtherZone.mjs
@@ -23,8 +23,8 @@ function getParseableZonedStringWithLocalTimeInOtherZone(
   targetTimeZone,
   sourceDisambiguationPolicy = 'reject'
 ) {
-  let instant = sourceDateTime.toInstant(sourceTimeZone, { disambiguation: sourceDisambiguationPolicy });
-  return instant.toString(targetTimeZone);
+  const zonedDateTime = sourceDateTime.toZonedDateTime(sourceTimeZone, { disambiguation: sourceDisambiguationPolicy });
+  return zonedDateTime.withTimeZone(targetTimeZone).toString();
 }
 
 const result = getParseableZonedStringWithLocalTimeInOtherZone(

--- a/docs/cookbook/localTimeForFutureEvents.mjs
+++ b/docs/cookbook/localTimeForFutureEvents.mjs
@@ -31,8 +31,9 @@ const tc39meetings = [
 const localTimeZone = Temporal.TimeZone.from('Asia/Tokyo');
 const localTimes = tc39meetings.map(({ dateTime, timeZone }) => {
   return Temporal.DateTime.from(dateTime)
-    .toInstant(timeZone, { disambiguation: 'reject' })
-    .toDateTimeISO(localTimeZone);
+    .toZonedDateTime(timeZone, { disambiguation: 'reject' })
+    .withTimeZone(localTimeZone)
+    .toDateTime();
 });
 
 assert.deepEqual(

--- a/docs/cookbook/nextWeeklyOccurrence.mjs
+++ b/docs/cookbook/nextWeeklyOccurrence.mjs
@@ -2,15 +2,17 @@
  * Returns the local date and time for the next occurrence of a weekly occurring
  * event.
  *
- * @param {Temporal.Instant} now - Starting point
- * @param {Temporal.TimeZone} localTimeZone - Time zone for return value
+ * FIXME: This should use ZonedDateTime arithmetic once ZonedDateTime.add() and
+ * subtract() are implemented.
+ *
+ * @param {Temporal.ZonedDateTime} now - Starting point
  * @param {number} weekday - Weekday event occurs on (Monday=1, Sunday=7)
  * @param {Temporal.Time} eventTime - Time event occurs at
  * @param {Temporal.TimeZone} eventTimeZone - Time zone where event is planned
  * @returns {Temporal.DateTime} Local date and time of next occurrence
  */
-function nextWeeklyOccurrence(now, localTimeZone, weekday, eventTime, eventTimeZone) {
-  const dateTime = now.toDateTimeISO(eventTimeZone);
+function nextWeeklyOccurrence(now, weekday, eventTime, eventTimeZone) {
+  const dateTime = now.withTimeZone(eventTimeZone).toDateTime();
   const nextDate = dateTime.toDate().add({ days: (weekday + 7 - dateTime.dayOfWeek) % 7 });
   let nextOccurrence = nextDate.toDateTime(eventTime);
 
@@ -19,7 +21,7 @@ function nextWeeklyOccurrence(now, localTimeZone, weekday, eventTime, eventTimeZ
     nextOccurrence = nextOccurrence.add({ days: 7 });
   }
 
-  return nextOccurrence.toInstant(eventTimeZone).toDateTimeISO(localTimeZone);
+  return eventTimeZone.getInstantFor(nextOccurrence).toZonedDateTime(now.timeZone, now.calendar).toDateTime();
 }
 
 // "Weekly on Thursdays at 08:45 California time":
@@ -27,11 +29,10 @@ const weekday = 4;
 const eventTime = Temporal.Time.from('08:45');
 const eventTimeZone = Temporal.TimeZone.from('America/Los_Angeles');
 
-const rightBefore = Temporal.Instant.from('2020-03-26T08:30-07:00[America/Los_Angeles]');
-const localTimeZone = Temporal.TimeZone.from('Europe/London');
-let next = nextWeeklyOccurrence(rightBefore, localTimeZone, weekday, eventTime, eventTimeZone);
+const rightBefore = Temporal.ZonedDateTime.from('2020-03-26T15:30+00:00[Europe/London]');
+let next = nextWeeklyOccurrence(rightBefore, weekday, eventTime, eventTimeZone);
 assert.equal(next.toString(), '2020-03-26T15:45:00');
 
-const rightAfter = Temporal.Instant.from('2020-03-26T09:00-07:00[America/Los_Angeles]');
-next = nextWeeklyOccurrence(rightAfter, localTimeZone, weekday, eventTime, eventTimeZone);
+const rightAfter = Temporal.ZonedDateTime.from('2020-03-26T16:00+00:00[Europe/London]');
+next = nextWeeklyOccurrence(rightAfter, weekday, eventTime, eventTimeZone);
 assert.equal(next.toString(), '2020-04-02T16:45:00');

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -850,39 +850,6 @@ For usage examples and a more complete explanation of how this disambiguation wo
 
 If the result is earlier or later than the range that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
 
-### datetime.**toInstant**(_timeZone_ : object | string, _options_?: object) : Temporal.Instant
-
-**Parameters:**
-
-- `timeZone` (optional string or object): The time zone in which to interpret `dateTime`, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
-- `options` (optional object): An object with properties representing options for the operation.
-  The following options are recognized:
-  - `disambiguation` (string): How to disambiguate if the date and time given by `dateTime` does not exist in the time zone, or exists more than once.
-    Allowed values are `'compatible'`, `'earlier'`, `'later'`, and `'reject'`.
-    The default is `'compatible'`.
-
-**Returns:** A `Temporal.Instant` object indicating the exact time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
-
-This method is one way to convert a `Temporal.DateTime` to a `Temporal.Instant`.
-It is identical to [`(Temporal.TimeZone.from(timeZone || 'UTC')).getInstantFor(dateTime, disambiguation)`](./timezone.html#getInstantFor).
-
-In the case of ambiguity, the `disambiguation` option controls what exact time to return:
-
-- `'compatible'` (the default): Acts like `'earlier'` for backward transitions and `'later'` for forward transitions.
-- `'earlier'`: The earlier of two possible exact times.
-- `'later'`: The later of two possible exact times.
-- `'reject'`: Throw a `RangeError` instead.
-
-When interoperating with existing code or services, `'compatible'` mode matches the behavior of legacy `Date` as well as libraries like moment.js, Luxon, and date-fns.
-This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
-
-During "skipped" clock time like the hour after DST starts in the Spring, this method interprets invalid times using the pre-transition time zone offset if `'compatible'` or `'later'` is used or the post-transition time zone offset if `'earlier'` is used.
-This behavior avoids exceptions when converting non-existent `Temporal.DateTime` values to `Temporal.Instant`, but it also means that values during these periods will result in a different `Temporal.DateTime` in "round-trip" conversions to `Temporal.Instant` and back again.
-
-For usage examples and a more complete explanation of how this disambiguation works and why it is necessary, see [Resolving ambiguity](./ambiguity.md).
-
-If the result is earlier or later than the range that `Temporal.Instant` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
-
 ### datetime.**toDate**() : Temporal.Date
 
 **Returns:** a `Temporal.Date` object that is the same as the date portion of `datetime`.

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -284,69 +284,6 @@ console.log(zdt.year, zdt.era);
 ```
 <!-- prettier-ignore-end -->
 
-### instant.**toDateTimeISO**(_timeZone_: object | string) : Temporal.DateTime
-
-**Parameters:**
-
-- `timeZone` (object or string): A `Temporal.TimeZone` object, or an object implementing the [time zone protocol](./timezone.md#protocol), or a string description of the time zone; either its IANA name or UTC offset.
-
-**Returns:** a `Temporal.DateTime` object representing the calendar date, wall-clock time in `timeZone`, according to the reckoning of the ISO 8601 calendar, at the exact time indicated by `instant`.
-
-For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
-A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
-
-This method is one way to convert a `Temporal.Instant` to a `Temporal.DateTime`.
-It is the same as `toDateTime()`, but always uses the ISO 8601 calendar.
-Use this method if you are not doing computations in other calendars.
-
-Example usage:
-
-```js
-// Converting an exact time to a calendar date / wall-clock time
-timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
-timestamp.toDateTime('Europe/Berlin'); // => 2019-03-31T01:45
-timestamp.toDateTime('UTC'); // => 2019-03-31T00:45
-timestamp.toDateTime('-08:00'); // => 2019-03-30T16:45
-```
-
-### instant.**toDateTime**(_timeZone_: object | string, _calendar_: object | string) : Temporal.DateTime
-
-**Parameters:**
-
-- `timeZone` (object or string): A `Temporal.TimeZone` object, or an object implementing the [time zone protocol](./timezone.md#protocol), or a string description of the time zone; either its IANA name or UTC offset.
-- `calendar` (object or string): A `Temporal.Calendar` object, or a plain object, or a calendar identifier.
-
-**Returns:** a `Temporal.DateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the instant time indicated by `instant`.
-
-For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
-A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
-
-For a list of calendar identifiers, see the documentation for [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#Parameters).
-
-This method is one way to convert a `Temporal.Instant` to a `Temporal.DateTime`.
-
-If you only want to use the ISO 8601 calendar, use `toDateTimeISO()`.
-
-Example usage:
-
-<!-- prettier-ignore-start -->
-```js
-// What time was the Unix epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA) in the Gregorian calendar?
-epoch = Temporal.Instant.fromEpochSeconds(0);
-tz = Temporal.TimeZone.from('America/New_York');
-epoch.toDateTime(tz, 'gregory');
-  // => 1969-12-31T19:00[c=gregory]
-
-// What time was the Unix epoch in Tokyo in the Japanese calendar?
-tz = Temporal.TimeZone.from('Asia/Tokyo');
-cal = Temporal.Calendar.from('japanese');
-dt = epoch.toDateTime(tz, cal);
-  // => 1970-01-01T09:00[c=japanese]
-console.log(dt.year, dt.era);
-  // => 45 showa
-```
-<!-- prettier-ignore-end -->
-
 ### instant.**add**(_duration_: Temporal.Duration | object | string) : Temporal.Instant
 
 **Parameters:**

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -550,8 +550,6 @@ export namespace Temporal {
         | /** @deprecated */ 'nanoseconds'
       >
     ): Temporal.Instant;
-    toDateTime(tzLike: TimeZoneProtocol | string, calendar: CalendarProtocol | string): Temporal.DateTime;
-    toDateTimeISO(tzLike: TimeZoneProtocol | string): Temporal.DateTime;
     toZonedDateTime(tzLike: TimeZoneProtocol | string, calendar: CalendarProtocol | string): Temporal.ZonedDateTime;
     toZonedDateTimeISO(tzLike: TimeZoneProtocol | string): Temporal.ZonedDateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
@@ -934,7 +932,6 @@ export namespace Temporal {
         | /** @deprecated */ 'nanoseconds'
       >
     ): Temporal.DateTime;
-    toInstant(tzLike: TimeZoneProtocol | string, options?: ToInstantOptions): Temporal.Instant;
     toZonedDateTime(tzLike: TimeZoneProtocol | string, options?: ToInstantOptions): Temporal.ZonedDateTime;
     toDate(): Temporal.Date;
     toYearMonth(): Temporal.YearMonth;

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -714,13 +714,6 @@ export class DateTime {
     throw new TypeError('use compare() or equals() to compare Temporal.DateTime');
   }
 
-  toInstant(temporalTimeZoneLike, options = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
-    options = ES.NormalizeOptionsObject(options);
-    const disambiguation = ES.ToTemporalDisambiguation(options);
-    return ES.GetTemporalInstantFor(timeZone, this, disambiguation);
-  }
   toZonedDateTime(temporalTimeZoneLike, options = undefined) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -240,18 +240,6 @@ export class Instant {
   valueOf() {
     throw new TypeError('use compare() or equals() to compare Temporal.Instant');
   }
-  toDateTime(temporalTimeZoneLike, calendarLike) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
-    const calendar = ES.ToTemporalCalendar(calendarLike);
-    return ES.GetTemporalDateTimeFor(timeZone, this, calendar);
-  }
-  toDateTimeISO(temporalTimeZoneLike) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
-    const calendar = GetISO8601Calendar();
-    return ES.GetTemporalDateTimeFor(timeZone, this, calendar);
-  }
   toZonedDateTime(temporalTimeZoneLike, calendarLike) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);

--- a/polyfill/test/DateTime/prototype/toZonedDateTime/length.js
+++ b/polyfill/test/DateTime/prototype/toZonedDateTime/length.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.datetime.prototype.tozoneddatetime
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(Temporal.DateTime.prototype.toZonedDateTime, "length", {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/DateTime/prototype/toZonedDateTime/plain-custom-timezone.js
+++ b/polyfill/test/DateTime/prototype/toZonedDateTime/plain-custom-timezone.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.datetime.prototype.toinstant
+esid: sec-temporal.datetime.prototype.tozoneddatetime
 includes: [compareArray.js]
 ---*/
 
@@ -67,7 +67,9 @@ const timeZone = new Proxy({
   },
 });
 
-const result = dateTime.toInstant(timeZone, options);
-assert.sameValue(result, instant);
+const result = dateTime.toZonedDateTime(timeZone, options);
+assert.sameValue(result.epochNanoseconds, instant.epochNanoseconds);
+assert.sameValue(result.timeZone, timeZone);
+assert.sameValue(result.calendar, dateTime.calendar);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/Instant/prototype/toZonedDateTime/branding.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/branding.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const toZonedDateTime = Temporal.Instant.prototype.toZonedDateTime;
+
+assert.sameValue(typeof toZonedDateTime, "function");
+
+assert.throws(TypeError, () => toZonedDateTime.call(undefined), "undefined");
+assert.throws(TypeError, () => toZonedDateTime.call(null), "null");
+assert.throws(TypeError, () => toZonedDateTime.call(true), "true");
+assert.throws(TypeError, () => toZonedDateTime.call(""), "empty string");
+assert.throws(TypeError, () => toZonedDateTime.call(Symbol()), "symbol");
+assert.throws(TypeError, () => toZonedDateTime.call(1), "1");
+assert.throws(TypeError, () => toZonedDateTime.call({}), "plain object");
+assert.throws(TypeError, () => toZonedDateTime.call(Temporal.Instant), "Temporal.Instant");
+assert.throws(TypeError, () => toZonedDateTime.call(Temporal.Instant.prototype), "Temporal.Instant.prototype");

--- a/polyfill/test/Instant/prototype/toZonedDateTime/calendar-convert.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/calendar-convert.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.todatetime
+esid: sec-temporal.instant.prototype.tozoneddatetime
 ---*/
 
 const values = [
@@ -24,13 +24,13 @@ for (const [input, output] of values) {
     return calendar;
   };
 
-  const dateTime = instant.toDateTime("UTC", input);
+  const zdt = instant.toZonedDateTime("UTC", input);
   assert.sameValue(called, 1);
-  assert.sameValue(dateTime.calendar, calendar);
+  assert.sameValue(zdt.calendar, calendar);
 }
 
 Temporal.Calendar.from = function() {
   throw new Test262Error("Should not call Calendar.from");
 };
 
-assert.throws(TypeError, () => instant.toDateTime("UTC", Symbol()));
+assert.throws(TypeError, () => instant.toZonedDateTime("UTC", Symbol()));

--- a/polyfill/test/Instant/prototype/toZonedDateTime/calendar-from-invalid-result.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/calendar-from-invalid-result.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.todatetime
+esid: sec-temporal.instant.prototype.tozoneddatetime
 ---*/
 
 const values = [
@@ -26,6 +26,6 @@ for (const [value, description] of values) {
     return value;
   };
 
-  assert.throws(TypeError, () => instant.toDateTime(timeZone, "test"), description);
+  assert.throws(TypeError, () => instant.toZonedDateTime(timeZone, "test"), description);
   assert.sameValue(called, 1);
 }

--- a/polyfill/test/Instant/prototype/toZonedDateTime/calendar-from-undefined.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/calendar-from-undefined.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tozoneddatetime
+includes: [compareArray.js]
+---*/
+
+const actual = [];
+const expected = [
+  "get Temporal.Calendar.from",
+];
+
+const instant = Temporal.Instant.from("1975-02-02T14:25:36.123456789Z");
+const dateTime = Temporal.DateTime.from("1963-07-02T12:34:56.987654321");
+
+const timeZone = new Proxy({
+  getDateTimeFor() {
+    actual.push("call timeZone.getDateTimeFor");
+    return dateTime;
+  },
+}, {
+  has(target, property) {
+    actual.push(`has timeZone.${property}`);
+    return property in target;
+  },
+  get(target, property) {
+    actual.push(`get timeZone.${property}`);
+    return target[property];
+  },
+});
+
+Object.defineProperty(Temporal.Calendar, "from", {
+  get() {
+    actual.push("get Temporal.Calendar.from");
+    return undefined;
+  },
+});
+
+const result = instant.toZonedDateTime(timeZone, "japanese");
+assert.sameValue(result.epochNanoseconds, instant.epochNanoseconds);
+assert.sameValue(result.calendar instanceof Temporal.Calendar, true);
+assert.sameValue(result.calendar.id, "japanese");
+
+assert.compareArray(actual, expected);

--- a/polyfill/test/Instant/prototype/toZonedDateTime/calendar-function.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/calendar-function.js
@@ -2,24 +2,19 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.todatetime
+esid: sec-temporal.instant.prototype.tozoneddatetime
 includes: [compareArray.js]
 ---*/
 
 const actual = [];
-const expected = [
-  "get timeZone.getDateTimeFor",
-  "call timeZone.getDateTimeFor",
-];
+const expected = [];
 
 const instant = Temporal.Instant.from("1975-02-02T14:25:36.123456789Z");
 const dateTime = Temporal.DateTime.from("1963-07-02T12:34:56.987654321");
 const calendar = function() {};
 const timeZone = new Proxy({
-  getDateTimeFor(instant, calendarArg) {
+  getDateTimeFor() {
     actual.push("call timeZone.getDateTimeFor");
-    assert.sameValue(instant instanceof Temporal.Instant, true, "Instant");
-    assert.sameValue(calendarArg, calendar);
     return dateTime;
   },
 }, {
@@ -40,7 +35,8 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = instant.toDateTime(timeZone, calendar);
-assert.sameValue(result, dateTime);
+const result = instant.toZonedDateTime(timeZone, calendar);
+assert.sameValue(result.epochNanoseconds, instant.epochNanoseconds);
+assert.sameValue(result.calendar, calendar);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/Instant/prototype/toZonedDateTime/calendar-object.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/calendar-object.js
@@ -2,24 +2,19 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.todatetime
+esid: sec-temporal.instant.prototype.tozoneddatetime
 includes: [compareArray.js]
 ---*/
 
 const actual = [];
-const expected = [
-  "get timeZone.getDateTimeFor",
-  "call timeZone.getDateTimeFor",
-];
+const expected = [];
 
 const instant = Temporal.Instant.from("1975-02-02T14:25:36.123456789Z");
 const dateTime = Temporal.DateTime.from("1963-07-02T12:34:56.987654321");
 const calendar = {};
 const timeZone = new Proxy({
-  getDateTimeFor(instant, calendarArg) {
+  getDateTimeFor() {
     actual.push("call timeZone.getDateTimeFor");
-    assert.sameValue(instant instanceof Temporal.Instant, true, "Instant");
-    assert.sameValue(calendarArg, calendar);
     return dateTime;
   },
 }, {
@@ -40,7 +35,8 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = instant.toDateTime(timeZone, calendar);
-assert.sameValue(result, dateTime);
+const result = instant.toZonedDateTime(timeZone, calendar);
+assert.sameValue(result.epochNanoseconds, instant.epochNanoseconds);
+assert.sameValue(result.calendar, calendar);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/Instant/prototype/toZonedDateTime/calendar.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/calendar.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.todatetime
+esid: sec-temporal.instant.prototype.tozoneddatetime
 includes: [compareArray.js]
 ---*/
 
@@ -12,8 +12,6 @@ const expected = [
   "call Temporal.TimeZone.from",
   "get Temporal.Calendar.from",
   "call Temporal.Calendar.from",
-  "get timeZone.getDateTimeFor",
-  "call timeZone.getDateTimeFor",
 ];
 
 const instant = Temporal.Instant.from("1975-02-02T14:25:36.123456789Z");
@@ -22,10 +20,8 @@ const dateTime = Temporal.DateTime.from("1963-07-02T12:34:56.987654321");
 const calendar = {};
 
 const timeZone = new Proxy({
-  getDateTimeFor(instant, calendarArg) {
+  getDateTimeFor() {
     actual.push("call timeZone.getDateTimeFor");
-    assert.sameValue(instant instanceof Temporal.Instant, true, "Instant");
-    assert.sameValue(calendarArg, calendar);
     return dateTime;
   },
 }, {
@@ -61,7 +57,8 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = instant.toDateTime("UTC", "iso8601");
-assert.sameValue(result, dateTime);
+const result = instant.toZonedDateTime("UTC", "iso8601");
+assert.sameValue(result.epochNanoseconds, instant.epochNanoseconds);
+assert.sameValue(result.calendar, calendar);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/Instant/prototype/toZonedDateTime/length.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/length.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tozoneddatetime
+info: |
+    Every built-in function object, including constructors, has a "length" property whose value is
+    an integer. Unless otherwise specified, this value is equal to the largest number of named
+    arguments shown in the subclause headings for the function description. Optional parameters
+    (which are indicated with brackets: [ ]) or rest parameters (which are shown using the form
+    «...name») are not included in the default argument count.
+
+    Unless otherwise specified, the "length" property of a built-in function object has the
+    attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(Temporal.Instant.prototype.toZonedDateTime, "length", {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/Instant/prototype/toZonedDateTime/plain-custom-timezone.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/plain-custom-timezone.js
@@ -2,25 +2,21 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.todatetime
+esid: sec-temporal.instant.prototype.tozoneddatetime
 includes: [compareArray.js]
 ---*/
 
 const actual = [];
-const expected = [
-  "get timeZone.getDateTimeFor",
-  "call timeZone.getDateTimeFor",
-];
+const expected = [];
 
 const instant = Temporal.Instant.from("1975-02-02T14:25:36.123456789Z");
 const dateTime = Temporal.DateTime.from("1963-07-02T12:00:00.987654321");
 const calendar = Temporal.Calendar.from("iso8601");
 const timeZone = new Proxy({
-  getDateTimeFor(instantArg) {
+  getDateTimeFor() {
     actual.push("call timeZone.getDateTimeFor");
-    assert.sameValue(instantArg, instant);
     return dateTime;
-  },
+  }
 }, {
   has(target, property) {
     actual.push(`has timeZone.${property}`);
@@ -32,7 +28,7 @@ const timeZone = new Proxy({
   },
 });
 
-const result = instant.toDateTime(timeZone, calendar);
-assert.sameValue(result, dateTime);
+const result = instant.toZonedDateTime(timeZone, calendar);
+assert.sameValue(result.epochNanoseconds, instant.epochNanoseconds);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/Instant/prototype/toZonedDateTime/prop-desc.js
+++ b/polyfill/test/Instant/prototype/toZonedDateTime/prop-desc.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+includes: [propertyHelper.js]
+---*/
+
+const { Instant } = Temporal;
+assert.sameValue(
+  typeof Instant.prototype.toZonedDateTime,
+  "function",
+  "`typeof Instant.prototype.toZonedDateTime` is `function`"
+);
+
+verifyProperty(Instant.prototype, "toZonedDateTime", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/branding.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/branding.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-const toDateTime = Temporal.Instant.prototype.toDateTime;
+const toDateTime = Temporal.ZonedDateTime.prototype.toDateTime;
 
 assert.sameValue(typeof toDateTime, "function");
 
@@ -12,5 +12,5 @@ assert.throws(TypeError, () => toDateTime.call(""), "empty string");
 assert.throws(TypeError, () => toDateTime.call(Symbol()), "symbol");
 assert.throws(TypeError, () => toDateTime.call(1), "1");
 assert.throws(TypeError, () => toDateTime.call({}), "plain object");
-assert.throws(TypeError, () => toDateTime.call(Temporal.Instant), "Temporal.Instant");
-assert.throws(TypeError, () => toDateTime.call(Temporal.Instant.prototype), "Temporal.Instant.prototype");
+assert.throws(TypeError, () => toDateTime.call(Temporal.ZonedDateTime), "Temporal.ZonedDateTime");
+assert.throws(TypeError, () => toDateTime.call(Temporal.ZonedDateTime.prototype), "Temporal.ZonedDateTime.prototype");

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/length.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.datetime.prototype.toinstant
+esid: sec-temporal.zoneddatetime.prototype.todatetime
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,8 +15,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.DateTime.prototype.toInstant, "length", {
-  value: 1,
+verifyProperty(Temporal.ZonedDateTime.prototype.toDateTime, "length", {
+  value: 0,
   writable: false,
   enumerable: false,
   configurable: true,

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/plain-custom-timezone.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/plain-custom-timezone.js
@@ -2,26 +2,20 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.todatetime
+esid: sec-temporal.zoneddatetime.prototype.todatetime
 includes: [compareArray.js]
 ---*/
 
 const actual = [];
 const expected = [
-  "get Temporal.Calendar.from",
   "get timeZone.getDateTimeFor",
   "call timeZone.getDateTimeFor",
 ];
 
-const instant = Temporal.Instant.from("1975-02-02T14:25:36.123456789Z");
-const dateTime = Temporal.DateTime.from("1963-07-02T12:34:56.987654321");
-
+const dateTime = Temporal.DateTime.from("1963-07-02T12:00:00.987654321");
 const timeZone = new Proxy({
-  getDateTimeFor(instant, calendar) {
+  getDateTimeFor() {
     actual.push("call timeZone.getDateTimeFor");
-    assert.sameValue(instant instanceof Temporal.Instant, true, "Instant");
-    assert.sameValue(calendar instanceof Temporal.Calendar, true, "Calendar");
-    assert.sameValue(calendar.id, "japanese");
     return dateTime;
   },
 }, {
@@ -35,14 +29,8 @@ const timeZone = new Proxy({
   },
 });
 
-Object.defineProperty(Temporal.Calendar, "from", {
-  get() {
-    actual.push("get Temporal.Calendar.from");
-    return undefined;
-  },
-});
-
-const result = instant.toDateTime(timeZone, "japanese");
+const zdt = new Temporal.ZonedDateTime(160583136123456789n, timeZone);
+const result = zdt.toDateTime();
 assert.sameValue(result, dateTime);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/prop-desc.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/prop-desc.js
@@ -5,14 +5,14 @@
 includes: [propertyHelper.js]
 ---*/
 
-const { Instant } = Temporal;
+const { ZonedDateTime } = Temporal;
 assert.sameValue(
-  typeof Instant.prototype.toDateTime,
+  typeof ZonedDateTime.prototype.toDateTime,
   "function",
-  "`typeof Instant.prototype.toDateTime` is `function`"
+  "`typeof ZonedDateTime.prototype.toDateTime` is `function`"
 );
 
-verifyProperty(Instant.prototype, "toDateTime", {
+verifyProperty(ZonedDateTime.prototype, "toDateTime", {
   writable: true,
   enumerable: false,
   configurable: true,

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/timezone-invalid-result.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/timezone-invalid-result.js
@@ -2,10 +2,9 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.todatetime
+esid: sec-temporal.zoneddatetime.prototype.todatetime
 ---*/
 
-const instant = Temporal.Instant.from("1975-02-02T14:25:36.123456789Z");
 const calendar = Temporal.Calendar.from("iso8601");
 
 const invalidValues = [
@@ -25,12 +24,12 @@ for (const dateTime of invalidValues) {
   const timeZone = {
     getDateTimeFor(instantArg, calendarArg) {
       assert.sameValue(instantArg instanceof Temporal.Instant, true, "Instant");
-      assert.sameValue(instantArg, instant);
       assert.sameValue(calendarArg instanceof Temporal.Calendar, true, "Calendar");
       assert.sameValue(calendarArg, calendar);
       return dateTime;
     },
   };
 
-  assert.throws(TypeError, () => instant.toDateTime(timeZone, calendar));
+  const zdt = new Temporal.ZonedDateTime(160583136123456789n, timeZone, calendar);
+  assert.throws(TypeError, () => zdt.toDateTime(timeZone, calendar));
 }

--- a/polyfill/test/ZonedDateTime/prototype/toInstant/length.js
+++ b/polyfill/test/ZonedDateTime/prototype/toInstant/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.instant.prototype.todatetime
+esid: sec-temporal.zoneddatetime.prototype.toinstant
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,8 +15,8 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.Instant.prototype.toDateTime, "length", {
-  value: 2,
+verifyProperty(Temporal.ZonedDateTime.prototype.toInstant, "length", {
+  value: 0,
   writable: false,
   enumerable: false,
   configurable: true,

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -39,12 +39,6 @@ describe('Instant', () => {
       it('Instant.prototype.round is a Function', () => {
         equal(typeof Instant.prototype.round, 'function');
       });
-      it('Instant.prototype.toDateTimeISO is a Function', () => {
-        equal(typeof Instant.prototype.toDateTimeISO, 'function');
-      });
-      it('Instant.prototype.toDateTime is a Function', () => {
-        equal(typeof Instant.prototype.toDateTime, 'function');
-      });
       it('Instant.prototype.toZonedDateTimeISO is a Function', () => {
         equal(typeof Instant.prototype.toZonedDateTimeISO, 'function');
       });
@@ -1297,8 +1291,6 @@ describe('Instant', () => {
     it('converting from DateTime', () => {
       const min = Temporal.DateTime.from('-271821-04-19T00:00:00.000000001');
       const max = Temporal.DateTime.from('+275760-09-13T23:59:59.999999999');
-      throws(() => min.toInstant('UTC'), RangeError);
-      throws(() => max.toInstant('UTC'), RangeError);
       const utc = Temporal.TimeZone.from('UTC');
       throws(() => utc.getInstantFor(min), RangeError);
       throws(() => utc.getInstantFor(max), RangeError);
@@ -1308,45 +1300,6 @@ describe('Instant', () => {
       const max = Instant.from('+275760-09-13T00:00Z');
       throws(() => min.subtract({ nanoseconds: 1 }), RangeError);
       throws(() => max.add({ nanoseconds: 1 }), RangeError);
-    });
-  });
-  describe('Instant.toDateTimeISO works', () => {
-    const inst = Instant.from('1976-11-18T14:23:30.123456789Z');
-    it('throws without parameter', () => {
-      throws(() => inst.toDateTimeISO(), RangeError);
-    });
-    it('time zone parameter UTC', () => {
-      const tz = Temporal.TimeZone.from('UTC');
-      const dt = inst.toDateTimeISO(tz);
-      equal(inst.epochNanoseconds, dt.toInstant(tz).epochNanoseconds);
-      equal(`${dt}`, '1976-11-18T14:23:30.123456789');
-    });
-    it('time zone parameter non-UTC', () => {
-      const tz = Temporal.TimeZone.from('America/New_York');
-      const dt = inst.toDateTimeISO(tz);
-      equal(inst.epochNanoseconds, dt.toInstant(tz).epochNanoseconds);
-      equal(`${dt}`, '1976-11-18T09:23:30.123456789');
-    });
-  });
-  describe('Instant.toDateTime works', () => {
-    const inst = Instant.from('1976-11-18T14:23:30.123456789Z');
-    it('throws without parameter', () => {
-      throws(() => inst.toDateTime(), RangeError);
-    });
-    it('throws with only one parameter', () => {
-      throws(() => inst.toDateTime('Asia/Singapore'));
-    });
-    it('time zone parameter UTC', () => {
-      const tz = Temporal.TimeZone.from('UTC');
-      const dt = inst.toDateTime(tz, 'gregory');
-      equal(inst.epochNanoseconds, dt.toInstant(tz).epochNanoseconds);
-      equal(`${dt}`, '1976-11-18T14:23:30.123456789[c=gregory]');
-    });
-    it('time zone parameter non-UTC', () => {
-      const tz = Temporal.TimeZone.from('America/New_York');
-      const dt = inst.toDateTime(tz, 'gregory');
-      equal(inst.epochNanoseconds, dt.toInstant(tz).epochNanoseconds);
-      equal(`${dt}`, '1976-11-18T09:23:30.123456789[c=gregory]');
     });
   });
   describe('Instant.toZonedDateTimeISO() works', () => {

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -15,7 +15,8 @@ describe('fromString regex', () => {
       it(isoString, () => {
         const [y, mon, d, h = 0, min = 0, s = 0, ms = 0, µs = 0, ns = 0] = components;
         const instant = Temporal.Instant.from(isoString);
-        const datetime = instant.toDateTimeISO('UTC');
+        const utc = Temporal.TimeZone.from('UTC');
+        const datetime = utc.getDateTimeFor(instant);
         equal(datetime.year, y);
         equal(datetime.month, mon);
         equal(datetime.day, d);

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -111,11 +111,6 @@ describe('Userland calendar', () => {
       const dt = tz.getDateTimeFor(instant, obj);
       equal(dt.calendar.id, obj.id);
     });
-    it('instant.toDateTime()', () => {
-      const inst = Temporal.Instant.fromEpochSeconds(0);
-      const dt = inst.toDateTime('UTC', obj);
-      equal(dt.calendar.id, obj.id);
-    });
     it('Temporal.now.dateTime()', () => {
       const nowDateTime = Temporal.now.dateTime(obj, 'UTC');
       equal(nowDateTime.calendar.id, obj.id);
@@ -202,11 +197,6 @@ describe('Userland calendar', () => {
         const tz = Temporal.TimeZone.from('UTC');
         const inst = Temporal.Instant.fromEpochSeconds(0);
         const dt = tz.getDateTimeFor(inst, 'zero-based');
-        equal(dt.calendar.id, 'zero-based');
-      });
-      it('works for Instant.toDateTime', () => {
-        const inst = Temporal.Instant.fromEpochSeconds(0);
-        const dt = inst.toDateTime('UTC', 'zero-based');
         equal(dt.calendar.id, 'zero-based');
       });
       it('works for Temporal.now.dateTime', () => {
@@ -359,11 +349,6 @@ describe('Userland calendar', () => {
       const dt = tz.getDateTimeFor(inst, obj);
       equal(dt.calendar.id, obj.id);
     });
-    it('instant.toDateTime()', () => {
-      const inst = Temporal.Instant.fromEpochSeconds(0);
-      const dt = inst.toDateTime('UTC', obj);
-      equal(dt.calendar.id, obj.id);
-    });
     it('Temporal.now.dateTime()', () => {
       const nowDateTime = Temporal.now.dateTime(obj, 'UTC');
       equal(nowDateTime.calendar.id, obj.id);
@@ -450,11 +435,6 @@ describe('Userland calendar', () => {
         const tz = Temporal.TimeZone.from('UTC');
         const inst = Temporal.Instant.fromEpochSeconds(0);
         const dt = tz.getDateTimeFor(inst, 'decimal');
-        equal(dt.calendar.id, 'decimal');
-      });
-      it('works for Instant.toDateTime', () => {
-        const inst = Temporal.Instant.fromEpochSeconds(0);
-        const dt = inst.toDateTime('UTC', 'decimal');
         equal(dt.calendar.id, 'decimal');
       });
       it('works for Temporal.now.dateTime', () => {

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -52,12 +52,10 @@ describe('Userland time zone', () => {
     it('has offset string +00:00', () => equal(obj.getOffsetStringFor(inst), '+00:00'));
     it('converts to DateTime', () => {
       equal(`${obj.getDateTimeFor(inst)}`, '1970-01-01T00:00:00');
-      equal(`${inst.toDateTimeISO(obj)}`, '1970-01-01T00:00:00');
-      equal(`${inst.toDateTime(obj, 'gregory')}`, '1970-01-01T00:00:00[c=gregory]');
+      equal(`${obj.getDateTimeFor(inst, 'gregory')}`, '1970-01-01T00:00:00[c=gregory]');
     });
     it('converts to Instant', () => {
       equal(`${obj.getInstantFor(dt)}`, '1976-11-18T15:23:30.123456789Z');
-      equal(`${dt.toInstant(obj)}`, '1976-11-18T15:23:30.123456789Z');
     });
     it('converts to string', () => equal(`${obj}`, obj.id));
     it('prints in instant.toString', () =>
@@ -102,15 +100,6 @@ describe('Userland time zone', () => {
         const inst = Temporal.Instant.fromEpochSeconds(0);
         equal(inst.toString('Etc/Custom/UTC_Subclass'), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Subclass]');
       });
-      it('works for Instant.toDateTime and toDateTimeISO', () => {
-        const inst = Temporal.Instant.fromEpochSeconds(0);
-        equal(`${inst.toDateTimeISO('Etc/Custom/UTC_Subclass')}`, '1970-01-01T00:00:00');
-        equal(`${inst.toDateTime('Etc/Custom/UTC_Subclass', 'gregory')}`, '1970-01-01T00:00:00[c=gregory]');
-      });
-      it('works for DateTime.toInstant', () => {
-        const dt = Temporal.DateTime.from('1970-01-01T00:00');
-        equal(dt.toInstant('Etc/Custom/UTC_Subclass').epochSeconds, 0);
-      });
       it('works for Temporal.now', () => {
         assert(Temporal.now.dateTimeISO('Etc/Custom/UTC_Subclass') instanceof Temporal.DateTime);
         assert(Temporal.now.dateTime('gregory', 'Etc/Custom/UTC_Subclass') instanceof Temporal.DateTime);
@@ -147,12 +136,13 @@ describe('Userland time zone', () => {
       equal(Temporal.TimeZone.prototype.getOffsetStringFor.call(obj, inst), '+00:00'));
     it('converts to DateTime', () => {
       equal(`${Temporal.TimeZone.prototype.getDateTimeFor.call(obj, inst)}`, '1970-01-01T00:00:00');
-      equal(`${inst.toDateTimeISO(obj)}`, '1970-01-01T00:00:00');
-      equal(`${inst.toDateTime(obj, 'gregory')}`, '1970-01-01T00:00:00[c=gregory]');
+      equal(
+        `${Temporal.TimeZone.prototype.getDateTimeFor.call(obj, inst, 'gregory')}`,
+        '1970-01-01T00:00:00[c=gregory]'
+      );
     });
     it('converts to Instant', () => {
       equal(`${Temporal.TimeZone.prototype.getInstantFor.call(obj, dt)}`, '1976-11-18T15:23:30.123456789Z');
-      equal(`${dt.toInstant(obj)}`, '1976-11-18T15:23:30.123456789Z');
     });
     it('prints in instant.toString', () =>
       equal(inst.toString(obj), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Protocol]'));
@@ -194,15 +184,6 @@ describe('Userland time zone', () => {
         const inst = Temporal.Instant.fromEpochSeconds(0);
         equal(inst.toString('Etc/Custom/UTC_Protocol'), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Protocol]');
       });
-      it('works for Instant.toDateTime and toDateTimeISO', () => {
-        const inst = Temporal.Instant.fromEpochSeconds(0);
-        equal(`${inst.toDateTimeISO('Etc/Custom/UTC_Protocol')}`, '1970-01-01T00:00:00');
-        equal(`${inst.toDateTime('Etc/Custom/UTC_Protocol', 'gregory')}`, '1970-01-01T00:00:00[c=gregory]');
-      });
-      it('works for DateTime.toInstant', () => {
-        const dt = Temporal.DateTime.from('1970-01-01T00:00');
-        equal(dt.toInstant('Etc/Custom/UTC_Protocol').epochSeconds, 0);
-      });
       it('works for Temporal.now', () => {
         assert(Temporal.now.dateTimeISO('Etc/Custom/UTC_Protocol') instanceof Temporal.DateTime);
         assert(Temporal.now.dateTime('gregory', 'Etc/Custom/UTC_Protocol') instanceof Temporal.DateTime);
@@ -224,7 +205,8 @@ describe('Userland time zone', () => {
         return -1111111111;
       }
       getPossibleInstantsFor(dateTime) {
-        const instant = dateTime.toInstant('UTC');
+        const utc = Temporal.TimeZone.from('UTC');
+        const instant = utc.getInstantFor(dateTime);
         return [instant.add({ nanoseconds: 1111111111 })];
       }
       getNextTransition() {
@@ -251,12 +233,10 @@ describe('Userland time zone', () => {
     it('has offset string -00:00:01.111111111', () => equal(obj.getOffsetStringFor(inst), '-00:00:01.111111111'));
     it('converts to DateTime', () => {
       equal(`${obj.getDateTimeFor(inst)}`, '1969-12-31T23:59:58.888888889');
-      equal(`${inst.toDateTimeISO(obj)}`, '1969-12-31T23:59:58.888888889');
-      equal(`${inst.toDateTime(obj, 'gregory')}`, '1969-12-31T23:59:58.888888889[c=gregory]');
+      equal(`${obj.getDateTimeFor(inst, 'gregory')}`, '1969-12-31T23:59:58.888888889[c=gregory]');
     });
     it('converts to Instant', () => {
       equal(`${obj.getInstantFor(dt)}`, '1976-11-18T15:23:31.2345679Z');
-      equal(`${dt.toInstant(obj)}`, '1976-11-18T15:23:31.2345679Z');
     });
     it('converts to string', () => equal(`${obj}`, obj.id));
     it('prints in instant.toString', () =>
@@ -300,15 +280,6 @@ describe('Userland time zone', () => {
       it('works for Instant.toString', () => {
         const inst = Temporal.Instant.fromEpochSeconds(0);
         equal(inst.toString('Custom/Subminute'), '1969-12-31T23:59:58.888888889-00:00:01.111111111[Custom/Subminute]');
-      });
-      it('works for Instant.toDateTime and toDateTimeISO', () => {
-        const inst = Temporal.Instant.fromEpochSeconds(0);
-        equal(`${inst.toDateTimeISO('Custom/Subminute')}`, '1969-12-31T23:59:58.888888889');
-        equal(`${inst.toDateTime('Custom/Subminute', 'gregory')}`, '1969-12-31T23:59:58.888888889[c=gregory]');
-      });
-      it('works for DateTime.toInstant', () => {
-        const dt = Temporal.DateTime.from('1970-01-01T00:00');
-        equal(dt.toInstant('Custom/Subminute').epochNanoseconds, 1111111111n);
       });
       it('works for Temporal.now', () => {
         assert(Temporal.now.dateTimeISO('Custom/Subminute') instanceof Temporal.DateTime);

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -641,22 +641,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.datetime.prototype.toinstant">
-      <h1>Temporal.DateTime.prototype.toInstant ( _temporalTimeZoneLike_ [ , _options_ ] )</h1>
-      <p>
-        The `toInstant` method takes two arguments, _temporalTimeZoneLike_ and _options_.
-        The following steps are taken:
-      </p>
-      <emu-alg>
-        1. Let _dateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
-        1. Set _options_ to ? NormalizeOptionsObject(_options_).
-        1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
-        1. Return ? GetTemporalInstantFor(_timeZone_, _dateTime_, _disambiguation_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.datetime.prototype.tozoneddatetime">
       <h1>Temporal.DateTime.prototype.toZonedDateTime ( _temporalTimeZoneLike_ [ , _options_ ] )</h1>
       <p>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -464,36 +464,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.instant.prototype.todatetime">
-      <h1>Temporal.Instant.prototype.toDateTime ( _temporalTimeZoneLike_, _calendarLike_ )</h1>
-      <p>
-        The `toDateTime` method takes two arguments, _temporalTimeZoneLike_ and _calendarLike_.
-        The following steps are taken:
-      </p>
-      <emu-alg>
-        1. Let _instant_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
-        1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
-        1. Return ? GetTemporalDateTimeFor(_timeZone_, _instant_, _calendar_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal.instant.prototype.todatetimeiso">
-      <h1>Temporal.Instant.prototype.toDateTimeISO ( _temporalTimeZoneLike_ )</h1>
-      <p>
-        The `toDateTimeISO` method takes one argument _temporalTimeZoneLike_.
-        The following steps are taken:
-      </p>
-      <emu-alg>
-        1. Let _instant_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
-        1. Let _calendar_ be ! GetISO8601Calendar().
-        1. Return ? GetTemporalDateTimeFor(_timeZone_, _instant_, _calendar_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.instant.prototype.tozoneddatetime">
       <h1>Temporal.Instant.prototype.toZonedDateTime ( _temporalTimeZoneLike_, _calendarLike_ )</h1>
       <p>


### PR DESCRIPTION
These conversions are redundant, they either go through ZonedDateTime or
TimeZone.

Cookbook examples that used these conversions are changed, where possible,
to use ZonedDateTime. Where that is not possible because of unimplemented
ZonedDateTime methods, we add a FIXME note and fall back to the more
verbose TimeZone conversion methods.

Updating some of the cookbook examples is taken from #700.

Closes: #1026