### PR TITLE
Clarify which time zones must be supported in a non-402 implementation

### DIFF
--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -2,6 +2,11 @@
   "https://tc39.es/ecma262/": [
     {
       "type": "op",
+      "aoid": "CodePointsToString",
+      "id": "sec-codepointstostring"
+    },
+    {
+      "type": "op",
       "aoid": "NumberToBigInt",
       "id": "sec-numbertobigint"
     },
@@ -14,6 +19,11 @@
       "type": "op",
       "aoid": "RequireInternalSlot",
       "id": "sec-requireinternalslot"
+    },
+    {
+      "type": "op",
+      "aoid": "StringToCodePoints",
+      "id": "sec-stringtocodepoints"
     },
     {
       "type": "op",
@@ -34,11 +44,6 @@
   "https://tc39.es/ecma402/": [
     {
       "type": "op",
-      "aoid": "IsValidTimeZoneName",
-      "id": "sec-isvalidtimezonename"
-    },
-    {
-      "type": "op",
       "aoid": "BasicFormatMatcher",
       "id": "sec-basicformatmatcher"
     },
@@ -51,16 +56,6 @@
       "type": "op",
       "aoid": "CanonicalizeLocaleList",
       "id": "sec-canonicalizelocalelist"
-    },
-    {
-      "type": "op",
-      "aoid": "CanonicalizeTimeZoneName",
-      "id": "sec-canonicalizetimezonename"
-    },
-    {
-      "type": "op",
-      "aoid": "DefaultTimeZone",
-      "id": "sec-defaulttimezone"
     },
     {
       "type": "op",

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -11,6 +11,75 @@
     </p>
   </emu-note>
 
+  <emu-clause id="sup-time-zone-names">
+    <h1><a href="https://tc39.es/ecma402/#sec-time-zone-names">Time Zone Names</a></h1>
+
+    <ins class="block">
+      <p>
+        <emu-xref href="#sec-time-zone-names"></emu-xref> defines a set of abstract operations concerning the names of supported time zones.
+        This section introduces additional requirements on these operations for implementations.
+      </p>
+    </ins>
+
+    <p>
+      The ECMAScript 2021 Internationalization API Specification identifies time zones using the Zone and Link names of the IANA Time Zone Database. Their canonical form is the corresponding Zone name in the casing used in the IANA Time Zone Database.
+    </p>
+
+    <p>
+      All registered Zone and Link names are allowed. Implementations must recognize all such names, and use best available current and historical information about their offsets from UTC and their daylight saving time rules in calculations. However, the set of combinations of time zone name and language tag for which localized time zone names are available is implementation dependent.
+    </p>
+
+    <emu-clause id="sup-isvalidtimezonename">
+      <h1><a href="https://tc39.es/ecma402/#sec-isvalidtimezonename">IsValidTimeZoneName</a> ( _timeZone_ )</h1>
+
+      <ins class="block">
+        <p>This definition supersedes the definition provided in <emu-xref href="#sec-isvalidtimezonename"></emu-xref>.</p>
+      </ins>
+      <p>
+        The IsValidTimeZoneName abstract operation verifies that the _timeZone_ argument (which must be a String value) represents a valid Zone or Link name of the IANA Time Zone Database.
+      </p>
+      <p>
+        The abstract operation returns true if _timeZone_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>, is equal to one of the Zone or Link names of the IANA Time Zone Database, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>. It returns false otherwise.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sup-canonicalizetimezonename">
+      <h1><a href="https://tc39.es/ecma402/#sec-canonicalizetimezonename">CanonicalizeTimeZoneName</a> <ins>( _timeZone_ )</ins></h1>
+
+      <ins class="block">
+        <p>This definition supersedes the definition provided in <emu-xref href="#sec-canonicalizetimezonename"></emu-xref>.</p>
+      </ins>
+      <p>
+        The CanonicalizeTimeZoneName abstract operation returns the canonical and case-regularized form of the _timeZone_ argument (which must be a String value that is a valid time zone name as verified by the IsValidTimeZoneName abstract operation).
+        The following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. <ins>Assert: Type(_timeZone_) is String.</ins>
+        1. <ins>Assert: ! IsValidTimeZoneName(_timeZone_) is *true*.</ins>
+        1. Let _ianaTimeZone_ be the Zone or Link name of the IANA Time Zone Database such that _timeZone_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>, is equal to _ianaTimeZone_, converted to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
+        1. If _ianaTimeZone_ is a Link name, let _ianaTimeZone_ be the corresponding Zone name as specified in the *"backward"* file of the IANA Time Zone Database.
+        1. If _ianaTimeZone_ is *"Etc/UTC"* or *"Etc/GMT"*, return *"UTC"*.
+        1. Return _ianaTimeZone_.
+      </emu-alg>
+
+      <p>
+        The Intl.DateTimeFormat constructor allows this time zone name; if the time zone is not specified, the host environment's current time zone is used. Implementations shall support UTC and the <del>host environment's current</del> time zone <ins>returned from DefaultTimeZone</ins> (if different from UTC) in formatting.
+      </p>
+    </emu-clause>
+
+    <emu-clause id="sup-defaulttimezone">
+      <h1><a href="https://tc39.es/ecma402/#sec-defaulttimezone">DefaultTimeZone</a> ( )</h1>
+
+      <ins class="block">
+        <p>This definition supersedes the definition provided in <emu-xref href="#sec-defaulttimezone"></emu-xref>.</p>
+      </ins>
+      <p>
+        The DefaultTimeZone abstract operation returns a String value representing the valid (<emu-xref href="#sec-isvalidtimezonename"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizetimezonename"></emu-xref>) time zone name for the host environment's current time zone.
+      </p>
+    </emu-clause>
+  </emu-clause>
+
   <emu-clause id="sec-datetimeformat-abstracts">
     <h1><a href="https://tc39.es/ecma402/#sec-datetimeformat-abstracts">Abstract Operations For DateTimeFormat Objects</a></h1>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -5,6 +5,99 @@
   <h1>Temporal.TimeZone Objects</h1>
   <p>A Temporal.TimeZone object is an immutable Object referencing a time zone.</p>
 
+  <emu-clause id="sec-time-zone-names">
+    <h1>Time Zone Names</h1>
+
+    <emu-note type="editor">
+      <p>
+        The normative intention of this section is that an implementation must support UTC and a local time zone, which may also be UTC, or a named time zone like `"Europe/London"`, or an offset time zone like `"+01:00"`; and that the local time zone must in any case be consistent with the time zone offsets that can be determined using `Date.prototype.getTimezoneOffset()`, `Date.prototype.toString()`, and `Date.prototype.toTimeString()`.
+        The exact formal definition of "local time zone" is still to be determined.
+      </p>
+    </emu-note>
+
+    <p>
+      An ECMAScript implementation must support a number of built-in time zones.
+      At a minimum, implementations must support a built-in time zone named *"UTC"*.
+      If the return value of DefaultTimeZone is different from *"UTC"*, and does not satisfy the syntax of a |TimeZoneNumericUTCOffset|, then implementations must support that time zone as a built-in time zone as well.
+      In addition, implementations may support any number of other built-in time zones.
+    </p>
+    <p>
+      Built-in time zones may be <dfn>named</dfn> time zones, represented by Strings for which IsValidTimeZoneName returns *true*.
+      They may also be <dfn>offset</dfn> time zones, represented by Strings that conform to the syntax of |TimeZoneNumericUTCOffset|.
+    <p>
+      <emu-xref href="#sec-temporal-timezone-constructor">The `Temporal.TimeZone` constructor</emu-xref>, when called with the name of a built-in time zone as the argument, will return a valid `Temporal.TimeZone` object.
+      When called with any other string, it will throw a *RangeError* exception.
+    </p>
+    <p>
+      Implementations are encouraged to support the Zone and Link names of the IANA Time Zone Database, and to use the best available current and historical information about their offsets from UTC and their daylight saving time rules in calculations.
+    </p>
+    <p>
+      An ECMAScript implementation that includes the ECMA-402 Internationalization API has additional requirements for the built-in time zones that must be supported, as specified in the ECMA-402 specification.
+    </p>
+
+    <emu-clause id="sec-isvalidtimezonename" aoid="IsValidTimeZoneName">
+      <h1>IsValidTimeZoneName ( _timeZone_ )</h1>
+
+      <p>
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the IsValidTimeZoneName abstract operation as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the IsValidTimeZoneName abstract operation is used.
+      </p>
+      <p>
+        The abstract operation IsValidTimeZoneName takes argument _timeZone_, a String value. It returns *true* if _timeZone_, converted to upper case, is equal to one of the built-in named time zone names, converted to upper case.
+        It returns *false* otherwise.
+      </p>
+      <p>
+        Once IsValidTimeZoneName has returned *true* for a particular value of _timeZone_, for the lifetime of the surrounding agent, it may no longer return *false* for that value of _timeZone_, or for the value of CanonicalizeTimeZoneName(_timeZone_).
+      </p>
+      <p>The minimum implementation of IsValidTimeZoneName, supporting only the *"UTC"* time zone, performs the following steps when called:
+      </p>
+
+      <emu-alg>
+        1. Assert: Type(_timeZone_) is String.
+        1. Let _tzText_ be ! StringToCodePoints(_timeZone_).
+        1. Let _tzUpperText_ be the result of toUppercase(_tzText_), according to the Unicode Default Case Conversion algorithm.
+        1. Let _tzUpper_ be ! CodePointsToString(_tzUpperText_).
+        1. If _tzUpper_ and *"UTC"* are the same sequence of code points, return *true*.
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-canonicalizetimezonename" aoid="CanonicalizeTimeZoneName">
+      <h1>CanonicalizeTimeZoneName ( _timeZone_ )</h1>
+
+      <p>
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the CanonicalizeTimeZoneName abstract operation as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the CanonicalizeTimeZoneName abstract operation is used.
+      </p>
+      <p>
+        The abstract operation CanonicalizeTimeZoneName takes argument _timeZone_, a String value, and returns the canonical and case-regularized form of _timeZone_.
+      </p>
+      <p>
+        CanonicalizeTimeZoneName may only be called with a _timeZone_ parameter that is a valid time zone name according to IsValidTimeZoneName.
+      </p>
+      <p>The minimum implementation of CanonicalizeTimeZoneName, supporting only the *"UTC"* time zone, performs the following steps when called:
+      </p>
+
+      <emu-alg>
+        1. Assert: Type(_timeZone_) is String.
+        1. Assert: ! IsValidTimeZoneName(_timeZone_) is *true*.
+        1. Return *"UTC"*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-defaulttimezone" aoid="DefaultTimeZone">
+      <h1>DefaultTimeZone ( )</h1>
+
+      <p>
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the DefaultTimeZone abstract operation as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the DefaultTimeZone abstract operation is used.
+      </p>
+      <p>
+        The DefaultTimeZone abstract operation returns a String value representing the host environment's current time zone, which is either a valid (<emu-xref href="#sec-isvalidtimezonename"></emu-xref>) and canonicalized (<emu-xref href="#sec-canonicalizetimezonename"></emu-xref>) time zone name, or an offset conforming to the syntax of a |TimeZoneNumericUTCOffset|.
+      </p>
+    </emu-clause>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-timezone-constructor">
     <h1>The Temporal.TimeZone Constructor</h1>
     <p>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -10,7 +10,7 @@
 
     <emu-note type="editor">
       <p>
-        The normative intention of this section is that an implementation must support UTC and a local time zone, which may also be UTC, or a named time zone like `"Europe/London"`, or an offset time zone like `"+01:00"`; and that the local time zone must in any case be consistent with the time zone offsets that can be determined using `Date.prototype.getTimezoneOffset()`, `Date.prototype.toString()`, and `Date.prototype.toTimeString()`.
+        The normative intention of this section is that an implementation must support UTC and a local time zone, which may also be UTC, or a named time zone like *"Europe/London"*, or an offset time zone like *"+01:00"*; and that the local time zone must in any case be consistent with the time zone offsets that can be determined using `Date.prototype.getTimezoneOffset()`, `Date.prototype.toString()`, and `Date.prototype.toTimeString()`.
         The exact formal definition of "local time zone" is still to be determined.
       </p>
     </emu-note>
@@ -22,8 +22,8 @@
       In addition, implementations may support any number of other built-in time zones.
     </p>
     <p>
-      Built-in time zones may be <dfn>named</dfn> time zones, represented by Strings for which IsValidTimeZoneName returns *true*.
-      They may also be <dfn>offset</dfn> time zones, represented by Strings that conform to the syntax of |TimeZoneNumericUTCOffset|.
+      Built-in time zones may be <dfn>named time zones</dfn>, represented by Strings for which IsValidTimeZoneName returns *true*.
+      They may also be <dfn>offset time zones</dfn>, represented by Strings that conform to the syntax of |TimeZoneNumericUTCOffset|.
     <p>
       <emu-xref href="#sec-temporal-timezone-constructor">The `Temporal.TimeZone` constructor</emu-xref>, when called with the name of a built-in time zone as the argument, will return a valid `Temporal.TimeZone` object.
       When called with any other string, it will throw a *RangeError* exception.
@@ -75,7 +75,8 @@
       <p>
         CanonicalizeTimeZoneName may only be called with a _timeZone_ parameter that is a valid time zone name according to IsValidTimeZoneName.
       </p>
-      <p>The minimum implementation of CanonicalizeTimeZoneName, supporting only the *"UTC"* time zone, performs the following steps when called:
+      <p>
+        The minimum implementation of CanonicalizeTimeZoneName, supporting only the *"UTC"* time zone, performs the following steps when called:
       </p>
 
       <emu-alg>


### PR DESCRIPTION
The abstract operations dealing with the system time zone and the time
zone names were part of 402, but here they need to move into 262, without
obligating non-402 implementations to offer the full list of time zone
names.

Closes: #1292