### PR TITLE
ToOptionalTemporalCalendar and GetOptionalTemporalCalendar abstract operations

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -495,11 +495,7 @@
       1. If Type(_value_) is Object, then
         1. If _value_ has either an [[InitializedTemporalDateTime]] or [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Return _value_.
-        1. Let _calendar_ be ? Get(_value_, *"calendar"*).
-        1. If _calendar_ is *undefined*, then
-          1. Set _calendar_ to ? GetISO8601Calendar().
-        1. Else,
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+        1. Let _calendar_ be ? GetOptionalTemporalCalendar(_value_).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"year"* »).
         1. Let _fields_ be ? ToTemporalDateTimeFields(_value_, _fieldNames_).
         1. Let _temporalDate_ be ? DateFromFields(_calendar_, _fields_, %Temporal.PlainDate%).
@@ -520,10 +516,7 @@
       1. Else,
         1. Let _string_ be ? ToString(_value_).
         1. Let _result_ be ? ParseISODateTime(_string_).
-        1. Let _calendar_ be _record_.[[Calendar]].
-        1. If _calendar_ is *undefined*, then
-          1. Set _calendar_ to ? GetISO8601Calendar().
-        1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_record_.[[Calendar]]).
         1. Let _offset_ be _result_.[[TimeZoneOffset]].
         1. Let _timeZone_ be _result_.[[TimeZoneIANAName]].
       1. If _timeZone_ is not *undefined*, then

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -98,6 +98,31 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-tooptionaltemporalcalendar" aoid="ToOptionalTemporalCalendar">
+      <h1>ToOptionalTemporalCalendar ( _temporalCalendarLike_ )</h1>
+      <p>
+        The abstract operation ToOptionalTemporalCalendar converts a value into an Object suitable for use as a calendar.
+        If the value is *undefined*, the ISO 8601 calendar is returned.
+      </p>
+      <emu-alg>
+        1. If _temporalCalendarLike_ is *undefined*, then
+          1. Return ? GetISO8601Calendar().
+        1. Return ? ToTemporalCalendar(_temporalCalendarLike_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-getoptionaltemporalcalendar" aoid="GetOptionalTemporalCalendar">
+      <h1>GetOptionalTemporalCalendar ( _item_ )</h1>
+      <p>
+        The abstract operation GetOptionalTemporalCalendar looks for a `calendar` property on the given _item_ and converts its value to an Object suitable for use as a calendar.
+        If no such property is present, the ISO 8601 calendar is returned.
+      </p>
+      <emu-alg>
+        1. Let _calendar_ be ? Get(_item_, *"calendar"*).
+        1. Return ? ToOptionalTemporalCalendar(_calendar_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-calendarfrom" aoid="CalendarFrom">
       <h1>CalendarFrom ( _identifier_ )</h1>
       <emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -26,10 +26,7 @@
         1. Let _y_ be ? ToInteger(_isoYear_).
         1. Let _m_ be ? ToInteger(_isoMonth_).
         1. Let _d_ be ? ToInteger(_isoDay_).
-        1. If _calendarLike_ is *undefined*, then
-          1. Set _calendar_ to ? GetISO8601Calendar().
-        1. Else,
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
         1. Return ? CreateTemporalDate(_y_, _m_, _d_, _calendar_, NewTarget).
       </emu-alg>
     </emu-clause>
@@ -751,9 +748,7 @@
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalDate]] internal slot, then
             1. Return _item_.
-          1. Let _calendar_ be ? Get(_item_, *"calendar"*).
-          1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+          1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"year"* »).
           1. Let _fields_ be ? ToTemporalDateFields(_item_, _fieldNames_).
           1. Return ? DateFromFields(_calendar_, _fields_, _constructor_, _overflow_).
@@ -761,9 +756,7 @@
         1. Let _result_ be ? ParseTemporalDateString(_string_).
         1. If ! ValidateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *false*, then
           1. Throw a *RangeError* exception.
-        1. Let _calendar_ be _result_.[[Calendar]].
-        1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().
-        1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. Set _result_ to ? RegulateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _overflow_).
         1. Return ? CreateTemporalDateFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -960,7 +960,7 @@
         1. Else,
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalDateTimeString(_string_).
-          1. If ! ValidateDateTime(__.[[Year]], __.[[Month]], __.[[Day]], __.[[Hour]], __.[[Minute]], __.[[Second]], __.[[Millisecond]], __.[[Microsecond]], __.[[Nanosecond]]) is *false*, then
+          1. If ! ValidateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *false*, then
             1. Throw a *RangeError* exception.
         1. Let _calendar_ be _result_.[[Calendar]].
         1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -35,10 +35,7 @@
         1. Let _millisecond_ be ? ToInteger(_millisecond_).
         1. Let _microsecond_ be ? ToInteger(_microsecond_).
         1. Let _nanosecond_ be ? ToInteger(_nanosecond_).
-        1. If _calendarLike_ is *undefined*, then
-          1. Set _calendar_ to ? GetISO8601Calendar().
-        1. Else,
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
         1. Return ? CreateTemporalDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_, NewTarget).
       </emu-alg>
     </emu-clause>
@@ -951,9 +948,7 @@
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
             1. Return _item_.
-          1. Let _calendar_ be ? Get(_item_, *"calendar"*).
-          1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+          1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"nanosecond"*, *"second"*, *"year"* »).
           1. Let _fields_ be ? ToTemporalDateTimeFields(_item_, _fieldNames_).
           1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _overflow_).
@@ -962,9 +957,7 @@
           1. Let _result_ be ? ParseTemporalDateTimeString(_string_).
           1. If ! ValidateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *false*, then
             1. Throw a *RangeError* exception.
-        1. Let _calendar_ be _result_.[[Calendar]].
-        1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().
-        1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. Return ? CreateTemporalDateTimeFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -29,10 +29,7 @@
           1. Set _referenceISOYear_ to *1972*<sub>𝔽</sub>.
         1. Let _m_ be ? ToInteger(_isoMonth_).
         1. Let _d_ be ? ToInteger(_isoDay_).
-        1. If _calendarLike_ is *undefined*, then
-          1. Set _calendar_ to ? GetISO8601Calendar().
-        1. Else,
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
         1. Let _ref_ be ? ToInteger(_referenceISOYear_).
         1. Return ? CreateTemporalMonthDay(_m_, _d_, _calendar_, _ref_, NewTarget).
       </emu-alg>
@@ -376,9 +373,7 @@
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalMonthDay]] internal slot, then
             1. Return _item_.
-          1. Let _calendar_ be ? Get(_item_, *"calendar"*).
-          1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+          1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"* »).
           1. Let _fields_ be ? ToTemporalMonthDayFields(_item_, _fieldNames_).
           1. Return ? MonthDayFromFields(_calendar_, _fields_, _overflow_, _constructor_).
@@ -390,9 +385,7 @@
           1. Let _referenceISOYear_ be _result_.[[Year]].
         1. If ! ValidateDate(_referenceISOYear_, _result_.[[Month]], _result_.[[Day]]) is *false*, then
           1. Throw a *RangeError* exception.
-        1. Let _calendar_ be _result_.[[Calendar]].
-        1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().
-        1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. Set _result_ to ? RegulateMonthDay(_result_.[[Month]], _result_.[[Day]], _overflow_).
         1. Return ? CreateTemporalMonthDayFromStatic(_constructor_, _result_.[[Month]], _result_.[[Day]], _referenceISOYear_, _calendar_).
       </emu-alg>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -29,10 +29,7 @@
           1. Set _referenceISODay_ to *1*<sub>𝔽</sub>.
         1. Let _y_ be ? ToInteger(_isoYear_).
         1. Let _m_ be ? ToInteger(_isoMonth_).
-        1. If _calendarLike_ is *undefined*, then
-          1. Set _calendar_ to ? GetISO8601Calendar().
-        1. Else,
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
         1. Let _ref_ be ? ToInteger(_referenceISODay_).
         1. Return ? CreateTemporalYearMonth(_y_, _m_, _calendar_, _ref_, NewTarget).
       </emu-alg>
@@ -591,9 +588,7 @@
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalYearMonth]] internal slot, then
             1. Return _item_.
-          1. Let _calendar_ be ? Get(_item_, *"calendar"*).
-          1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+          1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"year"* »).
           1. Let _fields_ be ? ToTemporalYearMonthFields(_item_, _fieldNames_).
           1. Return ? YearMonthFromFields(_calendar_, _fields_, _overflow_, _constructor_).
@@ -605,9 +600,7 @@
           1. Let _referenceISODay_ be _result_.[[Day]].
         1. If ! ValidateDate(_result_.[[Year]], _result_.[[Month]], _referenceISODay_) is *false*, then
           1. Throw a *RangeError* exception.
-        1. Let _calendar_ be _result_.[[Calendar]].
-        1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().
-        1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. Set _result_ to ? RegulateYearMonth(_result_.[[Year]], _result_.[[Month]], _overflow_).
         1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _calendar_, _referenceISODay_).
       </emu-alg>

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -215,10 +215,7 @@
           1. Let _timeZone_ be ? SystemTimeZone().
         1. Else,
           1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
-        1. If _calendarLike_ is *undefined*, then
-          1. Let _calendar_ be ? GetISO8601Calendar().
-        1. Else,
-          1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
         1. Let _instant_ be ? SystemInstant().
         1. Return ? GetTemporalDateTimeFor(_timeZone_, _instant_, _calendar_).
       </emu-alg>
@@ -231,10 +228,7 @@
           1. Let _timeZone_ be ? SystemTimeZone().
         1. Else,
           1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
-        1. If _calendarLike_ is *undefined*, then
-          1. Let _calendar_ be ? GetISO8601Calendar().
-        1. Else,
-          1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
         1. Let _ns_ be ? SystemUTCEpochNanoseconds().
         1. Return ? CreateTemporalZonedDateTime(_ns_, _timeZone_, _calendar_).
       </emu-alg>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -167,10 +167,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Set _instant_ to ? ToTemporalInstant(_instant_).
-        1. If _calendarLike_ is *undefined*, then
-          1. Let _calendar_ be ? GetISO8601Calendar().
-        1. Else,
-          1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
         1. Let _result_ be ! GetPartsFromEpoch(_instant_.[[Nanoseconds]]).
         1. Set _result_ to ? BalanceDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -30,10 +30,7 @@
         1. Set _epochNanoseconds_ to ? ToBigInt(_epochNanoseconds_).
         1. Perform ? RejectInstant(_epochNanoseconds_).
         1. Let _timeZone_ be ? ToTemporalTimeZone(_timeZoneLike_).
-        1. If _calendarLike_ is *undefined*, then
-          1. Set _calendar_ to ? GetISO8601Calendar().
-        1. Else,
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
         1. Return ? CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_, NewTarget).
       </emu-alg>
     </emu-clause>
@@ -1142,9 +1139,7 @@
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Return _item_.
-          1. Let _calendar_ be ? Get(_item_, *"calendar"*).
-          1. If _calendar_ is *undefined*, set it to ? GetISO8601Calendar().
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+          1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"nanosecond"*, *"second"*, *"year"* »).
           1. Let _fields_ be ? ToTemporalZonedDateTimeFields(_item_, _fieldNames_).
           1. Let _timeZone_ be ? Get(_fields_, *"timeZone"*).
@@ -1158,9 +1153,7 @@
           1. If _result_.[[TimeZoneName]] is *undefined*, throw a *RangeError* exception.
           1. Let _timeZone_ be ? TimeZoneFrom(_result_.[[TimeZoneName]]).
           1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
-          1. Let _calendar_ be _result_.[[Calendar]].
-          1. If _calendar_ is *undefined*, set _calendar_ to ? GetISO8601Calendar().
-          1. Set _calendar_ to ? ToTemporalCalendar(_calendar_).
+          1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
         1. Let _epochNanoseconds_ be ? InterpretTemporalZonedDateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).
         1. Return ? CreateTemporalZonedDateTimeFromStatic(_constructor_, _epochNanoseconds_, _timeZone_, _calendar_).


### PR DESCRIPTION
In order to avoid repeating ourselves in the spec text when specifying
APIs where the calendar is optional, we introduce the abstract operations
ToOptionalTemporalCalendar and GetOptionalTemporalCalendar.

The former returns the ISO 8601 calendar if given the value `undefined`,
and the latter expects an object and calls ToOptionalTemporalCalendar on
its `calendar` property.

Closes: #1209