### PR TITLE
Speed up Test262 runs another 2x-3x

### DIFF
--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -3,7 +3,7 @@
 TESTS=${@:-"./*/**/*.js"}
 
 export NODE_PATH=$PWD/node_modules
-npm run build
+npm run build262
 if [ ! -d "test262" ]; then
   git clone --depth 1 https://github.com/tc39/test262.git
 else
@@ -27,7 +27,7 @@ if [ "$(uname)" = 'Darwin' ]; then
 else
   threads=$(nproc --ignore 1)
 fi
-if [ $threads -gt 2 ]; then threads=2; fi
+if [ $threads -gt 8 ]; then threads=8; fi
 
 test262-harness \
   -t $threads \
@@ -35,6 +35,7 @@ test262-harness \
   --reporter-keys file,rawResult,result,scenario \
   --test262Dir ../test262 \
   --prelude "../$PRELUDE" \
+  --preprocessor ./preprocessor.test262.js \
   $TRANSFORMER_ARG \
   "$TESTS" \
   | ./parseResults.js

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -15,6 +15,7 @@
     "codecov:tests": "NODE_V8_COVERAGE=coverage/tmp npm run test && c8 report --reporter=text-lcov > coverage/tests.lcov && codecov -F tests -f coverage/tests.lcov",
     "codecov:test262": "COVERAGE=yes npm run test262 && codecov -F test262 -f coverage/test262.lcov",
     "build": "rollup -c rollup.config.js",
+    "build262": "TEST262=1 rollup -c rollup.config.js",
     "prepublishOnly": "npm run build",
     "playground": "node --experimental-modules --no-warnings --icu-data-dir node_modules/full-icu -r ./lib/init.js"
   },

--- a/polyfill/rollup.config.js
+++ b/polyfill/rollup.config.js
@@ -6,6 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 import { env } from 'process';
 
 const isProduction = env.NODE_ENV === 'production';
+const isTest262 = !!env.TEST262;
 const libName = 'temporal';
 const babelConfig = {
   exclude: 'node_modules/**',
@@ -23,7 +24,7 @@ const replaceConfig = { exclude: 'node_modules/**' };
 const resolveConfig = { preferBuiltins: false };
 
 export default [
-  {
+  !isTest262 && {
     input: 'lib/index.mjs',
     plugins: [
       replace({ ...replaceConfig, __debug__: !isProduction }),
@@ -57,7 +58,7 @@ export default [
       sourcemap: true
     }
   },
-  {
+  !isTest262 && {
     input: 'lib/shim.mjs',
     output: {
       name: libName,
@@ -67,4 +68,4 @@ export default [
     },
     plugins: [replace({ ...replaceConfig, __debug__: true }), commonjs(), resolve(resolveConfig), babel(babelConfig)]
   }
-];
+].filter(Boolean);

--- a/polyfill/test/parseResults.js
+++ b/polyfill/test/parseResults.js
@@ -18,7 +18,10 @@ function reportStatus(length = testCount) {
 
 stdin.on('data', function (chunk) {
   testOutput += chunk;
-  testCount = testOutput.split('"file":').length - 1;
+  const matches = testOutput.split('"file":').length - 1;
+  // We skipped execution of non-strict tests via a preprocessor, but the test
+  // is treated as passed and shows up here, so we'll divide total by 2.
+  testCount = Math.trunc(matches / 2);
   if (testCount >= nextReportCount || testOutput.endsWith(']\n')) {
     reportStatus();
     nextReportCount += 100;
@@ -27,7 +30,8 @@ stdin.on('data', function (chunk) {
 
 stdin.on('end', function () {
   stdout.write('\n');
-  const tests = JSON.parse(testOutput);
+  // filter out the non-strict tests because they were skipped via a preprocessor
+  const tests = JSON.parse(testOutput).filter((test) => test.scenario.includes('strict'));
   const failedTests = [];
   for (const test of tests) {
     const { result, scenario, file } = test;

--- a/polyfill/test/preprocessor.test262.js
+++ b/polyfill/test/preprocessor.test262.js
@@ -1,0 +1,12 @@
+module.exports = function (test) {
+  // skip non-strict tests to speed up test runs
+  if (!test.scenario.includes('strict')) {
+    test.result = {
+      pass: true,
+      stdout: '',
+      stderr: '',
+      error: null
+    };
+  }
+  return test;
+};


### PR DESCRIPTION
This PR continues where #1189 left off, specifically:

* Use a preprocessor to skip non-strict tests. This is ~8% slower than skipping the tests via the `[onlyStrict]` attribute inside the tests themselves, but skipping using a preprocessor is still more than 40% faster than running all tests twice
* Increase max threads from 2 to 8. This gave me a 60% speed boost on my Mac, although I assume this gain will be environment-dependent so YMMV.
* When running tests, only transpile polyfill code the harness uses.

The net result is that tests complete (including transpilation) in ~30s on my 2015 MacBook Pro. In CI where we're running codecov tests and the hardware is slower, it will still take a few minutes... but hopefully fewer minutes than before! ;-)