### PR TITLE
PlainDateTime relativeTo in Duration arithmetic

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -249,7 +249,7 @@ export class Duration {
       nanoseconds
     } = ES.ToLimitedTemporalDuration(other);
     options = ES.NormalizeOptionsObject(options);
-    void options; // TODO rounding options
+    const relativeTo = ES.ToRelativeTemporalObject(options);
     ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.AddDuration(
       GetSlot(this, YEARS),
       GetSlot(this, MONTHS),
@@ -270,7 +270,8 @@ export class Duration {
       seconds,
       milliseconds,
       microseconds,
-      nanoseconds
+      nanoseconds,
+      relativeTo
     ));
     const Construct = ES.SpeciesConstructor(this, Duration);
     const result = new Construct(
@@ -303,7 +304,7 @@ export class Duration {
       nanoseconds
     } = ES.ToLimitedTemporalDuration(other);
     options = ES.NormalizeOptionsObject(options);
-    void options; // TODO rounding options
+    const relativeTo = ES.ToRelativeTemporalObject(options);
     ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.AddDuration(
       GetSlot(this, YEARS),
       GetSlot(this, MONTHS),
@@ -324,7 +325,8 @@ export class Duration {
       -seconds,
       -milliseconds,
       -microseconds,
-      -nanoseconds
+      -nanoseconds,
+      relativeTo
     ));
     const Construct = ES.SpeciesConstructor(this, Duration);
     const result = new Construct(

--- a/polyfill/test/Duration/prototype/add/infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/add/infinity-throws-rangeerror.js
@@ -6,15 +6,12 @@ description: Temporal.Duration.prototype.add throws a RangeError if any value in
 esid: sec-temporal.duration.prototype.add
 ---*/
 
-const overflows = ['constrain', 'balance'];
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    assert.throws(RangeError, () => instance.add({ [field]: Infinity }, { overflow }));
-  });
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.add({ [field]: Infinity }));
 });
 
 let calls = 0;
@@ -25,10 +22,8 @@ const obj = {
   }
 };
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    calls = 0;
-    assert.throws(RangeError, () => instance.add({ [field]: obj }, { overflow }));
-    assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-  });
+fields.forEach((field) => {
+  calls = 0;
+  assert.throws(RangeError, () => instance.add({ [field]: obj }));
+  assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/add/infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/add/infinity-throws-rangeerror.js
@@ -9,9 +9,10 @@ esid: sec-temporal.duration.prototype.add
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 
 fields.forEach((field) => {
-  assert.throws(RangeError, () => instance.add({ [field]: Infinity }));
+  assert.throws(RangeError, () => instance.add({ [field]: Infinity }, { relativeTo }));
 });
 
 let calls = 0;
@@ -24,6 +25,6 @@ const obj = {
 
 fields.forEach((field) => {
   calls = 0;
-  assert.throws(RangeError, () => instance.add({ [field]: obj }));
+  assert.throws(RangeError, () => instance.add({ [field]: obj }, { relativeTo }));
   assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/add/negative-infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/add/negative-infinity-throws-rangeerror.js
@@ -6,15 +6,12 @@ description: Temporal.Duration.prototype.add throws a RangeError if any value in
 esid: sec-temporal.duration.prototype.add
 ---*/
 
-const overflows = ['constrain', 'balance'];
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    assert.throws(RangeError, () => instance.add({ [field]: -Infinity }, { overflow }));
-  });
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.add({ [field]: -Infinity }));
 });
 
 let calls = 0;
@@ -25,10 +22,8 @@ const obj = {
   }
 };
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    calls = 0;
-    assert.throws(RangeError, () => instance.add({ [field]: obj }, { overflow }));
-    assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-  });
+fields.forEach((field) => {
+  calls = 0;
+  assert.throws(RangeError, () => instance.add({ [field]: obj }));
+  assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/add/negative-infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/add/negative-infinity-throws-rangeerror.js
@@ -9,9 +9,10 @@ esid: sec-temporal.duration.prototype.add
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 
 fields.forEach((field) => {
-  assert.throws(RangeError, () => instance.add({ [field]: -Infinity }));
+  assert.throws(RangeError, () => instance.add({ [field]: -Infinity }, { relativeTo }));
 });
 
 let calls = 0;
@@ -24,6 +25,6 @@ const obj = {
 
 fields.forEach((field) => {
   calls = 0;
-  assert.throws(RangeError, () => instance.add({ [field]: obj }));
+  assert.throws(RangeError, () => instance.add({ [field]: obj }, { relativeTo }));
   assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/add/order-of-operations.js
+++ b/polyfill/test/Duration/prototype/add/order-of-operations.js
@@ -6,7 +6,8 @@ esid: sec-temporal.duration.prototype.add
 includes: [compareArray.js]
 ---*/
 
-const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const instance = new Temporal.Duration(1, 2, 0, 4, 5, 6, 7, 987, 654, 321);
+const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 const expected = [
   "get days",
   "valueOf days",
@@ -61,11 +62,11 @@ const argument = new Proxy(fields, {
     return key in target;
   },
 });
-const result = instance.add(argument);
+const result = instance.add(argument, { relativeTo });
 assert.sameValue(result.years, 2, "years result");
 assert.sameValue(result.months, 3, "months result");
-assert.sameValue(result.weeks, 4, "weeks result");
-assert.sameValue(result.days, 5, "days result");
+assert.sameValue(result.weeks, 0, "weeks result");
+assert.sameValue(result.days, 12, "days result");
 assert.sameValue(result.hours, 6, "hours result");
 assert.sameValue(result.minutes, 7, "minutes result");
 assert.sameValue(result.seconds, 8, "seconds result");

--- a/polyfill/test/Duration/prototype/add/subclass-constructor-not-object.js
+++ b/polyfill/test/Duration/prototype/add/subclass-constructor-not-object.js
@@ -6,7 +6,7 @@ esid: sec-temporal.duration.prototype.add
 ---*/
 
 function check(value, description) {
-  const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+  const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
   duration.constructor = value;
   assert.throws(TypeError, () => duration.add({ nanoseconds: 1 }), description);
 }

--- a/polyfill/test/Duration/prototype/add/subclass-constructor-throws.js
+++ b/polyfill/test/Duration/prototype/add/subclass-constructor-throws.js
@@ -7,7 +7,7 @@ esid: sec-temporal.duration.prototype.add
 
 function CustomError() {}
 
-const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
 Object.defineProperty(duration, "constructor", {
   get() {
     throw new CustomError();

--- a/polyfill/test/Duration/prototype/add/subclass-constructor-undefined.js
+++ b/polyfill/test/Duration/prototype/add/subclass-constructor-undefined.js
@@ -10,21 +10,21 @@ let called = 0;
 
 class MyDuration extends Temporal.Duration {
   constructor(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds) {
-    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [1, 2, 3, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
+    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [0, 0, 0, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
     ++called;
     super(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
 }
 
-const instance = MyDuration.from("P1Y2M3W4DT5H6M7.987654321S");
+const instance = MyDuration.from("P4DT5H6M7.987654321S");
 assert.sameValue(called, 1);
 
 MyDuration.prototype.constructor = undefined;
 
 const result = instance.add({ nanoseconds: 1 });
-assert.sameValue(result.years, 1, "years result");
-assert.sameValue(result.months, 2, "months result");
-assert.sameValue(result.weeks, 3, "weeks result");
+assert.sameValue(result.years, 0, "years result");
+assert.sameValue(result.months, 0, "months result");
+assert.sameValue(result.weeks, 0, "weeks result");
 assert.sameValue(result.days, 4, "days result");
 assert.sameValue(result.hours, 5, "hours result");
 assert.sameValue(result.minutes, 6, "minutes result");

--- a/polyfill/test/Duration/prototype/add/subclass-invalid-result.js
+++ b/polyfill/test/Duration/prototype/add/subclass-invalid-result.js
@@ -7,7 +7,7 @@ features: [Symbol.species]
 ---*/
 
 function check(value, description) {
-  const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+  const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
   duration.constructor = {
     [Symbol.species]: function() {
       return value;

--- a/polyfill/test/Duration/prototype/add/subclass-out-of-range.js
+++ b/polyfill/test/Duration/prototype/add/subclass-out-of-range.js
@@ -21,6 +21,3 @@ assert.sameValue(called, 1);
 
 assert.throws(RangeError, () => instance.add({ nanoseconds: Number.MAX_VALUE }));
 assert.sameValue(called, 1);
-
-assert.throws(RangeError, () => instance.add({ nanoseconds: Number.MAX_VALUE }, { overflow: "balance" }));
-assert.sameValue(called, 1);

--- a/polyfill/test/Duration/prototype/add/subclass-species-not-constructor.js
+++ b/polyfill/test/Duration/prototype/add/subclass-species-not-constructor.js
@@ -7,7 +7,7 @@ features: [Symbol.species]
 ---*/
 
 function check(value, description) {
-  const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+  const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
   duration.constructor = {
     [Symbol.species]: value,
   };

--- a/polyfill/test/Duration/prototype/add/subclass-species-null.js
+++ b/polyfill/test/Duration/prototype/add/subclass-species-null.js
@@ -11,13 +11,13 @@ let called = 0;
 
 class MyDuration extends Temporal.Duration {
   constructor(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds) {
-    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [1, 2, 3, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
+    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [0, 0, 0, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
     ++called;
     super(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
 }
 
-const instance = MyDuration.from("P1Y2M3W4DT5H6M7.987654321S");
+const instance = MyDuration.from("P4DT5H6M7.987654321S");
 assert.sameValue(called, 1);
 
 MyDuration.prototype.constructor = {
@@ -25,9 +25,9 @@ MyDuration.prototype.constructor = {
 };
 
 const result = instance.add({ nanoseconds: 1 });
-assert.sameValue(result.years, 1, "years result");
-assert.sameValue(result.months, 2, "months result");
-assert.sameValue(result.weeks, 3, "weeks result");
+assert.sameValue(result.years, 0, "years result");
+assert.sameValue(result.months, 0, "months result");
+assert.sameValue(result.weeks, 0, "weeks result");
 assert.sameValue(result.days, 4, "days result");
 assert.sameValue(result.hours, 5, "hours result");
 assert.sameValue(result.minutes, 6, "minutes result");

--- a/polyfill/test/Duration/prototype/add/subclass-species-throws.js
+++ b/polyfill/test/Duration/prototype/add/subclass-species-throws.js
@@ -8,7 +8,7 @@ features: [Symbol.species]
 
 function CustomError() {}
 
-const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
 duration.constructor = {
   get [Symbol.species]() {
     throw new CustomError();

--- a/polyfill/test/Duration/prototype/add/subclass-species-undefined.js
+++ b/polyfill/test/Duration/prototype/add/subclass-species-undefined.js
@@ -11,13 +11,13 @@ let called = 0;
 
 class MyDuration extends Temporal.Duration {
   constructor(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds) {
-    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [1, 2, 3, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
+    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [0, 0, 0, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
     ++called;
     super(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
 }
 
-const instance = MyDuration.from("P1Y2M3W4DT5H6M7.987654321S");
+const instance = MyDuration.from("P4DT5H6M7.987654321S");
 assert.sameValue(called, 1);
 
 MyDuration.prototype.constructor = {
@@ -25,9 +25,9 @@ MyDuration.prototype.constructor = {
 };
 
 const result = instance.add({ nanoseconds: 1 });
-assert.sameValue(result.years, 1, "years result");
-assert.sameValue(result.months, 2, "months result");
-assert.sameValue(result.weeks, 3, "weeks result");
+assert.sameValue(result.years, 0, "years result");
+assert.sameValue(result.months, 0, "months result");
+assert.sameValue(result.weeks, 0, "weeks result");
 assert.sameValue(result.days, 4, "days result");
 assert.sameValue(result.hours, 5, "hours result");
 assert.sameValue(result.minutes, 6, "minutes result");

--- a/polyfill/test/Duration/prototype/add/subclass.js
+++ b/polyfill/test/Duration/prototype/add/subclass.js
@@ -9,8 +9,8 @@ includes: [compareArray.js]
 let called = 0;
 
 const constructorArguments = [
-  [1, 2, 3, 4, 5, 6, 7, 987, 654, 321],
-  [1, 2, 3, 4, 5, 6, 7, 987, 654, 322],
+  [0, 0, 0, 4, 5, 6, 7, 987, 654, 321],
+  [0, 0, 0, 4, 5, 6, 7, 987, 654, 322],
 ];
 
 class MyDuration extends Temporal.Duration {
@@ -21,13 +21,13 @@ class MyDuration extends Temporal.Duration {
   }
 }
 
-const instance = MyDuration.from("P1Y2M3W4DT5H6M7.987654321S");
+const instance = MyDuration.from("P4DT5H6M7.987654321S");
 assert.sameValue(called, 1);
 
 const result = instance.add({ nanoseconds: 1 });
-assert.sameValue(result.years, 1, "years result");
-assert.sameValue(result.months, 2, "months result");
-assert.sameValue(result.weeks, 3, "weeks result");
+assert.sameValue(result.years, 0, "years result");
+assert.sameValue(result.months, 0, "months result");
+assert.sameValue(result.weeks, 0, "weeks result");
 assert.sameValue(result.days, 4, "days result");
 assert.sameValue(result.hours, 5, "hours result");
 assert.sameValue(result.minutes, 6, "minutes result");

--- a/polyfill/test/Duration/prototype/subtract/infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/subtract/infinity-throws-rangeerror.js
@@ -6,15 +6,12 @@ description: Temporal.Duration.prototype.subtract throws a RangeError if any val
 esid: sec-temporal.duration.prototype.subtract
 ---*/
 
-const overflows = ['constrain', 'balance'];
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    assert.throws(RangeError, () => instance.subtract({ [field]: Infinity }, { overflow }));
-  });
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.subtract({ [field]: Infinity }));
 });
 
 let calls = 0;
@@ -25,10 +22,8 @@ const obj = {
   }
 };
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    calls = 0;
-    assert.throws(RangeError, () => instance.subtract({ [field]: obj }, { overflow }));
-    assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-  });
+fields.forEach((field) => {
+  calls = 0;
+  assert.throws(RangeError, () => instance.subtract({ [field]: obj }));
+  assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/subtract/infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/subtract/infinity-throws-rangeerror.js
@@ -9,9 +9,10 @@ esid: sec-temporal.duration.prototype.subtract
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 
 fields.forEach((field) => {
-  assert.throws(RangeError, () => instance.subtract({ [field]: Infinity }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: Infinity }, { relativeTo }));
 });
 
 let calls = 0;
@@ -24,6 +25,6 @@ const obj = {
 
 fields.forEach((field) => {
   calls = 0;
-  assert.throws(RangeError, () => instance.subtract({ [field]: obj }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: obj }, { relativeTo }));
   assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/subtract/negative-infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/subtract/negative-infinity-throws-rangeerror.js
@@ -6,15 +6,12 @@ description: Temporal.Duration.prototype.subtract throws a RangeError if any val
 esid: sec-temporal.duration.prototype.subtract
 ---*/
 
-const overflows = ['constrain', 'balance'];
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    assert.throws(RangeError, () => instance.subtract({ [field]: -Infinity }, { overflow }));
-  });
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.subtract({ [field]: -Infinity }));
 });
 
 let calls = 0;
@@ -25,10 +22,8 @@ const obj = {
   }
 };
 
-overflows.forEach((overflow) => {
-  fields.forEach((field) => {
-    calls = 0;
-    assert.throws(RangeError, () => instance.subtract({ [field]: obj }, { overflow }));
-    assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-  });
+fields.forEach((field) => {
+  calls = 0;
+  assert.throws(RangeError, () => instance.subtract({ [field]: obj }));
+  assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/subtract/negative-infinity-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/subtract/negative-infinity-throws-rangeerror.js
@@ -9,9 +9,10 @@ esid: sec-temporal.duration.prototype.subtract
 const fields = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
 
 const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 
 fields.forEach((field) => {
-  assert.throws(RangeError, () => instance.subtract({ [field]: -Infinity }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: -Infinity }, { relativeTo }));
 });
 
 let calls = 0;
@@ -24,6 +25,6 @@ const obj = {
 
 fields.forEach((field) => {
   calls = 0;
-  assert.throws(RangeError, () => instance.subtract({ [field]: obj }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: obj }, { relativeTo }));
   assert.sameValue(calls, 1, "it fails after fetching the primitive value");
 });

--- a/polyfill/test/Duration/prototype/subtract/order-of-operations.js
+++ b/polyfill/test/Duration/prototype/subtract/order-of-operations.js
@@ -6,7 +6,8 @@ esid: sec-temporal.duration.prototype.subtract
 includes: [compareArray.js]
 ---*/
 
-const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const instance = new Temporal.Duration(1, 2, 1, 4, 5, 6, 7, 987, 654, 321);
+const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
 const expected = [
   "get days",
   "valueOf days",
@@ -61,10 +62,10 @@ const argument = new Proxy(fields, {
     return key in target;
   },
 });
-const result = instance.subtract(argument);
+const result = instance.subtract(argument, { relativeTo });
 assert.sameValue(result.years, 0, "years result");
 assert.sameValue(result.months, 1, "months result");
-assert.sameValue(result.weeks, 2, "weeks result");
+assert.sameValue(result.weeks, 0, "weeks result");
 assert.sameValue(result.days, 3, "days result");
 assert.sameValue(result.hours, 4, "hours result");
 assert.sameValue(result.minutes, 5, "minutes result");

--- a/polyfill/test/Duration/prototype/subtract/subclass-constructor-not-object.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass-constructor-not-object.js
@@ -6,7 +6,7 @@ esid: sec-temporal.duration.prototype.subtract
 ---*/
 
 function check(value, description) {
-  const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+  const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
   duration.constructor = value;
   assert.throws(TypeError, () => duration.subtract({ nanoseconds: 1 }), description);
 }

--- a/polyfill/test/Duration/prototype/subtract/subclass-constructor-throws.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass-constructor-throws.js
@@ -7,7 +7,7 @@ esid: sec-temporal.duration.prototype.subtract
 
 function CustomError() {}
 
-const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
 Object.defineProperty(duration, "constructor", {
   get() {
     throw new CustomError();

--- a/polyfill/test/Duration/prototype/subtract/subclass-constructor-undefined.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass-constructor-undefined.js
@@ -10,21 +10,21 @@ let called = 0;
 
 class MyDuration extends Temporal.Duration {
   constructor(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds) {
-    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [1, 2, 3, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
+    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [0, 0, 0, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
     ++called;
     super(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
 }
 
-const instance = MyDuration.from("P1Y2M3W4DT5H6M7.987654321S");
+const instance = MyDuration.from("P4DT5H6M7.987654321S");
 assert.sameValue(called, 1);
 
 MyDuration.prototype.constructor = undefined;
 
 const result = instance.subtract({ nanoseconds: 1 });
-assert.sameValue(result.years, 1, "years result");
-assert.sameValue(result.months, 2, "months result");
-assert.sameValue(result.weeks, 3, "weeks result");
+assert.sameValue(result.years, 0, "years result");
+assert.sameValue(result.months, 0, "months result");
+assert.sameValue(result.weeks, 0, "weeks result");
 assert.sameValue(result.days, 4, "days result");
 assert.sameValue(result.hours, 5, "hours result");
 assert.sameValue(result.minutes, 6, "minutes result");

--- a/polyfill/test/Duration/prototype/subtract/subclass-invalid-result.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass-invalid-result.js
@@ -7,7 +7,7 @@ features: [Symbol.species]
 ---*/
 
 function check(value, description) {
-  const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+  const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
   duration.constructor = {
     [Symbol.species]: function() {
       return value;

--- a/polyfill/test/Duration/prototype/subtract/subclass-out-of-range.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass-out-of-range.js
@@ -21,6 +21,3 @@ assert.sameValue(called, 1);
 
 assert.throws(RangeError, () => instance.subtract({ nanoseconds: Number.MAX_VALUE }));
 assert.sameValue(called, 1);
-
-assert.throws(RangeError, () => instance.subtract({ nanoseconds: Number.MAX_VALUE }, { overflow: "balance" }));
-assert.sameValue(called, 1);

--- a/polyfill/test/Duration/prototype/subtract/subclass-species-not-constructor.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass-species-not-constructor.js
@@ -7,7 +7,7 @@ features: [Symbol.species]
 ---*/
 
 function check(value, description) {
-  const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+  const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
   duration.constructor = {
     [Symbol.species]: value,
   };

--- a/polyfill/test/Duration/prototype/subtract/subclass-species-null.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass-species-null.js
@@ -11,13 +11,13 @@ let called = 0;
 
 class MyDuration extends Temporal.Duration {
   constructor(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds) {
-    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [1, 2, 3, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
+    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [0, 0, 0, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
     ++called;
     super(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
 }
 
-const instance = MyDuration.from("P1Y2M3W4DT5H6M7.987654321S");
+const instance = MyDuration.from("P4DT5H6M7.987654321S");
 assert.sameValue(called, 1);
 
 MyDuration.prototype.constructor = {
@@ -25,9 +25,9 @@ MyDuration.prototype.constructor = {
 };
 
 const result = instance.subtract({ nanoseconds: 1 });
-assert.sameValue(result.years, 1, "years result");
-assert.sameValue(result.months, 2, "months result");
-assert.sameValue(result.weeks, 3, "weeks result");
+assert.sameValue(result.years, 0, "years result");
+assert.sameValue(result.months, 0, "months result");
+assert.sameValue(result.weeks, 0, "weeks result");
 assert.sameValue(result.days, 4, "days result");
 assert.sameValue(result.hours, 5, "hours result");
 assert.sameValue(result.minutes, 6, "minutes result");

--- a/polyfill/test/Duration/prototype/subtract/subclass-species-throws.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass-species-throws.js
@@ -8,7 +8,7 @@ features: [Symbol.species]
 
 function CustomError() {}
 
-const duration = Temporal.Duration.from({ years: 1, months: 2, weeks: 3, days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
+const duration = Temporal.Duration.from({ days: 4, hours: 5, minutes: 6, seconds: 7, milliseconds: 987, microseconds: 654, nanoseconds: 321 });
 duration.constructor = {
   get [Symbol.species]() {
     throw new CustomError();

--- a/polyfill/test/Duration/prototype/subtract/subclass-species-undefined.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass-species-undefined.js
@@ -11,13 +11,13 @@ let called = 0;
 
 class MyDuration extends Temporal.Duration {
   constructor(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds) {
-    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [1, 2, 3, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
+    assert.compareArray([years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds], [0, 0, 0, 4, 5, 6, 7, 987, 654, 321], "constructor arguments");
     ++called;
     super(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
 }
 
-const instance = MyDuration.from("P1Y2M3W4DT5H6M7.987654321S");
+const instance = MyDuration.from("P4DT5H6M7.987654321S");
 assert.sameValue(called, 1);
 
 MyDuration.prototype.constructor = {
@@ -25,9 +25,9 @@ MyDuration.prototype.constructor = {
 };
 
 const result = instance.subtract({ nanoseconds: 1 });
-assert.sameValue(result.years, 1, "years result");
-assert.sameValue(result.months, 2, "months result");
-assert.sameValue(result.weeks, 3, "weeks result");
+assert.sameValue(result.years, 0, "years result");
+assert.sameValue(result.months, 0, "months result");
+assert.sameValue(result.weeks, 0, "weeks result");
 assert.sameValue(result.days, 4, "days result");
 assert.sameValue(result.hours, 5, "hours result");
 assert.sameValue(result.minutes, 6, "minutes result");

--- a/polyfill/test/Duration/prototype/subtract/subclass.js
+++ b/polyfill/test/Duration/prototype/subtract/subclass.js
@@ -9,8 +9,8 @@ includes: [compareArray.js]
 let called = 0;
 
 const constructorArguments = [
-  [1, 2, 3, 4, 5, 6, 7, 987, 654, 321],
-  [1, 2, 3, 4, 5, 6, 7, 987, 654, 320],
+  [0, 0, 0, 4, 5, 6, 7, 987, 654, 321],
+  [0, 0, 0, 4, 5, 6, 7, 987, 654, 320],
 ];
 
 class MyDuration extends Temporal.Duration {
@@ -21,13 +21,13 @@ class MyDuration extends Temporal.Duration {
   }
 }
 
-const instance = MyDuration.from("P1Y2M3W4DT5H6M7.987654321S");
+const instance = MyDuration.from("P4DT5H6M7.987654321S");
 assert.sameValue(called, 1);
 
 const result = instance.subtract({ nanoseconds: 1 });
-assert.sameValue(result.years, 1, "years result");
-assert.sameValue(result.months, 2, "months result");
-assert.sameValue(result.weeks, 3, "weeks result");
+assert.sameValue(result.years, 0, "years result");
+assert.sameValue(result.months, 0, "months result");
+assert.sameValue(result.weeks, 0, "weeks result");
 assert.sameValue(result.days, 4, "days result");
 assert.sameValue(result.hours, 5, "hours result");
 assert.sameValue(result.minutes, 6, "minutes result");

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -365,8 +365,8 @@
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Set _other_ to ? ToLimitedTemporalDuration(_other_, « »).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
-        1. <mark>TODO: rounding options</mark>.
-        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _other_.[[Years]], _other_.[[Months]], _other_.[[Weeks]], _other_.[[Days]], _other_.[[Hours]], _other_.[[Minutes]], _other_.[[Seconds]], _other_.[[Milliseconds]], _other_.[[Microseconds]], _other_.[[Nanoseconds]]).
+        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_options_).
+        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _other_.[[Years]], _other_.[[Months]], _other_.[[Weeks]], _other_.[[Days]], _other_.[[Hours]], _other_.[[Minutes]], _other_.[[Seconds]], _other_.[[Milliseconds]], _other_.[[Microseconds]], _other_.[[Nanoseconds]], _relativeTo_).
         1. Return ? CreateTemporalDurationFromInstance(_duration_, _result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -382,8 +382,8 @@
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Set _other_ to ? ToLimitedTemporalDuration(_other_, « »).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
-        1. <mark>TODO: rounding options</mark>.
-        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], −_other_.[[Years]], −_other_.[[Months]], −_other_.[[Weeks]], −_other_.[[Days]], −_other_.[[Hours]], −_other_.[[Minutes]], −_other_.[[Seconds]], −_other_.[[Milliseconds]], −_other_.[[Microseconds]], −_other_.[[Nanoseconds]]).
+        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_options_).
+        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], −_other_.[[Years]], −_other_.[[Months]], −_other_.[[Weeks]], −_other_.[[Days]], −_other_.[[Hours]], −_other_.[[Minutes]], −_other_.[[Seconds]], −_other_.[[Milliseconds]], −_other_.[[Microseconds]], −_other_.[[Nanoseconds]], _relativeTo_).
         1. Return ? CreateTemporalDurationFromInstance(_duration_, _result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -1058,31 +1058,42 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-addduration" aoid="AddDuration">
-      <h1>AddDuration ( _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_ )</h1>
+      <h1>AddDuration ( _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_, _relativeTo_ )</h1>
       <p>
-        The abstract operation AddDuration adds the components of a second duration to those of a first duration, and balances the duration to ensure that no mixed signs remain in the result (or throws a *RangeError* if that is not possible).
+        The abstract operation AddDuration adds the components of a second duration to those of a first duration, and balances the duration relative to the given date _relativeTo_ to ensure that no mixed signs remain in the result.
       </p>
       <emu-alg>
         1. Assert: _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_ are integer Number values.
+        1. Let _largestUnit1_ be ! DefaultTemporalLargestUnit(_y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
+        1. Let _largestUnit2_ be ! DefaultTemporalLargestUnit(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _largestUnit_ be ! LargerOfTwoTemporalDurationUnits(_largestUnit1_, _largestUnit2_).
+        1. Let _unbalanceResult1_ be ? UnbalanceDurationRelative(_y1_, _mon1_, _w1_, _d1_, *"days"*, _relativeTo_).
+        1. If _relativeTo_ is not *undefined*, then
+          1. Let _datePart1_ be ? CreateTemporalDuration(0, 0, 0, _unbalanceResult1_.[[Days]], 0, 0, 0, 0, 0, 0).
+          1. Let _moveResult_ be ? MoveRelativeDate(_relativeTo_.[[Calendar]], _relativeTo_, _datePart1_).
+          1. Let _intermediate_ be _moveResult_.[[RelativeTo]].
+        1. Else,
+          1. Let _intermediate_ be *undefined*.
+        1. Let _unbalanceResult2_ be ? UnbalanceDurationRelative(_y2_, _mon2_, _w2_, _d2_, *"days"*, _intermediate_).
         1. Let _nanoseconds_ be _ns1_ + _ns2_.
         1. Let _microseconds_ be _mus1_ + _mus2_.
         1. Let _milliseconds_ be _ms1_ + _ms2_.
         1. Let _seconds_ be _s1_ + _s2_.
         1. Let _minutes_ be _min1_ + _min2_.
         1. Let _hours_ be _h1_ + _h2_.
-        1. Let _days_ be _d1_ + _d2_.
-        1. Let _weeks_ be _w1_ + _w2_.
-        1. Let _months_ be _mon1_ + _mon2_.
-        1. Let _years_ be _y1_ + _y2_.
-        1. Let _largestUnit_ be ! DefaultTemporalLargestUnit(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Let _balanceResult_ be ? BalanceDuration(_days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_).
-        1. Set _days_ to _balanceResult_.[[Days]].
-        1. Set _hours_ to _balanceResult_.[[Hours]].
-        1. Set _minutes_ to _balanceResult_.[[Minutes]].
-        1. Set _seconds_ to _balanceResult_.[[Seconds]].
-        1. Set _milliseconds_ to _balanceResult_.[[Milliseconds]].
-        1. Set _microseconds_ to _balanceResult_.[[Microseconds]].
-        1. Set _nanoseconds_ to _balanceResult_.[[Nanoseconds]].
+        1. Let _days_ be _unbalanceResult1_.[[Days]] + _unbalanceResult2_.[[Days]].
+        1. Let _balanceRelativeResult_ be ? BalanceDurationRelative(0, 0, 0, _days_, _largestUnit_, _relativeTo_).
+        1. Let _balanceResult_ be ? BalanceDuration(_balanceRelativeResult_.[[Days]], _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_).
+        1. Let _years_ be _balanceRelativeResult_.[[Years]].
+        1. Let _months_ be _balanceRelativeResult_.[[Months]].
+        1. Let _weeks_ be _balanceRelativeResult_.[[Weeks]].
+        1. Let _days_ be _balanceResult_.[[Days]].
+        1. Let _hours_ be _balanceResult_.[[Hours]].
+        1. Let _minutes_ be _balanceResult_.[[Minutes]].
+        1. Let _seconds_ be _balanceResult_.[[Seconds]].
+        1. Let _milliseconds_ be _balanceResult_.[[Milliseconds]].
+        1. Let _microseconds_ be _balanceResult_.[[Microseconds]].
+        1. Let _nanoseconds_ be _balanceResult_.[[Nanoseconds]].
         1. If ! ValidateDuration(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_) is *false*, then
           1. Throw a *RangeError* exception.
         1. Return the new Record {


### PR DESCRIPTION
This implements the relativeTo option in Duration.add() and subtract(), for PlainDateTime values. ZonedDateTime values will follow in a subsequent pull request.

See: #856 
