### PR TITLE
Fix Test262 errors and speed up tests by 10x-20x

### DIFF
--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -35,6 +35,7 @@ if [ $threads -gt 2 ]; then threads=2; fi
 test262-harness \
   -t $threads \
   -r json \
+  --reporter-keys file,rawResult,result,scenario \
   --test262Dir ../test262 \
   --prelude "../$PRELUDE" \
   --transformer ./transform.test262.js \


### PR DESCRIPTION
I did a little bit of debugging into the Test262 failures. I suspect that they were caused by the *huge* size of the JSON output from these tests. When I looked at the actual JSON output, almost all of it was the `contents` key, which is the source code of the test including all included files.  But our reporting UI doesn't actually use that source code at all.

The test262 harness has a CLI option to customize which keys are emitted in the JSON output, so I added a whitelist of keys that parseResults.py is actually using. 

The result was an error-free execution of Test262 on my Mac in about 35 seconds, which is at least 10x faster than before.

As a follow-up if I have time, I'll investigate changing the reporter from python to JS via https://github.com/bocoup/test262-stream which should speed up the test running by another 20%+ and remove the Python dependency.

Fixes #1094.