### PR TITLE
Rename toString option `calendar`=>`calendarName`

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -561,7 +561,7 @@ date.equals(date); // => true
 
 - `options` (optional object): An object with properties influencing the formatting.
   The following options are recognized:
-  - `calendar` (string): Whether to show the calendar annotation in the return value.
+  - `calendarName` (string): Whether to show the calendar annotation in the return value.
     Valid values are `'auto'`, `'always'`, and `'never'`.
     The default is `'auto'`.
 
@@ -571,7 +571,7 @@ This method overrides the `Object.prototype.toString()` method and provides a co
 The string can be passed to `Temporal.PlainDate.from()` to create a new `Temporal.PlainDate` object.
 
 Normally, a calendar annotation is shown when `date`'s calendar is not the ISO 8601 calendar.
-By setting the `calendar` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
 For more information on the calendar annotation, see [ISO string extensions](./iso-string-ext.md#calendar-systems).
 
 Example usage:

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -701,7 +701,7 @@ dt1.equals(dt1); // => true
 
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
-  - `calendar` (string): Whether to show the calendar annotation in the return value.
+  - `calendarName` (string): Whether to show the calendar annotation in the return value.
     Valid values are `'auto'`, `'always'`, and `'never'`.
     The default is `'auto'`.
   - `fractionalSecondDigits` (number or string): How many digits to print after the decimal point in the output string.
@@ -726,7 +726,7 @@ The value is truncated to fit the requested precision, unless a different roundi
 Note that rounding may change the value of other units as well.
 
 Normally, a calendar annotation is shown when `datetime`'s calendar is not the ISO 8601 calendar.
-By setting the `calendar` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
 For more information on the calendar annotation, see [ISO string extensions](./iso-string-ext.md#calendar-systems).
 
 Example usage:

--- a/docs/monthday.md
+++ b/docs/monthday.md
@@ -196,7 +196,7 @@ dt1.equals(dt1); // => true
 
 - `options` (optional object): An object with properties influencing the formatting.
   The following options are recognized:
-  - `calendar` (string): Whether to show the calendar annotation in the return value.
+  - `calendarName` (string): Whether to show the calendar annotation in the return value.
     Valid values are `'auto'`, `'always'`, and `'never'`.
     The default is `'auto'`.
 
@@ -206,7 +206,7 @@ This method overrides the `Object.prototype.toString()` method and provides a co
 The string can be passed to `Temporal.PlainMonthDay.from()` to create a new `Temporal.PlainMonthDay` object.
 
 Normally, a calendar annotation is shown when `monthDay`'s calendar is not the ISO 8601 calendar.
-By setting the `calendar` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
 For more information on the calendar annotation, see [ISO string extensions](./iso-string-ext.md#calendar-systems).
 
 Example usage:

--- a/docs/time.md
+++ b/docs/time.md
@@ -463,7 +463,7 @@ time.equals(time); // => true
 
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
-  - `calendar` (string): Whether to show the calendar annotation in the return value.
+  - `calendarName` (string): Whether to show the calendar annotation in the return value.
     Valid values are `'auto'`, `'always'`, and `'never'`.
     The default is `'auto'`.
   - `fractionalSecondDigits` (number or string): How many digits to print after the decimal point in the output string.
@@ -488,7 +488,7 @@ The value is truncated to fit the requested precision, unless a different roundi
 Note that rounding may change the value of other units as well.
 
 Normally, a calendar annotation is shown when `time`'s calendar is not the ISO 8601 calendar.
-By setting the `calendar` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
 For more information on the calendar annotation, see [ISO string extensions](./iso-string-ext.md#calendar-systems).
 
 Example usage:

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -457,7 +457,7 @@ ym.equals(ym); // => true
 
 - `options` (optional object): An object with properties influencing the formatting.
   The following options are recognized:
-  - `calendar` (string): Whether to show the calendar annotation in the return value.
+  - `calendarName` (string): Whether to show the calendar annotation in the return value.
     Valid values are `'auto'`, `'always'`, and `'never'`.
     The default is `'auto'`.
 
@@ -467,7 +467,7 @@ This method overrides the `Object.prototype.toString()` method and provides a co
 The string can be passed to `Temporal.PlainYearMonth.from()` to create a new `Temporal.PlainYearMonth` object.
 
 Normally, a calendar annotation is shown when `yearMonth`'s calendar is not the ISO 8601 calendar.
-By setting the `calendar` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
 For more information on the calendar annotation, see [ISO string extensions](./iso-string-ext.md#calendar-systems).
 
 Example usage:

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1071,7 +1071,7 @@ zdt1.equals(zdt1); // => true
   - `timeZoneName` (string): Whether to show the time zone name annotation in the return value.
     Valid values are `'auto'` and `'never'`.
     The default is `'auto'`.
-  - `calendar` (string): Whether to show the calendar annotation in the return value.
+  - `calendarName` (string): Whether to show the calendar annotation in the return value.
     Valid values are `'auto'`, `'always'`, and `'never'`.
     The default is `'auto'`.
   - `fractionalSecondDigits` (number or string): How many digits to print after the decimal point in the output string.
@@ -1102,7 +1102,7 @@ The value is truncated to fit the requested precision, unless a different roundi
 Note that rounding may change the value of other units as well.
 
 Normally, a calendar annotation is shown when `zonedDateTime`'s calendar is not the ISO 8601 calendar.
-By setting the `calendar` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
 For more information on the calendar annotation, see [ISO string extensions](./iso-string-ext.md#calendar-systems).
 
 Likewise, passing `'never'` to the `timeZoneName` or `offset` options controls whether the time zone offset (`+01:00`) or name annotation (`[Europe/Paris]`) are shown.

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -479,7 +479,7 @@ export const ES = ObjectAssign({}, ES2020, {
     return ES.GetOption(options, 'offset', ['prefer', 'use', 'ignore', 'reject'], fallback);
   },
   ToShowCalendarOption: (options) => {
-    return ES.GetOption(options, 'calendar', ['auto', 'always', 'never'], 'auto');
+    return ES.GetOption(options, 'calendarName', ['auto', 'always', 'never'], 'auto');
   },
   ToShowTimeZoneNameOption: (options) => {
     return ES.GetOption(options, 'timeZoneName', ['auto', 'never'], 'auto');

--- a/polyfill/test/plaindate.mjs
+++ b/polyfill/test/plaindate.mjs
@@ -855,23 +855,23 @@ describe('Date', () => {
       equal(new PlainDate(1914, 2, 23).toString(), '1914-02-23');
     });
     const d = new PlainDate(1976, 11, 18);
-    it('shows only non-ISO calendar if calendar = auto', () => {
-      equal(d.toString({ calendar: 'auto' }), '1976-11-18');
-      equal(d.withCalendar('gregory').toString({ calendar: 'auto' }), '1976-11-18[c=gregory]');
+    it('shows only non-ISO calendar if calendarName = auto', () => {
+      equal(d.toString({ calendarName: 'auto' }), '1976-11-18');
+      equal(d.withCalendar('gregory').toString({ calendarName: 'auto' }), '1976-11-18[c=gregory]');
     });
-    it('shows ISO calendar if calendar = always', () => {
-      equal(d.toString({ calendar: 'always' }), '1976-11-18[c=iso8601]');
+    it('shows ISO calendar if calendarName = always', () => {
+      equal(d.toString({ calendarName: 'always' }), '1976-11-18[c=iso8601]');
     });
-    it('omits non-ISO calendar if calendar = never', () => {
-      equal(d.withCalendar('gregory').toString({ calendar: 'never' }), '1976-11-18');
+    it('omits non-ISO calendar if calendarName = never', () => {
+      equal(d.withCalendar('gregory').toString({ calendarName: 'never' }), '1976-11-18');
     });
     it('default is calendar = auto', () => {
       equal(d.toString(), '1976-11-18');
       equal(d.withCalendar('gregory').toString(), '1976-11-18[c=gregory]');
     });
     it('throws on invalid calendar', () => {
-      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendar) => {
-        throws(() => d.toString({ calendar }), RangeError);
+      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {
+        throws(() => d.toString({ calendarName }), RangeError);
       });
     });
   });

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -1641,23 +1641,23 @@ describe('DateTime', () => {
       equal(dt2.toString(), '1976-11-18T15:23:30');
       equal(dt3.toString(), '1976-11-18T15:23:30.1234');
     });
-    it('shows only non-ISO calendar if calendar = auto', () => {
-      equal(dt1.toString({ calendar: 'auto' }), '1976-11-18T15:23:00');
-      equal(dt1.withCalendar('gregory').toString({ calendar: 'auto' }), '1976-11-18T15:23:00[c=gregory]');
+    it('shows only non-ISO calendar if calendarName = auto', () => {
+      equal(dt1.toString({ calendarName: 'auto' }), '1976-11-18T15:23:00');
+      equal(dt1.withCalendar('gregory').toString({ calendarName: 'auto' }), '1976-11-18T15:23:00[c=gregory]');
     });
-    it('shows ISO calendar if calendar = always', () => {
-      equal(dt1.toString({ calendar: 'always' }), '1976-11-18T15:23:00[c=iso8601]');
+    it('shows ISO calendar if calendarName = always', () => {
+      equal(dt1.toString({ calendarName: 'always' }), '1976-11-18T15:23:00[c=iso8601]');
     });
-    it('omits non-ISO calendar if calendar = never', () => {
-      equal(dt1.withCalendar('gregory').toString({ calendar: 'never' }), '1976-11-18T15:23:00');
+    it('omits non-ISO calendar if calendarName = never', () => {
+      equal(dt1.withCalendar('gregory').toString({ calendarName: 'never' }), '1976-11-18T15:23:00');
     });
     it('default is calendar = auto', () => {
       equal(dt1.toString(), '1976-11-18T15:23:00');
       equal(dt1.withCalendar('gregory').toString(), '1976-11-18T15:23:00[c=gregory]');
     });
     it('throws on invalid calendar', () => {
-      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendar) => {
-        throws(() => dt1.toString({ calendar }), RangeError);
+      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {
+        throws(() => dt1.toString({ calendarName }), RangeError);
       });
     });
     it('truncates to minute', () => {

--- a/polyfill/test/plainmonthday.mjs
+++ b/polyfill/test/plainmonthday.mjs
@@ -216,24 +216,24 @@ describe('MonthDay', () => {
   describe('MonthDay.toString()', () => {
     const md1 = PlainMonthDay.from('11-18');
     const md2 = PlainMonthDay.from({ month: 11, day: 18, calendar: 'gregory' });
-    it('shows only non-ISO calendar if calendar = auto', () => {
-      equal(md1.toString({ calendar: 'auto' }), '11-18');
-      equal(md2.toString({ calendar: 'auto' }), '1972-11-18[c=gregory]');
+    it('shows only non-ISO calendar if calendarName = auto', () => {
+      equal(md1.toString({ calendarName: 'auto' }), '11-18');
+      equal(md2.toString({ calendarName: 'auto' }), '1972-11-18[c=gregory]');
     });
-    it('shows ISO calendar if calendar = always', () => {
-      equal(md1.toString({ calendar: 'always' }), '11-18[c=iso8601]');
+    it('shows ISO calendar if calendarName = always', () => {
+      equal(md1.toString({ calendarName: 'always' }), '11-18[c=iso8601]');
     });
-    it('omits non-ISO calendar, but not year, if calendar = never', () => {
-      equal(md1.toString({ calendar: 'never' }), '11-18');
-      equal(md2.toString({ calendar: 'never' }), '1972-11-18');
+    it('omits non-ISO calendar, but not year, if calendarName = never', () => {
+      equal(md1.toString({ calendarName: 'never' }), '11-18');
+      equal(md2.toString({ calendarName: 'never' }), '1972-11-18');
     });
     it('default is calendar = auto', () => {
       equal(md1.toString(), '11-18');
       equal(md2.toString(), '1972-11-18[c=gregory]');
     });
     it('throws on invalid calendar', () => {
-      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendar) => {
-        throws(() => md1.toString({ calendar }), RangeError);
+      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {
+        throws(() => md1.toString({ calendarName }), RangeError);
       });
     });
   });

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -1084,23 +1084,23 @@ describe('Time', () => {
       equal(t3.toString(), '15:23:30.1234');
     });
     const t3g = new PlainTime(15, 23, 30, 123, 400, 0, 'gregory');
-    it('shows only non-ISO calendar if calendar = auto', () => {
-      equal(t3.toString({ calendar: 'auto' }), '15:23:30.1234');
-      equal(t3g.toString({ calendar: 'auto' }), '15:23:30.1234[c=gregory]');
+    it('shows only non-ISO calendar if calendarName = auto', () => {
+      equal(t3.toString({ calendarName: 'auto' }), '15:23:30.1234');
+      equal(t3g.toString({ calendarName: 'auto' }), '15:23:30.1234[c=gregory]');
     });
-    it('shows ISO calendar if calendar = always', () => {
-      equal(t3.toString({ calendar: 'always' }), '15:23:30.1234[c=iso8601]');
+    it('shows ISO calendar if calendarName = always', () => {
+      equal(t3.toString({ calendarName: 'always' }), '15:23:30.1234[c=iso8601]');
     });
-    it('omits non-ISO calendar if calendar = never', () => {
-      equal(t3g.toString({ calendar: 'never' }), '15:23:30.1234');
+    it('omits non-ISO calendar if calendarName = never', () => {
+      equal(t3g.toString({ calendarName: 'never' }), '15:23:30.1234');
     });
     it('default is calendar = auto', () => {
       equal(t3.toString(), '15:23:30.1234');
       equal(t3g.toString(), '15:23:30.1234[c=gregory]');
     });
     it('throws on invalid calendar', () => {
-      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendar) => {
-        throws(() => t3.toString({ calendar }), RangeError);
+      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {
+        throws(() => t3.toString({ calendarName }), RangeError);
       });
     });
     it('truncates to minute', () => {

--- a/polyfill/test/plainyearmonth.mjs
+++ b/polyfill/test/plainyearmonth.mjs
@@ -703,24 +703,24 @@ describe('YearMonth', () => {
   describe('YearMonth.toString()', () => {
     const ym1 = PlainYearMonth.from('1976-11');
     const ym2 = PlainYearMonth.from({ year: 1976, month: 11, calendar: 'gregory' });
-    it('shows only non-ISO calendar if calendar = auto', () => {
-      equal(ym1.toString({ calendar: 'auto' }), '1976-11');
-      equal(ym2.toString({ calendar: 'auto' }), '1976-11-01[c=gregory]');
+    it('shows only non-ISO calendar if calendarName = auto', () => {
+      equal(ym1.toString({ calendarName: 'auto' }), '1976-11');
+      equal(ym2.toString({ calendarName: 'auto' }), '1976-11-01[c=gregory]');
     });
-    it('shows ISO calendar if calendar = always', () => {
-      equal(ym1.toString({ calendar: 'always' }), '1976-11[c=iso8601]');
+    it('shows ISO calendar if calendarName = always', () => {
+      equal(ym1.toString({ calendarName: 'always' }), '1976-11[c=iso8601]');
     });
-    it('omits non-ISO calendar, but not day, if calendar = never', () => {
-      equal(ym1.toString({ calendar: 'never' }), '1976-11');
-      equal(ym2.toString({ calendar: 'never' }), '1976-11-01');
+    it('omits non-ISO calendar, but not day, if calendarName = never', () => {
+      equal(ym1.toString({ calendarName: 'never' }), '1976-11');
+      equal(ym2.toString({ calendarName: 'never' }), '1976-11-01');
     });
     it('default is calendar = auto', () => {
       equal(ym1.toString(), '1976-11');
       equal(ym2.toString(), '1976-11-01[c=gregory]');
     });
     it('throws on invalid calendar', () => {
-      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendar) => {
-        throws(() => ym1.toString({ calendar }), RangeError);
+      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {
+        throws(() => ym1.toString({ calendarName }), RangeError);
       });
     });
   });

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -905,7 +905,7 @@ describe('ZonedDateTime', () => {
     it('throws if given a Temporal object with a time zone', () => {
       throws(() => zdt.with(dstStartDay), TypeError);
     });
-    it('throws if calendar is included', () => {
+    it('throws if calendarName is included', () => {
       throws(() => zdt.with({ month: 2, calendar: 'japanese' }), TypeError);
     });
     it('throws if given a Temporal object with a calendar', () => {
@@ -1311,7 +1311,7 @@ describe('ZonedDateTime', () => {
       throws(() => zdt.equals({ year: 1969, month: 12, timeZone: 'America/New_York' }), TypeError);
       throws(() => zdt.equals({ year: 1969, month: 12, day: 31 }), TypeError);
       throws(
-        () => zdt.equals({ years: 1969, months: 12, days: 31, timeZone: 'America/New_York', calendar: 'gregory' }),
+        () => zdt.equals({ years: 1969, months: 12, days: 31, timeZone: 'America/New_York', calendarName: 'gregory' }),
         TypeError
       );
     });
@@ -1325,26 +1325,29 @@ describe('ZonedDateTime', () => {
       equal(zdt2.toString(), '1976-11-18T15:23:30+01:00[Europe/Vienna]');
       equal(zdt3.toString(), '1976-11-18T15:23:30.1234+01:00[Europe/Vienna]');
     });
-    it('shows only non-ISO calendar if calendar = auto', () => {
-      equal(zdt1.toString({ calendar: 'auto' }), '1976-11-18T15:23:00+01:00[Europe/Vienna]');
+    it('shows only non-ISO calendar if calendarName = auto', () => {
+      equal(zdt1.toString({ calendarName: 'auto' }), '1976-11-18T15:23:00+01:00[Europe/Vienna]');
       equal(
-        zdt1.withCalendar('gregory').toString({ calendar: 'auto' }),
+        zdt1.withCalendar('gregory').toString({ calendarName: 'auto' }),
         '1976-11-18T15:23:00+01:00[Europe/Vienna][c=gregory]'
       );
     });
-    it('shows ISO calendar if calendar = always', () => {
-      equal(zdt1.toString({ calendar: 'always' }), '1976-11-18T15:23:00+01:00[Europe/Vienna][c=iso8601]');
+    it('shows ISO calendar if calendarName = always', () => {
+      equal(zdt1.toString({ calendarName: 'always' }), '1976-11-18T15:23:00+01:00[Europe/Vienna][c=iso8601]');
     });
-    it('omits non-ISO calendar if calendar = never', () => {
-      equal(zdt1.withCalendar('gregory').toString({ calendar: 'never' }), '1976-11-18T15:23:00+01:00[Europe/Vienna]');
+    it('omits non-ISO calendar if calendarName = never', () => {
+      equal(
+        zdt1.withCalendar('gregory').toString({ calendarName: 'never' }),
+        '1976-11-18T15:23:00+01:00[Europe/Vienna]'
+      );
     });
     it('default is calendar = auto', () => {
       equal(zdt1.toString(), '1976-11-18T15:23:00+01:00[Europe/Vienna]');
       equal(zdt1.withCalendar('gregory').toString(), '1976-11-18T15:23:00+01:00[Europe/Vienna][c=gregory]');
     });
     it('throws on invalid calendar', () => {
-      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendar) => {
-        throws(() => zdt1.toString({ calendar }), RangeError);
+      ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {
+        throws(() => zdt1.toString({ calendarName }), RangeError);
       });
     });
     it('shows time zone if timeZoneName = auto', () => {
@@ -1361,10 +1364,10 @@ describe('ZonedDateTime', () => {
     });
     it('combinations of calendar, time zone, and offset', () => {
       const zdt = zdt1.withCalendar('gregory');
-      equal(zdt.toString({ timeZoneName: 'never', calendar: 'never' }), '1976-11-18T15:23:00+01:00');
-      equal(zdt.toString({ offset: 'never', calendar: 'never' }), '1976-11-18T15:23:00[Europe/Vienna]');
+      equal(zdt.toString({ timeZoneName: 'never', calendarName: 'never' }), '1976-11-18T15:23:00+01:00');
+      equal(zdt.toString({ offset: 'never', calendarName: 'never' }), '1976-11-18T15:23:00[Europe/Vienna]');
       equal(zdt.toString({ offset: 'never', timeZoneName: 'never' }), '1976-11-18T15:23:00[c=gregory]');
-      equal(zdt.toString({ offset: 'never', timeZoneName: 'never', calendar: 'never' }), '1976-11-18T15:23:00');
+      equal(zdt.toString({ offset: 'never', timeZoneName: 'never', calendarName: 'never' }), '1976-11-18T15:23:00');
     });
     it('truncates to minute', () => {
       [zdt1, zdt2, zdt3].forEach((zdt) =>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -176,14 +176,13 @@
   <emu-clause id="sec-temporal-toshowcalendaroption" aoid="ToShowCalendarOption">
     <h1>ToShowCalendarOption ( _normalizedOptions_ )</h1>
     <p>
-      The abstract operation ToShowCalendarOption extracts the value of the property named *"calendar"* from _normalizedOptions_ and makes sure it is a valid value for the option.
+      The abstract operation ToShowCalendarOption extracts the value of the property named *"calendarName"* from _normalizedOptions_ and makes sure it is a valid value for the option.
     </p>
     <emu-note>
-      This property is used in `toString` methods in Temporal.
-      It is different from the `calendar` property passed to `from` methods.
+      This property is used in `toString` methods in Temporal to control whether a calendar annotation should be output.
     </emu-note>
     <emu-alg>
-      1. Return ? GetOption(_normalizedOptions_, *"calendar"*, *"string"*, « *"auto"*, *"always"*, *"never"* », *"auto"*).
+      1. Return ? GetOption(_normalizedOptions_, *"calendarName"*, *"string"*, « *"auto"*, *"always"*, *"never"* », *"auto"*).
     </emu-alg>
   </emu-clause>
 


### PR DESCRIPTION
This PR renames the `toString()` option property `calendar` to `calendarName`, to better match the recent rename of `timeZone` to `timeZoneName` in the same context. 