### PR TITLE
Add precision options to Duration.toString()

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -583,7 +583,21 @@ Object.assign({}, d).days; // => undefined
 Object.assign({}, d.getFields()).days; // => 3
 ```
 
-### duration.**toString**() : string
+### duration.**toString**(_options_?: object) : string
+
+**Parameters:**
+
+- `options` (optional object): An object with properties representing options for the operation.
+  The following options are recognized:
+  - `fractionalSecondDigits` (number or string): How many digits to print after the decimal point in the output string.
+    Valid values are `'auto'`, 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9.
+    The default is `'auto'`.
+  - `smallestUnit` (string): The smallest unit of time to include in the output string.
+    This option overrides `fractionalSecondDigits` if both are given.
+    Valid values are `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+  - `roundingMode` (string): How to handle the remainder.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    The default is `'trunc'`.
 
 **Returns:** the duration as an ISO 8601 string.
 
@@ -591,6 +605,12 @@ This method overrides `Object.prototype.toString()` and provides the ISO 8601 de
 
 > **NOTE**: If any of `duration.milliseconds`, `duration.microseconds`, or `duration.nanoseconds` are over 999, then deserializing from the result of `duration.toString()` will yield an equal but different object.
 > See [Duration balancing](./balancing.md#serialization) for more information.
+
+The output precision can be controlled with the `fractionalSecondDigits` or `smallestUnit` option.
+If no options are given, the default is `fractionalSecondDigits: 'auto'`, which omits trailing zeroes after the decimal point.
+
+The value is truncated to fit the requested precision, unless a different rounding mode is given with the `roundingMode` option, as in `Temporal.Duration.round()`.
+Note that rounding may change the value of other units as well.
 
 Usage examples:
 
@@ -608,6 +628,13 @@ nobal = Temporal.Duration.from({ milliseconds: 3500 });
 console.log(`${nobal}`, nobal.seconds, nobal.milliseconds); // => PT3.500S 0 3500
 bal = Temporal.Duration.from({ milliseconds: 3500 }, { overflow: 'balance' });
 console.log(`${bal}`, bal.seconds, bal.milliseconds); // => PT3.500S 3 500
+
+d = Temporal.Duration.from('PT59.999999999S');
+d.toString({ smallestUnit: 'seconds' });   // => PT59S
+d.toString({ fractionalSecondDigits: 0 }); // => PT59S
+d.toString({ fractionalSecondDigits: 4 }); // => PT59.9999S
+d.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' });
+// => PT60.00000000S
 ```
 
 ### duration.**toJSON**() : string

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -555,9 +555,12 @@ export class Duration {
     if (!fields) throw new TypeError('invalid receiver');
     return fields;
   }
-  toString() {
+  toString(options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    return ES.TemporalDurationToString(this);
+    options = ES.NormalizeOptionsObject(options);
+    const { precision, unit, increment } = ES.ToDurationSecondsStringPrecision(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
+    return ES.TemporalDurationToString(this, precision, { unit, increment, roundingMode });
   }
   toJSON() {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');

--- a/polyfill/test/Duration/prototype/toString/options-undefined.js
+++ b/polyfill/test/Duration/prototype/toString/options-undefined.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+---*/
+
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 650, 0);
+
+const explicit = duration.toString(undefined);
+assert.sameValue(explicit, "P1Y2M3W4DT5H6M7.98765S", "default precision is auto, and rounding is trunc");
+
+const implicit = duration.toString();
+assert.sameValue(implicit, "P1Y2M3W4DT5H6M7.98765S", "default precision is auto, and rounding is trunc");

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -133,21 +133,21 @@ describe('Duration', () => {
     it('Duration.from("P1D") == P1D', () => equal(`${Duration.from('P1D')}`, 'P1D'));
     it('lowercase variant', () => equal(`${Duration.from('p1y1m1dt1h1m1s')}`, 'P1Y1M1DT1H1M1S'));
     it('upto nine decimal places work', () => {
-      equal(`${Duration.from('P1Y1M1W1DT1H1M1.1S')}`, 'P1Y1M1W1DT1H1M1.100S');
-      equal(`${Duration.from('P1Y1M1W1DT1H1M1.12S')}`, 'P1Y1M1W1DT1H1M1.120S');
+      equal(`${Duration.from('P1Y1M1W1DT1H1M1.1S')}`, 'P1Y1M1W1DT1H1M1.1S');
+      equal(`${Duration.from('P1Y1M1W1DT1H1M1.12S')}`, 'P1Y1M1W1DT1H1M1.12S');
       equal(`${Duration.from('P1Y1M1W1DT1H1M1.123S')}`, 'P1Y1M1W1DT1H1M1.123S');
-      equal(`${Duration.from('P1Y1M1W1DT1H1M1.1234S')}`, 'P1Y1M1W1DT1H1M1.123400S');
-      equal(`${Duration.from('P1Y1M1W1DT1H1M1.12345S')}`, 'P1Y1M1W1DT1H1M1.123450S');
+      equal(`${Duration.from('P1Y1M1W1DT1H1M1.1234S')}`, 'P1Y1M1W1DT1H1M1.1234S');
+      equal(`${Duration.from('P1Y1M1W1DT1H1M1.12345S')}`, 'P1Y1M1W1DT1H1M1.12345S');
       equal(`${Duration.from('P1Y1M1W1DT1H1M1.123456S')}`, 'P1Y1M1W1DT1H1M1.123456S');
-      equal(`${Duration.from('P1Y1M1W1DT1H1M1.1234567S')}`, 'P1Y1M1W1DT1H1M1.123456700S');
-      equal(`${Duration.from('P1Y1M1W1DT1H1M1.12345678S')}`, 'P1Y1M1W1DT1H1M1.123456780S');
+      equal(`${Duration.from('P1Y1M1W1DT1H1M1.1234567S')}`, 'P1Y1M1W1DT1H1M1.1234567S');
+      equal(`${Duration.from('P1Y1M1W1DT1H1M1.12345678S')}`, 'P1Y1M1W1DT1H1M1.12345678S');
       equal(`${Duration.from('P1Y1M1W1DT1H1M1.123456789S')}`, 'P1Y1M1W1DT1H1M1.123456789S');
     });
     it('above nine decimal places throw', () => {
       throws(() => Duration.from('P1Y1M1W1DT1H1M1.123456789123S'), RangeError);
     });
     it('variant decimal separator', () => {
-      equal(`${Duration.from('P1Y1M1W1DT1H1M1,12S')}`, 'P1Y1M1W1DT1H1M1.120S');
+      equal(`${Duration.from('P1Y1M1W1DT1H1M1,12S')}`, 'P1Y1M1W1DT1H1M1.12S');
     });
     it('decimal places only allowed in time units', () => {
       [
@@ -224,21 +224,21 @@ describe('Duration', () => {
   });
   describe('toString()', () => {
     it('excessive sub-second units balance themselves when serializing', () => {
-      equal(`${Duration.from({ milliseconds: 3500 })}`, 'PT3.500S');
-      equal(`${Duration.from({ microseconds: 3500 })}`, 'PT0.003500S');
-      equal(`${Duration.from({ nanoseconds: 3500 })}`, 'PT0.000003500S');
+      equal(`${Duration.from({ milliseconds: 3500 })}`, 'PT3.5S');
+      equal(`${Duration.from({ microseconds: 3500 })}`, 'PT0.0035S');
+      equal(`${Duration.from({ nanoseconds: 3500 })}`, 'PT0.0000035S');
       equal(`${new Duration(0, 0, 0, 0, 0, 0, 0, 1111, 1111, 1111)}`, 'PT1.112112111S');
-      equal(`${Duration.from({ seconds: 120, milliseconds: 3500 })}`, 'PT123.500S');
+      equal(`${Duration.from({ seconds: 120, milliseconds: 3500 })}`, 'PT123.5S');
     });
     it('negative sub-second units are balanced correctly', () => {
-      equal(`${Duration.from({ milliseconds: -250 })}`, '-PT0.250S');
-      equal(`${Duration.from({ milliseconds: -3500 })}`, '-PT3.500S');
-      equal(`${Duration.from({ microseconds: -250 })}`, '-PT0.000250S');
-      equal(`${Duration.from({ microseconds: -3500 })}`, '-PT0.003500S');
-      equal(`${Duration.from({ nanoseconds: -250 })}`, '-PT0.000000250S');
-      equal(`${Duration.from({ nanoseconds: -3500 })}`, '-PT0.000003500S');
+      equal(`${Duration.from({ milliseconds: -250 })}`, '-PT0.25S');
+      equal(`${Duration.from({ milliseconds: -3500 })}`, '-PT3.5S');
+      equal(`${Duration.from({ microseconds: -250 })}`, '-PT0.00025S');
+      equal(`${Duration.from({ microseconds: -3500 })}`, '-PT0.0035S');
+      equal(`${Duration.from({ nanoseconds: -250 })}`, '-PT0.00000025S');
+      equal(`${Duration.from({ nanoseconds: -3500 })}`, '-PT0.0000035S');
       equal(`${new Duration(0, 0, 0, 0, 0, 0, 0, -1111, -1111, -1111)}`, '-PT1.112112111S');
-      equal(`${Duration.from({ seconds: -120, milliseconds: -3500 })}`, '-PT123.500S');
+      equal(`${Duration.from({ seconds: -120, milliseconds: -3500 })}`, '-PT123.5S');
     });
     it('emits a negative sign for a negative duration', () => {
       equal(`${Duration.from({ weeks: -1, days: -1 })}`, '-P1W1D');
@@ -253,6 +253,81 @@ describe('Duration', () => {
     it("serializing balance doesn't lose precision when values are precise", () => {
       const d = Duration.from({ milliseconds: Number.MAX_SAFE_INTEGER, microseconds: Number.MAX_SAFE_INTEGER });
       equal(`${d}`, 'PT9016206453995.731991S');
+    });
+    const d1 = new Duration(0, 0, 0, 0, 15, 23);
+    const d2 = new Duration(0, 0, 0, 0, 15, 23, 30);
+    const d3 = new Duration(0, 0, 0, 0, 15, 23, 30, 543, 200);
+    it('smallestUnits are aliases for fractional digits', () => {
+      equal(d3.toString({ smallestUnit: 'seconds' }), d3.toString({ fractionalSecondDigits: 0 }));
+      equal(d3.toString({ smallestUnit: 'milliseconds' }), d3.toString({ fractionalSecondDigits: 3 }));
+      equal(d3.toString({ smallestUnit: 'microseconds' }), d3.toString({ fractionalSecondDigits: 6 }));
+      equal(d3.toString({ smallestUnit: 'nanoseconds' }), d3.toString({ fractionalSecondDigits: 9 }));
+    });
+    it('throws on invalid or disallowed smallestUnit', () => {
+      ['eras', 'years', 'months', 'weeks', 'days', 'hours', 'minutes', 'nonsense'].forEach((smallestUnit) =>
+        throws(() => d1.toString({ smallestUnit }), RangeError)
+      );
+    });
+    it('accepts singular units', () => {
+      equal(d3.toString({ smallestUnit: 'second' }), d3.toString({ smallestUnit: 'seconds' }));
+      equal(d3.toString({ smallestUnit: 'millisecond' }), d3.toString({ smallestUnit: 'milliseconds' }));
+      equal(d3.toString({ smallestUnit: 'microsecond' }), d3.toString({ smallestUnit: 'microseconds' }));
+      equal(d3.toString({ smallestUnit: 'nanosecond' }), d3.toString({ smallestUnit: 'nanoseconds' }));
+    });
+    it('truncates or pads to 2 places', () => {
+      const options = { fractionalSecondDigits: 2 };
+      equal(d1.toString(options), 'PT15H23M0.00S');
+      equal(d2.toString(options), 'PT15H23M30.00S');
+      equal(d3.toString(options), 'PT15H23M30.54S');
+    });
+    it('pads to 7 places', () => {
+      const options = { fractionalSecondDigits: 7 };
+      equal(d1.toString(options), 'PT15H23M0.0000000S');
+      equal(d2.toString(options), 'PT15H23M30.0000000S');
+      equal(d3.toString(options), 'PT15H23M30.5432000S');
+    });
+    it('auto is the default', () => {
+      [d1, d2, d3].forEach((d) => equal(d.toString({ fractionalSecondDigits: 'auto' }), d.toString()));
+    });
+    it('throws on out of range or invalid fractionalSecondDigits', () => {
+      [-1, 10, Infinity, NaN, 'not-auto'].forEach((fractionalSecondDigits) =>
+        throws(() => d1.toString({ fractionalSecondDigits }), RangeError)
+      );
+    });
+    it('accepts and truncates fractional fractionalSecondDigits', () => {
+      equal(d3.toString({ fractionalSecondDigits: 5.5 }), 'PT15H23M30.54320S');
+    });
+    it('smallestUnit overrides fractionalSecondDigits', () => {
+      equal(d3.toString({ smallestUnit: 'seconds', fractionalSecondDigits: 9 }), 'PT15H23M30S');
+    });
+    it('throws on invalid roundingMode', () => {
+      throws(() => d1.toString({ roundingMode: 'cile' }), RangeError);
+    });
+    it('rounds to nearest', () => {
+      equal(d3.toString({ smallestUnit: 'seconds', roundingMode: 'nearest' }), 'PT15H23M31S');
+      equal(d3.toString({ fractionalSecondDigits: 3, roundingMode: 'nearest' }), 'PT15H23M30.543S');
+    });
+    it('rounds up', () => {
+      equal(d3.toString({ smallestUnit: 'seconds', roundingMode: 'ceil' }), 'PT15H23M31S');
+      equal(d3.toString({ fractionalSecondDigits: 3, roundingMode: 'ceil' }), 'PT15H23M30.544S');
+    });
+    it('rounds down', () => {
+      equal(d3.negated().toString({ smallestUnit: 'seconds', roundingMode: 'floor' }), '-PT15H23M31S');
+      equal(d3.negated().toString({ fractionalSecondDigits: 3, roundingMode: 'floor' }), '-PT15H23M30.544S');
+    });
+    it('truncates', () => {
+      equal(d3.toString({ smallestUnit: 'seconds', roundingMode: 'trunc' }), 'PT15H23M30S');
+      equal(d3.toString({ fractionalSecondDigits: 3, roundingMode: 'trunc' }), 'PT15H23M30.543S');
+    });
+    it('rounding can affect units up to seconds', () => {
+      const d4 = Duration.from('P1Y1M1W1DT23H59M59.999999999S');
+      equal(d4.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' }), 'P1Y1M1W1DT23H59M60.00000000S');
+    });
+    it('options may only be an object or undefined', () => {
+      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
+        throws(() => d1.toString(badOptions), TypeError)
+      );
+      [{}, () => {}, undefined].forEach((options) => equal(d1.toString(options), 'PT15H23M'));
     });
   });
   describe('toLocaleString()', () => {
@@ -1283,18 +1358,18 @@ describe('Duration', () => {
       equal(`${d.round({ smallestUnit: 'seconds', roundingIncrement: 15, relativeTo })}`, 'P5Y5M5W5DT5H5M');
     });
     it('rounds to an increment of milliseconds', () => {
-      equal(`${d.round({ smallestUnit: 'milliseconds', roundingIncrement: 10, relativeTo })}`, 'P5Y5M5W5DT5H5M5.010S');
+      equal(`${d.round({ smallestUnit: 'milliseconds', roundingIncrement: 10, relativeTo })}`, 'P5Y5M5W5DT5H5M5.01S');
     });
     it('rounds to an increment of microseconds', () => {
       equal(
         `${d.round({ smallestUnit: 'microseconds', roundingIncrement: 10, relativeTo })}`,
-        'P5Y5M5W5DT5H5M5.005010S'
+        'P5Y5M5W5DT5H5M5.00501S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
         `${d.round({ smallestUnit: 'nanoseconds', roundingIncrement: 10, relativeTo })}`,
-        'P5Y5M5W5DT5H5M5.005005010S'
+        'P5Y5M5W5DT5H5M5.00500501S'
       );
     });
     it('valid hour increments divide into 24', () => {

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -678,7 +678,7 @@ describe('Instant', () => {
       ['minutes', 'PT376435H24M', '-PT376435H23M'],
       ['seconds', 'PT376435H23M9S', '-PT376435H23M8S'],
       ['milliseconds', 'PT376435H23M8.149S', '-PT376435H23M8.148S'],
-      ['microseconds', 'PT376435H23M8.148530S', '-PT376435H23M8.148529S'],
+      ['microseconds', 'PT376435H23M8.14853S', '-PT376435H23M8.148529S'],
       ['nanoseconds', 'PT376435H23M8.148529313S', '-PT376435H23M8.148529313S']
     ];
     incrementOneCeil.forEach(([smallestUnit, expectedPositive, expectedNegative]) => {
@@ -693,7 +693,7 @@ describe('Instant', () => {
       ['minutes', 'PT376435H23M', '-PT376435H24M'],
       ['seconds', 'PT376435H23M8S', '-PT376435H23M9S'],
       ['milliseconds', 'PT376435H23M8.148S', '-PT376435H23M8.149S'],
-      ['microseconds', 'PT376435H23M8.148529S', '-PT376435H23M8.148530S'],
+      ['microseconds', 'PT376435H23M8.148529S', '-PT376435H23M8.14853S'],
       ['nanoseconds', 'PT376435H23M8.148529313S', '-PT376435H23M8.148529313S']
     ];
     incrementOneFloor.forEach(([smallestUnit, expectedPositive, expectedNegative]) => {
@@ -763,7 +763,7 @@ describe('Instant', () => {
           roundingIncrement: 10,
           roundingMode: 'nearest'
         })}`,
-        'PT376435H23M8.150S'
+        'PT376435H23M8.15S'
       );
     });
     it('rounds to an increment of microseconds', () => {
@@ -774,7 +774,7 @@ describe('Instant', () => {
           roundingIncrement: 10,
           roundingMode: 'nearest'
         })}`,
-        'PT376435H23M8.148530S'
+        'PT376435H23M8.14853S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
@@ -785,7 +785,7 @@ describe('Instant', () => {
           roundingIncrement: 10,
           roundingMode: 'nearest'
         })}`,
-        'PT376435H23M8.148529310S'
+        'PT376435H23M8.14852931S'
       );
     });
     it('valid hour increments divide into 24', () => {
@@ -997,7 +997,7 @@ describe('Instant', () => {
       ['minutes', 'PT440609H57M', '-PT440609H56M'],
       ['seconds', 'PT440609H56M4S', '-PT440609H56M3S'],
       ['milliseconds', 'PT440609H56M3.149S', '-PT440609H56M3.148S'],
-      ['microseconds', 'PT440609H56M3.148530S', '-PT440609H56M3.148529S'],
+      ['microseconds', 'PT440609H56M3.14853S', '-PT440609H56M3.148529S'],
       ['nanoseconds', 'PT440609H56M3.148529313S', '-PT440609H56M3.148529313S']
     ];
     incrementOneCeil.forEach(([smallestUnit, expectedPositive, expectedNegative]) => {
@@ -1012,7 +1012,7 @@ describe('Instant', () => {
       ['minutes', 'PT440609H56M', '-PT440609H57M'],
       ['seconds', 'PT440609H56M3S', '-PT440609H56M4S'],
       ['milliseconds', 'PT440609H56M3.148S', '-PT440609H56M3.149S'],
-      ['microseconds', 'PT440609H56M3.148529S', '-PT440609H56M3.148530S'],
+      ['microseconds', 'PT440609H56M3.148529S', '-PT440609H56M3.14853S'],
       ['nanoseconds', 'PT440609H56M3.148529313S', '-PT440609H56M3.148529313S']
     ];
     incrementOneFloor.forEach(([smallestUnit, expectedPositive, expectedNegative]) => {
@@ -1082,7 +1082,7 @@ describe('Instant', () => {
           roundingIncrement: 10,
           roundingMode: 'nearest'
         })}`,
-        'PT440609H56M3.150S'
+        'PT440609H56M3.15S'
       );
     });
     it('rounds to an increment of microseconds', () => {
@@ -1093,7 +1093,7 @@ describe('Instant', () => {
           roundingIncrement: 10,
           roundingMode: 'nearest'
         })}`,
-        'PT440609H56M3.148530S'
+        'PT440609H56M3.14853S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
@@ -1104,7 +1104,7 @@ describe('Instant', () => {
           roundingIncrement: 10,
           roundingMode: 'nearest'
         })}`,
-        'PT440609H56M3.148529310S'
+        'PT440609H56M3.14852931S'
       );
     });
     it('valid hour increments divide into 24', () => {

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -751,19 +751,19 @@ describe('DateTime', () => {
     it('rounds to an increment of milliseconds', () => {
       equal(
         `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'P973DT4H17M4.860S'
+        'P973DT4H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
         `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'P973DT4H17M4.864200S'
+        'P973DT4H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
         `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'P973DT4H17M4.864197530S'
+        'P973DT4H17M4.86419753S'
       );
     });
     it('valid hour increments divide into 24', () => {
@@ -1072,19 +1072,19 @@ describe('DateTime', () => {
     it('rounds to an increment of milliseconds', () => {
       equal(
         `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'P973DT4H17M4.860S'
+        'P973DT4H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
         `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'P973DT4H17M4.864200S'
+        'P973DT4H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
         `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'P973DT4H17M4.864197530S'
+        'P973DT4H17M4.86419753S'
       );
     });
     it('valid hour increments divide into 24', () => {

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -440,19 +440,19 @@ describe('Time', () => {
     it('rounds to an increment of milliseconds', () => {
       equal(
         `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT4H17M4.860S'
+        'PT4H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
         `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT4H17M4.864200S'
+        'PT4H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
         `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT4H17M4.864197530S'
+        'PT4H17M4.86419753S'
       );
     });
     it('valid hour increments divide into 24', () => {
@@ -708,19 +708,19 @@ describe('Time', () => {
     it('rounds to an increment of milliseconds', () => {
       equal(
         `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT4H17M4.860S'
+        'PT4H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
         `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT4H17M4.864200S'
+        'PT4H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
         `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT4H17M4.864197530S'
+        'PT4H17M4.86419753S'
       );
     });
     it('valid hour increments divide into 24', () => {

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -1404,19 +1404,19 @@ describe('ZonedDateTime', () => {
     it('rounds to an increment of milliseconds', () => {
       equal(
         `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT23356H17M4.860S'
+        'PT23356H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
         `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT23356H17M4.864200S'
+        'PT23356H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
         `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT23356H17M4.864197530S'
+        'PT23356H17M4.86419753S'
       );
     });
     it('valid hour increments divide into 24', () => {
@@ -1735,19 +1735,19 @@ describe('ZonedDateTime', () => {
     it('rounds to an increment of milliseconds', () => {
       equal(
         `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT23356H17M4.860S'
+        'PT23356H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
         `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT23356H17M4.864200S'
+        'PT23356H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
         `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
-        'PT23356H17M4.864197530S'
+        'PT23356H17M4.86419753S'
       );
     });
     it('valid hour increments divide into 24', () => {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -363,6 +363,79 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-todurationsecondsstringprecision" aoid="ToDurationSecondsStringPrecision">
+    <h1>ToDurationSecondsStringPrecision ( _normalizedOptions_ )</h1>
+    <p>
+      The abstract operation ToDurationSecondsStringPrecision combines the values of the options `smallestUnit` and `fractionalSecondDigits` to yield a precision for printing seconds to a string, and a rounding unit and increment.
+      The precision may be an integer 0 through 9 signifying a number of digits after the decimal point in the seconds, or the string *"auto"* signifying to drop trailing zeroes after the decimal point.
+    </p>
+    <p>
+      This operation differs from ToSecondsStringPrecision in that it is intended to be used with `Temporal.Duration`.
+      It returns plural unit strings and does not support minutes.
+    </p>
+    <emu-alg>
+      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* », *undefined*).
+      1. If the value of _smallestUnit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
+        1. Set _smallestUnit_ to the corresponding Plural value of the same row.
+      1. If _smallestUnit_ is *"seconds"*, then
+        1. Return the new Record {
+            [[Precision]]: 0,
+            [[Unit]]: *"seconds"*,
+            [[Increment]]: 1
+          }.
+      1. If _smallestUnit_ is *"milliseconds"*, then
+        1. Return the new Record {
+            [[Precision]]: 3,
+            [[Unit]]: *"milliseconds"*,
+            [[Increment]]: 1
+          }.
+      1. If _smallestUnit_ is *"microseconds"*, then
+        1. Return the new Record {
+            [[Precision]]: 6,
+            [[Unit]]: *"microseconds"*,
+            [[Increment]]: 1
+          }.
+      1. If _smallestUnit_ is *"nanoseconds"*, then
+        1. Return the new Record {
+            [[Precision]]: 9,
+            [[Unit]]: *"nanoseconds"*,
+            [[Increment]]: 1
+          }.
+      1. Assert: _smallestUnit_ is *undefined*.
+      1. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
+      1. If _digits_ is *"auto"*, then
+        1. Return the new Record {
+            [[Precision]]: *"auto"*,
+            [[Unit]]: *"nanoseconds"*,
+            [[Increment]]: 1
+          }.
+      1. If _digits_ is 0, then
+        1. Return the new Record {
+            [[Precision]]: 0,
+            [[Unit]]: *"seconds"*,
+            [[Increment]]: 1
+          }.
+      1. If _digits_ is 1, 2, or 3, then
+        1. Return the new Record {
+            [[Precision]]: _digits_,
+            [[Unit]]: *"milliseconds"*,
+            [[Increment]]: 10<sup>3 − _digits_</sup>
+          }.
+      1. If _digits_ is 4, 5, or 6, then
+        1. Return the new Record {
+            [[Precision]]: _digits_,
+            [[Unit]]: *"microseconds"*,
+            [[Increment]]: 10<sup>6 − _digits_</sup>
+          }.
+      1. Assert: _digits_ is 7, 8, or 9.
+      1. Return the new Record {
+          [[Precision]]: _digits_,
+          [[Unit]]: *"nanoseconds"*,
+          [[Increment]]: 10<sup>9 − _digits_</sup>
+        }.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-tolargesttemporalunit" aoid="ToLargestTemporalUnit">
     <h1>ToLargestTemporalUnit ( _normalizedOptions_, _disallowedUnits_, _defaultUnit_ )</h1>
     <emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -508,14 +508,19 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.duration.prototype.tostring">
-      <h1>Temporal.Duration.prototype.toString ( )</h1>
+      <h1>Temporal.Duration.prototype.toString ( [ _options_ ] )</h1>
       <p>
+        The `toString` method takes one argument _options_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return ! TemporalDurationToString(_duration_).
+        1. Set _options_ to ? NormalizeOptionsObject(_options_).
+        1. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
+        1. Let _result_ be ? RoundDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Return ! TemporalDurationToString(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _precision_.[[Precision]]).
       </emu-alg>
     </emu-clause>
 
@@ -527,7 +532,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return ! TemporalDurationToString(_duration_).
+        1. Return ! TemporalDurationToString(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"auto"*).
       </emu-alg>
     </emu-clause>
 
@@ -543,7 +548,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return ! TemporalDurationToString(_duration_).
+        1. Return ! TemporalDurationToString(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"auto"*).
       </emu-alg>
     </emu-clause>
 
@@ -1475,18 +1480,12 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-temporaldurationtostring" aoid="TemporalDurationToString">
-      <h1>TemporalDurationToString ( _duration_ )</h1>
+      <h1>TemporalDurationToString ( _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _precision_ )</h1>
       <emu-alg>
-        1. Let _years_ be _duration_.[[Years]].
-        1. Let _months_ be _duration_.[[Months]].
-        1. Let _weeks_ be _duration_.[[Weeks]].
-        1. Let _days_ be _duration_.[[Days]].
-        1. Let _hours_ _duration_.[[Hours]].
-        1. Let _minutes_ _duration_.[[Minutes]].
-        1. Let _seconds_ be the mathematical value of _duration_.[[Seconds]].
-        1. Let _milliseconds_ be the mathematical value of _duration_.[[Milliseconds]].
-        1. Let _microseconds_ be the mathematical value of _duration_.[[Microseconds]].
-        1. Let _nanoseconds_ be the mathematical value of _duration_.[[Nanoseconds]].
+        1. Set _seconds_ to the mathematical value of _seconds_.
+        1. Set _milliseconds_ to the mathematical value of _milliseconds_.
+        1. Set _microseconds_ to the mathematical value of _microseconds_.
+        1. Set _nanoseconds_ to the mathematical value of _nanoseconds_.
         1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Set _microseconds_ to _microseconds_ + the integral part of _nanoseconds_ / 1000.
         1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
@@ -1511,17 +1510,19 @@
         1. If _minutes_ is not 0, then
           1. Set _timePart_ to the string concatenation of _timePart_, abs(_minutes_) formatted as a decimal number, and the code unit 0x004D (LATIN CAPITAL LETTER M).
         1. If any of _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are not 0, then
-          1. Let _nanosecondsPart_, _microsecondsPart_, and _millisecondsPart_ be *""*.
-          1. If _nanoseconds_ is not 0, then
-            1. Set _nanosecondsPart_ to _nanoseconds_ formatted as a three-digit decimal number, padded to the left with zeroes if necessary.
-            1. Set _microsecondsPart_ and _millisecondsPart_ to *"000"*.
-          1. If _microseconds_ is not 0, then
-            1. Set _microsecondsPart_ be _microseconds_ formatted as a three-digit decimal number, padded to the left with zeroes if necessary.
-            1. Set _millisecondsPart_ to *"000"*.
-          1. If _milliseconds_ is not 0, then
-            1. Set _millisecondsPart_ to _milliseconds_ formatted as a three-digit decimal number, padded to the left with zeroes if necessary.
-          1. Let _decimalPart_ be the string-concatenation of _millisecondsPart_, _microsecondsPart_, and _nanosecondsPart_.
-          1. Let _secondsPart_ be _seconds_ formatted as a decimal number.
+          1. Let _fraction_ be abs(_milliseconds_) × 10<sup>6</sup> + abs(_microseconds_) × 10<sup>3</sup> + abs(_nanoseconds_).
+          1. Let _decimalPart_ be *""*.
+          1. If _precision_ is *"auto"*, then
+            1. If _fraction_ ≠ 0, then
+              1. Let _decimalPart_ be _fraction_ formatted as a nine-digit decimal number, padded to the left with zeroes if necessary.
+              1. Set _fractionString_ to the longest possible substring of _decimalPart_ starting at position 0 and not ending with the code unit 0x0030 (DIGIT ZERO).
+          1. Else if _precision_ ≠ 0, then
+            1. Let _decimalPart_ be _fraction_ formatted as a decimal number.
+            1. Let _len_ be the length of _fractionString_.
+            1. If _len_ &gt; _precision_, then
+              1. Set _decimalPart_ to the substring of _decimalPart_ from 0 to min(_len_, _precision_).
+            1. Pad _decimalPart_ to the left with zeroes up to the length _precision_, if necessary.
+          1. Let _secondsPart_ be abs(_seconds_) formatted as a decimal number.
           1. If _decimalPart_ is not *""*, then
             1. Set _secondsPart_ to the string-concatenation of _secondsPart_, the code unit 0x002E (FULL STOP), and _decimalPart_.
           1. Set _timePart_ to the string concatenation of _timePart_, _secondsPart_, and the code unit 0x0053 (LATIN CAPITAL LETTER S).


### PR DESCRIPTION
I overlooked Duration in #329. This adds the same options except that the
values for smallestUnit are preferred to be plural, and 'minutes' is not
allowed.

Closes: #1257