### PR TITLE
plain rename: rename now.foo methods

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,12 +32,12 @@ A cookbook to help you get started and learn the ins and outs of Temporal is ava
 - `Temporal.now.timeZone()` - get the current system time zone
 - `Temporal.now.zonedDateTime(calendar)` - get the current date and wall-clock time in the system time zone and specified calendar
 - `Temporal.now.zonedDateTimeISO()` - get the current date and wall-clock time in the system time zone and ISO-8601 calendar
-- `Temporal.now.date(calendar)` - get the current date in the system time zone and specified calendar
-- `Temporal.now.dateISO()` - get the current date in the system time zone and ISO-8601 calendar
+- `Temporal.now.plainDate(calendar)` - get the current date in the system time zone and specified calendar
+- `Temporal.now.plainDateISO()` - get the current date in the system time zone and ISO-8601 calendar
 - `Temporal.now.time(calendar)` - get the current wall-clock time in the system time zone and specified calendar
-- `Temporal.now.timeISO()` - get the current wall-clock time in the system time zone and ISO-8601 calendar
-- `Temporal.now.dateTime(calendar)` - get the current system date/time in the system time zone, but return an object that doesn't remember its time zone so should NOT be used to derive other values (e.g. 12 hours later) in time zones that use Daylight Saving Time (DST).
-- `Temporal.now.dateTimeISO()` - same as above, but return the DateTime in the ISO-8601 calendar
+- `Temporal.now.plainTimeISO()` - get the current wall-clock time in the system time zone and ISO-8601 calendar
+- `Temporal.now.plainDateTime(calendar)` - get the current system date/time in the system time zone, but return an object that doesn't remember its time zone so should NOT be used to derive other values (e.g. 12 hours later) in time zones that use Daylight Saving Time (DST).
+- `Temporal.now.plainDateTimeISO()` - same as above, but return the DateTime in the ISO-8601 calendar
 
 See [Temporal.now Documentation](./now.md) for detailed documentation.
 

--- a/docs/calendar-draft.md
+++ b/docs/calendar-draft.md
@@ -303,7 +303,7 @@ Here is an illustrated version of this option:
 
 ### New Factory Methods (Option 6)
 
-With this option, separate methods would indicate whether the Full ISO calendar should be used versus a potentially non-ISO calendar.  For example, `Temporal.now.dateISO` would be added to supplement `Temporal.now.date`.  See the full table below.
+With this option, separate methods would indicate whether the Full ISO calendar should be used versus a potentially non-ISO calendar.  For example, `Temporal.now.plainDateISO` would be added to supplement `Temporal.now.plainDate`.  See the full table below.
 
 ### Methods of Construction
 
@@ -316,8 +316,8 @@ The following table describes these semantics.  Option 5 is not shown because th
 | T.Date.from(string)\* | *From String* | Explicit | Partial ISO | Environ. | *From String* |
 | T.Date.from(fields)\*\* | *From Object* | Explicit | Partial ISO | Environ. | *From Object* |
 | new T.Date() | Full ISO | Full ISO | Full ISO | Full ISO | Full ISO |
-| T.now.date() | Full ISO | Explicit | Partial ISO | Environ. | Explicit |
-| T.now.dateISO() | N/A | N/A | N/A | N/A | Full ISO |
+| T.now.plainDate() | Full ISO | Explicit | Partial ISO | Environ. | Explicit |
+| T.now.plainDateISO() | N/A | N/A | N/A | N/A | Full ISO |
 | instant.inTimeZone() | Full ISO | Explicit | Partial ISO | Environ. | Explicit |
 | instant.inZoneISO() | N/A | N/A | N/A | N/A | Full ISO |
 | date.getMonthDay()\*\*\*\* | Inherit | Inherit | Explicit | Inherit | Inherit |
@@ -355,31 +355,31 @@ Code:
 
 ```javascript
 /// Options 1 and 4: calendar implicit
-const today = Temporal.now.date();
+const today = Temporal.now.plainDate();
 // OPTION 1 BUG: the ISO calendar is implicit when creating the MonthDay
 const monthDay = today.getMonthDay();
 console.log("Today is:", monthDay.toLocaleString());
 
 /// Options 2 and 6: calendar in factory method
 const calendar = navigator.locales[0].getLikelyCalendar();
-const today = Temporal.now.date(calendar);
+const today = Temporal.now.plainDate(calendar);
 const monthDay = today.getMonthDay();
 console.log("Today is:", monthDay.toLocaleString());
 
 /// Option 3 and 5: getMonthDay() requires a calendar to be given
-const today = Temporal.now.date();
+const today = Temporal.now.plainDate();
 const calendar = navigator.locales[0].getLikelyCalendar();
 const monthDay = today.withCalendar(calendar).getMonthDay();
 console.log("Today is:", monthDay.toLocaleString());
 
 /// Option 3 and 5 alternative: add argument to getMonthDay()
-const today = Temporal.now.date();
+const today = Temporal.now.plainDate();
 const calendar = navigator.locales[0].getLikelyCalendar();
 const monthDay = today.getMonthDay(calendar);
 console.log("Today is:", monthDay.toLocaleString());
 
 /// Alternative using Intl settings
-const today = Temporal.now.date();
+const today = Temporal.now.plainDate();
 console.log("Today is:", today.toLocaleString(undefined, {
   month: "long",
   day: "numeric"
@@ -402,7 +402,7 @@ Code:
 
 ```javascript
 /// Options 1 and 4: calendar implicit
-const today = Temporal.now.date();
+const today = Temporal.now.plainDate();
 console.log("Today is:", today.toLocaleString());
 // OPTION 1 BUG:
 // Arithmetic in months must take place in the user calendar
@@ -411,13 +411,13 @@ console.log("Next month is: ", nextMonth.toLocaleString());
 
 /// Options 2 and 6: calendar in factory method
 const calendar = navigator.locales[0].getLikelyCalendar();
-const today = Temporal.now.date(calendar);
+const today = Temporal.now.plainDate(calendar);
 console.log("Today is:", today.toLocaleString());
 const nextMonth = today.add({ months: 1 });
 console.log("Next month is: ", nextMonth.toLocaleString());
 
 /// Options 3 and 5: calendar only when needed
-const today = Temporal.now.date();
+const today = Temporal.now.plainDate();
 console.log("Today is:", today.toLocaleString());
 const calendar = navigator.locales[0].getLikelyCalendar();
 const nextMonth = today.withCalendar(calendar).add({ months: 1 });
@@ -440,7 +440,7 @@ Code:
 
 ```javascript
 /// Options 1 and 4: calendar implicit
-const date = Temporal.now.date();
+const date = Temporal.now.plainDate();
 console.log("Today is:", date.toLocaleString());
 // OPTION 1 BUG:
 // The MonthDay needs to be represented in the user calendar; otherwise,
@@ -450,13 +450,13 @@ console.log(`Is ${monthDay.toLocaleString()} your birthday?`);
 
 /// Options 2 and 6: calendar in factory method
 const calendar = navigator.locales[0].getLikelyCalendar();
-const date = Temporal.now.date(calendar);
+const date = Temporal.now.plainDate(calendar);
 console.log("Today is:", date.toLocaleString());
 const monthDay = date.getMonthDay();
 console.log(`Is ${monthDay.toLocaleString()} your birthday?`);
 
 /// Options 3 and 5: calendar only when needed
-const date = Temporal.now.date();
+const date = Temporal.now.plainDate();
 console.log("Today is:", date.toLocaleString());
 const calendar = navigator.locales[0].getLikelyCalendar();
 const monthDay = date.withCalendar(calendar).getMonthDay();
@@ -479,7 +479,7 @@ Code:
 
 ```javascript
 /// Options 1 and 4: calendar implicit
-const date = Temporal.now.date();
+const date = Temporal.now.plainDate();
 // OPTION 1 BUG:
 // The YearMonth needs to be represented in the user calendar
 const yearMonth = date.getYearMonth();
@@ -488,13 +488,13 @@ console.log("Number of days this month:", yearMonth.daysInMonth);
 
 /// Options 2 and 6: calendar in factory method
 const calendar = navigator.locales[0].getLikelyCalendar();
-const date = Temporal.now.date(calendar);
+const date = Temporal.now.plainDate(calendar);
 const yearMonth = date.getYearMonth();
 console.log("Today is:", date.toLocaleString());
 console.log("Number of days this month:", yearMonth.daysInMonth);
 
 /// Options 3 and 5: calendar only when needed
-const date = Temporal.now.date();
+const date = Temporal.now.plainDate();
 const calendar = navigator.locales[0].getLikelyCalendar();
 const yearMonth = date.withCalendar(calendar).getYearMonth();
 console.log("Today is:", date.toLocaleString());
@@ -659,7 +659,7 @@ The fourth way to get a Temporal.Date is to get the current time according to th
 As above, this API depends on whether we decide to use a default calendar.  If we require an explicit calendar, it would be similar to above:
 
 ```javascript
-Temporal.now.date = function(calendar) {
+Temporal.now.plainDate = function(calendar) {
 	const instant = Temporal.now.instant();  // use intrinsic
 	const timeZone = Temporal.now.timeZone();  // use intrinsic
 	return instant.inTimeZone(timeZone, calendar);  // use intrinsic

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -322,7 +322,7 @@ An example HTML form inspired by [Days Calculator](https://www.timeanddate.com/d
   // Do initialization that doesn't necessarily need to be included in
   // the example; see 'Calendar input element'
   const futureDatePicker = document.querySelector('input[name="futuredate"]');
-  const today = Temporal.now.date();
+  const today = Temporal.now.plainDate();
   futureDatePicker.min = today;
   futureDatePicker.value = today.add({ months: 1 });
 }

--- a/docs/cookbook/calendarInput.js
+++ b/docs/cookbook/calendarInput.js
@@ -1,5 +1,5 @@
 const datePicker = document.getElementById('calendar-input');
 const browserCalendar = new Intl.DateTimeFormat().resolvedOptions().calendar;
-const today = Temporal.now.date(browserCalendar);
+const today = Temporal.now.plainDate(browserCalendar);
 datePicker.max = today;
 datePicker.value = today;

--- a/docs/cookbook/futureDateForm.js
+++ b/docs/cookbook/futureDateForm.js
@@ -14,7 +14,7 @@ function englishPlural(n, singular, plural) {
 if (futuredateParam !== null) {
   const futureDate = Temporal.Date.from(futuredateParam);
   const browserCalendar = new Intl.DateTimeFormat().resolvedOptions().calendar;
-  const today = Temporal.now.date(browserCalendar);
+  const today = Temporal.now.plainDate(browserCalendar);
   const until = today.until(futureDate, { largestUnit: 'days' });
   const untilMonths = until.round({ largestUnit: 'months', relativeTo: today });
 

--- a/docs/cookbook/getCurrentDate.mjs
+++ b/docs/cookbook/getCurrentDate.mjs
@@ -5,8 +5,8 @@
  *
  */
 
-const date = Temporal.now.dateISO(); // Gets the current date
+const date = Temporal.now.plainDateISO(); // Gets the current date
 date.toString(); // returns the date in ISO 8601 date format
 
 // If you additionally want the time:
-Temporal.now.dateTimeISO().toString(); // date and time in ISO 8601 format
+Temporal.now.plainDateTimeISO().toString(); // date and time in ISO 8601 format

--- a/docs/cookbook/storageTank.js
+++ b/docs/cookbook/storageTank.js
@@ -11,7 +11,7 @@ const labelFormatter = new Intl.DateTimeFormat(undefined, {
   timeZone: Temporal.now.timeZone()
 });
 const browserCalendar = labelFormatter.resolvedOptions().calendar;
-const tankMidnight = Temporal.now.date(browserCalendar, tankTimeZone).toPlainDateTime().toInstant(tankTimeZone);
+const tankMidnight = Temporal.now.plainDate(browserCalendar, tankTimeZone).toPlainDateTime().toInstant(tankTimeZone);
 const atOrAfterMidnight = (x) => Temporal.Instant.compare(x, tankMidnight) >= 0;
 const dataStartIndex = tankDataX.findIndex(atOrAfterMidnight);
 const graphLabels = tankDataX.slice(dataStartIndex).map((x) => labelFormatter.format(x));

--- a/docs/date.md
+++ b/docs/date.md
@@ -230,7 +230,7 @@ Usage example:
 // Attempt to write some mnemonic poetry
 const monthsByDays = {};
 for (let month = 1; month <= 12; month++) {
-  const date = Temporal.now.date().with({ month });
+  const date = Temporal.now.plainDate().with({ month });
   monthsByDays[date.daysInMonth] = (monthsByDays[date.daysInMonth] || []).concat(date);
 }
 
@@ -251,7 +251,7 @@ For the ISO 8601 calendar, this is 365 or 366, depending on whether the year is 
 Usage example:
 
 ```javascript
-date = Temporal.now.date();
+date = Temporal.now.plainDate();
 percent = date.dayOfYear / date.daysInYear;
 `The year is ${percent.toLocaleString('en', { style: 'percent' })} over!`;
 // example output: "The year is 10% over!"
@@ -278,7 +278,7 @@ Usage example:
 
 ```javascript
 // Is this year a leap year?
-date = Temporal.now.date();
+date = Temporal.now.plainDate();
 date.inLeapYear; // example output: true
 // Is 2100 a leap year? (no, because it's divisible by 100 and not 400)
 date.with({ year: 2100 }).inLeapYear; // => false

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -294,7 +294,7 @@ Usage example:
 // Attempt to write some mnemonic poetry
 const monthsByDays = {};
 for (let month = 1; month <= 12; month++) {
-  const dt = Temporal.now.dateTime().with({ month });
+  const dt = Temporal.now.plainDateTime().with({ month });
   monthsByDays[dt.daysInMonth] = (monthsByDays[dt.daysInMonth] || []).concat(dt);
 }
 
@@ -315,7 +315,7 @@ For the ISO 8601 calendar, this is 365 or 366, depending on whether the year is 
 Usage example:
 
 ```javascript
-dt = Temporal.now.dateTime();
+dt = Temporal.now.plainDateTime();
 percent = dt.dayOfYear / dt.daysInYear;
 `The year is ${percent.toLocaleString('en', { style: 'percent' })} over!`;
 // example output: "The year is 10% over!"
@@ -342,7 +342,7 @@ Usage example:
 
 ```javascript
 // Is this year a leap year?
-dt = Temporal.now.dateTime();
+dt = Temporal.now.plainDateTime();
 dt.inLeapYear; // example output: true
 // Is 2100 a leap year? (no, because it's divisible by 100 and not 400)
 dt.with({ year: 2100 }).inLeapYear; // => false

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -462,7 +462,7 @@ d = d.round({
   smallestUnit: 'months',
   roundingIncrement: 3,
   roundingMode: 'trunc',
-  relativeTo: Temporal.now.date()
+  relativeTo: Temporal.now.plainDate()
 });
 quarters = d.months / 3;
 quarters; // => 3

--- a/docs/now.md
+++ b/docs/now.md
@@ -127,9 +127,9 @@ financialCentres = {
   'London': 'Europe/London',
   'Tokyo': 'Asia/Tokyo',
 };
-console.log(`Here: ${Temporal.now.dateTimeISO()}`);
+console.log(`Here: ${Temporal.now.plainDateTimeISO()}`);
 Object.entries(financialCentres).forEach(([name, timeZone]) => {
-  console.log(`${name}: ${Temporal.now.dateTimeISO(timeZone)}`);
+  console.log(`${name}: ${Temporal.now.plainDateTimeISO(timeZone)}`);
 });
 // example output:
 // Here: 2020-01-24T21:51:02.142905166
@@ -152,7 +152,7 @@ Object.entries(financialCentres).forEach(([name, timeZone]) => {
 This method gets the current calendar date and wall-clock time according to the system settings.
 Optionally a time zone can be given in which the time is computed, instead of the current system time zone.
 
-If you only want to use the ISO 8601 calendar, use `Temporal.now.dateTimeISO()`.
+If you only want to use the ISO 8601 calendar, use `Temporal.now.plainDateTimeISO()`.
 
 ### Temporal.now.**dateISO**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Date
 
@@ -172,7 +172,7 @@ Example usage:
 
 ```js
 // Is it New Year in the ISO 8601 calendar?
-date = Temporal.now.dateISO();
+date = Temporal.now.plainDateISO();
 if (date.month === 1 && date.day === 1) console.log('New year!');
 ```
 
@@ -189,15 +189,15 @@ if (date.month === 1 && date.day === 1) console.log('New year!');
 This method gets the current calendar date according to the system settings.
 Optionally a time zone can be given in which the time is computed, instead of the current system time zone.
 
-If you only want to use the ISO 8601 calendar, use `Temporal.now.dateISO()`.
+If you only want to use the ISO 8601 calendar, use `Temporal.now.plainDateISO()`.
 
 ```js
 // Is it Nowruz (New Year in the Persian calendar)?
-date = Temporal.now.date('persian');
+date = Temporal.now.plainDate('persian');
 if (date.month === 1 && date.day === 1) console.log('New year!');
 ```
 
-### Temporal.now.**timeISO**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Time
+### Temporal.now.**plainTimeISO**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Time
 
 **Parameters:**
 
@@ -213,6 +213,6 @@ Example usage:
 
 ```js
 // Is it lunchtime?
-time = Temporal.now.timeISO();
+time = Temporal.now.plainTimeISO();
 if (time.hour === 12) console.log('Lunchtime!');
 ```

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1503,7 +1503,7 @@ export namespace Temporal {
      * object implementing the time zone protocol. If omitted, the environment's
      * current time zone will be used.
      */
-    export function timeISO(tzLike?: TimeZoneProtocol | string): Temporal.Time;
+    export function plainTimeISO(tzLike?: TimeZoneProtocol | string): Temporal.Time;
 
     /**
      * Get the environment's current time zone.

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -4,11 +4,11 @@ import { GetIntrinsic } from './intrinsicclass.mjs';
 
 export const now = {
   instant,
-  dateTime,
-  dateTimeISO,
-  date,
-  dateISO,
-  timeISO,
+  plainDateTime,
+  plainDateTimeISO,
+  plainDate,
+  plainDateISO,
+  plainTimeISO,
   timeZone
 };
 
@@ -16,26 +16,26 @@ function instant() {
   const Instant = GetIntrinsic('%Temporal.Instant%');
   return new Instant(ES.SystemUTCEpochNanoSeconds());
 }
-function dateTime(calendarLike, temporalTimeZoneLike = timeZone()) {
+function plainDateTime(calendarLike, temporalTimeZoneLike = timeZone()) {
   const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
   const calendar = ES.ToTemporalCalendar(calendarLike);
   const inst = instant();
   return ES.GetTemporalDateTimeFor(timeZone, inst, calendar);
 }
-function dateTimeISO(temporalTimeZoneLike = timeZone()) {
+function plainDateTimeISO(temporalTimeZoneLike = timeZone()) {
   const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
   const calendar = GetISO8601Calendar();
   const inst = instant();
   return ES.GetTemporalDateTimeFor(timeZone, inst, calendar);
 }
-function date(calendarLike, temporalTimeZoneLike = timeZone()) {
-  return ES.TemporalDateTimeToDate(dateTime(calendarLike, temporalTimeZoneLike));
+function plainDate(calendarLike, temporalTimeZoneLike = timeZone()) {
+  return ES.TemporalDateTimeToDate(plainDateTime(calendarLike, temporalTimeZoneLike));
 }
-function dateISO(temporalTimeZoneLike = timeZone()) {
-  return ES.TemporalDateTimeToDate(dateTimeISO(temporalTimeZoneLike));
+function plainDateISO(temporalTimeZoneLike = timeZone()) {
+  return ES.TemporalDateTimeToDate(plainDateTimeISO(temporalTimeZoneLike));
 }
-function timeISO(temporalTimeZoneLike = timeZone()) {
-  return ES.TemporalDateTimeToTime(dateTimeISO(temporalTimeZoneLike));
+function plainTimeISO(temporalTimeZoneLike = timeZone()) {
+  return ES.TemporalDateTimeToTime(plainDateTimeISO(temporalTimeZoneLike));
 }
 function timeZone() {
   return ES.SystemTimeZone();

--- a/polyfill/test/now.mjs
+++ b/polyfill/test/now.mjs
@@ -21,48 +21,49 @@ describe('Temporal.now', () => {
     it('Temporal.now is an object', () => equal(typeof Temporal.now, 'object'));
     it('Temporal.now has 7 properties', () => equal(Object.keys(Temporal.now).length, 7));
     it('Temporal.now.instant is a function', () => equal(typeof Temporal.now.instant, 'function'));
-    it('Temporal.now.dateTime is a function', () => equal(typeof Temporal.now.dateTime, 'function'));
-    it('Temporal.now.dateTimeISO is a function', () => equal(typeof Temporal.now.dateTimeISO, 'function'));
-    it('Temporal.now.date is a function', () => equal(typeof Temporal.now.date, 'function'));
-    it('Temporal.now.dateISO is a function', () => equal(typeof Temporal.now.dateISO, 'function'));
-    it('Temporal.now.timeISO is a function', () => equal(typeof Temporal.now.timeISO, 'function'));
+    it('Temporal.now.plainDateTime is a function', () => equal(typeof Temporal.now.plainDateTime, 'function'));
+    it('Temporal.now.plainDateTimeISO is a function', () => equal(typeof Temporal.now.plainDateTimeISO, 'function'));
+    it('Temporal.now.plainDate is a function', () => equal(typeof Temporal.now.plainDate, 'function'));
+    it('Temporal.now.plainDateISO is a function', () => equal(typeof Temporal.now.plainDateISO, 'function'));
+    it('Temporal.now.plainTimeISO is a function', () => equal(typeof Temporal.now.plainTimeISO, 'function'));
     it('Temporal.now.timeZone is a function', () => equal(typeof Temporal.now.timeZone, 'function'));
   });
   describe('Temporal.now.instant()', () => {
     it('Temporal.now.instant() returns an Instant', () => assert(Temporal.now.instant() instanceof Temporal.Instant));
   });
-  describe('Temporal.now.dateTimeISO()', () => {
+  describe('Temporal.now.plainDateTimeISO()', () => {
     it('returns a DateTime in the ISO calendar', () => {
-      const dt = Temporal.now.dateTimeISO();
+      const dt = Temporal.now.plainDateTimeISO();
       assert(dt instanceof Temporal.DateTime);
       equal(dt.calendar.id, 'iso8601');
     });
   });
-  describe('Temporal.now.dateTime()', () => {
+  describe('Temporal.now.plainDateTime()', () => {
     it('returns a DateTime in the correct calendar', () => {
-      const dt = Temporal.now.dateTime('gregory');
+      const dt = Temporal.now.plainDateTime('gregory');
       assert(dt instanceof Temporal.DateTime);
       equal(dt.calendar.id, 'gregory');
     });
-    it('requires a calendar', () => throws(() => Temporal.now.dateTime(), RangeError));
+    it('requires a calendar', () => throws(() => Temporal.now.plainDateTime(), RangeError));
   });
-  describe('Temporal.now.dateISO()', () => {
+  describe('Temporal.now.plainDateISO()', () => {
     it('returns a Date in the ISO calendar', () => {
-      const d = Temporal.now.dateISO();
+      const d = Temporal.now.plainDateISO();
       assert(d instanceof Temporal.Date);
       equal(d.calendar.id, 'iso8601');
     });
   });
-  describe('Temporal.now.date()', () => {
+  describe('Temporal.now.plainDate()', () => {
     it('returns a Date in the correct calendar', () => {
-      const d = Temporal.now.date('gregory');
+      const d = Temporal.now.plainDate('gregory');
       assert(d instanceof Temporal.Date);
       equal(d.calendar.id, 'gregory');
     });
-    it('requires a calendar', () => throws(() => Temporal.now.date(), RangeError));
+    it('requires a calendar', () => throws(() => Temporal.now.plainDate(), RangeError));
   });
-  describe('Temporal.now.timeISO()', () => {
-    it('Temporal.now.timeISO() returns a Time', () => assert(Temporal.now.timeISO() instanceof Temporal.Time));
+  describe('Temporal.now.plainTimeISO()', () => {
+    it('Temporal.now.plainTimeISO() returns a Time', () =>
+      assert(Temporal.now.plainTimeISO() instanceof Temporal.Time));
   });
 });
 

--- a/polyfill/test/now/date/calendar-convert.js
+++ b/polyfill/test/now/date/calendar-convert.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 ---*/
 
 const values = [
@@ -22,7 +22,7 @@ for (const [input, output] of values) {
     return calendar;
   };
 
-  const date = Temporal.now.date(input, "UTC");
+  const date = Temporal.now.plainDate(input, "UTC");
   assert.sameValue(called, 1);
   assert.sameValue(date.calendar, calendar);
 }
@@ -31,4 +31,4 @@ Temporal.Calendar.from = function() {
   throw new Test262Error("Should not call Calendar.from");
 };
 
-assert.throws(TypeError, () => Temporal.now.date(Symbol(), "UTC"));
+assert.throws(TypeError, () => Temporal.now.plainDate(Symbol(), "UTC"));

--- a/polyfill/test/now/date/calendar-from-invalid-result.js
+++ b/polyfill/test/now/date/calendar-from-invalid-result.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 ---*/
 
 const values = [
@@ -25,6 +25,6 @@ for (const [value, description] of values) {
     return value;
   };
 
-  assert.throws(TypeError, () => Temporal.now.date("test", timeZone), description);
+  assert.throws(TypeError, () => Temporal.now.plainDate("test", timeZone), description);
   assert.sameValue(called, 1);
 }

--- a/polyfill/test/now/date/calendar-from-undefined.js
+++ b/polyfill/test/now/date/calendar-from-undefined.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 includes: [compareArray.js]
 ---*/
 
@@ -40,7 +40,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.date("japanese", timeZone);
+const result = Temporal.now.plainDate("japanese", timeZone);
 assert.sameValue(result instanceof Temporal.Date, true);
 for (const property of ["year", "month", "day"]) {
   assert.sameValue(result[property], dateTime[property], property);

--- a/polyfill/test/now/date/calendar-function.js
+++ b/polyfill/test/now/date/calendar-function.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 includes: [compareArray.js]
 ---*/
 
@@ -38,7 +38,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.date(calendar, timeZone);
+const result = Temporal.now.plainDate(calendar, timeZone);
 assert.sameValue(result instanceof Temporal.Date, true);
 for (const property of ["year", "month", "day"]) {
   assert.sameValue(result[property], dateTime[property], property);

--- a/polyfill/test/now/date/calendar-object.js
+++ b/polyfill/test/now/date/calendar-object.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 includes: [compareArray.js]
 ---*/
 
@@ -38,7 +38,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.date(calendar, timeZone);
+const result = Temporal.now.plainDate(calendar, timeZone);
 assert.sameValue(result instanceof Temporal.Date, true);
 for (const property of ["year", "month", "day"]) {
   assert.sameValue(result[property], dateTime[property], property);

--- a/polyfill/test/now/date/calendar.js
+++ b/polyfill/test/now/date/calendar.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 includes: [compareArray.js]
 ---*/
 
@@ -59,7 +59,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.date("iso8601", "UTC");
+const result = Temporal.now.plainDate("iso8601", "UTC");
 assert.sameValue(result instanceof Temporal.Date, true);
 for (const property of ["year", "month", "day"]) {
   assert.sameValue(result[property], dateTime[property], property);

--- a/polyfill/test/now/date/length.js
+++ b/polyfill/test/now/date/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.now.date, "length", {
+verifyProperty(Temporal.now.plainDate, "length", {
   value: 1,
   writable: false,
   enumerable: false,

--- a/polyfill/test/now/date/timezone-invalid-result.js
+++ b/polyfill/test/now/date/timezone-invalid-result.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 ---*/
 
 const invalidValues = [
@@ -28,5 +28,5 @@ for (const dateTime of invalidValues) {
     },
   };
 
-  assert.throws(TypeError, () => Temporal.now.date("iso8601", timeZone));
+  assert.throws(TypeError, () => Temporal.now.plainDate("iso8601", timeZone));
 }

--- a/polyfill/test/now/date/timezone-object.js
+++ b/polyfill/test/now/date/timezone-object.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 includes: [compareArray.js]
 ---*/
 
@@ -39,7 +39,7 @@ Object.defineProperty(Temporal.TimeZone, "from", {
   },
 });
 
-const result = Temporal.now.date("iso8601", timeZone);
+const result = Temporal.now.plainDate("iso8601", timeZone);
 assert.sameValue(result instanceof Temporal.Date, true);
 for (const property of ["year", "month", "day"]) {
   assert.sameValue(result[property], dateTime[property], property);

--- a/polyfill/test/now/date/timezone.js
+++ b/polyfill/test/now/date/timezone.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 includes: [compareArray.js]
 ---*/
 
@@ -54,7 +54,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.date(calendar, "UTC");
+const result = Temporal.now.plainDate(calendar, "UTC");
 assert.sameValue(result instanceof Temporal.Date, true);
 for (const property of ["year", "month", "day"]) {
   assert.sameValue(result[property], dateTime[property], property);

--- a/polyfill/test/now/date/toDate-override.js
+++ b/polyfill/test/now/date/toDate-override.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.date
+esid: sec-temporal.now.plaindate
 includes: [compareArray.js]
 ---*/
 
@@ -52,7 +52,7 @@ Object.defineProperty(Temporal.TimeZone, "from", {
   },
 });
 
-const result = Temporal.now.date("iso8601", "UTC");
+const result = Temporal.now.plainDate("iso8601", "UTC");
 assert.notSameValue(result, undefined);
 assert.sameValue(result instanceof Temporal.Date, true);
 for (const property of ["year", "month", "day"]) {

--- a/polyfill/test/now/dateTime/calendar-convert.js
+++ b/polyfill/test/now/dateTime/calendar-convert.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 ---*/
 
 const values = [
@@ -22,7 +22,7 @@ for (const [input, output] of values) {
     return calendar;
   };
 
-  const dateTime = Temporal.now.dateTime(input, "UTC");
+  const dateTime = Temporal.now.plainDateTime(input, "UTC");
   assert.sameValue(called, 1);
   assert.sameValue(dateTime.calendar, calendar);
 }
@@ -31,4 +31,4 @@ Temporal.Calendar.from = function() {
   throw new Test262Error("Should not call Calendar.from");
 };
 
-assert.throws(TypeError, () => Temporal.now.dateTime(Symbol(), "UTC"));
+assert.throws(TypeError, () => Temporal.now.plainDateTime(Symbol(), "UTC"));

--- a/polyfill/test/now/dateTime/calendar-from-invalid-result.js
+++ b/polyfill/test/now/dateTime/calendar-from-invalid-result.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 ---*/
 
 const values = [
@@ -25,6 +25,6 @@ for (const [value, description] of values) {
     return value;
   };
 
-  assert.throws(TypeError, () => Temporal.now.dateTime("test", timeZone), description);
+  assert.throws(TypeError, () => Temporal.now.plainDateTime("test", timeZone), description);
   assert.sameValue(called, 1);
 }

--- a/polyfill/test/now/dateTime/calendar-from-undefined.js
+++ b/polyfill/test/now/dateTime/calendar-from-undefined.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 includes: [compareArray.js]
 ---*/
 
@@ -40,7 +40,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.dateTime("japanese", timeZone);
+const result = Temporal.now.plainDateTime("japanese", timeZone);
 assert.sameValue(result, dateTime);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/now/dateTime/calendar-function.js
+++ b/polyfill/test/now/dateTime/calendar-function.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 includes: [compareArray.js]
 ---*/
 
@@ -38,7 +38,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.dateTime(calendar, timeZone);
+const result = Temporal.now.plainDateTime(calendar, timeZone);
 assert.sameValue(result, dateTime);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/now/dateTime/calendar-object.js
+++ b/polyfill/test/now/dateTime/calendar-object.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 includes: [compareArray.js]
 ---*/
 
@@ -38,7 +38,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.dateTime(calendar, timeZone);
+const result = Temporal.now.plainDateTime(calendar, timeZone);
 assert.sameValue(result, dateTime);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/now/dateTime/calendar.js
+++ b/polyfill/test/now/dateTime/calendar.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 includes: [compareArray.js]
 ---*/
 
@@ -59,7 +59,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.dateTime("iso8601", "UTC");
+const result = Temporal.now.plainDateTime("iso8601", "UTC");
 assert.sameValue(result, dateTime);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/now/dateTime/length.js
+++ b/polyfill/test/now/dateTime/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.now.dateTime, "length", {
+verifyProperty(Temporal.now.plainDateTime, "length", {
   value: 1,
   writable: false,
   enumerable: false,

--- a/polyfill/test/now/dateTime/timezone-invalid-result.js
+++ b/polyfill/test/now/dateTime/timezone-invalid-result.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 ---*/
 
 const invalidValues = [
@@ -28,5 +28,5 @@ for (const dateTime of invalidValues) {
     },
   };
 
-  assert.throws(TypeError, () => Temporal.now.dateTime("iso8601", timeZone));
+  assert.throws(TypeError, () => Temporal.now.plainDateTime("iso8601", timeZone));
 }

--- a/polyfill/test/now/dateTime/timezone-object.js
+++ b/polyfill/test/now/dateTime/timezone-object.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 includes: [compareArray.js]
 ---*/
 
@@ -39,7 +39,7 @@ Object.defineProperty(Temporal.TimeZone, "from", {
   },
 });
 
-const result = Temporal.now.dateTime("iso8601", timeZone);
+const result = Temporal.now.plainDateTime("iso8601", timeZone);
 assert.sameValue(result, dateTime);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/now/dateTime/timezone.js
+++ b/polyfill/test/now/dateTime/timezone.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.datetime
+esid: sec-temporal.now.plaindatetime
 includes: [compareArray.js]
 ---*/
 
@@ -54,7 +54,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.dateTime(calendar, "UTC");
+const result = Temporal.now.plainDateTime(calendar, "UTC");
 assert.sameValue(result, dateTime);
 
 assert.compareArray(actual, expected);

--- a/polyfill/test/now/timeISO/length.js
+++ b/polyfill/test/now/timeISO/length.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.timeiso
+esid: sec-temporal.nowplaintimeiso
 info: |
     Every built-in function object, including constructors, has a "length" property whose value is
     an integer. Unless otherwise specified, this value is equal to the largest number of named
@@ -15,7 +15,7 @@ info: |
 includes: [propertyHelper.js]
 ---*/
 
-verifyProperty(Temporal.now.timeISO, "length", {
+verifyProperty(Temporal.now.plainTimeISO, "length", {
   value: 0,
   writable: false,
   enumerable: false,

--- a/polyfill/test/now/timeISO/timezone-invalid-result.js
+++ b/polyfill/test/now/timeISO/timezone-invalid-result.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.timeiso
+esid: sec-temporal.nowplaintimeiso
 ---*/
 
 const invalidValues = [
@@ -28,5 +28,5 @@ for (const dateTime of invalidValues) {
     },
   };
 
-  assert.throws(TypeError, () => Temporal.now.timeISO(timeZone));
+  assert.throws(TypeError, () => Temporal.now.plainTimeISO(timeZone));
 }

--- a/polyfill/test/now/timeISO/timezone-object.js
+++ b/polyfill/test/now/timeISO/timezone-object.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.timeiso
+esid: sec-temporal.nowplaintimeiso
 includes: [compareArray.js]
 ---*/
 
@@ -39,7 +39,7 @@ Object.defineProperty(Temporal.TimeZone, "from", {
   },
 });
 
-const result = Temporal.now.timeISO(timeZone);
+const result = Temporal.now.plainTimeISO(timeZone);
 assert.sameValue(result instanceof Temporal.Time, true);
 for (const property of ["hour", "minute", "second", "millisecond", "microsecond", "nanosecond"]) {
   assert.sameValue(result[property], dateTime[property], property);

--- a/polyfill/test/now/timeISO/timezone.js
+++ b/polyfill/test/now/timeISO/timezone.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.timeiso
+esid: sec-temporal.nowplaintimeiso
 includes: [compareArray.js]
 ---*/
 
@@ -52,7 +52,7 @@ Object.defineProperty(Temporal.Calendar, "from", {
   },
 });
 
-const result = Temporal.now.timeISO("UTC");
+const result = Temporal.now.plainTimeISO("UTC");
 assert.sameValue(result instanceof Temporal.Time, true);
 for (const property of ["hour", "minute", "second", "millisecond", "microsecond", "nanosecond"]) {
   assert.sameValue(result[property], dateTime[property], property);

--- a/polyfill/test/now/timeISO/toTime-override.js
+++ b/polyfill/test/now/timeISO/toTime-override.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.now.timeiso
+esid: sec-temporal.nowplaintimeiso
 includes: [compareArray.js]
 ---*/
 
@@ -52,7 +52,7 @@ Object.defineProperty(Temporal.TimeZone, "from", {
   },
 });
 
-const result = Temporal.now.timeISO("UTC");
+const result = Temporal.now.plainTimeISO("UTC");
 assert.sameValue(result instanceof Temporal.Time, true);
 for (const property of ["hour", "minute", "second", "millisecond", "microsecond", "nanosecond"]) {
   assert.sameValue(result[property], dateTime[property], property);

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -111,12 +111,12 @@ describe('Userland calendar', () => {
       const dt = tz.getDateTimeFor(instant, obj);
       equal(dt.calendar.id, obj.id);
     });
-    it('Temporal.now.dateTime()', () => {
-      const nowDateTime = Temporal.now.dateTime(obj, 'UTC');
+    it('Temporal.now.plainDateTime()', () => {
+      const nowDateTime = Temporal.now.plainDateTime(obj, 'UTC');
       equal(nowDateTime.calendar.id, obj.id);
     });
-    it('Temporal.now.date()', () => {
-      const nowDate = Temporal.now.date(obj, 'UTC');
+    it('Temporal.now.plainDate()', () => {
+      const nowDate = Temporal.now.plainDate(obj, 'UTC');
       equal(nowDate.calendar.id, obj.id);
     });
     describe('Making available globally', () => {
@@ -199,12 +199,12 @@ describe('Userland calendar', () => {
         const dt = tz.getDateTimeFor(inst, 'zero-based');
         equal(dt.calendar.id, 'zero-based');
       });
-      it('works for Temporal.now.dateTime', () => {
-        const nowDateTime = Temporal.now.dateTime('zero-based', 'UTC');
+      it('works for Temporal.now.plainDateTime', () => {
+        const nowDateTime = Temporal.now.plainDateTime('zero-based', 'UTC');
         equal(nowDateTime.calendar.id, 'zero-based');
       });
-      it('works for Temporal.now.date', () => {
-        const nowDate = Temporal.now.date('zero-based', 'UTC');
+      it('works for Temporal.now.plainDate', () => {
+        const nowDate = Temporal.now.plainDate('zero-based', 'UTC');
         equal(nowDate.calendar.id, 'zero-based');
       });
       after(() => {
@@ -418,12 +418,12 @@ describe('Userland calendar', () => {
       const dt = tz.getDateTimeFor(inst, obj);
       equal(dt.calendar.id, obj.id);
     });
-    it('Temporal.now.dateTime()', () => {
-      const nowDateTime = Temporal.now.dateTime(obj, 'UTC');
+    it('Temporal.now.plainDateTime()', () => {
+      const nowDateTime = Temporal.now.plainDateTime(obj, 'UTC');
       equal(nowDateTime.calendar.id, obj.id);
     });
-    it('Temporal.now.date()', () => {
-      const nowDate = Temporal.now.date(obj, 'UTC');
+    it('Temporal.now.plainDate()', () => {
+      const nowDate = Temporal.now.plainDate(obj, 'UTC');
       equal(nowDate.calendar.id, obj.id);
     });
     describe('Making available globally', () => {
@@ -506,12 +506,12 @@ describe('Userland calendar', () => {
         const dt = tz.getDateTimeFor(inst, 'decimal');
         equal(dt.calendar.id, 'decimal');
       });
-      it('works for Temporal.now.dateTime', () => {
-        const nowDateTime = Temporal.now.dateTime('decimal', 'UTC');
+      it('works for Temporal.now.plainDateTime', () => {
+        const nowDateTime = Temporal.now.plainDateTime('decimal', 'UTC');
         equal(nowDateTime.calendar.id, 'decimal');
       });
-      it('works for Temporal.now.date', () => {
-        const nowDate = Temporal.now.date('decimal', 'UTC');
+      it('works for Temporal.now.plainDate', () => {
+        const nowDate = Temporal.now.plainDate('decimal', 'UTC');
         equal(nowDate.calendar.id, 'decimal');
       });
       after(() => {

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -66,11 +66,11 @@ describe('Userland time zone', () => {
     it('has no next transitions', () => assert.equal(obj.getNextTransition(), null));
     it('has no previous transitions', () => assert.equal(obj.getPreviousTransition(), null));
     it('works in Temporal.now', () => {
-      assert(Temporal.now.dateTimeISO(obj) instanceof Temporal.DateTime);
-      assert(Temporal.now.dateTime('gregory', obj) instanceof Temporal.DateTime);
-      assert(Temporal.now.dateISO(obj) instanceof Temporal.Date);
-      assert(Temporal.now.date('gregory', obj) instanceof Temporal.Date);
-      assert(Temporal.now.timeISO(obj) instanceof Temporal.Time);
+      assert(Temporal.now.plainDateTimeISO(obj) instanceof Temporal.DateTime);
+      assert(Temporal.now.plainDateTime('gregory', obj) instanceof Temporal.DateTime);
+      assert(Temporal.now.plainDateISO(obj) instanceof Temporal.Date);
+      assert(Temporal.now.plainDate('gregory', obj) instanceof Temporal.Date);
+      assert(Temporal.now.plainTimeISO(obj) instanceof Temporal.Time);
     });
     describe('Making available globally', () => {
       const originalTemporalTimeZoneFrom = Temporal.TimeZone.from;
@@ -104,11 +104,11 @@ describe('Userland time zone', () => {
         equal(inst.toString({ timeZone: 'Etc/Custom/UTC_Subclass' }), '1970-01-01T00:00:00+00:00');
       });
       it('works for Temporal.now', () => {
-        assert(Temporal.now.dateTimeISO('Etc/Custom/UTC_Subclass') instanceof Temporal.DateTime);
-        assert(Temporal.now.dateTime('gregory', 'Etc/Custom/UTC_Subclass') instanceof Temporal.DateTime);
-        assert(Temporal.now.dateISO('Etc/Custom/UTC_Subclass') instanceof Temporal.Date);
-        assert(Temporal.now.date('gregory', 'Etc/Custom/UTC_Subclass') instanceof Temporal.Date);
-        assert(Temporal.now.timeISO('Etc/Custom/UTC_Subclass') instanceof Temporal.Time);
+        assert(Temporal.now.plainDateTimeISO('Etc/Custom/UTC_Subclass') instanceof Temporal.DateTime);
+        assert(Temporal.now.plainDateTime('gregory', 'Etc/Custom/UTC_Subclass') instanceof Temporal.DateTime);
+        assert(Temporal.now.plainDateISO('Etc/Custom/UTC_Subclass') instanceof Temporal.Date);
+        assert(Temporal.now.plainDate('gregory', 'Etc/Custom/UTC_Subclass') instanceof Temporal.Date);
+        assert(Temporal.now.plainTimeISO('Etc/Custom/UTC_Subclass') instanceof Temporal.Time);
       });
       after(() => {
         Temporal.TimeZone.from = originalTemporalTimeZoneFrom;
@@ -153,11 +153,11 @@ describe('Userland time zone', () => {
       equal(zdt.toString(), '1970-01-01T00:00:00+00:00[Etc/Custom/UTC_Protocol]');
     });
     it('works in Temporal.now', () => {
-      assert(Temporal.now.dateTimeISO(obj) instanceof Temporal.DateTime);
-      assert(Temporal.now.dateTime('gregory', obj) instanceof Temporal.DateTime);
-      assert(Temporal.now.dateISO(obj) instanceof Temporal.Date);
-      assert(Temporal.now.date('gregory', obj) instanceof Temporal.Date);
-      assert(Temporal.now.timeISO(obj) instanceof Temporal.Time);
+      assert(Temporal.now.plainDateTimeISO(obj) instanceof Temporal.DateTime);
+      assert(Temporal.now.plainDateTime('gregory', obj) instanceof Temporal.DateTime);
+      assert(Temporal.now.plainDateISO(obj) instanceof Temporal.Date);
+      assert(Temporal.now.plainDate('gregory', obj) instanceof Temporal.Date);
+      assert(Temporal.now.plainTimeISO(obj) instanceof Temporal.Time);
     });
     describe('Making available globally', () => {
       const originalTemporalTimeZoneFrom = Temporal.TimeZone.from;
@@ -191,11 +191,11 @@ describe('Userland time zone', () => {
         equal(inst.toString({ timeZone: 'Etc/Custom/UTC_Protocol' }), '1970-01-01T00:00:00+00:00');
       });
       it('works for Temporal.now', () => {
-        assert(Temporal.now.dateTimeISO('Etc/Custom/UTC_Protocol') instanceof Temporal.DateTime);
-        assert(Temporal.now.dateTime('gregory', 'Etc/Custom/UTC_Protocol') instanceof Temporal.DateTime);
-        assert(Temporal.now.dateISO('Etc/Custom/UTC_Protocol') instanceof Temporal.Date);
-        assert(Temporal.now.date('gregory', 'Etc/Custom/UTC_Protocol') instanceof Temporal.Date);
-        assert(Temporal.now.timeISO('Etc/Custom/UTC_Protocol') instanceof Temporal.Time);
+        assert(Temporal.now.plainDateTimeISO('Etc/Custom/UTC_Protocol') instanceof Temporal.DateTime);
+        assert(Temporal.now.plainDateTime('gregory', 'Etc/Custom/UTC_Protocol') instanceof Temporal.DateTime);
+        assert(Temporal.now.plainDateISO('Etc/Custom/UTC_Protocol') instanceof Temporal.Date);
+        assert(Temporal.now.plainDate('gregory', 'Etc/Custom/UTC_Protocol') instanceof Temporal.Date);
+        assert(Temporal.now.plainTimeISO('Etc/Custom/UTC_Protocol') instanceof Temporal.Time);
       });
       after(() => {
         Temporal.TimeZone.from = originalTemporalTimeZoneFrom;
@@ -254,11 +254,11 @@ describe('Userland time zone', () => {
     it('has no next transitions', () => assert.equal(obj.getNextTransition(), null));
     it('has no previous transitions', () => assert.equal(obj.getPreviousTransition(), null));
     it('works in Temporal.now', () => {
-      assert(Temporal.now.dateTimeISO(obj) instanceof Temporal.DateTime);
-      assert(Temporal.now.dateTime('gregory', obj) instanceof Temporal.DateTime);
-      assert(Temporal.now.dateISO(obj) instanceof Temporal.Date);
-      assert(Temporal.now.date('gregory', obj) instanceof Temporal.Date);
-      assert(Temporal.now.timeISO(obj) instanceof Temporal.Time);
+      assert(Temporal.now.plainDateTimeISO(obj) instanceof Temporal.DateTime);
+      assert(Temporal.now.plainDateTime('gregory', obj) instanceof Temporal.DateTime);
+      assert(Temporal.now.plainDateISO(obj) instanceof Temporal.Date);
+      assert(Temporal.now.plainDate('gregory', obj) instanceof Temporal.Date);
+      assert(Temporal.now.plainTimeISO(obj) instanceof Temporal.Time);
     });
     describe('Making available globally', () => {
       const originalTemporalTimeZoneFrom = Temporal.TimeZone.from;
@@ -292,11 +292,11 @@ describe('Userland time zone', () => {
         equal(inst.toString({ timeZone: 'Custom/Subminute' }), '1969-12-31T23:59:58.888888889-00:00:01.111111111');
       });
       it('works for Temporal.now', () => {
-        assert(Temporal.now.dateTimeISO('Custom/Subminute') instanceof Temporal.DateTime);
-        assert(Temporal.now.dateTime('gregory', 'Custom/Subminute') instanceof Temporal.DateTime);
-        assert(Temporal.now.dateISO('Custom/Subminute') instanceof Temporal.Date);
-        assert(Temporal.now.date('gregory', 'Custom/Subminute') instanceof Temporal.Date);
-        assert(Temporal.now.timeISO('Custom/Subminute') instanceof Temporal.Time);
+        assert(Temporal.now.plainDateTimeISO('Custom/Subminute') instanceof Temporal.DateTime);
+        assert(Temporal.now.plainDateTime('gregory', 'Custom/Subminute') instanceof Temporal.DateTime);
+        assert(Temporal.now.plainDateISO('Custom/Subminute') instanceof Temporal.Date);
+        assert(Temporal.now.plainDate('gregory', 'Custom/Subminute') instanceof Temporal.Date);
+        assert(Temporal.now.plainTimeISO('Custom/Subminute') instanceof Temporal.Time);
       });
       after(() => {
         Temporal.TimeZone.from = originalTemporalTimeZoneFrom;

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -94,8 +94,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.now.datetime">
-      <h1>Temporal.now.dateTime ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
+    <emu-clause id="sec-temporal.now.plaindatetime">
+      <h1>Temporal.now.plainDateTime ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
         The `dateTime` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
         The following steps are taken:
@@ -105,8 +105,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.now.datetimeiso">
-      <h1>Temporal.now.dateTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
+    <emu-clause id="sec-temporal.now.plaindatetimeiso">
+      <h1>Temporal.now.plainDateTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
         The `dateTimeISO` method takes one argument _temporalTimeZoneLike_.
         The following steps are taken:
@@ -116,8 +116,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.now.date">
-      <h1>Temporal.now.date ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
+    <emu-clause id="sec-temporal.now.plaindate">
+      <h1>Temporal.now.plainDate ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
         The `date` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
         The following steps are taken:
@@ -128,8 +128,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.now.dateiso">
-      <h1>Temporal.now.dateISO ( [ _temporalTimeZoneLike_ ] )</h1>
+    <emu-clause id="sec-temporal.now.plaindateiso">
+      <h1>Temporal.now.plainDateISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
         The `dateISO` method takes one argument _temporalTimeZoneLike_.
         The following steps are taken:
@@ -140,10 +140,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.now.timeiso">
-      <h1>Temporal.now.timeISO ( [ _temporalTimeZoneLike_ ] )</h1>
+    <emu-clause id="sec-temporal.now.plaintimeiso">
+      <h1>Temporal.now.plainTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `timeISO` method takes one argument _temporalTimeZoneLike_.
+        The `plainTimeISO` method takes one argument _temporalTimeZoneLike_.
         The following steps are taken:
       </p>
       <emu-alg>


### PR DESCRIPTION
rename now.date, now.dateISO, now.dateTime, now.dateTimeISO and
now.timeISO to now.plainDate, now.plainDateISO, now.plainDateTime,
now.plainDateTimeISO, now.plainTimeISO respectively.

Fixes: #1072 

- [x] Rename conversion methods, e.g. toDate=>toPlainDate
- [x] Rename now methods
- [ ] Rename the types themselves
- [ ] Mop-up changes that are not publicly visible (e.g. renaming abstract operations)