### PR TITLE
Change default of until/since rounding to 'trunc'

### DIFF
--- a/docs/date.md
+++ b/docs/date.md
@@ -318,7 +318,7 @@ date = Temporal.PlainDate.from('2006-01-24');
 date.with({ day: 1 }); // => 2006-01-01
 // What's the last day of the next month?
 const nextMonthDate = date.add({ months: 1 });
-nextMonthDate.with({day: nextMonthDate.daysInMonth }); // => 2006-02-28
+nextMonthDate.with({ day: nextMonthDate.daysInMonth }); // => 2006-02-28
 ```
 
 ### date.**withCalendar**(_calendar_: object | string) : Temporal.PlainDate
@@ -435,7 +435,7 @@ date.subtract({ months: 1 }, { overflow: 'reject' }); // => throws
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the time elapsed after `date` and until `other`.
 
@@ -501,7 +501,7 @@ earlier.toPlainDateTime(noon).until(later.toPlainDateTime(noon), { largestUnit: 
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the time elapsed before `date` and since `other`.
 
@@ -660,7 +660,7 @@ If `time` is given, this method is equivalent to [`Temporal.PlainTime.from(time)
 
 If `time` is given but is not a `Temporal.PlainTime` object, then it will be converted to one as if it were passed to `Temporal.PlainTime.from()`.
 
-In the case of ambiguity caused by DST or other time zone changes, the earlier time will be used for backward transitions and  the later time for forward transitions.
+In the case of ambiguity caused by DST or other time zone changes, the earlier time will be used for backward transitions and the later time for forward transitions.
 When interoperating with existing code or services, this matches the behavior of legacy `Date` as well as libraries like moment.js, Luxon, and date-fns.
 This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
 

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -495,7 +495,7 @@ dt.subtract({ months: 1 }); // => throws
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `datetime` and until `other`.
 
@@ -543,7 +543,7 @@ dt1.until(dt2, { largestUnit: 'nanoseconds' });
 
 // Rounding, for example if you don't care about sub-seconds
 dt1.until(dt2, { smallestUnit: 'seconds' });
-  // => P8456DT12H5M30S
+  // => P8456DT12H5M29S
 
 // Months and years can be different lengths
 [jan1, feb1, mar1] = [1, 2, 3].map((month) =>
@@ -552,7 +552,7 @@ jan1.until(feb1);                            // => P31D
 jan1.until(feb1, { largestUnit: 'months' }); // => P1M
 feb1.until(mar1);                            // => P29D
 feb1.until(mar1, { largestUnit: 'months' }); // => P1M
-jan1.until(mar1);                            // => P121D
+jan1.until(mar1);                            // => P60D
 ```
 <!-- prettier-ignore-end -->
 
@@ -573,7 +573,7 @@ jan1.until(mar1);                            // => P121D
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `datetime` and since `other`.
 

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -365,7 +365,7 @@ Temporal.now.instant().subtract(oneHour);
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the difference between `instant` and `other`.
 
@@ -410,10 +410,10 @@ missionLength.toLocaleString();
 
 // Rounding, for example if you don't care about the minutes and seconds
 approxMissionLength = startOfMoonMission.until(endOfMoonMission, {
-  largestUnit: 'days',
+  largestUnit: 'hours',
   smallestUnit: 'hours'
 });
-  // => P8DT3H
+  // => P195H
 
 // A billion (10^9) seconds since the epoch in different units
 epoch = Temporal.Instant.fromEpochSeconds(0);
@@ -429,8 +429,10 @@ ns.add({ nanoseconds: 1 });
 
 // Calculate the difference in years, eliminating the ambiguity by
 // explicitly using the corresponding calendar date in UTC:
-utc = Temporal.TimeZone.from('UTC');
-epoch.toPlainDateTime(utc).until(billion.toPlainDateTime(utc), { largestUnit: 'years' });
+epoch.toZonedDateTimeISO('UTC').until(
+  billion.toZonedDateTimeISO('UTC'), 
+  { largestUnit: 'years' }
+);
   // => P31Y8M8DT1H46M40S
 ```
 <!-- prettier-ignore-end -->
@@ -452,7 +454,7 @@ epoch.toPlainDateTime(utc).until(billion.toPlainDateTime(utc), { largestUnit: 'y
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the difference between `instant` and `other`.
 

--- a/docs/time.md
+++ b/docs/time.md
@@ -304,7 +304,7 @@ time.subtract({ minutes: 5, nanoseconds: 800 }); // => 19:34:09.068345405
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `time` and until `other`.
 
@@ -332,12 +332,12 @@ Usage example:
 <!-- prettier-ignore-start -->
 ```javascript
 time = Temporal.PlainTime.from('20:13:20.971398099');
-time.until(Temporal.PlainTime.from('22:39:09.068346205')); // => PT2H25M49.903051894S
+time.until(Temporal.PlainTime.from('22:39:09.068346205')); // => PT2H25M48.096948106S
 time.until(Temporal.PlainTime.from('19:39:09.068346205')); // => -PT34M11.903051894S
 
 // Rounding, for example if you don't care about sub-seconds
 time.until(Temporal.PlainTime.from('22:39:09.068346205'), { smallestUnit: 'seconds' });
-  // => PT2H25M50S
+  // => PT2H25M48S
 ```
 <!-- prettier-ignore-end -->
 
@@ -358,7 +358,7 @@ time.until(Temporal.PlainTime.from('22:39:09.068346205'), { smallestUnit: 'secon
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `time` and since `other`.
 
@@ -374,7 +374,7 @@ Usage example:
 ```javascript
 time = Temporal.PlainTime.from('20:13:20.971398099');
 time.since(Temporal.PlainTime.from('19:39:09.068346205')); // => PT34M11.903051894S
-time.since(Temporal.PlainTime.from('22:39:09.068346205')); // => -PT2H25M49.903051894S
+time.since(Temporal.PlainTime.from('22:39:09.068346205')); // => -PT2H25M48.096948106S
 ```
 
 ### time.**round**(_options_: object) : Temporal.PlainTime
@@ -595,7 +595,7 @@ This method produces identical results to [`Temporal.PlainDate.from(date).toZone
 
 If `date` is not a `Temporal.PlainDate` object, then it will be converted to one as if it were passed to `Temporal.PlainDate.from()`.
 
-In the case of ambiguity caused by DST or other time zone changes, the earlier time will be used for backward transitions and  the later time for forward transitions.
+In the case of ambiguity caused by DST or other time zone changes, the earlier time will be used for backward transitions and the later time for forward transitions.
 When interoperating with existing code or services, this matches the behavior of legacy `Date` as well as libraries like moment.js, Luxon, and date-fns.
 This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
 

--- a/docs/yearmonth.md
+++ b/docs/yearmonth.md
@@ -344,7 +344,7 @@ ym.subtract({ years: 20, months: 4 }); // => 1999-02
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `yearMonth` and until `other`.
 
@@ -405,7 +405,7 @@ ym.toPlainDate({ day: 1 }).until(other.toPlainDate({ day: 1 }), { largestUnit: '
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `yearMonth` and since `other`.
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -847,7 +847,7 @@ earlierHours.since(zdt, { largestUnit: 'hours' }).hours; // => -24
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `zonedDateTime` and until `other`.
 
@@ -912,7 +912,7 @@ zdt1.until(zdt2, { largestUnit: 'nanoseconds' });
 
 // Rounding, for example if you don't care about sub-seconds
 zdt1.until(zdt2, { smallestUnit: 'seconds' });
-  // => PT202956H5M30S
+  // => PT202956H5M29S
 
 // Months and years can be different lengths
 [jan1, feb1, mar1] = [1, 2, 3].map((month) =>
@@ -942,7 +942,7 @@ jan1.until(mar1, { largestUnit: 'days' }); // => P60D
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
     Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `zonedDateTime` and since `other`.
 

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -216,9 +216,10 @@ export namespace Temporal {
      * - `nearest`: Round to the nearest of the values allowed by
      *   `roundingIncrement` and `smallestUnit`. When there is a tie, round away
      *   from zero like `ceil` for positive durations and like `floor` for
-     *   negative durations. This mode is the default.
+     *   negative durations.
      * - `ceil`: Always round up, towards the end of time.
-     * - `trunc`: Always round down, towards the beginning of time.
+     * - `trunc`: Always round down, towards the beginning of time. This mode is
+     *   the default.
      * - `floor`: Also round down, towards the beginning of time. This mode acts
      *   the same as `trunc`, but it's included for consistency with
      *   `Temporal.Duration.round()` where negative values are allowed and

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -106,7 +106,7 @@ export class Instant {
     const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('seconds', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit, disallowedUnits);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const maximumIncrements = {
       hours: 24,
       minutes: 60,
@@ -148,7 +148,7 @@ export class Instant {
     const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('seconds', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit, disallowedUnits);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const maximumIncrements = {
       hours: 24,
       minutes: 60,

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -180,7 +180,7 @@ export class PlainDate {
     const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit, disallowedUnits);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
 
     const result = calendar.dateUntil(this, other, { largestUnit });
@@ -237,7 +237,7 @@ export class PlainDate {
     const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit, disallowedUnits);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
 
     let { years, months, weeks, days } = calendar.dateUntil(this, other, { largestUnit });

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -370,7 +370,7 @@ export class PlainDateTime {
     const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
 
     let {
@@ -463,7 +463,7 @@ export class PlainDateTime {
     const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
 
     let {

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -215,7 +215,7 @@ export class PlainTime {
     const largestUnit = ES.ToLargestTemporalUnit(options, 'hours', ['years', 'months', 'weeks', 'days']);
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const maximumIncrements = {
       hours: 24,
       minutes: 60,
@@ -270,7 +270,7 @@ export class PlainTime {
     const largestUnit = ES.ToLargestTemporalUnit(options, 'hours', ['years', 'months', 'weeks', 'days']);
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const maximumIncrements = {
       hours: 24,
       minutes: 60,

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -189,7 +189,7 @@ export class PlainYearMonth {
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'months', disallowedUnits);
     const largestUnit = ES.ToLargestTemporalUnit(options, 'years', disallowedUnits);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
 
     const fieldNames = ES.CalendarFields(calendar, ['month', 'year']);
@@ -262,7 +262,7 @@ export class PlainYearMonth {
     const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'months', disallowedUnits);
     const largestUnit = ES.ToLargestTemporalUnit(options, 'years', disallowedUnits);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
 
     const fieldNames = ES.CalendarFields(calendar, ['month', 'year']);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -330,7 +330,7 @@ export class ZonedDateTime {
     const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('hours', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
 
     let years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
@@ -423,7 +423,7 @@ export class ZonedDateTime {
     const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('hours', smallestUnit);
     const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    let roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    let roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
 

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -651,8 +651,8 @@ describe('Instant', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than seconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'hours' })}`, 'PT376435H');
-      equal(`${later.since(earlier, { smallestUnit: 'minutes' })}`, 'PT22586123M');
+      equal(`${later.since(earlier, { smallestUnit: 'hours', roundingMode: 'nearest' })}`, 'PT376435H');
+      equal(`${later.since(earlier, { smallestUnit: 'minutes', roundingMode: 'nearest' })}`, 'PT22586123M');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => later.since(earlier, { roundingMode: 'cile' }), RangeError);
@@ -718,37 +718,73 @@ describe('Instant', () => {
         equal(`${earlier.since(later, { largestUnit, smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
-      equal(`${later.since(earlier, { largestUnit, smallestUnit: 'milliseconds' })}`, 'PT376435H23M8.149S');
+    it('trunc is the default', () => {
+      equal(`${later.since(earlier, { largestUnit, smallestUnit: 'milliseconds' })}`, 'PT376435H23M8.148S');
       equal(`${later.since(earlier, { largestUnit, smallestUnit: 'microseconds' })}`, 'PT376435H23M8.148529S');
     });
     it('rounds to an increment of hours', () => {
-      equal(`${later.since(earlier, { largestUnit, smallestUnit: 'hours', roundingIncrement: 3 })}`, 'PT376434H');
+      equal(
+        `${later.since(earlier, {
+          largestUnit,
+          smallestUnit: 'hours',
+          roundingIncrement: 3,
+          roundingMode: 'nearest'
+        })}`,
+        'PT376434H'
+      );
     });
     it('rounds to an increment of minutes', () => {
-      equal(`${later.since(earlier, { largestUnit, smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'PT376435H30M');
+      equal(
+        `${later.since(earlier, {
+          largestUnit,
+          smallestUnit: 'minutes',
+          roundingIncrement: 30,
+          roundingMode: 'nearest'
+        })}`,
+        'PT376435H30M'
+      );
     });
     it('rounds to an increment of seconds', () => {
       equal(
-        `${later.since(earlier, { largestUnit, smallestUnit: 'seconds', roundingIncrement: 15 })}`,
+        `${later.since(earlier, {
+          largestUnit,
+          smallestUnit: 'seconds',
+          roundingIncrement: 15,
+          roundingMode: 'nearest'
+        })}`,
         'PT376435H23M15S'
       );
     });
     it('rounds to an increment of milliseconds', () => {
       equal(
-        `${later.since(earlier, { largestUnit, smallestUnit: 'milliseconds', roundingIncrement: 10 })}`,
+        `${later.since(earlier, {
+          largestUnit,
+          smallestUnit: 'milliseconds',
+          roundingIncrement: 10,
+          roundingMode: 'nearest'
+        })}`,
         'PT376435H23M8.150S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
-        `${later.since(earlier, { largestUnit, smallestUnit: 'microseconds', roundingIncrement: 10 })}`,
+        `${later.since(earlier, {
+          largestUnit,
+          smallestUnit: 'microseconds',
+          roundingIncrement: 10,
+          roundingMode: 'nearest'
+        })}`,
         'PT376435H23M8.148530S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${later.since(earlier, { largestUnit, smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`,
+        `${later.since(earlier, {
+          largestUnit,
+          smallestUnit: 'nanoseconds',
+          roundingIncrement: 10,
+          roundingMode: 'nearest'
+        })}`,
         'PT376435H23M8.148529310S'
       );
     });
@@ -934,8 +970,8 @@ describe('Instant', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than seconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'hours' })}`, 'PT440610H');
-      equal(`${earlier.until(later, { smallestUnit: 'minutes' })}`, 'PT26436596M');
+      equal(`${earlier.until(later, { smallestUnit: 'hours', roundingMode: 'nearest' })}`, 'PT440610H');
+      equal(`${earlier.until(later, { smallestUnit: 'minutes', roundingMode: 'nearest' })}`, 'PT26436596M');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => earlier.until(later, { roundingMode: 'cile' }), RangeError);
@@ -1001,34 +1037,73 @@ describe('Instant', () => {
         equal(`${later.until(earlier, { largestUnit, smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
-      equal(`${earlier.until(later, { largestUnit, smallestUnit: 'milliseconds' })}`, 'PT440609H56M3.149S');
+    it('trunc is the default', () => {
+      equal(`${earlier.until(later, { largestUnit, smallestUnit: 'milliseconds' })}`, 'PT440609H56M3.148S');
       equal(`${earlier.until(later, { largestUnit, smallestUnit: 'microseconds' })}`, 'PT440609H56M3.148529S');
     });
     it('rounds to an increment of hours', () => {
-      equal(`${earlier.until(later, { largestUnit, smallestUnit: 'hours', roundingIncrement: 4 })}`, 'PT440608H');
+      equal(
+        `${earlier.until(later, {
+          largestUnit,
+          smallestUnit: 'hours',
+          roundingIncrement: 4,
+          roundingMode: 'nearest'
+        })}`,
+        'PT440608H'
+      );
     });
     it('rounds to an increment of minutes', () => {
-      equal(`${earlier.until(later, { largestUnit, smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'PT440610H');
+      equal(
+        `${earlier.until(later, {
+          largestUnit,
+          smallestUnit: 'minutes',
+          roundingIncrement: 30,
+          roundingMode: 'nearest'
+        })}`,
+        'PT440610H'
+      );
     });
     it('rounds to an increment of seconds', () => {
-      equal(`${earlier.until(later, { largestUnit, smallestUnit: 'seconds', roundingIncrement: 15 })}`, 'PT440609H56M');
+      equal(
+        `${earlier.until(later, {
+          largestUnit,
+          smallestUnit: 'seconds',
+          roundingIncrement: 15,
+          roundingMode: 'nearest'
+        })}`,
+        'PT440609H56M'
+      );
     });
     it('rounds to an increment of milliseconds', () => {
       equal(
-        `${earlier.until(later, { largestUnit, smallestUnit: 'milliseconds', roundingIncrement: 10 })}`,
+        `${earlier.until(later, {
+          largestUnit,
+          smallestUnit: 'milliseconds',
+          roundingIncrement: 10,
+          roundingMode: 'nearest'
+        })}`,
         'PT440609H56M3.150S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
-        `${earlier.until(later, { largestUnit, smallestUnit: 'microseconds', roundingIncrement: 10 })}`,
+        `${earlier.until(later, {
+          largestUnit,
+          smallestUnit: 'microseconds',
+          roundingIncrement: 10,
+          roundingMode: 'nearest'
+        })}`,
         'PT440609H56M3.148530S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${earlier.until(later, { largestUnit, smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`,
+        `${earlier.until(later, {
+          largestUnit,
+          smallestUnit: 'nanoseconds',
+          roundingIncrement: 10,
+          roundingMode: 'nearest'
+        })}`,
         'PT440609H56M3.148529310S'
       );
     });

--- a/polyfill/test/plaindate.mjs
+++ b/polyfill/test/plaindate.mjs
@@ -352,9 +352,9 @@ describe('Date', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${earlier.until(later, { smallestUnit: 'months' })}`, 'P32M');
-      equal(`${earlier.until(later, { smallestUnit: 'weeks' })}`, 'P139W');
+      equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
+      equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
+      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => earlier.until(later, { roundingMode: 'cile' }), RangeError);
@@ -411,21 +411,30 @@ describe('Date', () => {
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${later.until(earlier, { smallestUnit: 'years' })}`, '-P3Y');
+    it('trunc is the default', () => {
+      equal(`${earlier.until(later, { smallestUnit: 'years' })}`, 'P2Y');
+      equal(`${later.until(earlier, { smallestUnit: 'years' })}`, '-P2Y');
     });
     it('rounds to an increment of years', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years', roundingIncrement: 4 })}`, 'P4Y');
+      equal(`${earlier.until(later, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'nearest' })}`, 'P4Y');
     });
     it('rounds to an increment of months', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'months', roundingIncrement: 10 })}`, 'P30M');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'months', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'P30M'
+      );
     });
     it('rounds to an increment of weeks', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingIncrement: 12 })}`, 'P144W');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'weeks', roundingIncrement: 12, roundingMode: 'nearest' })}`,
+        'P144W'
+      );
     });
     it('rounds to an increment of days', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'days', roundingIncrement: 100 })}`, 'P1000D');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'days', roundingIncrement: 100, roundingMode: 'nearest' })}`,
+        'P1000D'
+      );
     });
     it('accepts singular units', () => {
       equal(`${earlier.until(later, { largestUnit: 'year' })}`, `${earlier.until(later, { largestUnit: 'years' })}`);
@@ -441,8 +450,8 @@ describe('Date', () => {
     it('rounds relative to the receiver', () => {
       const date1 = Temporal.PlainDate.from('2019-01-01');
       const date2 = Temporal.PlainDate.from('2019-02-15');
-      equal(`${date1.until(date2, { smallestUnit: 'months' })}`, 'P2M');
-      equal(`${date2.until(date1, { smallestUnit: 'months' })}`, '-P1M');
+      equal(`${date1.until(date2, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P2M');
+      equal(`${date2.until(date1, { smallestUnit: 'months', roundingMode: 'nearest' })}`, '-P1M');
     });
   });
   describe('order of operations in until - TODO: add since', () => {
@@ -591,9 +600,9 @@ describe('Date', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${later.since(earlier, { smallestUnit: 'months' })}`, 'P32M');
-      equal(`${later.since(earlier, { smallestUnit: 'weeks' })}`, 'P139W');
+      equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
+      equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
+      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => later.since(earlier, { roundingMode: 'cile' }), RangeError);
@@ -650,21 +659,30 @@ describe('Date', () => {
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${earlier.since(later, { smallestUnit: 'years' })}`, '-P3Y');
+    it('trunc is the default', () => {
+      equal(`${later.since(earlier, { smallestUnit: 'years' })}`, 'P2Y');
+      equal(`${earlier.since(later, { smallestUnit: 'years' })}`, '-P2Y');
     });
     it('rounds to an increment of years', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years', roundingIncrement: 4 })}`, 'P4Y');
+      equal(`${later.since(earlier, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'nearest' })}`, 'P4Y');
     });
     it('rounds to an increment of months', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'months', roundingIncrement: 10 })}`, 'P30M');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'months', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'P30M'
+      );
     });
     it('rounds to an increment of weeks', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingIncrement: 12 })}`, 'P144W');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'weeks', roundingIncrement: 12, roundingMode: 'nearest' })}`,
+        'P144W'
+      );
     });
     it('rounds to an increment of days', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'days', roundingIncrement: 100 })}`, 'P1000D');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'days', roundingIncrement: 100, roundingMode: 'nearest' })}`,
+        'P1000D'
+      );
     });
     it('accepts singular units', () => {
       equal(`${later.since(earlier, { largestUnit: 'year' })}`, `${later.since(earlier, { largestUnit: 'years' })}`);
@@ -680,8 +698,8 @@ describe('Date', () => {
     it('rounds relative to the receiver', () => {
       const date1 = PlainDate.from('2019-01-01');
       const date2 = PlainDate.from('2019-02-15');
-      equal(`${date2.since(date1, { smallestUnit: 'months' })}`, 'P1M');
-      equal(`${date1.since(date2, { smallestUnit: 'months' })}`, '-P2M');
+      equal(`${date2.since(date1, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P1M');
+      equal(`${date1.since(date2, { smallestUnit: 'months', roundingMode: 'nearest' })}`, '-P2M');
     });
   });
   describe('date.add() works', () => {

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -591,9 +591,9 @@ describe('DateTime', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${earlier.until(later, { smallestUnit: 'months' })}`, 'P32M');
-      equal(`${earlier.until(later, { smallestUnit: 'weeks' })}`, 'P139W');
+      equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
+      equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
+      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => earlier.until(later, { roundingMode: 'cile' }), RangeError);
@@ -674,28 +674,43 @@ describe('DateTime', () => {
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
+    it('trunc is the default', () => {
       equal(`${earlier.until(later, { smallestUnit: 'minutes' })}`, 'P973DT4H17M');
-      equal(`${earlier.until(later, { smallestUnit: 'seconds' })}`, 'P973DT4H17M5S');
+      equal(`${earlier.until(later, { smallestUnit: 'seconds' })}`, 'P973DT4H17M4S');
     });
     it('rounds to an increment of hours', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3 })}`, 'P973DT3H');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        'P973DT3H'
+      );
     });
     it('rounds to an increment of minutes', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'P973DT4H30M');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        'P973DT4H30M'
+      );
     });
     it('rounds to an increment of seconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15 })}`, 'P973DT4H17M');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        'P973DT4H17M'
+      );
     });
     it('rounds to an increment of milliseconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10 })}`, 'P973DT4H17M4.860S');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'P973DT4H17M4.860S'
+      );
     });
     it('rounds to an increment of microseconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10 })}`, 'P973DT4H17M4.864200S');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'P973DT4H17M4.864200S'
+      );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`,
+        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
         'P973DT4H17M4.864197530S'
       );
     });
@@ -793,8 +808,8 @@ describe('DateTime', () => {
     it('rounds relative to the receiver', () => {
       const dt1 = PlainDateTime.from('2019-01-01');
       const dt2 = PlainDateTime.from('2020-07-02');
-      equal(`${dt1.until(dt2, { smallestUnit: 'years' })}`, 'P2Y');
-      equal(`${dt2.until(dt1, { smallestUnit: 'years' })}`, '-P1Y');
+      equal(`${dt1.until(dt2, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P2Y');
+      equal(`${dt2.until(dt1, { smallestUnit: 'years', roundingMode: 'nearest' })}`, '-P1Y');
     });
   });
   describe('DateTime.since()', () => {
@@ -897,9 +912,9 @@ describe('DateTime', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${later.since(earlier, { smallestUnit: 'months' })}`, 'P32M');
-      equal(`${later.since(earlier, { smallestUnit: 'weeks' })}`, 'P139W');
+      equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
+      equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
+      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => later.since(earlier, { roundingMode: 'cile' }), RangeError);
@@ -980,28 +995,43 @@ describe('DateTime', () => {
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
+    it('trunc is the default', () => {
       equal(`${later.since(earlier, { smallestUnit: 'minutes' })}`, 'P973DT4H17M');
-      equal(`${later.since(earlier, { smallestUnit: 'seconds' })}`, 'P973DT4H17M5S');
+      equal(`${later.since(earlier, { smallestUnit: 'seconds' })}`, 'P973DT4H17M4S');
     });
     it('rounds to an increment of hours', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3 })}`, 'P973DT3H');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        'P973DT3H'
+      );
     });
     it('rounds to an increment of minutes', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'P973DT4H30M');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        'P973DT4H30M'
+      );
     });
     it('rounds to an increment of seconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15 })}`, 'P973DT4H17M');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        'P973DT4H17M'
+      );
     });
     it('rounds to an increment of milliseconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10 })}`, 'P973DT4H17M4.860S');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'P973DT4H17M4.860S'
+      );
     });
     it('rounds to an increment of microseconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10 })}`, 'P973DT4H17M4.864200S');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'P973DT4H17M4.864200S'
+      );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`,
+        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
         'P973DT4H17M4.864197530S'
       );
     });
@@ -1099,8 +1129,8 @@ describe('DateTime', () => {
     it('rounds relative to the receiver', () => {
       const dt1 = PlainDateTime.from('2019-01-01');
       const dt2 = PlainDateTime.from('2020-07-02');
-      equal(`${dt2.since(dt1, { smallestUnit: 'years' })}`, 'P1Y');
-      equal(`${dt1.since(dt2, { smallestUnit: 'years' })}`, '-P2Y');
+      equal(`${dt2.since(dt1, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P1Y');
+      equal(`${dt1.since(dt2, { smallestUnit: 'years', roundingMode: 'nearest' })}`, '-P2Y');
     });
   });
   describe('DateTime.round works', () => {

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -431,27 +431,45 @@ describe('Time', () => {
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
+    it('trunc is the default', () => {
       equal(`${earlier.until(later, { smallestUnit: 'minutes' })}`, 'PT4H17M');
-      equal(`${earlier.until(later, { smallestUnit: 'seconds' })}`, 'PT4H17M5S');
+      equal(`${earlier.until(later, { smallestUnit: 'seconds' })}`, 'PT4H17M4S');
     });
     it('rounds to an increment of hours', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3 })}`, 'PT3H');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        'PT3H'
+      );
     });
     it('rounds to an increment of minutes', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'PT4H30M');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        'PT4H30M'
+      );
     });
     it('rounds to an increment of seconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15 })}`, 'PT4H17M');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        'PT4H17M'
+      );
     });
     it('rounds to an increment of milliseconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10 })}`, 'PT4H17M4.860S');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT4H17M4.860S'
+      );
     });
     it('rounds to an increment of microseconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10 })}`, 'PT4H17M4.864200S');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT4H17M4.864200S'
+      );
     });
     it('rounds to an increment of nanoseconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`, 'PT4H17M4.864197530S');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT4H17M4.864197530S'
+      );
     });
     it('valid hour increments divide into 24', () => {
       [1, 2, 3, 4, 6, 8, 12].forEach((roundingIncrement) => {
@@ -681,27 +699,45 @@ describe('Time', () => {
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
+    it('trunc is the default', () => {
       equal(`${later.since(earlier, { smallestUnit: 'minutes' })}`, 'PT4H17M');
-      equal(`${later.since(earlier, { smallestUnit: 'seconds' })}`, 'PT4H17M5S');
+      equal(`${later.since(earlier, { smallestUnit: 'seconds' })}`, 'PT4H17M4S');
     });
     it('rounds to an increment of hours', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3 })}`, 'PT3H');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        'PT3H'
+      );
     });
     it('rounds to an increment of minutes', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'PT4H30M');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        'PT4H30M'
+      );
     });
     it('rounds to an increment of seconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15 })}`, 'PT4H17M');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        'PT4H17M'
+      );
     });
     it('rounds to an increment of milliseconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10 })}`, 'PT4H17M4.860S');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT4H17M4.860S'
+      );
     });
     it('rounds to an increment of microseconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10 })}`, 'PT4H17M4.864200S');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT4H17M4.864200S'
+      );
     });
     it('rounds to an increment of nanoseconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`, 'PT4H17M4.864197530S');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT4H17M4.864197530S'
+      );
     });
     it('valid hour increments divide into 24', () => {
       [1, 2, 3, 4, 6, 8, 12].forEach((roundingIncrement) => {

--- a/polyfill/test/plainyearmonth.mjs
+++ b/polyfill/test/plainyearmonth.mjs
@@ -340,15 +340,15 @@ describe('YearMonth', () => {
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${later.until(earlier, { smallestUnit: 'years' })}`, '-P3Y');
+    it('trunc is the default', () => {
+      equal(`${earlier.until(later, { smallestUnit: 'years' })}`, 'P2Y');
+      equal(`${later.until(earlier, { smallestUnit: 'years' })}`, '-P2Y');
     });
     it('rounds to an increment of years', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years', roundingIncrement: 4 })}`, 'P4Y');
+      equal(`${earlier.until(later, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'nearest' })}`, 'P4Y');
     });
     it('rounds to an increment of months', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'months', roundingIncrement: 10 })}`, 'P2Y10M');
+      equal(`${earlier.until(later, { smallestUnit: 'months', roundingIncrement: 5 })}`, 'P2Y5M');
       equal(
         `${earlier.until(later, { largestUnit: 'months', smallestUnit: 'months', roundingIncrement: 10 })}`,
         'P30M'
@@ -479,15 +479,15 @@ describe('YearMonth', () => {
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${earlier.since(later, { smallestUnit: 'years' })}`, '-P3Y');
+    it('trunc is the default', () => {
+      equal(`${later.since(earlier, { smallestUnit: 'years' })}`, 'P2Y');
+      equal(`${earlier.since(later, { smallestUnit: 'years' })}`, '-P2Y');
     });
     it('rounds to an increment of years', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years', roundingIncrement: 4 })}`, 'P4Y');
+      equal(`${later.since(earlier, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'nearest' })}`, 'P4Y');
     });
     it('rounds to an increment of months', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'months', roundingIncrement: 10 })}`, 'P2Y10M');
+      equal(`${later.since(earlier, { smallestUnit: 'months', roundingIncrement: 5 })}`, 'P2Y5M');
       equal(
         `${later.since(earlier, { largestUnit: 'months', smallestUnit: 'months', roundingIncrement: 10 })}`,
         'P30M'

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -1224,10 +1224,10 @@ describe('ZonedDateTime', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than hours', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${earlier.until(later, { smallestUnit: 'months' })}`, 'P32M');
-      equal(`${earlier.until(later, { smallestUnit: 'weeks' })}`, 'P139W');
-      equal(`${earlier.until(later, { smallestUnit: 'days' })}`, 'P973D');
+      equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
+      equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
+      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
+      equal(`${earlier.until(later, { smallestUnit: 'days', roundingMode: 'nearest' })}`, 'P973D');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => earlier.until(later, { roundingMode: 'cile' }), RangeError);
@@ -1308,28 +1308,43 @@ describe('ZonedDateTime', () => {
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
+    it('trunc is the default', () => {
       equal(`${earlier.until(later, { smallestUnit: 'minutes' })}`, 'PT23356H17M');
-      equal(`${earlier.until(later, { smallestUnit: 'seconds' })}`, 'PT23356H17M5S');
+      equal(`${earlier.until(later, { smallestUnit: 'seconds' })}`, 'PT23356H17M4S');
     });
     it('rounds to an increment of hours', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3 })}`, 'PT23355H');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        'PT23355H'
+      );
     });
     it('rounds to an increment of minutes', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'PT23356H30M');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        'PT23356H30M'
+      );
     });
     it('rounds to an increment of seconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15 })}`, 'PT23356H17M');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        'PT23356H17M'
+      );
     });
     it('rounds to an increment of milliseconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10 })}`, 'PT23356H17M4.860S');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT23356H17M4.860S'
+      );
     });
     it('rounds to an increment of microseconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10 })}`, 'PT23356H17M4.864200S');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT23356H17M4.864200S'
+      );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`,
+        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
         'PT23356H17M4.864197530S'
       );
     });
@@ -1427,8 +1442,8 @@ describe('ZonedDateTime', () => {
     it('rounds relative to the receiver', () => {
       const dt1 = ZonedDateTime.from('2019-01-01T00:00+00:00[UTC]');
       const dt2 = ZonedDateTime.from('2020-07-02T00:00+00:00[UTC]');
-      equal(`${dt1.until(dt2, { smallestUnit: 'years' })}`, 'P2Y');
-      equal(`${dt2.until(dt1, { smallestUnit: 'years' })}`, '-P1Y');
+      equal(`${dt1.until(dt2, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P2Y');
+      equal(`${dt2.until(dt1, { smallestUnit: 'years', roundingMode: 'nearest' })}`, '-P1Y');
     });
   });
   describe('ZonedDateTime.since()', () => {
@@ -1541,9 +1556,9 @@ describe('ZonedDateTime', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years' })}`, 'P3Y');
-      equal(`${later.since(earlier, { smallestUnit: 'months' })}`, 'P32M');
-      equal(`${later.since(earlier, { smallestUnit: 'weeks' })}`, 'P139W');
+      equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
+      equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
+      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => later.since(earlier, { roundingMode: 'cile' }), RangeError);
@@ -1624,28 +1639,43 @@ describe('ZonedDateTime', () => {
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
       });
     });
-    it('nearest is the default', () => {
+    it('trunc is the default', () => {
       equal(`${later.since(earlier, { smallestUnit: 'minutes' })}`, 'PT23356H17M');
-      equal(`${later.since(earlier, { smallestUnit: 'seconds' })}`, 'PT23356H17M5S');
+      equal(`${later.since(earlier, { smallestUnit: 'seconds' })}`, 'PT23356H17M4S');
     });
     it('rounds to an increment of hours', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3 })}`, 'PT23355H');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        'PT23355H'
+      );
     });
     it('rounds to an increment of minutes', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30 })}`, 'PT23356H30M');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        'PT23356H30M'
+      );
     });
     it('rounds to an increment of seconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15 })}`, 'PT23356H17M');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        'PT23356H17M'
+      );
     });
     it('rounds to an increment of milliseconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10 })}`, 'PT23356H17M4.860S');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT23356H17M4.860S'
+      );
     });
     it('rounds to an increment of microseconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10 })}`, 'PT23356H17M4.864200S');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        'PT23356H17M4.864200S'
+      );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10 })}`,
+        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
         'PT23356H17M4.864197530S'
       );
     });
@@ -1743,8 +1773,8 @@ describe('ZonedDateTime', () => {
     it('rounds relative to the receiver', () => {
       const dt1 = ZonedDateTime.from('2019-01-01T00:00+00:00[UTC]');
       const dt2 = ZonedDateTime.from('2020-07-02T00:00+00:00[UTC]');
-      equal(`${dt2.since(dt1, { smallestUnit: 'years' })}`, 'P1Y');
-      equal(`${dt1.since(dt2, { smallestUnit: 'years' })}`, '-P2Y');
+      equal(`${dt2.since(dt1, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P1Y');
+      equal(`${dt1.since(dt2, { smallestUnit: 'years', roundingMode: 'nearest' })}`, '-P2Y');
     });
   });
 
@@ -2512,7 +2542,7 @@ describe('ZonedDateTime', () => {
     it('Difference rounding (nearest day) is DST-aware', () => {
       const start = ZonedDateTime.from('2020-03-10T02:30-07:00[America/Los_Angeles]');
       const end = ZonedDateTime.from('2020-03-07T14:15-08:00[America/Los_Angeles]');
-      const diff = start.until(end, { smallestUnit: 'days' }); // roundingMode: 'nearest'
+      const diff = start.until(end, { smallestUnit: 'days', roundingMode: 'nearest' }); // roundingMode: 'nearest'
       equal(`${diff}`, '-P3D');
     });
 
@@ -2582,14 +2612,14 @@ describe('ZonedDateTime', () => {
     it('Rounding up to hours causes one more day of overflow (positive)', () => {
       const start = ZonedDateTime.from('2020-01-01T00:00-08:00[America/Los_Angeles]');
       const end = ZonedDateTime.from('2020-01-03T23:59-08:00[America/Los_Angeles]');
-      const diff = start.until(end, { largestUnit: 'days', smallestUnit: 'hours' });
+      const diff = start.until(end, { largestUnit: 'days', smallestUnit: 'hours', roundingMode: 'nearest' });
       equal(`${diff}`, 'P3D');
     });
 
     it('Rounding up to hours causes one more day of overflow (negative)', () => {
       const start = ZonedDateTime.from('2020-01-01T00:00-08:00[America/Los_Angeles]');
       const end = ZonedDateTime.from('2020-01-03T23:59-08:00[America/Los_Angeles]');
-      const diff = end.until(start, { largestUnit: 'days', smallestUnit: 'hours' });
+      const diff = end.until(start, { largestUnit: 'days', smallestUnit: 'hours', roundingMode: 'nearest' });
       equal(`${diff}`, '-P3D');
     });
 

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -277,7 +277,7 @@
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"seconds"*, _smallestUnit_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be the mathematical value of ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. If _smallestUnit_ is *"hours"*, then
@@ -315,7 +315,7 @@
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"seconds"*, _smallestUnit_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be the mathematical value of ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. If _smallestUnit_ is *"hours"*, then

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -449,7 +449,7 @@
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"days"*, _disallowedUnits_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"days"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _largestUnit_).
         1. If _smallestUnit_ is not *"days"* or _roundingIncrement_ ≠ 1, then
@@ -479,7 +479,7 @@
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"days"*, _disallowedUnits_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"days"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _largestUnit_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -498,7 +498,7 @@
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"days"*, _smallestUnit_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _diff_ be ? DifferenceDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _calendar_, _largestUnit_).
@@ -528,7 +528,7 @@
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"days"*, _smallestUnit_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -311,7 +311,7 @@
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"hours"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _result_ be ! DifferenceTime(_temporalTime_.[[Hour]], _temporalTime_.[[Minute]], _temporalTime_.[[Second]], _temporalTime_.[[Millisecond]], _temporalTime_.[[Microsecond]], _temporalTime_.[[Nanosecond]], _other_.[[Hour]], _other_.[[Minute]], _other_.[[Second]], _other_.[[Millisecond]], _other_.[[Microsecond]], _other_.[[Nanosecond]]).
@@ -335,7 +335,7 @@
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"hours"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -290,7 +290,7 @@
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"months"*, _disallowedUnits_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"years"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
         1. <mark>TODO: Delegate to calendar.</mark>
         1. Let _years_ be _yearMonth_.[[ISOYear]] - _other_.[[ISOYear]].
@@ -325,7 +325,7 @@
         1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"months"*, _disallowedUnits_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"years"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
         1. <mark>TODO: Delegate to calendar.</mark>


### PR DESCRIPTION
Updates the default rounding mode for until/since to match user expectations that by default these methods measure "whole units" not partial remainders.

Docs are also updated, including fixing code example results for until/since, many of which were wrong due to this PR as well as other recent changes to `until`/`since` behavior.

BTW, I ran Test262 locally and all tests passed.

Fixes #1122.