### PR TITLE
Fix spec lint issues

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13,14 +13,14 @@ contributors: Maggie Pint, Matt Johnson, Brian Terlson, Daniel Ehrenberg, Philip
 </emu-intro>
 
 <emu-import href="spec/temporal.html"></emu-import>
-<emu-import href="spec/date.html"></emu-import>
-<emu-import href="spec/time.html"></emu-import>
-<emu-import href="spec/datetime.html"></emu-import>
+<emu-import href="spec/plaindate.html"></emu-import>
+<emu-import href="spec/plaintime.html"></emu-import>
+<emu-import href="spec/plaindatetime.html"></emu-import>
 <emu-import href="spec/zoneddatetime.html"></emu-import>
 <emu-import href="spec/duration.html"></emu-import>
 <emu-import href="spec/instant.html"></emu-import>
-<emu-import href="spec/yearmonth.html"></emu-import>
-<emu-import href="spec/monthday.html"></emu-import>
+<emu-import href="spec/plainyearmonth.html"></emu-import>
+<emu-import href="spec/plainmonthday.html"></emu-import>
 <emu-import href="spec/timezone.html"></emu-import>
 <emu-import href="spec/calendar.html"></emu-import>
 <emu-import href="spec/isocalendar.html"></emu-import>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -534,11 +534,9 @@
         1. If Type(_item_) is Object, then
           1. Let _timeZoneLike_ be ? Get(_item_, *"timeZone"*).
           1. If _timeZoneLike_ is *undefined*, then
-            <!-- Treat _item_ itself as a TimeZone -->
             1. Let _timeZone_ be ? ToTemporalTimeZone(_item_).
             1. Let _temporalTime_ be *undefined*.
           1. Else,
-            <!-- Treat _item_ as a property bag -->
             1. Let _timeZone_ be ? ToTemporalTimeZone(_timeZoneLike_).
             1. Let _temporalTime_ be ? Get(_item_, *"time"*).
         1. Else,


### PR DESCRIPTION
These problems were preventing builds from completing, which in turn prevented the Temporal website from updating.

The long-term solution is to ensure that ecmarkup must pass for a PR to merge. In the meantime, here's a PR to get builds working again. 