### PR TITLE
Reduce potential precision loss in ZDT `hoursInDay`

### DIFF
--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -145,8 +145,7 @@ export class ZonedDateTime {
     const timeZone = GetSlot(this, TIME_ZONE);
     const todayNs = GetSlot(ES.GetTemporalInstantFor(timeZone, today, 'compatible'), EPOCHNANOSECONDS);
     const tomorrowNs = GetSlot(ES.GetTemporalInstantFor(timeZone, tomorrow, 'compatible'), EPOCHNANOSECONDS);
-    const { quotient, remainder } = tomorrowNs.subtract(todayNs).divmod(3.6e12);
-    return quotient.toJSNumber() + remainder.toJSNumber() / 3.6e12;
+    return tomorrowNs.subtract(todayNs).toJSNumber() / 3.6e12;
   }
   get daysInWeek() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');


### PR DESCRIPTION
Do all calculations using integer math and only do a single integer-division operation at the end.