### PR TITLE
Document calendar comparison in compare() and equals()

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -124,10 +124,13 @@ Compares two `Temporal.PlainDate` objects.
 Returns an integer indicating whether `one` comes before or after or is equal to `two`.
 
 - &minus;1 if `one` comes before `two`;
-- 0 if `one` and `two` are the same;
+- 0 if `one` and `two` are the same date and their `calendar` properties are also the same;
 - 1 if `one` comes after `two`.
 
 If `one` or `two` are not `Temporal.PlainDate` objects, then they will be converted to one as if they were passed to `Temporal.PlainDate.from()`.
+
+Note that this function will not return 0 if the two objects have different `calendar` properties, even if the actual dates are equal.
+If the dates are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
 
 This function can be used to sort arrays of `Temporal.PlainDate` objects.
 For example:
@@ -540,7 +543,7 @@ This function exists because it's not possible to compare using `date == other` 
 
 If you don't need to know the order in which the two dates occur, then this function may be less typing and more efficient than `Temporal.PlainDate.compare`.
 
-Note that this function will return `true` if the two dates are equal, even if they are expressed in different calendar systems.
+Note that this function will return `false` if the two objects have different `calendar` properties, even if the actual dates are equal.
 
 If `other` is not a `Temporal.PlainDate` object, then it will be converted to one as if it were passed to `Temporal.PlainDate.from()`.
 

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -170,10 +170,13 @@ Compares two `Temporal.PlainDateTime` objects.
 Returns an integer indicating whether `one` comes before or after or is equal to `two`.
 
 - &minus;1 if `one` comes before `two`;
-- 0 if `one` and `two` are the same;
+- 0 if `one` and `two` are the same date and their `calendar` properties are also the same;
 - 1 if `one` comes after `two`.
 
 If `one` and `two` are not `Temporal.PlainDateTime` objects, then they will be converted to one as if they were passed to `Temporal.PlainDateTime.from()`.
+
+Note that this function will not return 0 if the two objects have different `calendar` properties, even if the actual dates and times are equal.
+If the dates and times are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
 
 This function can be used to sort arrays of `Temporal.PlainDateTime` objects.
 For example:
@@ -746,7 +749,7 @@ This function exists because it's not possible to compare using `datetime == oth
 
 If you don't need to know the order in which the two dates/times occur, then this function may be less typing and more efficient than `Temporal.PlainDateTime.compare`.
 
-Note that this function will return `true` if the two date/times are equal, even if they are expressed in different calendar systems.
+Note that this function will return `false` if the two objects have different `calendar` properties, even if the actual dates and times are equal.
 
 If `other` is not a `Temporal.PlainDateTime` object, then it will be converted to one as if it were passed to `Temporal.PlainDateTime.from()`.
 

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -121,10 +121,13 @@ Compares two `Temporal.PlainYearMonth` objects.
 Returns an integer indicating whether `one` comes before or after or is equal to `two`.
 
 - &minus;1 if `one` comes before `two`;
-- 0 if `one` and `two` are the same;
+- 0 if `one` and `two` are the same month and their `calendar` properties are also the same;
 - 1 if `one` comes after `two`.
 
 If `one` and `two` are not `Temporal.PlainYearMonth` objects, then they will be converted to one as if they were passed to `Temporal.PlainYearMonth.from()`.
+
+Note that this function will not return 0 if the two objects have different `calendar` properties, even if the actual years and months are equal.
+If the months are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
 
 This function can be used to sort arrays of `Temporal.PlainYearMonth` objects.
 For example:
@@ -443,9 +446,9 @@ This function exists because it's not possible to compare using `yearMonth == ot
 
 If `other` is not a `Temporal.PlainYearMonth` object, then it will be converted to one as if it were passed to `Temporal.PlainYearMonth.from()`.
 
-Note that equality of two months from different calendar systems only makes sense in a few cases, such as when the two calendar systems both use the Gregorian year.
+Note that this function will return `false` if the two objects have different `calendar` properties, even if the actual years and months are equal.
 
-Even if you are using the same calendar system, if you don't need to know the order in which the two months occur, then this function may be less typing and more efficient than `Temporal.PlainYearMonth.compare`.
+If you don't need to know the order in which the two months occur, then this function may be less typing and more efficient than `Temporal.PlainYearMonth.compare`.
 
 Example usage:
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -228,6 +228,7 @@ This function can be used to sort arrays of `Temporal.ZonedDateTime` objects.
 Comparison will use exact time, not clock time, because sorting is almost always based on when events happened in the real world.
 Note that during the hour before and after DST ends, sorting of clock time may not match the order the events actually occurred.
 
+Note that this function will not return 0 if the two objects have different `calendar` or `timeZone` properties, even if the exact timestamps are equal.
 If exact timestamps are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
 If those are equal too, then `.timeZone.id` will be compared lexicographically.
 


### PR DESCRIPTION
The documentation was not clear on this, and in the case of equals() was
actually wrong. A true result from equals() implies a zero result from
compare().

Closes: #1199