### PR TITLE
Allow calendars to validate fields and coerce types

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -310,16 +310,44 @@ impl['gregory'] = ObjectAssign({}, impl['iso8601'], {
   },
 
   dateFromFields(fields, overflow) {
+    const result = {};
     // Intentionally alphabetical
-    fields = ES.ToRecord(fields, [['day'], ['era', 'ad'], ['month'], ['year']]);
-    const isoYear = gre.isoYear(fields.year, fields.era);
-    return impl['iso8601'].dateFromFields({ ...fields, year: isoYear }, overflow);
+    for (const [name, defaultValue] of [['day'], ['era', 'ad'], ['month'], ['year']]) {
+      let value = fields[name];
+      if (value === undefined) {
+        if (defaultValue === undefined) {
+          throw new TypeError(`required property '${name}' missing or undefined`);
+        } else {
+          value = defaultValue;
+        }
+      }
+      if (name != 'era') {
+        value = ES.ToInteger(value);
+      }
+      result[name] = value;
+    }
+    const isoYear = gre.isoYear(result.year, result.era);
+    return impl['iso8601'].dateFromFields({ ...result, year: isoYear }, overflow);
   },
   yearMonthFromFields(fields, overflow) {
+    const result = {};
     // Intentionally alphabetical
-    fields = ES.ToRecord(fields, [['era', 'ad'], ['month'], ['year']]);
-    const isoYear = gre.isoYear(fields.year, fields.era);
-    return impl['iso8601'].yearMonthFromFields({ ...fields, year: isoYear }, overflow);
+    for (const [name, defaultValue] of [['era', 'ad'], ['month'], ['year']]) {
+      let value = fields[name];
+      if (value === undefined) {
+        if (defaultValue === undefined) {
+          throw new TypeError(`required property '${name}' missing or undefined`);
+        } else {
+          value = defaultValue;
+        }
+      }
+      if (name != 'era') {
+        value = ES.ToInteger(value);
+      }
+      result[name] = value;
+    }
+    const isoYear = gre.isoYear(result.year, result.era);
+    return impl['iso8601'].yearMonthFromFields({ ...result, year: isoYear }, overflow);
   }
 });
 
@@ -407,15 +435,35 @@ impl['japanese'] = ObjectAssign({}, impl['iso8601'], {
 
   dateFromFields(fields, overflow) {
     // Intentionally alphabetical
-    fields = ES.ToRecord(fields, [['day'], ['era'], ['month'], ['year']]);
-    const isoYear = jpn.isoYear(fields.year, fields.era);
-    return impl['iso8601'].dateFromFields({ ...fields, year: isoYear }, overflow);
+    const result = {};
+    for (const name of ['day', 'era', 'month', 'year']) {
+      let value = fields[name];
+      if (value === undefined) {
+        throw new TypeError(`required property '${name}' missing or undefined`);
+      }
+      if (name != 'era') {
+        value = ES.ToInteger(value);
+      }
+      result[name] = value;
+    }
+    const isoYear = jpn.isoYear(result.year, result.era);
+    return impl['iso8601'].dateFromFields({ ...result, year: isoYear }, overflow);
   },
   yearMonthFromFields(fields, overflow) {
+    const result = {};
     // Intentionally alphabetical
-    fields = ES.ToRecord(fields, [['era'], ['month'], ['year']]);
-    const isoYear = jpn.isoYear(fields.year, fields.era);
-    return impl['iso8601'].yearMonthFromFields({ ...fields, year: isoYear }, overflow);
+    for (const name of ['era', 'month', 'year']) {
+      let value = fields[name];
+      if (value === undefined) {
+        throw new TypeError(`required property '${name}' missing or undefined`);
+      }
+      if (name != 'era') {
+        value = ES.ToInteger(value);
+      }
+      result[name] = value;
+    }
+    const isoYear = jpn.isoYear(result.year, result.era);
+    return impl['iso8601'].yearMonthFromFields({ ...result, year: isoYear }, overflow);
   }
 });
 

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -171,22 +171,39 @@ DefineIntrinsic('Temporal.Calendar.prototype.toString', Calendar.prototype.toStr
 
 impl['iso8601'] = {
   dateFromFields(fields, overflow) {
-    let { year, month, day } = ES.ToTemporalDateFields(fields, []);
-    year = ES.ToInteger(year);
-    month = ES.ToInteger(month);
-    day = ES.ToInteger(day);
+    const result = {};
+    for (const name of ['day', 'month', 'year']) {
+      let value = fields[name];
+      if (value === undefined) {
+        throw new TypeError(`required property '${name}' missing or undefined`);
+      }
+      result[name] = ES.ToInteger(value);
+    }
+    const { day, month, year } = result;
     return ES.RegulateDate(year, month, day, overflow);
   },
   yearMonthFromFields(fields, overflow) {
-    let { year, month } = ES.ToTemporalYearMonthFields(fields, []);
-    year = ES.ToInteger(year);
-    month = ES.ToInteger(month);
+    const result = {};
+    for (const name of ['month', 'year']) {
+      let value = fields[name];
+      if (value === undefined) {
+        throw new TypeError(`required property '${name}' missing or undefined`);
+      }
+      result[name] = ES.ToInteger(value);
+    }
+    const { month, year } = result;
     return ES.RegulateYearMonth(year, month, overflow);
   },
   monthDayFromFields(fields, overflow) {
-    let { month, day } = ES.ToTemporalMonthDayFields(fields, []);
-    month = ES.ToInteger(month);
-    day = ES.ToInteger(day);
+    const result = {};
+    for (const name of ['day', 'month']) {
+      let value = fields[name];
+      if (value === undefined) {
+        throw new TypeError(`required property '${name}' missing or undefined`);
+      }
+      result[name] = ES.ToInteger(value);
+    }
+    const { day, month } = result;
     return ES.RegulateMonthDay(month, day, overflow);
   },
   fields(fields) {

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -171,15 +171,22 @@ DefineIntrinsic('Temporal.Calendar.prototype.toString', Calendar.prototype.toStr
 
 impl['iso8601'] = {
   dateFromFields(fields, overflow) {
-    const { year, month, day } = ES.ToRecord(fields, [['day'], ['month'], ['year']]);
+    let { year, month, day } = ES.ToTemporalDateFields(fields, []);
+    year = ES.ToInteger(year);
+    month = ES.ToInteger(month);
+    day = ES.ToInteger(day);
     return ES.RegulateDate(year, month, day, overflow);
   },
   yearMonthFromFields(fields, overflow) {
-    const { year, month } = ES.ToRecord(fields, [['month'], ['year']]);
+    let { year, month } = ES.ToTemporalYearMonthFields(fields, []);
+    year = ES.ToInteger(year);
+    month = ES.ToInteger(month);
     return ES.RegulateYearMonth(year, month, overflow);
   },
   monthDayFromFields(fields, overflow) {
-    const { month, day } = ES.ToRecord(fields, [['day'], ['month']]);
+    let { month, day } = ES.ToTemporalMonthDayFields(fields, []);
+    month = ES.ToInteger(month);
+    day = ES.ToInteger(day);
     return ES.RegulateMonthDay(month, day, overflow);
   },
   fields(fields) {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -90,6 +90,8 @@ const BUILTIN_FIELDS = new Set([
   'nanoseconds'
 ]);
 
+const FREEFORM_FIELDS = new Set(['year', 'month', 'day']);
+
 import * as PARSE from './regex.mjs';
 
 const ES2020 = {
@@ -830,8 +832,6 @@ export const ES = ObjectAssign({}, ES2020, {
       calendar = relativeTo.calendar;
       if (calendar === undefined) calendar = ES.GetISO8601Calendar();
       calendar = ES.ToTemporalCalendar(calendar);
-      const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'year']);
-      const fields = ES.ToTemporalDateTimeFields(relativeTo, fieldNames);
       ({
         year,
         month,
@@ -842,7 +842,7 @@ export const ES = ObjectAssign({}, ES2020, {
         millisecond,
         microsecond,
         nanosecond
-      } = ES.InterpretTemporalDateTimeFields(calendar, fields, 'constrain'));
+      } = ES.InterpretTemporalDateTimeFields(calendar, relativeTo, 'constrain'));
       offset = relativeTo.offset;
       timeZone = relativeTo.timeZone;
     } else {
@@ -967,7 +967,7 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     return any ? any : false;
   },
-  ToRecord: (bag, fields) => {
+  ToRecord: (bag, fields, someRequired = true) => {
     if (ES.Type(bag) !== 'Object') return false;
     const result = {};
     let any = false;
@@ -982,13 +982,13 @@ export const ES = ObjectAssign({}, ES2020, {
       } else {
         any = true;
       }
-      if (BUILTIN_FIELDS.has(property)) {
+      if (BUILTIN_FIELDS.has(property) && !FREEFORM_FIELDS.has(property)) {
         result[property] = ES.ToInteger(value);
       } else {
         result[property] = value;
       }
     }
-    if (!any) {
+    if (!any && someRequired) {
       throw new TypeError('no supported properties found');
     }
     return result;
@@ -1034,15 +1034,19 @@ export const ES = ObjectAssign({}, ES2020, {
     });
     return ES.ToRecord(bag, entries);
   },
-  ToTemporalTimeRecord: (bag) => {
-    return ES.ToRecord(bag, [
-      ['hour', 0],
-      ['microsecond', 0],
-      ['millisecond', 0],
-      ['minute', 0],
-      ['nanosecond', 0],
-      ['second', 0]
-    ]);
+  ToTemporalTimeRecord: (bag, someRequired = true) => {
+    return ES.ToRecord(
+      bag,
+      [
+        ['hour', 0],
+        ['microsecond', 0],
+        ['millisecond', 0],
+        ['minute', 0],
+        ['nanosecond', 0],
+        ['second', 0]
+      ],
+      someRequired
+    );
   },
   ToTemporalYearMonthFields: (bag, fieldNames) => {
     const entries = [['month'], ['year']];
@@ -1083,9 +1087,7 @@ export const ES = ObjectAssign({}, ES2020, {
       let calendar = item.calendar;
       if (calendar === undefined) calendar = ES.GetISO8601Calendar();
       calendar = ES.ToTemporalCalendar(calendar);
-      const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'year']);
-      const fields = ES.ToTemporalDateFields(item, fieldNames);
-      return ES.DateFromFields(calendar, fields, constructor, overflow);
+      return ES.DateFromFields(calendar, item, constructor, overflow);
     }
     let { year, month, day, calendar } = ES.ParseTemporalDateString(ES.ToString(item));
     ES.RejectDate(year, month, day);
@@ -1101,7 +1103,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const year = GetSlot(date, ISO_YEAR);
     const month = GetSlot(date, ISO_MONTH);
     const day = GetSlot(date, ISO_DAY);
-    let { hour, minute, second, millisecond, microsecond, nanosecond } = ES.ToTemporalTimeRecord(fields);
+    let { hour, minute, second, millisecond, microsecond, nanosecond } = ES.ToTemporalTimeRecord(fields, false);
     ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateTime(
       hour,
       minute,
@@ -1122,8 +1124,6 @@ export const ES = ObjectAssign({}, ES2020, {
       if (calendar === undefined) calendar = ES.GetISO8601Calendar();
       calendar = ES.ToTemporalCalendar(calendar);
 
-      const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'year']);
-      const fields = ES.ToTemporalDateTimeFields(item, fieldNames);
       ({
         year,
         month,
@@ -1134,7 +1134,7 @@ export const ES = ObjectAssign({}, ES2020, {
         millisecond,
         microsecond,
         nanosecond
-      } = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow));
+      } = ES.InterpretTemporalDateTimeFields(calendar, item, overflow));
     } else {
       ({
         year,
@@ -1225,9 +1225,7 @@ export const ES = ObjectAssign({}, ES2020, {
       let calendar = item.calendar;
       if (calendar === undefined) calendar = ES.GetISO8601Calendar();
       calendar = ES.ToTemporalCalendar(calendar);
-      const fieldNames = ES.CalendarFields(calendar, ['day', 'month']);
-      const fields = ES.ToTemporalMonthDayFields(item, fieldNames);
-      return ES.MonthDayFromFields(calendar, fields, constructor, overflow);
+      return ES.MonthDayFromFields(calendar, item, constructor, overflow);
     }
 
     let { month, day, referenceISOYear = 1972, calendar } = ES.ParseTemporalMonthDayString(ES.ToString(item));
@@ -1279,9 +1277,7 @@ export const ES = ObjectAssign({}, ES2020, {
       let calendar = item.calendar;
       if (calendar === undefined) calendar = ES.GetISO8601Calendar();
       calendar = ES.ToTemporalCalendar(calendar);
-      const fieldNames = ES.CalendarFields(calendar, ['month', 'year']);
-      const fields = ES.ToTemporalYearMonthFields(item, fieldNames);
-      return ES.YearMonthFromFields(calendar, fields, constructor, overflow);
+      return ES.YearMonthFromFields(calendar, item, constructor, overflow);
     }
 
     let { year, month, referenceISODay = 1, calendar } = ES.ParseTemporalYearMonthString(ES.ToString(item));
@@ -1368,8 +1364,6 @@ export const ES = ObjectAssign({}, ES2020, {
       calendar = item.calendar;
       if (calendar === undefined) calendar = ES.GetISO8601Calendar();
       calendar = ES.ToTemporalCalendar(calendar);
-      const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'year']);
-      const fields = ES.ToTemporalZonedDateTimeFields(item, fieldNames);
       ({
         year,
         month,
@@ -1380,9 +1374,13 @@ export const ES = ObjectAssign({}, ES2020, {
         millisecond,
         microsecond,
         nanosecond
-      } = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow));
-      timeZone = ES.ToTemporalTimeZone(fields.timeZone);
-      offset = fields.offset;
+      } = ES.InterpretTemporalDateTimeFields(calendar, item, overflow));
+      timeZone = item['timeZone'];
+      if (timeZone === undefined) {
+        throw new TypeError('required property timeZone missing or undefined');
+      }
+      timeZone = ES.ToTemporalTimeZone(timeZone);
+      offset = item.offset;
       if (offset !== undefined) offset = ES.ToString(offset);
     } else {
       let ianaName;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -90,7 +90,7 @@ const BUILTIN_FIELDS = new Set([
   'nanoseconds'
 ]);
 
-const FREEFORM_FIELDS = new Set(['year', 'month', 'day']);
+const CALENDAR_FIELDS = new Set(['year', 'month', 'day']);
 
 import * as PARSE from './regex.mjs';
 
@@ -982,7 +982,7 @@ export const ES = ObjectAssign({}, ES2020, {
       } else {
         any = true;
       }
-      if (BUILTIN_FIELDS.has(property) && !FREEFORM_FIELDS.has(property)) {
+      if (BUILTIN_FIELDS.has(property) && !CALENDAR_FIELDS.has(property)) {
         result[property] = ES.ToInteger(value);
       } else {
         result[property] = value;

--- a/polyfill/test/PlainDate/prototype/getFields/order-of-operations.js
+++ b/polyfill/test/PlainDate/prototype/getFields/order-of-operations.js
@@ -9,11 +9,8 @@ features: [Reflect]
 
 const expected = [
   "get day",
-  "valueOf day",
   "get month",
-  "valueOf month",
   "get year",
-  "valueOf year"
 ];
 const actual = [];
 
@@ -41,7 +38,7 @@ Object.defineProperties(ObservedDate.prototype, {
 const instance = new ObservedDate(2000, 5, 2);
 
 const result = instance.getFields();
-assert.sameValue(result.year, 2000, "year result");
-assert.sameValue(result.month, 5, "month result");
-assert.sameValue(result.day, 2, "day result");
 assert.compareArray(actual, expected, "order of operations");
+assert.sameValue(result.year.valueOf(), 2000, "year result");
+assert.sameValue(result.month.valueOf(), 5, "month result");
+assert.sameValue(result.day.valueOf(), 2, "day result");

--- a/polyfill/test/PlainDateTime/constructor/from/order-of-operations.js
+++ b/polyfill/test/PlainDateTime/constructor/from/order-of-operations.js
@@ -10,6 +10,10 @@ const expected = [
   "get calendar",
   "get day",
   "valueOf day",
+  "get month",
+  "valueOf month",
+  "get year",
+  "valueOf year",
   "get hour",
   "valueOf hour",
   "get microsecond",
@@ -18,14 +22,10 @@ const expected = [
   "valueOf millisecond",
   "get minute",
   "valueOf minute",
-  "get month",
-  "valueOf month",
   "get nanosecond",
   "valueOf nanosecond",
   "get second",
-  "valueOf second",
-  "get year",
-  "valueOf year",
+  "valueOf second"
 ];
 const actual = [];
 const fields = {

--- a/polyfill/test/PlainDateTime/prototype/getFields/order-of-operations.js
+++ b/polyfill/test/PlainDateTime/prototype/getFields/order-of-operations.js
@@ -9,7 +9,6 @@ features: [Reflect]
 
 const expected = [
   "get day",
-  "valueOf day",
   "get hour",
   "valueOf hour",
   "get microsecond",
@@ -19,13 +18,11 @@ const expected = [
   "get minute",
   "valueOf minute",
   "get month",
-  "valueOf month",
   "get nanosecond",
   "valueOf nanosecond",
   "get second",
   "valueOf second",
-  "get year",
-  "valueOf year"
+  "get year"
 ];
 const actual = [];
 
@@ -59,13 +56,13 @@ Object.defineProperties(ObservedDateTime.prototype, {
 const instance = new ObservedDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
 
 const result = instance.getFields();
-assert.sameValue(result.year, 2000, "year result");
-assert.sameValue(result.month, 5, "month result");
-assert.sameValue(result.day, 2, "day result");
+assert.compareArray(actual, expected, "order of operations");
+assert.sameValue(result.year.valueOf(), 2000, "year result");
+assert.sameValue(result.month.valueOf(), 5, "month result");
+assert.sameValue(result.day.valueOf(), 2, "day result");
 assert.sameValue(result.hour, 12, "hour result");
 assert.sameValue(result.minute, 34, "minute result");
 assert.sameValue(result.second, 56, "second result");
 assert.sameValue(result.millisecond, 987, "millisecond result");
 assert.sameValue(result.microsecond, 654, "microsecond result");
 assert.sameValue(result.nanosecond, 321, "nanosecond result");
-assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/PlainMonthDay/prototype/getFields/order-of-operations.js
+++ b/polyfill/test/PlainMonthDay/prototype/getFields/order-of-operations.js
@@ -9,9 +9,7 @@ features: [Reflect]
 
 const expected = [
   "get day",
-  "valueOf day",
   "get month",
-  "valueOf month"
 ];
 const actual = [];
 
@@ -38,6 +36,6 @@ Object.defineProperties(ObservedMonthDay.prototype, {
 const instance = new ObservedMonthDay(5, 2);
 
 const result = instance.getFields();
-assert.sameValue(result.month, 5, "month result");
-assert.sameValue(result.day, 2, "day result");
 assert.compareArray(actual, expected, "order of operations");
+assert.sameValue(result.month.valueOf(), 5, "month result");
+assert.sameValue(result.day.valueOf(), 2, "day result");

--- a/polyfill/test/PlainYearMonth/prototype/getFields/order-of-operations.js
+++ b/polyfill/test/PlainYearMonth/prototype/getFields/order-of-operations.js
@@ -9,9 +9,7 @@ features: [Reflect]
 
 const expected = [
   "get month",
-  "valueOf month",
-  "get year",
-  "valueOf year",
+  "get year"
 ];
 const actual = [];
 
@@ -38,6 +36,6 @@ Object.defineProperties(ObservedYearMonth.prototype, {
 const instance = new ObservedYearMonth(2000, 5);
 
 const result = instance.getFields();
-assert.sameValue(result.year, 2000, "year result");
-assert.sameValue(result.month, 5, "month result");
 assert.compareArray(actual, expected, "order of operations");
+assert.sameValue(result.year.valueOf(), 2000, "year result");
+assert.sameValue(result.month.valueOf(), 5, "month result");

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -564,6 +564,72 @@ describe('Userland calendar', () => {
       delete Temporal.PlainMonthDay.prototype.season;
     });
   });
+  describe('calendar with non-integer support for builtin field', () => {
+    // Contrived example of a calendar identical to the ISO calendar except that
+    // months are referenced by name.
+    const monthNames = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December'
+    ];
+
+    class NamedMonthsCalendar extends Temporal.Calendar {
+      constructor() {
+        super('iso8601');
+      }
+      toString() {
+        return 'months';
+      }
+      getMonthName(isoMonth) {
+        return monthNames[isoMonth - 1];
+      }
+      getIsoMonth(month) {
+        return monthNames.findIndex((element) => element == month) + 1;
+      }
+      month(date) {
+        const { isoMonth } = date.getISOFields();
+        return this.getMonthName(isoMonth);
+      }
+      dateFromFields(fields, options, constructor) {
+        return super.dateFromFields({ ...fields, month: this.getIsoMonth(fields.month) }, options, constructor);
+      }
+      yearMonthFromFields(fields, options, constructor) {
+        return super.yearMonthFromFields({ ...fields, month: this.getIsoMonth(fields.month) }, options, constructor);
+      }
+      monthDayFromFields(fields, options, constructor) {
+        return super.monthDayFromFields({ ...fields, month: this.getIsoMonth(fields.month) }, options, constructor);
+      }
+    }
+    const calendar = new NamedMonthsCalendar();
+    const datetime = new Temporal.PlainDateTime(2019, 9, 15, 0, 0, 0, 0, 0, 0, calendar);
+    const date = new Temporal.PlainDate(2019, 9, 15, calendar);
+    const yearmonth = new Temporal.PlainYearMonth(2019, 9, calendar);
+    const monthday = new Temporal.PlainMonthDay(9, 15, calendar);
+    it('property getter works', () => {
+      equal(datetime.month, 'September');
+      equal(date.month, 'September');
+      equal(yearmonth.month, 'September');
+      equal(monthday.month, 'September');
+    });
+    it('accepts a string month in from()', () => {
+      equal(
+        `${Temporal.PlainDateTime.from({ year: 2019, month: 'March', day: 15, calendar })}`,
+        '2019-03-15T00:00:00[c=months]'
+      );
+      equal(`${Temporal.PlainDate.from({ year: 2019, month: 'March', day: 15, calendar })}`, '2019-03-15[c=months]');
+      equal(`${Temporal.PlainYearMonth.from({ year: 2019, month: 'September', calendar })}`, '2019-09-01[c=months]');
+      equal(`${Temporal.PlainMonthDay.from({ month: 'September', day: 15, calendar })}`, '1972-09-15[c=months]');
+    });
+  });
 });
 
 import { normalize } from 'path';

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -569,21 +569,7 @@
         1. If _value_ has either an [[InitializedTemporalDateTime]] or [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Return _value_.
         1. Let _calendar_ be ? GetOptionalTemporalCalendar(_value_).
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"year"* »).
-        1. Let _fields_ be ? ToTemporalDateTimeFields(_value_, _fieldNames_).
-        1. Let _temporalDate_ be ? DateFromFields(_calendar_, _fields_, %Temporal.PlainDate%).
-        1. Let _timeResult_ be ? ToTemporalTimeRecord(_fields_).
-        1. Let _result_ be the new Record {
-            [[Year]]: _temporalDate_.[[ISOYear]],
-            [[Month]]: _temporalDate_.[[ISOMonth]],
-            [[Day]]: _temporalDate_.[[ISODay]],
-            [[Hour]]: _timeResult_.[[Hour]],
-            [[Minute]]: _timeResult_.[[Minute]],
-            [[Second]]: _timeResult_.[[Second]],
-            [[Millisecond]]: _timeResult_.[[Millisecond]],
-            [[Microsecond]]: _timeResult_.[[Microsecond]],
-            [[Nanosecond]]: _timeResult_.[[Nanosecond]]
-          }.
+        1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _value_, *"constrain"*).
         1. Let _offset_ be ? Get(_value_, *"offset"*).
         1. Let _timeZone_ be ? Get(_value_, *"timeZone"*).
       1. Else,

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -319,8 +319,11 @@
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Set _fields_ to ? ToTemporalDateFields(_fields_, « *"day"*, *"month"*, *"year"* »).
         1. Let _year_ be ? Get(_fields_, *"year"*).
+        1. Set _year_ to ? ToIntegerOrInfinity(_year_).
         1. Let _month_ be ? Get(_fields_, *"month"*).
+        1. Set _month_ to ? ToIntegerOrInfinity(_month_).
         1. Let _day_ be ? Get(_fields_, *"day"*).
+        1. Set _day_ to ? ToIntegerOrInfinity(_day_).
         1. Return ? RegulateDate(_year_, _month_, _day_, _overflow_).
       </emu-alg>
     </emu-clause>
@@ -335,7 +338,9 @@
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Set _fields_ to ? ToTemporalYearMonthFields(_fields_, « *"month"*, *"year"* »).
         1. Let _year_ be ? Get(_fields_, *"year"*).
+        1. Set _year_ to ? ToIntegerOrInfinity(_year_).
         1. Let _month_ be ? Get(_fields_, *"month"*).
+        1. Set _month_ to ? ToIntegerOrInfinity(_month_).
         1. Let _result_ be ? RegulateYearMonth(_year_, _month_, _overflow_).
         1. Return the new Record {
             [[Year]]: _result_.[[Year]],
@@ -355,7 +360,9 @@
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Set _fields_ to ? ToTemporalMonthDayFields(_fields_, « *"day"*, *"month"* »).
         1. Let _month_ be ? Get(_fields_, *"month"*).
+        1. Set _month_ to ? ToIntegerOrInfinity(_month_).
         1. Let _day_ be ? Get(_fields_, *"day"*).
+        1. Set _day_ to ? ToIntegerOrInfinity(_day_).
         1. Let _result_ be ? RegulateMonthDay(_month_, _day_, _overflow_).
         1. Let _referenceISOYear_ be the first leap year after the Unix epoch (1972).
         1. Return the new Record {

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -317,12 +317,14 @@
       <emu-alg>
         1. Assert: Type(_fields_) is Object.
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Set _fields_ to ? ToTemporalDateFields(_fields_, « *"day"*, *"month"*, *"year"* »).
         1. Let _year_ be ? Get(_fields_, *"year"*).
+        1. If _year_ is *undefined*, throw a *TypeError* exception.
         1. Set _year_ to ? ToIntegerOrInfinity(_year_).
         1. Let _month_ be ? Get(_fields_, *"month"*).
+        1. If _month_ is *undefined*, throw a *TypeError* exception.
         1. Set _month_ to ? ToIntegerOrInfinity(_month_).
         1. Let _day_ be ? Get(_fields_, *"day"*).
+        1. If _day_ is *undefined*, throw a *TypeError* exception.
         1. Set _day_ to ? ToIntegerOrInfinity(_day_).
         1. Return ? RegulateDate(_year_, _month_, _day_, _overflow_).
       </emu-alg>
@@ -336,10 +338,11 @@
       <emu-alg>
         1. Assert: Type(_fields_) is Object.
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Set _fields_ to ? ToTemporalYearMonthFields(_fields_, « *"month"*, *"year"* »).
         1. Let _year_ be ? Get(_fields_, *"year"*).
+        1. If _year_ is *undefined*, throw a *TypeError* exception.
         1. Set _year_ to ? ToIntegerOrInfinity(_year_).
         1. Let _month_ be ? Get(_fields_, *"month"*).
+        1. If _month_ is *undefined*, throw a *TypeError* exception.
         1. Set _month_ to ? ToIntegerOrInfinity(_month_).
         1. Let _result_ be ? RegulateYearMonth(_year_, _month_, _overflow_).
         1. Return the new Record {
@@ -358,10 +361,11 @@
       <emu-alg>
         1. Assert: Type(_fields_) is Object.
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Set _fields_ to ? ToTemporalMonthDayFields(_fields_, « *"day"*, *"month"* »).
         1. Let _month_ be ? Get(_fields_, *"month"*).
+        1. If _month_ is *undefined*, throw a *TypeError* exception.
         1. Set _month_ to ? ToIntegerOrInfinity(_month_).
         1. Let _day_ be ? Get(_fields_, *"day"*).
+        1. If _day_ is *undefined*, throw a *TypeError* exception.
         1. Set _day_ to ? ToIntegerOrInfinity(_day_).
         1. Let _result_ be ? RegulateMonthDay(_month_, _day_, _overflow_).
         1. Let _referenceISOYear_ be the first leap year after the Unix epoch (1972).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -754,9 +754,7 @@
           1. If _item_ has an [[InitializedTemporalDate]] internal slot, then
             1. Return _item_.
           1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"year"* »).
-          1. Let _fields_ be ? ToTemporalDateFields(_item_, _fieldNames_).
-          1. Return ? DateFromFields(_calendar_, _fields_, _constructor_, _overflow_).
+          1. Return ? DateFromFields(_calendar_, _item_, _constructor_, _overflow_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalDateString(_string_).
         1. If ! ValidateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *false*, then
@@ -845,7 +843,6 @@
           1. Let _value_ be ? Get(_temporalDateLike_, _property_).
           1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
             1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. Return _result_.
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -920,7 +920,7 @@
       </p>
       <emu-alg>
         1. Let _temporalDate_ be ? DateFromFields(_calendar_, _fields_, %Temporal.PlainDate%, _overflow_).
-        1. Let _timeResult_ be ? ToTemporalTimeRecord(_fields_).
+        1. Let _timeResult_ be ? ToTemporalTimeRecord(_fields_, *false*).
         1. Let _timeResult_ be ? RegulateTime(_timeResult_.[[Hour]], _timeResult_.[[Minute]], _timeResult_.[[Second]], _timeResult_.[[Millisecond]], _timeResult_.[[Microsecond]], _timeResult_.[[Nanosecond]], _overflow_).
         1. Return the new Record {
           [[Year]]: _temporalDate_.[[ISOYear]],
@@ -949,9 +949,7 @@
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
             1. Return _item_.
           1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"nanosecond"*, *"second"*, *"year"* »).
-          1. Let _fields_ be ? ToTemporalDateTimeFields(_item_, _fieldNames_).
-          1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _overflow_).
+          1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _item_, _overflow_).
         1. Else,
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalDateTimeString(_string_).
@@ -1124,7 +1122,6 @@
           1. Let _value_ be ? Get(_temporalDateLike_, _property_).
           1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
             1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
           1. Let _property_ be the Property value of the current row.

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -387,9 +387,7 @@
           1. If _item_ has an [[InitializedTemporalMonthDay]] internal slot, then
             1. Return _item_.
           1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"* »).
-          1. Let _fields_ be ? ToTemporalMonthDayFields(_item_, _fieldNames_).
-          1. Return ? MonthDayFromFields(_calendar_, _fields_, _overflow_, _constructor_).
+          1. Return ? MonthDayFromFields(_calendar_, _item_, _overflow_, _constructor_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalMonthDayString(_string_).
         1. If _result_.[[Year]] is *undefined*, then
@@ -511,7 +509,6 @@
           1. Let _value_ be ? Get(_temporalMonthDayLike_, _property_).
           1. If _property_ is one of *"month"* or *"year"*, then
             1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. Let _year_ be the first leap year after the Unix epoch (1972).
         1. Perform ! CreateDataPropertyOrThrow(_result_, *"year"*, _year_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -870,7 +870,7 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-totemporaltimerecord" aoid="ToTemporalTimeRecord">
-      <h1>ToTemporalTimeRecord ( _temporalTimeLike_ )</h1>
+      <h1>ToTemporalTimeRecord ( _temporalTimeLike_ [ , _someRequired_ ] )</h1>
       <emu-alg>
         1. Assert: Type(_temporalTimeLike_) is Object.
         1. Let _result_ be the new Record {
@@ -885,7 +885,8 @@
           1. Let _property_ be the Property value of the current row.
           1. Let _value_ be ? Get(_temporalTimeLike_, _property_).
           1. If _value_ is *undefined*, then
-            1. Throw a *TypeError* exception.
+            1. If _someRequired_ is not *false*, then
+              1. Throw a *TypeError* exception.
           1. Set _value_ to ? ToIntegerOrInfinity(_value_).
           1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
         1. Return _result_.

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -870,7 +870,7 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-totemporaltimerecord" aoid="ToTemporalTimeRecord">
-      <h1>ToTemporalTimeRecord ( _temporalTimeLike_ [ , _someRequired_ ] )</h1>
+      <h1>ToTemporalTimeRecord ( _temporalTimeLike_ [ , _allowUndefined_ ] )</h1>
       <emu-alg>
         1. Assert: Type(_temporalTimeLike_) is Object.
         1. Let _result_ be the new Record {
@@ -881,14 +881,16 @@
           [[Microsecond]]: *undefined*,
           [[Nanosecond]]: *undefined*
           }.
+        1. Let _someDefined_ be *false*.
         1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
           1. Let _property_ be the Property value of the current row.
           1. Let _value_ be ? Get(_temporalTimeLike_, _property_).
-          1. If _value_ is *undefined*, then
-            1. If _someRequired_ is not *false*, then
-              1. Throw a *TypeError* exception.
-          1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-          1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+          1. If _value_ is not *undefined*, then
+            1. Set _someDefined_ to *true*.
+            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
+            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. If _allowUndefined_ is *false* and _someDefined_ is *false*, then
+          1. Throw a *TypeError* exception.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -602,9 +602,7 @@
           1. If _item_ has an [[InitializedTemporalYearMonth]] internal slot, then
             1. Return _item_.
           1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"year"* »).
-          1. Let _fields_ be ? ToTemporalYearMonthFields(_item_, _fieldNames_).
-          1. Return ? YearMonthFromFields(_calendar_, _fields_, _overflow_, _constructor_).
+          1. Return ? YearMonthFromFields(_calendar_, _item_, _overflow_, _constructor_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalYearMonthString(_string_).
         1. If _result_.[[Day]] is *undefined*, then
@@ -745,7 +743,6 @@
           1. Let _value_ be ? Get(_temporalDateLike_, _property_).
           1. If _property_ is either *"month"*, or *"year"*, then
             1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. Perform ! CreateDataPropertyOrThrow(_result_, *"day"*, 1).
         1. Return _result_.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1128,7 +1128,7 @@
     <emu-clause id="sec-temporal-totemporalzoneddatetime" aoid="ToTemporalZonedDateTime">
       <h1>ToTemporalZonedDateTime ( _item_ [ , _constructor_ [ , _overflow_, _disambiguation_, _offset_ ] ] )</h1>
       <p>
-        The abstract operation ToTemporalZonedDateTime returns its argument _item_ if it is already a Temporal.ZonedDateTime instance, converts _item_ to a new Temporal.PlainDate instance if possible, and throws otherwise.
+        The abstract operation ToTemporalZonedDateTime returns its argument _item_ if it is already a Temporal.ZonedDateTime instance, converts _item_ to a new Temporal.ZonedDateTime instance if possible, and throws otherwise.
       </p>
       <emu-alg>
         1. If _constructor_ is not given, set it to %Temporal.ZonedDateTime%.
@@ -1142,9 +1142,9 @@
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Return _item_.
           1. Let _calendar_ be ? GetOptionalTemporalCalendar(_item_).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"nanosecond"*, *"second"*, *"year"* »).
-          1. Let _fields_ be ? ToTemporalZonedDateTimeFields(_item_, _fieldNames_).
           1. Let _timeZone_ be ? Get(_fields_, *"timeZone"*).
+          1. If _timeZone_ is *undefined*, then
+            1. Throw a *TypeError* exception.
           1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
           1. Let _offsetString_ be ? Get(_fields_, *"offset"*).
           1. If _offsetString_ is not *undefined*, set it to ? ToString(_offsetString_).
@@ -1259,7 +1259,6 @@
           1. Let _value_ be ? Get(_temporalDateLike_, _property_).
           1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
             1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. For each row of <emu-xref href="#table-temporal-temporalzoneddatetimelike-properties"></emu-xref>, except the header row, in table order, do
           1. Let _property_ be the Property value of the current row.


### PR DESCRIPTION
Do not coerce {day, month, year} to integers except in ISO calendar implementation.

Fixes #1229.