### PR TITLE
Add fallback fonts to object model diagram on docs home page

### DIFF
--- a/docs/object-model.svg
+++ b/docs/object-model.svg
@@ -5,7 +5,7 @@
   fill="none"
   stroke-width="381"
   viewBox="18000 54000 343000 198882"
-  font-family="Trebuchet MS"
+  font-family="'Trebuchet MS', Helvetica, sans-serif"
   font-weight="700"
   font-size="18px"
 >


### PR DESCRIPTION
Fixes #1098 by adding fallback fonts for Linux.  It's possible that there still may be some disparity on Linux but it should be less after this PR, and if so we can look at changing the font stack to make it more universal.

To verify this PR, visit https://raw.githubusercontent.com/justingrant/proposal-temporal/4c0b92d26ad4270f38d1d24b27f04d27dff1c3f2/docs/object-model.svg in Firefox on Ubuntu (although probably should repro in any Linux distro). 

Then compare to https://tc39.es/proposal-temporal/docs/object-model.svg, which may look broken.

If the former one looks better than the latter, then at least this PR improves things. 