### PR TITLE
Mop up missing Temporal.now renames to plainXxx

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ A cookbook to help you get started and learn the ins and outs of Temporal is ava
 - `Temporal.now.zonedDateTimeISO()` - get the current date and wall-clock time in the system time zone and ISO-8601 calendar
 - `Temporal.now.plainDate(calendar)` - get the current date in the system time zone and specified calendar
 - `Temporal.now.plainDateISO()` - get the current date in the system time zone and ISO-8601 calendar
-- `Temporal.now.time(calendar)` - get the current wall-clock time in the system time zone and specified calendar
+- `Temporal.now.plainTime(calendar)` - get the current wall-clock time in the system time zone and specified calendar
 - `Temporal.now.plainTimeISO()` - get the current wall-clock time in the system time zone and ISO-8601 calendar
 - `Temporal.now.plainDateTime(calendar)` - get the current system date/time in the system time zone, but return an object that doesn't remember its time zone so should NOT be used to derive other values (e.g. 12 hours later) in time zones that use Daylight Saving Time (DST).
 - `Temporal.now.plainDateTimeISO()` - same as above, but return the DateTime in the ISO-8601 calendar

--- a/docs/now.md
+++ b/docs/now.md
@@ -104,7 +104,7 @@ nextTransition.toPlainDateTime(tz);
 // On 2020-03-08T03:00 the clock will change from UTC -08:00 to -07:00
 ```
 
-### Temporal.now.**dateTimeISO**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.DateTime
+### Temporal.now.**plainDateTimeISO**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.DateTime
 
 **Parameters:**
 
@@ -139,7 +139,7 @@ Object.entries(financialCentres).forEach(([name, timeZone]) => {
 ```
 <!-- prettier-ignore-end -->
 
-### Temporal.now.**dateTime**(_calendar_: object | string, _timeZone_: object | string = Temporal.now.timeZone()) : Temporal.DateTime
+### Temporal.now.**plainDateTime**(_calendar_: object | string, _timeZone_: object | string = Temporal.now.timeZone()) : Temporal.DateTime
 
 **Parameters:**
 
@@ -154,7 +154,7 @@ Optionally a time zone can be given in which the time is computed, instead of th
 
 If you only want to use the ISO 8601 calendar, use `Temporal.now.plainDateTimeISO()`.
 
-### Temporal.now.**dateISO**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Date
+### Temporal.now.**plainDateISO**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Date
 
 **Parameters:**
 
@@ -176,7 +176,7 @@ date = Temporal.now.plainDateISO();
 if (date.month === 1 && date.day === 1) console.log('New year!');
 ```
 
-### Temporal.now.**date**(_calendar_: object | string, _timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Date
+### Temporal.now.**plainDate**(_calendar_: object | string, _timeZone_: object | string = Temporal.now.timeZone()) : Temporal.Date
 
 **Parameters:**
 

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -97,7 +97,7 @@
     <emu-clause id="sec-temporal.now.plaindatetime">
       <h1>Temporal.now.plainDateTime ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `dateTime` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
+        The `plainDateTime` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
         The following steps are taken:
       </p>
       <emu-alg>
@@ -108,7 +108,7 @@
     <emu-clause id="sec-temporal.now.plaindatetimeiso">
       <h1>Temporal.now.plainDateTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `dateTimeISO` method takes one argument _temporalTimeZoneLike_.
+        The `plainDateTimeISO` method takes one argument _temporalTimeZoneLike_.
         The following steps are taken:
       </p>
       <emu-alg>
@@ -119,7 +119,7 @@
     <emu-clause id="sec-temporal.now.plaindate">
       <h1>Temporal.now.plainDate ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `date` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
+        The `plainDate` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
         The following steps are taken:
       </p>
       <emu-alg>
@@ -131,7 +131,7 @@
     <emu-clause id="sec-temporal.now.plaindateiso">
       <h1>Temporal.now.plainDateISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `dateISO` method takes one argument _temporalTimeZoneLike_.
+        The `plainDateISO` method takes one argument _temporalTimeZoneLike_.
         The following steps are taken:
       </p>
       <emu-alg>


### PR DESCRIPTION
While building another PR, I noticed that some of the Temporal.now methods hadn't been renamed in #1120 in in a few places in the spec and docs. (polyfill code looks OK). This PR mops up those missing renames. 

Also, there's a `now.time()` method that's listed in the docs home page but isn't mentioned or implemented elsewhere in Temporal, including in the drilldown docs for `now`. This PR renames this method to `plainTime` in the docs home page, and I opened #1133 for the missing implementation.