### PR TITLE
polyfill: allow and ignore timezone in from

### DIFF
--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -19,7 +19,7 @@ export const instant = new RegExp(
   'i'
 );
 export const datetime = new RegExp(
-  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source}(?:${zonesplit.source})?)?(?:${calendar.source})?$`,
+  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?(?:${zonesplit.source})?(?:${calendar.source})?$`,
   'i'
 );
 

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -15,7 +15,7 @@ const zonesplit = new RegExp(`(?:([zZ])|(?:${offset.source})?)(?:\\[(${timeZoneI
 const calendar = new RegExp(`\\[c=(${calendarID.source})\\]`);
 
 export const instant = new RegExp(
-  `^${datesplit.source}(?:T|\\s+)${timesplit.source}${zonesplit.source}(?:${calendar.source})?$`,
+  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?${zonesplit.source}(?:${calendar.source})?$`,
   'i'
 );
 export const datetime = new RegExp(

--- a/polyfill/test/plaindate.mjs
+++ b/polyfill/test/plaindate.mjs
@@ -944,6 +944,8 @@ describe('Date', () => {
       equal(`${PlainDate.from('+0019761118T152330.1+0000')}`, '1976-11-18');
     });
     it('no junk at end of string', () => throws(() => PlainDate.from('1976-11-18junk'), RangeError));
+    it('ignores if a timezone is specified', () =>
+      equal(`${PlainDate.from('2020-01-01[Asia/Kolkata]')}`, '2020-01-01'));
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
         throws(() => PlainDate.from({ year: 1976, month: 11, day: 18 }, badOptions), TypeError)

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -1340,6 +1340,8 @@ describe('DateTime', () => {
     });
     it('no junk at end of string', () =>
       throws(() => PlainDateTime.from('1976-11-18T15:23:30.123456789junk'), RangeError));
+    it('ignores if a timezone is specified', () =>
+      equal(`${PlainDateTime.from('2020-01-01T01:23:45[Asia/Kolkata]')}`, '2020-01-01T01:23:45'));
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
         throws(() => PlainDateTime.from({ year: 1976, month: 11, day: 18 }, badOptions), TypeError)

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -33,6 +33,8 @@ describe('fromString regex', () => {
       test(`${dateTimeString}:30${zoneString}`, components.slice(0, 6));
       test(`${dateTimeString}:30.123456789${zoneString}`, components);
     }
+    // Without time component
+    test('2020-01-01Z', [2020, 1, 1, 0, 0, 0]);
     // Time separators
     ['T', 't', ' '].forEach((timeSep) =>
       generateTest(`1976-11-18${timeSep}15:23`, 'Z', [1976, 11, 18, 15, 23, 30, 123, 456, 789])

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -296,7 +296,7 @@ const dateSpecMonthDay = seq(['--'], dateMonth, ['-'], dateDay);
 const dateSpecYearMonth = seq(dateYear, ['-'], dateMonth);
 const date = choice(seq(dateYear, '-', dateMonth, '-', dateDay), seq(dateYear, dateMonth, dateDay));
 const time = seq(timeSpec, [timeZone]);
-const dateTime = choice(date, seq(date, dateTimeSeparator, time));
+const dateTime = seq(date, [seq(dateTimeSeparator, timeSpec)], [timeZone]);
 const calendarDateTime = seq(dateTime, [calendar]);
 
 const durationFractionalPart = withCode(between(1, 9, digit()), (data, result) => {
@@ -348,16 +348,21 @@ const duration = seq(
   choice(durationDate, durationTime)
 );
 
-const instant = seq(date, dateTimeSeparator, timeSpec, timeZoneOffsetRequired);
-const zonedDateTime = seq(date, dateTimeSeparator, timeSpec, [timeZoneNumericUTCOffset], timeZoneBracketedAnnotation, [
-  calendar
-]);
+const instant = seq(date, dateTimeSeparator, [timeSpec], timeZoneOffsetRequired);
+const zonedDateTime = seq(
+  date,
+  dateTimeSeparator,
+  [timeSpec],
+  [timeZoneNumericUTCOffset],
+  timeZoneBracketedAnnotation,
+  [calendar]
+);
 
 // goal elements
 const goals = {
   Instant: instant,
   Date: calendarDateTime,
-  DateTime: dateTime,
+  DateTime: calendarDateTime,
   Duration: duration,
   MonthDay: choice(dateSpecMonthDay, dateTime),
   Time: choice(time, dateTime),

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -394,6 +394,7 @@ describe('ZonedDateTime', () => {
         `${ZonedDateTime.from('1976-11-18T15-08:00[America/Los_Angeles]')}`,
         '1976-11-18T15:00:00-08:00[America/Los_Angeles]'
       );
+      equal(`${ZonedDateTime.from('2020-01-01[Asia/Tokyo]')}`, '2020-01-01T00:00:00+09:00[Asia/Tokyo]');
     });
     it('no junk at end of string', () =>
       throws(() => ZonedDateTime.from('1976-11-18T15:23:30.123456789-08:00[America/Los_Angeles]junk'), RangeError));

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -911,7 +911,7 @@
       CalendarDate :
           Date Calendar?
 
-      TimeSpecSeparator
+      TimeSpecSeparator :
           DateTimeSeparator TimeSpec
 
       DateTime :

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -911,9 +911,11 @@
       CalendarDate :
           Date Calendar?
 
+      TimeSpecSeparator
+          DateTimeSeparator TimeSpec
+
       DateTime :
-          Date
-          Date DateTimeSeparator Time
+          Date TimeSpecSeparator? TimeZone?
 
       CalendarDateTime:
           DateTime Calendar?
@@ -955,13 +957,13 @@
           Sign? DurationDesignator DurationTime
 
       TemporalInstantString :
-          Date DateTimeSeparator TimeSpec TimeZoneOffsetRequired
+          Date DateTimeSeparator TimeSpec? TimeZoneOffsetRequired
 
       TemporalDateString :
           CalendarDateTime
 
       TemporalDateTimeString :
-          DateTime
+          CalendarDateTime
 
       TemporalDurationString :
           Duration
@@ -987,7 +989,7 @@
           DateTime
 
       TemporalZonedDateTimeString :
-          Date DateTimeSeparator TimeSpec TimeZoneNumericUTCOffset? TimeZoneBracketedAnnotation Calendar?
+          Date DateTimeSeparator TimeSpec? TimeZoneNumericUTCOffset? TimeZoneBracketedAnnotation Calendar?
 
       TemporalCalendarString :
           CalendarName


### PR DESCRIPTION
Allows and ignores the timezone part in PlainDate.from and
PlainDateTime.from, as discussed previously.

Fixes: https://github.com/tc39/proposal-temporal/issues/1082

---

I decided to keep the spec changes out for now, because the grammars list in the spec need some serious refactoring.