### PR TITLE
Make Instant.from always use the offset

### DIFF
--- a/docs/cookbook/sortExactTimeStrings.mjs
+++ b/docs/cookbook/sortExactTimeStrings.mjs
@@ -20,7 +20,7 @@ function sortInstantStrings(strings, reverse = false) {
 // simple string comparison order would not be correct here:
 const a = '2020-01-23T17:04:36.491865121-08:00';
 const b = '2020-02-10T17:04:36.491865121-08:00';
-const c = '2020-04-01T05:01:00-05:00[America/New_York]';
+const c = '2020-04-01T05:01:00-04:00[America/New_York]';
 const d = '2020-04-01T10:00:00+01:00[Europe/London]';
 const e = '2020-04-01T11:02:00+02:00[Europe/Berlin]';
 
@@ -31,6 +31,6 @@ assert.deepEqual(results, [
   '2020-01-23T17:04:36.491865121-08:00',
   '2020-02-10T17:04:36.491865121-08:00',
   '2020-04-01T10:00:00+01:00[Europe/London]',
-  '2020-04-01T05:01:00-05:00[America/New_York]',
+  '2020-04-01T05:01:00-04:00[America/New_York]',
   '2020-04-01T11:02:00+02:00[Europe/Berlin]'
 ]);

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -62,8 +62,7 @@ This static method creates a new `Temporal.Instant` object from another value.
 If the value is another `Temporal.Instant` object, a new object representing the same exact time is returned.
 
 Any other value is converted to a string, which is expected to be in ISO 8601 format, including a date, a time, and a time zone.
-If the exact time cannot be uniquely determined from the string, then this function throws an exception.
-This includes the case when `thing` is a validly-formatted ISO 8601 string denoting a time that doesn't exist, for example because it was skipped in a daylight saving time transition.
+The time zone name, if given, is ignored; only the time zone offset is taken into account.
 
 Example usage:
 
@@ -77,8 +76,6 @@ instant === Temporal.Instant.from(instant); // => true
 // Not enough information to denote an exact time:
 /* WRONG */ instant = Temporal.Instant.from('2019-03-30'); // no time; throws
 /* WRONG */ instant = Temporal.Instant.from('2019-03-30T01:45'); // no time zone; throws
-/* WRONG */ instant = Temporal.Instant.from('2019-03031T02:45+01:00[Europe/Berlin]');
-    // time skipped in DST transition; throws
 ```
 <!-- prettier-ignore-end -->
 

--- a/polyfill/test/Instant/constructor/from/timezone-custom.js
+++ b/polyfill/test/Instant/constructor/from/timezone-custom.js
@@ -6,78 +6,13 @@ esid: sec-temporal.instant.from
 includes: [compareArray.js]
 ---*/
 
-const actual = [];
-const expected = [
-  "get Temporal.TimeZone.from",
-  "call Temporal.TimeZone.from",
-  "get timeZone.getPossibleInstantsFor",
-  "call timeZone.getPossibleInstantsFor",
-];
-
 const dateTimeString = "1975-02-02T14:25:36.123456789";
-
-const timeZone = new Proxy({
-  name: "Custom/TimeZone",
-
-  toString() {
-    actual.push("call timeZone.toString");
-    return {
-      get toString() {
-        actual.push("get name.toString");
-        return function() {
-          actual.push("call name.toString");
-          return "Custom/TimeZone";
-        };
-      }
-    };
-  },
-
-  getOffsetStringFor() {
-    actual.push("call timeZone.getOffsetStringFor");
-    return {
-      get toString() {
-        actual.push("get offset.toString");
-        return function() {
-          actual.push("call offset.toString");
-          return "+02:59";
-        };
-      }
-    };
-  },
-
-  getDateTimeFor() {
-    actual.push("call timeZone.getDateTimeFor");
-    return Temporal.DateTime.from("1963-07-02T12:00:00.987654321");
-  },
-
-  getPossibleInstantsFor(dateTimeArg) {
-    actual.push("call timeZone.getPossibleInstantsFor");
-    assert.sameValue(dateTimeArg.toString(), dateTimeString);
-    return [Temporal.Instant.fromEpochMilliseconds(-205156799345)];
-  },
-}, {
-  has(target, property) {
-    actual.push(`has timeZone.${property}`);
-    return property in target;
-  },
-  get(target, property) {
-    actual.push(`get timeZone.${property}`);
-    return target[property];
-  },
-});
 
 Object.defineProperty(Temporal.TimeZone, "from", {
   get() {
-    actual.push("get Temporal.TimeZone.from");
-    return function(argument) {
-      actual.push("call Temporal.TimeZone.from");
-      assert.sameValue(argument, "Custom/TimeZone");
-      return timeZone;
-    };
+    throw new Test262Error("should not get Temporal.TimeZone.from");
   },
 });
 
 const instant = Temporal.Instant.from(dateTimeString + "+01:00[Custom/TimeZone]");
-assert.sameValue(instant.epochMilliseconds, -205156799345);
-
-assert.compareArray(actual, expected);
+assert.sameValue(instant.epochMilliseconds, 160579536123);

--- a/polyfill/test/Instant/constructor/from/timezone-from-undefined.js
+++ b/polyfill/test/Instant/constructor/from/timezone-from-undefined.js
@@ -6,19 +6,11 @@ esid: sec-temporal.instant.from
 includes: [compareArray.js]
 ---*/
 
-const actual = [];
-const expected = [
-  "get Temporal.TimeZone.from",
-];
-
 Object.defineProperty(Temporal.TimeZone, "from", {
   get() {
-    actual.push("get Temporal.TimeZone.from");
-    return undefined;
+    throw new Test262Error("should not get Temporal.TimeZone.from");
   },
 });
 
 const instant = Temporal.Instant.from("1975-02-02T14:25:36.123456789Z");
 assert.sameValue(instant.epochNanoseconds, 160583136123456789n);
-
-assert.compareArray(actual, expected);

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -412,8 +412,14 @@ describe('Instant', () => {
         BigInt(Date.UTC(1900, 0, 1, 12)) * BigInt(1e6)
       );
     });
-    it('throws when unable to disambiguate using offset', () => {
-      throws(() => Instant.from('2019-02-16T23:45-04:00[America/Sao_Paulo]'), RangeError);
+    it('throws when offset unavailable to disambiguate', () => {
+      throws(() => Instant.from('2019-02-16T23:45[America/Sao_Paulo]'), RangeError);
+    });
+    it('ignores the bracketed IANA time zone when the offset is incorrect', () => {
+      equal(
+        Instant.from('2019-02-16T23:45-04:00[America/Sao_Paulo]').epochNanoseconds,
+        BigInt(Date.UTC(2019, 1, 17, 3, 45)) * BigInt(1e6)
+      );
     });
     it('Instant.from(string-convertible) converts to string', () => {
       const obj = {

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -412,7 +412,7 @@ describe('Instant', () => {
         BigInt(Date.UTC(1900, 0, 1, 12)) * BigInt(1e6)
       );
     });
-    it('throws when offset unavailable to disambiguate', () => {
+    it('throws when offset not provided', () => {
       throws(() => Instant.from('2019-02-16T23:45[America/Sao_Paulo]'), RangeError);
     });
     it('ignores the bracketed IANA time zone when the offset is incorrect', () => {

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -42,7 +42,6 @@ describe('fromString regex', () => {
       generateTest('1976-11-18T15:23', `${zoneString}[Europe/Vienna]`, [1976, 11, 18, 14, 23, 30, 123, 456, 789]);
       generateTest('1976-11-18T15:23', `+01:00[${zoneString}]`, [1976, 11, 18, 14, 23, 30, 123, 456, 789]);
     });
-    generateTest('1976-11-18T15:23', '[Europe/Vienna]', [1976, 11, 18, 14, 23, 30, 123, 456, 789]);
     // Time zone with only offset
     ['-04:00', '-04', '-0400', '-04:00:00', '-040000', '-04:00:00.000000000', '-040000.0'].forEach((zoneString) =>
       generateTest('1976-11-18T15:23', zoneString, [1976, 11, 18, 19, 23, 30, 123, 456, 789])

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -832,9 +832,16 @@
           `Etc/GMT` ASCIISign Hour
           TimeZoneUTCOffsetName
 
+      TimeZoneBracketedAnnotation :
+          `[` TimeZoneBracketedName `]`
+
       TimeZone :
           TimeZoneUTCOffset
-          TimeZoneNumericUTCOffset? `[` TimeZoneBracketedName `]`
+          TimeZoneNumericUTCOffset? TimeZoneBracketedAnnotation
+
+      TimeZoneOffsetRequired :
+          UTCDesignator
+          TimeZoneNumericUTCOffset TimeZoneBracketedAnnotation?
 
       CalChar :
           Alpha
@@ -907,7 +914,7 @@
           Sign? DurationDesignator DurationTime
 
       TemporalInstantString :
-          Date DateTimeSeparator TimeSpec TimeZone
+          Date DateTimeSeparator TimeSpec TimeZoneOffsetRequired
 
       TemporalDateString :
           CalendarDateTime
@@ -939,7 +946,7 @@
           DateTime
 
       TemporalZonedDateTimeString :
-          Date DateTimeSeparator TimeSpec TimeZoneNumericUTCOffset? `[` TimeZoneBracketedName `]` Calendar?
+          Date DateTimeSeparator TimeSpec TimeZoneNumericUTCOffset? TimeZoneBracketedAnnotation Calendar?
 
       TemporalCalendarString :
           CalendarName

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -601,10 +601,9 @@
         1. If _constructor_ is not given, set it to %Temporal.Instant%.
         1. If Type(_item_) is Object and _item_ has an [[InitializedTemporalInstant]] internal slot, then
           1. Return _item_.
-        1. Else,
-          1. Let _string_ be ? ToString(_item_).
-          1. Let _instant_ be ? ParseTemporalInstant(_string_).
-        1. Return ? CreateTemporalInstantFromStatic(_constructor_, _instant_).
+        1. Let _string_ be ? ToString(_item_).
+        1. Let _epochNanoseconds_ be ? ParseTemporalInstant(_string_).
+        1. Return ? CreateTemporalInstantFromStatic(_constructor_, _epochNanoseconds_).
       </emu-alg>
     </emu-clause>
 
@@ -613,17 +612,14 @@
       <emu-alg>
         1. Assert: Type(_isoString_) is String.
         1. Let _result_ be ? ParseTemporalInstantString(_isoString_).
-        1. Let _calendar_ be ? GetISO8601Calendar().
-        1. Let _dateTime_ be ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[microsecond]], _result_.[[Nanosecond]], _calendar_).
-        1. If _result_.[[TimeZoneZ]] is not *undefined*, then
-          1. Let _timeZone_ be ? TimeZoneFrom(*"UTC"*).
-        1. Else,
-          1. Let _timeZone_ be ? TimeZoneFrom(_result_.[[TimeZoneName]]).
-        1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
-        1. If _possibleInstants_'s length is 1, then
-          1. Return _possibleInstants_[0].[[Nanoseconds]].
-        1. <mark>TODO: Disambiguate using _result_.[[TimeZoneOffsetString]].</mark>
-        1. Return <mark>TODO</mark>.
+        1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
+        1. If _offsetString_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Let _utc_ be ? GetEpochFromParts(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+        1. If _utc_ &lt; −8.64 × 10<sup>21</sup><sub>ℝ</sub> or _utc_ &gt; 8.64 × 10<sup>21</sup><sub>ℝ</sub>, then
+          1. Throw a *RangeError* exception.
+        1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
+        1. Return _utc_ − _offsetNanoseconds_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
When parsing an ISO 8601 string, Temporal.Instant.from should always
use the offset, and ignore the bracketed IANA name, even if the two
disagree.

Closes: #716