### PR TITLE
Fix Instant's _repr_ to use Z suffix not +00:00

### DIFF
--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -16,8 +16,7 @@ export class Instant {
     SetSlot(this, EPOCHNANOSECONDS, ns);
 
     if (typeof __debug__ !== 'undefined' && __debug__) {
-      const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
-      const repr = ES.TemporalInstantToString(this, new TemporalTimeZone('UTC'), 'auto');
+      const repr = ES.TemporalInstantToString(this, undefined, 'auto');
       Object.defineProperty(this, '_repr_', {
         value: `${this[Symbol.toStringTag]} <${repr}>`,
         writable: false,


### PR DESCRIPTION
Fixes #1110 by switching from using the `'UTC'` timezone to an `undefined` timezone when calling `ES.TemporalInstantToString`.

With the fix: 
![image](https://user-images.githubusercontent.com/277214/98433630-90f66600-207d-11eb-82af-928e60d8c82e.png)
