### PR TITLE
Rename types with plain prefix

### DIFF
--- a/docs/ambiguity.md
+++ b/docs/ambiguity.md
@@ -174,7 +174,7 @@ inst = dt.toInstantISO('America/Sao_Paulo'); // can be ambiguous
 // the offset is lost when converting from an exact type to a non-exact type
 zdt = Temporal.ZonedDateTime.from('2020-11-01T01:30-08:00[America/Los_Angeles]');
   // => 2020-11-01T01:30-08:00[America/Los_Angeles]
-dt = zdt.toDateTime(); // offset is lost!
+dt = zdt.toPlainDateTime(); // offset is lost!
   // => 2020-11-01T01:30
 zdtAmbiguous = dt.toZonedDateTime('America/Los_Angeles'); // can be ambiguous
   // => 2020-11-01T01:30-07:00[America/Los_Angeles]
@@ -239,7 +239,7 @@ earlier = Temporal.ZonedDateTime.from(props, { disambiguation: 'earlier' });
   // => 2020-03-08T01:30-08:00[America/Los_Angeles] (1:30 clock time; still in Standard Time)
 later = Temporal.ZonedDateTime.from(props, { disambiguation: 'later' });
   // => 2020-03-08T03:30-07:00[America/Los_Angeles] ('later' is same as 'compatible' for backwards transitions)
-later.toDateTime().since(earlier.toDateTime());
+later.toPlainDateTime().since(earlier.toPlainDateTime());
   // => PT2H  (2 hour difference in clock time...
 later.since(earlier);
   // => PT1H   ... but 1 hour later in real-world time)
@@ -269,7 +269,7 @@ later = Temporal.ZonedDateTime.from(props, { disambiguation: 'later' });
   // => 2020-11-01T01:30-08:00[America/Los_Angeles] 
   // Same clock time, but one hour later.
   // -08:00 offset indicates Standard Time.
-later.toDateTime().since(earlier.toDateTime());
+later.toPlainDateTime().since(earlier.toPlainDateTime());
   // => PT0S  
   // (same clock time...
 later.since(earlier);

--- a/docs/cookbook/adjustDayOfMonth.mjs
+++ b/docs/cookbook/adjustDayOfMonth.mjs
@@ -14,6 +14,6 @@ assert.equal(lastOfThisMonth.toString(), '2020-04-30');
 
 // On the 18th of this month at 8 PM:
 
-const thisMonth18thAt8PM = date.with({ day: 18 }).toDateTime(Temporal.Time.from('20:00'));
+const thisMonth18thAt8PM = date.with({ day: 18 }).toPlainDateTime(Temporal.Time.from('20:00'));
 
 assert.equal(thisMonth18thAt8PM.toString(), '2020-04-18T20:00:00');

--- a/docs/cookbook/birthdayIn2030.mjs
+++ b/docs/cookbook/birthdayIn2030.mjs
@@ -1,6 +1,6 @@
 const birthday = Temporal.MonthDay.from('12-15');
 
-const birthdayIn2030 = birthday.toDate({ year: 2030 });
+const birthdayIn2030 = birthday.toPlainDate({ year: 2030 });
 birthdayIn2030.dayOfWeek; // => 7
 
 assert(birthdayIn2030 instanceof Temporal.Date);

--- a/docs/cookbook/bridgePublicHolidays.mjs
+++ b/docs/cookbook/bridgePublicHolidays.mjs
@@ -8,7 +8,7 @@
  * @returns {Temporal.Date[]} List of dates to be taken off work
  */
 function bridgePublicHolidays(holiday, year) {
-  const date = holiday.toDate({ year });
+  const date = holiday.toPlainDate({ year });
   switch (date.dayOfWeek) {
     case 1: // Mon
     case 3: // Wed

--- a/docs/cookbook/calculateDailyOccurrence.mjs
+++ b/docs/cookbook/calculateDailyOccurrence.mjs
@@ -9,7 +9,7 @@
  */
 function* calculateDailyOccurrence(startDate, time, timeZone) {
   for (let date = startDate; ; date = date.add({ days: 1 })) {
-    yield date.toDateTime(time).toZonedDateTime(timeZone);
+    yield date.toPlainDateTime(time).toZonedDateTime(timeZone);
   }
 }
 

--- a/docs/cookbook/getBusinessOpenStateText.mjs
+++ b/docs/cookbook/getBusinessOpenStateText.mjs
@@ -25,12 +25,12 @@ function getBusinessOpenStateText(now, businessHours, soonWindow) {
     return Temporal.Instant.compare(i, start) >= 0 && Temporal.Instant.compare(i, end) < 0;
   }
 
-  const dateTime = now.toDateTime();
+  const dateTime = now.toPlainDateTime();
   const weekday = dateTime.dayOfWeek % 7; // convert to 0-based, for array indexing
 
   // Because of times wrapping around at midnight, we may need to consider
   // yesterday's and tomorrow's hours as well
-  const today = dateTime.toDate();
+  const today = dateTime.toPlainDate();
   const yesterday = today.subtract({ days: 1 });
   const tomorrow = today.add({ days: 1 });
 
@@ -43,8 +43,8 @@ function getBusinessOpenStateText(now, businessHours, soonWindow) {
     const { open, close } = yesterdayHours;
     if (Temporal.Time.compare(close, open) < 0) {
       businessHoursOverlappingToday.push({
-        open: now.timeZone.getInstantFor(yesterday.toDateTime(open)),
-        close: now.timeZone.getInstantFor(today.toDateTime(close))
+        open: now.timeZone.getInstantFor(yesterday.toPlainDateTime(open)),
+        close: now.timeZone.getInstantFor(today.toPlainDateTime(close))
       });
     }
   }
@@ -53,8 +53,8 @@ function getBusinessOpenStateText(now, businessHours, soonWindow) {
     const { open, close } = todayHours;
     const todayOrTomorrow = Temporal.Time.compare(close, open) >= 0 ? today : tomorrow;
     businessHoursOverlappingToday.push({
-      open: now.timeZone.getInstantFor(today.toDateTime(open)),
-      close: now.timeZone.getInstantFor(todayOrTomorrow.toDateTime(close))
+      open: now.timeZone.getInstantFor(today.toPlainDateTime(open)),
+      close: now.timeZone.getInstantFor(todayOrTomorrow.toPlainDateTime(close))
     });
   }
 

--- a/docs/cookbook/getFirstTuesdayOfMonth.mjs
+++ b/docs/cookbook/getFirstTuesdayOfMonth.mjs
@@ -6,7 +6,7 @@
  */
 function getFirstTuesday(queriedMonth) {
   // We first need to convert to a date
-  const firstOfMonth = queriedMonth.toDate({ day: 1 });
+  const firstOfMonth = queriedMonth.toPlainDate({ day: 1 });
 
   // We have Monday = 1, Sunday = 7, and we want to add a positive number
   // smaller than 7 to get to the first Tuesday.
@@ -24,12 +24,12 @@ assert.equal(firstTuesdayOfMonth.toString(), '2020-02-04');
 assert.equal(firstTuesdayOfMonth.dayOfWeek, 2);
 
 // Similarly, to get the second Tuesday:
-const secondWeek = myMonth.toDate({ day: 8 });
+const secondWeek = myMonth.toPlainDate({ day: 8 });
 const secondTuesday = secondWeek.add({ days: [1, 0, 6, 5, 4, 3, 2][secondWeek.dayOfWeek - 1] });
 assert.equal(secondTuesday.day, firstTuesdayOfMonth.day + 7);
 
 // And the last Tuesday:
-const lastOfMonth = myMonth.toDate({ day: myMonth.daysInMonth });
+const lastOfMonth = myMonth.toPlainDate({ day: myMonth.daysInMonth });
 const lastTuesday = lastOfMonth.subtract({ days: [6, 0, 1, 2, 3, 4, 5][lastOfMonth.dayOfWeek - 1] });
 assert.equal(lastTuesday.toString(), '2020-02-25');
 assert.equal(lastTuesday.dayOfWeek, 2);

--- a/docs/cookbook/getWeeklyDaysInMonth.mjs
+++ b/docs/cookbook/getWeeklyDaysInMonth.mjs
@@ -7,7 +7,7 @@
  * @returns {Temporal.Date[]} Array of dates
  */
 function getWeeklyDaysInMonth(yearMonth, dayNumberOfTheWeek) {
-  const firstOfMonth = yearMonth.toDate({ day: 1 });
+  const firstOfMonth = yearMonth.toPlainDate({ day: 1 });
   let nextWeekday = firstOfMonth.add({ days: (7 + dayNumberOfTheWeek - firstOfMonth.dayOfWeek) % 7 });
   const result = [];
   while (nextWeekday.month === yearMonth.month) {

--- a/docs/cookbook/localTimeForFutureEvents.mjs
+++ b/docs/cookbook/localTimeForFutureEvents.mjs
@@ -33,7 +33,7 @@ const localTimes = tc39meetings.map(({ dateTime, timeZone }) => {
   return Temporal.DateTime.from(dateTime)
     .toZonedDateTime(timeZone, { disambiguation: 'reject' })
     .withTimeZone(localTimeZone)
-    .toDateTime();
+    .toPlainDateTime();
 });
 
 assert.deepEqual(

--- a/docs/cookbook/meetingPlanner.js
+++ b/docs/cookbook/meetingPlanner.js
@@ -10,7 +10,7 @@ const timeZones = [
 
 // Start the table at midnight local time
 const browserCalendar = new Intl.DateTimeFormat().resolvedOptions().calendar;
-const calendarNow = now.toDateTime(here, browserCalendar);
+const calendarNow = now.toPlainDateTime(here, browserCalendar);
 const startTime = calendarNow
   .with(Temporal.Time.from('00:00')) // midnight
   .toInstant(here);
@@ -27,7 +27,7 @@ timeZones.forEach(({ name, tz }) => {
   for (let hours = 0; hours < 24; hours++) {
     const cell = document.createElement('td');
 
-    const dt = startTime.add({ hours }).toDateTime(tz);
+    const dt = startTime.add({ hours }).toPlainDateTime(tz);
     cell.className = `time-${dt.hour}`;
 
     // Highlight the current hour in each row

--- a/docs/cookbook/nextWeeklyOccurrence.mjs
+++ b/docs/cookbook/nextWeeklyOccurrence.mjs
@@ -12,16 +12,16 @@
  * @returns {Temporal.DateTime} Local date and time of next occurrence
  */
 function nextWeeklyOccurrence(now, weekday, eventTime, eventTimeZone) {
-  const dateTime = now.withTimeZone(eventTimeZone).toDateTime();
-  const nextDate = dateTime.toDate().add({ days: (weekday + 7 - dateTime.dayOfWeek) % 7 });
-  let nextOccurrence = nextDate.toDateTime(eventTime);
+  const dateTime = now.withTimeZone(eventTimeZone).toPlainDateTime();
+  const nextDate = dateTime.toPlainDate().add({ days: (weekday + 7 - dateTime.dayOfWeek) % 7 });
+  let nextOccurrence = nextDate.toPlainDateTime(eventTime);
 
   // Handle the case where the event is today but already happened
   if (Temporal.DateTime.compare(dateTime, nextOccurrence) > 0) {
     nextOccurrence = nextOccurrence.add({ days: 7 });
   }
 
-  return eventTimeZone.getInstantFor(nextOccurrence).toZonedDateTime(now).toDateTime();
+  return eventTimeZone.getInstantFor(nextOccurrence).toZonedDateTime(now).toPlainDateTime();
 }
 
 // "Weekly on Thursdays at 08:45 California time":

--- a/docs/cookbook/noonOnDate.mjs
+++ b/docs/cookbook/noonOnDate.mjs
@@ -1,6 +1,6 @@
 const date = Temporal.Date.from('2020-05-14');
 
-const noonOnDate = date.toDateTime(Temporal.Time.from({ hour: 12 }));
+const noonOnDate = date.toPlainDateTime(Temporal.Time.from({ hour: 12 }));
 
 assert(noonOnDate instanceof Temporal.DateTime);
 assert.equal(noonOnDate.toString(), '2020-05-14T12:00:00');

--- a/docs/cookbook/storageTank.js
+++ b/docs/cookbook/storageTank.js
@@ -11,7 +11,7 @@ const labelFormatter = new Intl.DateTimeFormat(undefined, {
   timeZone: Temporal.now.timeZone()
 });
 const browserCalendar = labelFormatter.resolvedOptions().calendar;
-const tankMidnight = Temporal.now.date(browserCalendar, tankTimeZone).toDateTime().toInstant(tankTimeZone);
+const tankMidnight = Temporal.now.date(browserCalendar, tankTimeZone).toPlainDateTime().toInstant(tankTimeZone);
 const atOrAfterMidnight = (x) => Temporal.Instant.compare(x, tankMidnight) >= 0;
 const dataStartIndex = tankDataX.findIndex(atOrAfterMidnight);
 const graphLabels = tankDataX.slice(dataStartIndex).map((x) => labelFormatter.format(x));

--- a/docs/date.md
+++ b/docs/date.md
@@ -10,7 +10,7 @@ A `Temporal.Date` represents a calendar date.
 For example, it could be used to represent an event on a calendar which happens during the whole day no matter which time zone it's happening in.
 
 `Temporal.Date` refers to the whole of a specific day; if you need to refer to a specific time on that day, use `Temporal.DateTime`.
-A `Temporal.Date` can be converted into a `Temporal.DateTime` by combining it with a `Temporal.Time` using the `toDateTime()` method.
+A `Temporal.Date` can be converted into a `Temporal.DateTime` by combining it with a `Temporal.Time` using the `toPlainDateTime()` method.
 
 `Temporal.YearMonth` and `Temporal.MonthDay` carry less information than `Temporal.Date` and should be used when complete information is not required.
 
@@ -33,7 +33,7 @@ Otherwise, `Temporal.Date.from()`, which accepts more kinds of input, allows inp
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in that calendar, even if you are passing a different calendar as the `calendar` parameter.
 
-The range of allowed values for this type is exactly enough that calling [`toDate()`](./datetime.html#toDate) on any valid `Temporal.DateTime` will succeed.
+The range of allowed values for this type is exactly enough that calling [`toPlainDate()`](./datetime.html#toPlainDate) on any valid `Temporal.DateTime` will succeed.
 If `isoYear`, `isoMonth`, and `isoDay` form a date outside of this range, then this function will throw a `RangeError`.
 
 > **NOTE**: The `isoMonth` argument ranges from 1 to 12, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
@@ -486,7 +486,7 @@ later.until(earlier, { largestUnit: 'years' }); // => -P12Y5M7D
 // point in time from which you want to reckon the difference. For
 // example, using noon:
 noon = Temporal.Time.from('12:00');
-earlier.toDateTime(noon).until(later.toDateTime(noon), { largestUnit: 'hours' });
+earlier.toPlainDateTime(noon).until(later.toPlainDateTime(noon), { largestUnit: 'hours' });
   // => PT109032H
 ```
 <!-- prettier-ignore-end -->
@@ -696,7 +696,7 @@ date.toZonedDateTime('America/Los_Angeles', time); // => 2006-08-24T15:23:30.003
 date.toZonedDateTime('America/Los_Angeles'); // => 2006-08-24T00:00-07:00[America/Los_Angeles]
 ```
 
-### date.**toDateTime**(_time_?: Temporal.Time | object | string) : Temporal.DateTime
+### date.**toPlainDateTime**(_time_?: Temporal.Time | object | string) : Temporal.DateTime
 
 **Parameters:**
 
@@ -708,7 +708,7 @@ This method can be used to convert `Temporal.Date` into a `Temporal.DateTime`, b
 The default `time`, if it is not given, is midnight (00:00).
 The converted object carries a copy of all the relevant fields of `date` and `time`.
 
-If `time` is given, this is equivalent to [`Temporal.Time.from(time).toDateTime(date)`](./time.html#toDateTime).
+If `time` is given, this is equivalent to [`Temporal.Time.from(time).toPlainDateTime(date)`](./time.html#toPlainDateTime).
 
 If `time` is given and is not a `Temporal.Time` object, then it will be converted to one as if it were passed to `Temporal.Time.from()`.
 
@@ -717,27 +717,27 @@ Usage example:
 ```javascript
 date = Temporal.Date.from('2006-08-24');
 time = Temporal.Time.from('15:23:30.003');
-date.toDateTime(time); // => 2006-08-24T15:23:30.003
-date.toDateTime(); // => 2006-08-24T00:00
+date.toPlainDateTime(time); // => 2006-08-24T15:23:30.003
+date.toPlainDateTime(); // => 2006-08-24T00:00
 ```
 
-### date.**toYearMonth**() : Temporal.YearMonth
+### date.**toPlainYearMonth**() : Temporal.YearMonth
 
 **Returns:** a `Temporal.YearMonth` object that is the same as the year and month of `date`.
 
-### date.**toMonthDay**() : Temporal.MonthDay
+### date.**toPlainMonthDay**() : Temporal.MonthDay
 
 **Returns:** a `Temporal.MonthDay` object that is the same as the month and day of `date`.
 
 The above two methods can be used to convert `Temporal.Date` into a `Temporal.YearMonth` or `Temporal.MonthDay` respectively.
-The converted object carries a copy of all the relevant fields of `date` (for example, in `toYearMonth()`, the `year` and `month` properties are copied.)
+The converted object carries a copy of all the relevant fields of `date` (for example, in `toPlainYearMonth()`, the `year` and `month` properties are copied.)
 
 Usage example:
 
 ```javascript
 date = Temporal.Date.from('2006-08-24');
-date.toYearMonth(); // => 2006-08
-date.toMonthDay(); // => 08-24
+date.toPlainYearMonth(); // => 2006-08
+date.toPlainMonthDay(); // => 08-24
 ```
 
 ### date.**getFields**() : { year: number, month: number, day: number, calendar: object, [propName: string]: unknown }

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -47,7 +47,7 @@ Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in tha
 > **NOTE**: Although Temporal does not deal with leap seconds, dates coming from other software may have a `second` value of 60.
 > This value will cause the constructor will throw, so if you have to interoperate with times that may contain leap seconds, use `Temporal.DateTime.from()` instead.
 
-The range of allowed values for this type is exactly enough that calling [`toDateTime()`](./instant.html#toDateTime) on any valid `Temporal.Instant` with any valid `Temporal.TimeZone` will succeed.
+The range of allowed values for this type is exactly enough that calling [`toPlainDateTime()`](./instant.html#toPlainDateTime) on any valid `Temporal.Instant` with any valid `Temporal.TimeZone` will succeed.
 If the parameters passed in to this constructor form a date outside of this range, then this function will throw a `RangeError`.
 
 > **NOTE**: The `isoMonth` argument ranges from 1 to 12, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
@@ -857,33 +857,33 @@ For usage examples and a more complete explanation of how this disambiguation wo
 
 If the result is earlier or later than the range that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown, no matter the value of `disambiguation`.
 
-### datetime.**toDate**() : Temporal.Date
+### datetime.**toPlainDate**() : Temporal.Date
 
 **Returns:** a `Temporal.Date` object that is the same as the date portion of `datetime`.
 
-### datetime.**toYearMonth**() : Temporal.YearMonth
+### datetime.**toPlainYearMonth**() : Temporal.YearMonth
 
 **Returns:** a `Temporal.YearMonth` object that is the same as the year and month of `datetime`.
 
-### datetime.**toMonthDay**() : Temporal.MonthDay
+### datetime.**toPlainMonthDay**() : Temporal.MonthDay
 
 **Returns:** a `Temporal.MonthDay` object that is the same as the month and day of `datetime`.
 
-### datetime.**toTime**() : Temporal.Time
+### datetime.**toPlainTime**() : Temporal.Time
 
 **Returns:** a `Temporal.Time` object that is the same as the wall-clock time portion of `datetime`.
 
 The above four methods can be used to convert `Temporal.DateTime` into a `Temporal.Date`, `Temporal.YearMonth`, `Temporal.MonthDay`, or `Temporal.Time` respectively.
-The converted object carries a copy of all the relevant fields of `datetime` (for example, in `toDate()`, the `year`, `month`, and `day` properties are copied.)
+The converted object carries a copy of all the relevant fields of `datetime` (for example, in `toPlainDate()`, the `year`, `month`, and `day` properties are copied.)
 
 Usage example:
 
 ```javascript
 dt = Temporal.DateTime.from('1995-12-07T03:24:30.000003500');
-dt.toDate(); // => 1995-12-07
-dt.toYearMonth(); // => 1995-12
-dt.toMonthDay(); // => 12-07
-dt.toTime(); // => 03:24:30.000003500
+dt.toPlainDate(); // => 1995-12-07
+dt.toPlainYearMonth(); // => 1995-12
+dt.toPlainMonthDay(); // => 12-07
+dt.toPlainTime(); // => 03:24:30.000003500
 ```
 
 ### datetime.**getFields**() : { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, calendar: object, [propName: string]: unknown }

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -259,7 +259,7 @@ A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki
 
 For a list of calendar identifiers, see the documentation for [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#Parameters).
 
-If you only want to use the ISO 8601 calendar, use `toDateTimeISO()`.
+If you only want to use the ISO 8601 calendar, use `toPlainDateTimeISO()`.
 
 Example usage:
 
@@ -425,7 +425,7 @@ ns.add({ nanoseconds: 1 });
 // Calculate the difference in years, eliminating the ambiguity by
 // explicitly using the corresponding calendar date in UTC:
 utc = Temporal.TimeZone.from('UTC');
-epoch.toDateTime(utc).until(billion.toDateTime(utc), { largestUnit: 'years' });
+epoch.toPlainDateTime(utc).until(billion.toPlainDateTime(utc), { largestUnit: 'years' });
   // => P31Y8M8DT1H46M40S
 ```
 <!-- prettier-ignore-end -->

--- a/docs/localdatetime-draft.md
+++ b/docs/localdatetime-draft.md
@@ -56,11 +56,11 @@ class Temporal.LocalDateTime {
 
   // type conversion
   toInstant(): Temporal.Instant;
-  toDateTime(): Temporal.DateTime;
-  toDate(): Temporal.Date;
-  toYearMonth(): Temporal.YearMonth;
-  toMonthDay(): Temporal.MonthDay;
-  toTime(): Temporal.Time;
+  toPlainDateTime(): Temporal.DateTime;
+  toPlainDate(): Temporal.Date;
+  toPlainYearMonth(): Temporal.YearMonth;
+  toPlainMonthDay(): Temporal.MonthDay;
+  toPlainTime(): Temporal.Time;
 
   // comparison
   static compare(one: Temporal.LocalDateTime, two: Temporal.LocalDateTime): number;

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -9,7 +9,7 @@ A `Temporal.MonthDay` represents a particular day on the calendar, but without a
 For example, it could be used to represent a yearly recurring event, like "Bastille Day is on the 14th of July."
 
 If you need to refer to a certain instance of a calendar event, in a particular year, use `Temporal.Date` or even `Temporal.DateTime`.
-A `Temporal.MonthDay` can be converted into a `Temporal.Date` by combining it with a year, using the `toDate()` method.
+A `Temporal.MonthDay` can be converted into a `Temporal.Date` by combining it with a year, using the `toPlainDate()` method.
 
 ## Constructor
 
@@ -146,7 +146,7 @@ Since `Temporal.MonthDay` objects are immutable, use this method instead of modi
 
 > **NOTE**: Unlike in `Temporal.Date.prototype.with()`, a `calendar` property is not allowed on `monthDayLike`.
 > It is not possible to convert a `Temporal.MonthDay` to another calendar system without knowing the year.
-> If you need to do this, use `monthDay.toDate({ year }).withCalendar(calendar).toMonthDay()`.
+> If you need to do this, use `monthDay.toPlainDate({ year }).withCalendar(calendar).toPlainMonthDay()`.
 
 Usage example:
 ```javascript
@@ -283,7 +283,7 @@ This method overrides `Object.prototype.valueOf()` and always throws an exceptio
 This is because it's not possible to compare `Temporal.MonthDay` objects with the relational operators `<`, `<=`, `>`, or `>=`.
 Instead, use `monthDay.equals()` to check for equality.
 
-### monthDay.**toDate**(_year_: object, _options_?: object) : Temporal.Date
+### monthDay.**toPlainDate**(_year_: object, _options_?: object) : Temporal.Date
 
 **Parameters:**
 - `year` (object): An object with a `'year'` property, which must have a day corresponding to `monthDay`.
@@ -301,12 +301,12 @@ The converted object carries a copy of all the relevant fields of `monthDay`.
 Usage example:
 ```javascript
 md = Temporal.MonthDay.from('08-24');
-md.toDate({ year: 2017 })  // => 2017-08-24
+md.toPlainDate({ year: 2017 })  // => 2017-08-24
 
 md = Temporal.MonthDay.from('02-29');
-md.toDate({ year: 2020 })  // => 2020-02-29
-md.toDate({ year: 2017 })  // => 2017-02-28
-md.toDate({ year: 2017 }, { overflow: 'reject' })  // throws
+md.toPlainDate({ year: 2020 })  // => 2020-02-29
+md.toPlainDate({ year: 2017 })  // => 2017-02-28
+md.toPlainDate({ year: 2017 }, { overflow: 'reject' })  // throws
 ```
 
 In calendars where more information than just the year is needed to convert a `Temporal.MonthDay` to a `Temporal.Date`, you can pass the necessary properties in the _year_ object.
@@ -319,7 +319,7 @@ md = Temporal.MonthDay.from({
   day: 1
 });
 
-date = md.toDate({ era: 'reiwa', year: 2 });
+date = md.toPlainDate({ era: 'reiwa', year: 2 });
 ```
 
 ### monthDay.**getFields**() : { month: number, day: number, calendar: object, [propName: string]: unknown }

--- a/docs/now.md
+++ b/docs/now.md
@@ -98,8 +98,8 @@ now = Temporal.now.instant();
 nextTransition = tz.getNextTransition(now);
 before = tz.getOffsetStringFor(nextTransition.subtract({ nanoseconds: 1 }));
 after = tz.getOffsetStringFor(nextTransition.add({ nanoseconds: 1 }));
-console.log(`On ${nextTransition.toDateTime(tz)} the clock will change from UTC ${before} to ${after}`);
-nextTransition.toDateTime(tz);
+console.log(`On ${nextTransition.toPlainDateTime(tz)} the clock will change from UTC ${before} to ${after}`);
+nextTransition.toPlainDateTime(tz);
 // example output:
 // On 2020-03-08T03:00 the clock will change from UTC -08:00 to -07:00
 ```

--- a/docs/time.md
+++ b/docs/time.md
@@ -10,7 +10,7 @@ A `Temporal.Time` represents a wall-clock time, with a precision in nanoseconds,
 For example, it could be used to represent an event that happens daily at a certain time, no matter what time zone.
 
 `Temporal.Time` refers to a time with no associated calendar date; if you need to refer to a specific time on a specific day, use `Temporal.DateTime`.
-A `Temporal.Time` can be converted into a `Temporal.DateTime` by combining it with a `Temporal.Date` using the `toDateTime()` method.
+A `Temporal.Time` can be converted into a `Temporal.DateTime` by combining it with a `Temporal.Date` using the `toPlainDateTime()` method.
 
 ## Constructor
 
@@ -620,7 +620,7 @@ date = Temporal.Date.from('2006-08-24');
 time.toZonedDateTime('America/Los_Angeles', date); // => 2006-08-24T15:23:30.003-07:00[America/Los_Angeles]
 ```
 
-### time.**toDateTime**(_date_: Temporal.Date | object | string) : Temporal.DateTime
+### time.**toPlainDateTime**(_date_: Temporal.Date | object | string) : Temporal.DateTime
 
 **Parameters:**
 
@@ -631,7 +631,7 @@ time.toZonedDateTime('America/Los_Angeles', date); // => 2006-08-24T15:23:30.003
 This method can be used to convert `Temporal.Time` into a `Temporal.DateTime`, by supplying the calendar date to use.
 The converted object carries a copy of all the relevant fields of `date` and `time`.
 
-This has identical results to [`Temporal.Date.from(date).toDateTime(time)`](./date.html#toDateTime).
+This has identical results to [`Temporal.Date.from(date).toPlainDateTime(time)`](./date.html#toPlainDateTime).
 
 If `date` is not a `Temporal.Date` object, then it will be converted to one as if it were passed to `Temporal.Date.from()`.
 
@@ -640,7 +640,7 @@ Usage example:
 ```javascript
 time = Temporal.Time.from('15:23:30.003');
 date = Temporal.Date.from('2006-08-24');
-time.toDateTime(date); // => 2006-08-24T15:23:30.003
+time.toPlainDateTime(date); // => 2006-08-24T15:23:30.003
 ```
 
 ### time.**getFields**() : { hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number }

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -9,7 +9,7 @@ A `Temporal.YearMonth` represents a particular month on the calendar.
 For example, it could be used to represent a particular instance of a monthly recurring event, like "the June 2019 meeting".
 
 `Temporal.YearMonth` refers to the whole of a specific month; if you need to refer to a calendar event on a certain day, use `Temporal.Date` or even `Temporal.DateTime`.
-A `Temporal.YearMonth` can be converted into a `Temporal.Date` by combining it with a day of the month, using the `toDate()` method.
+A `Temporal.YearMonth` can be converted into a `Temporal.Date` by combining it with a day of the month, using the `toPlainDate()` method.
 
 ## Constructor
 
@@ -31,7 +31,7 @@ Otherwise, `Temporal.YearMonth.from()`, which accepts more kinds of input, allow
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 Together, `isoYear`, `isoMonth`, and `referenceISODay` must represent a valid date in that calendar, even if you are passing a different calendar as the `calendar` parameter.
 
-The range of allowed values for this type is exactly enough that calling [`toYearMonth()`](./date.html#toYearMonth) on any valid `Temporal.Date` will succeed.
+The range of allowed values for this type is exactly enough that calling [`toPlainYearMonth()`](./date.html#toPlainYearMonth) on any valid `Temporal.Date` will succeed.
 If `isoYear` and `isoMonth` are outside of this range, then this function will throw a `RangeError`.
 
 > **NOTE**: The `isoMonth` argument ranges from 1 to 12, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
@@ -251,7 +251,7 @@ If the result is earlier or later than the range of dates that `Temporal.YearMon
 
 > **NOTE**: Unlike in `Temporal.Date.prototype.with()`, a `calendar` property is not allowed on `yearMonthLike`.
 > It is not possible to convert a `Temporal.YearMonth` to another calendar system without knowing the day of the month.
-> If you need to do this, use `yearMonth.toDate({ day }).withCalendar(calendar).toYearMonth()`.
+> If you need to do this, use `yearMonth.toPlainDate({ day }).withCalendar(calendar).toPlainYearMonth()`.
 
 Usage example:
 
@@ -383,7 +383,7 @@ other.until(ym, { largestUnit: 'months' }); // => -P154M
 // day of the month (and if applicable, the time of that day) from which
 // you want to reckon the difference. For example, using the first of
 // the month to calculate a number of days:
-ym.toDate({ day: 1 }).until(other.toDate({ day: 1 }), { largestUnit: 'days' }); // => P4687D
+ym.toPlainDate({ day: 1 }).until(other.toPlainDate({ day: 1 }), { largestUnit: 'days' }); // => P4687D
 ```
 <!-- prettier-ignore-end -->
 
@@ -560,7 +560,7 @@ This method overrides `Object.prototype.valueOf()` and always throws an exceptio
 This is because it's not possible to compare `Temporal.YearMonth` objects with the relational operators `<`, `<=`, `>`, or `>=`.
 Use `Temporal.YearMonth.compare()` for this, or `yearMonth.equals()` for equality.
 
-### yearMonth.**toDate**(_day_: object) : Temporal.Date
+### yearMonth.**toPlainDate**(_day_: object) : Temporal.Date
 
 **Parameters:**
 
@@ -575,7 +575,7 @@ Usage example:
 
 ```javascript
 ym = Temporal.YearMonth.from('2019-06');
-ym.toDate({ day: 24 }); // => 2019-06-24
+ym.toPlainDate({ day: 24 }); // => 2019-06-24
 ```
 
 ### yearMonth.**getFields**() : { year: number, month: number, calendar: object, [propName: string]: unknown }

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -255,7 +255,7 @@ one = Temporal.ZonedDateTime.from('2020-11-01T01:45-07:00[America/Los_Angeles]')
 two = Temporal.ZonedDateTime.from('2020-11-01T01:15-08:00[America/Los_Angeles]');
 Temporal.ZonedDateTime.compare(one, two);
   // => -1, because `one` is earlier in the real world
-Temporal.DateTime.compare(one.toDateTime(), two.toDateTime());
+Temporal.DateTime.compare(one.toPlainDateTime(), two.toPlainDateTime());
   // => 1, because `one` is later in clock time
 Temporal.Instant.compare(one.toInstant(), two.toInstant());
   // => -1, because `Temporal.Instant` and `Temporal.ZonedDateTime` both compare real-world exact times
@@ -659,13 +659,13 @@ If the result is earlier or later than the range of dates that `Temporal.ZonedDa
 
 If a `timeZone` and/or `calendar` field is included with a different ID than the current object's fields, then `with` will first convert all existing fields to the new time zone and/or calendar and then fields in the input will be played on top of the new time zone or calendar.
 This makes `.with({timeZone})` is an easy way to convert to a new time zone while updating the clock time.
-However, to keep clock time as-is while resetting the time zone, use the `.toDateTime()` method instead. Examples:
+However, to keep clock time as-is while resetting the time zone, use the `.toPlainDateTime()` method instead. Examples:
 
 ```javascript
 // update local time to match new time zone
 const sameInstantInOtherTz = zdt.with({ timeZone: 'Europe/London' });
 // create instance with same local time in a new time zone
-const newTzSameLocalTime = zdt.toDateTime().toZonedDateTime('Europe/London');
+const newTzSameLocalTime = zdt.toPlainDateTime().toZonedDateTime('Europe/London');
 ```
 
 Some input values can cause conflict between the `offsetNanoseconds` field and the `timeZone` field.
@@ -896,8 +896,8 @@ Examples:
 
 If `largestUnit` is `'hours'` or smaller, then the result will be the same as if `Temporal.Instant.prototype.until()` was used.
 If both values have the same local time, then the result will be the same as if `Temporal.DateTime.prototype.until()` was used.
-To calculate the difference between calendar dates only, use `.toDate().until(other.toDate())`.
-To calculate the difference between clock times only, use `.toTime().until(other.toTime())`.
+To calculate the difference between calendar dates only, use `.toPlainDate().until(other.toPlainDate())`.
+To calculate the difference between clock times only, use `.toPlainTime().until(other.toPlainTime())`.
 
 If the other `Temporal.ZonedDateTime` is in a different time zone, then the same days can be different lengths in each time zone, e.g. if only one of them observes DST.
 Therefore, a `RangeError` will be thrown if `largestUnit` is `'days'` or larger and the two instances' time zones have different `id` fields.
@@ -1213,15 +1213,15 @@ Use `Temporal.ZonedDateTime.compare()` for this, or `zonedDateTime.equals()` for
 
 **Returns:** A `Temporal.Instant` object that represents the same instant as `zonedDateTime`.
 
-### zonedDateTime.**toDate**() : Temporal.Date
+### zonedDateTime.**toPlainDate**() : Temporal.Date
 
 **Returns:** a `Temporal.Date` object that is the same as the date portion of `zonedDateTime`.
 
-### zonedDateTime.**toTime**() : Temporal.Time
+### zonedDateTime.**toPlainTime**() : Temporal.Time
 
 **Returns:** a `Temporal.Time` object that is the same as the wall-clock time portion of `zonedDateTime`.
 
-### zonedDateTime.**toDateTime**() : Temporal.DateTime
+### zonedDateTime.**toPlainDateTime**() : Temporal.DateTime
 
 **Returns:** a `Temporal.DateTime` object that is the same as the date and time portion of `zonedDateTime`.
 
@@ -1230,27 +1230,27 @@ Use `Temporal.ZonedDateTime.compare()` for this, or `zonedDateTime.equals()` for
 > However, unless you perform those operations across a time zone offset transition, it's impossible to notice the difference.
 > Therefore, be very careful when performing this conversion because subsequent results may look correct most of the time while failing around time zone transitions like when DST starts or ends.
 
-### zonedDateTime.**toYearMonth**() : Temporal.YearMonth
+### zonedDateTime.**toPlainYearMonth**() : Temporal.YearMonth
 
 **Returns:** a `Temporal.YearMonth` object that is the same as the year and month of `zonedDateTime`.
 
-### zonedDateTime.**toMonthDay**() : Temporal.MonthDay
+### zonedDateTime.**toPlainMonthDay**() : Temporal.MonthDay
 
 **Returns:** a `Temporal.MonthDay` object that is the same as the month and day of `zonedDateTime`.
 
 The above six methods can be used to convert `Temporal.ZonedDateTime` into a `Temporal.Instant`, `Temporal.Date`, `Temporal.Time`, `Temporal.DateTime`, `Temporal.YearMonth`, or `Temporal.MonthDay` respectively.
-The converted object carries a copy of all the relevant data of `zonedDateTime` (for example, in `toDate()`, the `year`, `month`, and `day` properties are the same.)
+The converted object carries a copy of all the relevant data of `zonedDateTime` (for example, in `toPlainDate()`, the `year`, `month`, and `day` properties are the same.)
 
 Usage example:
 
 ```javascript
 zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00[Africa/Johannesburg]');
 zdt.toInstant(); // => 1995-12-07T01:24:30Z
-zdt.toDateTime(); // => 1995-12-07T03:24:30
-zdt.toDate(); // => 1995-12-07
-zdt.toYearMonth(); // => 1995-12
-zdt.toMonthDay(); // => 12-07
-zdt.toTime(); // => 03:24:30
+zdt.toPlainDateTime(); // => 1995-12-07T03:24:30
+zdt.toPlainDate(); // => 1995-12-07
+zdt.toPlainYearMonth(); // => 1995-12
+zdt.toPlainMonthDay(); // => 12-07
+zdt.toPlainTime(); // => 03:24:30
 ```
 
 ### zonedDateTime.**getFields**() : { year: number, month: number, day: number, hour: number, minute: number, second: number, millisecond: number, microsecond: number, nanosecond: number, offset: string, timeZone: object, calendar: object, [propName: string]: unknown }

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -779,14 +779,14 @@ export namespace Temporal {
         | /** @deprecated */ 'day'
       >
     ): Temporal.Duration;
-    toDateTime(temporalTime?: Temporal.Time | TimeLike | string): Temporal.DateTime;
+    toPlainDateTime(temporalTime?: Temporal.Time | TimeLike | string): Temporal.DateTime;
     toZonedDateTime(
       timeZone: TimeZoneProtocol | string,
       temporalTime?: Temporal.Time | TimeLike | string,
       options?: ToInstantOptions
     ): Temporal.ZonedDateTime;
-    toYearMonth(): Temporal.YearMonth;
-    toMonthDay(): Temporal.MonthDay;
+    toPlainYearMonth(): Temporal.YearMonth;
+    toPlainMonthDay(): Temporal.MonthDay;
     getFields(): DateFields;
     getISOFields(): DateISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
@@ -952,10 +952,10 @@ export namespace Temporal {
       >
     ): Temporal.DateTime;
     toZonedDateTime(tzLike: TimeZoneProtocol | string, options?: ToInstantOptions): Temporal.ZonedDateTime;
-    toDate(): Temporal.Date;
-    toYearMonth(): Temporal.YearMonth;
-    toMonthDay(): Temporal.MonthDay;
-    toTime(): Temporal.Time;
+    toPlainDate(): Temporal.Date;
+    toPlainYearMonth(): Temporal.YearMonth;
+    toPlainMonthDay(): Temporal.MonthDay;
+    toPlainTime(): Temporal.Time;
     getFields(): DateTimeFields;
     getISOFields(): DateTimeISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
@@ -991,7 +991,7 @@ export namespace Temporal {
     readonly calendar: CalendarProtocol;
     equals(other: Temporal.MonthDay | MonthDayLike | string): boolean;
     with(monthDayLike: MonthDayLike, options?: AssignmentOptions): Temporal.MonthDay;
-    toDate(year: { year: number }, options?: AssignmentOptions): Temporal.Date;
+    toPlainDate(year: { year: number }, options?: AssignmentOptions): Temporal.Date;
     getFields(): MonthDayFields;
     getISOFields(): DateISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
@@ -1029,7 +1029,7 @@ export namespace Temporal {
    * need to refer to a specific time on a specific day, use
    * `Temporal.DateTime`. A `Temporal.Time` can be converted into a
    * `Temporal.DateTime` by combining it with a `Temporal.Date` using the
-   * `toDateTime()` method.
+   * `toPlainDateTime()` method.
    *
    * See https://tc39.es/proposal-temporal/docs/time.html for more details.
    */
@@ -1110,7 +1110,7 @@ export namespace Temporal {
         | /** @deprecated */ 'nanoseconds'
       >
     ): Temporal.Time;
-    toDateTime(temporalDate: Temporal.Date | DateLike | string): Temporal.DateTime;
+    toPlainDateTime(temporalDate: Temporal.Date | DateLike | string): Temporal.DateTime;
     toZonedDateTime(
       timeZoneLike: TimeZoneProtocol | string,
       temporalDate: Temporal.Date | DateLike | string,
@@ -1213,7 +1213,7 @@ export namespace Temporal {
       other: Temporal.YearMonth | YearMonthLike | string,
       options?: DifferenceOptions<'years' | 'months' | /** @deprecated */ 'year' | /** @deprecated */ 'month'>
     ): Temporal.Duration;
-    toDate(day: { day: number }): Temporal.Date;
+    toPlainDate(day: { day: number }): Temporal.Date;
     getFields(): YearMonthFields;
     getISOFields(): DateISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
@@ -1383,11 +1383,11 @@ export namespace Temporal {
     ): Temporal.ZonedDateTime;
     startOfDay(): Temporal.ZonedDateTime;
     toInstant(): Temporal.Instant;
-    toDateTime(): Temporal.DateTime;
-    toDate(): Temporal.Date;
-    toYearMonth(): Temporal.YearMonth;
-    toMonthDay(): Temporal.MonthDay;
-    toTime(): Temporal.Time;
+    toPlainDateTime(): Temporal.DateTime;
+    toPlainDate(): Temporal.Date;
+    toPlainYearMonth(): Temporal.YearMonth;
+    toPlainMonthDay(): Temporal.MonthDay;
+    toPlainTime(): Temporal.Time;
     getFields(): ZonedDateTimeFields;
     getISOFields(): ZonedDateTimeISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;

--- a/polyfill/lib/date.mjs
+++ b/polyfill/lib/date.mjs
@@ -307,7 +307,7 @@ export class Date {
   valueOf() {
     throw new TypeError('use compare() or equals() to compare Temporal.Date');
   }
-  toDateTime(temporalTime = undefined) {
+  toPlainDateTime(temporalTime = undefined) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     const year = GetSlot(this, ISO_YEAR);
     const month = GetSlot(this, ISO_MONTH);
@@ -362,7 +362,7 @@ export class Date {
     const ZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
     return new ZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
-  toYearMonth() {
+  toPlainYearMonth() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
     const calendar = GetSlot(this, CALENDAR);
@@ -370,7 +370,7 @@ export class Date {
     const fields = ES.ToTemporalDateFields(this, fieldNames);
     return calendar.yearMonthFromFields(fields, {}, YearMonth);
   }
-  toMonthDay() {
+  toPlainMonthDay() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     const MonthDay = GetIntrinsic('%Temporal.MonthDay%');
     const calendar = GetSlot(this, CALENDAR);

--- a/polyfill/lib/datetime.mjs
+++ b/polyfill/lib/datetime.mjs
@@ -671,11 +671,11 @@ export class DateTime {
     const ZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
     return new ZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, GetSlot(this, CALENDAR));
   }
-  toDate() {
+  toPlainDate() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return ES.TemporalDateTimeToDate(this);
   }
-  toYearMonth() {
+  toPlainYearMonth() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
     const calendar = GetSlot(this, CALENDAR);
@@ -683,7 +683,7 @@ export class DateTime {
     const fields = ES.ToTemporalDateFields(this, fieldNames);
     return calendar.yearMonthFromFields(fields, {}, YearMonth);
   }
-  toMonthDay() {
+  toPlainMonthDay() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const MonthDay = GetIntrinsic('%Temporal.MonthDay%');
     const calendar = GetSlot(this, CALENDAR);
@@ -691,7 +691,7 @@ export class DateTime {
     const fields = ES.ToTemporalDateFields(this, fieldNames);
     return calendar.monthDayFromFields(fields, {}, MonthDay);
   }
-  toTime() {
+  toPlainTime() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return ES.TemporalDateTimeToTime(this);
   }

--- a/polyfill/lib/monthday.mjs
+++ b/polyfill/lib/monthday.mjs
@@ -116,7 +116,7 @@ export class MonthDay {
   valueOf() {
     throw new TypeError('use equals() to compare Temporal.MonthDay');
   }
-  toDate(item, options = undefined) {
+  toPlainDate(item, options = undefined) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
 

--- a/polyfill/lib/time.mjs
+++ b/polyfill/lib/time.mjs
@@ -362,7 +362,7 @@ export class Time {
     throw new TypeError('use compare() or equals() to compare Temporal.Time');
   }
 
-  toDateTime(temporalDate) {
+  toPlainDateTime(temporalDate) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
 
     temporalDate = ES.ToTemporalDate(temporalDate, GetIntrinsic('%Temporal.Date%'));

--- a/polyfill/lib/yearmonth.mjs
+++ b/polyfill/lib/yearmonth.mjs
@@ -317,7 +317,7 @@ export class YearMonth {
   valueOf() {
     throw new TypeError('use compare() or equals() to compare Temporal.YearMonth');
   }
-  toDate(item) {
+  toPlainDate(item) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
 

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -441,19 +441,19 @@ export class ZonedDateTime {
     const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
     return new TemporalInstant(GetSlot(this, EPOCHNANOSECONDS));
   }
-  toDate() {
+  toPlainDate() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return ES.TemporalDateTimeToDate(dateTime(this));
   }
-  toTime() {
+  toPlainTime() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return ES.TemporalDateTimeToTime(dateTime(this));
   }
-  toDateTime() {
+  toPlainDateTime() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return dateTime(this);
   }
-  toYearMonth() {
+  toPlainYearMonth() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const YearMonth = GetIntrinsic('%Temporal.YearMonth%');
     const calendar = GetSlot(this, CALENDAR);
@@ -461,7 +461,7 @@ export class ZonedDateTime {
     const fields = ES.ToTemporalDateFields(this, fieldNames);
     return calendar.yearMonthFromFields(fields, {}, YearMonth);
   }
-  toMonthDay() {
+  toPlainMonthDay() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const MonthDay = GetIntrinsic('%Temporal.MonthDay%');
     const calendar = GetSlot(this, CALENDAR);

--- a/polyfill/test/Date/prototype/toDateTime/branding.js
+++ b/polyfill/test/Date/prototype/toDateTime/branding.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.date.prototype.todatetime
+esid: sec-temporal.date.prototype.toplaindatetime
 ---*/
 
-const toDateTime = Temporal.Date.prototype.toDateTime;
+const toDateTime = Temporal.Date.prototype.toPlainDateTime;
 
 assert.sameValue(typeof toDateTime, "function");
 

--- a/polyfill/test/Date/prototype/toDateTime/length.js
+++ b/polyfill/test/Date/prototype/toDateTime/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.date.prototype.todatetime
+esid: sec-temporal.date.prototype.toplaindatetime
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.Date.prototype.toDateTime, "length", {
+verifyProperty(Temporal.Date.prototype.toPlainDateTime, "length", {
   value: 0,
   writable: false,
   enumerable: false,

--- a/polyfill/test/Date/prototype/toDateTime/prop-desc.js
+++ b/polyfill/test/Date/prototype/toDateTime/prop-desc.js
@@ -2,17 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.date.prototype.todatetime
+esid: sec-temporal.date.prototype.toplaindatetime
 includes: [propertyHelper.js]
 ---*/
 
 assert.sameValue(
-  typeof Temporal.Date.prototype.toDateTime,
+  typeof Temporal.Date.prototype.toPlainDateTime,
   "function",
-  "`typeof Date.prototype.toDateTime` is `function`"
+  "`typeof Date.prototype.toPlainDateTime` is `function`"
 );
 
-verifyProperty(Temporal.Date.prototype, "toDateTime", {
+verifyProperty(Temporal.Date.prototype, "toPlainDateTime", {
   writable: true,
   enumerable: false,
   configurable: true,

--- a/polyfill/test/Date/prototype/toMonthDay/branding.js
+++ b/polyfill/test/Date/prototype/toMonthDay/branding.js
@@ -2,10 +2,10 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.date.prototype.tomonthday
+esid: sec-temporal.date.prototype.toplainmonthday
 ---*/
 
-const toMonthDay = Temporal.Date.prototype.toMonthDay;
+const toMonthDay = Temporal.Date.prototype.toPlainMonthDay;
 
 assert.sameValue(typeof toMonthDay, "function");
 

--- a/polyfill/test/Date/prototype/toMonthDay/length.js
+++ b/polyfill/test/Date/prototype/toMonthDay/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.date.prototype.tomonthday
+esid: sec-temporal.date.prototype.toplainmonthday
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.Date.prototype.toMonthDay, "length", {
+verifyProperty(Temporal.Date.prototype.toPlainMonthDay, "length", {
   value: 0,
   writable: false,
   enumerable: false,

--- a/polyfill/test/Date/prototype/toMonthDay/prop-desc.js
+++ b/polyfill/test/Date/prototype/toMonthDay/prop-desc.js
@@ -2,17 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.date.prototype.tomonthday
+esid: sec-temporal.date.prototype.toplainmonthday
 includes: [propertyHelper.js]
 ---*/
 
 assert.sameValue(
-  typeof Temporal.Date.prototype.toMonthDay,
+  typeof Temporal.Date.prototype.toPlainMonthDay,
   "function",
-  "`typeof Date.prototype.toMonthDay` is `function`"
+  "`typeof Date.prototype.toPlainMonthDay` is `function`"
 );
 
-verifyProperty(Temporal.Date.prototype, "toMonthDay", {
+verifyProperty(Temporal.Date.prototype, "toPlainMonthDay", {
   writable: true,
   enumerable: false,
   configurable: true,

--- a/polyfill/test/Date/prototype/toYearMonth/branding.js
+++ b/polyfill/test/Date/prototype/toYearMonth/branding.js
@@ -5,7 +5,7 @@
 esid: sec-temporal.date.prototype.toyearmonth
 ---*/
 
-const toYearMonth = Temporal.Date.prototype.toYearMonth;
+const toYearMonth = Temporal.Date.prototype.toPlainYearMonth;
 
 assert.sameValue(typeof toYearMonth, "function");
 

--- a/polyfill/test/Date/prototype/toYearMonth/length.js
+++ b/polyfill/test/Date/prototype/toYearMonth/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.date.prototype.toyearmonth
+esid: sec-temporal.date.prototype.toplainyearmonth
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.Date.prototype.toYearMonth, "length", {
+verifyProperty(Temporal.Date.prototype.toPlainYearMonth, "length", {
   value: 0,
   writable: false,
   enumerable: false,

--- a/polyfill/test/Date/prototype/toYearMonth/prop-desc.js
+++ b/polyfill/test/Date/prototype/toYearMonth/prop-desc.js
@@ -2,17 +2,17 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.date.prototype.toyearmonth
+esid: sec-temporal.date.prototype.toplainyearmonth
 includes: [propertyHelper.js]
 ---*/
 
 assert.sameValue(
-  typeof Temporal.Date.prototype.toYearMonth,
+  typeof Temporal.Date.prototype.toPlainYearMonth,
   "function",
-  "`typeof Date.prototype.toYearMonth` is `function`"
+  "`typeof Date.prototype.toPlainYearMonth` is `function`"
 );
 
-verifyProperty(Temporal.Date.prototype, "toYearMonth", {
+verifyProperty(Temporal.Date.prototype, "toPlainYearMonth", {
   writable: true,
   enumerable: false,
   configurable: true,

--- a/polyfill/test/DateTime/prototype/toDate/length.js
+++ b/polyfill/test/DateTime/prototype/toDate/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.datetime.prototype.todate
+esid: sec-temporal.datetime.prototype.toplaindate
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.DateTime.prototype.toDate, "length", {
+verifyProperty(Temporal.DateTime.prototype.toPlainDate, "length", {
   value: 0,
   writable: false,
   enumerable: false,

--- a/polyfill/test/DateTime/prototype/toMonthDay/length.js
+++ b/polyfill/test/DateTime/prototype/toMonthDay/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.datetime.prototype.tomonthday
+esid: sec-temporal.datetime.prototype.toplainmonthday
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.DateTime.prototype.toMonthDay, "length", {
+verifyProperty(Temporal.DateTime.prototype.toPlainMonthDay, "length", {
   value: 0,
   writable: false,
   enumerable: false,

--- a/polyfill/test/DateTime/prototype/toTime/length.js
+++ b/polyfill/test/DateTime/prototype/toTime/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.datetime.prototype.totime
+esid: sec-temporal.datetime.prototype.toplaintime
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.DateTime.prototype.toTime, "length", {
+verifyProperty(Temporal.DateTime.prototype.toPlainTime, "length", {
   value: 0,
   writable: false,
   enumerable: false,

--- a/polyfill/test/DateTime/prototype/toYearMonth/length.js
+++ b/polyfill/test/DateTime/prototype/toYearMonth/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.datetime.prototype.toyearmonth
+esid: sec-temporal.datetime.prototype.toplainyearmonth
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.DateTime.prototype.toYearMonth, "length", {
+verifyProperty(Temporal.DateTime.prototype.toPlainYearMonth, "length", {
   value: 0,
   writable: false,
   enumerable: false,

--- a/polyfill/test/MonthDay/prototype/toDate/infinity-throws-rangeerror.js
+++ b/polyfill/test/MonthDay/prototype/toDate/infinity-throws-rangeerror.js
@@ -2,13 +2,13 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Temporal.MonthDay.prototype.toDate throws a RangeError if the argument is Infinity
-esid: sec-temporal.monthday.prototype.todate
+description: Temporal.MonthDay.prototype.toPlainDate throws a RangeError if the argument is Infinity
+esid: sec-temporal.monthday.prototype.toplaindate
 ---*/
 
 const instance = new Temporal.MonthDay(5, 2);
 
-assert.throws(RangeError, () => instance.toDate({ year: Infinity }));
+assert.throws(RangeError, () => instance.toPlainDate({ year: Infinity }));
 
 let calls = 0;
 const fields = {
@@ -29,5 +29,5 @@ const obj = new Proxy(fields, {
   },
 });
 
-assert.throws(RangeError, () => instance.toDate(obj));
+assert.throws(RangeError, () => instance.toPlainDate(obj));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");

--- a/polyfill/test/MonthDay/prototype/toDate/length.js
+++ b/polyfill/test/MonthDay/prototype/toDate/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.monthday.prototype.todate
+esid: sec-temporal.monthday.prototype.toplaindate
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.MonthDay.prototype.toDate, "length", {
+verifyProperty(Temporal.MonthDay.prototype.toPlainDate, "length", {
   value: 1,
   writable: false,
   enumerable: false,

--- a/polyfill/test/MonthDay/prototype/toDate/negative-infinity-throws-rangeerror.js
+++ b/polyfill/test/MonthDay/prototype/toDate/negative-infinity-throws-rangeerror.js
@@ -2,13 +2,13 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Temporal.MonthDay.prototype.toDate throws a RangeError if the argument is -Infinity
-esid: sec-temporal.monthday.prototype.todate
+description: Temporal.MonthDay.prototype.toPlainDate throws a RangeError if the argument is -Infinity
+esid: sec-temporal.monthday.prototype.toplaindate
 ---*/
 
 const instance = new Temporal.MonthDay(5, 2);
 
-assert.throws(RangeError, () => instance.toDate({ year: -Infinity }));
+assert.throws(RangeError, () => instance.toPlainDate({ year: -Infinity }));
 
 let calls = 0;
 const fields = {
@@ -29,5 +29,5 @@ const obj = new Proxy(fields, {
   },
 });
 
-assert.throws(RangeError, () => instance.toDate(obj));
+assert.throws(RangeError, () => instance.toPlainDate(obj));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");

--- a/polyfill/test/Time/prototype/toDateTime/length.js
+++ b/polyfill/test/Time/prototype/toDateTime/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.time.prototype.todatetime
+esid: sec-temporal.time.prototype.toplaindatetime
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.Time.prototype.toDateTime, "length", {
+verifyProperty(Temporal.Time.prototype.toPlainDateTime, "length", {
   value: 1,
   writable: false,
   enumerable: false,

--- a/polyfill/test/YearMonth/prototype/toDate/infinity-throws-rangeerror.js
+++ b/polyfill/test/YearMonth/prototype/toDate/infinity-throws-rangeerror.js
@@ -2,13 +2,13 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Temporal.YearMonth.prototype.toDate throws a RangeError if the argument is Infinity
-esid: sec-temporal.yearmonth.prototype.todate
+description: Temporal.YearMonth.prototype.toPlainDate throws a RangeError if the argument is Infinity
+esid: sec-temporal.yearmonth.prototype.toplaindate
 ---*/
 
 const instance = new Temporal.YearMonth(2000, 5);
 
-assert.throws(RangeError, () => instance.toDate({ day: Infinity }));
+assert.throws(RangeError, () => instance.toPlainDate({ day: Infinity }));
 
 let calls = 0;
 const obj = {
@@ -20,5 +20,5 @@ const obj = {
   }
 };
 
-assert.throws(RangeError, () => instance.toDate(obj));
+assert.throws(RangeError, () => instance.toPlainDate(obj));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");

--- a/polyfill/test/YearMonth/prototype/toDate/length.js
+++ b/polyfill/test/YearMonth/prototype/toDate/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.yearmonth.prototype.todate
+esid: sec-temporal.yearmonth.prototype.toplaindate
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.YearMonth.prototype.toDate, "length", {
+verifyProperty(Temporal.YearMonth.prototype.toPlainDate, "length", {
   value: 1,
   writable: false,
   enumerable: false,

--- a/polyfill/test/YearMonth/prototype/toDate/negative-infinity-throws-rangeerror.js
+++ b/polyfill/test/YearMonth/prototype/toDate/negative-infinity-throws-rangeerror.js
@@ -2,13 +2,13 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Temporal.YearMonth.prototype.toDate throws a RangeError if the argument is -Infinity
-esid: sec-temporal.yearmonth.prototype.todate
+description: Temporal.YearMonth.prototype.toPlainDate throws a RangeError if the argument is -Infinity
+esid: sec-temporal.yearmonth.prototype.toplaindate
 ---*/
 
 const instance = new Temporal.YearMonth(2000, 5);
 
-assert.throws(RangeError, () => instance.toDate({ day: -Infinity }));
+assert.throws(RangeError, () => instance.toPlainDate({ day: -Infinity }));
 
 let calls = 0;
 const obj = {
@@ -20,5 +20,5 @@ const obj = {
   }
 };
 
-assert.throws(RangeError, () => instance.toDate(obj));
+assert.throws(RangeError, () => instance.toPlainDate(obj));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/branding.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/branding.js
@@ -1,16 +1,16 @@
 // Copyright (C) 2020 Igalia, S.L. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 
-const toDateTime = Temporal.ZonedDateTime.prototype.toDateTime;
+const toPlainDateTime = Temporal.ZonedDateTime.prototype.toPlainDateTime;
 
-assert.sameValue(typeof toDateTime, "function");
+assert.sameValue(typeof toPlainDateTime, "function");
 
-assert.throws(TypeError, () => toDateTime.call(undefined), "undefined");
-assert.throws(TypeError, () => toDateTime.call(null), "null");
-assert.throws(TypeError, () => toDateTime.call(true), "true");
-assert.throws(TypeError, () => toDateTime.call(""), "empty string");
-assert.throws(TypeError, () => toDateTime.call(Symbol()), "symbol");
-assert.throws(TypeError, () => toDateTime.call(1), "1");
-assert.throws(TypeError, () => toDateTime.call({}), "plain object");
-assert.throws(TypeError, () => toDateTime.call(Temporal.ZonedDateTime), "Temporal.ZonedDateTime");
-assert.throws(TypeError, () => toDateTime.call(Temporal.ZonedDateTime.prototype), "Temporal.ZonedDateTime.prototype");
+assert.throws(TypeError, () => toPlainDateTime.call(undefined), "undefined");
+assert.throws(TypeError, () => toPlainDateTime.call(null), "null");
+assert.throws(TypeError, () => toPlainDateTime.call(true), "true");
+assert.throws(TypeError, () => toPlainDateTime.call(""), "empty string");
+assert.throws(TypeError, () => toPlainDateTime.call(Symbol()), "symbol");
+assert.throws(TypeError, () => toPlainDateTime.call(1), "1");
+assert.throws(TypeError, () => toPlainDateTime.call({}), "plain object");
+assert.throws(TypeError, () => toPlainDateTime.call(Temporal.ZonedDateTime), "Temporal.ZonedDateTime");
+assert.throws(TypeError, () => toPlainDateTime.call(Temporal.ZonedDateTime.prototype), "Temporal.ZonedDateTime.prototype");

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/length.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.zoneddatetime.prototype.todatetime
+esid: sec-temporal.zoneddatetime.prototype.toplaindatetime
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.ZonedDateTime.prototype.toDateTime, "length", {
+verifyProperty(Temporal.ZonedDateTime.prototype.toPlainDateTime, "length", {
   value: 0,
   writable: false,
   enumerable: false,

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/plain-custom-timezone.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/plain-custom-timezone.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.zoneddatetime.prototype.todatetime
+esid: sec-temporal.zoneddatetime.prototype.toplaindatetime
 includes: [compareArray.js]
 ---*/
 
@@ -30,7 +30,7 @@ const timeZone = new Proxy({
 });
 
 const zdt = new Temporal.ZonedDateTime(160583136123456789n, timeZone);
-const result = zdt.toDateTime();
+const result = zdt.toPlainDateTime();
 assert.sameValue(result, dateTime);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/prop-desc.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/prop-desc.js
@@ -7,12 +7,12 @@ includes: [propertyHelper.js]
 
 const { ZonedDateTime } = Temporal;
 assert.sameValue(
-  typeof ZonedDateTime.prototype.toDateTime,
+  typeof ZonedDateTime.prototype.toPlainDateTime,
   "function",
-  "`typeof ZonedDateTime.prototype.toDateTime` is `function`"
+  "`typeof ZonedDateTime.prototype.toPlainDateTime` is `function`"
 );
 
-verifyProperty(ZonedDateTime.prototype, "toDateTime", {
+verifyProperty(ZonedDateTime.prototype, "toPlainDateTime", {
   writable: true,
   enumerable: false,
   configurable: true,

--- a/polyfill/test/ZonedDateTime/prototype/toDateTime/timezone-invalid-result.js
+++ b/polyfill/test/ZonedDateTime/prototype/toDateTime/timezone-invalid-result.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.zoneddatetime.prototype.todatetime
+esid: sec-temporal.zoneddatetime.prototype.toplaindatetime
 ---*/
 
 const calendar = Temporal.Calendar.from("iso8601");
@@ -31,5 +31,5 @@ for (const dateTime of invalidValues) {
   };
 
   const zdt = new Temporal.ZonedDateTime(160583136123456789n, timeZone, calendar);
-  assert.throws(TypeError, () => zdt.toDateTime(timeZone, calendar));
+  assert.throws(TypeError, () => zdt.toPlainDateTime(timeZone, calendar));
 }

--- a/polyfill/test/date.mjs
+++ b/polyfill/test/date.mjs
@@ -69,17 +69,17 @@ describe('Date', () => {
       it('Date.prototype.equals is a Function', () => {
         equal(typeof Date.prototype.equals, 'function');
       });
-      it('Date.prototype.toDateTime is a Function', () => {
-        equal(typeof Date.prototype.toDateTime, 'function');
+      it('Date.prototype.toPlainDateTime is a Function', () => {
+        equal(typeof Date.prototype.toPlainDateTime, 'function');
       });
       it('Date.prototype.toZonedDateTime is a Function', () => {
         equal(typeof Date.prototype.toZonedDateTime, 'function');
       });
-      it('Date.prototype.toYearMonth is a Function', () => {
-        equal(typeof Date.prototype.toYearMonth, 'function');
+      it('Date.prototype.toPlainYearMonth is a Function', () => {
+        equal(typeof Date.prototype.toPlainYearMonth, 'function');
       });
-      it('Date.prototype.toMonthDay is a Function', () => {
-        equal(typeof Date.prototype.toMonthDay, 'function');
+      it('Date.prototype.toPlainMonthDay is a Function', () => {
+        equal(typeof Date.prototype.toPlainMonthDay, 'function');
       });
       it('Date.prototype.getFields is a Function', () => {
         equal(typeof Date.prototype.getFields, 'function');
@@ -186,21 +186,21 @@ describe('Date', () => {
       throws(() => original.with('18:05:42.577'), TypeError);
     });
   });
-  describe('Date.toDateTime() works', () => {
+  describe('Date.toPlainDateTime() works', () => {
     const date = Date.from('1976-11-18');
-    const dt = date.toDateTime(Temporal.Time.from('11:30:23'));
+    const dt = date.toPlainDateTime(Temporal.Time.from('11:30:23'));
     it('returns a Temporal.DateTime', () => assert(dt instanceof Temporal.DateTime));
     it('combines the date and time', () => equal(`${dt}`, '1976-11-18T11:30:23'));
     it('casts argument', () => {
-      equal(`${date.toDateTime({ hour: 11, minute: 30, second: 23 })}`, '1976-11-18T11:30:23');
-      equal(`${date.toDateTime('11:30:23')}`, '1976-11-18T11:30:23');
+      equal(`${date.toPlainDateTime({ hour: 11, minute: 30, second: 23 })}`, '1976-11-18T11:30:23');
+      equal(`${date.toPlainDateTime('11:30:23')}`, '1976-11-18T11:30:23');
     });
     it('object must contain at least one correctly-spelled property', () => {
-      throws(() => date.toDateTime({}), TypeError);
-      throws(() => date.toDateTime({ minutes: 30 }), TypeError);
+      throws(() => date.toPlainDateTime({}), TypeError);
+      throws(() => date.toPlainDateTime({ minutes: 30 }), TypeError);
     });
     it('optional argument defaults to midnight', () => {
-      equal(`${date.toDateTime()}`, '1976-11-18T00:00:00');
+      equal(`${date.toPlainDateTime()}`, '1976-11-18T00:00:00');
     });
   });
   describe('Date.toZonedDateTime()', function () {
@@ -1047,26 +1047,26 @@ describe('Date', () => {
     it('converting from DateTime', () => {
       const min = Temporal.DateTime.from('-271821-04-19T00:00:00.000000001');
       const max = Temporal.DateTime.from('+275760-09-13T23:59:59.999999999');
-      equal(`${min.toDate()}`, '-271821-04-19');
-      equal(`${max.toDate()}`, '+275760-09-13');
+      equal(`${min.toPlainDate()}`, '-271821-04-19');
+      equal(`${max.toPlainDate()}`, '+275760-09-13');
     });
     it('converting from YearMonth', () => {
       const min = Temporal.YearMonth.from('-271821-04');
       const max = Temporal.YearMonth.from('+275760-09');
-      throws(() => min.toDate({ day: 1 }), RangeError);
-      throws(() => max.toDate({ day: 30 }), RangeError);
-      equal(`${min.toDate({ day: 19 })}`, '-271821-04-19');
-      equal(`${max.toDate({ day: 13 })}`, '+275760-09-13');
+      throws(() => min.toPlainDate({ day: 1 }), RangeError);
+      throws(() => max.toPlainDate({ day: 30 }), RangeError);
+      equal(`${min.toPlainDate({ day: 19 })}`, '-271821-04-19');
+      equal(`${max.toPlainDate({ day: 13 })}`, '+275760-09-13');
     });
     it('converting from MonthDay', () => {
       const jan1 = Temporal.MonthDay.from('01-01');
       const dec31 = Temporal.MonthDay.from('12-31');
       const minYear = -271821;
       const maxYear = 275760;
-      throws(() => jan1.toDate({ year: minYear }), RangeError);
-      throws(() => dec31.toDate({ year: maxYear }), RangeError);
-      equal(`${jan1.toDate({ year: minYear + 1 })}`, '-271820-01-01');
-      equal(`${dec31.toDate({ year: maxYear - 1 })}`, '+275759-12-31');
+      throws(() => jan1.toPlainDate({ year: minYear }), RangeError);
+      throws(() => dec31.toPlainDate({ year: maxYear }), RangeError);
+      equal(`${jan1.toPlainDate({ year: minYear + 1 })}`, '-271820-01-01');
+      equal(`${dec31.toPlainDate({ year: maxYear - 1 })}`, '+275759-12-31');
     });
     it('adding and subtracting beyond limit', () => {
       const min = Date.from('-271821-04-19');

--- a/polyfill/test/datetime.mjs
+++ b/polyfill/test/datetime.mjs
@@ -93,11 +93,11 @@ describe('DateTime', () => {
       it('DateTime.prototype.toZonedDateTime is a Function', () => {
         equal(typeof DateTime.prototype.toZonedDateTime, 'function');
       });
-      it('DateTime.prototype.toDate is a Function', () => {
-        equal(typeof DateTime.prototype.toDate, 'function');
+      it('DateTime.prototype.toPlainDate is a Function', () => {
+        equal(typeof DateTime.prototype.toPlainDate, 'function');
       });
-      it('DateTime.prototype.toTime is a Function', () => {
-        equal(typeof DateTime.prototype.toTime, 'function');
+      it('DateTime.prototype.toPlainTime is a Function', () => {
+        equal(typeof DateTime.prototype.toPlainTime, 'function');
       });
       it('DateTime.prototype.getFields is a Function', () => {
         equal(typeof DateTime.prototype.getFields, 'function');
@@ -1492,12 +1492,12 @@ describe('DateTime', () => {
       const lastNs = Temporal.Time.from('23:59:59.999999999');
       const min = Temporal.Date.from('-271821-04-19');
       const max = Temporal.Date.from('+275760-09-13');
-      throws(() => min.toDateTime(midnight), RangeError);
-      throws(() => midnight.toDateTime(min), RangeError);
-      equal(`${min.toDateTime(firstNs)}`, '-271821-04-19T00:00:00.000000001');
-      equal(`${firstNs.toDateTime(min)}`, '-271821-04-19T00:00:00.000000001');
-      equal(`${max.toDateTime(lastNs)}`, '+275760-09-13T23:59:59.999999999');
-      equal(`${lastNs.toDateTime(max)}`, '+275760-09-13T23:59:59.999999999');
+      throws(() => min.toPlainDateTime(midnight), RangeError);
+      throws(() => midnight.toPlainDateTime(min), RangeError);
+      equal(`${min.toPlainDateTime(firstNs)}`, '-271821-04-19T00:00:00.000000001');
+      equal(`${firstNs.toPlainDateTime(min)}`, '-271821-04-19T00:00:00.000000001');
+      equal(`${max.toPlainDateTime(lastNs)}`, '+275760-09-13T23:59:59.999999999');
+      equal(`${lastNs.toPlainDateTime(max)}`, '+275760-09-13T23:59:59.999999999');
     });
     it('adding and subtracting beyond limit', () => {
       const min = DateTime.from('-271821-04-19T00:00:00.000000001');

--- a/polyfill/test/monthday.mjs
+++ b/polyfill/test/monthday.mjs
@@ -190,27 +190,27 @@ describe('MonthDay', () => {
     it('<=', () => throws(() => md1 <= md2));
     it('>=', () => throws(() => md1 >= md2));
   });
-  describe('MonthDay.toDate()', () => {
+  describe('MonthDay.toPlainDate()', () => {
     const md = MonthDay.from('01-22');
     it("doesn't take a primitive argument", () => {
-      throws(() => md.toDate(2002), TypeError);
-      throws(() => md.toDate('2002'), TypeError);
-      throws(() => md.toDate(null), TypeError);
+      throws(() => md.toPlainDate(2002), TypeError);
+      throws(() => md.toPlainDate('2002'), TypeError);
+      throws(() => md.toPlainDate(null), TypeError);
     });
     it('takes an object argument with year property', () => {
-      equal(`${md.toDate({ year: 2002 })}`, '2002-01-22');
+      equal(`${md.toPlainDate({ year: 2002 })}`, '2002-01-22');
     });
     it('needs at least a year property on the object in the ISO calendar', () => {
-      throws(() => md.toDate({ something: 'nothing' }), TypeError);
+      throws(() => md.toPlainDate({ something: 'nothing' }), TypeError);
     });
     it("constrains if the MonthDay doesn't exist in the year", () => {
       const leapDay = MonthDay.from('02-29');
-      equal(`${leapDay.toDate({ year: 2019 })}`, '2019-02-28');
-      equal(`${leapDay.toDate({ year: 2019 }, { overflow: 'constrain' })}`, '2019-02-28');
+      equal(`${leapDay.toPlainDate({ year: 2019 })}`, '2019-02-28');
+      equal(`${leapDay.toPlainDate({ year: 2019 }, { overflow: 'constrain' })}`, '2019-02-28');
     });
     it("can also reject if the MonthDay doesn't exist in the year", () => {
       const leapDay = MonthDay.from('02-29');
-      throws(() => leapDay.toDate({ year: 2019 }, { overflow: 'reject' }));
+      throws(() => leapDay.toPlainDate({ year: 2019 }, { overflow: 'reject' }));
     });
   });
   describe('MonthDay.toString()', () => {

--- a/polyfill/test/now/date/toDate-override.js
+++ b/polyfill/test/now/date/toDate-override.js
@@ -15,11 +15,11 @@ const expected = [
 ];
 const dateTime = Temporal.DateTime.from("1963-07-02T12:34:56.987654321");
 
-Object.defineProperty(Temporal.DateTime.prototype, "toDate", {
+Object.defineProperty(Temporal.DateTime.prototype, "toPlainDate", {
   get() {
-    actual.push("get Temporal.DateTime.prototype.toDate");
+    actual.push("get Temporal.DateTime.prototype.toPlainDate");
     return function() {
-      actual.push("call Temporal.DateTime.prototype.toDate");
+      actual.push("call Temporal.DateTime.prototype.toPlainDate");
     };
   },
 });

--- a/polyfill/test/now/timeISO/toTime-override.js
+++ b/polyfill/test/now/timeISO/toTime-override.js
@@ -15,11 +15,11 @@ const expected = [
 ];
 const dateTime = Temporal.DateTime.from("1963-07-02T12:34:56.987654321");
 
-Object.defineProperty(Temporal.DateTime.prototype, "toTime", {
+Object.defineProperty(Temporal.DateTime.prototype, "toPlainTime", {
   get() {
-    actual.push("get Temporal.DateTime.prototype.toTime");
+    actual.push("get Temporal.DateTime.prototype.toPlainTime");
     return function() {
-      actual.push("call Temporal.DateTime.prototype.toTime");
+      actual.push("call Temporal.DateTime.prototype.toPlainTime");
     };
   },
 });

--- a/polyfill/test/time.mjs
+++ b/polyfill/test/time.mjs
@@ -66,8 +66,8 @@ describe('Time', () => {
       it('Time.prototype.equals is a Function', () => {
         equal(typeof Time.prototype.equals, 'function');
       });
-      it('Time.prototype.toDateTime is a Function', () => {
-        equal(typeof Time.prototype.toDateTime, 'function');
+      it('Time.prototype.toPlainDateTime is a Function', () => {
+        equal(typeof Time.prototype.toPlainDateTime, 'function');
       });
       it('Time.prototype.toZonedDateTime is a Function', () => {
         equal(typeof Time.prototype.toZonedDateTime, 'function');
@@ -230,17 +230,17 @@ describe('Time', () => {
       throws(() => time.with('2019-05-17'), TypeError);
     });
   });
-  describe('time.toDateTime() works', () => {
+  describe('time.toPlainDateTime() works', () => {
     const time = Time.from('11:30:23.123456789');
-    const dt = time.toDateTime(Temporal.Date.from('1976-11-18'));
+    const dt = time.toPlainDateTime(Temporal.Date.from('1976-11-18'));
     it('returns a Temporal.DateTime', () => assert(dt instanceof Temporal.DateTime));
     it('combines the date and time', () => equal(`${dt}`, '1976-11-18T11:30:23.123456789'));
     it('casts argument', () => {
-      equal(`${time.toDateTime({ year: 1976, month: 11, day: 18 })}`, '1976-11-18T11:30:23.123456789');
-      equal(`${time.toDateTime('1976-11-18')}`, '1976-11-18T11:30:23.123456789');
+      equal(`${time.toPlainDateTime({ year: 1976, month: 11, day: 18 })}`, '1976-11-18T11:30:23.123456789');
+      equal(`${time.toPlainDateTime('1976-11-18')}`, '1976-11-18T11:30:23.123456789');
     });
     it('object must contain at least the required properties', () => {
-      throws(() => time.toDateTime({ year: 1976 }), TypeError);
+      throws(() => time.toPlainDateTime({ year: 1976 }), TypeError);
     });
   });
   describe('time.toZonedDateTime()', function () {
@@ -1211,7 +1211,7 @@ describe('Time', () => {
     });
     it('Time.from(dateTime) returns the same time properties', () => {
       const dt = DateTime.from('2020-02-12T11:42:00+01:00[Europe/Amsterdam]');
-      deepEqual(Time.from(dt).getFields(), dt.toTime().getFields());
+      deepEqual(Time.from(dt).getFields(), dt.toPlainTime().getFields());
     });
     it('Time.from(time) is not the same object', () => {
       const t = Time.from('2020-02-12T11:42:00+01:00[Europe/Amsterdam]');

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -248,7 +248,7 @@ describe('Userland calendar', () => {
       const seconds = hour * 100 + minute * 10 + second;
       const date = new Temporal.Date(1970, 1, 1, 'iso8601').add({ days });
       const time = new Temporal.Time().add({ seconds });
-      return date.toDateTime(time);
+      return date.toPlainDateTime(time);
     }
     function isoToDecimal(datetime) {
       const {

--- a/polyfill/test/yearmonth.mjs
+++ b/polyfill/test/yearmonth.mjs
@@ -681,8 +681,8 @@ describe('YearMonth', () => {
     it('converting from Date', () => {
       const min = Temporal.Date.from('-271821-04-19');
       const max = Temporal.Date.from('+275760-09-13');
-      equal(`${min.toYearMonth()}`, '-271821-04');
-      equal(`${max.toYearMonth()}`, '+275760-09');
+      equal(`${min.toPlainYearMonth()}`, '-271821-04');
+      equal(`${max.toPlainYearMonth()}`, '+275760-09');
     });
     it('adding and subtracting beyond limit', () => {
       const min = YearMonth.from('-271821-04');

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -149,20 +149,20 @@ describe('ZonedDateTime', () => {
       it('ZonedDateTime.prototype.toInstant is a Function', () => {
         equal(typeof ZonedDateTime.prototype.toInstant, 'function');
       });
-      it('ZonedDateTime.prototype.toDate is a Function', () => {
-        equal(typeof ZonedDateTime.prototype.toDate, 'function');
+      it('ZonedDateTime.prototype.toPlainDate is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toPlainDate, 'function');
       });
-      it('ZonedDateTime.prototype.toTime is a Function', () => {
-        equal(typeof ZonedDateTime.prototype.toTime, 'function');
+      it('ZonedDateTime.prototype.toPlainTime is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toPlainTime, 'function');
       });
-      it('ZonedDateTime.prototype.toDateTime is a Function', () => {
-        equal(typeof ZonedDateTime.prototype.toDateTime, 'function');
+      it('ZonedDateTime.prototype.toPlainDateTime is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toPlainDateTime, 'function');
       });
-      it('ZonedDateTime.prototype.toYearMonth is a Function', () => {
-        equal(typeof ZonedDateTime.prototype.toDateTime, 'function');
+      it('ZonedDateTime.prototype.toPlainYearMonth is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toPlainYearMonth, 'function');
       });
-      it('ZonedDateTime.prototype.toMonthDay is a Function', () => {
-        equal(typeof ZonedDateTime.prototype.toDateTime, 'function');
+      it('ZonedDateTime.prototype.toPlainMonthDay is a Function', () => {
+        equal(typeof ZonedDateTime.prototype.toPlainMonthDay, 'function');
       });
       it('ZonedDateTime.prototype.getFields is a Function', () => {
         equal(typeof ZonedDateTime.prototype.getFields, 'function');
@@ -709,7 +709,7 @@ describe('ZonedDateTime', () => {
       equal(zdt.epochNanoseconds, zdt2.epochNanoseconds);
       equal(zdt2.calendar.id, 'gregory');
       equal(zdt2.timeZone.id, 'America/Vancouver');
-      notEqual(`${zdt.toDateTime()}`, `${zdt2.toDateTime()}`);
+      notEqual(`${zdt.toPlainDateTime()}`, `${zdt2.toPlainDateTime()}`);
     });
   });
   describe('ZonedDateTime.withCalendar()', () => {
@@ -1280,49 +1280,49 @@ describe('ZonedDateTime', () => {
       equal(`${zdt.toInstant()}`, '+000000-02-29T00:01:15Z');
     });
   });
-  describe('ZonedDateTime.toDate()', () => {
+  describe('ZonedDateTime.toPlainDate()', () => {
     it('works', () => {
       const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTimeISO(tz);
-      equal(`${zdt.toDate()}`, '2019-10-29');
+      equal(`${zdt.toPlainDate()}`, '2019-10-29');
     });
     it('preserves the calendar', () => {
       const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTime({
         timeZone: tz,
         calendar: 'gregory'
       });
-      equal(zdt.toDate().calendar.id, 'gregory');
+      equal(zdt.toPlainDate().calendar.id, 'gregory');
     });
   });
-  describe('ZonedDateTime.toTime()', () => {
+  describe('ZonedDateTime.toPlainTime()', () => {
     it('works', () => {
       const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTimeISO(tz);
-      equal(`${zdt.toTime()}`, '02:46:38.271986102');
+      equal(`${zdt.toPlainTime()}`, '02:46:38.271986102');
     });
   });
-  describe('ZonedDateTime.toYearMonth()', () => {
+  describe('ZonedDateTime.toPlainYearMonth()', () => {
     it('works', () => {
       const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTimeISO(tz);
-      equal(`${zdt.toYearMonth()}`, '2019-10');
+      equal(`${zdt.toPlainYearMonth()}`, '2019-10');
     });
     it('preserves the calendar', () => {
       const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTime({
         timeZone: tz,
         calendar: 'gregory'
       });
-      equal(zdt.toYearMonth().calendar.id, 'gregory');
+      equal(zdt.toPlainYearMonth().calendar.id, 'gregory');
     });
   });
-  describe('ZonedDateTime.toMonthDay()', () => {
+  describe('ZonedDateTime.toPlainMonthDay()', () => {
     it('works', () => {
       const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTimeISO(tz);
-      equal(`${zdt.toMonthDay()}`, '10-29');
+      equal(`${zdt.toPlainMonthDay()}`, '10-29');
     });
     it('preserves the calendar', () => {
       const zdt = Temporal.Instant.from('2019-10-29T09:46:38.271986102Z').toZonedDateTime({
         timeZone: tz,
         calendar: 'gregory'
       });
-      equal(zdt.toMonthDay().calendar.id, 'gregory');
+      equal(zdt.toPlainMonthDay().calendar.id, 'gregory');
     });
   });
 
@@ -1451,19 +1451,19 @@ describe('ZonedDateTime', () => {
     });
     it('startOfDay works', () => {
       const start = dayBeforeDstStart.startOfDay();
-      equal(`${start.toDate()}`, `${dayBeforeDstStart.toDate()}`);
-      equal(`${start.toTime()}`, '00:00:00');
+      equal(`${start.toPlainDate()}`, `${dayBeforeDstStart.toPlainDate()}`);
+      equal(`${start.toPlainTime()}`, '00:00:00');
     });
     it('startOfDay works when day starts at 1:00 due to DST start at midnight', () => {
       const zdt = ZonedDateTime.from('2015-10-18T12:00:00-02:00[America/Sao_Paulo]');
-      equal(`${zdt.startOfDay().toTime()}`, '01:00:00');
+      equal(`${zdt.startOfDay().toPlainTime()}`, '01:00:00');
     });
 
     const dayAfterSamoaDateLineChange = ZonedDateTime.from('2011-12-31T22:00+14:00[Pacific/Apia]');
     const dayBeforeSamoaDateLineChange = ZonedDateTime.from('2011-12-29T22:00-10:00[Pacific/Apia]');
     it('startOfDay works after Samoa date line change', () => {
       const start = dayAfterSamoaDateLineChange.startOfDay();
-      equal(`${start.toTime()}`, '00:00:00');
+      equal(`${start.toPlainTime()}`, '00:00:00');
     });
     it('hoursInDay works after Samoa date line change', () => {
       equal(dayAfterSamoaDateLineChange.hoursInDay, 24);
@@ -1582,7 +1582,7 @@ describe('ZonedDateTime', () => {
       const clockBefore = ZonedDateTime.from('1999-12-31T23:30-08:00[America/Vancouver]');
       const clockAfter = ZonedDateTime.from('2000-01-01T01:30-04:00[America/Halifax]');
       equal(ZonedDateTime.compare(clockBefore, clockAfter), 1);
-      equal(Temporal.DateTime.compare(clockBefore.toDateTime(), clockAfter.toDateTime()), -1);
+      equal(Temporal.DateTime.compare(clockBefore.toPlainDateTime(), clockAfter.toPlainDateTime()), -1);
     });
   });
 });

--- a/spec/date.html
+++ b/spec/date.html
@@ -297,8 +297,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.date.prototype.toyearmonth">
-      <h1>Temporal.Date.prototype.toYearMonth ( )</h1>
+    <emu-clause id="sec-temporal.date.prototype.toplainyearmonth">
+      <h1>Temporal.Date.prototype.toPlainYearMonth ( )</h1>
       <p>
         The following steps are taken:
       </p>
@@ -313,8 +313,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.date.prototype.tomonthday">
-      <h1>Temporal.Date.prototype.toMonthDay ( )</h1>
+    <emu-clause id="sec-temporal.date.prototype.toplainmonthday">
+      <h1>Temporal.Date.prototype.toPlainMonthDay ( )</h1>
       <p>
         The following steps are taken:
       </p>
@@ -503,10 +503,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.date.prototype.todatetime">
-      <h1>Temporal.Date.prototype.toDateTime ( [ _temporalTime_ ] )</h1>
+    <emu-clause id="sec-temporal.date.prototype.toplaindatetime">
+      <h1>Temporal.Date.prototype.toPlainDateTime ( [ _temporalTime_ ] )</h1>
       <p>
-        The `toDateTime` method takes one argument _temporalTime_.
+        The `toPlainDateTime` method takes one argument _temporalTime_.
         The following steps are taken:
       </p>
       <emu-alg>

--- a/spec/datetime.html
+++ b/spec/datetime.html
@@ -650,8 +650,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.datetime.prototype.todate">
-      <h1>Temporal.DateTime.prototype.toDate ( )</h1>
+    <emu-clause id="sec-temporal.datetime.prototype.toplaindate">
+      <h1>Temporal.DateTime.prototype.toPlainDate ( )</h1>
       <p>
         The following steps are taken:
       </p>
@@ -662,8 +662,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.datetime.prototype.toyearmonth">
-      <h1>Temporal.DateTime.prototype.toYearMonth ( )</h1>
+    <emu-clause id="sec-temporal.datetime.prototype.toplainyearmonth">
+      <h1>Temporal.DateTime.prototype.toPlainYearMonth ( )</h1>
       <p>
         The following steps are taken:
       </p>
@@ -678,8 +678,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.datetime.prototype.tomonthday">
-      <h1>Temporal.DateTime.prototype.toMonthDay ( )</h1>
+    <emu-clause id="sec-temporal.datetime.prototype.toplainmonthday">
+      <h1>Temporal.DateTime.prototype.toPlainMonthDay ( )</h1>
       <p>
         The following steps are taken:
       </p>
@@ -694,8 +694,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.datetime.prototype.totime">
-      <h1>Temporal.DateTime.prototype.toTime ( )</h1>
+    <emu-clause id="sec-temporal.datetime.prototype.toplaintime">
+      <h1>Temporal.DateTime.prototype.toPlainTime ( )</h1>
       <p>
         The following steps are taken:
       </p>

--- a/spec/monthday.html
+++ b/spec/monthday.html
@@ -222,10 +222,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.monthday.prototype.todate">
-      <h1>Temporal.MonthDay.prototype.toDate ( _item_ [ , _options_ ] )</h1>
+    <emu-clause id="sec-temporal.monthday.prototype.toplaindate">
+      <h1>Temporal.MonthDay.prototype.toPlainDate ( _item_ [ , _options_ ] )</h1>
       <p>
-        The `toDate` method takes two arguments, _item_ and _options_.
+        The `toPlainDate` method takes two arguments, _item_ and _options_.
         The following steps are taken:
       </p>
       <emu-alg>

--- a/spec/time.html
+++ b/spec/time.html
@@ -373,10 +373,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.time.prototype.todatetime">
-      <h1>Temporal.Time.prototype.toDateTime ( _temporalDate_ )</h1>
+    <emu-clause id="sec-temporal.time.prototype.toplaindatetime">
+      <h1>Temporal.Time.prototype.toPlainDateTime ( _temporalDate_ )</h1>
       <p>
-        The `toDateTime` method takes one argument _temporalDate_.
+        The `toPlainDateTime` method takes one argument _temporalDate_.
         The following steps are taken:
       </p>
       <emu-alg>

--- a/spec/yearmonth.html
+++ b/spec/yearmonth.html
@@ -408,10 +408,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.yearmonth.prototype.todate">
-      <h1>Temporal.YearMonth.prototype.toDate ( _item_ )</h1>
+    <emu-clause id="sec-temporal.yearmonth.prototype.toplaindate">
+      <h1>Temporal.YearMonth.prototype.toPlainDate ( _item_ )</h1>
       <p>
-        The `toDate` method takes one argument _item_.
+        The `toPlainDate` method takes one argument _item_.
         The following steps are taken:
       </p>
       <emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -819,8 +819,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.zoneddatetime.prototype.todate">
-      <h1>Temporal.ZonedDateTime.prototype.toDate ( )</h1>
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.toplaindate">
+      <h1>Temporal.ZonedDateTime.prototype.toPlainDate ( )</h1>
       <p>
         The following steps are taken:
       </p>
@@ -834,8 +834,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.zoneddatetime.prototype.totime">
-      <h1>Temporal.ZonedDateTime.prototype.toTime ( )</h1>
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.toplaintime">
+      <h1>Temporal.ZonedDateTime.prototype.toPlainTime ( )</h1>
       <p>
         The following steps are taken:
       </p>
@@ -849,8 +849,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.zoneddatetime.prototype.todatetime">
-      <h1>Temporal.ZonedDateTime.prototype.toDateTime ( )</h1>
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.toplaindatetime">
+      <h1>Temporal.ZonedDateTime.prototype.toPlainDateTime ( )</h1>
       <p>
         The following steps are taken:
       </p>
@@ -863,8 +863,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.zoneddatetime.prototype.toyearmonth">
-      <h1>Temporal.ZonedDateTime.prototype.toYearMonth ( )</h1>
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.toplainyearmonth">
+      <h1>Temporal.ZonedDateTime.prototype.toPlainYearMonth ( )</h1>
       <p>
         The following steps are taken:
       </p>
@@ -878,8 +878,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.zoneddatetime.prototype.tomonthday">
-      <h1>Temporal.ZonedDateTime.prototype.toMonthDay ( )</h1>
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.toplainmonthday">
+      <h1>Temporal.ZonedDateTime.prototype.toPlainMonthDay ( )</h1>
       <p>
         The following steps are taken:
       </p>


### PR DESCRIPTION
Fixes: #1072 

- [x] Rename conversion methods, e.g. toDate=>toPlainDate
- [ ] Rename now methods
- [ ] Rename the types themselves
- [ ] Mop-up changes that are not publicly visible (e.g. renaming abstract operations)