### PR TITLE
More relativeTo rounding

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1952,12 +1952,12 @@ export const ES = ObjectAssign({}, ES2020, {
     const sign = MathSign(nanoseconds);
     nanoseconds = bigInt(nanoseconds);
     let dayLengthNs = 86400e9;
-    if (sign === 0) return { days: 0, nanoseconds: bigInt.zero };
+    if (sign === 0) return { days: 0, nanoseconds: bigInt.zero, dayLengthNs };
     if (!ES.IsTemporalZonedDateTime(relativeTo)) {
       let days;
       ({ quotient: days, remainder: nanoseconds } = nanoseconds.divmod(dayLengthNs));
       days = days.toJSNumber();
-      return { days, nanoseconds };
+      return { days, nanoseconds, dayLengthNs: sign * dayLengthNs };
     }
     let isOverflow = false;
     let days = 0;
@@ -1991,7 +1991,7 @@ export const ES = ObjectAssign({}, ES2020, {
         days += sign;
       }
     } while (isOverflow);
-    return { days, nanoseconds };
+    return { days, nanoseconds, dayLengthNs };
   },
   BalanceDuration: (days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, largestUnit) => {
     nanoseconds = ES.TotalDurationNanoseconds(

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -975,20 +975,23 @@ describe('Duration', () => {
     const oneDay = new Duration(0, 0, 0, 1);
     const hours12 = new Duration(0, 0, 0, 0, 12);
     describe('relativeTo affects days if ZonedDateTime, and duration encompasses DST change', () => {
-      it.skip('start inside repeated hour, end after', () => {
+      it('start inside repeated hour, end after', () => {
         equal(`${hours25.round({ largestUnit: 'days', relativeTo: inRepeatedHour })}`, 'P1D');
         equal(`${oneDay.round({ largestUnit: 'hours', relativeTo: inRepeatedHour })}`, 'PT25H');
       });
-      it.skip('start after repeated hour, end inside (negative)', () => {
+      it('start after repeated hour, end inside (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-04T01:00[America/Vancouver]');
         equal(`${hours25.negated().round({ largestUnit: 'days', relativeTo })}`, '-P1D');
         equal(`${oneDay.negated().round({ largestUnit: 'hours', relativeTo })}`, '-PT25H');
       });
       it('start inside repeated hour, end in skipped hour', () => {
-        // gain one hour at the beginning, lose one at the end, days average 24h
         equal(
           `${Duration.from({ days: 126, hours: 1 }).round({ largestUnit: 'days', relativeTo: inRepeatedHour })}`,
           'P126DT1H'
+        );
+        equal(
+          `${Duration.from({ days: 126, hours: 1 }).round({ largestUnit: 'hours', relativeTo: inRepeatedHour })}`,
+          'PT3026H'
         );
       });
       it('start in normal hour, end in skipped hour', () => {
@@ -996,11 +999,11 @@ describe('Duration', () => {
         equal(`${hours25.round({ largestUnit: 'days', relativeTo })}`, 'P1DT1H');
         equal(`${oneDay.round({ largestUnit: 'hours', relativeTo })}`, 'PT24H');
       });
-      it.skip('start before skipped hour, end >1 day after', () => {
+      it('start before skipped hour, end >1 day after', () => {
         equal(`${hours25.round({ largestUnit: 'days', relativeTo: skippedHourDay })}`, 'P1DT2H');
         equal(`${oneDay.round({ largestUnit: 'hours', relativeTo: skippedHourDay })}`, 'PT23H');
       });
-      it.skip('start after skipped hour, end >1 day before (negative)', () => {
+      it('start after skipped hour, end >1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-11T00:00[America/Vancouver]');
         equal(`${hours25.negated().round({ largestUnit: 'days', relativeTo })}`, '-P1DT2H');
         equal(`${oneDay.negated().round({ largestUnit: 'hours', relativeTo })}`, '-PT23H');
@@ -1012,11 +1015,11 @@ describe('Duration', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-10T12:00[America/Vancouver]');
         equal(`${hours12.negated().round({ largestUnit: 'days', relativeTo })}`, '-PT12H');
       });
-      it.skip('start before repeated hour, end >1 day after', () => {
+      it('start before repeated hour, end >1 day after', () => {
         equal(`${hours25.round({ largestUnit: 'days', relativeTo: repeatedHourDay })}`, 'P1D');
         equal(`${oneDay.round({ largestUnit: 'hours', relativeTo: repeatedHourDay })}`, 'PT25H');
       });
-      it.skip('start after repeated hour, end >1 day before (negative)', () => {
+      it('start after repeated hour, end >1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-04T00:00[America/Vancouver]');
         equal(`${hours25.negated().round({ largestUnit: 'days', relativeTo })}`, '-P1D');
         equal(`${oneDay.negated().round({ largestUnit: 'hours', relativeTo })}`, '-PT25H');
@@ -1028,13 +1031,13 @@ describe('Duration', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-03T12:00[America/Vancouver]');
         equal(`${hours12.negated().round({ largestUnit: 'days', relativeTo })}`, '-PT12H');
       });
-      it.skip('Samoa skipped 24 hours', () => {
+      it('Samoa skipped 24 hours', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2011-12-29T12:00-10:00[Pacific/Apia]');
         equal(`${hours25.round({ largestUnit: 'days', relativeTo })}`, 'P2DT1H');
         equal(`${Duration.from({ hours: 48 }).round({ largestUnit: 'days', relativeTo })}`, 'P3D');
       });
     });
-    it.skip('casts relativeTo to ZonedDateTime if possible', () => {
+    it('casts relativeTo to ZonedDateTime if possible', () => {
       equal(`${hours25.round({ largestUnit: 'days', relativeTo: '2019-11-03T00:00[America/Vancouver]' })}`, 'P1D');
       equal(
         `${hours25.round({
@@ -1535,33 +1538,29 @@ describe('Duration', () => {
     const hours12 = new Duration(0, 0, 0, 0, 12);
     const hours25 = new Duration(0, 0, 0, 0, 25);
     describe('relativeTo affects days if ZonedDateTime, and duration encompasses DST change', () => {
-      it.skip('start inside repeated hour, end after', () => {
+      it('start inside repeated hour, end after', () => {
         equal(hours25.total({ unit: 'days', relativeTo: inRepeatedHour }), 1);
         equal(oneDay.total({ unit: 'hours', relativeTo: inRepeatedHour }), 25);
       });
-      it.skip('start after repeated hour, end inside (negative)', () => {
+      it('start after repeated hour, end inside (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-04T01:00[America/Vancouver]');
         equal(hours25.negated().total({ unit: 'days', relativeTo }), -1);
         equal(oneDay.negated().total({ unit: 'hours', relativeTo }), -25);
       });
-      it.skip('start inside repeated hour, end in skipped hour', () => {
-        // gain one hour at the beginning, lose one at the end, days average 24h
-        equal(Duration.from({ days: 126, hours: 1 }).total({ unit: 'days', relativeTo: inRepeatedHour }), 126 + 1 / 24);
-        equal(
-          Duration.from({ days: 126, hours: 1 }).total({ unit: 'hours', relativeTo: inRepeatedHour }),
-          126 * 24 + 1
-        );
+      it('start inside repeated hour, end in skipped hour', () => {
+        equal(Duration.from({ days: 126, hours: 1 }).total({ unit: 'days', relativeTo: inRepeatedHour }), 126 + 1 / 23);
+        equal(Duration.from({ days: 126, hours: 1 }).total({ unit: 'hours', relativeTo: inRepeatedHour }), 3026);
       });
       it('start in normal hour, end in skipped hour', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-09T02:30[America/Vancouver]');
         equal(hours25.total({ unit: 'days', relativeTo }), 1 + 1 / 24);
         equal(oneDay.total({ unit: 'hours', relativeTo }), 24);
       });
-      it.skip('start before skipped hour, end >1 day after', () => {
+      it('start before skipped hour, end >1 day after', () => {
         equal(hours25.total({ unit: 'days', relativeTo: skippedHourDay }), 1 + 2 / 24);
         equal(oneDay.total({ unit: 'hours', relativeTo: skippedHourDay }), 23);
       });
-      it.skip('start after skipped hour, end >1 day before (negative)', () => {
+      it('start after skipped hour, end >1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-11T00:00[America/Vancouver]');
         equal(hours25.negated().total({ unit: 'days', relativeTo }), -1 - 2 / 24);
         equal(oneDay.negated().total({ unit: 'hours', relativeTo }), -23);
@@ -1573,11 +1572,11 @@ describe('Duration', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-10T12:00[America/Vancouver]');
         equal(hours12.negated().total({ unit: 'days', relativeTo }), -12 / 23);
       });
-      it.skip('start before repeated hour, end >1 day after', () => {
+      it('start before repeated hour, end >1 day after', () => {
         equal(hours25.total({ unit: 'days', relativeTo: repeatedHourDay }), 1);
         equal(oneDay.total({ unit: 'hours', relativeTo: repeatedHourDay }), 25);
       });
-      it.skip('start after repeated hour, end >1 day before (negative)', () => {
+      it('start after repeated hour, end >1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-04T00:00[America/Vancouver]');
         equal(hours25.negated().total({ unit: 'days', relativeTo }), -1);
         equal(oneDay.negated().total({ unit: 'hours', relativeTo }), -25);
@@ -1589,7 +1588,7 @@ describe('Duration', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-03T12:00[America/Vancouver]');
         equal(hours12.negated().total({ unit: 'days', relativeTo }), -12 / 25);
       });
-      it.skip('Samoa skipped 24 hours', () => {
+      it('Samoa skipped 24 hours', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2011-12-29T12:00-10:00[Pacific/Apia]');
         equal(hours25.total({ unit: 'days', relativeTo }), 2 + 1 / 24);
         equal(Duration.from({ hours: 48 }).total({ unit: 'days', relativeTo }), 3);
@@ -1597,12 +1596,12 @@ describe('Duration', () => {
         equal(Duration.from({ days: 3 }).total({ unit: 'hours', relativeTo }), 48);
       });
     });
-    it.skip('totaling back up to days', () => {
+    it('totaling back up to days', () => {
       const relativeTo = Temporal.ZonedDateTime.from('2019-11-02T00:00[America/Vancouver]');
       equal(Duration.from({ hours: 48 }).total({ unit: 'days' }), 2);
       equal(Duration.from({ hours: 48 }).total({ unit: 'days', relativeTo }), 1 + 24 / 25);
     });
-    it.skip('casts relativeTo to ZonedDateTime if possible', () => {
+    it('casts relativeTo to ZonedDateTime if possible', () => {
       equal(oneDay.total({ unit: 'hours', relativeTo: '2019-11-03T00:00[America/Vancouver]' }), 25);
       equal(
         oneDay.total({ unit: 'hours', relativeTo: { year: 2019, month: 11, day: 3, timeZone: 'America/Vancouver' } }),

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -974,12 +974,12 @@ describe('Duration', () => {
     const inRepeatedHour = Temporal.ZonedDateTime.from('2019-11-03T01:00-07:00[America/Vancouver]');
     const oneDay = new Duration(0, 0, 0, 1);
     const hours12 = new Duration(0, 0, 0, 0, 12);
-    describe.skip('relativeTo affects days if ZonedDateTime, and duration encompasses DST change', () => {
-      it('start inside repeated hour, end after', () => {
+    describe('relativeTo affects days if ZonedDateTime, and duration encompasses DST change', () => {
+      it.skip('start inside repeated hour, end after', () => {
         equal(`${hours25.round({ largestUnit: 'days', relativeTo: inRepeatedHour })}`, 'P1D');
         equal(`${oneDay.round({ largestUnit: 'hours', relativeTo: inRepeatedHour })}`, 'PT25H');
       });
-      it('start after repeated hour, end inside (negative)', () => {
+      it.skip('start after repeated hour, end inside (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-04T01:00[America/Vancouver]');
         equal(`${hours25.negated().round({ largestUnit: 'days', relativeTo })}`, '-P1D');
         equal(`${oneDay.negated().round({ largestUnit: 'hours', relativeTo })}`, '-PT25H');
@@ -996,11 +996,11 @@ describe('Duration', () => {
         equal(`${hours25.round({ largestUnit: 'days', relativeTo })}`, 'P1DT1H');
         equal(`${oneDay.round({ largestUnit: 'hours', relativeTo })}`, 'PT24H');
       });
-      it('start before skipped hour, end >1 day after', () => {
+      it.skip('start before skipped hour, end >1 day after', () => {
         equal(`${hours25.round({ largestUnit: 'days', relativeTo: skippedHourDay })}`, 'P1DT2H');
         equal(`${oneDay.round({ largestUnit: 'hours', relativeTo: skippedHourDay })}`, 'PT23H');
       });
-      it('start after skipped hour, end >1 day before (negative)', () => {
+      it.skip('start after skipped hour, end >1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-11T00:00[America/Vancouver]');
         equal(`${hours25.negated().round({ largestUnit: 'days', relativeTo })}`, '-P1DT2H');
         equal(`${oneDay.negated().round({ largestUnit: 'hours', relativeTo })}`, '-PT23H');
@@ -1012,11 +1012,11 @@ describe('Duration', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-10T12:00[America/Vancouver]');
         equal(`${hours12.negated().round({ largestUnit: 'days', relativeTo })}`, '-PT12H');
       });
-      it('start before repeated hour, end >1 day after', () => {
+      it.skip('start before repeated hour, end >1 day after', () => {
         equal(`${hours25.round({ largestUnit: 'days', relativeTo: repeatedHourDay })}`, 'P1D');
         equal(`${oneDay.round({ largestUnit: 'hours', relativeTo: repeatedHourDay })}`, 'PT25H');
       });
-      it('start after repeated hour, end >1 day before (negative)', () => {
+      it.skip('start after repeated hour, end >1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-04T00:00[America/Vancouver]');
         equal(`${hours25.negated().round({ largestUnit: 'days', relativeTo })}`, '-P1D');
         equal(`${oneDay.negated().round({ largestUnit: 'hours', relativeTo })}`, '-PT25H');
@@ -1028,7 +1028,7 @@ describe('Duration', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-03T12:00[America/Vancouver]');
         equal(`${hours12.negated().round({ largestUnit: 'days', relativeTo })}`, '-PT12H');
       });
-      it('Samoa skipped 24 hours', () => {
+      it.skip('Samoa skipped 24 hours', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2011-12-29T12:00-10:00[Pacific/Apia]');
         equal(`${hours25.round({ largestUnit: 'days', relativeTo })}`, 'P2DT1H');
         equal(`${Duration.from({ hours: 48 }).round({ largestUnit: 'days', relativeTo })}`, 'P3D');
@@ -1534,17 +1534,17 @@ describe('Duration', () => {
     const inRepeatedHour = Temporal.ZonedDateTime.from('2019-11-03T01:00-07:00[America/Vancouver]');
     const hours12 = new Duration(0, 0, 0, 0, 12);
     const hours25 = new Duration(0, 0, 0, 0, 25);
-    describe.skip('relativeTo affects days if ZonedDateTime, and duration encompasses DST change', () => {
-      it('start inside repeated hour, end after', () => {
+    describe('relativeTo affects days if ZonedDateTime, and duration encompasses DST change', () => {
+      it.skip('start inside repeated hour, end after', () => {
         equal(hours25.total({ unit: 'days', relativeTo: inRepeatedHour }), 1);
         equal(oneDay.total({ unit: 'hours', relativeTo: inRepeatedHour }), 25);
       });
-      it('start after repeated hour, end inside (negative)', () => {
+      it.skip('start after repeated hour, end inside (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-04T01:00[America/Vancouver]');
         equal(hours25.negated().total({ unit: 'days', relativeTo }), -1);
         equal(oneDay.negated().total({ unit: 'hours', relativeTo }), -25);
       });
-      it('start inside repeated hour, end in skipped hour', () => {
+      it.skip('start inside repeated hour, end in skipped hour', () => {
         // gain one hour at the beginning, lose one at the end, days average 24h
         equal(Duration.from({ days: 126, hours: 1 }).total({ unit: 'days', relativeTo: inRepeatedHour }), 126 + 1 / 24);
         equal(
@@ -1557,11 +1557,11 @@ describe('Duration', () => {
         equal(hours25.total({ unit: 'days', relativeTo }), 1 + 1 / 24);
         equal(oneDay.total({ unit: 'hours', relativeTo }), 24);
       });
-      it('start before skipped hour, end >1 day after', () => {
+      it.skip('start before skipped hour, end >1 day after', () => {
         equal(hours25.total({ unit: 'days', relativeTo: skippedHourDay }), 1 + 2 / 24);
         equal(oneDay.total({ unit: 'hours', relativeTo: skippedHourDay }), 23);
       });
-      it('start after skipped hour, end >1 day before (negative)', () => {
+      it.skip('start after skipped hour, end >1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-11T00:00[America/Vancouver]');
         equal(hours25.negated().total({ unit: 'days', relativeTo }), -1 - 2 / 24);
         equal(oneDay.negated().total({ unit: 'hours', relativeTo }), -23);
@@ -1573,11 +1573,11 @@ describe('Duration', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-10T12:00[America/Vancouver]');
         equal(hours12.negated().total({ unit: 'days', relativeTo }), -12 / 23);
       });
-      it('start before repeated hour, end >1 day after', () => {
+      it.skip('start before repeated hour, end >1 day after', () => {
         equal(hours25.total({ unit: 'days', relativeTo: repeatedHourDay }), 1);
         equal(oneDay.total({ unit: 'hours', relativeTo: repeatedHourDay }), 25);
       });
-      it('start after repeated hour, end >1 day before (negative)', () => {
+      it.skip('start after repeated hour, end >1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-04T00:00[America/Vancouver]');
         equal(hours25.negated().total({ unit: 'days', relativeTo }), -1);
         equal(oneDay.negated().total({ unit: 'hours', relativeTo }), -25);
@@ -1589,7 +1589,7 @@ describe('Duration', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-03T12:00[America/Vancouver]');
         equal(hours12.negated().total({ unit: 'days', relativeTo }), -12 / 25);
       });
-      it('Samoa skipped 24 hours', () => {
+      it.skip('Samoa skipped 24 hours', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2011-12-29T12:00-10:00[Pacific/Apia]');
         equal(hours25.total({ unit: 'days', relativeTo }), 2 + 1 / 24);
         equal(Duration.from({ hours: 48 }).total({ unit: 'days', relativeTo }), 3);

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -1401,7 +1401,7 @@ describe('Duration', () => {
           const partialMonth = (daysPastJuly1 + partialDay) / 31;
           const totalMonths = 5 * 12 + 5 + 1 + partialMonth; // +1 for 5 weeks
           const total = d.total({ unit: 'months', relativeTo });
-          equal(total, totalMonths); // 66.32930780242619
+          assert(Math.abs(total - totalMonths) < Number.EPSILON); // 66.32930780242619
         }
       );
     });
@@ -1461,22 +1461,22 @@ describe('Duration', () => {
       nanoseconds: d2Nanoseconds
     };
     it('relativeTo not required to round fixed-length units in durations without variable units', () => {
-      equal(d2.total({ unit: 'days' }), totalD2.days);
-      equal(d2.total({ unit: 'hours' }), totalD2.hours);
-      equal(d2.total({ unit: 'minutes' }), totalD2.minutes);
-      equal(d2.total({ unit: 'seconds' }), totalD2.seconds);
-      equal(d2.total({ unit: 'milliseconds' }), totalD2.milliseconds);
-      equal(d2.total({ unit: 'microseconds' }), totalD2.microseconds);
+      assert(Math.abs(d2.total({ unit: 'days' }) - totalD2.days) < Number.EPSILON);
+      assert(Math.abs(d2.total({ unit: 'hours' }) - totalD2.hours) < Number.EPSILON);
+      assert(Math.abs(d2.total({ unit: 'minutes' }) - totalD2.minutes) < Number.EPSILON);
+      assert(Math.abs(d2.total({ unit: 'seconds' }) - totalD2.seconds) < Number.EPSILON);
+      assert(Math.abs(d2.total({ unit: 'milliseconds' }) - totalD2.milliseconds) < Number.EPSILON);
+      assert(Math.abs(d2.total({ unit: 'microseconds' }) - totalD2.microseconds) < Number.EPSILON);
       equal(d2.total({ unit: 'nanoseconds' }), totalD2.nanoseconds);
     });
     it('relativeTo not required to round fixed-length units in durations without variable units (negative)', () => {
       const negativeD2 = d2.negated();
-      equal(negativeD2.total({ unit: 'days' }), -totalD2.days);
-      equal(negativeD2.total({ unit: 'hours' }), -totalD2.hours);
-      equal(negativeD2.total({ unit: 'minutes' }), -totalD2.minutes);
-      equal(negativeD2.total({ unit: 'seconds' }), -totalD2.seconds);
-      equal(negativeD2.total({ unit: 'milliseconds' }), -totalD2.milliseconds);
-      equal(negativeD2.total({ unit: 'microseconds' }), -totalD2.microseconds);
+      assert(Math.abs(negativeD2.total({ unit: 'days' }) - -totalD2.days) < Number.EPSILON);
+      assert(Math.abs(negativeD2.total({ unit: 'hours' }) - -totalD2.hours) < Number.EPSILON);
+      assert(Math.abs(negativeD2.total({ unit: 'minutes' }) - -totalD2.minutes) < Number.EPSILON);
+      assert(Math.abs(negativeD2.total({ unit: 'seconds' }) - -totalD2.seconds) < Number.EPSILON);
+      assert(Math.abs(negativeD2.total({ unit: 'milliseconds' }) - -totalD2.milliseconds) < Number.EPSILON);
+      assert(Math.abs(negativeD2.total({ unit: 'microseconds' }) - -totalD2.microseconds) < Number.EPSILON);
       equal(negativeD2.total({ unit: 'nanoseconds' }), -totalD2.nanoseconds);
     });
 
@@ -1505,7 +1505,7 @@ describe('Duration', () => {
     };
     for (const [unit, expected] of Object.entries(totalResults)) {
       it(`total(${unit}) = ${expected}`, () => {
-        equal(d.total({ unit, relativeTo }), expected);
+        assert(Math.abs(d.total({ unit, relativeTo }) - expected) < Number.EPSILON);
       });
     }
     for (const unit of ['microseconds', 'nanoseconds']) {
@@ -1515,13 +1515,18 @@ describe('Duration', () => {
     }
     it('balances differently depending on relativeTo', () => {
       const fortyDays = Duration.from({ days: 40 });
-      equal(fortyDays.total({ unit: 'months', relativeTo: '2020-02-01' }), 1 + 11 / 31);
-      equal(fortyDays.total({ unit: 'months', relativeTo: '2020-01-01' }), 1 + 9 / 29);
+      assert(Math.abs(fortyDays.total({ unit: 'months', relativeTo: '2020-02-01' }) - (1 + 11 / 31)) < Number.EPSILON);
+      assert(Math.abs(fortyDays.total({ unit: 'months', relativeTo: '2020-01-01' }) - (1 + 9 / 29)) < Number.EPSILON);
     });
     it('balances differently depending on relativeTo (negative)', () => {
       const negativeFortyDays = Duration.from({ days: -40 });
-      equal(negativeFortyDays.total({ unit: 'months', relativeTo: '2020-03-01' }), -1 - 11 / 31);
-      equal(negativeFortyDays.total({ unit: 'months', relativeTo: '2020-04-01' }), -1 - 9 / 29);
+      assert(
+        Math.abs(negativeFortyDays.total({ unit: 'months', relativeTo: '2020-03-01' }) - (-1 - 11 / 31)) <
+          Number.EPSILON
+      );
+      assert(
+        Math.abs(negativeFortyDays.total({ unit: 'months', relativeTo: '2020-04-01' }) - (-1 - 9 / 29)) < Number.EPSILON
+      );
     });
     const oneDay = new Duration(0, 0, 0, 1);
     it('relativeTo does not affect days if PlainDateTime', () => {
@@ -1548,29 +1553,35 @@ describe('Duration', () => {
         equal(oneDay.negated().total({ unit: 'hours', relativeTo }), -25);
       });
       it('start inside repeated hour, end in skipped hour', () => {
-        equal(Duration.from({ days: 126, hours: 1 }).total({ unit: 'days', relativeTo: inRepeatedHour }), 126 + 1 / 23);
+        const totalDays = Duration.from({ days: 126, hours: 1 }).total({ unit: 'days', relativeTo: inRepeatedHour });
+        assert(Math.abs(totalDays - (126 + 1 / 23)) < Number.EPSILON);
         equal(Duration.from({ days: 126, hours: 1 }).total({ unit: 'hours', relativeTo: inRepeatedHour }), 3026);
       });
       it('start in normal hour, end in skipped hour', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-09T02:30[America/Vancouver]');
-        equal(hours25.total({ unit: 'days', relativeTo }), 1 + 1 / 24);
+        const totalDays = hours25.total({ unit: 'days', relativeTo });
+        assert(Math.abs(totalDays - (1 + 1 / 24)) < Number.EPSILON);
         equal(oneDay.total({ unit: 'hours', relativeTo }), 24);
       });
       it('start before skipped hour, end >1 day after', () => {
-        equal(hours25.total({ unit: 'days', relativeTo: skippedHourDay }), 1 + 2 / 24);
+        const totalDays = hours25.total({ unit: 'days', relativeTo: skippedHourDay });
+        assert(Math.abs(totalDays - (1 + 2 / 24)) < Number.EPSILON);
         equal(oneDay.total({ unit: 'hours', relativeTo: skippedHourDay }), 23);
       });
       it('start after skipped hour, end >1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-11T00:00[America/Vancouver]');
-        equal(hours25.negated().total({ unit: 'days', relativeTo }), -1 - 2 / 24);
+        const totalDays = hours25.negated().total({ unit: 'days', relativeTo });
+        assert(Math.abs(totalDays - (-1 - 2 / 24)) < Number.EPSILON);
         equal(oneDay.negated().total({ unit: 'hours', relativeTo }), -23);
       });
       it('start before skipped hour, end <1 day after', () => {
-        equal(hours12.total({ unit: 'days', relativeTo: skippedHourDay }), 12 / 23);
+        const totalDays = hours12.total({ unit: 'days', relativeTo: skippedHourDay });
+        assert(Math.abs(totalDays - 12 / 23) < Number.EPSILON);
       });
       it('start after skipped hour, end <1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-03-10T12:00[America/Vancouver]');
-        equal(hours12.negated().total({ unit: 'days', relativeTo }), -12 / 23);
+        const totalDays = hours12.negated().total({ unit: 'days', relativeTo });
+        assert(Math.abs(totalDays - -12 / 23) < Number.EPSILON);
       });
       it('start before repeated hour, end >1 day after', () => {
         equal(hours25.total({ unit: 'days', relativeTo: repeatedHourDay }), 1);
@@ -1582,15 +1593,18 @@ describe('Duration', () => {
         equal(oneDay.negated().total({ unit: 'hours', relativeTo }), -25);
       });
       it('start before repeated hour, end <1 day after', () => {
-        equal(hours12.total({ unit: 'days', relativeTo: repeatedHourDay }), 12 / 25);
+        const totalDays = hours12.total({ unit: 'days', relativeTo: repeatedHourDay });
+        assert(Math.abs(totalDays - 12 / 25) < Number.EPSILON);
       });
       it('start after repeated hour, end <1 day before (negative)', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2019-11-03T12:00[America/Vancouver]');
-        equal(hours12.negated().total({ unit: 'days', relativeTo }), -12 / 25);
+        const totalDays = hours12.negated().total({ unit: 'days', relativeTo });
+        assert(Math.abs(totalDays - -12 / 25) < Number.EPSILON);
       });
       it('Samoa skipped 24 hours', () => {
         const relativeTo = Temporal.ZonedDateTime.from('2011-12-29T12:00-10:00[Pacific/Apia]');
-        equal(hours25.total({ unit: 'days', relativeTo }), 2 + 1 / 24);
+        const totalDays = hours25.total({ unit: 'days', relativeTo });
+        assert(Math.abs(totalDays - (2 + 1 / 24)) < Number.EPSILON);
         equal(Duration.from({ hours: 48 }).total({ unit: 'days', relativeTo }), 3);
         equal(Duration.from({ days: 2 }).total({ unit: 'hours', relativeTo }), 24);
         equal(Duration.from({ days: 3 }).total({ unit: 'hours', relativeTo }), 48);
@@ -1599,7 +1613,8 @@ describe('Duration', () => {
     it('totaling back up to days', () => {
       const relativeTo = Temporal.ZonedDateTime.from('2019-11-02T00:00[America/Vancouver]');
       equal(Duration.from({ hours: 48 }).total({ unit: 'days' }), 2);
-      equal(Duration.from({ hours: 48 }).total({ unit: 'days', relativeTo }), 1 + 24 / 25);
+      const totalDays = Duration.from({ hours: 48 }).total({ unit: 'days', relativeTo });
+      assert(Math.abs(totalDays - (1 + 24 / 25)) < Number.EPSILON);
     });
     it('casts relativeTo to ZonedDateTime if possible', () => {
       equal(oneDay.total({ unit: 'hours', relativeTo: '2019-11-03T00:00[America/Vancouver]' }), 25);
@@ -1610,11 +1625,13 @@ describe('Duration', () => {
     });
     it('balances up to the next unit after rounding', () => {
       const almostWeek = Duration.from({ days: 6, hours: 20 });
-      equal(almostWeek.total({ unit: 'weeks', relativeTo: '2020-01-01' }), (6 + 20 / 24) / 7);
+      const totalWeeks = almostWeek.total({ unit: 'weeks', relativeTo: '2020-01-01' });
+      assert(Math.abs(totalWeeks - (6 + 20 / 24) / 7) < Number.EPSILON);
     });
     it('balances up to the next unit after rounding (negative)', () => {
       const almostWeek = Duration.from({ days: -6, hours: -20 });
-      equal(almostWeek.total({ unit: 'weeks', relativeTo: '2020-01-01' }), -((6 + 20 / 24) / 7));
+      const totalWeeks = almostWeek.total({ unit: 'weeks', relativeTo: '2020-01-01' });
+      assert(Math.abs(totalWeeks - -((6 + 20 / 24) / 7)) < Number.EPSILON);
     });
     it('balances days up to both years and months', () => {
       const twoYears = Duration.from({ months: 11, days: 396 });

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -440,7 +440,9 @@
         1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
         1. Let _adjustResult_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
         1. Let _balanceResult_ be ? BalanceDurationRelative(_adjustResult_.[[Years]], _adjustResult_.[[Months]], _adjustResult_.[[Weeks]], _adjustResult_.[[Days]], _largestUnit_, _relativeTo_).
-        1. Let _result_ be ? BalanceDuration(_balanceResult_.[[Days]], _adjustResult_.[[Hours]], _adjustResult_.[[Minutes]], _adjustResult_.[[Seconds]], _adjustResult_.[[Milliseconds]], _adjustResult_.[[Microseconds]], _adjustResult.[[Nanoseconds]]).
+        1. If _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+          1. Set _relativeTo_ to ? MoveRelativeZonedDateTime(_relativeTo_, _balanceResult_.[[Years]], _balanceResult_.[[Months]], _balanceResult_.[[Weeks]], 0).
+        1. Let _result_ be ? BalanceDuration(_balanceResult_.[[Days]], _adjustResult_.[[Hours]], _adjustResult_.[[Minutes]], _adjustResult_.[[Seconds]], _adjustResult_.[[Milliseconds]], _adjustResult_.[[Microseconds]], _adjustResult.[[Nanoseconds]], _largestUnit_, _relativeTo_).
         1. Return ? CreateTemporalDurationFromInstance(_duration_, _balanceResult_.[[Years]], _balanceResult_.[[Months]], _balanceResult_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -461,7 +463,10 @@
         1. Else,
           1. Let _unit_ be ? ToTemporalDurationTotalUnit(_revisedOptions_).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_years_, _months_, _weeks_, _days_, _unit_, _relativeTo_).
-        1. Let _balanceResult_ be ? BalanceDuration(_unbalanceResult_.[[Days]], _unbalanceResult_.[[Hours]], _unbalanceResult_.[[Minutes]], _unbalanceResult_.[[Seconds]], _unbalanceResult_.[[Milliseconds]], _unbalanceResult_.[[Microseconds]], _unbalanceResult_.[[Nanoseconds]], _unit_).
+        1. Let _intermediate_ be *undefined*.
+        1. If _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+          1. Set _intermediate_ to ? MoveRelativeZonedDateTime(_relativeTo_, _unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], 0).
+        1. Let _balanceResult_ be ? BalanceDuration(_unbalanceResult_.[[Days]], _unbalanceResult_.[[Hours]], _unbalanceResult_.[[Minutes]], _unbalanceResult_.[[Seconds]], _unbalanceResult_.[[Milliseconds]], _unbalanceResult_.[[Microseconds]], _unbalanceResult_.[[Nanoseconds]], _unit_, _intermediate_).
         1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], 1, _unit_, *"trunc"*, _relativeTo_).
         1. If _unit_ is *"years"*, then
           1. Let _whole_ be _roundResult_.[[Years]].
@@ -882,26 +887,23 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-balanceduration" aoid="BalanceDuration">
-      <h1>BalanceDuration ( _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_ )</h1>
+      <h1>BalanceDuration ( _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_ [ , _relativeTo_ ] )</h1>
       <emu-alg>
-        1. Set _nanoseconds_ to ! TotalDurationNanoseconds(_days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, 0).
-        1. Set _days_, _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ to 0.
+        1. If _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+          1. Let _endNs_ be ? AddZonedDateTime(_relativeTo_.[[Nanoseconds]], _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, *"constrain"*).
+          1. Set _nanoseconds_ to _endNs_ − _relativeTo_.[[Nanoseconds]].
+        1. Else,
+          1. Set _nanoseconds_ to ! TotalDurationNanoseconds(_days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, 0).
+        1. If _largestUnit_ is one of *"years"*, *"months"*, *"weeks"*, or *"days"*, then
+          1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
+          1. Set _days_ to _result_.[[Days]].
+          1. Set _nanoseconds_ to _result_.[[Nanoseconds]].
+        1. Else,
+          1. Set _days_ to 0.
+        1. Set _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ to 0.
         1. If _nanoseconds_ &lt; 0, let _sign_ be −1; else, let _sign_ be 1.
         1. Set _nanoseconds_ to abs(_nanoseconds_).
-        1. If _largestUnit_ is *"years"*, *"months"*, *"weeks"*, or *"days"*, then
-          1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
-          1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
-          1. Set _milliseconds_ to floor(_microseconds_ / 1000).
-          1. Set _microseconds_ to _microseconds_ modulo 1000.
-          1. Set _seconds_ to floor(_milliseconds_ / 1000).
-          1. Set _milliseconds_ to _milliseconds_ modulo 1000.
-          1. Set _minutes_ to floor(_seconds_ / 60).
-          1. Set _seconds_ to _seconds_ modulo 60.
-          1. Set _hours_ to floor(_minutes_ / 60).
-          1. Set _minutes_ to _minutes_ modulo 60.
-          1. Set _days_ to floor(_hours_ / 24).
-          1. Set _hours_ to _hours_ modulo 24.
-        1. Else if _largestUnit_ is *"hours"*, then
+        1. If _largestUnit_ is *"years"*, *"months"*, *"weeks"*, *"days"*, or *"hours"*, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
           1. Set _milliseconds_ to floor(_microseconds_ / 1000).
@@ -939,7 +941,7 @@
         1. Else,
           1. Assert: _largestUnit_ is *"nanoseconds"*.
         1. Return the new Record {
-          [[Days]]: 𝔽(_days_) × _sign_,
+          [[Days]]: 𝔽(_days_),
           [[Hours]]: 𝔽(_hours_) × _sign_,
           [[Minutes]]: 𝔽(_minutes_) × _sign_,
           [[Seconds]]: 𝔽(_seconds_) × _sign_,

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1245,23 +1245,44 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-moverelativezoneddatetime" aoid="MoveRelativeZonedDateTime">
+      <h1>MoveRelativeZonedDateTime ( _zonedDateTime_, _years_, _months_, _weeks_, _days_ )</h1>
+      <p>
+        The abstract operation MoveRelativeZonedDateTime adjusts the calendar part of a Temporal.ZonedDateTime instance for use as the "relative-to" parameter of another operation.
+      </p>
+      <emu-alg>
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, *"constrain"*).
+        1. Let _intermediate_ be ? CreateTemporalZonedDateTime(_intermediateNs_, _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]]).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-roundduration" aoid="RoundDuration">
       <h1>RoundDuration ( _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _increment_, _unit_, _roundingMode_ [ , _relativeTo_ ] )</h1>
       <emu-alg>
         1. Let _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, and _increment_ each be the mathematical values of themselves.
         1. If _unit_ is *"years"*, *"months"*, or *"weeks"*, and _relativeTo_ is *undefined*, then
           1. Throw a *RangeError* exception.
+        1. Let _zonedRelativeTo_ be *undefined*.
         1. If _relativeTo_ is not *undefined*, then
           1. If _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Let _instant_ be ? CreateTemporalInstant(_relativeTo_[[Nanoseconds]]).
+            1. Set _zonedRelativeTo_ to _relativeTo_.
             1. Set _relativeTo_ to ? GetTemporalDateTimeFor(_relativeTo_.[[TimeZone]], _instant_, _relativeTo_.[[Calendar]]).
           1. Else,
             1. Perform ? RequireInternalSlot(_relativeTo_, [[InitializedTemporalDateTime]]).
           1. Let _calendar_ be _relativeTo_.[[Calendar]].
           1. Let _dateAdd_ be ? Get(_calendar_, *"dateAdd"*).
           1. Let _options_ be ? ObjectCreate(%Object.prototype%).
-        1. Let _fractionalSeconds_ be _nanoseconds_ × 10<sup>−9</sup> + _microseconds_ × 10<sup>−6</sup> + _milliseconds_ × 10<sup>−3</sup> + _seconds_.
-        1. Let _fractionalDays_ be ((_fractionalSeconds_ / 60 + _minutes_) / 60 + _hours_) / 24 + _days_.
+        1. If _unit_ is one of *"years"*, *"months"*, *"weeks"*, or *"days"*, then
+          1. Let _nanoseconds_ be ! TotalDurationNanoseconds(0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, 0).
+          1. Let _intermediate_ be *undefined*.
+          1. If _zonedRelativeTo_ is not *undefined*, then
+            1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _years_, _months_, _weeks_, _days_).
+          1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_).
+          1. Set _days_ to _days_ + _result_.[[Days]] + _result_.[[Nanoseconds]] / abs(_result_.[[DayLength]]).
+          1. Set _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
+        1. Else,
+          1. Let _fractionalSeconds_ be _nanoseconds_ × 10<sup>−9</sup> + _microseconds_ × 10<sup>−6</sup> + _milliseconds_ × 10<sup>−3</sup> + _seconds_.
         1. Let _remainder_ be *undefined*.
         1. If _unit_ is *"years"*, then
           1. Let _yearsDuration_ be ? CreateTemporalDuration(_years_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
@@ -1286,7 +1307,7 @@
           1. Let _fractionalYears_ be _years_ + _days_ / abs(_oneYearDays_).
           1. Set _years_ to ? RoundNumberToIncrement(_fractionalYears_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalYears_ - _years_.
-          1. Set _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
+          1. Set _months_, _weeks_, and _days_ to 0.
         1. Else if _unit_ is *"months"*, then
           1. Let _yearsMonths_ be ? CreateTemporalDuration(_years_, _months_, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _yearsMonthsLater_ be ? Call(_dateAdd_, _calendar_, « _relativeTo_, _yearsMonths_, _options_, %Temporal.PlainDate%).
@@ -1310,7 +1331,7 @@
           1. Let _fractionalMonths_ be _months_ + _days_ / abs(_oneMonthDays_).
           1. Set _months_ to ? RoundNumberToIncrement(_fractionalMonths_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalMonths_ - _months_.
-          1. Set _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
+          1. Set _weeks_ and _days_ to 0.
         1. Else if _unit_ is *"weeks"*, then
           1. Let _sign_ be ! Sign(_days_).
           1. If _sign_ is 0, set _sign_ to 1.
@@ -1324,14 +1345,14 @@
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneWeekDays_ to _moveResult_.[[Days]].
-          1. Let _fractionalWeeks_ be _weeks_ + _fractionalDays_ / abs(_oneWeekDays_).
+          1. Let _fractionalWeeks_ be _weeks_ + _days_ / abs(_oneWeekDays_).
           1. Set _weeks_ to ? RoundNumberToIncrement(_fractionalWeeks_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalWeeks_ - _weeks_.
-          1. Set _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
+          1. Set _days_ to 0.
         1. Else if _unit_ is *"days"*, then
-          1. Set _days_ to ? RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
+          1. Let _fractionalDays_ be _days_.
+          1. Set _days_ to ? RoundNumberToIncrement(_days_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalDays_ - _days_.
-          1. Set _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"hours"*, then
           1. Let _fractionalHours_ be (_fractionalSeconds_ / 60 + _minutes_) / 60 + _hours_.
           1. Set _hours_ to ? RoundNumberToIncrement(_fractionalHours_, _increment_, _roundingMode_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1391,23 +1391,17 @@
         1. Let _nsDifference_ be _ns2_ − _ns1_.
         1. If _nsDifference_ is 0, then
           1. Return the new Record { [[Years]]: 0, [[Months]]: 0, [[Weeks]]: 0, [[Days]]: 0, [[Hours]]: 0, [[Minutes]]: 0, [[Seconds]]: 0, [[Milliseconds]]: 0, [[Microseconds]]: 0, [[Nanoseconds]]: 0 }.
-        1. Let _direction_ be ! Sign(_nsDifference_).
         1. Let _startInstant_ be ? CreateInstant(_ns1_).
         1. Let _startDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _startInstant_, _calendar_).
         1. Let _endInstant_ be ? CreateInstant(_ns2_).
         1. Let _endDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _endInstant_, _calendar_).
         1. Let _dateDifference_ be ? DifferenceDateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_).
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZone_, _calendar_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], 0, 0, 0, 0, 0, 0, *"constrain"*).
-        1. If _direction_ = 1, then
-          1. Repeat, while ! DurationSign(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], 0, 0, 0, 0, 0, 0) = 1 and _intermediateNs_ &gt; _ns2_,
-            1. Set _dateDifference_ to ? AddDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], 0, 0, 0, 0, 0, 0, 0, 0, 0, −1, 0, 0, 0, 0, 0, 0, _startDateTime_).
-            1. Set _intermediateNs_ to ? AddZonedDateTime(_ns1_, _timeZone_, _calendar_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], 0, 0, 0, 0, 0, 0, *"constrain"*).
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZone_, _calendar_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], 0, 0, 0, 0, 0, 0, 0, *"constrain"*).
         1. Let _timeRemainderNs_ be _ns2_ − _intermediateNs_.
         1. Let _intermediate_ be ? CreateTemporalZonedDateTime(_intermediateNs_, _timeZone_, _calendar_).
         1. Let _result_ be ? NanosecondsToDays(_timeRemainderNs_, _intermediate_).
         1. Let _timeDifference_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], *"hours"*).
-        1. Let _dateDifference_ be ? AddDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], 0, 0, 0, 0, 0, 0, 0, 0, 0, _result_.[[Days]], 0, 0, 0, 0, 0, 0, _startDateTime_).
-        1. Return the new Record { [[Years]]: _dateDifference_.[[Years]], [[Months]]: _dateDifference_.[[Months]], [[Weeks]]: _dateDifference_.[[Weeks]], [[Days]]: _dateDifference_.[[Days]], [[Hours]]: _timeDifference_.[[Hours]], [[Minutes]]: _timeDifference_.[[Minutes]], [[Seconds]]: _timeDifference_.[[Seconds]], [[Milliseconds]]: _timeDifference_.[[Milliseconds]], [[Microseconds]]: _timeDifference_.[[Microseconds]], [[Nanoseconds]]: _timeDifference_.[[Nanoseconds]] }.
+        1. Return the new Record { [[Years]]: _dateDifference_.[[Years]], [[Months]]: _dateDifference_.[[Months]], [[Weeks]]: _dateDifference_.[[Weeks]], [[Days]]: _result_.[[Days]], [[Hours]]: _timeDifference_.[[Hours]], [[Minutes]]: _timeDifference_.[[Minutes]], [[Seconds]]: _timeDifference_.[[Seconds]], [[Milliseconds]]: _timeDifference_.[[Milliseconds]], [[Microseconds]]: _timeDifference_.[[Microseconds]], [[Nanoseconds]]: _timeDifference_.[[Nanoseconds]] }.
       </emu-alg>
     </emu-clause>
 
@@ -1428,15 +1422,26 @@
             [[Nanoseconds]]: _nanoseconds_ modulo _dayLengthNs_,
             [[DayLength]]: _sign_ × _dayLengthNs_
             }.
-        1. Let _days_ be 0.
+        1. Let _startInstant_ be ? CreateTemporalInstant(_relativeTo_.[[Nanoseconds]]).
+        1. Let _startDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _startInstant_, _calendar_).
+        1. Let _endNs_ be _relativeTo_.[[Nanoseconds]] + _nanoseconds_.
+        1. Let _endInstant_ be ? CreateTemporalInstant(_endNs_).
+        1. Let _endDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _endInstant_, _calendar_).
+        1. Let _dateDifference_ be ? DifferenceDateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, *"days"*).
+        1. Let _days_ be _dateDifference_.[[Days]].
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_startNs_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, 0, 0, 0, 0, 0, 0, *"constrain"*).
+        1. If _sign_ = 1, then
+          1. Repeat, while _days_ &gt; 0 and _intermediateNs_ &gt; _endNs_,
+            1. Set _days_ to _days_ − 1.
+            1. Set _intermediateNs_ to ? AddZonedDateTime(_startNs_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, 0, 0, 0, 0, 0, 0, *"constrain"*).
+        1. Set _nanoseconds_ to _endNs_ − _intermediateNs_.
         1. Let _done_ be *false*.
-        1. Let _relativeNs_ be _relativeTo_.[[Nanoseconds]].
         1. Repeat, while _done_ is *false*,
-          1. Let _oneDayFartherNs_ be ? AddZonedDateTime(_relativeNs_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _sign_, 0, 0, 0, 0, 0, 0, *"constrain"*).
-          1. Set _dayLengthNs_ to _oneDayFartherNs_ − _relativeNs_.
+          1. Let _oneDayFartherNs_ be ? AddZonedDateTime(_intermediateNs_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _sign_, 0, 0, 0, 0, 0, 0, *"constrain"*).
+          1. Set _dayLengthNs_ to _oneDayFartherNs_ − _intermediateNs_.
           1. If (_nanoseconds_ − _dayLengthNs_) × _sign_ ≥ 0, then
             1. Set _nanoseconds_ to _nanoseconds_ − _dayLengthNs_.
-            1. Set _relativeNs_ to _oneDayFartherNs_.
+            1. Set _intermediateNs_ to _oneDayFartherNs_.
             1. Set _days_ to _days_ + _sign_.
           1. Else,
             1. Set _done_ to *true*.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1415,23 +1415,25 @@
       <h1>NanosecondsToDays ( _nanoseconds_, _relativeTo_ )</h1>
       <p>
         The abstract operation NanosecondsToDays takes a number of nanoseconds relative to a Temporal.ZonedDateTime _relativeTo_, and converts it into a number of days and remainder of nanoseconds, taking into account any offset changes in the time zone of _relativeTo_.
+        It also returns the signed length of the last day in nanoseconds, for rounding purposes.
       </p>
       <emu-alg>
         1. Let _sign_ be ! Sign(_nanoseconds_).
         1. Let _dayLengthNs_ be 8.64 × 10<sup>13</sup><sub>ℝ</sub>.
         1. If _sign_ = 0, then
-          1. Return the new Record { [[Days]]: 0, [[Nanoseconds]]: 0 }.
+          1. Return the new Record { [[Days]]: 0, [[Nanoseconds]]: 0, [[DayLength]]: _dayLengthNs_ }.
         1. If _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Return the new Record {
             [[Days]]: the integral part of _nanoseconds_ ÷ _dayLengthNs_,
-            [[Nanoseconds]]: _nanoseconds_ modulo _dayLengthNs_
+            [[Nanoseconds]]: _nanoseconds_ modulo _dayLengthNs_,
+            [[DayLength]]: _sign_ × _dayLengthNs_
             }.
         1. Let _days_ be 0.
         1. Let _done_ be *false*.
         1. Let _relativeNs_ be _relativeTo_.[[Nanoseconds]].
         1. Repeat, while _done_ is *false*,
           1. Let _oneDayFartherNs_ be ? AddZonedDateTime(_relativeNs_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _sign_, 0, 0, 0, 0, 0, 0, *"constrain"*).
-          1. Let _dayLengthNs_ be _oneDayFartherNs_ − _relativeNs_.
+          1. Set _dayLengthNs_ to _oneDayFartherNs_ − _relativeNs_.
           1. If (_nanoseconds_ − _dayLengthNs_) × _sign_ ≥ 0, then
             1. Set _nanoseconds_ to _nanoseconds_ − _dayLengthNs_.
             1. Set _relativeNs_ to _oneDayFartherNs_.
@@ -1440,7 +1442,8 @@
             1. Set _done_ to *true*.
         1. Return the new Record {
           [[Days]]: _days_,
-          [[Nanoseconds]]: _nanoseconds_
+          [[Nanoseconds]]: _nanoseconds_,
+          [[DayLength]]: _dayLengthNs_
           }.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
This fixes rounding and totalling Durations with a ZonedDateTime `relativeTo` parameter. ~~There is still one bug in the algorithm, which is causing one rounding test to fail, and the corresponding totalling test, so those two remain skipped until I can track down the bug.~~

Closes: #1171