### PR TITLE
Minor docs updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,8 @@ See [Temporal.PlainTime Documentation](./time.md) for detailed documentation.
 
 ### **Temporal.PlainDateTime**
 
-A `Temporal.PlainDateTime` represents a calendar date and wall-clock time that does not carry time zone information. It can be converted to a `Temporal.ZonedDateTime` or a `Temporal.Instant` using a `Temporal.TimeZone`.
+A `Temporal.PlainDateTime` represents a calendar date and wall-clock time that does not carry time zone information.
+It can be converted to a `Temporal.ZonedDateTime` using a `Temporal.TimeZone`.
 For use cases that require a time zone, especially using arithmetic or other derived values, consider using `Temporal.ZonedDateTime` instead because that type automatically adjusts for Daylight Saving Time.
 
 See [Temporal.PlainDateTime Documentation](./datetime.md) for detailed documentation.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -153,7 +153,7 @@ See also [Push back a launch date](#push-back-a-launch-date) for an easier way t
 ### Preserving local time
 
 Map a zoneless date and time of day into a `Temporal.Instant` instance at which the local date and time of day in a specified time zone matches it.
-This is easily done with `dateTime.toInstant()`, but here is an example of implementing different disambiguation behaviors than the `'compatible'`, `'earlier'`, `'later'`, and `'reject'` ones built in to Temporal.
+This is easily done with `dateTime.toZonedDateTime(timeZone).toInstant()`, but here is an example of implementing different disambiguation behaviors than the `'compatible'`, `'earlier'`, `'later'`, and `'reject'` ones built in to Temporal.
 
 ```javascript
 {{cookbook/getInstantWithLocalTimeInZone.mjs}}

--- a/docs/date.md
+++ b/docs/date.md
@@ -10,7 +10,8 @@ A `Temporal.PlainDate` represents a calendar date.
 For example, it could be used to represent an event on a calendar which happens during the whole day no matter which time zone it's happening in.
 
 `Temporal.PlainDate` refers to the whole of a specific day; if you need to refer to a specific time on that day, use `Temporal.PlainDateTime`.
-A `Temporal.PlainDate` can be converted into a `Temporal.PlainDateTime` by combining it with a `Temporal.PlainTime` using the `toPlainDateTime()` method.
+A `Temporal.PlainDate` can be converted into a `Temporal.ZonedDateTime` by combining it with a `Temporal.PlainTime` and `Temporal.TimeZone` using the `toZonedDateTime()` method.
+It can also be combined with a `Temporal.PlainTime` to yield a "zoneless" `Temporal.PlainDateTime` using the `toPlainDateTime()` method.
 
 `Temporal.PlainYearMonth` and `Temporal.PlainMonthDay` carry less information than `Temporal.PlainDate` and should be used when complete information is not required.
 

--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -6,18 +6,20 @@
 </details>
 
 A `Temporal.PlainDateTime` represents a calendar date and wall-clock time, with a precision in nanoseconds, and without any time zone.
-Of the `Temporal` classes carrying human-readable time information, it is the most general and complete one.
+
+For use cases that require a time zone, especially using arithmetic or other derived values, consider using [`Temporal.ZonedDateTime`](./zoneddatetime.md) instead because that type automatically adjusts for Daylight Saving Time.
+A `Temporal.PlainDateTime` can be converted to a `Temporal.ZonedDateTime` using a `Temporal.TimeZone`.
+
 `Temporal.PlainDate`, `Temporal.PlainTime`, `Temporal.PlainYearMonth`, and `Temporal.PlainMonthDay` all carry less information and should be used when complete information is not required.
 
+A `Temporal.PlainDateTime` can be converted into any of the types mentioned above using conversion methods like `toZonedDateTime` or `toPlainDate`.
+
 "Calendar date" and "wall-clock time" refer to the concept of time as expressed in everyday usage.
-`Temporal.PlainDateTime` does not represent an exact point in time; that is what `Temporal.Instant` is for.
+`Temporal.PlainDateTime` does not represent an exact point in time; that is what exact-time types like `Temporal.ZonedDateTime` and `Temporal.Instant` are for.
 
-One example of when it would be appropriate to use `Temporal.PlainDateTime` and not `Temporal.Instant` is when integrating with wearable devices.
+One example of when it may be appropriate to use `Temporal.PlainDateTime` and not `Temporal.ZonedDateTime` nor `Temporal.Instant` is when integrating with wearable devices.
 FitBit, for example, always records sleep data in the user's wall-clock time, wherever they are in the world.
-Otherwise they would be recorded as sleeping at strange hours when travelling, even if their sleep rhythm was on a healthy schedule for the time zone they were in.
-
-A `Temporal.PlainDateTime` can be converted to a `Temporal.Instant` using a `Temporal.TimeZone`.
-A `Temporal.PlainDateTime` can also be converted into any of the other `Temporal` objects that carry less information, such as `Temporal.PlainDate` for the date or `Temporal.PlainTime` for the time.
+Storing the time zone is not needed, and the plain (not exact) time is needed, because otherwise they would be recorded as sleeping at strange hours when travelling.
 
 ## Constructor
 
@@ -47,7 +49,7 @@ Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in tha
 > **NOTE**: Although Temporal does not deal with leap seconds, dates coming from other software may have a `second` value of 60.
 > This value will cause the constructor will throw, so if you have to interoperate with times that may contain leap seconds, use `Temporal.PlainDateTime.from()` instead.
 
-The range of allowed values for this type is exactly enough that calling [`toPlainDateTime()`](./instant.html#toPlainDateTime) on any valid `Temporal.Instant` with any valid `Temporal.TimeZone` will succeed.
+The range of allowed values for this type is exactly enough that calling `timeZone.getDateTimeFor(instant)` will succeed when `timeZone` is any built-in `Temporal.TimeZone` and `instant` is any valid `Temporal.Instant`.
 If the parameters passed in to this constructor form a date outside of this range, then this function will throw a `RangeError`.
 
 > **NOTE**: The `isoMonth` argument ranges from 1 to 12, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
@@ -819,8 +821,7 @@ Use `Temporal.PlainDateTime.compare()` for this, or `datetime.equals()` for equa
 
 **Returns:** A `Temporal.ZonedDateTime` object representing the calendar date and wall-clock time from `dateTime` projected into `timeZone`.
 
-This method is one way to convert a `Temporal.PlainDateTime` to a `Temporal.ZonedDateTime`.
-It is identical to [`(Temporal.TimeZone.from(timeZone)).getZonedDateTimeFor(dateTime, disambiguation)`](./timezone.html#getZonedDateTimeFor).
+This method converts a `Temporal.PlainDateTime` to a `Temporal.ZonedDateTime` by adding a time zone.
 
 For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
 A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.

--- a/docs/head.html.part
+++ b/docs/head.html.part
@@ -81,6 +81,8 @@
         line-height: 1.1;
         display: inline-block;
       }
+      a code { color: inherit; }
+      a code:hover { text-decoration: underline; }
       pre code { line-height: 1.4; }
       pre code[class*="language-"] { font-size: 0.85em; }
       pre[class*="language-"] { padding: 0.5em; }

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -264,7 +264,7 @@ A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki
 
 For a list of calendar identifiers, see the documentation for [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#Parameters).
 
-If you only want to use the ISO 8601 calendar, use `toPlainDateTimeISO()`.
+If you only want to use the ISO 8601 calendar, use `toZonedDateTimeISO()`.
 
 Example usage:
 

--- a/docs/now.md
+++ b/docs/now.md
@@ -98,10 +98,9 @@ now = Temporal.now.instant();
 nextTransition = tz.getNextTransition(now);
 before = tz.getOffsetStringFor(nextTransition.subtract({ nanoseconds: 1 }));
 after = tz.getOffsetStringFor(nextTransition.add({ nanoseconds: 1 }));
-console.log(`On ${nextTransition.toPlainDateTime(tz)} the clock will change from UTC ${before} to ${after}`);
-nextTransition.toPlainDateTime(tz);
+console.log(`At ${nextTransition.toZonedDateTimeISO(tz)} the offset will change from UTC ${before} to ${after}`);
 // example output:
-// On 2020-03-08T03:00 the clock will change from UTC -08:00 to -07:00
+// At 2021-03-14T03:00:00-07:00[America/Los_Angeles] the offset will change from UTC -08:00 to -07:00
 ```
 
 ### Temporal.now.**plainDateTimeISO**(_timeZone_: object | string = Temporal.now.timeZone()) : Temporal.PlainDateTime

--- a/docs/time.md
+++ b/docs/time.md
@@ -10,7 +10,8 @@ A `Temporal.PlainTime` represents a wall-clock time, with a precision in nanosec
 For example, it could be used to represent an event that happens daily at a certain time, no matter what time zone.
 
 `Temporal.PlainTime` refers to a time with no associated calendar date; if you need to refer to a specific time on a specific day, use `Temporal.PlainDateTime`.
-A `Temporal.PlainTime` can be converted into a `Temporal.PlainDateTime` by combining it with a `Temporal.PlainDate` using the `toPlainDateTime()` method.
+A `Temporal.PlainTime` can be converted into a `Temporal.ZonedDateTime` by combining it with a `Temporal.PlainDate` and `Temporal.TimeZone` using the `toZonedDateTime()` method.
+It can also be combined with a `Temporal.PlainDate` to yield a "zoneless" `Temporal.PlainDateTime` using the `toPlainDateTime()` method.
 
 ## Constructor
 

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -242,7 +242,7 @@ tz.getDateTimeFor(epoch); // => 1969-12-31T19:00
 **Returns:** A `Temporal.Instant` object indicating the exact time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
 
 This method is one way to convert a `Temporal.PlainDateTime` to a `Temporal.Instant`.
-The result is identical to `dateTime.toZonedDateTime(timeZone, { disambiguation })`.
+The result is identical to `dateTime.toZonedDateTime(timeZone, { disambiguation }).toInstant()`.
 
 If `dateTime` is not a `Temporal.PlainDateTime` object, then it will be converted to one as if it were passed to `Temporal.PlainDateTime.from()`.
 

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -21,7 +21,7 @@ The other, more difficult, way to create a custom time zone is to create a plain
 The object must have at least `getOffsetNanosecondsFor()`, `getPossibleInstantsFor()`, and `toString()` methods.
 Any object with those three methods will return the correct output from any Temporal property or method.
 However, most other code will assume that custom time zones act like built-in `Temporal.TimeZone` objects.
-To interoperate with libraries or other code that you didn't write, then you should implement all the other `Temporal.TimeZone` members as well: `id`, `getOffsetStringFor()`, `getDateTimeFor()`, `getZonedDateTimeFor()`, `getInstantFor()`, `getNextTransition()`, `getPreviousTransition()`, and `toJSON()`.
+To interoperate with libraries or other code that you didn't write, then you should implement all the other `Temporal.TimeZone` members as well: `id`, `getOffsetStringFor()`, `getDateTimeFor()`, `getInstantFor()`, `getNextTransition()`, `getPreviousTransition()`, and `toJSON()`.
 Your object must not have a `timeZone` property, so that it can be distinguished in `Temporal.TimeZone.from()` from other Temporal objects that have a time zone.
 
 The identifier of a custom time zone must consist of one or more components separated by slashes (`/`), as described in the [tzdata documentation](https://htmlpreview.github.io/?https://github.com/eggert/tz/blob/master/theory.html#naming).
@@ -70,7 +70,7 @@ For example:
 ```javascript
 tz1 = new Temporal.TimeZone('-08:00');
 tz2 = new Temporal.TimeZone('America/Vancouver');
-inst = Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1 }).toInstant(tz2);
+inst = Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: tz2 }).toInstant();
 tz1.getNextTransition(inst); // => null
 tz2.getPreviousTransition(inst); // => 2020-03-08T10:00Z
 ```
@@ -198,36 +198,6 @@ tz = Temporal.TimeZone.from('-08:00');
 tz.getOffsetStringFor(timestamp); // => -08:00
 ```
 
-### timeZone.**getZonedDateTimeFor**(_instant_: Temporal.Instant | string, _calendar_?: object | string) : Temporal.ZonedDateTime
-
-**Parameters:**
-
-- `instant` (`Temporal.Instant` or value convertible to one): An exact time to convert.
-- `calendar` (optional object or string): A `Temporal.Calendar` object, or a plain object, or a calendar identifier.
-  The default is to use the ISO 8601 calendar.
-
-**Returns:** A `Temporal.ZonedDateTime` object indicating the calendar date and wall-clock time in `timeZone`, according to the reckoning of `calendar`, at the exact time indicated by `instant`.
-
-This method is one way to convert a `Temporal.Instant` to a `Temporal.ZonedDateTime`.
-
-If `instant` is not a `Temporal.Instant` object, then it will be converted to one as if it were passed to `Temporal.Instant.from()`.
-
-When subclassing `Temporal.TimeZone`, this method doesn't need to be overridden because the default implementation gives a result equivalent to calling `new Temporal.ZonedDateTime(instant.epochNanoseconds, timeZone, calendar)`.
-
-Example usage:
-
-```javascript
-// Converting a specific exact time to a calendar date / wall-clock time
-timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
-tz = Temporal.TimeZone.from('Europe/Berlin');
-tz.getZonedDateTimeFor(timestamp); // => 2019-03-31T01:45+02:00[Europe/Berlin]
-
-// What time was the Unix Epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA)?
-epoch = Temporal.Instant.fromEpochSeconds(0);
-tz = Temporal.TimeZone.from('America/New_York');
-tz.getZonedDateTimeFor(epoch); // => 1969-12-31T19:00-05:00[America/New_York]
-```
-
 ### timeZone.**getDateTimeFor**(_instant_: Temporal.Instant | string, _calendar_?: object | string) : Temporal.PlainDateTime
 
 **Parameters:**
@@ -272,7 +242,7 @@ tz.getDateTimeFor(epoch); // => 1969-12-31T19:00
 **Returns:** A `Temporal.Instant` object indicating the exact time in `timeZone` at the time of the calendar date and wall-clock time from `dateTime`.
 
 This method is one way to convert a `Temporal.PlainDateTime` to a `Temporal.Instant`.
-The result is identical to [`Temporal.PlainDateTime.from(dateTime).toInstant(timeZone, disambiguation)`](./datetime.html#toInstant).
+The result is identical to `dateTime.toZonedDateTime(timeZone, { disambiguation })`.
 
 If `dateTime` is not a `Temporal.PlainDateTime` object, then it will be converted to one as if it were passed to `Temporal.PlainDateTime.from()`.
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -111,7 +111,7 @@ Temporal.Instant.from('2020-08-05T20:06:13+05:45[+05:45]');
 Temporal.Instant('2020-08-05T20:06:13+05:45').toZonedDateTime('+05:45', 'iso8601');
 ```
 
-Note that using `Temporal.ZonedDateTime` with a single-offset time zone will not adjust for Daylight Savings Time or other time zone changes.
+Note that using `Temporal.ZonedDateTime` with a single-offset time zone will not adjust for Daylight Saving Time or other time zone changes.
 Therefore, using offset time zones with `Temporal.ZonedDateTime` is relatively unusual.
 Instead of using `Temporal.ZonedDateTime` with an offset time zone, it may be easier for most use cases to use `Temporal.PlainDateTime` and/or `Temporal.Instant` instead.
 


### PR DESCRIPTION
* Remove references to removed PlainDateTime.prototype.toInstant` & `Instant.prototype.toPlainDateTime`
* Remove docs for TimeZone.prototype.getZonedDateTimeFor method that was never implemented. Consider for V2.
* Revised the PlainDateTime summary docs
* Fixed a few code samples
* Fixed CSS color for links in a `<code>` tag
* Fixed a few typos