### PR TITLE
Restore `ZonedDateTime.prototype.offsetNanoseconds` convenience property

### DIFF
--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -169,6 +169,10 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return ES.GetOffsetStringFor(GetSlot(this, TIME_ZONE), GetSlot(this, INSTANT));
   }
+  get offsetNanoseconds() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.GetOffsetNanosecondsFor(GetSlot(this, TIME_ZONE), GetSlot(this, INSTANT));
+  }
   with(temporalZonedDateTimeLike, options = undefined) {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     if (ES.Type(temporalZonedDateTimeLike) !== 'Object') {

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -218,6 +218,7 @@ describe('ZonedDateTime', () => {
       it('zdt.monthsInYear is 12', () => equal(zdt.monthsInYear, 12));
       it('zdt.inLeapYear is true', () => equal(zdt.inLeapYear, true));
       it('zdt.offset is +00:00', () => equal(zdt.offset, '+00:00'));
+      it('zdt.offsetNanoseconds is 0', () => equal(zdt.offsetNanoseconds, 0));
       it('string output is 1976-11-18T15:23:30.123456789+00:00[UTC]', () =>
         equal(`${zdt}`, '1976-11-18T15:23:30.123456789+00:00[UTC]'));
     });
@@ -254,6 +255,7 @@ describe('ZonedDateTime', () => {
       it('zdt.monthsInYear is 12', () => equal(zdt.monthsInYear, 12));
       it('zdt.inLeapYear is true', () => equal(zdt.inLeapYear, true));
       it('zdt.offset is +01:00', () => equal(zdt.offset, '+01:00'));
+      it('zdt.offsetNanoseconds is 3600e9', () => equal(zdt.offsetNanoseconds, 3600e9));
       it('string output is 1976-11-18T16:23:30.123456789+01:00[Europe/Vienna][c=gregory]', () =>
         equal(`${zdt}`, '1976-11-18T16:23:30.123456789+01:00[Europe/Vienna][c=gregory]'));
     });

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -529,6 +529,21 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.zoneddatetime.prototype.offsetnanoseconds">
+      <h1>get Temporal.ZonedDateTime.prototype.offsetNanoseconds</h1>
+      <p>
+        `Temporal.ZonedDateTime.prototype.offsetNanoseconds` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Let _zonedDateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
+        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _instant_ be ? CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
+        1. Return ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-get-temporal.zoneddatetime.prototype.offset">
       <h1>get Temporal.ZonedDateTime.prototype.offset</h1>
       <p>


### PR DESCRIPTION
`ZonedDateTime.prototype.offsetNanoseconds` was present in the docs and .d.ts (and was in #700) but seems to have been missed in the official polyfill implementation of ZonedDateTime. This PR fixes that gap.  It also updates the docs for the change we made in #935 to make `offset` a field and `offsetNanoseconds` a convenience property instead of the opposite.