### PR TITLE
Initial implementation of all ICU calendars

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1288,7 +1288,7 @@ const makeHelperGregorian = (id, originalEras) => {
         const matchingEra = this.eras.find((e, i) => {
           if (i === this.eras.length - 1) {
             if (e.reverseOf) {
-              // This is a reverse-sign era (like BC) which must be the oldest
+              // This is a reverse-sign era (like BCE) which must be the oldest
               // era. Count years backwards.
               if (year > 0) throw new RangeError(`Signed year ${year} is invalid for era ${e.name}`);
               eraYear = e.anchorEpoch.year - year;
@@ -1409,7 +1409,7 @@ const makeHelperOrthodox = (id, originalEras) => {
 
 // `coptic` and `ethiopic` calendars are very similar to `ethioaa` calendar,
 // with the following differences:
-// - Coptic uses BC-like positive numbers for years before its epoch (the other
+// - Coptic uses BCE-like positive numbers for years before its epoch (the other
 //   two use negative year numbers before epoch)
 // - Coptic has a different epoch date
 // - Ethiopic has an additional second era that starts at the same date as the
@@ -1445,10 +1445,21 @@ const helperBuddhist = ObjectAssign(
   }
 );
 
-const helperGregory = makeHelperGregorian('gregory', [
-  { name: 'ad', isoEpoch: { year: 1, month: 1, day: 1 } },
-  { name: 'bc', reverseOf: 'ad' }
-]);
+const helperGregory = ObjectAssign(
+  {},
+  makeHelperGregorian('gregory', [
+    { name: 'ce', isoEpoch: { year: 1, month: 1, day: 1 } },
+    { name: 'bce', reverseOf: 'ce' }
+  ]),
+  {
+    reviseIntlEra(calendarDate /*, isoDate*/) {
+      let { era, eraYear } = calendarDate;
+      if (era === 'bc') era = 'bce';
+      if (era === 'ad') era = 'ce';
+      return { era, eraYear };
+    }
+  }
+);
 
 const helperJapanese = ObjectAssign(
   {},
@@ -1482,7 +1493,7 @@ const helperJapanese = ObjectAssign(
     // The Japanese calendar `year` is just the ISO year, because (unlike other
     // ICU calendars) there's no obvious "default era", we use the ISO year.
     // Pre-Meiji eras are unstable (they change a lot due to historical
-    // scholarship) so we're tentatively using AD/BC for those older eras. This
+    // scholarship) so we're tentatively using CE/BCE for those older eras. This
     // may change depending on the resolution of
     // https://github.com/tc39/proposal-temporal/issues/526.
     { name: 'reiwa', isoEpoch: { year: 2019, month: 5, day: 1 }, anchorEpoch: { year: 2019, month: 5, day: 1 } },
@@ -1490,8 +1501,8 @@ const helperJapanese = ObjectAssign(
     { name: 'showa', isoEpoch: { year: 1926, month: 12, day: 25 }, anchorEpoch: { year: 1926, month: 12, day: 25 } },
     { name: 'taisho', isoEpoch: { year: 1912, month: 7, day: 30 }, anchorEpoch: { year: 1912, month: 7, day: 30 } },
     { name: 'meiji', isoEpoch: { year: 1868, month: 9, day: 8 }, anchorEpoch: { year: 1868, month: 9, day: 8 } },
-    { name: 'ad', isoEpoch: { year: 1, month: 1, day: 1 } },
-    { name: 'bc', reverseOf: 'ad' }
+    { name: 'ce', isoEpoch: { year: 1, month: 1, day: 1 } },
+    { name: 'bce', reverseOf: 'ce' }
   ]),
   {
     // The last 3 Japanese eras confusingly return only one character in the
@@ -1502,7 +1513,7 @@ const helperJapanese = ObjectAssign(
       const { era, eraYear } = calendarDate;
       const { year: isoYear } = isoDate;
       if (this.eras.find((e) => e.name === era)) return { era, eraYear };
-      return isoYear < 1 ? { era: 'bc', eraYear: 1 - isoYear } : { era: 'ad', eraYear: isoYear };
+      return isoYear < 1 ? { era: 'bce', eraYear: 1 - isoYear } : { era: 'ce', eraYear: isoYear };
     }
   }
 );

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -442,13 +442,13 @@ const nonIsoHelperBase = {
         result.month = +matches[1];
         if (result.month < 1) {
           throw new RangeError(
-            `Invalid month ${value} from ${isoString}[c=${this.id}]` +
+            `Invalid month ${value} from ${isoString}[u-ca-${this.id}]` +
               ' (probably due to https://bugs.chromium.org/p/v8/issues/detail?id=10527)'
           );
         }
         if (result.month > 13) {
           throw new RangeError(
-            `Invalid month ${value} from ${isoString}[c=${this.id}]` +
+            `Invalid month ${value} from ${isoString}[u-ca-${this.id}]` +
               ' (probably due to https://bugs.chromium.org/p/v8/issues/detail?id=10529)'
           );
         }
@@ -475,7 +475,7 @@ const nonIsoHelperBase = {
       // Node 12 has outdated ICU data that lacks the `relatedYear` field in the
       // output of Intl.DateTimeFormat.formatToParts.
       throw new RangeError(
-        `Intl.DateTimeFormat.formatToParts is missing year for ${this.id} calendar. Try Node 14+ or a modern browser.`
+        `Intl.DateTimeFormat.formatToParts lacks relatedYear in ${this.id} calendar. Try Node 14+ or modern browsers.`
       );
     }
     const calendarDate = this.adjustCalendarDate(result, cache, 'constrain', true);
@@ -1404,12 +1404,14 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
       const newYearGuess = dateTimeFormat.formatToParts(legacyDate);
       const calendarMonthString = newYearGuess.find((tv) => tv.type === 'month').value;
       const calendarDay = +newYearGuess.find((tv) => tv.type === 'day').value;
-      const calendarYearToVerify = +newYearGuess.find((tv) => tv.type === 'relatedYear').value;
-      if (calendarYearToVerify === undefined) {
+      let calendarYearToVerify = newYearGuess.find((tv) => tv.type === 'relatedYear');
+      if (calendarYearToVerify !== undefined) {
+        calendarYearToVerify = +calendarYearToVerify.value;
+      } else {
         // Node 12 has outdated ICU data that lacks the `relatedYear` field in the
         // output of Intl.DateTimeFormat.formatToParts.
         throw new RangeError(
-          `Intl.DateTimeFormat.formatToParts is missing year for ${this.id} calendar. Try Node 14+ or a modern browser.`
+          `Intl.DateTimeFormat.formatToParts lacks relatedYear in ${this.id} calendar. Try Node 14+ or modern browsers.`
         );
       }
       return { calendarMonthString, calendarDay, calendarYearToVerify };

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1029,6 +1029,7 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
               // constrain to last day of previous month (Av)
               month = 5;
               day = 30;
+              monthCode = 'M5';
             }
           }
         } else {
@@ -1038,7 +1039,7 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
         }
       }
       if (monthCode === undefined) monthCode = this.getMonthCode(year, month);
-      return { ...calendarDate, month, monthCode, year, eraYear };
+      return { ...calendarDate, day, month, monthCode, year, eraYear };
     }
   },
   // All built-in calendars except Chinese/Dangi and Hebrew use an era

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -7,7 +7,6 @@ import { CALENDAR_ID, ISO_YEAR, ISO_MONTH, ISO_DAY, CreateSlots, GetSlot, HasSlo
 const ArrayIncludes = Array.prototype.includes;
 const ObjectAssign = Object.assign;
 
-const BUILTIN_CALENDAR_IDS = ['gregory', 'iso8601', 'japanese'];
 const impl = {};
 
 export class Calendar {
@@ -40,24 +39,21 @@ export class Calendar {
     if (ES.Type(fields) !== 'Object') throw new TypeError('invalid fields');
     options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
-    const { year, month, day } = impl[GetSlot(this, CALENDAR_ID)].dateFromFields(fields, overflow);
-    return new constructor(year, month, day, this);
+    return impl[GetSlot(this, CALENDAR_ID)].dateFromFields(fields, overflow, constructor, this);
   }
   yearMonthFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     if (ES.Type(fields) !== 'Object') throw new TypeError('invalid fields');
     options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
-    const { year, month } = impl[GetSlot(this, CALENDAR_ID)].yearMonthFromFields(fields, overflow);
-    return new constructor(year, month, this, /* referenceISODay = */ 1);
+    return impl[GetSlot(this, CALENDAR_ID)].yearMonthFromFields(fields, overflow, constructor, this);
   }
   monthDayFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     if (ES.Type(fields) !== 'Object') throw new TypeError('invalid fields');
     options = ES.NormalizeOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
-    const { month, day } = impl[GetSlot(this, CALENDAR_ID)].monthDayFromFields(fields, overflow);
-    return new constructor(month, day, this, /* referenceISOYear = */ 1972);
+    return impl[GetSlot(this, CALENDAR_ID)].monthDayFromFields(fields, overflow, constructor, this);
   }
   fields(fields) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
@@ -180,19 +176,21 @@ MakeIntrinsicClass(Calendar, 'Temporal.Calendar');
 DefineIntrinsic('Temporal.Calendar.from', Calendar.from);
 
 impl['iso8601'] = {
-  dateFromFields(fields, overflow) {
+  dateFromFields(fields, overflow, constructor, calendar) {
     fields = ES.PrepareTemporalFields(fields, [['day'], ['month', undefined], ['monthCode', undefined], ['year']]);
     fields = resolveNonLunisolarMonth(fields);
-    const { year, month, day } = fields;
-    return ES.RegulateDate(year, month, day, overflow);
+    let { year, month, day } = fields;
+    ({ year, month, day } = ES.RegulateDate(year, month, day, overflow));
+    return new constructor(year, month, day, calendar);
   },
-  yearMonthFromFields(fields, overflow) {
+  yearMonthFromFields(fields, overflow, constructor, calendar) {
     fields = ES.PrepareTemporalFields(fields, [['month', undefined], ['monthCode', undefined], ['year']]);
     fields = resolveNonLunisolarMonth(fields);
-    const { year, month } = fields;
-    return ES.RegulateYearMonth(year, month, overflow);
+    let { year, month } = fields;
+    ({ year, month } = ES.RegulateYearMonth(year, month, overflow));
+    return new constructor(year, month, calendar, /* referenceISODay */ 1);
   },
-  monthDayFromFields(fields, overflow) {
+  monthDayFromFields(fields, overflow, constructor, calendar) {
     fields = ES.PrepareTemporalFields(fields, [
       ['day'],
       ['month', undefined],
@@ -203,8 +201,9 @@ impl['iso8601'] = {
       throw new TypeError('either year or monthCode required with month');
     }
     fields = resolveNonLunisolarMonth(fields);
-    const { month, day } = fields;
-    return ES.RegulateMonthDay(month, day, overflow);
+    let { month, day } = fields;
+    ({ month, day } = ES.RegulateMonthDay(month, day, overflow));
+    return new constructor(month, day, calendar, /* referenceISOYear */ 1972);
   },
   fields(fields) {
     return fields;
@@ -333,128 +332,1015 @@ function resolveNonLunisolarMonth(calendarDate) {
   return { ...calendarDate, month, monthCode };
 }
 
-// Implementation details for Gregorian calendar
-const gre = {
-  isoYear(eraYear, era) {
-    return era === 'bce' ? -(eraYear - 1) : eraYear;
-  },
-  validateFields(fields) {
-    if ((fields.era === undefined || fields.eraYear === undefined) && fields.year === undefined) {
-      throw new TypeError(
-        "required properties missing or undefined: must include 'year' and/or both 'era' and 'eraYear'"
+// Note: other built-in calendars than iso8601 are not part of the Temporal
+// proposal for ECMA-262. An implementation of these calendars is present in
+// this polyfill in order to validate the Temporal API and to get early feedback
+// about non-ISO calendars. However, non-ISO calendar implementation is subject
+// to change because these calendars are implementation-defined.
+
+/**
+ * This prototype implementation of non-ISO calendars makes many repeated calls
+ * to Intl APIs which may be slow (e.g. >0.2ms). This trivial cache will speed
+ * up these repeat accesses. Each cache instance is associated (via a WeakMap)
+ * to a specific Temporal object, which speeds up multiple calendar calls on the
+ * same Temporal object instance.  No invalidation or pruning is necessary
+ * because each object's cache is thrown away when the object is GC-ed.
+ */
+class OneObjectCache {
+  constructor() {
+    this.map = new Map();
+    this.calls = 0;
+    this.now = globalThis.performance ? globalThis.performance.now() : Date.now();
+    this.hits = 0;
+    this.misses = 0;
+  }
+  get(key) {
+    const result = this.map.get(key);
+    if (result) {
+      this.hits++;
+      this.report();
+    }
+    this.calls++;
+    return result;
+  }
+  set(key, value) {
+    this.map.set(key, value);
+    this.misses++;
+    this.report();
+  }
+  report() {
+    if (this.calls === 0) return;
+    /*
+    const ms = (globalThis.performance ? globalThis.performance.now() : Date.now()) - this.now;
+    const hitRate = ((100 * this.hits) / this.calls).toFixed(0);
+    console.log(`${this.calls} calls in ${ms.toFixed(2)}ms. Hits: ${this.hits} (${hitRate}%). Misses: ${this.misses}.`);
+    */
+  }
+  setObject(obj) {
+    if (OneObjectCache.objectMap.get(obj)) throw new RangeError('object already cached');
+    OneObjectCache.objectMap.set(obj, this);
+    this.report();
+  }
+}
+OneObjectCache.objectMap = new WeakMap();
+OneObjectCache.getCacheForObject = function (obj) {
+  let cache = OneObjectCache.objectMap.get(obj);
+  if (!cache) {
+    cache = new OneObjectCache();
+    OneObjectCache.objectMap.set(obj, cache);
+  }
+  return cache;
+};
+
+function toUtcIsoDateString({ isoYear, isoMonth, isoDay }) {
+  const yearString = ES.ISOYearString(isoYear);
+  const monthString = ES.ISODateTimePartString(isoMonth);
+  const dayString = ES.ISODateTimePartString(isoDay);
+  return `${yearString}-${monthString}-${dayString}T00:00Z`;
+}
+
+function simpleDateDiff(one, two) {
+  return {
+    years: one.year - two.year,
+    months: one.month - two.month,
+    days: one.day - two.day
+  };
+}
+
+/**
+ * Implementation that's common to all non-trivial non-ISO calendars
+ */
+const nonIsoHelperBase = {
+  // The properties and methods below here should be the same for all lunar/lunisolar calendars.
+  isoToCalendarDate(isoDate, cache) {
+    let { year: isoYear, month: isoMonth, day: isoDay } = isoDate;
+    const key = JSON.stringify({ func: 'isoToCalendarDate', isoYear, isoMonth, isoDay, id: this.id });
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    const dateTimeFormat = new Intl.DateTimeFormat(`en-US-u-ca-${this.id}`, {
+      day: 'numeric',
+      month: 'numeric',
+      year: 'numeric',
+      era: this.eraLength,
+      timeZone: 'UTC'
+    });
+    let parts, isoString;
+    try {
+      isoString = toUtcIsoDateString({ isoYear, isoMonth, isoDay });
+      parts = dateTimeFormat.formatToParts(new Date(isoString));
+    } catch (e) {
+      throw new RangeError(`Invalid ISO date: ${JSON.stringify({ isoYear, isoMonth, isoDay })}`);
+    }
+    const result = {};
+    for (let { type, value } of parts) {
+      if (type === 'year') result.eraYear = +value;
+      if (type === 'relatedYear') result.eraYear = +value;
+      if (type === 'month') {
+        const matches = /^([-0-9.]+)(.*?)$/.exec(value);
+        if (!matches || matches.length != 3) throw new RangeError(`Unexpected month: ${value}`);
+        result.month = +matches[1];
+        if (result.month < 1) {
+          throw new RangeError(
+            `Invalid month ${value} from ${isoString}[c=${this.id}]` +
+              ' (probably due to https://bugs.chromium.org/p/v8/issues/detail?id=10527)'
+          );
+        }
+        if (result.month > 13) {
+          throw new RangeError(
+            `Invalid month ${value} from ${isoString}[c=${this.id}]` +
+              ' (probably due to https://bugs.chromium.org/p/v8/issues/detail?id=10529)'
+          );
+        }
+        if (matches[2]) result.monthExtra = matches[2];
+      }
+      if (type === 'day') result.day = +value;
+      if (this.hasEra && type === 'era' && value != null && value !== '') {
+        // The convention for Temporal era values is lowercase, so following
+        // that convention in this prototype. Punctuation is removed, accented
+        // letters are normalized, and spaces are replaced with dashes.
+        // E.g.: "ERA0" => "era0", "Before R.O.C." => "before-roc", "En’ō" => "eno"
+        // The call to normalize() and the replacement regex deals with era
+        // names that contain non-ASCII characters like Japanese eras. Also
+        // ignore extra content in parentheses like JPN era date ranges.
+        value = value.split(' (')[0];
+        result.era = value
+          .normalize('NFD')
+          .replace(/[^-0-9 \p{L}]/gu, '')
+          .replace(' ', '-')
+          .toLowerCase();
+      }
+    }
+    if (result.eraYear === undefined) {
+      // Node 12 has outdated ICU data that lacks the `relatedYear` field in the
+      // output of Intl.DateTimeFormat.formatToParts.
+      throw new RangeError(
+        `Intl.DateTimeFormat.formatToParts is missing year for ${this.id} calendar. Try Node 14+ or a modern browser.`
       );
     }
-    if (fields.eraYear === undefined) {
-      return;
+    const calendarDate = this.adjustCalendarDate(result, cache, 'constrain', true);
+    if (calendarDate.year === undefined) throw new RangeError(`Missing year converting ${JSON.stringify(isoDate)}`);
+    if (calendarDate.month === undefined) throw new RangeError(`Missing month converting ${JSON.stringify(isoDate)}`);
+    if (calendarDate.day === undefined) throw new RangeError(`Missing day converting ${JSON.stringify(isoDate)}`);
+    cache.set(key, calendarDate);
+    return calendarDate;
+  },
+  validateCalendarDate(calendarDate) {
+    let { month, year, day, era, eraYear, monthCode, monthExtra } = calendarDate;
+    // When there's a suffix (e.g. "5bis" for a leap month in Chinese calendar)
+    // the derived class must deal with it.
+    if (monthExtra !== undefined) throw new RangeError('Unexpected `monthExtra` value');
+    if (year === undefined && eraYear === undefined) throw new TypeError('year or eraYear is required');
+    if (month === undefined && monthCode === undefined) throw new TypeError('month or monthCode is required');
+    if (day === undefined) throw new RangeError('Missing day');
+    if (eraYear !== undefined && era === undefined && this.hasEra) throw new TypeError('era is required');
+    if (era !== undefined && !this.hasEra) throw new RangeError(`No eras in ${this.id} calendar`);
+    if (era !== undefined && eraYear === undefined && this.hasEra) throw new TypeError('eraYear is required');
+    if (monthCode !== undefined) {
+      if (typeof monthCode !== 'string') {
+        throw new RangeError(`monthCode must be a string, not ${ES.Type(monthCode).toLowerCase()}`);
+      }
+      if (!/^(1?\d)(L?)$/.test(monthCode)) throw new RangeError(`Invalid monthCode: ${monthCode}`);
     }
-    if (fields.eraYear < 1) {
-      throw new RangeError('the Gregorian calendar does not support negative or zero years');
+  },
+  /**
+   * Allows derived calendars to add additional fields and/or to make
+   * adjustments e.g. to set the era based on the date or to revise the month
+   * number in lunisolar calendars per
+   * https://github.com/tc39/proposal-temporal/issues/1203.
+   *
+   * The base implementation fills in missing values by assuming the simplest
+   * possible calendar:
+   * - no eras or a constant era defined in `.constantEra`
+   * - non-lunisolar calendar (no leap months)
+   * */
+  adjustCalendarDate(calendarDate /*, cache, overflow, fromLegacyDate = false */) {
+    if (this.calendarType === 'lunisolar') throw new RangeError('Override required for lunisolar calendars');
+    this.validateCalendarDate(calendarDate);
+    let { month, year, eraYear, monthCode } = calendarDate;
+    if (year === undefined) year = eraYear;
+    if (eraYear === undefined) eraYear = year;
+    if (monthCode !== undefined) {
+      month = +monthCode;
     }
-    if (fields.year === undefined) {
-      return;
+    // For calendars that always use the same era, set it here so that derived
+    // calendars won't need to implement this method simply to set the era.
+    if (this.constantEra) calendarDate = { ...calendarDate, era: this.constantEra };
+    return { ...calendarDate, year, eraYear, month, monthCode: `${month}` };
+  },
+  regulateMonthDayNaive(calendarDate, overflow, cache) {
+    const largestMonth = this.monthsInYear(calendarDate, cache);
+    let { month, day } = calendarDate;
+    if (overflow === 'reject') {
+      if (month < 1 || month > largestMonth) throw new RangeError(`Invalid month: ${month}`);
+      if (day < 1 || day > this.maximumMonthLength(calendarDate)) throw new RangeError(`Invalid day: ${day}`);
+    } else {
+      if (month < 1) month = 1;
+      if (month > largestMonth) month = largestMonth;
+      if (day < 1) day = 1;
+      if (day > this.maximumMonthLength(calendarDate)) day = this.maximumMonthLength(calendarDate);
     }
-    const yearEra = gre.isoYear(fields.eraYear, fields.era);
-    if (yearEra !== fields.year) {
-      throw new RangeError("the provided 'era' and 'eraYear' conflict with the provided 'year'");
+    return { ...calendarDate, month, day };
+  },
+  calendarToIsoDate(date, overflow = 'constrain', cache) {
+    // First, normalize the calendar date to ensure that (year, month, day)
+    // are all present, converting monthCode and eraYear if needed.
+    date = this.adjustCalendarDate(date, cache, overflow, false);
+
+    // Fix obviously out-of-bounds values. Values that are valid generally, but
+    // not in this particular year, will be handled lower below.
+    date = this.regulateMonthDayNaive(date, overflow, cache);
+
+    const { year, month, day } = date;
+    const key = JSON.stringify({ func: 'calendarToIsoDate', year, month, day, overflow, id: this.id });
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    // First, try to roughly guess the result
+    let isoEstimate = this.estimateIsoDate({ year, month, day });
+    const calculateSameMonthResult = (diffDays) => {
+      // If the estimate is in the same year & month as the target, then we can
+      // calculate the result exactly and short-circuit any additional logic.
+      // This optimization assumes that months are continuous (no skipped days)
+      // so it breaks in the case of calendar changes like 1582's skipping of
+      // days in October in the Roman calendar. This is just a prototype
+      // implementation so this error is OK for now.
+      let testIsoEstimate = this.addDaysIso(isoEstimate, diffDays);
+      if (date.day > this.minimumMonthLength(date)) {
+        // There's a chance that the calendar date is out of range. Throw or
+        // constrain if so.
+        let testCalendarDate = this.isoToCalendarDate(testIsoEstimate, cache);
+        while (testCalendarDate.month !== month || testCalendarDate.year !== year) {
+          if (overflow === 'reject') {
+            throw new RangeError(`day ${day} does not exist in month ${month} of year ${year}`);
+          }
+          // Back up a day at a time until we're not hanging over the month end
+          testIsoEstimate = this.addDaysIso(testIsoEstimate, -1);
+          testCalendarDate = this.isoToCalendarDate(testIsoEstimate, cache);
+        }
+      }
+      return testIsoEstimate;
+    };
+    let roundtripEstimate = this.isoToCalendarDate(isoEstimate, cache);
+    let diff = simpleDateDiff(date, roundtripEstimate);
+    const diffTotalDaysEstimate = diff.years * 365 + diff.months * 30 + diff.days;
+    isoEstimate = this.addDaysIso(isoEstimate, diffTotalDaysEstimate);
+    roundtripEstimate = this.isoToCalendarDate(isoEstimate, cache);
+    diff = simpleDateDiff(date, roundtripEstimate);
+    let sign = 0;
+    if (diff.years === 0 && diff.months === 0) {
+      isoEstimate = calculateSameMonthResult(diff.days);
+    } else {
+      sign = this.compareCalendarDates(date, roundtripEstimate);
     }
+
+    // If the initial guess is not in the same month, then then bisect the
+    // distance to the target, starting with 8 days per step.
+    let increment = 8;
+    while (sign) {
+      isoEstimate = this.addDaysIso(isoEstimate, sign * increment);
+      const oldRoundtripEstimate = roundtripEstimate;
+      roundtripEstimate = this.isoToCalendarDate(isoEstimate, cache);
+      const oldSign = sign;
+      sign = this.compareCalendarDates(date, roundtripEstimate);
+      if (sign) {
+        diff = simpleDateDiff(date, roundtripEstimate);
+        if (diff.years === 0 && diff.months === 0) {
+          isoEstimate = calculateSameMonthResult(diff.days);
+          sign = 0; // signal the loop condition that there's a match.
+        } else if (oldSign && sign !== oldSign) {
+          if (increment > 1) {
+            // If the estimate overshot the target, try again with a smaller increment
+            // in the reverse direction.
+            increment /= 2;
+          } else {
+            // Increment is 1, and neither the previous estimate nor the new
+            // estimate is correct. The only way that can happen is if the
+            // original date was an invalid value that will be constrained or
+            // rejected here.
+            if (overflow === 'reject') {
+              throw new RangeError(`Can't find ISO date from calendar date: ${JSON.stringify({ year, month, day })}`);
+            } else {
+              // To constrain, pick the earliest value
+              const order = this.compareCalendarDates(roundtripEstimate, oldRoundtripEstimate);
+              // If current value is larger, then back up to the previous value.
+              if (order > 0) isoEstimate = this.addDaysIso(isoEstimate, -1);
+              sign = 0;
+            }
+          }
+        }
+      }
+    }
+    cache.set(key, isoEstimate);
+    return isoEstimate;
+  },
+  temporalToCalendarDate(date, cache) {
+    const isoDate = { year: GetSlot(date, ISO_YEAR), month: GetSlot(date, ISO_MONTH), day: GetSlot(date, ISO_DAY) };
+    const result = this.isoToCalendarDate(isoDate, cache);
+    return result;
+  },
+  compareCalendarDates(date1, date2) {
+    // `date1` and `date2` are already records. The calls below simply validate
+    // that all three required fields are present.
+    date1 = ES.PrepareTemporalFields(date1, [['day'], ['month'], ['year']]);
+    date2 = ES.PrepareTemporalFields(date2, [['day'], ['month'], ['year']]);
+    if (date1.year !== date2.year) return ES.ComparisonResult(date1.year - date2.year);
+    // NOTE: we're assuming that month numbers correspond to chronological order for a given year
+    if (date1.month !== date2.month) return ES.ComparisonResult(date1.month - date2.month);
+    if (date1.day !== date2.day) return ES.ComparisonResult(date1.day - date2.day);
+    return 0;
+  },
+  /** Ensure that a calendar date actually exists. If not, return the closest earlier date. */
+  regulateDate(calendarDate, overflow = 'constrain', cache) {
+    const isoDate = this.calendarToIsoDate(calendarDate, overflow, cache);
+    return this.isoToCalendarDate(isoDate, cache);
+  },
+  addDaysIso(isoDate, days) {
+    const added = ES.AddDate(isoDate.year, isoDate.month, isoDate.day, 0, 0, 0, days, 'constrain');
+    return added;
+  },
+  addDaysCalendar(calendarDate, days, cache) {
+    const isoDate = this.calendarToIsoDate(calendarDate, 'constrain', cache);
+    const addedIso = this.addDaysIso(isoDate, days);
+    const addedCalendar = this.isoToCalendarDate(addedIso, cache);
+    return addedCalendar;
+  },
+  addMonthsCalendar(calendarDate, months, overflow, cache) {
+    const { day } = calendarDate;
+    for (let i = 0, absMonths = Math.abs(months); i < absMonths; i++) {
+      const days = months < 0 ? -this.daysInPreviousMonth(calendarDate, cache) : this.daysInMonth(calendarDate, cache);
+      const isoDate = this.calendarToIsoDate(calendarDate, 'constrain', cache);
+      const addedIso = this.addDaysIso(isoDate, days, cache);
+      calendarDate = this.isoToCalendarDate(addedIso, cache);
+      if (calendarDate.day !== day) {
+        // try to retain the original day-of-month, if possible
+        calendarDate = this.regulateDate({ ...calendarDate, day }, 'constrain', cache);
+      }
+    }
+    if (overflow === 'reject' && calendarDate.day !== day) {
+      throw new RangeError(`Day ${day} does not exist in resulting calendar month`);
+    }
+    return calendarDate;
+  },
+  addCalendar(calendarDate, { years = 0, months = 0, weeks = 0, days = 0 }, overflow, cache) {
+    const { year, month, day } = calendarDate;
+    const addedMonths = this.addMonthsCalendar({ year: year + years, month, day }, months, overflow, cache);
+    days += weeks * 7;
+    const addedDays = this.addDaysCalendar(addedMonths, days, cache);
+    return addedDays;
+  },
+  untilCalendar(calendarOne, calendarTwo, largestUnit, cache) {
+    let days = 0;
+    let weeks = 0;
+    let months = 0;
+    let years = 0;
+    switch (largestUnit) {
+      case 'days':
+        days = this.calendarDaysUntil(calendarOne, calendarTwo, cache);
+        break;
+      case 'weeks': {
+        const totalDays = this.calendarDaysUntil(calendarOne, calendarTwo, cache);
+        days = totalDays % 7;
+        weeks = (totalDays - days) / 7;
+        break;
+      }
+      case 'months':
+      case 'years': {
+        const diffYears = calendarTwo.year - calendarOne.year;
+        const diffMonths = calendarTwo.month - calendarOne.month;
+        const diffDays = calendarTwo.day - calendarOne.day;
+        const sign = this.compareCalendarDates(calendarTwo, calendarOne);
+        if (largestUnit === 'years' && diffYears) {
+          const isOneFurtherInYear = diffMonths * sign < 0 || (diffMonths === 0 && diffDays * sign < 0);
+          years = isOneFurtherInYear ? diffYears - sign : diffYears;
+        }
+        const yearsAdded = years ? this.addCalendar(calendarOne, { years }, 'constrain', cache) : calendarOne;
+        // Now we have less than one year remaining. Add one month at a time
+        // until we go over the target, then back up one month and calculate
+        // remaining days and weeks.
+        let current;
+        let next = yearsAdded;
+        do {
+          months++;
+          current = next;
+          next = this.addMonthsCalendar(current, sign, 'constrain', cache);
+          if (next.day !== calendarOne.day) {
+            // In case the day was constrained down, try to un-constrain it
+            next = this.regulateDate({ ...next, day: calendarOne.day }, 'constrain', cache);
+          }
+        } while (this.compareCalendarDates(calendarTwo, next) * sign >= 0);
+        months--; // correct for loop above which overshoots by 1
+        const remainingDays = this.calendarDaysUntil(current, calendarTwo, cache);
+        days = remainingDays % 7;
+        weeks = (remainingDays - days) / 7;
+        break;
+      }
+    }
+    return { years, months, weeks, days };
+  },
+  daysInMonth(calendarDate, cache) {
+    // Add the length of the smallest possible month. If it rolls over to the
+    // next month, then back up to the end of the previous month to know its day
+    // count. If it doesn't roll over, add the same number of days again until
+    // we get a rollover.
+    //
+    // NOTE: This won't work for months where days are skipped (e.g. Gregorian
+    // switchover) which is OK because this is a prototype implementation.
+    const { month: originalCalendarMonth } = calendarDate;
+    const increment = this.minimumMonthLength(calendarDate);
+
+    // easiest case: we already know the month length if min and max are the same.
+    if (increment === this.maximumMonthLength(calendarDate)) return increment;
+
+    let addedIsoDate = this.calendarToIsoDate(calendarDate, 'constrain', cache);
+    let addedCalendarDate;
+    do {
+      addedIsoDate = this.addDaysIso(addedIsoDate, increment);
+      addedCalendarDate = this.isoToCalendarDate(addedIsoDate, cache);
+    } while (addedCalendarDate.month === originalCalendarMonth);
+
+    // Now back up to the last day of the original month
+    const endOfMonthIso = this.addDaysIso(addedIsoDate, -addedCalendarDate.day);
+    const endOfMonthCalendar = this.isoToCalendarDate(endOfMonthIso, cache);
+    return endOfMonthCalendar.day;
+  },
+  daysInPreviousMonth(calendarDate, cache) {
+    const { day, month, year } = calendarDate;
+
+    // Check to see if we already know the month length, and return it if so
+    const previousMonthYear = month > 1 ? year : year - 1;
+    let previousMonthDate = { year: previousMonthYear, month, day: 1 };
+    const previousMonth = month > 1 ? month - 1 : this.monthsInYear(previousMonthDate, cache);
+    previousMonthDate = { ...previousMonthDate, month: previousMonth };
+    const min = this.minimumMonthLength(previousMonthDate);
+    const max = this.maximumMonthLength(previousMonthDate);
+    if (min === max) return max;
+
+    const isoDate = this.calendarToIsoDate(calendarDate, 'constrain', cache);
+    const lastDayOfPreviousMonthIso = this.addDaysIso(isoDate, -day);
+    const lastDayOfPreviousMonthCalendar = this.isoToCalendarDate(lastDayOfPreviousMonthIso, cache);
+    return lastDayOfPreviousMonthCalendar.day;
+  },
+  startOfCalendarYear(calendarDate) {
+    return { year: calendarDate.year, month: 1, day: 1 };
+  },
+  startOfCalendarMonth(calendarDate) {
+    return { year: calendarDate.year, month: calendarDate.month, day: 1 };
+  },
+  calendarDaysUntil(calendarOne, calendarTwo, cache) {
+    const oneIso = this.calendarToIsoDate(calendarOne, 'constrain', cache);
+    const twoIso = this.calendarToIsoDate(calendarTwo, 'constrain', cache);
+    return this.isoDaysUntil(oneIso, twoIso);
+  },
+  isoDaysUntil(oneIso, twoIso) {
+    const duration = ES.DifferenceDate(
+      oneIso.year,
+      oneIso.month,
+      oneIso.day,
+      twoIso.year,
+      twoIso.month,
+      twoIso.day,
+      'days'
+    );
+    return duration.days;
+  },
+  // The short era format works for all calendars except Japanese, which will
+  // override.
+  eraLength: 'short',
+  // All built-in calendars except Chinese/Dangi and Hebrew use an era
+  hasEra: true,
+  monthDayFromFields(fields, overflow, cache) {
+    let { year, month, monthCode, day, era, eraYear } = fields;
+    if (monthCode === undefined) {
+      if (year === undefined && (era === undefined || eraYear === undefined)) {
+        throw new TypeError('`monthCode`, `year`, or `era` and `eraYear` is required');
+      }
+      ({ monthCode, year } = this.adjustCalendarDate({ year, month, monthCode, day, era, eraYear }));
+    }
+
+    let isoYear, isoMonth, isoDay;
+    let closest;
+    // Look backwards starting from 1972 up to 100 years to find a year that
+    // has this month and day. Normal months and days will match immediately,
+    // but for leap days and leap months we may have to look for a while.
+    const startDateIso = { year: 1972, month: 1, day: 1 };
+    const { year: calendarYear } = this.isoToCalendarDate(startDateIso, cache);
+    for (let i = 0; i < 100; i++) {
+      const testCalendarDate = { day, monthCode, year: calendarYear - i };
+      const isoDate = this.calendarToIsoDate(testCalendarDate, 'constrain', cache);
+      const roundTripCalendarDate = this.isoToCalendarDate(isoDate, cache);
+      ({ year: isoYear, month: isoMonth, day: isoDay } = isoDate);
+      if (roundTripCalendarDate.monthCode === monthCode && roundTripCalendarDate.day === day) {
+        return { month: isoMonth, day: isoDay, year: isoYear };
+      } else if (overflow === 'constrain') {
+        const constrained = this.regulateDate(testCalendarDate, 'constrain', cache);
+        // non-ISO constrain algorithm tries to find the closest date in a matching month
+        if (
+          closest === undefined ||
+          constrained.month > closest.month ||
+          (constrained.month === closest.month && constrained.day > closest.day)
+        ) {
+          closest = constrained;
+        }
+      }
+    }
+    if (overflow === 'constrain' && closest !== undefined) return closest;
+    throw new RangeError(`No recent ${this.id} year with month ${monthCode} and day ${day}`);
   }
 };
 
-// 'iso8601' calendar is equivalent to 'gregory' except for ISO 8601 week
-// numbering rules, which we do not currently use in Temporal, and the addition
-// of BCE/CE eras which means no negative years or year 0.
-impl['gregory'] = ObjectAssign({}, impl['iso8601'], {
-  era(date) {
-    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    return GetSlot(date, ISO_YEAR) < 1 ? 'bce' : 'ce';
+const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
+  id: 'hebrew',
+  calendarType: 'lunisolar',
+  inLeapYear(calendarDate /*, cache */) {
+    const { year } = calendarDate;
+    // FYI: In addition to adding a month in leap years, the Hebrew calendar
+    // also has per-year changes to the number of days of Heshvan and Kislev.
+    // Given that these can be calculated by counting the number of days in
+    // those months, I assume that these DO NOT need to be exposed as
+    // Hebrew-only prototype fields or methods.
+    return (7 * year + 1) % 19 < 7;
   },
-  eraYear(date) {
-    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    const isoYear = GetSlot(date, ISO_YEAR);
-    return isoYear < 1 ? -isoYear + 1 : isoYear;
+  monthsInYear(calendarDate) {
+    return this.inLeapYear(calendarDate) ? 13 : 12;
   },
-  fields(fields) {
-    if (fields.includes('year')) fields.push('eraYear');
-    if (fields.includes('eraYear')) fields.push('era');
-    else if (fields.includes('era')) fields.push('eraYear');
-    return fields;
+  minimumMonthLength(calendarDate) {
+    return this.minMaxMonthLength(calendarDate, 'min');
   },
-  dateFromFields(fields, overflow) {
-    // Intentionally alphabetical
-    fields = ES.PrepareTemporalFields(fields, [
-      ['day'],
-      ['era', undefined],
-      ['eraYear', undefined],
-      ['month', undefined],
-      ['monthCode', undefined],
-      ['year', undefined]
-    ]);
-    gre.validateFields(fields);
-    let isoYear = fields.year;
-    if (fields.era !== undefined) {
-      isoYear = gre.isoYear(fields.eraYear, fields.era);
+  maximumMonthLength(calendarDate) {
+    return this.minMaxMonthLength(calendarDate, 'max');
+  },
+  minMaxMonthLength(calendarDate, minOrMax) {
+    const { month, year } = calendarDate;
+    const monthCode = this.getMonthCode(year, month);
+    const monthInfo = Object.entries(this.months).find((m) => m[1].monthCode === monthCode);
+    if (monthInfo === undefined) throw new TypeError(`unmatched Hebrew month: ${month}`);
+    const daysInMonth = monthInfo[1].days;
+    return typeof daysInMonth === 'number' ? daysInMonth : daysInMonth[minOrMax];
+  },
+  /** Take a guess at what ISO date a particular calendar date corresponds to */
+  estimateIsoDate(calendarDate) {
+    const { year } = calendarDate;
+    return { year: year - 3760, month: 1, day: 1 };
+  },
+  months: {
+    Tishri: { leap: 1, regular: 1, monthCode: '1', days: 30 },
+    Heshvan: { leap: 2, regular: 2, monthCode: '2', days: { min: 29, max: 30 } },
+    Kislev: { leap: 3, regular: 3, monthCode: '3', days: { min: 29, max: 30 } },
+    Tevet: { leap: 4, regular: 4, monthCode: '4', days: 29 },
+    Shevat: { leap: 5, regular: 5, monthCode: '5', days: 30 },
+    Adar: { leap: undefined, regular: 6, monthCode: '6', days: 29 },
+    'Adar I': { leap: 6, regular: undefined, monthCode: '5L', days: 30 },
+    'Adar II': { leap: 7, regular: undefined, monthCode: '6', days: 29 },
+    Nisan: { leap: 8, regular: 7, monthCode: '7', days: 30 },
+    Iyar: { leap: 9, regular: 8, monthCode: '8', days: 29 },
+    Sivan: { leap: 10, regular: 9, monthCode: '9', days: 30 },
+    Tamuz: { leap: 11, regular: 10, monthCode: '10', days: 29 },
+    Av: { leap: 12, regular: 11, monthCode: '11', days: 30 },
+    Elul: { leap: 13, regular: 12, monthCode: '12', days: 29 }
+  },
+  getMonthCode(year, month) {
+    if (this.inLeapYear({ year })) {
+      return month === 6 ? '5L' : `${month < 6 ? month : month - 1}`;
+    } else {
+      return `${month}`;
     }
-    return impl['iso8601'].dateFromFields({ ...fields, year: isoYear }, overflow);
   },
-  yearMonthFromFields(fields, overflow) {
-    // Intentionally alphabetical
-    fields = ES.PrepareTemporalFields(fields, [
-      ['era', undefined],
-      ['eraYear', undefined],
-      ['month', undefined],
-      ['monthCode', undefined],
-      ['year', undefined]
-    ]);
-    gre.validateFields(fields);
-    let isoYear = fields.year;
-    if (fields.era !== undefined) {
-      isoYear = gre.isoYear(fields.eraYear, fields.era);
+  adjustCalendarDate(calendarDate, cache, overflow = 'constrain', fromLegacyDate = false) {
+    // The current Intl implementation skips index 6 (Adar I) in non-leap years
+    let { year, eraYear, month, monthCode, day, monthExtra } = calendarDate;
+    if (year === undefined) year = eraYear;
+    if (eraYear === undefined) eraYear = year;
+    if (fromLegacyDate) {
+      // DateTimeFormat.formatToParts returns either a numeric string (e.g. "4")
+      // or the name of a month (e.g. "Tevet"), even when the month format is
+      // set to 'numeric. Even running the same exact code in the Chrome dev
+      // tools debugger yields different results!  I assume it's a caching bug
+      // somewhere in the Intl code. I've not been able to reproduce the cause
+      // of the divergent behavior. But given that this implementation is a
+      // prototype and will be thrown away in a few months, for now we'll defend
+      // against this behavior here by handling either a numeric string or a
+      // name.
+      if (monthExtra) {
+        const monthInfo = this.months[monthExtra];
+        if (!monthInfo) throw new RangeError(`Unrecognized month from formatToParts: ${monthExtra}`);
+        month = this.inLeapYear({ year }) ? monthInfo.leap : monthInfo.regular;
+      }
+      monthCode = this.getMonthCode(year, month);
+      const result = { year, month, day, era: undefined, eraYear, monthCode };
+      return result;
+    } else {
+      // When called without input coming from legacy Date output, simply ensure
+      // that all fields are present.
+      this.validateCalendarDate(calendarDate);
+      if (month === undefined) {
+        if (monthCode.endsWith('L')) {
+          if (monthCode !== '5L') throw new RangeError(`Hebrew leap month must have monthCode 5L, not ${monthCode}`);
+          month = 6;
+          if (!this.inLeapYear({ year })) {
+            if (overflow === 'reject') {
+              throw new RangeError(`Hebrew monthCode 5L is invalid in year ${year} which is not a leap year`);
+            } else {
+              // constrain to last day of previous month (Av)
+              month = 5;
+              day = 30;
+            }
+          }
+        } else {
+          month = monthCodeNumberPart(monthCode);
+          // if leap month is before this one, the month index is one more than the month code
+          if (this.inLeapYear({ year }) && month > 6) month++;
+        }
+      }
+      if (monthCode === undefined) monthCode = this.getMonthCode(year, month);
+      return { ...calendarDate, month, monthCode, year, eraYear };
     }
-    return impl['iso8601'].yearMonthFromFields({ ...fields, year: isoYear }, overflow);
   },
-  monthDayFromFields(fields, overflow) {
-    // Intentionally alphabetical
-    fields = ES.PrepareTemporalFields(fields, [
-      ['day'],
-      ['era', undefined],
-      ['eraYear', undefined],
-      ['month', undefined],
-      ['monthCode', undefined],
-      ['year', undefined]
-    ]);
-    // validateFields doesn't validate month and monthCode; chaining up to
-    // impl['iso8601'] does. We only need to validate year/era/eraYear if we
-    // have month without monthCode.
-    if (fields.month !== undefined && fields.monthCode === undefined) gre.validateFields(fields);
-    let isoYear = fields.year;
-    if (fields.era !== undefined) {
-      isoYear = gre.isoYear(fields.eraYear, fields.era);
-    }
-    return impl['iso8601'].monthDayFromFields({ ...fields, year: isoYear }, overflow);
+  // All built-in calendars except Chinese/Dangi and Hebrew use an era
+  hasEra: false
+});
+
+/**
+ * For Temporal purposes, the Islamic calendar is simple because it's always the
+ * same 12 months in the same order.
+ */
+const helperIslamic = ObjectAssign({}, nonIsoHelperBase, {
+  id: 'islamic',
+  calendarType: 'lunar',
+  inLeapYear(calendarDate, cache) {
+    // In leap years, the 12th month has 30 days. In non-leap years: 29.
+    const days = this.daysInMonth({ year: calendarDate.year, month: 12, day: 1 }, cache);
+    return days === 30;
+  },
+  monthsInYear(/* calendarYear, cache */) {
+    return 12;
+  },
+  minimumMonthLength: (/* calendarDate */) => 29,
+  maximumMonthLength: (/* calendarDate */) => 30,
+  DAYS_PER_ISLAMIC_YEAR: 354 + 11 / 30,
+  DAYS_PER_ISO_YEAR: 365.2425,
+  constantEra: 'ah',
+  estimateIsoDate(calendarDate) {
+    const { year } = this.adjustCalendarDate(calendarDate);
+    return { year: Math.floor((year * this.DAYS_PER_ISLAMIC_YEAR) / this.DAYS_PER_ISO_YEAR) + 622, month: 1, day: 1 };
   }
 });
 
-// Implementation details for Japanese calendar
-//
-// NOTE: For convenience, this hacky class only supports the most recent five
-// eras, those of the modern period. For the full list, see:
-// https://github.com/unicode-org/cldr/blob/master/common/supplemental/supplementalData.xml#L4310-L4546
-//
-// NOTE: Japan started using the Gregorian calendar in 6 Meiji, replacing a
-// lunisolar calendar. So the day before January 1 of 6 Meiji (1873) was not
-// December 31, but December 2, of 5 Meiji (1872). The existing Ecma-402
-// Japanese calendar doesn't seem to take this into account, so neither do we:
-// > args = ['en-ca-u-ca-japanese', { era: 'short' }]
-// > new Date('1873-01-01T12:00').toLocaleString(...args)
-// '1 1, 6 Meiji, 12:00:00 PM'
-// > new Date('1872-12-31T12:00').toLocaleString(...args)
-// '12 31, 5 Meiji, 12:00:00 PM'
-const jpn = {
-  eraStartDates: ['1868-09-08', '1912-07-30', '1926-12-25', '1989-01-08', '2019-05-01'],
-  eraAddends: [1867, 1911, 1925, 1988, 2018],
+const helperPersian = ObjectAssign({}, nonIsoHelperBase, {
+  id: 'persian',
+  calendarType: 'solar',
+  inLeapYear(calendarDate, cache) {
+    // Same logic (count days in the last month) for Persian as for Islamic,
+    // even though Persian is solar and Islamic is lunar.
+    return helperIslamic.inLeapYear(calendarDate, cache);
+  },
+  monthsInYear(/* calendarYear, cache */) {
+    return 12;
+  },
+  minimumMonthLength(calendarDate) {
+    const { month } = calendarDate;
+    if (month === 12) return 29;
+    return month <= 6 ? 31 : 30;
+  },
+  maximumMonthLength(calendarDate) {
+    const { month } = calendarDate;
+    if (month === 12) return 30;
+    return month <= 6 ? 31 : 30;
+  },
+  constantEra: 'ap',
+  estimateIsoDate(calendarDate) {
+    const { year } = this.adjustCalendarDate(calendarDate);
+    return { year: year + 621, month: 1, day: 1 };
+  }
+});
 
-  // This is what API consumers pass in as the value of the 'era' field. We use
-  // string constants consisting of the romanized name
+const helperIndian = ObjectAssign({}, nonIsoHelperBase, {
+  id: 'indian',
+  calendarType: 'solar',
+  inLeapYear(calendarDate /*, cache*/) {
+    // From https://en.wikipedia.org/wiki/Indian_national_calendar:
+    // Years are counted in the Saka era, which starts its year 0 in the year 78
+    // of the Common Era. To determine leap years, add 78 to the Saka year – if
+    // the result is a leap year in the Gregorian calendar, then the Saka year
+    // is a leap year as well.
+    return isGregorianLeapYear(calendarDate.year + 78);
+  },
+  monthsInYear(/* calendarYear, cache */) {
+    return 12;
+  },
+  minimumMonthLength(calendarDate) {
+    const { month } = calendarDate;
+    if (month === 1) return this.inLeapYear(calendarDate) ? 31 : 30;
+    return month <= 6 ? 31 : 30;
+  },
+  maximumMonthLength(calendarDate) {
+    return this.minimumMonthLength(calendarDate);
+  },
+  constantEra: 'saka',
+  estimateIsoDate(calendarDate) {
+    const { year } = this.adjustCalendarDate(calendarDate);
+    // The Indian calendar has a 1:1 correspondence to the ISO calendar. Indian
+    // months always start at the same well-known Gregorian month and day. So
+    // this conversion could be easy and much faster. See
+    // https://en.wikipedia.org/wiki/Indian_national_calendar
+    return { year: year + 78, month: 1, day: 1 };
+  }
+});
+
+/**
+ * This function adds additional metadata that makes it easier to work with
+ * eras. Note that it mutates and normalizes the original era objects, which is
+ * OK because this is non-observable, internal-only metadata.
+ *
+ * The result is an array of eras with this shape:
+ * ```
+ * interface Era {
+ *   // name of the era
+ *   name: string;
+ *
+ *   // alternate name of the era used in old versions of ICU data
+ *   // format is `era{n}` where n is the zero-based index of the era
+ *   // with the oldest era being 0.
+ *   genericName: string;
+ *
+ *   // Signed calendar year where this era begins. Will be
+ *   // 1 (or 0 for zero-based eras) for the anchor era assuming that `year`
+ *   // numbering starts at the beginning of the anchor era, which is true
+ *   // for all ICU calendars except Japanese. If an era starts mid-year
+ *   // then a calendar month and day are included. Otherwise
+ *   // `{ month: 1, day: 1 }` is assumed.
+ *   anchorEpoch:  { year: number } | { year: number, month: number, day: number }
+ *
+ *   // ISO date of the first day of this era
+ *   isoEpoch: { year: number, month: number, day: number}
+ *
+ *   // If present, then this era counts years backwards like BC
+ *   // and this property points to the forward era. This must be
+ *   // the last (oldest) era in the array.
+ *   reverseOf: Era;
+ *
+ *   // If true, the era's years are 0-based. If omitted or false,
+ *   // then the era's years are 1-based.
+ *   hasYearZero: boolean = false;
+ * }
+ * ```
+ * */
+function adjustEras(eras) {
+  if (eras.length === 0) {
+    throw new RangeError('Invalid era data: eras are required');
+  }
+  if (eras.length === 1 && eras[0].reverseOf) {
+    throw new RangeError('Invalid era data: anchor era cannot count years backwards');
+  }
+  if (eras.length === 1 && !eras[0].name) {
+    throw new RangeError('Invalid era data: at least one named era is required');
+  }
+  if (eras.filter((e) => e.reverseOf != null).length > 1) {
+    throw new RangeError('Invalid era data: only one era can count years backwards');
+  }
+
+  // Find the "anchor era" which is the default era used when eraYear is
+  // specified without also providing an era. Reversed eras can never be
+  // anchors. The era without an `anchorEpoch` property is the anchor.
+  let anchorEra;
+  eras.forEach((e) => {
+    if (e.isAnchor || (!e.anchorEpoch && !e.reverseOf)) {
+      if (anchorEra) throw new RangeError('Invalid era data: cannot have multiple anchor eras');
+      anchorEra = e;
+      e.anchorEpoch = { year: e.hasYearZero ? 0 : 1 };
+    } else if (!e.name) {
+      throw new RangeError('If era name is blank, it must be the anchor era');
+    }
+  });
+
+  // If the era name is undefined, then it's an anchor that doesn't interact
+  // with eras at all. For example, Japanese `year` is always the same as ISO
+  // `year`.  So this "era" is the anchor era but isn't used for era matching.
+  // Strip it from the list that's returned.
+  eras = eras.filter((e) => e.name);
+
+  eras.forEach((e) => {
+    // Some eras are mirror images of another era e.g. B.C. is the reverse of A.D.
+    // Replace the string-valued "reverseOf" property with the actual era object
+    // that's reversed.
+    const { reverseOf } = e;
+    if (reverseOf) {
+      const reversedEra = eras.find((era) => era.name === reverseOf);
+      if (reversedEra === undefined) throw new RangeError(`Invalid era data: unmatched reverseOf era: ${reverseOf}`);
+      e.reverseOf = reversedEra;
+      e.anchorEpoch = reversedEra.anchorEpoch;
+      e.isoEpoch = reversedEra.isoEpoch;
+    }
+    if (e.anchorEpoch.month === undefined) e.anchorEpoch.month = 1;
+    if (e.anchorEpoch.day === undefined) e.anchorEpoch.day = 1;
+  });
+
+  // Ensure that the latest epoch is first in the array. This lets us try to
+  // match eras in index order, with the last era getting the remaining older
+  // years. Any reverse-signed era must be at the end.
+  eras.sort((e1, e2) => {
+    if (e1.reverseOf) return e2;
+    if (e2.reverseOf) return e1;
+    return e2.isoEpoch.year - e1.isoEpoch.year;
+  });
+
+  // If there's a reversed era, then the one before it must be the era that's
+  // being reversed.
+  const lastEraReversed = eras[eras.length - 1].reverseOf;
+  if (lastEraReversed) {
+    if (lastEraReversed !== eras[eras.length - 2]) throw new RangeError('Invalid era data: invalid reverse-sign era');
+  }
+
+  // Finally, add a "genericName" property in the format "era{n} where `n` is
+  // zero-based index, with the oldest era being zero. This format is used by
+  // older versions of ICU data.
+  eras.forEach((e, i) => {
+    e.genericName = `era${eras.length - 1 - i}`;
+  });
+
+  return { eras, anchorEra: anchorEra || eras[0] };
+}
+
+function isGregorianLeapYear(year) {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+/** Base for all Gregorian-like calendars. */
+const makeHelperGregorian = (id, originalEras) => {
+  const { eras, anchorEra } = adjustEras(originalEras);
+  return ObjectAssign({}, nonIsoHelperBase, {
+    id,
+    eras,
+    anchorEra,
+    calendarType: 'solar',
+    inLeapYear(calendarDate /*, cache */) {
+      const { year } = this.estimateIsoDate(calendarDate);
+      return isGregorianLeapYear(year);
+    },
+    monthsInYear(/* calendarDate */) {
+      return 12;
+    },
+    minimumMonthLength(calendarDate) {
+      const { month } = calendarDate;
+      if (month === 2) return this.inLeapYear(calendarDate) ? 29 : 28;
+      return [4, 6, 9, 11].indexOf(month) >= 0 ? 30 : 31;
+    },
+    maximumMonthLength(calendarDate) {
+      return this.minimumMonthLength(calendarDate);
+    },
+    /** Fill in missing parts of the (year, era, eraYear) tuple */
+    completeEraYear(calendarDate) {
+      const checkField = (name, value) => {
+        const currentValue = calendarDate[name];
+        if (currentValue != null && currentValue != value) {
+          throw new RangeError(`Input ${name} ${currentValue} doesn't match calculated value ${value}`);
+        }
+      };
+
+      let { year, eraYear, era } = calendarDate;
+      if (year != null) {
+        const matchingEra = this.eras.find((e, i) => {
+          if (i === this.eras.length - 1) {
+            if (e.reverseOf) {
+              // This is a reverse-sign era (like BC) which must be the oldest
+              // era. Count years backwards.
+              if (year > 0) throw new RangeError(`Signed year ${year} is invalid for era ${e.name}`);
+              eraYear = e.anchorEpoch.year - year;
+              return true;
+            }
+            // last era always gets all "leftover" (older than epoch) years,
+            // so no need for a comparison like below.
+            eraYear = year - e.anchorEpoch.year + (e.hasYearZero ? 0 : 1);
+            return true;
+          }
+          const comparison = nonIsoHelperBase.compareCalendarDates(calendarDate, e.anchorEpoch);
+          if (comparison >= 0) {
+            eraYear = year - e.anchorEpoch.year + (e.hasYearZero ? 0 : 1);
+            return true;
+          }
+          return false;
+        });
+        if (!matchingEra) throw new RangeError(`Year ${year} was not matched by any era`);
+        era = matchingEra.name;
+        checkField('era', era);
+        checkField('eraYear', eraYear);
+      } else if (eraYear != null) {
+        const matchingEra =
+          era === undefined ? undefined : this.eras.find((e) => e.name === era || e.genericName === era);
+        if (!matchingEra) throw new RangeError(`Era ${era} (ISO year ${eraYear}) was not matched by any era`);
+        if (eraYear < 1 && matchingEra.reverseOf) {
+          throw new RangeError(`Years in ${era} era must be positive, not ${year}`);
+        }
+        if (matchingEra.reverseOf) {
+          year = matchingEra.anchorEpoch.year - eraYear;
+        } else {
+          year = eraYear + matchingEra.anchorEpoch.year - (matchingEra.hasYearZero ? 0 : 1);
+        }
+        checkField('year', year);
+      } else {
+        throw new RangeError('Either `year` or `eraYear` and `era` are required');
+      }
+      return { ...calendarDate, year, eraYear, era };
+    },
+    adjustCalendarDate(calendarDate /*, cache, overflow, fromLegacyDate = false */) {
+      // Because this is not a lunisolar calendar, it's safe to convert monthCode to a number
+      const { month, monthCode } = calendarDate;
+      if (month === undefined) calendarDate = { ...calendarDate, month: monthCodeNumberPart(monthCode) };
+      this.validateCalendarDate(calendarDate);
+      calendarDate = this.completeEraYear(calendarDate);
+      calendarDate = nonIsoHelperBase.adjustCalendarDate(calendarDate);
+      return calendarDate;
+    },
+    estimateIsoDate(calendarDate) {
+      calendarDate = this.adjustCalendarDate(calendarDate);
+      const { year, month, day } = calendarDate;
+      const { anchorEra } = this;
+      const isoYearEstimate = year + anchorEra.isoEpoch.year - (anchorEra.hasYearZero ? 0 : 1);
+      return ES.RegulateDate(isoYearEstimate, month, day, 'constrain');
+    }
+  });
+};
+
+const makeHelperOrthodox = (id, originalEras) => {
+  const base = makeHelperGregorian(id, originalEras);
+  return ObjectAssign(base, {
+    inLeapYear(calendarDate /*, cache */) {
+      // Leap years happen one year before the Julian leap year. Note that this
+      // calendar is based on the Julian calendar which has a leap year every 4
+      // years, unlike the Gregorian calendar which doesn't have leap years on
+      // years divisible by 100 except years divisible by 400.
+      //
+      // Note that we're assuming that leap years in before-epoch times match
+      // how leap years are defined now. This is probably not accurate but I'm
+      // not sure how better to do it.
+      const { year } = calendarDate;
+      return (year + 1) % 4 === 0;
+    },
+    monthsInYear(/* calendarDate */) {
+      return 13;
+    },
+    minimumMonthLength(calendarDate) {
+      const { month } = calendarDate;
+      // Ethiopian/Coptic calendars have 12 30-day months and an extra 5-6 day 13th month.
+      if (month === 13) return this.inLeapYear(calendarDate) ? 6 : 5;
+      return 30;
+    },
+    maximumMonthLength(calendarDate) {
+      return this.minimumMonthLength(calendarDate);
+    }
+  });
+};
+
+// `coptic` and `ethiopic` calendars are very similar to `ethioaa` calendar,
+// with the following differences:
+// - Coptic uses BC-like positive numbers for years before its epoch (the other
+//   two use negative year numbers before epoch)
+// - Coptic has a different epoch date
+// - Ethiopic has an additional second era that starts at the same date as the
+//   zero era of ethioaa.
+const helperEthioaa = makeHelperOrthodox('ethioaa', [{ name: 'era0', isoEpoch: { year: -5492, month: 7, day: 17 } }]);
+const helperCoptic = makeHelperOrthodox('coptic', [
+  { name: 'era1', isoEpoch: { year: 284, month: 8, day: 29 } },
+  { name: 'era0', reverseOf: 'era1' }
+]);
+// Anchor is currently the older era to match ethioaa, but should it be the newer era?
+// See https://github.com/tc39/ecma402/issues/534 for discussion.
+const helperEthiopic = makeHelperOrthodox('ethiopic', [
+  { name: 'era0', isoEpoch: { year: -5492, month: 7, day: 17 } },
+  { name: 'era1', isoEpoch: { year: 8, month: 8, day: 27 }, anchorEpoch: { year: 5501 } }
+]);
+
+const helperRoc = makeHelperGregorian('roc', [
+  { name: 'minguo', isoEpoch: { year: 1912, month: 1, day: 1 } },
+  { name: 'before-roc', reverseOf: 'minguo' }
+]);
+
+const helperBuddhist = makeHelperGregorian('buddhist', [
+  { name: 'be', hasYearZero: true, isoEpoch: { year: -543, month: 1, day: 1 } }
+]);
+
+const helperGregory = makeHelperGregorian('gregory', [
+  { name: 'ad', isoEpoch: { year: 1, month: 1, day: 1 } },
+  { name: 'bc', reverseOf: 'ad' }
+]);
+
+const helperJapanese = ObjectAssign(
+  {},
+  // NOTE: For convenience, this hacky implementation only supports the most
+  // recent five eras, those of the modern period. For the full list, see:
+  // https://github.com/unicode-org/cldr/blob/master/common/supplemental/supplementalData.xml#L4310-L4546
+  //
+  // NOTE: Japan started using the Gregorian calendar in 6 Meiji, replacing a
+  // lunisolar calendar. So the day before January 1 of 6 Meiji (1873) was not
+  // December 31, but December 2, of 5 Meiji (1872). The existing Ecma-402
+  // Japanese calendar doesn't seem to take this into account, so neither do we:
+  // > args = ['en-ca-u-ca-japanese', { era: 'short' }]
+  // > new Date('1873-01-01T12:00').toLocaleString(...args)
+  // '1 1, 6 Meiji, 12:00:00 PM'
+  // > new Date('1872-12-31T12:00').toLocaleString(...args)
+  // '12 31, 5 Meiji, 12:00:00 PM'
+  //
+  // Era codes are constants consisting of the romanized era name.
   // Unfortunately these are not unique throughout history, so this should be
   // solved: https://github.com/tc39/proposal-temporal/issues/526
   // Otherwise, we'd have to introduce some era numbering system, which (as far
@@ -464,102 +1350,421 @@ const jpn = {
   // starting point for eras (0645-06-19) is not the only possible one, since
   // there are unofficial eras before that.
   // https://en.wikipedia.org/wiki/Japanese_era_name
-  eraNames: ['meiji', 'taisho', 'showa', 'heisei', 'reiwa'],
   // Note: C locale era names available at
   // https://github.com/unicode-org/icu/blob/master/icu4c/source/data/locales/root.txt#L1582-L1818
+  makeHelperGregorian('japanese', [
+    // The Japanese calendar `year` is just the ISO year, because (unlike other
+    // ICU calendars) there's no obvious "default era". So we use the ISO year.
+    { name: undefined, isoEpoch: { year: 1, month: 1, day: 1 } },
+    { name: 'meiji', isoEpoch: { year: 1868, month: 9, day: 8 }, anchorEpoch: { year: 1868, month: 9, day: 8 } },
+    { name: 'taisho', isoEpoch: { year: 1912, month: 7, day: 30 }, anchorEpoch: { year: 1912, month: 7, day: 30 } },
+    { name: 'showa', isoEpoch: { year: 1926, month: 12, day: 25 }, anchorEpoch: { year: 1926, month: 12, day: 25 } },
+    { name: 'heisei', isoEpoch: { year: 1989, month: 1, day: 8 }, anchorEpoch: { year: 1989, month: 1, day: 8 } },
+    { name: 'reiwa', isoEpoch: { year: 2019, month: 5, day: 1 }, anchorEpoch: { year: 2019, month: 5, day: 1 } }
+  ]),
+  {
+    // The last 3 Japanese eras confusingly return only one character in the
+    // default "short" era, so need to use the long format.
+    eraLength: 'long'
+  }
+);
 
-  compareDate(one, two) {
-    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
-      const val1 = GetSlot(one, slot);
-      const val2 = GetSlot(two, slot);
-      if (val1 !== val2) return ES.ComparisonResult(val1 - val2);
-    }
+const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
+  id: 'chinese',
+  calendarType: 'lunisolar',
+  inLeapYear(calendarDate, cache) {
+    const months = this.getMonthList(calendarDate.year, cache);
+    return Object.entries(months).length === 13;
   },
-
-  findEra(date) {
-    const TemporalDate = GetIntrinsic('%Temporal.PlainDate%');
-    const idx = jpn.eraStartDates.findIndex((dateStr) => {
-      const { year, month, day } = ES.ParseTemporalDateString(dateStr);
-      const startDate = new TemporalDate(year, month, day);
-      return jpn.compareDate(date, startDate) < 0;
+  monthsInYear(calendarDate, cache) {
+    return this.inLeapYear(calendarDate, cache) ? 13 : 12;
+  },
+  minimumMonthLength: (/* calendarDate */) => 29,
+  maximumMonthLength: (/* calendarDate */) => 30,
+  getMonthList(calendarYear, cache) {
+    if (calendarYear === undefined) {
+      throw new TypeError('Missing year');
+    }
+    const key = JSON.stringify({ func: 'getMonthList', calendarYear, id: this.id });
+    const cached = cache.get(key);
+    if (cached) return cached;
+    const dateTimeFormat = new Intl.DateTimeFormat(`en-US-u-ca-${this.id}`, {
+      day: 'numeric',
+      month: 'numeric',
+      year: 'numeric',
+      era: 'short',
+      timeZone: 'UTC'
     });
-    if (idx === -1) return jpn.eraStartDates.length - 1;
-    if (idx === 0) return 0;
-    return idx - 1;
-  },
 
-  validateFields(fields) {
-    if ((fields.era === undefined || fields.eraYear === undefined) && fields.year === undefined) {
-      throw new TypeError(
-        "required properties missing or undefined: must include 'year' and/or both 'era' and 'eraYear'"
-      );
+    const getCalendarDate = (isoYear, daysPastFeb1) => {
+      const isoStringFeb1 = toUtcIsoDateString({ isoYear, isoMonth: 2, isoDay: 1 });
+      const legacyDate = new Date(isoStringFeb1);
+      // Now add the requested number of days, which may wrap to the next month.
+      legacyDate.setUTCDate(daysPastFeb1 + 1);
+      const newYearGuess = dateTimeFormat.formatToParts(legacyDate);
+      const calendarMonthString = newYearGuess.find((tv) => tv.type === 'month').value;
+      const calendarDay = +newYearGuess.find((tv) => tv.type === 'day').value;
+      const calendarYearToVerify = +newYearGuess.find((tv) => tv.type === 'relatedYear').value;
+      if (calendarYearToVerify === undefined) {
+        // Node 12 has outdated ICU data that lacks the `relatedYear` field in the
+        // output of Intl.DateTimeFormat.formatToParts.
+        throw new RangeError(
+          `Intl.DateTimeFormat.formatToParts is missing year for ${this.id} calendar. Try Node 14+ or a modern browser.`
+        );
+      }
+      return { calendarMonthString, calendarDay, calendarYearToVerify };
+    };
+
+    // First, find a date close to Chinese New Year. Feb 17 will either be in
+    // the first month or near the end of the last month of the previous year.
+    let isoDaysDelta = 17;
+    let { calendarMonthString, calendarDay, calendarYearToVerify } = getCalendarDate(calendarYear, isoDaysDelta);
+
+    // If we didn't guess the first month correctly, add (almost in some months)
+    // a lunar month
+    if (calendarMonthString !== '1') {
+      isoDaysDelta += 29;
+      ({ calendarMonthString, calendarDay } = getCalendarDate(calendarYear, isoDaysDelta));
     }
-    if (fields.eraYear === undefined) {
-      return;
-    }
-    if (fields.eraYear < 1 && fields.era !== jpn.eraNames[0]) {
-      throw new RangeError(
-        "this implementation of the Japanese calendar does not accept 'eraYear' less than 1 unless the era is 'meiji'"
-      );
-    }
-    if (fields.year === undefined) {
-      return;
-    }
-    const yearEra = jpn.isoYear(fields.eraYear, fields.era);
-    // Note: This uses ISO year as the algorithmic year for this implementation
-    // of the Japanese calendar. It intends all client to use the era and
-    // eraYear, and chooses ISO 8601 year for algorithm year only to ease
-    // conversion.
-    if (yearEra !== fields.year) {
-      throw new RangeError("the provided 'era' and 'eraYear' conflict with the provided 'year'");
+
+    // Now back up to near the start of the first month, but not too near that
+    // off-by-one issues matter.
+    isoDaysDelta -= calendarDay - 5;
+    const result = {};
+    let monthIndex = 1;
+    let oldCalendarDay;
+    let oldMonthString;
+    let done = false;
+    do {
+      ({ calendarMonthString, calendarDay, calendarYearToVerify } = getCalendarDate(calendarYear, isoDaysDelta));
+      if (oldCalendarDay) {
+        result[oldMonthString].daysInMonth = oldCalendarDay + 30 - calendarDay;
+      }
+      if (calendarYearToVerify !== calendarYear) {
+        done = true;
+      } else {
+        result[calendarMonthString] = { monthIndex: monthIndex++ };
+        // Move to the next month. Because months are sometimes 29 days, the day of the
+        // calendar month will move forward slowly but not enough to flip over to a new
+        // month before the loop ends at 12-13 months.
+        isoDaysDelta += 30;
+      }
+      oldCalendarDay = calendarDay;
+      oldMonthString = calendarMonthString;
+    } while (!done);
+    result[oldMonthString].daysInMonth = oldCalendarDay + 30 - calendarDay;
+
+    cache.set(key, result);
+    return result;
+  },
+  estimateIsoDate(calendarDate) {
+    const { year } = calendarDate;
+    return { year, month: 1, day: 1 };
+  },
+  adjustCalendarDate(calendarDate, cache, overflow = 'constrain', fromLegacyDate = false) {
+    let { year, month, monthExtra, day, monthCode, eraYear } = calendarDate;
+    if (fromLegacyDate) {
+      // Legacy Date output returns a string that's an integer with an optional
+      // "bis" suffix used only by the Chinese/Dangi calendar to indicate a leap
+      // month. Below we'll normalize the output.
+      year = eraYear;
+      if (monthExtra && monthExtra !== 'bis') throw new RangeError(`Unexpected leap month suffix: ${monthExtra}`);
+      const monthCode = monthExtra === undefined ? `${month}` : `${month}L`;
+      const monthString = `${month}${monthExtra || ''}`;
+      const months = this.getMonthList(year, cache);
+      const monthInfo = months[monthString];
+      if (monthInfo === undefined) throw new RangeError(`Unmatched month ${monthString} in Chinese year ${year}`);
+      month = monthInfo.monthIndex;
+      return { year, month, day, era: undefined, eraYear, monthCode };
+    } else {
+      // When called without input coming from legacy Date output,
+      // simply ensure that all fields are present.
+      this.validateCalendarDate(calendarDate);
+      if (year === undefined) year = eraYear;
+      if (eraYear === undefined) eraYear = year;
+      if (month === undefined) {
+        const months = this.getMonthList(year, cache);
+        let monthInfo = months[monthCode.replace('L', 'bis')];
+        month = monthInfo && monthInfo.monthIndex;
+        // If this leap month isn't present in this year, constrain down to the last day of the previous month.
+        if (
+          month === undefined &&
+          monthCode.endsWith('L') &&
+          !['1L', '12L', '13L'].includes(monthCode) &&
+          overflow === 'constrain'
+        ) {
+          const withoutL = monthCode.slice(0, -1);
+          monthInfo = months[withoutL];
+          if (monthInfo) {
+            ({ daysInMonth: day, monthIndex: month } = monthInfo);
+          }
+        }
+        if (month === undefined) {
+          throw new RangeError(`Unmatched month ${monthCode} in Chinese year ${year}`);
+        }
+      }
+      if (monthCode === undefined) monthCode = +month;
+      return { ...calendarDate, year, eraYear, month, monthCode, day };
     }
   },
+  // All built-in calendars except Chinese/Dangi and Hebrew use an era
+  hasEra: false
+});
 
-  isoYear(eraYear, era) {
-    const eraIdx = jpn.eraNames.indexOf(era);
-    if (eraIdx === -1) throw new RangeError(`invalid era ${era}`);
-    return eraYear + jpn.eraAddends[eraIdx];
+// Dangi (Korean) calendar has same implementation as Chinese
+const helperDangi = ObjectAssign({}, { ...helperChinese, id: 'dangi' });
+
+/**
+ * Common implementation of all non-ISO calendars.
+ * Per-calendar id and logic live in `id` and `helper` properties attached later.
+ * This split allowed an easy separation between code that was similar between
+ * ISO and non-ISO implementations vs. code that was very different.
+ */
+const nonIsoGeneralImpl = {
+  dateFromFields(fields, overflow, constructor, calendar) {
+    const cache = new OneObjectCache();
+    // Intentionally alphabetical
+    fields = this.toRecord(cache, fields, [
+      ['day'],
+      ['era', undefined],
+      ['eraYear', undefined],
+      ['month', undefined],
+      ['monthCode', undefined],
+      ['year', undefined]
+    ]);
+    const { year, month, day } = this.helper.calendarToIsoDate(fields, overflow, cache);
+    const result = new constructor(year, month, day, calendar);
+    cache.setObject(result);
+    return result;
+  },
+  yearMonthFromFields(fields, overflow, constructor, calendar) {
+    const cache = new OneObjectCache();
+    // Intentionally alphabetical
+    fields = this.toRecord(cache, fields, [
+      ['era', undefined],
+      ['eraYear', undefined],
+      ['month', undefined],
+      ['monthCode', undefined],
+      ['year', undefined]
+    ]);
+    if (fields.month === undefined && typeof fields.monthCode !== 'string') {
+      throw new TypeError(`monthCode must be a string, not ${ES.Type(fields.monthCode).toLowerCase()}`);
+    }
+    const { year, month, day } = this.helper.calendarToIsoDate({ ...fields, day: 1 }, overflow, cache);
+    const result = new constructor(year, month, calendar, /* referenceISODay = */ day);
+    cache.setObject(result);
+    return result;
+  },
+  monthDayFromFields(fields, overflow, constructor, calendar) {
+    // All built-in calendars require `day`, but some allow other fields to be
+    // substituted for `month`. And for lunisolar calendars, either `monthCode`
+    // or `year` must be provided because `month` is ambiguous without a year or
+    // a code.
+    const cache = new OneObjectCache();
+    fields = this.toRecord(cache, fields, [
+      ['day'],
+      ['month', undefined],
+      ['year', undefined],
+      ['monthCode', undefined],
+      ['era', undefined],
+      ['eraYear', undefined]
+    ]);
+    const { year, month, day } = this.helper.monthDayFromFields(fields, overflow, cache);
+    // `year` is a reference year where this month/day exists in this calendar
+    const result = new constructor(month, day, calendar, /* referenceISOYear */ year);
+    cache.setObject(result);
+    return result;
+  },
+  /**
+   * ES.PrepareTemporalFields is an expensive operation for this prototype
+   * implementation because it calls all properties without any caching,
+   * resulting in 1+ expensive (and redundant) calls.  This method checks to see
+   * if this access can be optimized if the bag is a Temporal object by
+   * converting to a calendar date in one call and then using the resulting
+   * plain-object bag.
+   */
+  toRecord(cache, bag, fields) {
+    let bagCache, key;
+    if (
+      ES.IsTemporalZonedDateTime(bag) ||
+      ES.IsTemporalDateTime(bag) ||
+      ES.IsTemporalDate(bag) ||
+      ES.IsTemporalMonthDay(bag) ||
+      ES.IsTemporalYearMonth(bag)
+    ) {
+      bagCache = OneObjectCache.getCacheForObject(bag);
+      key = JSON.stringify({ func: 'toRecord', fields });
+      const cached = bagCache.get(key);
+      if (cached) return cached;
+      return this.helper.temporalToCalendarDate(bag, cache);
+    }
+    // If it's not a Temporal object, no caching because it could mutate
+    return ES.PrepareTemporalFields(bag, fields);
+  },
+  fields(fields) {
+    if (fields.includes('year')) fields = [...fields, 'era', 'eraYear'];
+    return fields;
+  },
+  mergeFields(fields, additionalFields) {
+    const { month, monthCode, year, era, eraYear, ...original } = fields;
+    const {
+      month: newMonth,
+      monthCode: newMonthCode,
+      year: newYear,
+      era: newEra,
+      eraYear: newEraYear
+    } = additionalFields;
+    if (newMonth === undefined && newMonthCode === undefined) {
+      original.month = month;
+      original.monthCode = monthCode;
+    }
+    if (newYear === undefined && newEra === undefined && newEraYear === undefined) {
+      original.year = year;
+      original.era = era;
+      original.eraYear = eraYear;
+    }
+    return { ...original, ...additionalFields };
+  },
+  dateAdd(date, duration, overflow) {
+    const { years, months, weeks, days } = duration;
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    const added = this.helper.addCalendar(calendarDate, { years, months, weeks, days }, overflow, cache);
+    const isoAdded = this.helper.calendarToIsoDate(added, 'constrain', cache);
+    return isoAdded;
+  },
+  dateUntil(one, two, largestUnit) {
+    const cacheOne = OneObjectCache.getCacheForObject(one);
+    const cacheTwo = OneObjectCache.getCacheForObject(two);
+    const calendarOne = this.helper.temporalToCalendarDate(one, cacheOne);
+    const calendarTwo = this.helper.temporalToCalendarDate(two, cacheTwo);
+    const result = this.helper.untilCalendar(calendarOne, calendarTwo, largestUnit, cacheOne);
+    return result;
+  },
+  year(date) {
+    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
+      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    }
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.year;
+  },
+  month(date) {
+    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
+      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    }
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.month;
+  },
+  day(date) {
+    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
+      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    }
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.day;
+  },
+  era(date) {
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    if (!this.helper.hasEra) return undefined;
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.era;
+  },
+  eraYear(date) {
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    if (!this.helper.hasEra) return undefined;
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.eraYear;
+  },
+  monthCode(date) {
+    if (!HasSlot(date, ISO_MONTH)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    return calendarDate.monthCode;
+  },
+  dayOfWeek(date) {
+    return impl['iso8601'].dayOfWeek(date);
+  },
+  dayOfYear(date) {
+    const cache = OneObjectCache.getCacheForObject(date);
+    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    const calendarDate = this.helper.isoToCalendarDate(date, cache);
+    const startOfYear = this.helper.startOfCalendarYear(calendarDate);
+    const diffDays = this.helper.calendarDaysUntil(startOfYear, calendarDate, cache);
+    return diffDays + 1;
+  },
+  weekOfYear(date) {
+    return impl['iso8601'].weekOfYear(date);
+  },
+  daysInWeek(date) {
+    return impl['iso8601'].daysInWeek(date);
+  },
+  daysInMonth(date) {
+    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH)) {
+      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    }
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+
+    // Easy case: if the helper knows the length without any heavy calculation.
+    const max = this.helper.maximumMonthLength(calendarDate);
+    const min = this.helper.minimumMonthLength(calendarDate);
+    if (max === min) return max;
+
+    // The harder case is where months vary every year, e.g. islamic calendars.
+    // Find the answer by calculating the difference in days between the first
+    // day of the current month and the first day of the next month.
+    const startOfMonthCalendar = this.helper.startOfCalendarMonth(calendarDate);
+    const startOfNextMonthCalendar = this.helper.addMonthsCalendar(startOfMonthCalendar, 1, 'constrain', cache);
+    const result = this.helper.calendarDaysUntil(startOfMonthCalendar, startOfNextMonthCalendar, cache);
+    return result;
+  },
+  daysInYear(date) {
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    const startOfYearCalendar = this.helper.startOfCalendarYear(calendarDate);
+    const startOfNextYearCalendar = this.helper.addCalendar(startOfYearCalendar, { years: 1 }, 'constrain', cache);
+    const result = this.helper.calendarDaysUntil(startOfYearCalendar, startOfNextYearCalendar, cache);
+    return result;
+  },
+  monthsInYear(date) {
+    if (!HasSlot(date, ISO_YEAR)) ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    const result = this.helper.monthsInYear(calendarDate, cache);
+    return result;
+  },
+  inLeapYear(date) {
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+    const cache = OneObjectCache.getCacheForObject(date);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
+    const result = this.helper.inLeapYear(calendarDate, cache);
+    return result;
   }
 };
 
-impl['japanese'] = ObjectAssign({}, impl['iso8601'], {
-  era(date) {
-    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
-      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    }
-    return jpn.eraNames[jpn.findEra(date)];
-  },
-
-  eraYear(date) {
-    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
-      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    }
-    const eraIdx = jpn.findEra(date);
-    return GetSlot(date, ISO_YEAR) - jpn.eraAddends[eraIdx];
-  },
-
-  fields(fields) {
-    if (fields.includes('year')) fields.push('eraYear');
-    if (fields.includes('eraYear')) fields.push('era');
-    else if (fields.includes('era')) fields.push('eraYear');
-    return fields;
-  },
-
-  dateFromFields(fields, overflow) {
-    // Intentionally alphabetical
-    fields = ES.PrepareTemporalFields(fields, [['day'], ['era'], ['eraYear'], ['month'], ['year', undefined]]);
-    jpn.validateFields(fields);
-    const isoYear = jpn.isoYear(fields.eraYear, fields.era);
-    return impl['iso8601'].dateFromFields({ ...fields, year: isoYear }, overflow);
-  },
-  yearMonthFromFields(fields, overflow) {
-    // Intentionally alphabetical
-    fields = ES.PrepareTemporalFields(fields, [['era'], ['eraYear'], ['month'], ['year', undefined]]);
-    jpn.validateFields(fields);
-    const isoYear = jpn.isoYear(fields.eraYear, fields.era);
-    return impl['iso8601'].yearMonthFromFields({ ...fields, year: isoYear }, overflow);
-  }
+impl['hebrew'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperHebrew });
+impl['islamic'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperIslamic });
+['islamic-umalqura', 'islamic-tbla', 'islamic-civil', 'islamic-rgsa', 'islamicc'].forEach((id) => {
+  impl[id] = ObjectAssign({}, nonIsoGeneralImpl, { helper: { ...helperIslamic, id } });
 });
+impl['persian'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperPersian });
+impl['ethiopic'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperEthiopic });
+impl['ethioaa'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperEthioaa });
+impl['coptic'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperCoptic });
+impl['chinese'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperChinese });
+impl['dangi'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperDangi });
+impl['roc'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperRoc });
+impl['indian'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperIndian });
+impl['buddhist'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperBuddhist });
+impl['japanese'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperJapanese });
+impl['gregory'] = ObjectAssign({}, nonIsoGeneralImpl, { helper: helperGregory });
+
+const BUILTIN_CALENDAR_IDS = Object.keys(impl);
 
 function IsBuiltinCalendar(id) {
   return ArrayIncludes.call(BUILTIN_CALENDAR_IDS, id);

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -369,8 +369,8 @@ class OneObjectCache {
     this.report();
   }
   report() {
-    if (this.calls === 0) return;
     /*
+    if (this.calls === 0) return;
     const ms = (globalThis.performance ? globalThis.performance.now() : Date.now()) - this.now;
     const hitRate = ((100 * this.hits) / this.calls).toFixed(0);
     console.log(`${this.calls} calls in ${ms.toFixed(2)}ms. Hits: ${this.hits} (${hitRate}%). Misses: ${this.misses}.`);
@@ -500,7 +500,7 @@ const nonIsoHelperBase = {
       if (typeof monthCode !== 'string') {
         throw new RangeError(`monthCode must be a string, not ${ES.Type(monthCode).toLowerCase()}`);
       }
-      if (!/^(1?\d)(L?)$/.test(monthCode)) throw new RangeError(`Invalid monthCode: ${monthCode}`);
+      if (!/^M(1?\d)(L?)$/.test(monthCode)) throw new RangeError(`Invalid monthCode: ${monthCode}`);
     }
   },
   /**
@@ -521,12 +521,12 @@ const nonIsoHelperBase = {
     if (year === undefined) year = eraYear;
     if (eraYear === undefined) eraYear = year;
     if (monthCode !== undefined) {
-      month = +monthCode;
+      month = +monthCode.slice(1);
     }
     // For calendars that always use the same era, set it here so that derived
     // calendars won't need to implement this method simply to set the era.
     if (this.constantEra) calendarDate = { ...calendarDate, era: this.constantEra };
-    return { ...calendarDate, year, eraYear, month, monthCode: `${month}` };
+    return { ...calendarDate, year, eraYear, month, monthCode: `M${month}` };
   },
   regulateMonthDayNaive(calendarDate, overflow, cache) {
     const largestMonth = this.monthsInYear(calendarDate, cache);
@@ -884,26 +884,26 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
     return { year: year - 3760, month: 1, day: 1 };
   },
   months: {
-    Tishri: { leap: 1, regular: 1, monthCode: '1', days: 30 },
-    Heshvan: { leap: 2, regular: 2, monthCode: '2', days: { min: 29, max: 30 } },
-    Kislev: { leap: 3, regular: 3, monthCode: '3', days: { min: 29, max: 30 } },
-    Tevet: { leap: 4, regular: 4, monthCode: '4', days: 29 },
-    Shevat: { leap: 5, regular: 5, monthCode: '5', days: 30 },
-    Adar: { leap: undefined, regular: 6, monthCode: '6', days: 29 },
-    'Adar I': { leap: 6, regular: undefined, monthCode: '5L', days: 30 },
-    'Adar II': { leap: 7, regular: undefined, monthCode: '6', days: 29 },
-    Nisan: { leap: 8, regular: 7, monthCode: '7', days: 30 },
-    Iyar: { leap: 9, regular: 8, monthCode: '8', days: 29 },
-    Sivan: { leap: 10, regular: 9, monthCode: '9', days: 30 },
-    Tamuz: { leap: 11, regular: 10, monthCode: '10', days: 29 },
-    Av: { leap: 12, regular: 11, monthCode: '11', days: 30 },
-    Elul: { leap: 13, regular: 12, monthCode: '12', days: 29 }
+    Tishri: { leap: 1, regular: 1, monthCode: 'M1', days: 30 },
+    Heshvan: { leap: 2, regular: 2, monthCode: 'M2', days: { min: 29, max: 30 } },
+    Kislev: { leap: 3, regular: 3, monthCode: 'M3', days: { min: 29, max: 30 } },
+    Tevet: { leap: 4, regular: 4, monthCode: 'M4', days: 29 },
+    Shevat: { leap: 5, regular: 5, monthCode: 'M5', days: 30 },
+    Adar: { leap: undefined, regular: 6, monthCode: 'M6', days: 29 },
+    'Adar I': { leap: 6, regular: undefined, monthCode: 'M5L', days: 30 },
+    'Adar II': { leap: 7, regular: undefined, monthCode: 'M6', days: 29 },
+    Nisan: { leap: 8, regular: 7, monthCode: 'M7', days: 30 },
+    Iyar: { leap: 9, regular: 8, monthCode: 'M8', days: 29 },
+    Sivan: { leap: 10, regular: 9, monthCode: 'M9', days: 30 },
+    Tamuz: { leap: 11, regular: 10, monthCode: 'M10', days: 29 },
+    Av: { leap: 12, regular: 11, monthCode: 'M11', days: 30 },
+    Elul: { leap: 13, regular: 12, monthCode: 'M12', days: 29 }
   },
   getMonthCode(year, month) {
     if (this.inLeapYear({ year })) {
-      return month === 6 ? '5L' : `${month < 6 ? month : month - 1}`;
+      return month === 6 ? 'M5L' : `M${month < 6 ? month : month - 1}`;
     } else {
-      return `${month}`;
+      return `M${month}`;
     }
   },
   adjustCalendarDate(calendarDate, cache, overflow = 'constrain', fromLegacyDate = false) {
@@ -935,11 +935,11 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
       this.validateCalendarDate(calendarDate);
       if (month === undefined) {
         if (monthCode.endsWith('L')) {
-          if (monthCode !== '5L') throw new RangeError(`Hebrew leap month must have monthCode 5L, not ${monthCode}`);
+          if (monthCode !== 'M5L') throw new RangeError(`Hebrew leap month must have monthCode M5L, not ${monthCode}`);
           month = 6;
           if (!this.inLeapYear({ year })) {
             if (overflow === 'reject') {
-              throw new RangeError(`Hebrew monthCode 5L is invalid in year ${year} which is not a leap year`);
+              throw new RangeError(`Hebrew monthCode M5L is invalid in year ${year} which is not a leap year`);
             } else {
               // constrain to last day of previous month (Av)
               month = 5;
@@ -1471,7 +1471,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
       // month. Below we'll normalize the output.
       year = eraYear;
       if (monthExtra && monthExtra !== 'bis') throw new RangeError(`Unexpected leap month suffix: ${monthExtra}`);
-      const monthCode = monthExtra === undefined ? `${month}` : `${month}L`;
+      const monthCode = monthExtra === undefined ? `M${month}` : `M${month}L`;
       const monthString = `${month}${monthExtra || ''}`;
       const months = this.getMonthList(year, cache);
       const monthInfo = months[monthString];
@@ -1486,17 +1486,17 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
       if (eraYear === undefined) eraYear = year;
       if (month === undefined) {
         const months = this.getMonthList(year, cache);
-        let monthInfo = months[monthCode.replace('L', 'bis')];
+        let monthInfo = months[monthCode.replace('L', 'bis').slice(1)];
         month = monthInfo && monthInfo.monthIndex;
         // If this leap month isn't present in this year, constrain down to the last day of the previous month.
         if (
           month === undefined &&
           monthCode.endsWith('L') &&
-          !['1L', '12L', '13L'].includes(monthCode) &&
+          !['M1L', 'M12L', 'M13L'].includes(monthCode) &&
           overflow === 'constrain'
         ) {
-          const withoutL = monthCode.slice(0, -1);
-          monthInfo = months[withoutL];
+          const withoutML = monthCode.slice(1, -1);
+          monthInfo = months[withoutML];
           if (monthInfo) {
             ({ daysInMonth: day, monthIndex: month } = monthInfo);
           }
@@ -1505,7 +1505,12 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
           throw new RangeError(`Unmatched month ${monthCode} in Chinese year ${year}`);
         }
       }
-      if (monthCode === undefined) monthCode = +month;
+      if (monthCode === undefined) {
+        const months = this.getMonthList(year, cache);
+        const matchingMonthEntry = Object.entries(months).find(([, v]) => v.monthIndex === month);
+        if (matchingMonthEntry === undefined) throw new RangeError(`Invalid month ${month} in Chinese year ${year}`);
+        monthCode = `M${matchingMonthEntry[0].replace('bis', 'L')}`;
+      }
       return { ...calendarDate, year, eraYear, month, monthCode, day };
     }
   },

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1279,8 +1279,11 @@ export const ES = ObjectAssign({}, ES2020, {
       calendar = ES.ToTemporalCalendar(calendar);
       const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);
       const fields = ES.ToTemporalMonthDayFields(item, fieldNames);
-      if (calendarAbsent && fields.month !== undefined && fields.monthCode === undefined) {
-        fields.monthCode = `M${ES.ToString(fields.month)}`;
+      // Callers who omit the calendar are not writing calendar-independent
+      // code. In that case, `monthCode`/`year` can be omitted; `month` and
+      // `day` are sufficient. Add a `year` to satisfy calendar validation.
+      if (calendarAbsent && fields.month !== undefined && fields.monthCode === undefined && fields.year === undefined) {
+        fields.year = 1972;
       }
       return ES.MonthDayFromFields(calendar, fields, constructor, options);
     }

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -738,8 +738,8 @@ describe('Intl', () => {
         equal(monthsInYear, days.length);
         // This loop counts backwards so we'll have the right test for the month
         // before a leap month in lunisolar calendars.
-        for (let i = monthsInYear, leapMonthIndex = undefined; i >= 1; i--) {
-          const monthStart = date.with({ month: i });
+        for (let i = monthsInYear, leapMonthIndex = undefined, monthStart = undefined; i >= 1; i--) {
+          monthStart = monthStart ? monthStart.add({ months: -1 }) : date.add({ months: monthsInYear - 1 });
           const { month, monthCode, daysInMonth } = monthStart;
           equal(
             `${id} month ${i} (code ${monthCode}) days: ${daysInMonth}`,
@@ -760,7 +760,7 @@ describe('Intl', () => {
                 } else {
                   // verify that non-leap "L" months are constrained down to last day of previous month
                   const fakeL = monthStart.with({ monthCode: `M${month}L`, day: 5 });
-                  equal(fakeL.monthCode, `M${month}`);
+                  equal(`fake leap month ${fakeL.monthCode}`, `fake leap month M${month}`);
                   equal(fakeL.day, fakeL.daysInMonth);
                 }
               }

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -424,8 +424,8 @@ describe('Intl', () => {
         year1: { year: 5493, month: 5, day: 8, era: 'era0' }
       },
       gregory: {
-        year2000: { year: 2000, month: 1, day: 1, era: 'ad' },
-        year1: { year: 1, month: 1, day: 1, era: 'ad' }
+        year2000: { year: 2000, month: 1, day: 1, era: 'ce' },
+        year1: { year: 1, month: 1, day: 1, era: 'ce' }
       },
       hebrew: { year2000: { year: 5760, month: 4, day: 23 }, year1: { year: 3761, month: 4, day: 18 } },
       indian: {
@@ -465,7 +465,7 @@ describe('Intl', () => {
         year2000: { year: 2000, eraYear: 12, month: 1, day: 1, era: 'heisei' },
         // Pre-1582 dates are broken by https://bugs.chromium.org/p/chromium/issues/detail?id=1173158
         year1: RangeError
-        // year1: { year: 1, eraYear: 1, month: 1, day: 1, era: 'ad' }
+        // year1: { year: 1, eraYear: 1, month: 1, day: 1, era: 'ce' }
       },
       persian: {
         year2000: { year: 1378, month: 10, day: 11, era: 'ap' },
@@ -607,7 +607,7 @@ describe('Intl', () => {
       dangi: { year: 2000, month: 10, day: 16, monthCode: 'M10', eraYear: undefined, era: undefined },
       ethioaa: { year: 2000, month: 10, day: 11, monthCode: 'M10', eraYear: 2000, era: 'era0' },
       ethiopic: { year: 2000, month: 10, day: 11, monthCode: 'M10', eraYear: 2000, era: 'era0' },
-      gregory: { year: 2000, month: 10, day: 7, monthCode: 'M10', eraYear: 2000, era: 'ad' },
+      gregory: { year: 2000, month: 10, day: 7, monthCode: 'M10', eraYear: 2000, era: 'ce' },
       hebrew: { year: 2000, month: 10, day: 14, monthCode: 'M10', eraYear: undefined, era: undefined },
       indian: { year: 2000, month: 10, day: 6, monthCode: 'M10', eraYear: 2000, era: 'saka' },
       islamic: { year: 2000, month: 10, day: 15, monthCode: 'M10', eraYear: 2000, era: 'ah' },
@@ -629,7 +629,7 @@ describe('Intl', () => {
       dangi: { year: 2001, month: 6, day: 1, monthCode: 'M5', eraYear: undefined, era: undefined },
       ethioaa: { year: 2001, month: 5, day: 1, monthCode: 'M5', eraYear: 2001, era: 'era0' },
       ethiopic: { year: 2001, month: 5, day: 1, monthCode: 'M5', eraYear: 2001, era: 'era0' },
-      gregory: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ad' },
+      gregory: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ce' },
       hebrew: { year: 2001, month: 6, day: 1, monthCode: 'M5L', eraYear: undefined, era: undefined },
       indian: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'saka' },
       islamic: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ah' },
@@ -835,15 +835,15 @@ describe('Intl', () => {
       equal(date.eraYear, 45);
       date = Temporal.PlainDate.from({ era: 'meiji', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
       equal(`${date}`, '1868-01-01[u-ca-japanese]');
-      equal(date.era, 'ad');
+      equal(date.era, 'ce');
       equal(date.eraYear, 1868);
       throws(
-        () => Temporal.PlainDate.from({ era: 'bc', eraYear: 1, month: 1, day: 1, calendar: 'japanese' }),
+        () => Temporal.PlainDate.from({ era: 'bce', eraYear: 1, month: 1, day: 1, calendar: 'japanese' }),
         RangeError
       );
       // uncomment & revise `throws` above if https://bugs.chromium.org/p/chromium/issues/detail?id=1173158 is resolved
       // equal(`${date}`, '+000000-01-01[u-ca-japanese]');
-      // equal(date.era, 'bc');
+      // equal(date.era, 'bce');
       // equal(date.eraYear, 1);
     });
   });

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -213,6 +213,421 @@ describe('Intl', () => {
     });
   });
 
+  describe('Non-ISO Calendars', () => {
+    it('verify that Intl.DateTimeFormat.formatToParts output matches snapshot data', () => {
+      // This test isn't testing Temporal. Instead, it's verifying that the
+      // output of Intl.DateTimeFormat.formatToParts for non-ISO calendars
+      // hasn't changed. There are a number of outstanding bugs in this output
+      // that, when fixed, will break other tests. So this test is a signal that
+      // other tests are broken because the comparison data needs to be updated,
+      // not necessarily because Temporal is broken.
+      // prettier-ignore
+      // eslint-disable-next-line max-len, no-console, brace-style
+      const year2000Content = ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'hebrew', 'indian', 'islamic', 'islamic-umalqura', 'islamic-tbla', 'islamic-civil', 'islamic-rgsa', 'islamicc', 'japanese', 'persian', 'roc'].map((id) => `${id}: ${new Date('2000-01-01T00:00Z').toLocaleDateString('en-us', { calendar: id, timeZone: 'UTC' })}`).join('\n');
+      const year2000Snapshot =
+        'iso8601: 1/1/2000\n' +
+        'buddhist: 1/1/2543 BE\n' +
+        'chinese: 11/25/1999\n' +
+        'coptic: 4/22/1716 ERA1\n' +
+        'dangi: 11/25/1999\n' +
+        'ethioaa: 4/22/7492 ERA0\n' +
+        'ethiopic: 4/22/1992 ERA1\n' +
+        'hebrew: 23 Tevet 5760\n' +
+        'indian: 10/11/1921 Saka\n' +
+        'islamic: 9/25/1420 AH\n' +
+        'islamic-umalqura: 9/24/1420 AH\n' +
+        'islamic-tbla: 9/25/1420 AH\n' +
+        'islamic-civil: 9/24/1420 AH\n' +
+        'islamic-rgsa: 9/25/1420 AH\n' +
+        'islamicc: 9/24/1420 AH\n' +
+        'japanese: 1/1/12 H\n' +
+        'persian: 10/11/1378 AP\n' +
+        'roc: 1/1/89 Minguo';
+      equal(year2000Content, year2000Snapshot);
+
+      // prettier-ignore
+      // eslint-disable-next-line max-len, no-console, brace-style
+      const year1Content = ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'hebrew', 'indian', 'islamic', 'islamic-umalqura', 'islamic-tbla', 'islamic-civil', 'islamic-rgsa', 'islamicc', 'japanese', 'persian', 'roc'].map((id) => `${id}: ${new Date('0001-01-01T00:00Z').toLocaleDateString('en-us', { calendar: id, timeZone: 'UTC' })}`).join('\n');
+      const year1Snapshot =
+        'iso8601: 1/1/1\n' +
+        'buddhist: 1/3/544 BE\n' +
+        'chinese: 11/21/0\n' +
+        'coptic: 5/8/284 ERA0\n' +
+        'dangi: 11/21/0\n' +
+        'ethioaa: 5/8/5493 ERA0\n' +
+        'ethiopic: 5/8/5493 ERA0\n' +
+        'hebrew: 18 Tevet 3761\n' +
+        'indian: 10/11/-78 Saka\n' +
+        'islamic: -7/20/-639 AH\n' +
+        'islamic-umalqura: 5/18/-640 AH\n' +
+        'islamic-tbla: 5/19/-640 AH\n' +
+        'islamic-civil: 5/18/-640 AH\n' +
+        'islamic-rgsa: -7/20/-639 AH\n' +
+        'islamicc: 5/18/-640 AH\n' +
+        'japanese: 1/3/-643 Taika (645–650)\n' +
+        'persian: 10/11/-621 AP\n' +
+        'roc: 1/3/1911 Before R.O.C.';
+      equal(year1Content, year1Snapshot);
+    });
+
+    const fromWithCases = {
+      iso8601: { year2000: { year: 2000, month: 1, day: 1 }, year1: { year: 1, month: 1, day: 1 } },
+      buddhist: {
+        year2000: { year: 2543, month: 1, day: 1, era: 'be' },
+        year1: { year: 544, month: 1, day: 3, era: 'be' }
+      },
+      chinese: {
+        year2000: { year: 1999, month: 11, day: 25 },
+        // There's a 3bis (4th month) leap month in this year
+        year1: { year: 0, month: 12, monthCode: '11', day: 21 }
+      },
+      coptic: {
+        year2000: { year: 1716, month: 4, day: 22, era: 'era1' },
+        year1: { year: -283, eraYear: 284, month: 5, day: 8, era: 'era0' }
+      },
+      dangi: {
+        year2000: { year: 1999, month: 11, day: 25 },
+        // There's a 3bis (4th month) leap month in this year
+        year1: { year: 0, month: 12, monthCode: '11', day: 21 }
+      },
+      ethioaa: {
+        year2000: { year: 7492, month: 4, day: 22, era: 'era0' },
+        year1: { year: 5493, month: 5, day: 8, era: 'era0' }
+      },
+      ethiopic: {
+        year2000: { eraYear: 1992, year: 7492, month: 4, day: 22, era: 'era1' },
+        year1: { year: 5493, month: 5, day: 8, era: 'era0' }
+      },
+      hebrew: { year2000: { year: 5760, month: 4, day: 23 }, year1: { year: 3761, month: 4, day: 18 } },
+      indian: {
+        year2000: { year: 1921, month: 10, day: 11, era: 'saka' },
+        // with() fails due to https://bugs.chromium.org/p/v8/issues/detail?id=10529
+        // from() succeeds because the bug only gets triggered before 1/1/1 ISO.
+        year1: RangeError
+      },
+      // Older islamic dates will fail due to https://bugs.chromium.org/p/v8/issues/detail?id=10527
+      islamic: { year2000: { year: 1420, month: 9, day: 25, era: 'ah' }, year1: RangeError },
+      'islamic-umalqura': {
+        year2000: { year: 1420, month: 9, day: 24, era: 'ah' },
+        year1: { year: -640, month: 5, day: 18, era: 'ah' }
+      },
+      'islamic-tbla': {
+        year2000: { year: 1420, month: 9, day: 25, era: 'ah' },
+        year1: { year: -640, month: 5, day: 19, era: 'ah' }
+      },
+      'islamic-civil': {
+        year2000: { year: 1420, month: 9, day: 24, era: 'ah' },
+        year1: { year: -640, month: 5, day: 18, era: 'ah' }
+      },
+      'islamic-rgsa': { year2000: { year: 1420, month: 9, day: 25, era: 'ah' }, year1: RangeError },
+      islamicc: {
+        year2000: { year: 1420, month: 9, day: 24, era: 'ah' },
+        year1: { year: -640, month: 5, day: 18, era: 'ah' }
+      },
+      // TODO: Figure out how to handle dates before Taika (the first recorded Japanese era)
+      japanese: {
+        year2000: { year: 2000, eraYear: 12, month: 1, day: 1, era: 'heisei' },
+        year1: RangeError
+      },
+      persian: {
+        year2000: { year: 1378, month: 10, day: 11, era: 'ap' },
+        year1: { year: -621, month: 10, day: 11, era: 'ap' }
+      },
+      roc: {
+        year2000: { year: 89, month: 1, day: 1, era: 'minguo' },
+        year1: { year: -1910, eraYear: 1911, month: 1, day: 3, era: 'before-roc' }
+      }
+    };
+    for (let [id, tests] of Object.entries(fromWithCases)) {
+      const dates = {
+        year2000: Temporal.PlainDate.from('2000-01-01'),
+        year1: Temporal.PlainDate.from('0001-01-01')
+      };
+      for (const [name, date] of Object.entries(dates)) {
+        const getValues = (type) => {
+          let val = tests[name];
+          if (val[type]) val = val[type];
+          return val;
+        };
+        it(`from: ${id} ${name} ${getValues('from') === RangeError ? ' (throws)' : ''}`, () => {
+          const values = getValues('from');
+          if (values === RangeError) {
+            // Some calendars will fail due to Chromium bugs noted in the test definitions
+            throws(() => {
+              const inCal = date.withCalendar(id);
+              Temporal.PlainDate.from({
+                calendar: id,
+                year: inCal.year,
+                day: inCal.day,
+                monthCode: inCal.monthCode
+              });
+            }, RangeError);
+            return;
+          }
+          const inCal = date.withCalendar(id);
+          equal(`${name} ${id} day: ${inCal.day}`, `${name} ${id} day: ${values.day}`);
+          if (values.eraYear === undefined && values.era !== undefined) values.eraYear = values.year;
+
+          equal(`${name} ${id} eraYear: ${inCal.eraYear}`, `${name} ${id} eraYear: ${values.eraYear}`);
+          equal(`${name} ${id} era: ${inCal.era}`, `${name} ${id} era: ${values.era}`);
+          equal(`${name} ${id} year: ${inCal.year}`, `${name} ${id} year: ${values.year}`);
+
+          equal(`${name} ${id} month: ${inCal.month}`, `${name} ${id} month: ${values.month}`);
+          if (values.monthCode === undefined) values.monthCode = `${values.month}`;
+          equal(`${name} ${id} monthCode: ${inCal.monthCode}`, `${name} ${id} monthCode: ${values.monthCode}`);
+
+          if (values.era) {
+            // Now reverse the operation: create using calendar dates and verify
+            // that the same ISO date is returned.
+            const dateRoundtrip1 = Temporal.PlainDate.from({
+              calendar: id,
+              eraYear: values.eraYear,
+              era: values.era,
+              day: values.day,
+              monthCode: values.monthCode
+            });
+            equal(dateRoundtrip1.toString(), inCal.toString());
+          }
+          const dateRoundtrip2 = Temporal.PlainDate.from({
+            calendar: id,
+            year: values.year,
+            day: values.day,
+            monthCode: values.monthCode
+          });
+          equal(dateRoundtrip2.toString(), inCal.toString());
+          const dateRoundtrip3 = Temporal.PlainDate.from({
+            calendar: id,
+            year: values.year,
+            day: values.day,
+            month: values.month
+          });
+          equal(dateRoundtrip3.toString(), inCal.toString());
+          const dateRoundtrip4 = Temporal.PlainDate.from({
+            calendar: id,
+            year: values.year,
+            day: values.day,
+            monthCode: values.monthCode
+          });
+          equal(dateRoundtrip4.toString(), inCal.toString());
+        });
+        it(`with: ${id} ${name} ${getValues('with') === RangeError ? ' (throws)' : ''}`, () => {
+          const values = getValues('with');
+          const inCal = date.withCalendar(id);
+          if (values === RangeError) {
+            // Some calendars will fail due to Chromium bugs noted in the test definitions
+            throws(() => inCal.with({ day: 1 }).year, RangeError);
+            return;
+          }
+          const afterWithDay = inCal.with({ day: 1 });
+          let t = '(after setting year)';
+          equal(`${t} year: ${afterWithDay.year}`, `${t} year: ${inCal.year}`);
+          equal(`${t} month: ${afterWithDay.month}`, `${t} month: ${inCal.month}`);
+          equal(`${t} day: ${afterWithDay.day}`, `${t} day: 1`);
+          const afterWithMonth = afterWithDay.with({ month: 1 });
+          t = '(after setting month)';
+          equal(`${t} year: ${afterWithMonth.year}`, `${t} year: ${inCal.year}`);
+          equal(`${t} month: ${afterWithMonth.month}`, `${t} month: 1`);
+          equal(`${t} day: ${afterWithMonth.day}`, `${t} day: 1`);
+          const afterWithYear = afterWithMonth.with({ year: 2020 });
+          t = '(after setting day)';
+          equal(`${t} year: ${afterWithYear.year}`, `${t} year: 2020`);
+          equal(`${t} month: ${afterWithYear.month}`, `${t} month: 1`);
+          equal(`${t} day: ${afterWithYear.day}`, `${t} day: 1`);
+        });
+      }
+    }
+    /*
+      // This code below is useful for generating the snapshot content below in
+      // case more variations are needed.
+      year1Content = ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'hebrew',
+          'indian', 'islamic', 'islamic-umalqura', 'islamic-tbla', 'islamic-civil', 'islamic-rgsa', 'islamicc',
+          'japanese', 'persian', 'roc'].map((id) => {
+        const end = Temporal.PlainDate.from({ year: 2000, month: 1, day: 1, calendar: id }).add({months: 6});
+        const { year, month, day, monthCode, eraYear, era } = end;
+        const quotedId = id.includes('-') ? `'${id}'` : id;
+        return `  ${quotedId}: { year: ${year}, month: ${month}, day: ${day}, monthCode: '${monthCode
+                }', eraYear: ${eraYear}, era: ${era ? `'${era}'` : undefined} }`;
+      }).join(',\n');
+    */
+    const addDaysWeeksCases = {
+      iso8601: { year: 2000, month: 10, day: 7, monthCode: '10', eraYear: undefined, era: undefined },
+      buddhist: { year: 2000, month: 10, day: 8, monthCode: '10', eraYear: 2000, era: 'be' },
+      chinese: { year: 2000, month: 10, day: 16, monthCode: '10', eraYear: undefined, era: undefined },
+      coptic: { year: 2000, month: 10, day: 11, monthCode: '10', eraYear: 2000, era: 'era1' },
+      dangi: { year: 2000, month: 10, day: 16, monthCode: '10', eraYear: undefined, era: undefined },
+      ethioaa: { year: 2000, month: 10, day: 11, monthCode: '10', eraYear: 2000, era: 'era0' },
+      ethiopic: { year: 2000, month: 10, day: 11, monthCode: '10', eraYear: 2000, era: 'era0' },
+      hebrew: { year: 2000, month: 10, day: 14, monthCode: '10', eraYear: undefined, era: undefined },
+      indian: { year: 2000, month: 10, day: 6, monthCode: '10', eraYear: 2000, era: 'saka' },
+      islamic: { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
+      'islamic-umalqura': { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
+      'islamic-tbla': { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
+      'islamic-civil': { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
+      'islamic-rgsa': { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
+      islamicc: { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
+      japanese: { year: 2000, month: 10, day: 7, monthCode: '10', eraYear: 12, era: 'heisei' },
+      persian: { year: 2000, month: 10, day: 5, monthCode: '10', eraYear: 2000, era: 'ap' },
+      roc: { year: 2000, month: 10, day: 8, monthCode: '10', eraYear: 2000, era: 'minguo' }
+    };
+    const addMonthsCases = {
+      iso8601: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: undefined, era: undefined },
+      buddhist: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'be' },
+      chinese: { year: 2001, month: 6, day: 1, monthCode: '5', eraYear: undefined, era: undefined },
+      coptic: { year: 2001, month: 5, day: 1, monthCode: '5', eraYear: 2001, era: 'era1' },
+      dangi: { year: 2001, month: 6, day: 1, monthCode: '5', eraYear: undefined, era: undefined },
+      ethioaa: { year: 2001, month: 5, day: 1, monthCode: '5', eraYear: 2001, era: 'era0' },
+      ethiopic: { year: 2001, month: 5, day: 1, monthCode: '5', eraYear: 2001, era: 'era0' },
+      hebrew: { year: 2001, month: 6, day: 1, monthCode: '5L', eraYear: undefined, era: undefined },
+      indian: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'saka' },
+      islamic: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
+      'islamic-umalqura': { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
+      'islamic-tbla': { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
+      'islamic-civil': { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
+      'islamic-rgsa': { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
+      islamicc: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
+      japanese: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 13, era: 'heisei' },
+      persian: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ap' },
+      roc: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'minguo' }
+    };
+    const addYearsMonthsDaysCases = Object.entries(addMonthsCases).reduce((obj, entry) => {
+      obj[entry[0]] = { ...entry[1], day: 4 };
+      return obj;
+    }, {});
+    const tests = {
+      days: { duration: { days: 280 }, results: addDaysWeeksCases, startDate: { year: 2000, month: 1, day: 1 } },
+      weeks: { duration: { weeks: 40 }, results: addDaysWeeksCases, startDate: { year: 2000, month: 1, day: 1 } },
+      // 2001 is a leap year in both ICU lunisolar calendars: Hebrew and
+      // Chinese/Dangi. By adding 6 months we're ensuring that addition
+      // recognizes the leap month.
+      months: { duration: { months: 6 }, results: addMonthsCases, startDate: { year: 2000, month: 12, day: 1 } },
+      years: {
+        duration: { years: 3, months: 6, days: 3 },
+        results: addYearsMonthsDaysCases,
+        startDate: { year: 1997, month: 12, day: 1 }
+      }
+    };
+    // let totalNow = 0;
+    const calendars = Object.keys(addMonthsCases);
+    for (let id of calendars) {
+      for (let [unit, { duration, results, startDate }] of Object.entries(tests)) {
+        const values = results[id];
+        duration = Temporal.Duration.from(duration);
+        it(`${id} add ${duration}`, () => {
+          // const now = globalThis.performance ? globalThis.performance.now() : Date.now();
+          const start = Temporal.PlainDate.from({ ...startDate, calendar: id });
+          const end = start.add(duration);
+          equal(`add ${unit} ${id} day: ${end.day}`, `add ${unit} ${id} day: ${values.day}`);
+          equal(`add ${unit} ${id} eraYear: ${end.eraYear}`, `add ${unit} ${id} eraYear: ${values.eraYear}`);
+          equal(`add ${unit} ${id} era: ${end.era}`, `add ${unit} ${id} era: ${values.era}`);
+          equal(`add ${unit} ${id} year: ${end.year}`, `add ${unit} ${id} year: ${values.year}`);
+          equal(`add ${unit} ${id} month: ${end.month}`, `add ${unit} ${id} month: ${values.month}`);
+          equal(`add ${unit} ${id} monthCode: ${end.monthCode}`, `add ${unit} ${id} monthCode: ${values.monthCode}`);
+          const calculatedStart = end.subtract(duration);
+          equal(`start ${calculatedStart.toString()}`, `start ${start.toString()}`);
+          const diff = start.until(end, { largestUnit: unit });
+          equal(`diff ${unit} ${id}: ${diff}`, `diff ${unit} ${id}: ${duration}`);
+          // const ms = (globalThis.performance ? globalThis.performance.now() : Date.now()) - now;
+          // totalNow += ms;
+          // console.log(`${id} add ${duration}: ${ms.toFixed(2)}ms, total: ${totalNow.toFixed(2)}ms`);
+        });
+      }
+    }
+    /*
+      // content for tests below
+      ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'hebrew',
+                'indian', 'islamic', 'islamic-umalqura', 'islamic-tbla', 'islamic-civil', 'islamic-rgsa', 'islamicc',
+                'japanese', 'persian', 'roc'].map((id) => {
+        const date = Temporal.PlainDate.from({ year: 2001, month: 1, day: 1, calendar: id });
+        const monthsInYear = date.monthsInYear;
+        const daysInMonthArray = [];
+        let { year, inLeapYear: leap } = date;
+        for (let i = 1; i <= monthsInYear; i++) {
+          const monthStart = date.with({month: i});
+          const { monthCode, daysInMonth } = monthStart;
+          daysInMonthArray.push(monthStart.daysInMonth);
+          if (monthStart.monthCode.endsWith('L')) leap = `'${monthCode}'`;
+        }
+        const quotedId = id.includes('-') ? `'${id}'` : id;
+        return `${quotedId}: { year: ${year}, leap: ${leap}, days: [${daysInMonthArray.join(', ')}] }`;
+      }).join(',\n');
+    */
+    const daysInMonthCases = {
+      iso8601: { year: 2001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
+      buddhist: { year: 2001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
+      chinese: { year: 2001, leap: '4L', days: [30, 30, 29, 30, 29, 30, 29, 29, 30, 29, 30, 29, 30] },
+      coptic: { year: 2001, leap: false, days: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 5] },
+      dangi: { year: 2001, leap: '4L', days: [30, 30, 30, 29, 29, 30, 29, 29, 30, 29, 30, 29, 30] },
+      ethioaa: { year: 2001, leap: false, days: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 5] },
+      ethiopic: { year: 2001, leap: false, days: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 5] },
+      hebrew: { year: 2001, leap: '5L', days: [30, 30, 30, 29, 30, 30, 29, 30, 29, 30, 29, 30, 29] },
+      indian: { year: 2001, leap: false, days: [30, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 30] },
+      islamic: { year: 2001, leap: false, days: [29, 30, 29, 29, 30, 29, 30, 30, 29, 30, 30, 29] },
+      'islamic-umalqura': { year: 2001, leap: true, days: [30, 29, 30, 29, 30, 29, 30, 29, 30, 29, 30, 30] },
+      'islamic-tbla': { year: 2001, leap: true, days: [30, 29, 30, 29, 30, 29, 30, 29, 30, 29, 30, 30] },
+      'islamic-civil': { year: 2001, leap: true, days: [30, 29, 30, 29, 30, 29, 30, 29, 30, 29, 30, 30] },
+      'islamic-rgsa': { year: 2001, leap: false, days: [29, 30, 29, 29, 30, 29, 30, 30, 29, 30, 30, 29] },
+      islamicc: { year: 2001, leap: true, days: [30, 29, 30, 29, 30, 29, 30, 29, 30, 29, 30, 30] },
+      japanese: { year: 2001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
+      persian: { year: 2001, leap: false, days: [31, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 29] },
+      roc: { year: 2001, leap: true, days: [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] }
+    };
+    for (let id of calendars) {
+      let { year, leap, days } = daysInMonthCases[id];
+      let date = Temporal.PlainDate.from({ year, month: 1, day: 1, calendar: id });
+      it(`${id} leap year check for year ${year}`, () => {
+        if (typeof leap === 'boolean') {
+          equal(date.inLeapYear, leap);
+        } else {
+          equal(date.inLeapYear, true);
+          const leapMonth = date.with({ monthCode: leap });
+          equal(leapMonth.monthCode, leap);
+        }
+      });
+      it(`${id} months check for year ${year}`, () => {
+        const { monthsInYear } = date;
+        equal(monthsInYear, days.length);
+        // This loop counts backwards so we'll have the right test for the month
+        // before a leap month in lunisolar calendars.
+        for (let i = monthsInYear, leapMonthIndex = undefined; i >= 1; i--) {
+          const monthStart = date.with({ month: i });
+          const { month, monthCode, daysInMonth } = monthStart;
+          equal(
+            `${id} month ${i} (code ${monthCode}) days: ${daysInMonth}`,
+            `${id} month ${i} (code ${monthCode}) days: ${days[i - 1]}`
+          );
+          if (monthCode.endsWith('L')) {
+            equal(date.with({ monthCode }).monthCode, monthCode);
+            leapMonthIndex = i;
+          } else {
+            if (leapMonthIndex && i === leapMonthIndex - 1) {
+              const inLeapMonth = monthStart.with({ monthCode: `${month}L` });
+              equal(inLeapMonth.monthCode, `${monthCode}L`);
+            } else {
+              throws(() => monthStart.with({ monthCode: `${month}L` }, { overflow: 'reject' }), RangeError);
+              if (['chinese', 'dangi'].includes(id)) {
+                if (i === 1 || i === 12 || i === 13) {
+                  throws(() => monthStart.with({ monthCode: `${month}L` }), RangeError);
+                } else {
+                  // verify that non-leap "L" months are constrained down to last day of previous month
+                  const fakeL = monthStart.with({ monthCode: `${month}L`, day: 5 });
+                  equal(fakeL.monthCode, `${month}`);
+                  equal(fakeL.day, fakeL.daysInMonth);
+                }
+              }
+            }
+            if (!['chinese', 'dangi', 'hebrew'].includes(id)) {
+              // leap months should only be allowed for lunisolar calendars
+              throws(() => monthStart.with({ monthCode: `${month}L` }), RangeError);
+            }
+          }
+          throws(() => monthStart.with({ day: daysInMonth + 1 }, { overflow: 'reject' }), RangeError);
+          const oneDayPastMonthEnd = monthStart.with({ day: daysInMonth + 1 });
+          equal(oneDayPastMonthEnd.day, daysInMonth);
+        }
+      });
+    }
+  });
+
   describe('DateTimeFormat', () => {
     describe('supportedLocalesOf', () => {
       it('should return an Array', () => assert(Array.isArray(Intl.DateTimeFormat.supportedLocalesOf())));

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -882,6 +882,9 @@ describe('Intl', () => {
         if (test.monthCode === undefined) test.monthCode = `M${test.month}`;
         const { calendar, monthCode, month, day, year, isoReferenceYear } = test;
         const md = Temporal.PlainMonthDay.from({ year, month, day, calendar });
+        const isoString = md.toString();
+        const mdFromIso = Temporal.PlainMonthDay.from(isoString);
+        equal(mdFromIso, md);
         const isoFields = md.getISOFields();
         equal(md.monthCode, monthCode);
         equal(md.day, day);

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -402,7 +402,7 @@ describe('Intl', () => {
       chinese: {
         year2000: { year: 1999, month: 11, day: 25 },
         // There's a 3bis (4th month) leap month in this year
-        year1: { year: 0, month: 12, monthCode: '11', day: 21 }
+        year1: { year: 0, month: 12, monthCode: 'M11', day: 21 }
       },
       coptic: {
         year2000: { year: 1716, month: 4, day: 22, era: 'era1' },
@@ -411,7 +411,7 @@ describe('Intl', () => {
       dangi: {
         year2000: { year: 1999, month: 11, day: 25 },
         // There's a 3bis (4th month) leap month in this year
-        year1: { year: 0, month: 12, monthCode: '11', day: 21 }
+        year1: { year: 0, month: 12, monthCode: 'M11', day: 21 }
       },
       ethioaa: {
         year2000: { year: 7492, month: 4, day: 22, era: 'era0' },
@@ -512,7 +512,7 @@ describe('Intl', () => {
           equal(`${name} ${id} year: ${inCal.year}`, `${name} ${id} year: ${values.year}`);
 
           equal(`${name} ${id} month: ${inCal.month}`, `${name} ${id} month: ${values.month}`);
-          if (values.monthCode === undefined) values.monthCode = `${values.month}`;
+          if (values.monthCode === undefined) values.monthCode = `M${values.month}`;
           equal(`${name} ${id} monthCode: ${inCal.monthCode}`, `${name} ${id} monthCode: ${values.monthCode}`);
 
           if (values.era) {
@@ -581,57 +581,57 @@ describe('Intl', () => {
     /*
       // This code below is useful for generating the snapshot content below in
       // case more variations are needed.
-      year1Content = ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'hebrew',
+      year1Content = ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'gregory', 'hebrew',
           'indian', 'islamic', 'islamic-umalqura', 'islamic-tbla', 'islamic-civil', 'islamic-rgsa', 'islamicc',
           'japanese', 'persian', 'roc'].map((id) => {
         const end = Temporal.PlainDate.from({ year: 2000, month: 1, day: 1, calendar: id }).add({months: 6});
         const { year, month, day, monthCode, eraYear, era } = end;
         const quotedId = id.includes('-') ? `'${id}'` : id;
-        return `  ${quotedId}: { year: ${year}, month: ${month}, day: ${day}, monthCode: '${monthCode
+        return `  ${quotedId}: { year: ${year}, month: ${month}, day: ${day}, monthCode: 'M${monthCode
                 }', eraYear: ${eraYear}, era: ${era ? `'${era}'` : undefined} }`;
       }).join(',\n');
     */
     const addDaysWeeksCases = {
-      iso8601: { year: 2000, month: 10, day: 7, monthCode: '10', eraYear: undefined, era: undefined },
-      buddhist: { year: 2000, month: 10, day: 8, monthCode: '10', eraYear: 2000, era: 'be' },
-      chinese: { year: 2000, month: 10, day: 16, monthCode: '10', eraYear: undefined, era: undefined },
-      coptic: { year: 2000, month: 10, day: 11, monthCode: '10', eraYear: 2000, era: 'era1' },
-      dangi: { year: 2000, month: 10, day: 16, monthCode: '10', eraYear: undefined, era: undefined },
-      ethioaa: { year: 2000, month: 10, day: 11, monthCode: '10', eraYear: 2000, era: 'era0' },
-      ethiopic: { year: 2000, month: 10, day: 11, monthCode: '10', eraYear: 2000, era: 'era0' },
-      gregory: { year: 2000, month: 10, day: 7, monthCode: '10', eraYear: 2000, era: 'ad' },
-      hebrew: { year: 2000, month: 10, day: 14, monthCode: '10', eraYear: undefined, era: undefined },
-      indian: { year: 2000, month: 10, day: 6, monthCode: '10', eraYear: 2000, era: 'saka' },
-      islamic: { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
-      'islamic-umalqura': { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
-      'islamic-tbla': { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
-      'islamic-civil': { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
-      'islamic-rgsa': { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
-      islamicc: { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
-      japanese: { year: 2000, month: 10, day: 7, monthCode: '10', eraYear: 12, era: 'heisei' },
-      persian: { year: 2000, month: 10, day: 5, monthCode: '10', eraYear: 2000, era: 'ap' },
-      roc: { year: 2000, month: 10, day: 8, monthCode: '10', eraYear: 2000, era: 'minguo' }
+      iso8601: { year: 2000, month: 10, day: 7, monthCode: 'M10', eraYear: undefined, era: undefined },
+      buddhist: { year: 2000, month: 10, day: 8, monthCode: 'M10', eraYear: 2000, era: 'be' },
+      chinese: { year: 2000, month: 10, day: 16, monthCode: 'M10', eraYear: undefined, era: undefined },
+      coptic: { year: 2000, month: 10, day: 11, monthCode: 'M10', eraYear: 2000, era: 'era1' },
+      dangi: { year: 2000, month: 10, day: 16, monthCode: 'M10', eraYear: undefined, era: undefined },
+      ethioaa: { year: 2000, month: 10, day: 11, monthCode: 'M10', eraYear: 2000, era: 'era0' },
+      ethiopic: { year: 2000, month: 10, day: 11, monthCode: 'M10', eraYear: 2000, era: 'era0' },
+      gregory: { year: 2000, month: 10, day: 7, monthCode: 'M10', eraYear: 2000, era: 'ad' },
+      hebrew: { year: 2000, month: 10, day: 14, monthCode: 'M10', eraYear: undefined, era: undefined },
+      indian: { year: 2000, month: 10, day: 6, monthCode: 'M10', eraYear: 2000, era: 'saka' },
+      islamic: { year: 2000, month: 10, day: 15, monthCode: 'M10', eraYear: 2000, era: 'ah' },
+      'islamic-umalqura': { year: 2000, month: 10, day: 15, monthCode: 'M10', eraYear: 2000, era: 'ah' },
+      'islamic-tbla': { year: 2000, month: 10, day: 15, monthCode: 'M10', eraYear: 2000, era: 'ah' },
+      'islamic-civil': { year: 2000, month: 10, day: 15, monthCode: 'M10', eraYear: 2000, era: 'ah' },
+      'islamic-rgsa': { year: 2000, month: 10, day: 15, monthCode: 'M10', eraYear: 2000, era: 'ah' },
+      islamicc: { year: 2000, month: 10, day: 15, monthCode: 'M10', eraYear: 2000, era: 'ah' },
+      japanese: { year: 2000, month: 10, day: 7, monthCode: 'M10', eraYear: 12, era: 'heisei' },
+      persian: { year: 2000, month: 10, day: 5, monthCode: 'M10', eraYear: 2000, era: 'ap' },
+      roc: { year: 2000, month: 10, day: 8, monthCode: 'M10', eraYear: 2000, era: 'minguo' }
     };
     const addMonthsCases = {
-      iso8601: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: undefined, era: undefined },
-      buddhist: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'be' },
-      chinese: { year: 2001, month: 6, day: 1, monthCode: '5', eraYear: undefined, era: undefined },
-      coptic: { year: 2001, month: 5, day: 1, monthCode: '5', eraYear: 2001, era: 'era1' },
-      dangi: { year: 2001, month: 6, day: 1, monthCode: '5', eraYear: undefined, era: undefined },
-      ethioaa: { year: 2001, month: 5, day: 1, monthCode: '5', eraYear: 2001, era: 'era0' },
-      ethiopic: { year: 2001, month: 5, day: 1, monthCode: '5', eraYear: 2001, era: 'era0' },
-      gregory: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ad' },
-      hebrew: { year: 2001, month: 6, day: 1, monthCode: '5L', eraYear: undefined, era: undefined },
-      indian: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'saka' },
-      islamic: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
-      'islamic-umalqura': { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
-      'islamic-tbla': { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
-      'islamic-civil': { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
-      'islamic-rgsa': { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
-      islamicc: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
-      japanese: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 13, era: 'heisei' },
-      persian: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ap' },
-      roc: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'minguo' }
+      iso8601: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: undefined, era: undefined },
+      buddhist: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'be' },
+      chinese: { year: 2001, month: 6, day: 1, monthCode: 'M5', eraYear: undefined, era: undefined },
+      coptic: { year: 2001, month: 5, day: 1, monthCode: 'M5', eraYear: 2001, era: 'era1' },
+      dangi: { year: 2001, month: 6, day: 1, monthCode: 'M5', eraYear: undefined, era: undefined },
+      ethioaa: { year: 2001, month: 5, day: 1, monthCode: 'M5', eraYear: 2001, era: 'era0' },
+      ethiopic: { year: 2001, month: 5, day: 1, monthCode: 'M5', eraYear: 2001, era: 'era0' },
+      gregory: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ad' },
+      hebrew: { year: 2001, month: 6, day: 1, monthCode: 'M5L', eraYear: undefined, era: undefined },
+      indian: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'saka' },
+      islamic: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ah' },
+      'islamic-umalqura': { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ah' },
+      'islamic-tbla': { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ah' },
+      'islamic-civil': { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ah' },
+      'islamic-rgsa': { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ah' },
+      islamicc: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ah' },
+      japanese: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 13, era: 'heisei' },
+      persian: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'ap' },
+      roc: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'minguo' }
     };
     const addYearsMonthsDaysCases = Object.entries(addMonthsCases).reduce((obj, entry) => {
       obj[entry[0]] = { ...entry[1], day: 4 };
@@ -678,7 +678,7 @@ describe('Intl', () => {
     }
     /*
       // content for tests below
-      ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'hebrew',
+      ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'gregory', hebrew',
                 'indian', 'islamic', 'islamic-umalqura', 'islamic-tbla', 'islamic-civil', 'islamic-rgsa', 'islamicc',
                 'japanese', 'persian', 'roc'].map((id) => {
         const date = Temporal.PlainDate.from({ year: 2001, month: 1, day: 1, calendar: id });
@@ -689,7 +689,7 @@ describe('Intl', () => {
           const monthStart = date.with({month: i});
           const { monthCode, daysInMonth } = monthStart;
           daysInMonthArray.push(monthStart.daysInMonth);
-          if (monthStart.monthCode.endsWith('L')) leap = `'${monthCode}'`;
+          if (monthStart.monthCode.endsWith('L')) leap = `'M${monthCode}'`;
         }
         const quotedId = id.includes('-') ? `'${id}'` : id;
         return `${quotedId}: { year: ${year}, leap: ${leap}, days: [${daysInMonthArray.join(', ')}] }`;
@@ -698,13 +698,13 @@ describe('Intl', () => {
     const daysInMonthCases = {
       iso8601: { year: 2001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
       buddhist: { year: 2001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
-      chinese: { year: 2001, leap: '4L', days: [30, 30, 29, 30, 29, 30, 29, 29, 30, 29, 30, 29, 30] },
+      chinese: { year: 2001, leap: 'M4L', days: [30, 30, 29, 30, 29, 30, 29, 29, 30, 29, 30, 29, 30] },
       coptic: { year: 2001, leap: false, days: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 5] },
-      dangi: { year: 2001, leap: '4L', days: [30, 30, 30, 29, 29, 30, 29, 29, 30, 29, 30, 29, 30] },
+      dangi: { year: 2001, leap: 'M4L', days: [30, 30, 30, 29, 29, 30, 29, 29, 30, 29, 30, 29, 30] },
       ethioaa: { year: 2001, leap: false, days: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 5] },
       ethiopic: { year: 2001, leap: false, days: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 5] },
       gregory: { year: 2001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
-      hebrew: { year: 2001, leap: '5L', days: [30, 30, 30, 29, 30, 30, 29, 30, 29, 30, 29, 30, 29] },
+      hebrew: { year: 2001, leap: 'M5L', days: [30, 30, 30, 29, 30, 30, 29, 30, 29, 30, 29, 30, 29] },
       indian: { year: 2001, leap: false, days: [30, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 30] },
       islamic: { year: 2001, leap: false, days: [29, 30, 29, 29, 30, 29, 30, 30, 29, 30, 30, 29] },
       'islamic-umalqura': { year: 2001, leap: true, days: [30, 29, 30, 29, 30, 29, 30, 29, 30, 29, 30, 30] },
@@ -716,6 +716,7 @@ describe('Intl', () => {
       persian: { year: 2001, leap: false, days: [31, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 29] },
       roc: { year: 2001, leap: true, days: [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] }
     };
+    // totalNow = 0;
     for (let id of calendars) {
       let { year, leap, days } = daysInMonthCases[id];
       let date =
@@ -732,6 +733,7 @@ describe('Intl', () => {
         }
       });
       itOrSkip(id)(`${id} months check for year ${year}`, () => {
+        // const now = globalThis.performance ? globalThis.performance.now() : Date.now();
         const { monthsInYear } = date;
         equal(monthsInYear, days.length);
         // This loop counts backwards so we'll have the right test for the month
@@ -748,30 +750,33 @@ describe('Intl', () => {
             leapMonthIndex = i;
           } else {
             if (leapMonthIndex && i === leapMonthIndex - 1) {
-              const inLeapMonth = monthStart.with({ monthCode: `${month}L` });
+              const inLeapMonth = monthStart.with({ monthCode: `M${month}L` });
               equal(inLeapMonth.monthCode, `${monthCode}L`);
             } else {
-              throws(() => monthStart.with({ monthCode: `${month}L` }, { overflow: 'reject' }), RangeError);
+              throws(() => monthStart.with({ monthCode: `M${month}L` }, { overflow: 'reject' }), RangeError);
               if (['chinese', 'dangi'].includes(id)) {
                 if (i === 1 || i === 12 || i === 13) {
-                  throws(() => monthStart.with({ monthCode: `${month}L` }), RangeError);
+                  throws(() => monthStart.with({ monthCode: `M${month}L` }), RangeError);
                 } else {
                   // verify that non-leap "L" months are constrained down to last day of previous month
-                  const fakeL = monthStart.with({ monthCode: `${month}L`, day: 5 });
-                  equal(fakeL.monthCode, `${month}`);
+                  const fakeL = monthStart.with({ monthCode: `M${month}L`, day: 5 });
+                  equal(fakeL.monthCode, `M${month}`);
                   equal(fakeL.day, fakeL.daysInMonth);
                 }
               }
             }
             if (!['chinese', 'dangi', 'hebrew'].includes(id)) {
               // leap months should only be allowed for lunisolar calendars
-              throws(() => monthStart.with({ monthCode: `${month}L` }), RangeError);
+              throws(() => monthStart.with({ monthCode: `M${month}L` }), RangeError);
             }
           }
           throws(() => monthStart.with({ day: daysInMonth + 1 }, { overflow: 'reject' }), RangeError);
           const oneDayPastMonthEnd = monthStart.with({ day: daysInMonth + 1 });
           equal(oneDayPastMonthEnd.day, daysInMonth);
         }
+        // const ms = (globalThis.performance ? globalThis.performance.now() : Date.now()) - now;
+        // totalNow += ms;
+        // console.log(`${id} months check ${id}: ${ms.toFixed(2)}ms, total: ${totalNow.toFixed(2)}ms`);
       });
     }
   });

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -848,6 +848,41 @@ describe('Intl', () => {
     });
   });
 
+  describe('Hebrew leap months', () => {
+    it('Valid leap month: Adar I 5779', () => {
+      let date = Temporal.PlainDate.from({ year: 5779, month: 6, day: 1, calendar: 'hebrew' });
+      equal(date.month, 6);
+      equal(date.monthCode, 'M5L');
+      equal(date.day, 1);
+      date = Temporal.PlainDate.from({ year: 5779, monthCode: 'M5L', day: 1, calendar: 'hebrew' });
+      equal(date.month, 6);
+      equal(date.monthCode, 'M5L');
+      equal(date.day, 1);
+    });
+    it('Invalid leap months: e.g. M2L', () => {
+      for (let i = 1; i <= 12; i++) {
+        if (i === 5) continue; // M5L is the only valid month (Adar I)
+        throws(
+          () => Temporal.PlainDate.from({ year: 5779, monthCode: `M${i}L`, day: 1, calendar: 'hebrew' }),
+          RangeError
+        );
+      }
+    });
+    it('Leap month in non-leap year (reject): Adar I 5780', () => {
+      throws(
+        () =>
+          Temporal.PlainDate.from({ year: 5780, monthCode: 'M5L', day: 1, calendar: 'hebrew' }, { overflow: 'reject' }),
+        RangeError
+      );
+    });
+    it('Leap month in non-leap year (constrain): 15 Adar I 5780 => 30 Av 5780', () => {
+      const date = Temporal.PlainDate.from({ year: 5780, monthCode: 'M5L', day: 15, calendar: 'hebrew' });
+      equal(date.month, 5);
+      equal(date.monthCode, 'M5');
+      equal(date.day, 30);
+    });
+  });
+
   describe('DateTimeFormat', () => {
     describe('supportedLocalesOf', () => {
       it('should return an Array', () => assert(Array.isArray(Intl.DateTimeFormat.supportedLocalesOf())));

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -223,6 +223,7 @@ describe('Intl', () => {
     });
     const hasOutdatedChineseIcuData = !testChineseData.endsWith('2001');
     const itOrSkip = (id) => ((id === 'chinese' || id === 'dangi') && hasOutdatedChineseIcuData ? it.skip : it);
+    const nodeVersion = process.versions.node.split('.')[0];
 
     it('verify that Intl.DateTimeFormat.formatToParts output matches snapshot data', () => {
       // This test isn't testing Temporal. Instead, it's verifying that the
@@ -231,53 +232,165 @@ describe('Intl', () => {
       // that, when fixed, will break other tests. So this test is a signal that
       // other tests are broken because the comparison data needs to be updated,
       // not necessarily because Temporal is broken.
-      // prettier-ignore
-      // eslint-disable-next-line max-len, no-console, brace-style
-      const year2000Content = ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'hebrew', 'indian', 'islamic', 'islamic-umalqura', 'islamic-tbla', 'islamic-civil', 'islamic-rgsa', 'islamicc', 'japanese', 'persian', 'roc'].map((id) => `${id}: ${new Date('2000-01-01T00:00Z').toLocaleDateString('en-us', { calendar: id, timeZone: 'UTC' })}`).join('\n');
-      const year2000Snapshot =
-        'iso8601: 1/1/2000\n' +
-        'buddhist: 1/1/2543 BE\n' +
-        'chinese: 11/25/1999\n' +
-        'coptic: 4/22/1716 ERA1\n' +
-        'dangi: 11/25/1999\n' +
-        'ethioaa: 4/22/7492 ERA0\n' +
-        'ethiopic: 4/22/1992 ERA1\n' +
-        'hebrew: 23 Tevet 5760\n' +
-        'indian: 10/11/1921 Saka\n' +
-        'islamic: 9/25/1420 AH\n' +
-        'islamic-umalqura: 9/24/1420 AH\n' +
-        'islamic-tbla: 9/25/1420 AH\n' +
-        'islamic-civil: 9/24/1420 AH\n' +
-        'islamic-rgsa: 9/25/1420 AH\n' +
-        'islamicc: 9/24/1420 AH\n' +
-        'japanese: 1/1/12 H\n' +
-        'persian: 10/11/1378 AP\n' +
-        'roc: 1/1/89 Minguo';
-      equal(year2000Content, year2000Snapshot);
+      const getLocalizedDates = (isoString) => {
+        const calendars = [
+          'iso8601',
+          'buddhist',
+          'chinese',
+          'coptic',
+          'dangi',
+          'ethioaa',
+          'ethiopic',
+          'gregory',
+          'hebrew',
+          'indian',
+          'islamic',
+          'islamic-umalqura',
+          'islamic-tbla',
+          'islamic-civil',
+          'islamic-rgsa',
+          'islamicc',
+          'japanese',
+          'persian',
+          'roc'
+        ];
+        const date = new Date(isoString);
+        return calendars
+          .map((id) => `${id}: ${date.toLocaleDateString(`en-US-u-ca-${id}`, { timeZone: 'UTC' })}`)
+          .join('\n');
+      };
+      const year2000Content = getLocalizedDates('2000-01-01T00:00Z');
+      // to generate snapshot: `          '${year2000Content.replaceAll('\n', "\\n' +\n          '")}',\n`
+      const year1Content = getLocalizedDates('0001-01-01T00:00Z');
+      // to generate snapshot: `          '${year1Content.replaceAll('\n', "\\n' +\n          '")}',\n`
 
-      // prettier-ignore
-      // eslint-disable-next-line max-len, no-console, brace-style
-      const year1Content = ['iso8601', 'buddhist', 'chinese', 'coptic', 'dangi', 'ethioaa', 'ethiopic', 'hebrew', 'indian', 'islamic', 'islamic-umalqura', 'islamic-tbla', 'islamic-civil', 'islamic-rgsa', 'islamicc', 'japanese', 'persian', 'roc'].map((id) => `${id}: ${new Date('0001-01-01T00:00Z').toLocaleDateString('en-us', { calendar: id, timeZone: 'UTC' })}`).join('\n');
-      const year1Snapshot =
-        'iso8601: 1/1/1\n' +
-        'buddhist: 1/3/544 BE\n' +
-        'chinese: 11/21/0\n' +
-        'coptic: 5/8/284 ERA0\n' +
-        'dangi: 11/21/0\n' +
-        'ethioaa: 5/8/5493 ERA0\n' +
-        'ethiopic: 5/8/5493 ERA0\n' +
-        'hebrew: 18 Tevet 3761\n' +
-        'indian: 10/11/-78 Saka\n' +
-        'islamic: -7/20/-639 AH\n' +
-        'islamic-umalqura: 5/18/-640 AH\n' +
-        'islamic-tbla: 5/19/-640 AH\n' +
-        'islamic-civil: 5/18/-640 AH\n' +
-        'islamic-rgsa: -7/20/-639 AH\n' +
-        'islamicc: 5/18/-640 AH\n' +
-        'japanese: 1/3/-643 Taika (645–650)\n' +
-        'persian: 10/11/-621 AP\n' +
-        'roc: 1/3/1911 Before R.O.C.';
-      equal(year1Content, year1Snapshot);
+      const year2000Snapshots = {
+        node12:
+          'iso8601: 1/1/2000\n' +
+          'buddhist: 1/1/2543\n' +
+          'chinese: 11/25/16\n' +
+          'coptic: 4/22/1716\n' +
+          'dangi: 11/25/16\n' +
+          'ethioaa: 4/22/7492\n' +
+          'ethiopic: 4/22/1992\n' +
+          'gregory: 1/1/2000\n' +
+          'hebrew: 4/23/5760\n' +
+          'indian: 10/11/1921\n' +
+          'islamic: 9/25/1420\n' +
+          'islamic-umalqura: 9/24/1420\n' +
+          'islamic-tbla: 9/25/1420\n' +
+          'islamic-civil: 9/24/1420\n' +
+          'islamic-rgsa: 9/25/1420\n' +
+          'islamicc: 9/24/1420\n' +
+          'japanese: 1/1/12\n' +
+          'persian: 10/11/1378\n' +
+          'roc: 1/1/89',
+        node14:
+          'iso8601: 1/1/2000\n' +
+          'buddhist: 1/1/2543 BE\n' +
+          'chinese: 11/25/1999\n' +
+          'coptic: 4/22/1716 ERA1\n' +
+          'dangi: 11/25/1999\n' +
+          'ethioaa: 4/22/7492 ERA0\n' +
+          'ethiopic: 4/22/1992 ERA1\n' +
+          'gregory: 1/1/2000\n' +
+          'hebrew: 23 Tevet 5760\n' +
+          'indian: 10/11/1921 Saka\n' +
+          'islamic: 9/25/1420 AH\n' +
+          'islamic-umalqura: 9/24/1420 AH\n' +
+          'islamic-tbla: 9/25/1420 AH\n' +
+          'islamic-civil: 9/24/1420 AH\n' +
+          'islamic-rgsa: 9/25/1420 AH\n' +
+          'islamicc: 9/24/1420 AH\n' +
+          'japanese: 1/1/12 H\n' +
+          'persian: 10/11/1378 AP\n' +
+          'roc: 1/1/89 Minguo',
+        node15:
+          'iso8601: 1/1/2000\n' +
+          'buddhist: 1/1/2543 BE\n' +
+          'chinese: 11/25/1999\n' +
+          'coptic: 4/22/1716 ERA1\n' +
+          'dangi: 11/25/1999\n' +
+          'ethioaa: 4/22/7492 ERA0\n' +
+          'ethiopic: 4/22/1992 ERA1\n' +
+          'gregory: 1/1/2000\n' +
+          'hebrew: 23 Tevet 5760\n' +
+          'indian: 10/11/1921 Saka\n' +
+          'islamic: 9/25/1420 AH\n' +
+          'islamic-umalqura: 9/24/1420 AH\n' +
+          'islamic-tbla: 9/25/1420 AH\n' +
+          'islamic-civil: 9/24/1420 AH\n' +
+          'islamic-rgsa: 9/25/1420 AH\n' +
+          'islamicc: 9/24/1420 AH\n' +
+          'japanese: 1/1/12 H\n' +
+          'persian: 10/11/1378 AP\n' +
+          'roc: 1/1/89 Minguo'
+      };
+      equal(year2000Content, year2000Snapshots[`node${nodeVersion}`]);
+
+      const year1Snapshots = {
+        node12:
+          'iso8601: 1/1/1\n' +
+          'buddhist: 1/3/544\n' +
+          'chinese: 11/21/57\n' +
+          'coptic: 5/8/284\n' +
+          'dangi: 11/21/57\n' +
+          'ethioaa: 5/8/5493\n' +
+          'ethiopic: 5/8/5493\n' +
+          'gregory: 1/1/1\n' +
+          'hebrew: 4/18/3761\n' +
+          'indian: 10/11/-78\n' +
+          'islamic: -7/20/-639\n' +
+          'islamic-umalqura: 5/18/-640\n' +
+          'islamic-tbla: 5/19/-640\n' +
+          'islamic-civil: 5/18/-640\n' +
+          'islamic-rgsa: -7/20/-639\n' +
+          'islamicc: 5/18/-640\n' +
+          'japanese: 1/3/-643\n' +
+          'persian: 10/11/-621\n' +
+          'roc: 1/3/1911',
+        node14:
+          'iso8601: 1/1/1\n' +
+          'buddhist: 1/3/544 BE\n' +
+          'chinese: 11/21/0\n' +
+          'coptic: 5/8/284 ERA0\n' +
+          'dangi: 11/21/0\n' +
+          'ethioaa: 5/8/5493 ERA0\n' +
+          'ethiopic: 5/8/5493 ERA0\n' +
+          'gregory: 1/1/1\n' +
+          'hebrew: 18 Tevet 3761\n' +
+          'indian: 10/11/-78 Saka\n' +
+          'islamic: -7/20/-639 AH\n' +
+          'islamic-umalqura: 5/18/-640 AH\n' +
+          'islamic-tbla: 5/19/-640 AH\n' +
+          'islamic-civil: 5/18/-640 AH\n' +
+          'islamic-rgsa: -7/20/-639 AH\n' +
+          'islamicc: 5/18/-640 AH\n' +
+          'japanese: 1/3/-643 Taika (645–650)\n' +
+          'persian: 10/11/-621 AP\n' +
+          'roc: 1/3/1911 Before R.O.C.',
+        node15:
+          'iso8601: 1/1/1\n' +
+          'buddhist: 1/3/544 BE\n' +
+          'chinese: 11/21/0\n' +
+          'coptic: 5/8/284 ERA0\n' +
+          'dangi: 11/21/0\n' +
+          'ethioaa: 5/8/5493 ERA0\n' +
+          'ethiopic: 5/8/5493 ERA0\n' +
+          'gregory: 1/1/1\n' +
+          'hebrew: 18 Tevet 3761\n' +
+          'indian: 10/11/-78 Saka\n' +
+          'islamic: 5/20/-640 AH\n' +
+          'islamic-umalqura: 5/18/-640 AH\n' +
+          'islamic-tbla: 5/19/-640 AH\n' +
+          'islamic-civil: 5/18/-640 AH\n' +
+          'islamic-rgsa: 5/20/-640 AH\n' +
+          'islamicc: 5/18/-640 AH\n' +
+          'japanese: 1/3/-643 Taika (645–650)\n' +
+          'persian: 10/11/-621 AP\n' +
+          'roc: 1/3/1911 Before R.O.C.'
+      };
+      equal(year1Content, year1Snapshots[`node${nodeVersion}`]);
     });
 
     const fromWithCases = {
@@ -308,15 +421,24 @@ describe('Intl', () => {
         year2000: { eraYear: 1992, year: 7492, month: 4, day: 22, era: 'era1' },
         year1: { year: 5493, month: 5, day: 8, era: 'era0' }
       },
+      gregory: {
+        year2000: { year: 2000, month: 1, day: 1, era: 'ad' },
+        year1: { year: 1, month: 1, day: 1, era: 'ad' }
+      },
       hebrew: { year2000: { year: 5760, month: 4, day: 23 }, year1: { year: 3761, month: 4, day: 18 } },
       indian: {
         year2000: { year: 1921, month: 10, day: 11, era: 'saka' },
         // with() fails due to https://bugs.chromium.org/p/v8/issues/detail?id=10529
         // from() succeeds because the bug only gets triggered before 1/1/1 ISO.
-        year1: RangeError
+        // Fixed in Node 15
+        year1: { nodeBefore15: RangeError, year: -78, month: 10, day: 11, era: 'saka' }
       },
       // Older islamic dates will fail due to https://bugs.chromium.org/p/v8/issues/detail?id=10527
-      islamic: { year2000: { year: 1420, month: 9, day: 25, era: 'ah' }, year1: RangeError },
+      // Fixed in Node 15
+      islamic: {
+        year2000: { year: 1420, month: 9, day: 25, era: 'ah' },
+        year1: { nodeBefore15: RangeError, year: -640, month: 5, day: 20, era: 'ah' }
+      },
       'islamic-umalqura': {
         year2000: { year: 1420, month: 9, day: 24, era: 'ah' },
         year1: { year: -640, month: 5, day: 18, era: 'ah' }
@@ -329,7 +451,10 @@ describe('Intl', () => {
         year2000: { year: 1420, month: 9, day: 24, era: 'ah' },
         year1: { year: -640, month: 5, day: 18, era: 'ah' }
       },
-      'islamic-rgsa': { year2000: { year: 1420, month: 9, day: 25, era: 'ah' }, year1: RangeError },
+      'islamic-rgsa': {
+        year2000: { year: 1420, month: 9, day: 25, era: 'ah' },
+        year1: { nodeBefore15: RangeError, year: -640, month: 5, day: 20, era: 'ah' }
+      },
       islamicc: {
         year2000: { year: 1420, month: 9, day: 24, era: 'ah' },
         year1: { year: -640, month: 5, day: 18, era: 'ah' }
@@ -359,9 +484,13 @@ describe('Intl', () => {
           if (val[type]) val = val[type];
           return val;
         };
-        itOrSkip(id)(`from: ${id} ${name} ${getValues('from') === RangeError ? ' (throws)' : ''}`, () => {
-          const values = getValues('from');
-          if (values === RangeError) {
+        const fromValues = getValues('from');
+        const fromErrorExpected =
+          fromValues === RangeError ||
+          ((nodeVersion === '14' || nodeVersion === '12') && fromValues.nodeBefore15 === RangeError);
+        itOrSkip(id)(`from: ${id} ${name} ${fromErrorExpected ? ' (throws)' : ''}`, () => {
+          const values = fromValues;
+          if (fromErrorExpected) {
             // Some calendars will fail due to Chromium bugs noted in the test definitions
             throws(() => {
               const inCal = date.withCalendar(id);
@@ -420,10 +549,13 @@ describe('Intl', () => {
           });
           equal(dateRoundtrip4.toString(), inCal.toString());
         });
-        itOrSkip(id)(`with: ${id} ${name} ${getValues('with') === RangeError ? ' (throws)' : ''}`, () => {
-          const values = getValues('with');
+        const withValues = getValues('with');
+        const withErrorExpected =
+          withValues === RangeError ||
+          ((nodeVersion === '14' || nodeVersion === '12') && withValues.nodeBefore15 === RangeError);
+        itOrSkip(id)(`with: ${id} ${name} ${withErrorExpected ? ' (throws)' : ''}`, () => {
           const inCal = date.withCalendar(id);
-          if (values === RangeError) {
+          if (withErrorExpected) {
             // Some calendars will fail due to Chromium bugs noted in the test definitions
             throws(() => inCal.with({ day: 1 }).year, RangeError);
             return;
@@ -467,6 +599,7 @@ describe('Intl', () => {
       dangi: { year: 2000, month: 10, day: 16, monthCode: '10', eraYear: undefined, era: undefined },
       ethioaa: { year: 2000, month: 10, day: 11, monthCode: '10', eraYear: 2000, era: 'era0' },
       ethiopic: { year: 2000, month: 10, day: 11, monthCode: '10', eraYear: 2000, era: 'era0' },
+      gregory: { year: 2000, month: 10, day: 7, monthCode: '10', eraYear: 2000, era: 'ad' },
       hebrew: { year: 2000, month: 10, day: 14, monthCode: '10', eraYear: undefined, era: undefined },
       indian: { year: 2000, month: 10, day: 6, monthCode: '10', eraYear: 2000, era: 'saka' },
       islamic: { year: 2000, month: 10, day: 15, monthCode: '10', eraYear: 2000, era: 'ah' },
@@ -487,6 +620,7 @@ describe('Intl', () => {
       dangi: { year: 2001, month: 6, day: 1, monthCode: '5', eraYear: undefined, era: undefined },
       ethioaa: { year: 2001, month: 5, day: 1, monthCode: '5', eraYear: 2001, era: 'era0' },
       ethiopic: { year: 2001, month: 5, day: 1, monthCode: '5', eraYear: 2001, era: 'era0' },
+      gregory: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ad' },
       hebrew: { year: 2001, month: 6, day: 1, monthCode: '5L', eraYear: undefined, era: undefined },
       indian: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'saka' },
       islamic: { year: 2001, month: 6, day: 1, monthCode: '6', eraYear: 2001, era: 'ah' },
@@ -569,6 +703,7 @@ describe('Intl', () => {
       dangi: { year: 2001, leap: '4L', days: [30, 30, 30, 29, 29, 30, 29, 29, 30, 29, 30, 29, 30] },
       ethioaa: { year: 2001, leap: false, days: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 5] },
       ethiopic: { year: 2001, leap: false, days: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 5] },
+      gregory: { year: 2001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
       hebrew: { year: 2001, leap: '5L', days: [30, 30, 30, 29, 30, 30, 29, 30, 29, 30, 29, 30, 29] },
       indian: { year: 2001, leap: false, days: [30, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 30] },
       islamic: { year: 2001, leap: false, days: [29, 30, 29, 29, 30, 29, 30, 30, 29, 30, 30, 29] },
@@ -583,7 +718,10 @@ describe('Intl', () => {
     };
     for (let id of calendars) {
       let { year, leap, days } = daysInMonthCases[id];
-      let date = Temporal.PlainDate.from({ year, month: 1, day: 1, calendar: id });
+      let date =
+        hasOutdatedChineseIcuData && (id === 'chinese' || id === 'dangi')
+          ? undefined
+          : Temporal.PlainDate.from({ year, month: 1, day: 1, calendar: id });
       itOrSkip(id)(`${id} leap year check for year ${year}`, () => {
         if (typeof leap === 'boolean') {
           equal(date.inLeapYear, leap);

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -214,6 +214,16 @@ describe('Intl', () => {
   });
 
   describe('Non-ISO Calendars', () => {
+    const testChineseData = new Date('2001-02-01T00:00Z').toLocaleString('en-US-u-ca-chinese', {
+      day: 'numeric',
+      month: 'numeric',
+      year: 'numeric',
+      era: 'short',
+      timeZone: 'UTC'
+    });
+    const hasOutdatedChineseIcuData = !testChineseData.endsWith('2001');
+    const itOrSkip = (id) => ((id === 'chinese' || id === 'dangi') && hasOutdatedChineseIcuData ? it.skip : it);
+
     it('verify that Intl.DateTimeFormat.formatToParts output matches snapshot data', () => {
       // This test isn't testing Temporal. Instead, it's verifying that the
       // output of Intl.DateTimeFormat.formatToParts for non-ISO calendars
@@ -349,7 +359,7 @@ describe('Intl', () => {
           if (val[type]) val = val[type];
           return val;
         };
-        it(`from: ${id} ${name} ${getValues('from') === RangeError ? ' (throws)' : ''}`, () => {
+        itOrSkip(id)(`from: ${id} ${name} ${getValues('from') === RangeError ? ' (throws)' : ''}`, () => {
           const values = getValues('from');
           if (values === RangeError) {
             // Some calendars will fail due to Chromium bugs noted in the test definitions
@@ -410,7 +420,7 @@ describe('Intl', () => {
           });
           equal(dateRoundtrip4.toString(), inCal.toString());
         });
-        it(`with: ${id} ${name} ${getValues('with') === RangeError ? ' (throws)' : ''}`, () => {
+        itOrSkip(id)(`with: ${id} ${name} ${getValues('with') === RangeError ? ' (throws)' : ''}`, () => {
           const values = getValues('with');
           const inCal = date.withCalendar(id);
           if (values === RangeError) {
@@ -512,7 +522,7 @@ describe('Intl', () => {
       for (let [unit, { duration, results, startDate }] of Object.entries(tests)) {
         const values = results[id];
         duration = Temporal.Duration.from(duration);
-        it(`${id} add ${duration}`, () => {
+        itOrSkip(id)(`${id} add ${duration}`, () => {
           // const now = globalThis.performance ? globalThis.performance.now() : Date.now();
           const start = Temporal.PlainDate.from({ ...startDate, calendar: id });
           const end = start.add(duration);
@@ -574,7 +584,7 @@ describe('Intl', () => {
     for (let id of calendars) {
       let { year, leap, days } = daysInMonthCases[id];
       let date = Temporal.PlainDate.from({ year, month: 1, day: 1, calendar: id });
-      it(`${id} leap year check for year ${year}`, () => {
+      itOrSkip(id)(`${id} leap year check for year ${year}`, () => {
         if (typeof leap === 'boolean') {
           equal(date.inLeapYear, leap);
         } else {
@@ -583,7 +593,7 @@ describe('Intl', () => {
           equal(leapMonth.monthCode, leap);
         }
       });
-      it(`${id} months check for year ${year}`, () => {
+      itOrSkip(id)(`${id} months check for year ${year}`, () => {
         const { monthsInYear } = date;
         equal(monthsInYear, days.length);
         // This loop counts backwards so we'll have the right test for the month

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -397,7 +397,9 @@ describe('Intl', () => {
       iso8601: { year2000: { year: 2000, month: 1, day: 1 }, year1: { year: 1, month: 1, day: 1 } },
       buddhist: {
         year2000: { year: 2543, month: 1, day: 1, era: 'be' },
-        year1: { year: 544, month: 1, day: 3, era: 'be' }
+        // Pre-1582 (ISO) dates are broken by https://bugs.chromium.org/p/chromium/issues/detail?id=1173158
+        year1: RangeError
+        // year1: { year: 544, month: 1, day: 1, era: 'be' }
       },
       chinese: {
         year2000: { year: 1999, month: 11, day: 25 },
@@ -459,10 +461,11 @@ describe('Intl', () => {
         year2000: { year: 1420, month: 9, day: 24, era: 'ah' },
         year1: { year: -640, month: 5, day: 18, era: 'ah' }
       },
-      // TODO: Figure out how to handle dates before Taika (the first recorded Japanese era)
       japanese: {
         year2000: { year: 2000, eraYear: 12, month: 1, day: 1, era: 'heisei' },
+        // Pre-1582 dates are broken by https://bugs.chromium.org/p/chromium/issues/detail?id=1173158
         year1: RangeError
+        // year1: { year: 1, eraYear: 1, month: 1, day: 1, era: 'ad' }
       },
       persian: {
         year2000: { year: 1378, month: 10, day: 11, era: 'ap' },
@@ -470,7 +473,9 @@ describe('Intl', () => {
       },
       roc: {
         year2000: { year: 89, month: 1, day: 1, era: 'minguo' },
-        year1: { year: -1910, eraYear: 1911, month: 1, day: 3, era: 'before-roc' }
+        // Pre-1582 dates are broken by https://bugs.chromium.org/p/chromium/issues/detail?id=1173158
+        year1: RangeError
+        // year1: { year: -1910, eraYear: 1911, month: 1, day: 3, era: 'before-roc' }
       }
     };
     for (let [id, tests] of Object.entries(fromWithCases)) {
@@ -561,7 +566,7 @@ describe('Intl', () => {
             return;
           }
           const afterWithDay = inCal.with({ day: 1 });
-          let t = '(after setting year)';
+          let t = '(after setting day)';
           equal(`${t} year: ${afterWithDay.year}`, `${t} year: ${inCal.year}`);
           equal(`${t} month: ${afterWithDay.month}`, `${t} month: ${inCal.month}`);
           equal(`${t} day: ${afterWithDay.day}`, `${t} day: 1`);
@@ -570,9 +575,11 @@ describe('Intl', () => {
           equal(`${t} year: ${afterWithMonth.year}`, `${t} year: ${inCal.year}`);
           equal(`${t} month: ${afterWithMonth.month}`, `${t} month: 1`);
           equal(`${t} day: ${afterWithMonth.day}`, `${t} day: 1`);
-          const afterWithYear = afterWithMonth.with({ year: 2020 });
-          t = '(after setting day)';
-          equal(`${t} year: ${afterWithYear.year}`, `${t} year: 2020`);
+          // FYI: we're using 2220 here because it's larger than the ISO year 1582
+          // in all calendars affected by https://bugs.chromium.org/p/chromium/issues/detail?id=1173158
+          const afterWithYear = afterWithMonth.with({ year: 2220 });
+          t = '(after setting year)';
+          equal(`${t} year: ${afterWithYear.year}`, `${t} year: 2220`);
           equal(`${t} month: ${afterWithYear.month}`, `${t} month: 1`);
           equal(`${t} day: ${afterWithYear.day}`, `${t} day: 1`);
         });
@@ -593,7 +600,8 @@ describe('Intl', () => {
     */
     const addDaysWeeksCases = {
       iso8601: { year: 2000, month: 10, day: 7, monthCode: 'M10', eraYear: undefined, era: undefined },
-      buddhist: { year: 2000, month: 10, day: 8, monthCode: 'M10', eraYear: 2000, era: 'be' },
+      // See https://bugs.chromium.org/p/chromium/issues/detail?id=1173158
+      buddhist: RangeError, // { year: 2000, month: 10, day: 8, monthCode: 'M10', eraYear: 2000, era: 'be' },
       chinese: { year: 2000, month: 10, day: 16, monthCode: 'M10', eraYear: undefined, era: undefined },
       coptic: { year: 2000, month: 10, day: 11, monthCode: 'M10', eraYear: 2000, era: 'era1' },
       dangi: { year: 2000, month: 10, day: 16, monthCode: 'M10', eraYear: undefined, era: undefined },
@@ -614,7 +622,8 @@ describe('Intl', () => {
     };
     const addMonthsCases = {
       iso8601: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: undefined, era: undefined },
-      buddhist: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'be' },
+      // See https://bugs.chromium.org/p/chromium/issues/detail?id=1173158
+      buddhist: RangeError, // { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'be' },
       chinese: { year: 2001, month: 6, day: 1, monthCode: 'M5', eraYear: undefined, era: undefined },
       coptic: { year: 2001, month: 5, day: 1, monthCode: 'M5', eraYear: 2001, era: 'era1' },
       dangi: { year: 2001, month: 6, day: 1, monthCode: 'M5', eraYear: undefined, era: undefined },
@@ -634,7 +643,7 @@ describe('Intl', () => {
       roc: { year: 2001, month: 6, day: 1, monthCode: 'M6', eraYear: 2001, era: 'minguo' }
     };
     const addYearsMonthsDaysCases = Object.entries(addMonthsCases).reduce((obj, entry) => {
-      obj[entry[0]] = { ...entry[1], day: 4 };
+      obj[entry[0]] = entry[1] === RangeError ? RangeError : { ...entry[1], day: 4 };
       return obj;
     }, {});
     const tests = {
@@ -658,6 +667,10 @@ describe('Intl', () => {
         duration = Temporal.Duration.from(duration);
         itOrSkip(id)(`${id} add ${duration}`, () => {
           // const now = globalThis.performance ? globalThis.performance.now() : Date.now();
+          if (values === RangeError) {
+            throws(() => Temporal.PlainDate.from({ ...startDate, calendar: id }));
+            return;
+          }
           const start = Temporal.PlainDate.from({ ...startDate, calendar: id });
           const end = start.add(duration);
           equal(`add ${unit} ${id} day: ${end.day}`, `add ${unit} ${id} day: ${values.day}`);
@@ -697,7 +710,8 @@ describe('Intl', () => {
     */
     const daysInMonthCases = {
       iso8601: { year: 2001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
-      buddhist: { year: 2001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
+      // Buddhist uses 4001 to avoid https://bugs.chromium.org/p/chromium/issues/detail?id=1173158
+      buddhist: { year: 4001, leap: false, days: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31] },
       chinese: { year: 2001, leap: 'M4L', days: [30, 30, 29, 30, 29, 30, 29, 29, 30, 29, 30, 29, 30] },
       coptic: { year: 2001, leap: false, days: [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 5] },
       dangi: { year: 2001, leap: 'M4L', days: [30, 30, 30, 29, 29, 30, 29, 29, 30, 29, 30, 29, 30] },
@@ -779,6 +793,59 @@ describe('Intl', () => {
         // console.log(`${id} months check ${id}: ${ms.toFixed(2)}ms, total: ${totalNow.toFixed(2)}ms`);
       });
     }
+  });
+
+  describe('Japanese eras', () => {
+    it('Reiwa (2019-)', () => {
+      let date = Temporal.PlainDate.from({ era: 'reiwa', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '2020-01-01[u-ca-japanese]');
+    });
+    it('Heisei (1989-2019)', () => {
+      let date = Temporal.PlainDate.from({ era: 'heisei', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '1990-01-01[u-ca-japanese]');
+    });
+    it('Showa (1926-1989)', () => {
+      let date = Temporal.PlainDate.from({ era: 'showa', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '1927-01-01[u-ca-japanese]');
+    });
+    it('Taisho (1912-1926)', () => {
+      let date = Temporal.PlainDate.from({ era: 'taisho', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '1913-01-01[u-ca-japanese]');
+    });
+    it('Meiji (1868-1912)', () => {
+      let date = Temporal.PlainDate.from({ era: 'meiji', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '1869-01-01[u-ca-japanese]');
+    });
+    it('Dates in same year before Japanese era starts will resolve to previous era', () => {
+      let date = Temporal.PlainDate.from({ era: 'reiwa', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '2019-01-01[u-ca-japanese]');
+      equal(date.era, 'heisei');
+      equal(date.eraYear, 31);
+      date = Temporal.PlainDate.from({ era: 'heisei', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '1989-01-01[u-ca-japanese]');
+      equal(date.era, 'showa');
+      equal(date.eraYear, 64);
+      date = Temporal.PlainDate.from({ era: 'showa', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '1926-01-01[u-ca-japanese]');
+      equal(date.era, 'taisho');
+      equal(date.eraYear, 15);
+      date = Temporal.PlainDate.from({ era: 'taisho', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '1912-01-01[u-ca-japanese]');
+      equal(date.era, 'meiji');
+      equal(date.eraYear, 45);
+      date = Temporal.PlainDate.from({ era: 'meiji', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
+      equal(`${date}`, '1868-01-01[u-ca-japanese]');
+      equal(date.era, 'ad');
+      equal(date.eraYear, 1868);
+      throws(
+        () => Temporal.PlainDate.from({ era: 'bc', eraYear: 1, month: 1, day: 1, calendar: 'japanese' }),
+        RangeError
+      );
+      // uncomment & revise `throws` above if https://bugs.chromium.org/p/chromium/issues/detail?id=1173158 is resolved
+      // equal(`${date}`, '+000000-01-01[u-ca-japanese]');
+      // equal(date.era, 'bc');
+      // equal(date.eraYear, 1);
+    });
   });
 
   describe('DateTimeFormat', () => {


### PR DESCRIPTION
This PR adds initial implementations for all supported ICU non-ISO calendars, and proposes a few possible changes to the Temporal API to address issues found while building those calendars.  The goal of this PR is to validate the Temporal calendar API and to identify potential issues we may need to discuss and/or resolve. To set expectations, the calendar implementations themselves pass basic tests and match the output of `Intl.DateTimeFormat`, but are not intended to have production-ready accuracy nor performance.  Also, this PR has some gaps and unfinished parts, but I wanted to get it into GitHub so we can start discussion and resolve open issues. On a personal note, getting this PR into GitHub was helpful to keep my mind off the chaos in Washington today!  Fixes #1210. FIxes #1349.

At a high level, here's what's in this PR: 
* Calendar implementations for all ICU non-ISO calendars: buddhist, chinese, coptic, dangi, ethioaa, ethiopic, gregory, hebrew, indian, islamic, islamic-umalqura, islamic-tbla, islamic-civil, islamic-rgsa, islamicc, japanese, persian, roc.  The implementations themselves are kinda hacky. Conversion of ISO->calendar parses the output of `DateTimeFormat.formatToParts`. But calendar->ISO is even hackier: the code tries to roughly estimate an ISO date from the calendar date, then roundtrips back to calendar and then bisects the difference between estimate and actual values until we end up with the right values.  This is inefficient and slow, but it guarantees that this PR's results will always match DateTimeFormat's results and it's probably good enough for an interim implementation before a real production polyfill is built later this year.
* New fields for Temporal objects:
  * `monthCode` this is a year-independent, string-valued property that describes the month. For ICU calendars, it follows the iCalendar convention of `${month}` for non-leap months, and is `${previousMonth}L` for leap months (e.g. `'M5L'` for Hebrew Adar I)
  * `eraYear` - the era-relative year, as a number
* Implements the `month` field as the 1-based numeric index of the month in the current year. For, example, in a Chinese leap year the leap month with monthCode `M7L` will have `month === 8`.  Unlike `monthCode`, `month` is not guaranteed to refer to the same month name in every year for lunisolar calendars.
* Implements the `year` field as a signed value relative to an "anchor era" for each calendar, e.g. "AD" for Gregorian. This avoids potential confusion and security issues that could result from years counting backwards for years in eras like BC or the ROC calendar's Before R.O.C. era.
* Enables calendars to control validation of input fields. This enables developers to use `year` or an `eraYear`/`era` pair to specify the year in `from` or `with`, and it enables developers to use either `month` or `monthCode` to specify the month.
* Adds basic tests for each calendar, including conversion, field access, addition, and until.  Note that the tests will be somewhat brittle because they will break as soon as a few calendar-related Chromium ICU bugs are fixed. (see the tests for bug links).

Here's a summary of issues related to this PR. I marked those that already contain possible fixes in this PR. There's quite a few issues here, so even if the code here can fix some of these issues, it may make sense to split those fixes out into separate PRs.  For questions about specific issues, please discuss in those GH issues to keep our discussions in one spot!

Here's smaller issues that I expect to be are relatively non-controversial: 
* [x] #1227 JSON representation for Temporal.Calendar instances is always "{}"
* [x] #1228 Invalid non-numeric field values should throw
* [x] #1229 Calendars should be in charge of validating fields and coercing field types
* [x] #1240 PlainMonthDay / PlainYearMonth constructors should require the reference parameter for non-ISO calendars 

These issues I expect to require more discussion to resolve. 
* [x] #1231 Safer handling of negative years in non-ISO calendars
* [x] #1203 calendar.month should not be required to be a number
* [x] #1235 Calendars can't accept fields in `from()` or `with()` that are not emitted by `getFields()` 
* [x] #1237 How should the `overflow` option behave with leap days and months in `PlainMonthDay.from()` ?
* [x] #1239 Temporal.PlainMonthDay.equals() should compare calendar fields, not ISO fields. Or should we remove equals()?
* [x] #1253 Should calendar methods like dateFromFields be able to accept calendar-specific options?
* [x] #1300 How to handle dates before the start or after the end of eras that start or end mid-year?
* [x] #1349 Invalid ISO month codes (e.g. 'M15') don't throw, but should

The items below were handled in separate PRs: 
* [x] Documentation updates for new getters like monthCode and for changes to the Calendar API