### PR TITLE
Add timeZone option to Instant.toString()

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -89,10 +89,13 @@ An example of combining a day on the calendar (`Temporal.MonthDay`) and a year i
 
 ### Zoned instant from instant and time zone
 
-Use the optional parameter of `Temporal.Instant.prototype.toString()` to map an exact-time Temporal.Instant instance and a time zone name, into a string serialization of the wall-clock time in that time zone corresponding to the exact time.
+To serialize an exact-time Temporal.Instant into a string, use `toString()`.
+Without any arguments, this gives you a string in UTC time.
 
-Without the parameter, `Temporal.Instant.prototype.toString()` gives a serialization in UTC time.
-Using the parameter is useful if you need your serialized strings to be in a specific time zone.
+If you need your string to include a UTC offset, then use the `timeZone` option of `Temporal.Instant.prototype.toString()` which will return a string serialization of the wall-clock time in that time zone corresponding to the exact time.
+
+This loses the information about which time zone the string was in, because it only preserves the UTC offset from the time zone at that particular exact time.
+If you need your string to include the time zone name, use Temporal.ZonedDateTime instead, which retains this information.
 
 ```javascript
 {{cookbook/getParseableZonedStringAtInstant.mjs}}

--- a/docs/cookbook/getInstantWithLocalTimeInZone.mjs
+++ b/docs/cookbook/getInstantWithLocalTimeInZone.mjs
@@ -52,15 +52,15 @@ const germany = Temporal.TimeZone.from('Europe/Berlin');
 const nonexistentGermanWallTime = Temporal.DateTime.from('2019-03-31T02:45');
 
 const germanResults = {
-  earlier: /*     */ '2019-03-31T01:45:00+01:00[Europe/Berlin]',
-  later: /*       */ '2019-03-31T03:45:00+02:00[Europe/Berlin]',
-  compatible: /*  */ '2019-03-31T03:45:00+02:00[Europe/Berlin]',
-  clipEarlier: /* */ '2019-03-31T01:59:59.999999999+01:00[Europe/Berlin]',
-  clipLater: /*   */ '2019-03-31T03:00:00+02:00[Europe/Berlin]'
+  earlier: /*     */ '2019-03-31T01:45:00+01:00',
+  later: /*       */ '2019-03-31T03:45:00+02:00',
+  compatible: /*  */ '2019-03-31T03:45:00+02:00',
+  clipEarlier: /* */ '2019-03-31T01:59:59.999999999+01:00',
+  clipLater: /*   */ '2019-03-31T03:00:00+02:00'
 };
 for (const [disambiguation, result] of Object.entries(germanResults)) {
   assert.equal(
-    getInstantWithLocalTimeInZone(nonexistentGermanWallTime, germany, disambiguation).toString(germany),
+    getInstantWithLocalTimeInZone(nonexistentGermanWallTime, germany, disambiguation).toString({ timeZone: germany }),
     result
   );
 }
@@ -69,15 +69,17 @@ const brazilEast = Temporal.TimeZone.from('America/Sao_Paulo');
 const doubleEasternBrazilianWallTime = Temporal.DateTime.from('2019-02-16T23:45');
 
 const brazilianResults = {
-  earlier: /*     */ '2019-02-16T23:45:00-02:00[America/Sao_Paulo]',
-  later: /*       */ '2019-02-16T23:45:00-03:00[America/Sao_Paulo]',
-  compatible: /*  */ '2019-02-16T23:45:00-02:00[America/Sao_Paulo]',
-  clipEarlier: /* */ '2019-02-16T23:45:00-02:00[America/Sao_Paulo]',
-  clipLater: /*   */ '2019-02-16T23:45:00-03:00[America/Sao_Paulo]'
+  earlier: /*     */ '2019-02-16T23:45:00-02:00',
+  later: /*       */ '2019-02-16T23:45:00-03:00',
+  compatible: /*  */ '2019-02-16T23:45:00-02:00',
+  clipEarlier: /* */ '2019-02-16T23:45:00-02:00',
+  clipLater: /*   */ '2019-02-16T23:45:00-03:00'
 };
 for (const [disambiguation, result] of Object.entries(brazilianResults)) {
   assert.equal(
-    getInstantWithLocalTimeInZone(doubleEasternBrazilianWallTime, brazilEast, disambiguation).toString(brazilEast),
+    getInstantWithLocalTimeInZone(doubleEasternBrazilianWallTime, brazilEast, disambiguation).toString({
+      timeZone: brazilEast
+    }),
     result
   );
 }

--- a/docs/cookbook/getParseableZonedStringAtInstant.mjs
+++ b/docs/cookbook/getParseableZonedStringAtInstant.mjs
@@ -1,19 +1,22 @@
 const instant = Temporal.Instant.from('2020-01-03T10:41:51Z');
 
-const result = instant.toString('Europe/Paris');
+const result = instant.toString();
 
-assert.equal(result, '2020-01-03T11:41:51+01:00[Europe/Paris]');
+assert.equal(result, '2020-01-03T10:41:51Z');
 assert(instant.equals(Temporal.Instant.from(result)));
 
-// With an offset:
+// Include the UTC offset of a particular time zone:
 
-const result2 = instant.toString('-07:00');
+const result2 = instant.toString({ timeZone: 'America/Yellowknife' });
 
 assert.equal(result2, '2020-01-03T03:41:51-07:00');
+assert(instant.equals(Temporal.Instant.from(result2)));
 
-// With a Temporal.TimeZone object:
+// Include the UTC offset as well as preserving the time zone name:
 
-const timeZone = Temporal.TimeZone.from('Asia/Seoul');
-const result3 = instant.toString(timeZone);
+const zoned = instant.toZonedDateTimeISO('Asia/Seoul');
+const result3 = zoned.toString();
 
 assert.equal(result3, '2020-01-03T19:41:51+09:00[Asia/Seoul]');
+assert(instant.equals(Temporal.Instant.from(result3)));
+assert(zoned.equals(Temporal.ZonedDateTime.from(result3)));

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -545,14 +545,14 @@ one.equals(two); // => false
 one.equals(one); // => true
 ```
 
-### instant.**toString**(_timeZone_?: object | string, _options_?: object) : string
+### instant.**toString**(_options_?: object) : string
 
 **Parameters:**
 
-- `timeZone` (optional string or object): the time zone to express `instant` in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
-  The default is to use UTC.
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
+  - `timeZone` (string or object): the time zone to express `instant` in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#protocol), or a string.
+    The default is to use UTC.
   - `fractionalSecondDigits` (number or string): How many digits to print after the decimal point in the output string.
     Valid values are `'auto'`, 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9.
     The default is `'auto'`.
@@ -574,13 +574,17 @@ If no options are given, the default is `fractionalSecondDigits: 'auto'`, which 
 The value is truncated to fit the requested precision, unless a different rounding mode is given with the `roundingMode` option, as in `Temporal.DateTime.round()`.
 Note that rounding may change the value of other units as well.
 
+If the `timeZone` option is given, then the string will express the time in the given time zone, and contain the time zone's UTC offset.
+
 Example usage:
 
 ```js
 instant = Temporal.Instant.fromEpochMilliseconds(1574074321816);
 instant.toString(); // => 2019-11-18T10:52:01.816Z
-instant.toString(Temporal.TimeZone.from('UTC')); // => 2019-11-18T10:52:01.816Z
-instant.toString('Asia/Seoul'); // => 2019-11-18T19:52:01.816+09:00[Asia/Seoul]
+instant.toString({ timeZone: Temporal.TimeZone.from('UTC') });
+  // => 2019-11-18T10:52:01.816+00:00
+instant.toString({ timeZone: 'Asia/Seoul' });
+  // => 2019-11-18T19:52:01.816+09:00
 
 instant.toString(undefined, { smallestUnit: 'minute' });
   // => 2019-11-18T10:52Z

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -172,6 +172,12 @@ export namespace Temporal {
     }
   >;
 
+  export type InstantToStringOptions = Partial<
+    ToStringPrecisionOptions & {
+      timeZone: TimeZoneProtocol | string;
+    }
+  >;
+
   /**
    * Options to control the result of `until()` and `since()` methods in
    * `Temporal` types.
@@ -567,7 +573,7 @@ export namespace Temporal {
     toZonedDateTimeISO(tzLike: TimeZoneProtocol | string): Temporal.ZonedDateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
-    toString(tzLike?: TimeZoneProtocol | string, options?: ToStringPrecisionOptions): string;
+    toString(options?: InstantToStringOptions): string;
     valueOf(): never;
   }
 

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1370,20 +1370,6 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     return ES.ToString(ES.Call(toString, timeZone));
   },
-  ISOTimeZoneString: (timeZone, instant) => {
-    const name = ES.TimeZoneToString(timeZone);
-    const offset = ES.GetOffsetStringFor(timeZone, instant);
-
-    if (name === 'UTC') {
-      return 'Z';
-    }
-
-    if (name === offset) {
-      return offset;
-    }
-
-    return `${offset}[${name}]`;
-  },
   ISOYearString: (year) => {
     let yearString;
     if (year < 1000 || year > 9999) {
@@ -1413,7 +1399,12 @@ export const ES = ObjectAssign({}, ES2020, {
     return `${secs}.${fraction}`;
   },
   TemporalInstantToString: (instant, timeZone, precision) => {
-    const dateTime = ES.GetTemporalDateTimeFor(timeZone, instant);
+    let outputTimeZone = timeZone;
+    if (outputTimeZone === undefined) {
+      const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
+      outputTimeZone = new TemporalTimeZone('UTC');
+    }
+    const dateTime = ES.GetTemporalDateTimeFor(outputTimeZone, instant, 'iso8601');
     const year = ES.ISOYearString(dateTime.year);
     const month = ES.ISODateTimePartString(dateTime.month);
     const day = ES.ISODateTimePartString(dateTime.day);
@@ -1426,7 +1417,7 @@ export const ES = ObjectAssign({}, ES2020, {
       dateTime.nanosecond,
       precision
     );
-    const timeZoneString = ES.ISOTimeZoneString(timeZone, instant);
+    const timeZoneString = timeZone === undefined ? 'Z' : ES.GetOffsetStringFor(outputTimeZone, instant);
     return `${year}-${month}-${day}T${hour}:${minute}${seconds}${timeZoneString}`;
   },
   TemporalDurationToString: (duration) => {

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -210,10 +210,11 @@ export class Instant {
     const two = GetSlot(other, EPOCHNANOSECONDS);
     return bigInt(one).equals(two);
   }
-  toString(temporalTimeZoneLike = 'UTC', options = undefined) {
+  toString(options = undefined) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
     options = ES.NormalizeOptionsObject(options);
+    let timeZone = options.timeZone;
+    if (timeZone !== undefined) timeZone = ES.ToTemporalTimeZone(timeZone);
     const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const ns = GetSlot(this, EPOCHNANOSECONDS);
@@ -223,9 +224,7 @@ export class Instant {
   }
   toJSON() {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
-    const timeZone = new TemporalTimeZone('UTC');
-    return ES.TemporalInstantToString(this, timeZone, 'auto');
+    return ES.TemporalInstantToString(this, undefined, 'auto');
   }
   toLocaleString(locales = undefined, options = undefined) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -93,20 +93,19 @@ describe('Instant', () => {
       equal(`${instant}`, iso);
     });
     it('optional time zone parameter UTC', () => {
-      const iso = '1976-11-18T14:23:30.123456789Z';
-      const inst = Instant.from(iso);
-      const tz = Temporal.TimeZone.from('UTC');
-      equal(inst.toString(tz), iso);
+      const inst = Instant.from('1976-11-18T14:23:30.123456789Z');
+      const timeZone = Temporal.TimeZone.from('UTC');
+      equal(inst.toString({ timeZone }), '1976-11-18T14:23:30.123456789+00:00');
     });
     it('optional time zone parameter non-UTC', () => {
       const inst = Instant.from('1976-11-18T14:23:30.123456789Z');
-      const tz = Temporal.TimeZone.from('America/New_York');
-      equal(inst.toString(tz), '1976-11-18T09:23:30.123456789-05:00[America/New_York]');
+      const timeZone = Temporal.TimeZone.from('America/New_York');
+      equal(inst.toString({ timeZone }), '1976-11-18T09:23:30.123456789-05:00');
     });
     it('sub-minute offset', () => {
       const inst = Instant.from('1900-01-01T12:00Z');
-      const tz = Temporal.TimeZone.from('Europe/Amsterdam');
-      equal(inst.toString(tz), '1900-01-01T12:19:32+00:19:32[Europe/Amsterdam]');
+      const timeZone = Temporal.TimeZone.from('Europe/Amsterdam');
+      equal(inst.toString({ timeZone }), '1900-01-01T12:19:32+00:19:32');
     });
     const i1 = Instant.from('1976-11-18T15:23Z');
     const i2 = Instant.from('1976-11-18T15:23:30Z');
@@ -117,103 +116,82 @@ describe('Instant', () => {
       equal(i3.toString(), '1976-11-18T15:23:30.1234Z');
     });
     it('truncates to minute', () => {
-      [i1, i2, i3].forEach((i) => equal(i.toString(undefined, { smallestUnit: 'minute' }), '1976-11-18T15:23Z'));
+      [i1, i2, i3].forEach((i) => equal(i.toString({ smallestUnit: 'minute' }), '1976-11-18T15:23Z'));
     });
     it('other smallestUnits are aliases for fractional digits', () => {
-      equal(i3.toString(undefined, { smallestUnit: 'second' }), i3.toString(undefined, { fractionalSecondDigits: 0 }));
-      equal(
-        i3.toString(undefined, { smallestUnit: 'millisecond' }),
-        i3.toString(undefined, { fractionalSecondDigits: 3 })
-      );
-      equal(
-        i3.toString(undefined, { smallestUnit: 'microsecond' }),
-        i3.toString(undefined, { fractionalSecondDigits: 6 })
-      );
-      equal(
-        i3.toString(undefined, { smallestUnit: 'nanosecond' }),
-        i3.toString(undefined, { fractionalSecondDigits: 9 })
-      );
+      equal(i3.toString({ smallestUnit: 'second' }), i3.toString({ fractionalSecondDigits: 0 }));
+      equal(i3.toString({ smallestUnit: 'millisecond' }), i3.toString({ fractionalSecondDigits: 3 }));
+      equal(i3.toString({ smallestUnit: 'microsecond' }), i3.toString({ fractionalSecondDigits: 6 }));
+      equal(i3.toString({ smallestUnit: 'nanosecond' }), i3.toString({ fractionalSecondDigits: 9 }));
     });
     it('throws on invalid or disallowed smallestUnit', () => {
       ['era', 'year', 'month', 'day', 'hour', 'nonsense'].forEach((smallestUnit) =>
-        throws(() => i1.toString(undefined, { smallestUnit }), RangeError)
+        throws(() => i1.toString({ smallestUnit }), RangeError)
       );
     });
     it('accepts plural units', () => {
-      equal(i3.toString(undefined, { smallestUnit: 'minutes' }), i3.toString(undefined, { smallestUnit: 'minute' }));
-      equal(i3.toString(undefined, { smallestUnit: 'seconds' }), i3.toString(undefined, { smallestUnit: 'second' }));
-      equal(
-        i3.toString(undefined, { smallestUnit: 'milliseconds' }),
-        i3.toString(undefined, { smallestUnit: 'millisecond' })
-      );
-      equal(
-        i3.toString(undefined, { smallestUnit: 'microseconds' }),
-        i3.toString(undefined, { smallestUnit: 'microsecond' })
-      );
-      equal(
-        i3.toString(undefined, { smallestUnit: 'nanoseconds' }),
-        i3.toString(undefined, { smallestUnit: 'nanosecond' })
-      );
+      equal(i3.toString({ smallestUnit: 'minutes' }), i3.toString({ smallestUnit: 'minute' }));
+      equal(i3.toString({ smallestUnit: 'seconds' }), i3.toString({ smallestUnit: 'second' }));
+      equal(i3.toString({ smallestUnit: 'milliseconds' }), i3.toString({ smallestUnit: 'millisecond' }));
+      equal(i3.toString({ smallestUnit: 'microseconds' }), i3.toString({ smallestUnit: 'microsecond' }));
+      equal(i3.toString({ smallestUnit: 'nanoseconds' }), i3.toString({ smallestUnit: 'nanosecond' }));
     });
     it('truncates or pads to 2 places', () => {
       const options = { fractionalSecondDigits: 2 };
-      equal(i1.toString(undefined, options), '1976-11-18T15:23:00.00Z');
-      equal(i2.toString(undefined, options), '1976-11-18T15:23:30.00Z');
-      equal(i3.toString(undefined, options), '1976-11-18T15:23:30.12Z');
+      equal(i1.toString(options), '1976-11-18T15:23:00.00Z');
+      equal(i2.toString(options), '1976-11-18T15:23:30.00Z');
+      equal(i3.toString(options), '1976-11-18T15:23:30.12Z');
     });
     it('pads to 7 places', () => {
       const options = { fractionalSecondDigits: 7 };
-      equal(i1.toString(undefined, options), '1976-11-18T15:23:00.0000000Z');
-      equal(i2.toString(undefined, options), '1976-11-18T15:23:30.0000000Z');
-      equal(i3.toString(undefined, options), '1976-11-18T15:23:30.1234000Z');
+      equal(i1.toString(options), '1976-11-18T15:23:00.0000000Z');
+      equal(i2.toString(options), '1976-11-18T15:23:30.0000000Z');
+      equal(i3.toString(options), '1976-11-18T15:23:30.1234000Z');
     });
     it('auto is the default', () => {
-      [i1, i2, i3].forEach((i) => equal(i.toString(undefined, { fractionalSecondDigits: 'auto' }), i.toString()));
+      [i1, i2, i3].forEach((i) => equal(i.toString({ fractionalSecondDigits: 'auto' }), i.toString()));
     });
     it('throws on out of range or invalid fractionalSecondDigits', () => {
       [-1, 10, Infinity, NaN, 'not-auto'].forEach((fractionalSecondDigits) =>
-        throws(() => i1.toString(undefined, { fractionalSecondDigits }), RangeError)
+        throws(() => i1.toString({ fractionalSecondDigits }), RangeError)
       );
     });
     it('accepts and truncates fractional fractionalSecondDigits', () => {
-      equal(i3.toString(undefined, { fractionalSecondDigits: 5.5 }), '1976-11-18T15:23:30.12340Z');
+      equal(i3.toString({ fractionalSecondDigits: 5.5 }), '1976-11-18T15:23:30.12340Z');
     });
     it('smallestUnit overrides fractionalSecondDigits', () => {
-      equal(i3.toString(undefined, { smallestUnit: 'minute', fractionalSecondDigits: 9 }), '1976-11-18T15:23Z');
+      equal(i3.toString({ smallestUnit: 'minute', fractionalSecondDigits: 9 }), '1976-11-18T15:23Z');
     });
     it('throws on invalid roundingMode', () => {
-      throws(() => i1.toString(undefined, { roundingMode: 'cile' }), RangeError);
+      throws(() => i1.toString({ roundingMode: 'cile' }), RangeError);
     });
     it('rounds to nearest', () => {
-      equal(i2.toString(undefined, { smallestUnit: 'minute', roundingMode: 'nearest' }), '1976-11-18T15:24Z');
-      equal(i3.toString(undefined, { fractionalSecondDigits: 3, roundingMode: 'nearest' }), '1976-11-18T15:23:30.123Z');
+      equal(i2.toString({ smallestUnit: 'minute', roundingMode: 'nearest' }), '1976-11-18T15:24Z');
+      equal(i3.toString({ fractionalSecondDigits: 3, roundingMode: 'nearest' }), '1976-11-18T15:23:30.123Z');
     });
     it('rounds up', () => {
-      equal(i2.toString(undefined, { smallestUnit: 'minute', roundingMode: 'ceil' }), '1976-11-18T15:24Z');
-      equal(i3.toString(undefined, { fractionalSecondDigits: 3, roundingMode: 'ceil' }), '1976-11-18T15:23:30.124Z');
+      equal(i2.toString({ smallestUnit: 'minute', roundingMode: 'ceil' }), '1976-11-18T15:24Z');
+      equal(i3.toString({ fractionalSecondDigits: 3, roundingMode: 'ceil' }), '1976-11-18T15:23:30.124Z');
     });
     it('rounds down', () => {
       ['floor', 'trunc'].forEach((roundingMode) => {
-        equal(i2.toString(undefined, { smallestUnit: 'minute', roundingMode }), '1976-11-18T15:23Z');
-        equal(i3.toString(undefined, { fractionalSecondDigits: 3, roundingMode }), '1976-11-18T15:23:30.123Z');
+        equal(i2.toString({ smallestUnit: 'minute', roundingMode }), '1976-11-18T15:23Z');
+        equal(i3.toString({ fractionalSecondDigits: 3, roundingMode }), '1976-11-18T15:23:30.123Z');
       });
     });
     it('rounding down is towards the Big Bang, not towards 1 BCE', () => {
       const i4 = Instant.from('-000099-12-15T12:00:00.5Z');
-      equal(i4.toString(undefined, { smallestUnit: 'second', roundingMode: 'floor' }), '-000099-12-15T12:00:00Z');
+      equal(i4.toString({ smallestUnit: 'second', roundingMode: 'floor' }), '-000099-12-15T12:00:00Z');
     });
     it('rounding can affect all units', () => {
       const i5 = Instant.from('1999-12-31T23:59:59.999999999Z');
-      equal(
-        i5.toString(undefined, { fractionalSecondDigits: 8, roundingMode: 'nearest' }),
-        '2000-01-01T00:00:00.00000000Z'
-      );
+      equal(i5.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' }), '2000-01-01T00:00:00.00000000Z');
     });
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
-        throws(() => i1.toString(undefined, badOptions), TypeError)
+        throws(() => i1.toString(badOptions), TypeError)
       );
-      [{}, () => {}, undefined].forEach((options) => equal(i1.toString(undefined, options), '1976-11-18T15:23:00Z'));
+      [{}, () => {}, undefined].forEach((options) => equal(i1.toString(options), '1976-11-18T15:23:00Z'));
     });
   });
   describe('Instant.toJSON() works', () => {

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -58,8 +58,11 @@ describe('Userland time zone', () => {
       equal(`${obj.getInstantFor(dt)}`, '1976-11-18T15:23:30.123456789Z');
     });
     it('converts to string', () => equal(`${obj}`, obj.id));
-    it('prints in instant.toString', () =>
-      equal(inst.toString(obj), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Subclass]'));
+    it('offset prints in instant.toString', () => equal(inst.toString({ timeZone: obj }), '1970-01-01T00:00:00+00:00'));
+    it('prints in zdt.toString', () => {
+      const zdt = new Temporal.ZonedDateTime(0n, obj);
+      equal(zdt.toString(), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Subclass]');
+    });
     it('has no next transitions', () => assert.equal(obj.getNextTransition(), null));
     it('has no previous transitions', () => assert.equal(obj.getPreviousTransition(), null));
     it('works in Temporal.now', () => {
@@ -98,7 +101,7 @@ describe('Userland time zone', () => {
       });
       it('works for Instant.toString', () => {
         const inst = Temporal.Instant.fromEpochSeconds(0);
-        equal(inst.toString('Etc/Custom/UTC_Subclass'), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Subclass]');
+        equal(inst.toString({ timeZone: 'Etc/Custom/UTC_Subclass' }), '1970-01-01T00:00:00+00:00');
       });
       it('works for Temporal.now', () => {
         assert(Temporal.now.dateTimeISO('Etc/Custom/UTC_Subclass') instanceof Temporal.DateTime);
@@ -144,8 +147,11 @@ describe('Userland time zone', () => {
     it('converts to Instant', () => {
       equal(`${Temporal.TimeZone.prototype.getInstantFor.call(obj, dt)}`, '1976-11-18T15:23:30.123456789Z');
     });
-    it('prints in instant.toString', () =>
-      equal(inst.toString(obj), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Protocol]'));
+    it('offset prints in instant.toString', () => equal(inst.toString({ timeZone: obj }), '1970-01-01T00:00:00+00:00'));
+    it('prints in zdt.toString', () => {
+      const zdt = new Temporal.ZonedDateTime(0n, obj);
+      equal(zdt.toString(), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Protocol]');
+    });
     it('works in Temporal.now', () => {
       assert(Temporal.now.dateTimeISO(obj) instanceof Temporal.DateTime);
       assert(Temporal.now.dateTime('gregory', obj) instanceof Temporal.DateTime);
@@ -182,7 +188,7 @@ describe('Userland time zone', () => {
       });
       it('works for Instant.toString', () => {
         const inst = Temporal.Instant.fromEpochSeconds(0);
-        equal(inst.toString('Etc/Custom/UTC_Protocol'), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Protocol]');
+        equal(inst.toString({ timeZone: 'Etc/Custom/UTC_Protocol' }), '1970-01-01T00:00:00+00:00');
       });
       it('works for Temporal.now', () => {
         assert(Temporal.now.dateTimeISO('Etc/Custom/UTC_Protocol') instanceof Temporal.DateTime);
@@ -239,8 +245,12 @@ describe('Userland time zone', () => {
       equal(`${obj.getInstantFor(dt)}`, '1976-11-18T15:23:31.2345679Z');
     });
     it('converts to string', () => equal(`${obj}`, obj.id));
-    it('prints in instant.toString', () =>
-      equal(inst.toString(obj), '1969-12-31T23:59:58.888888889-00:00:01.111111111[Custom/Subminute]'));
+    it('offset prints in instant.toString', () =>
+      equal(inst.toString({ timeZone: obj }), '1969-12-31T23:59:58.888888889-00:00:01.111111111'));
+    it('prints in zdt.toString', () => {
+      const zdt = new Temporal.ZonedDateTime(0n, obj);
+      equal(zdt.toString(), '1969-12-31T23:59:58.888888889-00:00:01.111111111[Custom/Subminute]');
+    });
     it('has no next transitions', () => assert.equal(obj.getNextTransition(), null));
     it('has no previous transitions', () => assert.equal(obj.getPreviousTransition(), null));
     it('works in Temporal.now', () => {
@@ -279,7 +289,7 @@ describe('Userland time zone', () => {
       });
       it('works for Instant.toString', () => {
         const inst = Temporal.Instant.fromEpochSeconds(0);
-        equal(inst.toString('Custom/Subminute'), '1969-12-31T23:59:58.888888889-00:00:01.111111111[Custom/Subminute]');
+        equal(inst.toString({ timeZone: 'Custom/Subminute' }), '1969-12-31T23:59:58.888888889-00:00:01.111111111');
       });
       it('works for Temporal.now', () => {
         assert(Temporal.now.dateTimeISO('Custom/Subminute') instanceof Temporal.DateTime);

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -386,25 +386,24 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.instant.prototype.tostring">
-      <h1>Temporal.Instant.prototype.toString ( [ _temporalTimeZoneLike_ [ , _options_ ] ] )</h1>
+      <h1>Temporal.Instant.prototype.toString ( [ _options_ ] )</h1>
       <p>
-        The `toString` method takes two arguments, _temporalTimeZoneLike_ and _options_.
+        The `toString` method takes one argument _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
+        1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
+        1. If _timeZone_ is not *undefined*, then
+          1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
         1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _ns_ be the mathematical value of _instant_.[[Nanoseconds]].
         1. Let _roundedNs_ be ? RoundTemporalInstant(_ns_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Let _roundedInstant_ be ? CreateTemporalInstant(_roundedNs_).
-        1. If _temporalTimeZoneLike_ is *undefined*, then
-          1. Set _temporalTimeZoneLike_ to *"UTC"*.
-        1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
-        1. Let _calendar_ be ? GetISO8601Calendar().
-        1. Return ? TemporalInstantToString(_roundedInstant_, _timeZone_, _calendar_, _precision_.[[Precision]]).
+        1. Return ? TemporalInstantToString(_roundedInstant_, _timeZone_, _precision_.[[Precision]]).
       </emu-alg>
     </emu-clause>
 
@@ -418,9 +417,7 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. If the implementation does not include the ECMA-402 Internationalization API, then
-          1. Let _timeZone_ be ? CreateTemporalTimeZone(*"UTC"*).
-          1. Let _calendar_ be ? GetISO8601Calendar().
-          1. Return ? TemporalInstantToString(_instant_, _timeZone_, _calendar_, *"auto"*).
+          1. Return ? TemporalInstantToString(_instant_, *undefined*, *"auto"*).
         1. Let _dateFormat_ be ? Construct(%DateTimeFormat%, « _locales_, _options_ »).
         1. Return ? FormatDateTime(_dateFormat_, _instant_).
       </emu-alg>
@@ -434,9 +431,7 @@
       <emu-alg>
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. Let _timeZone_ be ? CreateTemporalTimeZone(*"UTC"*).
-        1. Let _calendar_ be ? GetISO8601Calendar().
-        1. Return ? TemporalInstantToString(_instant_, _timeZone_, _calendar_, *"auto"*).
+        1. Return ? TemporalInstantToString(_instant_, *undefined*, *"auto"*).
       </emu-alg>
     </emu-clause>
 
@@ -658,30 +653,21 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-temporalinstanttostring" aoid="TemporalInstantToString">
-      <h1>TemporalInstantToString ( _instant_, _timeZone_, _calendar_, _precision_ )</h1>
+      <h1>TemporalInstantToString ( _instant_, _timeZone_, _precision_ )</h1>
       <emu-alg>
         1. Assert: Type(_instant_) is Object.
         1. Assert: _instant_ has an [[InitializedTemporalInstant]] internal slot.
-        1. Let _dateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _outputTimeZone_ be _timeZone_.
+        1. If _outputTimeZone_ is *undefined*, then
+          1. Set _outputTimeZone_ to ? CreateTemporalTimeZone(*"UTC"*).
+        1. Let _isoCalendar_ be ? GetISO8601Calendar().
+        1. Let _dateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_, _isoCalendar_).
         1. Let _dateTimeString_ be ? TemporalDateTimeToString(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], *undefined*, _precision_, *"never"*).
-        1. Let _timeZoneString_ be ? ISOTimeZoneString(_timeZone_, _instant_).
+        1. If _timeZone_ is *undefined*, then
+          1. Let _timeZoneString_ be *"Z"*.
+        1. Else,
+          1. Let _timeZoneString_ be ? GetOffsetStringFor(_timeZone_, _instant_).
         1. Return the string-concatenation of _dateTimeString_ and _timeZoneString_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-isotimezonestring" aoid="ISOTimeZoneString">
-      <h1>ISOTimeZoneString ( _instant_, _timeZone_ )</h1>
-      <emu-alg>
-        1. Assert: Type(_instant_) is Object.
-        1. Assert: _instant_ has an [[InitializedTemporalInstant]] internal slot.
-        1. Assert?: Type(_timeZone_) is Object.
-        1. Let _name_ be ? TimeZoneToString(_timeZone_).
-        1. Let _offset_ be ? GetOffsetStringFor(_timeZone_, _instant_).
-        1. If _name_ is *"UTC"*, then
-          1. Return *"Z"*.
-        1. If _name_ is _offset_, then
-          1. Return _offset_.
-        1. Return the string-concatenation of _offset_, *"["*, _name_, and *"]"*.
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This adds an option for the time zone in which to print an Instant,
instead of having it be a separate argument. Also removes printing the
bracketed name from Instant.

Closes: #741