### PR TITLE
Fix spec text for determining calendar to format with in toLocaleString

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -333,8 +333,8 @@
             1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
           1. <ins>If _x_ has an [[InitializedTemporalTime]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainTimePattern]].</ins>
-            1. <ins>Let _calendarOverride_ be ? GetISO8601Calendar().</ins>
-            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(1970, 1, 1, _x_.[[ISOHour]], _x_.[[ISOMinute]], _x_.[[ISOSecond]], _x_.[[ISOMilliSecond]], _x_.[[ISOMicroSecond]], _x_.[[ISONanoSecond]], _calendarOverride_).</ins>
+            1. <ins>Let _isoCalendar_ be ? GetISO8601Calendar().</ins>
+            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(1970, 1, 1, _x_.[[ISOHour]], _x_.[[ISOMinute]], _x_.[[ISOSecond]], _x_.[[ISOMillisecond]], _x_.[[ISOMicrosecond]], _x_.[[ISONanosecond]], _isoCalendar_).</ins>
             1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
           1. <ins>If _x_ has an [[InitializedTemporalDateTime]] or an [[InitializedTemporalInstant]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainDateTimePattern]].</ins>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -336,11 +336,12 @@
             1. <ins>Let _isoCalendar_ be ? GetISO8601Calendar().</ins>
             1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(1970, 1, 1, _x_.[[ISOHour]], _x_.[[ISOMinute]], _x_.[[ISOSecond]], _x_.[[ISOMillisecond]], _x_.[[ISOMicrosecond]], _x_.[[ISONanosecond]], _isoCalendar_).</ins>
             1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
-          1. <ins>If _x_ has an [[InitializedTemporalDateTime]] or an [[InitializedTemporalInstant]] internal slot, then</ins>
+          1. <ins>If _x_ has an [[InitializedTemporalDateTime]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainDateTimePattern]].</ins>
             1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _x_, *"reject"*).</ins>
           1. <ins>If _x_ has an [[InitializedTemporalInstant]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalInstantPattern]].</ins>
+            1. <ins>Let _instant_ be _x_.</ins>
           1. <ins>If _x_ has an [[InitializedTemporalZonedDateTime]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalZonedDateTimePattern]].</ins>
             1. <ins>Let _calendar_ be ? CalendarToString(_x_.[[Calendar]]).</ins>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -312,24 +312,16 @@
           1. <ins>If _x_ has an [[InitializedTemporalYearMonth]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainYearMonthPattern]].</ins>
             1. <ins>Let _calendar_ be ? CalendarToString(_x_.[[Calendar]]).</ins>
-            1. <ins>If _calendar_ is _dateTimeFormat_.[[Calendar]], then</ins>
-              1. <ins>Let _calendarOverride_ be _x_.[[Calendar]].</ins>
-            1. <ins>Else if _calendar_ is *"iso8601"*, then</ins>
-              1. <ins>Let _calendarOverride_ be ? GetBuiltinCalendar(_dateTimeFormat_.[[Calendar]]).</ins>
-            1. <ins>Else,</ins>
+            1. <ins>If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then</ins>
               1. <ins>Throw a *RangeError* exception.</ins>
-            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _calendarOverride_).</ins>
+            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _x_.[[Calendar]]).</ins>
             1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
           1. <ins>If _x_ has an [[InitializedTemporalMonthDay]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainMonthDayPattern]].</ins>
             1. <ins>Let _calendar_ be ? CalendarToString(_x_.[[Calendar]]).</ins>
-            1. <ins>If _calendar_ is _dateTimeFormat_.[[Calendar]], then</ins>
-              1. <ins>Let _calendarOverride_ be _x_.[[Calendar]].</ins>
-            1. <ins>Else if _calendar_ is *"iso8601"*, then</ins>
-              1. <ins>Let _calendarOverride_ be ? GetBuiltinCalendar(_dateTimeFormat_.[[Calendar]]).</ins>
-            1. <ins>Else,</ins>
+            1. <ins>If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then</ins>
               1. <ins>Throw a *RangeError* exception.</ins>
-            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _calendarOverride_).</ins>
+            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _x_.[[Calendar]]).</ins>
             1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
           1. <ins>If _x_ has an [[InitializedTemporalTime]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainTimePattern]].</ins>
@@ -338,6 +330,9 @@
             1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
           1. <ins>If _x_ has an [[InitializedTemporalDateTime]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainDateTimePattern]].</ins>
+            1. <ins>Let _calendar_ be ? CalendarToString(_x_.[[Calendar]]).</ins>
+            1. <ins>If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then</ins>
+              1. <ins>Throw a *RangeError* exception.</ins>
             1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _x_, *"reject"*).</ins>
           1. <ins>If _x_ has an [[InitializedTemporalInstant]] internal slot, then</ins>
             1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalInstantPattern]].</ins>


### PR DESCRIPTION
Closes: #1221 