### PR TITLE
Add now.zonedDateTime() and now.zonedDateTimeISO()

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1409,6 +1409,49 @@ export namespace Temporal {
      * Get the current calendar date and clock time in a specific calendar and
      * time zone.
      *
+     * The `calendar` parameter is required. When using the ISO 8601 calendar or
+     * if you don't understand the need for or implications of a calendar, then
+     * a more ergonomic alternative to this method is
+     * `Temporal.now.dateTimeISO()`.
+     *
+     * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
+     * a `Temporal.Calendar` instance, or an object implementing the calendar
+     * protocol.
+     * @param {TimeZoneProtocol | string} [tzLike] -
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
+     */
+    export function zonedDateTime(
+      calendar: CalendarProtocol | string,
+      tzLike?: TimeZoneProtocol | string
+    ): Temporal.ZonedDateTime;
+
+    /**
+     * Get the current calendar date and clock time in a specific time zone,
+     * using the ISO 8601 calendar.
+     *
+     * The `calendar` parameter is required. When using the ISO 8601 calendar or
+     * if you don't understand the need for or implications of a calendar, then
+     * a more ergonomic alternative to this method is
+     * `Temporal.now.zonedDateTimeISO()`.
+     *
+     * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
+     * a `Temporal.Calendar` instance, or an object implementing the calendar
+     * protocol.
+     * @param {TimeZoneProtocol | string} [tzLike] -
+     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
+     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
+     * object implementing the time zone protocol. If omitted, the environment's
+     * current time zone will be used.
+     */
+    export function zonedDateTimeISO(tzLike?: TimeZoneProtocol | string): Temporal.DateTime;
+
+    /**
+     * Get the current calendar date and clock time in a specific calendar and
+     * time zone.
+     *
      * The calendar is required. When using the ISO 8601 calendar or if you
      * don't understand the need for or implications of a calendar, then a more
      * ergonomic alternative to this method is `Temporal.now.zonedDateTimeISO`.

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1446,7 +1446,7 @@ export namespace Temporal {
      * object implementing the time zone protocol. If omitted, the environment's
      * current time zone will be used.
      */
-    export function zonedDateTimeISO(tzLike?: TimeZoneProtocol | string): Temporal.DateTime;
+    export function zonedDateTimeISO(tzLike?: TimeZoneProtocol | string): Temporal.ZonedDateTime;
 
     /**
      * Get the current calendar date and clock time in a specific calendar and

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -9,7 +9,9 @@ export const now = {
   plainDate,
   plainDateISO,
   plainTimeISO,
-  timeZone
+  timeZone,
+  zonedDateTime,
+  zonedDateTimeISO
 };
 
 function instant() {
@@ -27,6 +29,18 @@ function plainDateTimeISO(temporalTimeZoneLike = timeZone()) {
   const calendar = GetISO8601Calendar();
   const inst = instant();
   return ES.GetTemporalDateTimeFor(timeZone, inst, calendar);
+}
+function zonedDateTime(calendarLike, temporalTimeZoneLike = timeZone()) {
+  const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+  const calendar = ES.ToTemporalCalendar(calendarLike);
+  const ZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
+  return new ZonedDateTime(ES.SystemUTCEpochNanoSeconds(), timeZone, calendar);
+}
+function zonedDateTimeISO(temporalTimeZoneLike = timeZone()) {
+  const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
+  const calendar = GetISO8601Calendar();
+  const ZonedDateTime = GetIntrinsic('%Temporal.ZonedDateTime%');
+  return new ZonedDateTime(ES.SystemUTCEpochNanoSeconds(), timeZone, calendar);
 }
 function plainDate(calendarLike, temporalTimeZoneLike = timeZone()) {
   return ES.TemporalDateTimeToDate(plainDateTime(calendarLike, temporalTimeZoneLike));

--- a/polyfill/test/now.mjs
+++ b/polyfill/test/now.mjs
@@ -19,7 +19,7 @@ import * as Temporal from 'proposal-temporal';
 describe('Temporal.now', () => {
   describe('Structure', () => {
     it('Temporal.now is an object', () => equal(typeof Temporal.now, 'object'));
-    it('Temporal.now has 7 properties', () => equal(Object.keys(Temporal.now).length, 7));
+    it('Temporal.now has 9 properties', () => equal(Object.keys(Temporal.now).length, 9));
     it('Temporal.now.instant is a function', () => equal(typeof Temporal.now.instant, 'function'));
     it('Temporal.now.plainDateTime is a function', () => equal(typeof Temporal.now.plainDateTime, 'function'));
     it('Temporal.now.plainDateTimeISO is a function', () => equal(typeof Temporal.now.plainDateTimeISO, 'function'));
@@ -27,6 +27,8 @@ describe('Temporal.now', () => {
     it('Temporal.now.plainDateISO is a function', () => equal(typeof Temporal.now.plainDateISO, 'function'));
     it('Temporal.now.plainTimeISO is a function', () => equal(typeof Temporal.now.plainTimeISO, 'function'));
     it('Temporal.now.timeZone is a function', () => equal(typeof Temporal.now.timeZone, 'function'));
+    it('Temporal.now.zonedDateTimeISO is a function', () => equal(typeof Temporal.now.zonedDateTimeISO, 'function'));
+    it('Temporal.now.zonedDateTime is a function', () => equal(typeof Temporal.now.zonedDateTime, 'function'));
   });
   describe('Temporal.now.instant()', () => {
     it('Temporal.now.instant() returns an Instant', () => assert(Temporal.now.instant() instanceof Temporal.Instant));
@@ -45,6 +47,45 @@ describe('Temporal.now', () => {
       equal(dt.calendar.id, 'gregory');
     });
     it('requires a calendar', () => throws(() => Temporal.now.plainDateTime(), RangeError));
+  });
+  describe('Temporal.now.zonedDateTimeISO()', () => {
+    it('returns a ZonedDateTime in the correct calendar and system time zone', () => {
+      const zdt = Temporal.now.zonedDateTimeISO();
+      const tz = Temporal.now.timeZone();
+      assert(zdt instanceof Temporal.ZonedDateTime);
+      assert(zdt.calendar instanceof Temporal.Calendar);
+      equal(zdt.calendar.id, 'iso8601');
+      assert(zdt.timeZone instanceof Temporal.TimeZone);
+      equal(zdt.timeZone.id, tz.id);
+    });
+    it('returns a ZonedDateTime in the correct calendar and specific time zone', () => {
+      const zdt = Temporal.now.zonedDateTimeISO('America/Los_Angeles');
+      assert(zdt instanceof Temporal.ZonedDateTime);
+      assert(zdt.calendar instanceof Temporal.Calendar);
+      equal(zdt.calendar.id, 'iso8601');
+      assert(zdt.timeZone instanceof Temporal.TimeZone);
+      equal(zdt.timeZone.id, 'America/Los_Angeles');
+    });
+  });
+  describe('Temporal.now.zonedDateTime()', () => {
+    it('returns a ZonedDateTime in the correct calendar and system time zone', () => {
+      const zdt = Temporal.now.zonedDateTime('gregory');
+      const tz = Temporal.now.timeZone();
+      assert(zdt instanceof Temporal.ZonedDateTime);
+      assert(zdt.calendar instanceof Temporal.Calendar);
+      equal(zdt.calendar.id, 'gregory');
+      assert(zdt.timeZone instanceof Temporal.TimeZone);
+      equal(zdt.timeZone.id, tz.id);
+    });
+    it('returns a ZonedDateTime in the correct calendar and specific time zone', () => {
+      const zdt = Temporal.now.zonedDateTime('gregory', 'America/Los_Angeles');
+      assert(zdt instanceof Temporal.ZonedDateTime);
+      assert(zdt.calendar instanceof Temporal.Calendar);
+      equal(zdt.calendar.id, 'gregory');
+      assert(zdt.timeZone instanceof Temporal.TimeZone);
+      equal(zdt.timeZone.id, 'America/Los_Angeles');
+    });
+    it('requires a calendar', () => throws(() => Temporal.now.zonedDateTime(), RangeError));
   });
   describe('Temporal.now.plainDateISO()', () => {
     it('returns a Date in the ISO calendar', () => {

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -186,18 +186,26 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-systeminstant" aoid="SystemInstant">
-      <h1>SystemInstant ( )</h1>
+    <emu-clause id="sec-temporal-systemutcepochnanoseconds" aoid="SystemUTCEpochNanoseconds">
+      <h1>SystemUTCEpochNanoseconds ( )</h1>
       <emu-alg>
         1. Let _ns_ be the approximate current UTC date and time, in nanoseconds since the epoch.
         1. Assert: ! ValidateInstant(_ns_) is *true*.
-        1. Return ? CreateTemporalInstant(_ns_).
+        1. Return _ns_.
       </emu-alg>
       <emu-note>
         <p>The precision of the result depends on the host. In particular, web browsers artificially
         limit it to prevent abuse of security flaws (e.g., Spectre) and to avoid certain methods of
         fingerprinting.</p>
       </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-systeminstant" aoid="SystemInstant">
+      <h1>SystemInstant ( )</h1>
+      <emu-alg>
+        1. Let _ns_ be ? SystemUTCEpochNanoseconds().
+        1. Return ? CreateTemporalInstant(_ns_).
+      </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal-systemdatetime" aoid="SystemDateTime">
@@ -227,8 +235,7 @@
           1. Let _calendar_ be ? GetISO8601Calendar().
         1. Else,
           1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
-        1. Let _ns_ be the approximate current UTC date and time, in nanoseconds since the epoch.
-        1. Assert: ! ValidateInstant(_ns_) is *true*.
+        1. Let _ns_ be ? SystemUTCEpochNanoseconds().
         1. Return ? CreateTemporalZonedDateTime(_ns_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -116,6 +116,28 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.now.zoneddatetime">
+      <h1>Temporal.now.zonedDateTime ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
+      <p>
+        The `zonedDateTime` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_, _calendar_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.now.zoneddatetimeiso">
+      <h1>Temporal.now.zonedDateTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
+      <p>
+        The `zonedDateTimeISO` method takes one argument _temporalTimeZoneLike_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.now.plaindate">
       <h1>Temporal.now.plainDate ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
@@ -191,6 +213,23 @@
           1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
         1. Let _instant_ be ? SystemInstant().
         1. Return ? GetTemporalDateTimeFor(_timeZone_, _instant_, _calendar_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-systemzoneddatetime" aoid="SystemZonedDateTime">
+      <h1>SystemZonedDateTime ( [ _temporalTimeZoneLike_ [ , _calendarLike_ ] ] )</h1>
+      <emu-alg>
+        1. If _temporalTimeZoneLike_ is *undefined*, then
+          1. Let _timeZone_ be ? SystemTimeZone().
+        1. Else,
+          1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
+        1. If _calendarLike_ is *undefined*, then
+          1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Else,
+          1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
+        1. Let _ns_ be the approximate current UTC date and time, in nanoseconds since the epoch.
+        1. Assert: ! ValidateInstant(_ns_) is *true*.
+        1. Return ? CreateTemporalZonedDateTime(_ns_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1296,6 +1296,5 @@
         1. Return ! AddInstant(_intermediateInstant_.[[Nanoseconds]], _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
       </emu-alg>
     </emu-clause>
-
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
These two `now` methods hadn't been added yet. Docs are already live. This commit includes polyfill implementation and tests. Spec updates will still be needed, and I'll file a new issue for that.