### PR TITLE
withTime() and withDate() methods on ZonedDateTime and PlainDateTime

### DIFF
--- a/docs/datetime.md
+++ b/docs/datetime.md
@@ -383,6 +383,82 @@ dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt.with({ year: 2015, second: 31 }); // => 2015-12-07T03:24:31.000003500
 ```
 
+### datetime.**withPlainTime**(_plainTime_?: object | string) : Temporal.PlainDateTime
+
+**Parameters:**
+
+- `plainTime` (`Temporal.PlainTime` or plain object or string): The clock time that should replace the current clock time of `datetime`.
+  If omitted, the clock time of the result will be `00:00:00`.
+
+**Returns:** a new `Temporal.PlainDateTime` object which is the date indicated by `datetime`, combined with the time represented by `plainTime`.
+
+Valid input to `withPlainTime` is the same as valid input to `Temporal.PlainTime.from`, including strings like `12:15:36`, plain object property bags like `{ hour: 20, minute: 30 }`, or `Temporal` objects that contain time fields: `Temporal.PlainTime`, `Temporal.ZonedDateTime`, or `Temporal.PlainDateTime`.
+
+This method is similar to `with`, but with a few important differences:
+
+- `withPlainTime` accepts strings, Temporal objects, or object property bags.
+  `with` only accepts object property bags and does not accept strings nor `Temporal.PlainTime` objects because they can contain calendar information.
+- `withPlainTime` will default all missing time units to zero, while `with` will only change units that are present in the input object.
+
+If `plainTime` is a `Temporal.PlainTime` object, then this method returns the same result as `plainTime.toPlainDateTime(datetime)` but can be easier to use, especially when chained to previous operations that return a `Temporal.PlainDateTime`.
+
+Usage example:
+
+```javascript
+dt = Temporal.PlainDateTime.from('2015-12-07T03:24:30.000003500');
+dt.withPlainTime({ hour: 10 }); // => 2015-12-07T10:00:00
+time = Temporal.PlainTime.from('11:22');
+dt.withPlainTime(time); // => 2015-12-07T11:22:00
+dt.withPlainTime('12:34'); // => 2015-12-07T12:34:00
+
+// easier for chaining
+dt.add({ days: 2, hours: 22 }).withTime('00:00'); // => 2015-12-10T00:00:00
+```
+
+### datetime.**withPlainDate**(_plainDate_: object | string) : Temporal.PlainDateTime
+
+**Parameters:**
+
+- `plainDate` (`Temporal.PlainDate` or plain object or string): The calendar date that should replace the current calendar date of `datetime`.
+
+**Returns:** a new `Temporal.PlainDateTime` object which is the date indicated by `datetime`, combined with the date represented by `plainDate`.
+
+Valid input to `withPlainDate` is the same as valid input to `Temporal.PlainDate.from`, including strings like `2000-03-01`, plain object property bags like `{ year: 2020, month: 3, day: 1 }`, or `Temporal` objects that contain a `year`, `month`, and `day` property, including `Temporal.PlainDate`, `Temporal.PlainDateTime`, or `Temporal.ZonedDateTime`.
+
+All three date units (`year`, `month`, and `day`) are required.
+`Temporal.YearMonth` and `Temporal.MonthDay` are not valid input because they lack all date units.
+Both of those types have a `toPlainDate` method that can be used to obtain a `Temporal.PlainDate` which can in turn be used as input to `withPlainDate`.
+
+If `plainDate` contains a non-ISO 8601 calendar, then the result of `withPlainDate` will be the calendar of `plainDate`.
+However, if `datetime.calendar` is already a non-ISO 8601 calendar, then this method wil throw a `RangeError`.
+To resolve the error, first convert one of the instances to the same calendar or the ISO 8601 calendar, e.g. using `.withCalendar('iso8601')`.
+
+This method is similar to `with`, but with a few important differences:
+
+- `withPlainDate` accepts strings, Temporal objects, or object property bags.
+  `with` only accepts object property bags and does not accept strings nor `Temporal.PlainDate` objects because they can contain calendar information.
+- `withPlainDate` will update all date units, while `with` only changes individual units that are present in the input, e.g. setting the `day` to `1` while leaving `month` and `year` unchanged.
+
+If `plainDate` is a `Temporal.PlainDate` object, then this method returns the same result as `plainDate.toPlainDateTime(datetime)` but can be easier to use, especially when chained to previous operations that return a `Temporal.PlainDateTime`.
+
+Usage example:
+
+```javascript
+dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30');
+dt.withPlainDate({ year: 2000, month: 6, day: 1 }); // => 2000-06-01T03:24:30
+date = Temporal.PlainDate.from('2020-01-23');
+dt.withPlainDate(date); // => 2020-01-23T03:24:30
+dt.withPlainDate('2018-09-15'); // => 2018-09-15T03:24:30
+
+// easier for chaining
+dt.add({ hours: 12 }).withPlainDate('2000-06-01'); // => 2000-06-01T15:24:30
+
+// result contains a non-ISO calendar if present in the input
+dt.withCalendar('japanese').withPlainDate('2008-09-06'); // => 2008-09-06T03:24:30[c=japanese]
+dt.withPlainDate('2017-09-06[c=japanese]'); // => 2017-09-06T03:24:30[c=japanese]
+dt.withCalendar('japanese').withPlainDate('2017-09-06[c=hebrew]'); // => RangeError (calendar conflict)
+```
+
 ### datetime.**withCalendar**(_calendar_: object | string) : Temporal.PlainDateTime
 
 **Parameters:**
@@ -525,7 +601,7 @@ Take care when using milliseconds, microseconds, or nanoseconds as the largest u
 For some durations, the resulting value may overflow `Number.MAX_SAFE_INTEGER` and lose precision in its least significant digit(s).
 Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.
 
-Computing the difference between two datetimes in different calendar systems is not supported.
+Computing the difference between two date/times in different calendar systems is not supported.
 If you need to do this, choose the calendar in which the computation takes place by converting one of the dates with `datetime.withCalendar()`.
 
 Usage example:
@@ -665,7 +741,7 @@ This function exists because it's not possible to compare using `datetime == oth
 
 If you don't need to know the order in which the two dates/times occur, then this function may be less typing and more efficient than `Temporal.PlainDateTime.compare`.
 
-Note that this function will return `true` if the two datetimes are equal, even if they are expressed in different calendar systems.
+Note that this function will return `true` if the two date/times are equal, even if they are expressed in different calendar systems.
 
 If `other` is not a `Temporal.PlainDateTime` object, then it will be converted to one as if it were passed to `Temporal.PlainDateTime.from()`.
 

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -943,6 +943,8 @@ export namespace Temporal {
     readonly inLeapYear: boolean;
     equals(other: Temporal.PlainDateTime | DateTimeLike | string): boolean;
     with(dateTimeLike: DateTimeLike, options?: AssignmentOptions): Temporal.PlainDateTime;
+    withTime(timeLike?: Temporal.PlainTime | TimeLike | string): Temporal.PlainDateTime;
+    withDate(dateLike: Temporal.PlainDate | DateLike | string): Temporal.PlainDateTime;
     withCalendar(calendar: CalendarProtocol | string): Temporal.PlainDateTime;
     add(durationLike: Temporal.Duration | DurationLike | string, options?: ArithmeticOptions): Temporal.PlainDateTime;
     subtract(
@@ -1392,6 +1394,8 @@ export namespace Temporal {
     readonly epochNanoseconds: bigint;
     equals(other: Temporal.ZonedDateTime | ZonedDateTimeLike | string): boolean;
     with(zonedDateTimeLike: ZonedDateTimeLike, options?: ZonedDateTimeAssignmentOptions): Temporal.ZonedDateTime;
+    withTime(timeLike?: Temporal.PlainTime | TimeLike | string): Temporal.ZonedDateTime;
+    withDate(dateLike: Temporal.PlainDate | DateLike | string): Temporal.ZonedDateTime;
     withCalendar(calendar: CalendarProtocol | string): Temporal.ZonedDateTime;
     withTimeZone(timeZone: TimeZoneProtocol | string): Temporal.ZonedDateTime;
     add(durationLike: Temporal.Duration | DurationLike | string, options?: ArithmeticOptions): Temporal.ZonedDateTime;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1366,7 +1366,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const sTwo = ES.CalendarToString(two);
     if (sOne === sTwo || sOne === 'iso8601') {
       return two;
-    } else if (two === 'iso8601') {
+    } else if (sTwo === 'iso8601') {
       return one;
     } else {
       throw new RangeError('irreconcilable calendars');

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -243,6 +243,49 @@ export class PlainDateTime {
     if (!ES.IsTemporalDateTime(result)) throw new TypeError('invalid result');
     return result;
   }
+  withPlainTime(temporalTime = undefined) {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    const year = GetSlot(this, ISO_YEAR);
+    const month = GetSlot(this, ISO_MONTH);
+    const day = GetSlot(this, ISO_DAY);
+    const dateCalendar = GetSlot(this, CALENDAR);
+    const Construct = ES.SpeciesConstructor(this, PlainDateTime);
+
+    if (temporalTime === undefined) return new Construct(year, month, day, 0, 0, 0, 0, 0, 0, dateCalendar);
+
+    temporalTime = ES.ToTemporalTime(temporalTime, GetIntrinsic('%Temporal.PlainTime%'));
+    const hour = GetSlot(temporalTime, ISO_HOUR);
+    const minute = GetSlot(temporalTime, ISO_MINUTE);
+    const second = GetSlot(temporalTime, ISO_SECOND);
+    const millisecond = GetSlot(temporalTime, ISO_MILLISECOND);
+    const microsecond = GetSlot(temporalTime, ISO_MICROSECOND);
+    const nanosecond = GetSlot(temporalTime, ISO_NANOSECOND);
+    const timeCalendar = GetSlot(temporalTime, CALENDAR);
+
+    const calendar = ES.ConsolidateCalendars(dateCalendar, timeCalendar);
+    return new Construct(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+  }
+  withPlainDate(temporalDate) {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+
+    temporalDate = ES.ToTemporalDate(temporalDate, GetIntrinsic('%Temporal.PlainDate%'));
+    const year = GetSlot(temporalDate, ISO_YEAR);
+    const month = GetSlot(temporalDate, ISO_MONTH);
+    const day = GetSlot(temporalDate, ISO_DAY);
+    const dateCalendar = GetSlot(temporalDate, CALENDAR);
+
+    const hour = GetSlot(this, ISO_HOUR);
+    const minute = GetSlot(this, ISO_MINUTE);
+    const second = GetSlot(this, ISO_SECOND);
+    const millisecond = GetSlot(this, ISO_MILLISECOND);
+    const microsecond = GetSlot(this, ISO_MICROSECOND);
+    const nanosecond = GetSlot(this, ISO_NANOSECOND);
+    const timeCalendar = GetSlot(this, CALENDAR);
+
+    const calendar = ES.ConsolidateCalendars(dateCalendar, timeCalendar);
+    const Construct = ES.SpeciesConstructor(this, PlainDateTime);
+    return new Construct(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+  }
   withCalendar(calendar) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     calendar = ES.ToTemporalCalendar(calendar);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -239,6 +239,81 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(result)) throw new TypeError('invalid result');
     return result;
   }
+  withPlainDate(temporalDate) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+
+    temporalDate = ES.ToTemporalDate(temporalDate, GetIntrinsic('%Temporal.PlainDate%'));
+
+    const year = GetSlot(temporalDate, ISO_YEAR);
+    const month = GetSlot(temporalDate, ISO_MONTH);
+    const day = GetSlot(temporalDate, ISO_DAY);
+    const dateCalendar = GetSlot(temporalDate, CALENDAR);
+    const timeCalendar = GetSlot(this, CALENDAR);
+    const thisDt = dateTime(this);
+    const hour = GetSlot(thisDt, ISO_HOUR);
+    const minute = GetSlot(thisDt, ISO_MINUTE);
+    const second = GetSlot(thisDt, ISO_SECOND);
+    const millisecond = GetSlot(thisDt, ISO_MILLISECOND);
+    const microsecond = GetSlot(thisDt, ISO_MICROSECOND);
+    const nanosecond = GetSlot(thisDt, ISO_NANOSECOND);
+
+    const calendar = ES.ConsolidateCalendars(dateCalendar, timeCalendar);
+    const timeZone = GetSlot(this, TIME_ZONE);
+    const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+    const dt = new PlainDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+    const instant = ES.GetTemporalInstantFor(timeZone, dt, 'compatible');
+    const Construct = ES.SpeciesConstructor(this, ZonedDateTime);
+    return new Construct(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
+  }
+  withPlainTime(temporalTime = undefined) {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+
+    const PlainTime = GetIntrinsic('%Temporal.PlainTime%');
+    temporalTime = temporalTime == undefined ? new PlainTime() : ES.ToTemporalTime(temporalTime, PlainTime);
+
+    const thisDt = dateTime(this);
+    const year = GetSlot(thisDt, ISO_YEAR);
+    const month = GetSlot(thisDt, ISO_MONTH);
+    const day = GetSlot(thisDt, ISO_DAY);
+    const dateCalendar = GetSlot(this, CALENDAR);
+    const hour = GetSlot(temporalTime, ISO_HOUR);
+    const minute = GetSlot(temporalTime, ISO_MINUTE);
+    const second = GetSlot(temporalTime, ISO_SECOND);
+    const millisecond = GetSlot(temporalTime, ISO_MILLISECOND);
+    const microsecond = GetSlot(temporalTime, ISO_MICROSECOND);
+    const nanosecond = GetSlot(temporalTime, ISO_NANOSECOND);
+    const timeCalendar = GetSlot(temporalTime, CALENDAR);
+
+    const calendar = ES.ConsolidateCalendars(dateCalendar, timeCalendar);
+    const timeZone = GetSlot(this, TIME_ZONE);
+    const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
+    const dt = new PlainDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
+    const instant = ES.GetTemporalInstantFor(timeZone, dt, 'compatible');
+    const Construct = ES.SpeciesConstructor(this, ZonedDateTime);
+    return new Construct(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
+  }
   withTimeZone(timeZone) {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     timeZone = ES.ToTemporalTimeZone(timeZone);

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -323,6 +323,58 @@ describe('DateTime', () => {
       throws(() => datetime.with({ year: 2021, timeZone: 'UTC' }), TypeError);
     });
   });
+  describe('.withPlainTime manipulation', () => {
+    const dt = Temporal.PlainDateTime.from('2015-12-07T03:24:30.000003500');
+    it('datetime.withPlainTime({ hour: 10 }) works', () => {
+      equal(`${dt.withPlainTime({ hour: 10 })}`, '2015-12-07T10:00:00');
+    });
+    it('datetime.withPlainTime(time) works', () => {
+      const time = Temporal.PlainTime.from('11:22');
+      equal(`${dt.withPlainTime(time)}`, '2015-12-07T11:22:00');
+    });
+    it("datetime.withPlainTime('12:34') works", () => {
+      equal(`${dt.withPlainTime('12:34')}`, '2015-12-07T12:34:00');
+    });
+    it('datetime.withPlainTime() defaults to midnight', () => {
+      equal(`${dt.withPlainTime()}`, '2015-12-07T00:00:00');
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => dt.withPlainTime({}), TypeError);
+      throws(() => dt.withPlainTime({ minutes: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${dt.withPlainTime({ hour: 10, seconds: 123 })}`, '2015-12-07T10:00:00');
+    });
+  });
+  describe('.withPlainDate manipulation', () => {
+    const dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30');
+    it('datetime.withPlainDate({ year: 2000, month: 6, day: 1 }) works', () => {
+      equal(`${dt.withPlainDate({ year: 2000, month: 6, day: 1 })}`, '2000-06-01T03:24:30');
+    });
+    it('datetime.withPlainDate(plainDate) works', () => {
+      const date = Temporal.PlainDate.from('2020-01-23');
+      equal(`${dt.withPlainDate(date)}`, '2020-01-23T03:24:30');
+    });
+    it("datetime.withPlainDate('2018-09-15') works", () => {
+      equal(`${dt.withPlainDate('2018-09-15')}`, '2018-09-15T03:24:30');
+    });
+    it('result contains a non-ISO calendar if present in the input', () => {
+      equal(`${dt.withCalendar('japanese').withPlainDate('2008-09-06')}`, '2008-09-06T03:24:30[c=japanese]');
+    });
+    it('calendar is unchanged if input has ISO calendar', () => {
+      equal(`${dt.withPlainDate('2008-09-06[c=japanese]')}`, '2008-09-06T03:24:30[c=japanese]');
+    });
+    it('throws if both `this` and `other` have a non-ISO calendar', () => {
+      throws(() => dt.withCalendar('gregory').withPlainDate('2008-09-06[c=japanese]'), RangeError);
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => dt.withPlainDate({}), TypeError);
+      throws(() => dt.withPlainDate({ months: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${dt.withPlainDate({ year: 2000, month: 6, day: 1, months: 123 })}`, '2000-06-01T03:24:30');
+    });
+  });
   describe('DateTime.compare() works', () => {
     const dt1 = PlainDateTime.from('1976-11-18T15:23:30.123456789');
     const dt2 = PlainDateTime.from('2019-10-29T10:46:38.271986102');

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -924,6 +924,71 @@ describe('ZonedDateTime', () => {
     });
   });
 
+  describe('.withPlainTime manipulation', () => {
+    const zdt = Temporal.ZonedDateTime.from('2015-12-07T03:24:30.000003500[America/Los_Angeles]');
+    it('withPlainTime({ hour: 10 }) works', () => {
+      equal(`${zdt.withPlainTime({ hour: 10 })}`, '2015-12-07T10:00:00-08:00[America/Los_Angeles]');
+    });
+    it('withPlainTime(time) works', () => {
+      const time = Temporal.PlainTime.from('11:22');
+      equal(`${zdt.withPlainTime(time)}`, '2015-12-07T11:22:00-08:00[America/Los_Angeles]');
+    });
+    it("withPlainTime('12:34') works", () => {
+      equal(`${zdt.withPlainTime('12:34')}`, '2015-12-07T12:34:00-08:00[America/Los_Angeles]');
+    });
+    it('withPlainTime() defaults to midnight', () => {
+      equal(`${zdt.withPlainTime()}`, '2015-12-07T00:00:00-08:00[America/Los_Angeles]');
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => zdt.withPlainTime({}), TypeError);
+      throws(() => zdt.withPlainTime({ minutes: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(`${zdt.withPlainTime({ hour: 10, seconds: 55 })}`, '2015-12-07T10:00:00-08:00[America/Los_Angeles]');
+    });
+  });
+  describe('.withPlainDate manipulation', () => {
+    const zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30[America/Los_Angeles]');
+    it('withPlainDate({ year: 2000, month: 6, day: 1 }) works', () => {
+      equal(`${zdt.withPlainDate({ year: 2000, month: 6, day: 1 })}`, '2000-06-01T03:24:30-07:00[America/Los_Angeles]');
+    });
+    it('withPlainDate(plainDate) works', () => {
+      const date = Temporal.PlainDate.from('2020-01-23');
+      equal(`${zdt.withPlainDate(date)}`, '2020-01-23T03:24:30-08:00[America/Los_Angeles]');
+    });
+    it("withPlainDate('2018-09-15') works", () => {
+      equal(`${zdt.withPlainDate('2018-09-15')}`, '2018-09-15T03:24:30-07:00[America/Los_Angeles]');
+    });
+    it('result contains a non-ISO calendar if present in the input', () => {
+      equal(
+        `${zdt.withCalendar('japanese').withPlainDate('2008-09-06')}`,
+        '2008-09-06T03:24:30-07:00[America/Los_Angeles][c=japanese]'
+      );
+    });
+    it('calendar is unchanged if input has ISO calendar', () => {
+      equal(
+        `${zdt.withPlainDate('2008-09-06[c=japanese]')}`,
+        '2008-09-06T03:24:30-07:00[America/Los_Angeles][c=japanese]'
+      );
+    });
+    it('throws if both `this` and `other` have a non-ISO calendar', () => {
+      throws(
+        () => zdt.withCalendar('gregory').withPlainDate('2008-09-06-07:00[America/Los_Angeles][c=japanese]'),
+        RangeError
+      );
+    });
+    it('object must contain at least one correctly-spelled property', () => {
+      throws(() => zdt.withPlainDate({}), TypeError);
+      throws(() => zdt.withPlainDate({ months: 12 }), TypeError);
+    });
+    it('incorrectly-spelled properties are ignored', () => {
+      equal(
+        `${zdt.withPlainDate({ year: 2000, month: 6, day: 1, months: 123 })}`,
+        '2000-06-01T03:24:30-07:00[America/Los_Angeles]'
+      );
+    });
+  });
+
   describe('ZonedDateTime.withTimeZone()', () => {
     const instant = Temporal.Instant.from('2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles]');
     const zdt = instant.toZonedDateTimeISO('UTC');

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -413,6 +413,42 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.plaindatetime.prototype.withplaintime">
+      <h1>Temporal.PlainDateTime.prototype.withPlainTime ( _plainTimeLike_ )</h1>
+      <p>
+        The `withPlainTime` method takes one argument _plainTimeLike_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _temporalDateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_temporalDateTime_, [[InitializedTemporalDateTime]]).
+        1. If _plainTimeLike_ is *undefined*, then
+          1. Return ? CreateTemporalDateTimeFromInstance(_temporalDateTime_, _temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], 0, 0, 0, 0, 0, 0, _temporalDateTime_.[[Calendar]]).
+        1. Let _plainTime_ be ? ToTemporalTime(_plainTimeLike_).
+        1. Let _dateCalendar_ be _temporalDateTime_.[[Calendar]].
+        1. Let _timeCalendar_ be _plainTime_.[[Calendar]].
+        1. Let _calendar_ be ? ConsolidateCalendars(_dateCalendar_, _timeCalendar_).
+        1. Return ? CreateTemporalDateTimeFromInstance(_temporalDateTime_, _temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _plainTime_.[[ISOHour]], _plainTime_.[[ISOMinute]], _plainTime_.[[ISOSecond]], _plainTime_.[[ISOMillisecond]], _plainTime_.[[ISOMicrosecond]], _plainTime_.[[ISONanosecond]], _calendar_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.plaindatetime.prototype.withplaindate">
+      <h1>Temporal.PlainDateTime.prototype.withPlainDate ( _plainDateLike_ )</h1>
+      <p>
+        The `withPlainDate` method takes one argument _plainDateLike_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _temporalDateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_temporalDateTime_, [[InitializedTemporalDateTime]]).
+        1. Let _plainDate_ be ? ToTemporalDate(_plainDateLike_).
+        1. Let _dateCalendar_ be _plainDate_.[[Calendar]].
+        1. Let _timeCalendar_ be _temporalDateTime_.[[Calendar]].
+        1. Let _calendar_ be ? ConsolidateCalendars(_dateCalendar_, _timeCalendar_).
+        1. Return ? CreateTemporalDateTimeFromInstance(_temporalDateTime_, _plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _calendar_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.plaindatetime.prototype.withcalendar">
       <h1>Temporal.PlainDateTime.prototype.withCalendar ( _calendar_ )</h1>
       <p>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -585,6 +585,53 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.withplaintime">
+      <h1>Temporal.ZonedDateTime.prototype.withPlainTime ( _plainTimeLike_ )</h1>
+      <p>
+        The `withPlainTime` method takes one argument _plainTimeLike_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _zonedDateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
+        1. If _plainTimeLike_ is *undefined*, then
+          1. Let _plainTime_ be ? CreateTemporalTime(0, 0, 0, 0, 0, 0).
+        1. Else,
+          1. Let _plainTime_ be ? ToTemporalTime(_plainTimeLike_).
+        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _instant_ be ? CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
+        1. Let _plainDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_).
+        1. Let _dateCalendar_ be _plainDateTime_.[[Calendar]].
+        1. Let _timeCalendar_ be _plainTime_.[[Calendar]].
+        1. Let _calendar_ be ? ConsolidateCalendars(_dateCalendar_, _timeCalendar_).
+        1. Let _resultPlainDateTime_ be ? CreateTemporalDateTime(_plainDateTime_.[[ISOYear]], _plainDateTime_.[[ISOMonth]], _plainDateTime_.[[ISODay]], _plainTime_.[[ISOHour]], _plainTime_.[[ISOMinute]], _plainTime_.[[ISOSecond]], _plainTime_.[[ISOMillisecond]], _plainTime_.[[ISOMicrosecond]], _plainTime_.[[ISONanosecond]], _calendar_).
+        1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _resultPlainDateTime_, *"compatible"*).
+        1. Return ? CreateTemporalZonedDateTimeFromInstance(_zonedDateTime_, _instant_.[[Nanoseconds]], _timeZone_, _calendar_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.zoneddatetime.prototype.withplaindate">
+      <h1>Temporal.ZonedDateTime.prototype.withPlainDate ( _plainDateLike_ )</h1>
+      <p>
+        The `withPlainDate` method takes one argument _plainDateLike_.
+        The following steps are taken:
+      </p>
+      <emu-alg>
+        1. Let _zonedDateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
+        1. Let _plainDate_ be ? ToTemporalDate(_plainDateLike_).
+        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _instant_ be ? CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
+        1. Let _plainDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_).
+        1. Let _dateCalendar_ be _plainDate_.[[Calendar]].
+        1. Let _timeCalendar_ be _plainDateTime_.[[Calendar]].
+        1. Let _calendar_ be ? ConsolidateCalendars(_dateCalendar_, _timeCalendar_).
+        1. Let _resultPlainDateTime_ be ? CreateTemporalDateTime(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], _plainDateTime_.[[ISOHour]], _plainDateTime_.[[ISOMinute]], _plainDateTime_.[[ISOSecond]], _plainDateTime_.[[ISOMillisecond]], _plainDateTime_.[[ISOMicrosecond]], _plainDateTime_.[[ISONanosecond]], _calendar_).
+        1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _resultPlainDateTime_, *"compatible"*).
+        1. Return ? CreateTemporalZonedDateTimeFromInstance(_zonedDateTime_, _instant_.[[Nanoseconds]], _timeZone_, _calendar_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal.zoneddatetime.prototype.withtimezone">
       <h1>Temporal.ZonedDateTime.prototype.withTimeZone ( _timeZoneLike_ )</h1>
       <p>


### PR DESCRIPTION
This PR implements a subset of the changes described in https://github.com/tc39/proposal-temporal/issues/522#issuecomment-726285736:

> * Add PlainDateTime.withPlainDate(), PlainDateTime.withPlainTime(), ZonedDateTime.withPlainDate(), and ZonedDateTime.withPlainTime() to address the use case of combining dates and times without spreading. These methods use the 'consolidate' behaviour for calendars (throw if non-ISO and different).

This PR includes docs, polyfill implementation, docs, and TS types but not spec updates for these methods. 

BTW, I found a bug in ES.ConsolidateCalendars that is fixed here. That method never worked if the second calendar was ISO. 