### PR TITLE
Update validation, coercion for all built-in fields.

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -630,6 +630,7 @@ export namespace Temporal {
     ): number;
     day(date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainMonthDay | DateLike | string): number;
     era(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): string | undefined;
+    eraYear(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): number | undefined;
     dayOfWeek?(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): number;
     dayOfYear?(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): number;
     weekOfYear?(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): number;
@@ -647,12 +648,12 @@ export namespace Temporal {
       date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainYearMonth | DateLike | string
     ): boolean;
     dateFromFields(
-      fields: { year: number; month: number; day: number },
+      fields: { year: number | undefined; month: number; day: number },
       options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.PlainDate>
     ): Temporal.PlainDate;
     yearMonthFromFields(
-      fields: { year: number; month: number },
+      fields: { year: number | undefined; month: number },
       options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.PlainYearMonth>
     ): Temporal.PlainYearMonth;
@@ -709,6 +710,7 @@ export namespace Temporal {
     ): number;
     day(date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainMonthDay | DateLike | string): number;
     era(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): string | undefined;
+    eraYear(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): number | undefined;
     dayOfWeek(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): number;
     dayOfYear(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): number;
     weekOfYear(date: Temporal.PlainDate | Temporal.PlainDateTime | DateLike | string): number;
@@ -724,17 +726,17 @@ export namespace Temporal {
       date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainYearMonth | DateLike | string
     ): boolean;
     dateFromFields(
-      fields: { year: number; month: number; day: number },
+      fields: { year: number | undefined; month: number; day: number },
       options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.PlainDate>
     ): Temporal.PlainDate;
     yearMonthFromFields(
-      fields: { year: number; month: number },
+      fields: { year: number | undefined; month: number },
       options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.PlainYearMonth>
     ): Temporal.PlainYearMonth;
     monthDayFromFields(
-      fields: { month: number; day: number },
+      fields: { month: number | undefined; day: number },
       options: AssignmentOptions,
       constructor: ConstructorOf<Temporal.PlainMonthDay>
     ): Temporal.PlainMonthDay;
@@ -799,6 +801,8 @@ export namespace Temporal {
       two: Temporal.PlainDate | DateLike | string
     ): ComparisonResult;
     constructor(isoYear: number, isoMonth: number, isoDay: number, calendar?: CalendarProtocol);
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
     readonly year: number;
     readonly month: number;
     readonly day: number;
@@ -924,6 +928,8 @@ export namespace Temporal {
       nanosecond?: number,
       calendar?: CalendarProtocol
     );
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
     readonly year: number;
     readonly month: number;
     readonly day: number;
@@ -1282,6 +1288,8 @@ export namespace Temporal {
       two: Temporal.PlainYearMonth | YearMonthLike | string
     ): ComparisonResult;
     constructor(isoYear: number, isoMonth: number, calendar?: CalendarProtocol, referenceISODay?: number);
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
     readonly year: number;
     readonly month: number;
     readonly calendar: CalendarProtocol;
@@ -1352,6 +1360,8 @@ export namespace Temporal {
       two: Temporal.ZonedDateTime | ZonedDateTimeLike | string
     ): ComparisonResult;
     constructor(epochNanoseconds: bigint, timeZone: TimeZoneProtocol | string, calendar?: CalendarProtocol | string);
+    readonly era: string | undefined;
+    readonly eraYear: number | undefined;
     readonly year: number;
     readonly month: number;
     readonly day: number;

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -67,19 +67,43 @@ export class PlainDate {
   }
   get era() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).era(this);
+    let result = GetSlot(this, CALENDAR).era(this);
+    if (result !== undefined) {
+      result = ES.ToString(result);
+    }
+    return result;
+  }
+  get eraYear() {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    let result = GetSlot(this, CALENDAR).eraYear(this);
+    if (result !== undefined) {
+      result = ES.ToInteger(result);
+    }
+    return result;
   }
   get year() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).year(this);
+    const result = GetSlot(this, CALENDAR).year(this);
+    if (result === undefined) {
+      throw new RangeError('calendar year result must be an integer');
+    }
+    return ES.ToInteger(result);
   }
   get month() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).month(this);
+    const result = GetSlot(this, CALENDAR).month(this);
+    if (result === undefined) {
+      throw new RangeError('calendar month result must be a positive integer');
+    }
+    return ES.ToPositiveInteger(result);
   }
   get day() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).day(this);
+    const result = GetSlot(this, CALENDAR).day(this);
+    if (result === undefined) {
+      throw new RangeError('calendar day result must be a positive integer');
+    }
+    return ES.ToPositiveInteger(result);
   }
   get dayOfWeek() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -122,15 +122,27 @@ export class PlainDateTime {
   }
   get year() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).year(this);
+    const result = GetSlot(this, CALENDAR).year(this);
+    if (result === undefined) {
+      throw new RangeError('calendar year result must be an integer');
+    }
+    return ES.ToInteger(result);
   }
   get month() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).month(this);
+    const result = GetSlot(this, CALENDAR).month(this);
+    if (result === undefined) {
+      throw new RangeError('calendar month result must be a positive integer');
+    }
+    return ES.ToPositiveInteger(result);
   }
   get day() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).day(this);
+    const result = GetSlot(this, CALENDAR).day(this);
+    if (result === undefined) {
+      throw new RangeError('calendar day result must be a positive integer');
+    }
+    return ES.ToPositiveInteger(result);
   }
   get hour() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
@@ -158,7 +170,19 @@ export class PlainDateTime {
   }
   get era() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).era(this);
+    let result = GetSlot(this, CALENDAR).era(this);
+    if (result !== undefined) {
+      result = ES.ToString(result);
+    }
+    return result;
+  }
+  get eraYear() {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    let result = GetSlot(this, CALENDAR).eraYear(this);
+    if (result !== undefined) {
+      result = ES.ToInteger(result);
+    }
+    return result;
   }
   get dayOfWeek() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -57,11 +57,19 @@ export class PlainMonthDay {
 
   get month() {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).month(this);
+    const result = GetSlot(this, CALENDAR).month(this);
+    if (result === undefined) {
+      throw new RangeError('calendar month result must be a positive integer');
+    }
+    return ES.ToPositiveInteger(result);
   }
   get day() {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).day(this);
+    const result = GetSlot(this, CALENDAR).day(this);
+    if (result === undefined) {
+      throw new RangeError('calendar day result must be a positive integer');
+    }
+    return ES.ToPositiveInteger(result);
   }
   get calendar() {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
@@ -138,7 +146,7 @@ export class PlainMonthDay {
         entries.push([fieldName, undefined]);
       }
     });
-    ObjectAssign(fields, ES.ToRecord(item, entries));
+    ObjectAssign(fields, ES.PrepareTemporalFields(item, entries));
 
     const Date = GetIntrinsic('%Temporal.PlainDate%');
     return ES.DateFromFields(calendar, fields, Date);

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -55,11 +55,19 @@ export class PlainYearMonth {
   }
   get year() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).year(this);
+    const result = GetSlot(this, CALENDAR).year(this);
+    if (result === undefined) {
+      throw new RangeError('calendar year result must be an integer');
+    }
+    return ES.ToInteger(result);
   }
   get month() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).month(this);
+    const result = GetSlot(this, CALENDAR).month(this);
+    if (result === undefined) {
+      throw new RangeError('calendar month result must be a positive integer');
+    }
+    return ES.ToPositiveInteger(result);
   }
   get calendar() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
@@ -67,7 +75,19 @@ export class PlainYearMonth {
   }
   get era() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).era(this);
+    let result = GetSlot(this, CALENDAR).era(this);
+    if (result !== undefined) {
+      result = ES.ToString(result);
+    }
+    return result;
+  }
+  get eraYear() {
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    let result = GetSlot(this, CALENDAR).eraYear(this);
+    if (result !== undefined) {
+      result = ES.ToInteger(result);
+    }
+    return result;
   }
   get daysInMonth() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
@@ -357,7 +377,7 @@ export class PlainYearMonth {
         entries.push([fieldName, undefined]);
       }
     });
-    ObjectAssign(fields, ES.ToRecord(item, entries));
+    ObjectAssign(fields, ES.PrepareTemporalFields(item, entries));
 
     const Date = GetIntrinsic('%Temporal.PlainDate%');
     return ES.DateFromFields(calendar, fields, Date, { overflow: 'reject' });

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -69,15 +69,27 @@ export class ZonedDateTime {
   }
   get year() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).year(dateTime(this));
+    const result = GetSlot(this, CALENDAR).year(dateTime(this));
+    if (result === undefined) {
+      throw new RangeError('calendar year result must be an integer');
+    }
+    return ES.ToInteger(result);
   }
   get month() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).month(dateTime(this));
+    const result = GetSlot(this, CALENDAR).month(dateTime(this));
+    if (result === undefined) {
+      throw new RangeError('calendar month result must be a positive integer');
+    }
+    return ES.ToPositiveInteger(result);
   }
   get day() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).day(dateTime(this));
+    const result = GetSlot(this, CALENDAR).day(dateTime(this));
+    if (result === undefined) {
+      throw new RangeError('calendar day result must be a positive integer');
+    }
+    return ES.ToPositiveInteger(result);
   }
   get hour() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
@@ -105,7 +117,19 @@ export class ZonedDateTime {
   }
   get era() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    return GetSlot(this, CALENDAR).era(dateTime(this));
+    let result = GetSlot(this, CALENDAR).era(dateTime(this));
+    if (result !== undefined) {
+      result = ES.ToString(result);
+    }
+    return result;
+  }
+  get eraYear() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    let result = GetSlot(this, CALENDAR).eraYear(dateTime(this));
+    if (result !== undefined) {
+      result = ES.ToInteger(result);
+    }
+    return result;
   }
   get epochSeconds() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/test/PlainDate/constructor/from/negative-infinity-handled.js
+++ b/polyfill/test/PlainDate/constructor/from/negative-infinity-handled.js
@@ -9,14 +9,8 @@ esid: sec-temporal.plaindate.from
 // constrain
 
 assert.throws(RangeError, () => Temporal.PlainDate.from({ year: -Infinity, month: 1, day: 1 }, { overflow: 'constrain' }));
-let result = Temporal.PlainDate.from({ year: 1970, month: -Infinity, day: 1 }, { overflow: 'constrain' });
-assert.sameValue(result.year, 1970);
-assert.sameValue(result.month, 1);
-assert.sameValue(result.day, 1);
-result = Temporal.PlainDate.from({ year: 1970, month: 1, day: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.year, 1970);
-assert.sameValue(result.month, 1);
-assert.sameValue(result.day, 1);
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 1970, month: -Infinity, day: 1 }, { overflow: 'constrain' }));
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 1970, month: 1, day: -Infinity }, { overflow: 'constrain' }));
 
 // reject
 
@@ -34,10 +28,10 @@ const obj = {
 
 assert.throws(RangeError, () => Temporal.PlainDate.from({ year: obj, month: 1, day: 1 }, { overflow: 'constrain' }));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-result = Temporal.PlainDate.from({ year: 1970, month: obj, day: 1 }, { overflow: 'constrain' });
-assert.sameValue(calls, 2, "it fetches the primitive value");
-result = Temporal.PlainDate.from({ year: 1970, month: 1, day: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 3, "it fetches the primitive value");
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 1970, month: obj, day: 1 }, { overflow: 'constrain' }));
+assert.sameValue(calls, 2, "it fails after fetching the primitive value");
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 1970, month: 1, day: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 3, "it fails after fetching the primitive value");
 
 assert.throws(RangeError, () => Temporal.PlainDate.from({ year: obj, month: 1, day: 1 }, { overflow: 'reject' }));
 assert.sameValue(calls, 4, "it fails after fetching the primitive value");

--- a/polyfill/test/PlainDate/prototype/with/negative-infinity-handled.js
+++ b/polyfill/test/PlainDate/prototype/with/negative-infinity-handled.js
@@ -11,14 +11,8 @@ const instance = new Temporal.PlainDate(2000, 5, 2);
 // constrain
 
 assert.throws(RangeError, () => instance.with({ year: -Infinity }, { overflow: 'constrain' }));
-let result = instance.with({ month: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.year, 2000);
-assert.sameValue(result.month, 1);
-assert.sameValue(result.day, 2);
-result = instance.with({ day: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.year, 2000);
-assert.sameValue(result.month, 5);
-assert.sameValue(result.day, 1);
+assert.throws(RangeError, () => instance.with({ month: -Infinity }, { overflow: 'constrain' }));
+assert.throws(RangeError, () => instance.with({ day: -Infinity }, { overflow: 'constrain' }));
 
 // reject
 
@@ -36,10 +30,10 @@ const obj = {
 
 assert.throws(RangeError, () => instance.with({ year: obj }, { overflow: 'constrain' }));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-result = instance.with({ month: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 2, "it fetches the primitive value");
-result = instance.with({ day: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 3, "it fetches the primitive value");
+assert.throws(RangeError, () => instance.with({ month: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 2, "it fails after fetching the primitive value");
+assert.throws(RangeError, () => instance.with({ day: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 3, "it fails after fetching the primitive value");
 
 assert.throws(RangeError, () => instance.with({ year: obj }, { overflow: 'reject' }));
 assert.sameValue(calls, 4, "it fails after fetching the primitive value");

--- a/polyfill/test/PlainDateTime/constructor/from/negative-infinity-handled.js
+++ b/polyfill/test/PlainDateTime/constructor/from/negative-infinity-handled.js
@@ -9,27 +9,9 @@ esid: sec-temporal.plaindatetime.from
 // constrain
 
 assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: -Infinity, month: 1, day: 1 }, { overflow: 'constrain' }));
-let result = Temporal.PlainDateTime.from({ year: 1970, month: -Infinity, day: 1 }, { overflow: 'constrain' });
-assert.sameValue(result.year, 1970);
-assert.sameValue(result.month, 1);
-assert.sameValue(result.day, 1);
-assert.sameValue(result.hour, 0);
-assert.sameValue(result.minute, 0);
-assert.sameValue(result.second, 0);
-assert.sameValue(result.millisecond, 0);
-assert.sameValue(result.microsecond, 0);
-assert.sameValue(result.nanosecond, 0);
-result = Temporal.PlainDateTime.from({ year: 1970, month: 1, day: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.year, 1970);
-assert.sameValue(result.month, 1);
-assert.sameValue(result.day, 1);
-assert.sameValue(result.hour, 0);
-assert.sameValue(result.minute, 0);
-assert.sameValue(result.second, 0);
-assert.sameValue(result.millisecond, 0);
-assert.sameValue(result.microsecond, 0);
-assert.sameValue(result.nanosecond, 0);
-result = Temporal.PlainDateTime.from({ year: 1970, month: 1, day: 1, hour: -Infinity }, { overflow: 'constrain' });
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 1970, month: -Infinity, day: 1 }, { overflow: 'constrain' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 1970, month: 1, day: -Infinity }, { overflow: 'constrain' }));
+let result = Temporal.PlainDateTime.from({ year: 1970, month: 1, day: 1, hour: -Infinity }, { overflow: 'constrain' });
 assert.sameValue(result.year, 1970);
 assert.sameValue(result.month, 1);
 assert.sameValue(result.day, 1);
@@ -112,10 +94,10 @@ const obj = {
 
 assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: obj, month: 1, day: 1 }, { overflow: 'constrain' }));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-result = Temporal.PlainDateTime.from({ year: 1970, month: obj, day: 1 }, { overflow: 'constrain' });
-assert.sameValue(calls, 2, "it fetches the primitive value");
-result = Temporal.PlainDateTime.from({ year: 1970, month: 1, day: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 3, "it fetches the primitive value");
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 1970, month: obj, day: 1 }, { overflow: 'constrain' }));
+assert.sameValue(calls, 2, "it fails after fetching the primitive value");
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 1970, month: 1, day: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 3, "it fails after fetching the primitive value");
 result = Temporal.PlainDateTime.from({ year: 1970, month: 1, day: 1, hour: obj }, { overflow: 'constrain' });
 assert.sameValue(calls, 4, "it fetches the primitive value");
 result = Temporal.PlainDateTime.from({ year: 1970, month: 1, day: 1, minute: obj }, { overflow: 'constrain' });

--- a/polyfill/test/PlainDateTime/prototype/with/negative-infinity-handled.js
+++ b/polyfill/test/PlainDateTime/prototype/with/negative-infinity-handled.js
@@ -11,27 +11,9 @@ const instance = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 32
 // constrain
 
 assert.throws(RangeError, () => instance.with({ year: -Infinity }, { overflow: 'constrain' }));
-let result = instance.with({ month: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.year, 2000);
-assert.sameValue(result.month, 1);
-assert.sameValue(result.day, 2);
-assert.sameValue(result.hour, 12);
-assert.sameValue(result.minute, 34);
-assert.sameValue(result.second, 56);
-assert.sameValue(result.millisecond, 987);
-assert.sameValue(result.microsecond, 654);
-assert.sameValue(result.nanosecond, 321);
-result = instance.with({ day: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.year, 2000);
-assert.sameValue(result.month, 5);
-assert.sameValue(result.day, 1);
-assert.sameValue(result.hour, 12);
-assert.sameValue(result.minute, 34);
-assert.sameValue(result.second, 56);
-assert.sameValue(result.millisecond, 987);
-assert.sameValue(result.microsecond, 654);
-assert.sameValue(result.nanosecond, 321);
-result = instance.with({ hour: -Infinity }, { overflow: 'constrain' });
+assert.throws(RangeError, () => instance.with({ month: -Infinity }, { overflow: 'constrain' }));
+assert.throws(RangeError, () => instance.with({ day: -Infinity }, { overflow: 'constrain' }));
+let result = instance.with({ hour: -Infinity }, { overflow: 'constrain' });
 assert.sameValue(result.year, 2000);
 assert.sameValue(result.month, 5);
 assert.sameValue(result.day, 2);
@@ -114,10 +96,10 @@ const obj = {
 
 assert.throws(RangeError, () => instance.with({ year: obj }, { overflow: 'constrain' }));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-result = instance.with({ month: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 2, "it fetches the primitive value");
-result = instance.with({ day: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 3, "it fetches the primitive value");
+assert.throws(RangeError, () => instance.with({ month: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 2, "it fails after fetching the primitive value");
+assert.throws(RangeError, () => instance.with({ day: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 3, "it fails after fetching the primitive value");
 result = instance.with({ hour: obj }, { overflow: 'constrain' });
 assert.sameValue(calls, 4, "it fetches the primitive value");
 result = instance.with({ minute: obj }, { overflow: 'constrain' });

--- a/polyfill/test/PlainMonthDay/constructor/from/negative-infinity-handled.js
+++ b/polyfill/test/PlainMonthDay/constructor/from/negative-infinity-handled.js
@@ -8,12 +8,8 @@ esid: sec-temporal.plainmonthday.from
 
 // constrain
 
-let result = Temporal.PlainMonthDay.from({ month: -Infinity, day: 1 }, { overflow: 'constrain' });
-assert.sameValue(result.month, 1);
-assert.sameValue(result.day, 1);
-result = Temporal.PlainMonthDay.from({ month: 1, day: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.month, 1);
-assert.sameValue(result.day, 1);
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: -Infinity, day: 1 }, { overflow: 'constrain' }));
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: 1, day: -Infinity }, { overflow: 'constrain' }));
 
 // reject
 
@@ -28,10 +24,10 @@ const obj = {
   }
 };
 
-result = Temporal.PlainMonthDay.from({ month: obj, day: 1 }, { overflow: 'constrain' });
-assert.sameValue(calls, 1, "it fetches the primitive value");
-result = Temporal.PlainMonthDay.from({ month: 1, day: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 2, "it fetches the primitive value");
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: obj, day: 1 }, { overflow: 'reject' }));
+assert.sameValue(calls, 1, "it fails after fetching the primitive value");
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: 1, day: obj }, { overflow: 'reject' }));
+assert.sameValue(calls, 2, "it fails after fetching the primitive value");
 
 assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: obj, day: 1 }, { overflow: 'reject' }));
 assert.sameValue(calls, 3, "it fails after fetching the primitive value");

--- a/polyfill/test/PlainMonthDay/prototype/with/negative-infinity-handled.js
+++ b/polyfill/test/PlainMonthDay/prototype/with/negative-infinity-handled.js
@@ -10,12 +10,8 @@ const instance = new Temporal.PlainMonthDay(5, 2);
 
 // constrain
 
-let result = instance.with({ month: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.month, 1);
-assert.sameValue(result.day, 2);
-result = instance.with({ day: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.month, 5);
-assert.sameValue(result.day, 1);
+assert.throws(RangeError, () => instance.with({ month: -Infinity }, { overflow: 'constrain' }));
+assert.throws(RangeError, () => instance.with({ day: -Infinity }, { overflow: 'constrain' }));
 
 // reject
 
@@ -30,10 +26,10 @@ const obj = {
   }
 };
 
-result = instance.with({ month: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 1, "it fetches the primitive value");
-result = instance.with({ day: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 2, "it fetches the primitive value");
+assert.throws(RangeError, () => instance.with({ month: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 1, "it fails after fetching the primitive value");
+assert.throws(RangeError, () => instance.with({ day: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 2, "it fails after fetching the primitive value");
 
 assert.throws(RangeError, () => instance.with({ month: obj }, { overflow: 'reject' }));
 assert.sameValue(calls, 3, "it fails after fetching the primitive value");

--- a/polyfill/test/PlainYearMonth/constructor/from/negative-infinity-handled.js
+++ b/polyfill/test/PlainYearMonth/constructor/from/negative-infinity-handled.js
@@ -9,9 +9,7 @@ esid: sec-temporal.plainyearmonth.from
 // constrain
 
 assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: -Infinity, month: 1 }, { overflow: 'constrain' }));
-let result = Temporal.PlainYearMonth.from({ year: 1970, month: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.year, 1970);
-assert.sameValue(result.month, 1);
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: 1970, month: -Infinity }, { overflow: 'constrain' }));
 
 // reject
 
@@ -28,8 +26,8 @@ const obj = {
 
 assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: obj, month: 1 }, { overflow: 'constrain' }));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-result = Temporal.PlainYearMonth.from({ year: 1970, month: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 2, "it fetches the primitive value");
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: 1970, month: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 2, "it fails after fetching the primitive value");
 
 assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: obj, month: 1 }, { overflow: 'reject' }));
 assert.sameValue(calls, 3, "it fails after fetching the primitive value");

--- a/polyfill/test/PlainYearMonth/prototype/with/negative-infinity-handled.js
+++ b/polyfill/test/PlainYearMonth/prototype/with/negative-infinity-handled.js
@@ -11,9 +11,7 @@ const instance = new Temporal.PlainYearMonth(2000, 5);
 // constrain
 
 assert.throws(RangeError, () => instance.with({ year: -Infinity }, { overflow: 'constrain' }));
-let result = instance.with({ month: -Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.year, 2000);
-assert.sameValue(result.month, 1);
+assert.throws(RangeError, () => instance.with({ month: -Infinity }, { overflow: 'constrain' }));
 
 // reject
 
@@ -30,8 +28,8 @@ const obj = {
 
 assert.throws(RangeError, () => instance.with({ year: obj }, { overflow: 'constrain' }));
 assert.sameValue(calls, 1, "it fails after fetching the primitive value");
-result = instance.with({ month: obj }, { overflow: 'constrain' });
-assert.sameValue(calls, 2, "it fetches the primitive value");
+assert.throws(RangeError, () => instance.with({ month: obj }, { overflow: 'constrain' }));
+assert.sameValue(calls, 2, "it fails after fetching the primitive value");
 
 assert.throws(RangeError, () => instance.with({ year: obj }, { overflow: 'reject' }));
 assert.sameValue(calls, 3, "it fails after fetching the primitive value");

--- a/polyfill/test/calendar.mjs
+++ b/polyfill/test/calendar.mjs
@@ -365,15 +365,17 @@ describe('Built-in calendars (not standardized yet)', () => {
     it('era AD', () => {
       const date = Temporal.PlainDate.from('1999-12-31[u-ca-gregory]');
       equal(date.era, 'ad');
+      equal(date.eraYear, 1999);
       equal(date.year, 1999);
     });
     it('era BC', () => {
       const date = Temporal.PlainDate.from('-000001-12-31[u-ca-gregory]');
       equal(date.era, 'bc');
-      equal(date.year, 2);
+      equal(date.eraYear, 2);
+      equal(date.year, -1);
     });
     it('can create from fields with era AD', () => {
-      const date = Temporal.PlainDate.from({ era: 'ad', year: 1999, month: 12, day: 31, calendar: 'gregory' });
+      const date = Temporal.PlainDate.from({ era: 'ad', eraYear: 1999, month: 12, day: 31, calendar: 'gregory' });
       equal(`${date}`, '1999-12-31[u-ca-gregory]');
     });
     it('era AD is the default', () => {
@@ -381,7 +383,7 @@ describe('Built-in calendars (not standardized yet)', () => {
       equal(`${date}`, '1999-12-31[u-ca-gregory]');
     });
     it('can create from fields with era BC', () => {
-      const date = Temporal.PlainDate.from({ era: 'bc', year: 2, month: 12, day: 31, calendar: 'gregory' });
+      const date = Temporal.PlainDate.from({ era: 'bc', eraYear: 2, month: 12, day: 31, calendar: 'gregory' });
       equal(`${date}`, '-000001-12-31[u-ca-gregory]');
     });
   });

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -91,7 +91,7 @@ describe('Intl', () => {
     it("works when the object's calendar is the same as the locale's calendar", () => {
       const dt = Temporal.PlainDateTime.from({
         era: 'showa',
-        year: 51,
+        eraYear: 51,
         month: 11,
         day: 18,
         hour: 15,
@@ -149,7 +149,7 @@ describe('Intl', () => {
       equal(date.toLocaleString('en', { second: 'numeric' }), '11/18/1976');
     });
     it("works when the object's calendar is the same as the locale's calendar", () => {
-      const d = Temporal.PlainDate.from({ era: 'showa', year: 51, month: 11, day: 18, calendar: 'japanese' });
+      const d = Temporal.PlainDate.from({ era: 'showa', eraYear: 51, month: 11, day: 18, calendar: 'japanese' });
       const result = d.toLocaleString('en-US-u-ca-japanese');
       assert(result === '11/18/51' || result === '11/18/51 S');
     });
@@ -179,7 +179,7 @@ describe('Intl', () => {
       equal(yearmonth.toLocaleString('en', { weekday: 'long' }), '11/1976');
     });
     it("works when the object's calendar is the same as the locale's calendar", () => {
-      const ym = Temporal.PlainYearMonth.from({ era: 'showa', year: 51, month: 11, calendar: 'japanese' });
+      const ym = Temporal.PlainYearMonth.from({ era: 'showa', eraYear: 51, month: 11, calendar: 'japanese' });
       const result = ym.toLocaleString('en-US-u-ca-japanese');
       assert(result === '11/51' || result === '11/51 S');
     });

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1454,4 +1454,199 @@
         }.
     </emu-alg>
   </emu-clause>
+
+  <emu-clause id="sec-temporal-topositiveintegerorinfinity" aoid="ToPositiveIntegerOrInfinity">
+    <h1>ToPositiveIntegerOrInfinity ( _argument_ )</h1>
+    <p>
+      The abstract operation ToPositiveIntegerOrInfinity takes argument _argument_. It converts _argument_ to +∞ or an integer _i_ for which <emu-eqn>0 &lt; i</emu-eqn>. It performs the following steps:
+    </p>
+    <emu-alg>
+      1. Let _integer_ be ? ToIntegerOrInfinity(_argument_).
+      1. If _integer_ is *-∞*<sub>𝔽</sub>, then
+        1. Throw a *RangeError* exception.
+      1. If _integer_ &le; 0, then
+        1. Throw a *RangeError* exception.
+      1. Return _integer_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-preparetemporalfields" aoid="PrepareTemporalFields">
+    <h1>PrepareTemporalFields ( _fields_, _fieldNames_, _requiredFields_ )</h1>
+    <p>
+      The abstract operation PrepareTemporalFields reads the relevant properties of an Object _fields_; ensures all the required properties are present; and creates a new Object with all the properties converted to the correct type. It performs the following steps:
+    </p>
+    <emu-note>The value of ? ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
+    <emu-alg>
+      1. Assert: Type(_fields_) is Object.
+      1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
+      1. For each value _property_ of _fieldNames_, do
+        1. Let _value_ be ? Get(_fields_, _property_).
+        1. If _value_ is *undefined*, then
+          1. If _requiredFields_ contains _property_, then
+            1. Throw a *TypeError* exception.
+          1. Else,
+            1. If the value of _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+              1. Set _value_ to the corresponding Default value of the same row.
+        1. Else,
+          1. If the value of _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+            1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.
+            1. Set _value_ to ? _Conversion_(_value_).
+        1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+      1. Return _result_.
+    </emu-alg>
+    <emu-table id="table-temporal-field-requirements">
+      <emu-caption>Temporal field requirements</emu-caption>
+      <table class="real-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Conversion</th>
+            <th>Default</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>*"year"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>*undefined*</td>
+          </tr>
+          <tr>
+            <td>*"month"*</td>
+            <td>ToPositiveIntegerOrInfinity</td>
+            <td>*undefined*</td>
+          </tr>
+          <tr>
+            <td>*"day"*</td>
+            <td>ToPositiveIntegerOrInfinity</td>
+            <td>*undefined*</td>
+          </tr>
+          <tr>
+            <td>*"hour"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"hour"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"minute"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"second"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"millisecond"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"microsecond"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"nanosecond"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"years"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"months"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"weeks"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"days"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"hours"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"minutes"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"seconds"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"milliseconds"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"microseconds"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"nanoseconds"*</td>
+            <td>ToIntegerOrInfinity</td>
+            <td>0</td>
+          </tr>
+          <tr>
+            <td>*"offset"*</td>
+            <td>ToString</td>
+            <td>*undefined*</td>
+          </tr>
+          <tr>
+            <td>*"era"*</td>
+            <td>ToString</td>
+            <td>*undefined*</td>
+          </tr>
+          <tr>
+            <td>*"eraYear"*</td>
+            <td>ToInteger</td>
+            <td>*undefined*</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-preparepartialtemporalfields" aoid="PreparePartialTemporalFields">
+    <h1>PreparePartialTemporalFields ( _fields_, _fieldNames_ )</h1>
+    <p>
+      The abstract operation PreparePartialTemporalFields reads the relevant properties of an Object _fields_ and creates a new Object with all the properties converted to the correct type. It performs the following steps:
+    </p>
+    <emu-note>The value of ? ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
+    <emu-alg>
+      1. If Type(_fields_) is not Object, then
+        1. Throw a *TypeError* exception.
+      1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
+      1. Let _any_ be *false*.
+      1. For each value _property_ of _fieldNames_, do
+        1. Let _value_ be ? Get(_fields_, _property_).
+        1. If _value_ is not *undefined*, then
+          1. Set _any_ to *true*.
+          1. If the value of _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+            1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.
+            1. Set _value_ to ? _Conversion_(_value_).
+        1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+      1. If _any_ is *false*, then
+        1. Throw a *TypeError* exception.
+      1. Return _result_.
+    </emu-alg>
+  </emu-clause>
 </emu-clause>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -297,8 +297,11 @@
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Set _fields_ to ? ToTemporalDateFields(_fields_, « *"day"*, *"month"*, *"year"* »).
         1. Let _year_ be ? Get(_fields_, *"year"*).
+        1. If _year_ is *undefined*, throw a *TypeError* exception.
         1. Let _month_ be ? Get(_fields_, *"month"*).
+        1. If _month_ is *undefined*, throw a *TypeError* exception.
         1. Let _day_ be ? Get(_fields_, *"day"*).
+        1. If _day_ is *undefined*, throw a *TypeError* exception.
         1. Return ? RegulateDate(_year_, _month_, _day_, _overflow_).
       </emu-alg>
     </emu-clause>
@@ -313,7 +316,9 @@
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Set _fields_ to ? ToTemporalYearMonthFields(_fields_, « *"month"*, *"year"* »).
         1. Let _year_ be ? Get(_fields_, *"year"*).
+        1. If _year_ is *undefined*, throw a *TypeError* exception.
         1. Let _month_ be ? Get(_fields_, *"month"*).
+        1. If _month_ is *undefined*, throw a *TypeError* exception.
         1. Let _result_ be ? RegulateYearMonth(_year_, _month_, _overflow_).
         1. Return the new Record {
             [[Year]]: _result_.[[Year]],
@@ -333,7 +338,9 @@
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Set _fields_ to ? ToTemporalMonthDayFields(_fields_, « *"day"*, *"month"* »).
         1. Let _month_ be ? Get(_fields_, *"month"*).
+        1. If _month_ is *undefined*, throw a *TypeError* exception.
         1. Let _day_ be ? Get(_fields_, *"day"*).
+        1. If _day_ is *undefined*, throw a *TypeError* exception.
         1. Let _result_ be ? RegulateMonthDay(_month_, _day_, _overflow_).
         1. Let _referenceISOYear_ be the first leap year after the Unix epoch (1972).
         1. Return the new Record {

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -939,7 +939,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return *undefined*.
             1. Let _era_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
-            1. Return 𝔽(_era_).
+            1. Return _era_.
           </emu-alg>
         </emu-clause>
 
@@ -1246,7 +1246,10 @@
             1. Perform ? RequireInternalSlot(_plainDate_, [[InitializedTemporalDate]]).
             1. Let _calendar_ be _plainDate_.[[Calendar]].
             1. Let _method_ be ? Get(_calendar_, *"era"*).
-            1. Return ? Call(_method_, _calendar_, « _plainDate_ »).
+            1. Let _result_ be ? Call(_method_, _calendar_, « _plainDate_ »).
+            1. If _result_ is not *undefined*, then
+              1. Set _result_ to ? ToString(_result_).
+            1. Return _result_.
           </emu-alg>
         </emu-clause>
 
@@ -1261,7 +1264,10 @@
             1. Perform ? RequireInternalSlot(_plainDate_, [[InitializedTemporalDate]]).
             1. Let _calendar_ be _plainDate_.[[Calendar]].
             1. Let _method_ be ? Get(_calendar_, *"eraYear"*).
-            1. Return ? Call(_method_, _calendar_, « _plainDate_ »).
+            1. Let _result_ be ? Call(_method_, _calendar_, « _plainDate_ »).
+            1. If _result_ is not *undefined*, then
+              1. Set _result_ to ? ToIntegerOrInfinity(_result_).
+            1. Return _result_.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -1294,7 +1300,10 @@
             1. Perform ? RequireInternalSlot(_plainDateTime_, [[InitializedTemporalDateTime]]).
             1. Let _calendar_ be _plainDateTime_.[[Calendar]].
             1. Let _method_ be ? Get(_calendar_, *"era"*).
-            1. Return ? Call(_method_, _calendar_, « _plainDateTime_ »).
+            1. Let _result_ be ? Call(_method_, _calendar_, « _plainDateTime_ »).
+            1. If _result_ is not *undefined*, then
+              1. Set _result_ to ? ToString(_result_).
+            1. Return _result_.
           </emu-alg>
         </emu-clause>
 
@@ -1309,7 +1318,10 @@
             1. Perform ? RequireInternalSlot(_plainDateTime_, [[InitializedTemporalDateTime]]).
             1. Let _calendar_ be _plainDateTime_.[[Calendar]].
             1. Let _method_ be ? Get(_calendar_, *"eraYear"*).
-            1. Return ? Call(_method_, _calendar_, « _plainDateTime_ »).
+            1. Let _result_ be ? Call(_method_, _calendar_, « _plainDateTime_ »).
+            1. If _result_ is not *undefined*, then
+              1. Set _result_ to ? ToIntegerOrInfinity(_result_).
+            1. Return _result_.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -1378,7 +1390,10 @@
             1. Perform ? RequireInternalSlot(_plainYearMonth_, [[InitializedTemporalYearMonth]]).
             1. Let _calendar_ be _plainYearMonth_.[[Calendar]].
             1. Let _method_ be ? Get(_calendar_, *"era"*).
-            1. Return ? Call(_method_, _calendar_, « _plainYearMonth_ »).
+            1. Let _result_ be ? Call(_method_, _calendar_, « _plainYearMonth_ »).
+            1. If _result_ is not *undefined*, then
+              1. Set _result_ to ? ToString(_result_).
+            1. Return _result_.
           </emu-alg>
         </emu-clause>
 
@@ -1393,7 +1408,10 @@
             1. Perform ? RequireInternalSlot(_plainYearMonth_, [[InitializedTemporalYearMonth]]).
             1. Let _calendar_ be _plainYearMonth_.[[Calendar]].
             1. Let _method_ be ? Get(_calendar_, *"eraYear"*).
-            1. Return ? Call(_method_, _calendar_, « _plainYearMonth_ »).
+            1. Let _result_ be ? Call(_method_, _calendar_, « _plainYearMonth_ »).
+            1. If _result_ is not *undefined*, then
+              1. Set _result_ to ? ToIntegerOrInfinity(_result_).
+            1. Return _result_.
           </emu-alg>
         </emu-clause>
       </emu-clause>
@@ -1426,7 +1444,10 @@
             1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
             1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
             1. Let _method_ be ? Get(_calendar_, *"era"*).
-            1. Return ? Call(_method_, _calendar_, « _zonedDateTime_ »).
+            1. Let _result_ be ? Call(_method_, _calendar_, « _zonedDateTime_ »).
+            1. If _result_ is not *undefined*, then
+              1. Set _result_ to ? ToString(_result_).
+            1. Return _result_.
           </emu-alg>
         </emu-clause>
 
@@ -1441,10 +1462,46 @@
             1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
             1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
             1. Let _method_ be ? Get(_calendar_, *"eraYear"*).
-            1. Return ? Call(_method_, _calendar_, « _zonedDateTime_ »).
+            1. Let _result_ ? Call(_method_, _calendar_, « _zonedDateTime_ »).
+            1. If _result_ is not *undefined*, then
+              1. Set _result_ to ? ToIntegerOrInfinity(_result_).
+            1. Return _result_.
           </emu-alg>
         </emu-clause>
       </emu-clause>
+    </ins>
+
+    <ins class="block">
+    <emu-clause id="sec-abstracts">
+      <h1>Abstract Operations</h1>
+
+      <emu-clause id="sup-temporal-preparetemporalfields">
+        <h1>PrepareTemporalFields ( _fields_, _fieldNames_, _requiredFields_ )</h1>
+        <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-preparetemporalfields"></emu-xref>.</p>
+        <emu-alg>
+          1. Assert: Type(_fields_) is Object.
+          1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
+          1. For each value _property_ of _fieldNames_, do
+            1. Let _value_ be ? Get(_fields_, _property_).
+            1. If _value_ is *undefined*, then
+              1. If _requiredFields_ contains _property_, then
+                1. Throw a *TypeError* exception.
+              1. Else,
+                1. If the value of _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+                  1. Set _value_ to the corresponding Default value of the same row.
+            1. Else,
+              1. If the value of _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+                1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.
+                1. Set _value_ to ? _Conversion_(_value_).
+            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+          1. Let _era_ be ? Get(_result_, *"era"*).
+          1. Let _eraYear_ be ? Get(_result_, *"eraYear"*).
+          1. If _era_ is *undefined* and _eraYear_ is not *undefined*, or if _era_ is not *undefined* and _eraYear_ is *undefined*, then
+            1. Throw a *RangeError* exception.
+          1. Return _result_.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
     </ins>
   </emu-clause>
 </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -140,7 +140,10 @@
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Let _calendar_ be _temporalDate_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"year"*).
-        1. Return ? Call(_method_, _calendar_, « _temporalDate_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _temporalDate_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -155,7 +158,10 @@
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Let _calendar_ be _temporalDate_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"month"*).
-        1. Return ? Call(_method_, _calendar_, « _temporalDate_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _temporalDate_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToPositiveIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -170,7 +176,10 @@
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Let _calendar_ be _temporalDate_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"day"*).
-        1. Return ? Call(_method_, _calendar_, « _temporalDate_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _temporalDate_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToPositiveIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -399,7 +408,7 @@
           1. Throw a *TypeError* exception.
         1. Let _calendar_ be _temporalDate_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"year"* »).
-        1. Let _partialDate_ be ? ToPartialDate(_temporalDateLike_, _fieldNames_).
+        1. Let _partialDate_ be ? PreparePartialTemporalFields(_temporalDateLike_, _fieldNames_).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _fields_ be ? ToTemporalDateFields(_temporalDate_, _fieldNames_).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialDate_).
@@ -805,35 +814,7 @@
     <emu-clause id="sec-temporal-totemporaldatefields" aoid="ToTemporalDateFields">
       <h1>ToTemporalDateFields ( _temporalDateLike_, _fieldNames_ )</h1>
       <emu-alg>
-        1. Assert: Type(_temporalDateLike_) is Object.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalDateLike_, _property_).
-          1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
-            1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-topartialdate" aoid="ToPartialDate">
-      <h1>ToPartialDate ( _temporalDateLike_, _fieldNames_ )</h1>
-      <emu-alg>
-        1. If Type(_temporalDateLike_) is not Object, then
-          1. Throw a *TypeError* exception.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _any_ be *false*.
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalDateLike_, _property_).
-          1. If _value_ is not *undefined*, then
-            1. Set _any_ to *true*.
-            1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
-              1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. If _any_ is *false*, then
-          1. Throw a *TypeError* exception.
-        1. Return _result_.
+        1. Return ? PrepareTemporalFields(_temporalDateLike_, _fieldNames_, «»).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -148,7 +148,10 @@
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _calendar_ be _dateTime_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"year"*).
-        1. Return ? Call(_method_, _calendar_, « _dateTime_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _dateTime_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -163,7 +166,10 @@
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _calendar_ be _dateTime_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"month"*).
-        1. Return ? Call(_method_, _calendar_, « _dateTime_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _dateTime_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToPositiveIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -178,7 +184,10 @@
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _calendar_ be _dateTime_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"day"*).
-        1. Return ? Call(_method_, _calendar_, « _dateTime_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _dateTime_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToPositiveIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -399,7 +408,7 @@
           1. Throw a *TypeError* exception.
         1. Let _calendar_ be _dateTime_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"nanosecond"*, *"second"*, *"year"* »).
-        1. Let _partialDateTime_ be ? ToPartialDateTime(_temporalDateTimeLike_, _fieldNames_).
+        1. Let _partialDateTime_ be ? PreparePartialTemporalFields(_temporalDateTimeLike_, _fieldNames_).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _fields_ be ? ToTemporalDateTimeFields(_datetime_, _fieldNames_).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialDateTime_).
@@ -933,33 +942,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-topartialdatetime" aoid="ToPartialDateTime">
-      <h1>ToPartialDateTime ( _temporalDateTimeLike_, _fieldNames_ )</h1>
-      <emu-alg>
-        1. If Type(_temporalDateTimeLike_) is not Object, then
-          1. Throw a *TypeError* exception.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _any_ be *false*.
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalDateTimeLike_, _property_).
-          1. If _value_ is not *undefined*, then
-            1. Set _any_ to *true*.
-            1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
-              1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _property_ be the Property value of the current row.
-          1. Let _value_ be ? Get(_temporalDateTimeLike_, _property_).
-          1. If _value_ is not *undefined*, then
-            1. Set _any_ to *true*.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. If _any_ is *false*, then
-          1. Throw a *TypeError* exception.
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-regulatedatetime" aoid="RegulateDateTime">
       <h1>RegulateDateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _overflow_ )</h1>
       <emu-alg>
@@ -1087,24 +1069,8 @@
 
     <emu-clause id="sec-temporal-totemporaldatetimefields" aoid="ToTemporalDateTimeFields">
       <h1>ToTemporalDateTimeFields ( _temporalDateTimeLike_, _fieldNames_ )</h1>
-      <emu-note>The value of ? ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
-        1. Assert: Type(_temporalDateTimeLike_) is Object.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalDateLike_, _property_).
-          1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
-            1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _property_ be the Property value of the current row.
-          1. Let _value_ be ? Get(_temporalDateTimeLike_, _property_).
-          1. If _value_ is *undefined* and the Optional value of the current row is *false*, then
-            1. Throw a *TypeError* exception.
-          1. Let _value_ be ? ToIntegerOrInfinity(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. Return _result_.
+        1. Return ? PrepareTemporalFields(_temporalDateTimeLike_, _fieldNames_, «»).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -128,7 +128,10 @@
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Let _calendar_ be _monthDay_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"month"*).
-        1. Return ? Call(_method_, _calendar_, « _monthDay_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _monthDay_ »).
+        1. If _result_ is not *undefined*, then
+          1. Set _result_ to ? ToPositiveIntegerOrInfinity(_result_).
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 
@@ -143,7 +146,10 @@
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Let _calendar_ be _monthDay_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"month"*).
-        1. Return ? Call(_method_, _calendar_, « _monthDay_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _monthDay_ »).
+        1. If _result_ is not *undefined*, then
+          1. Set _result_ to ? ToPositiveIntegerOrInfinity(_result_).
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 
@@ -166,7 +172,7 @@
           1. Throw a *TypeError* exception.
         1. Let _calendar_ be _monthDay_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"* »).
-        1. Let _partialMonthDay_ be ? ToPartialMonthDay(_temporalMonthDayLike_, _fieldNames_).
+        1. Let _partialMonthDay_ be ? PreparePartialTemporalFields(_temporalMonthDayLike_, _fieldNames_).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _fields_ be ? ToTemporalMonthDayFields(_monthDay_, _fieldNames_).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialMonthDay_).
@@ -260,13 +266,11 @@
         1. If Type(_item_) is not Object, then
           1. Throw a *TypeError* exception.
         1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"year"* »).
-        1. For each value _property_ of _inputFieldNames_, do
-          1. Let _value_ be ? Get(_item_, _property_).
-          1. If _property_ is *"year"*, and _value_ is *undefined*, then
-            1. Throw a *TypeError* exception.
-          1. Let _value_ be ? ToIntegerOrInfinity(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_fields_, _property_, _value_).
-        1. Return ? DateFromFields(_calendar_, _fields_, %Temporal.PlainDate%).
+        1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
+        1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
+        1. Let _options_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).
+        1. Return ? DateFromFields(_calendar_, _mergedFields_, _options_, %Temporal.PlainDate%).
       </emu-alg>
     </emu-clause>
 
@@ -384,26 +388,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-topartialmonthday" aoid="ToPartialMonthDay">
-      <h1>ToPartialMonthDay ( _temporalMonthDayLike_, _fieldNames_ )</h1>
-      <emu-alg>
-        1. If Type(_temporalMonthDayLike_) is not Object, then
-          1. Throw a *TypeError* exception.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _any_ be *false*.
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalMonthDayLike_, _property_).
-          1. If _value_ is not *undefined*, then
-            1. Set _any_ to *true*.
-            1. If _property_ is either *"month"* or *"day"*, then
-              1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. If _any_ is *false*, then
-          1. Throw a *TypeError* exception.
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-regulatemonthday" aoid="RegulateMonthDay">
       <h1>RegulateMonthDay ( _month_, _day_, _overflow_ )</h1>
       <emu-alg>
@@ -485,17 +469,7 @@
     <emu-clause id="sec-temporal-totemporalmonthdayfields" aoid="ToTemporalMonthDayFields">
       <h1>ToTemporalMonthDayFields ( _temporalMonthDayLike_, _fieldNames_ )</h1>
       <emu-alg>
-        1. Assert: Type(_temporalMonthDayLike_) is Object.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalMonthDayLike_, _property_).
-          1. If _property_ is one of *"month"* or *"year"*, then
-            1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. Let _year_ be the first leap year after the Unix epoch (1972).
-        1. Perform ! CreateDataPropertyOrThrow(_result_, *"year"*, _year_).
-        1. Return _result_.
+        1. Return ? PrepareTemporalFields(_temporalMonthDayLike_, _fieldNames_, «»).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -141,7 +141,10 @@
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"year"*).
-        1. Return ? Call(_method_, _calendar_, « _yearMonth_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _yearMonth_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -156,7 +159,10 @@
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _method_ be ? Get(_calendar_, *"month"*).
-        1. Return ? Call(_method_, _calendar_, « _yearMonth_ »).
+        1. Let _result_ be ? Call(_method_, _calendar_, « _yearMonth_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToPositiveIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -239,7 +245,7 @@
           1. Throw a *TypeError* exception.
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"year"* »).
-        1. Let _partialYearMonth_ be ? ToPartialYearMonth(_temporalYearMonthLike_, _fieldNames_).
+        1. Let _partialYearMonth_ be ? PreparePartialTemporalFields(_temporalYearMonthLike_, _fieldNames_).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _fields_ be ? ToTemporalYearMonthFields(_yearMonth_, _fieldNames_).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialYearMonth_).
@@ -467,15 +473,11 @@
         1. Let _receiverFieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"year"* »).
         1. Let _fields_ be ? ToTemporalYearMonthFields(_yearMonth_, _receiverFieldNames_).
         1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"day"* »).
-        1. For each value _property_ of _inputFieldNames_, do
-          1. Let _value_ be ? Get(_item_, _property_).
-          1. If _property_ is *"day"*, and _value_ is *undefined*, then
-            1. Throw a *TypeError* exception.
-          1. Let _value_ be ? ToIntegerOrInfinity(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_fields_, _property_, _value_).
+        1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
+        1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
         1. Let _options_ be ! OrdinaryObjectCreate(%Object.prototype%).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).
-        1. Return ? DateFromFields(_calendar_, _fields_, _options_, %Temporal.PlainDate%).
+        1. Return ? DateFromFields(_calendar_, _mergedFields_, _options_, %Temporal.PlainDate%).
       </emu-alg>
     </emu-clause>
 
@@ -593,26 +595,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-topartialyearmonth" aoid="ToPartialYearMonth">
-      <h1>ToPartialYearMonth ( _temporalYearMonthLike_, _fieldNames_ )</h1>
-      <emu-alg>
-        1. If Type(_temporalYearMonthLike_) is not Object, then
-          1. Throw a *TypeError* exception.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _any_ be *false*.
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalYearMonthLike_, _property_).
-          1. If _value_ is not *undefined*, then
-            1. Set _any_ to *true*.
-            1. If _property_ is either *"month"* or *"year"*, then
-              1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. If _any_ is *false*, then
-          1. Throw a *TypeError* exception.
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-regulateyearmonth" aoid="RegulateYearMonth">
       <h1>RegulateYearMonth ( _year_, _month_, _overflow_ )</h1>
       <emu-alg>
@@ -713,16 +695,7 @@
     <emu-clause id="sec-temporal-totemporalyearmonthfields" aoid="ToTemporalYearMonthFields">
       <h1>ToTemporalYearMonthFields ( _temporalYearMonthLike_, _fieldNames_ )</h1>
       <emu-alg>
-        1. Assert: Type(_temporalYearMonthLike_) is Object.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalDateLike_, _property_).
-          1. If _property_ is either *"month"*, or *"year"*, then
-            1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. Perform ! CreateDataPropertyOrThrow(_result_, *"day"*, 1).
-        1. Return _result_.
+        1. Return ? PrepareTemporalFields(_temporalYearMonthLike_, _fieldNames_, «»).
       </emu-alg>
     </emu-clause>
 

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -164,7 +164,10 @@
         1. Let _temporalDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _year_ be ? Get(_calendar_, *"year"*).
-        1. Return ? Call(_year_, _calendar_, « _temporalDateTime_ »).
+        1. Let _result_ be ? Call(_year_, _calendar_, « _temporalDateTime_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -182,7 +185,10 @@
         1. Let _temporalDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _month_ be ? Get(_calendar_, *"month"*).
-        1. Return ? Call(_month_, _calendar_, « _temporalDateTime_ »).
+        1. Let _result_ be ? Call(_month_, _calendar_, « _temporalDateTime_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToPositiveIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -200,7 +206,10 @@
         1. Let _temporalDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _day_ be ? Get(_calendar_, *"day"*).
-        1. Return ? Call(_day_, _calendar_, « _temporalDateTime_ »).
+        1. Let _result_ be ? Call(_day_, _calendar_, « _temporalDateTime_ »).
+        1. If _result_ is *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Return ? ToPositiveIntegerOrInfinity(_result_).
       </emu-alg>
     </emu-clause>
 
@@ -1121,7 +1130,7 @@
           1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
           1. Let _offsetString_ be ? Get(_fields_, *"offset"*).
           1. If _offsetString_ is not *undefined*, set it to ? ToString(_offsetString_).
-          1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _item_, _options_).
+          1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Else,
           1. Perform ? ToTemporalOverflow(_options_).
           1. Let _string_ be ? ToString(_item_).
@@ -1150,22 +1159,10 @@
         1. If _otherCalendar_ is not *undefined*, throw a *TypeError* exception.
         1. Let _timeZone_ be ? Get(_temporalZonedDateTimeLike_, *"timeZone"*).
         1. If _timeZone_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _any_ be *false*.
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalDateTimeLike_, _property_).
-          1. If _value_ is not *undefined*, then
-            1. Set _any_ to *true*.
-            1. If _property_ is one of *"year"*, *"month"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*, then
-              1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. Let _offset_ be ? Get(_temporalDateTimeLike_, *"offset"*).
-        1. If _offset_ is not *undefined*, then
-          1. Set _any_ to *true*.
-          1. Set _offset_ to ? ToString(_offset_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, *"offset"*, _offset_).
-        1. If _any_ is *false*, then
-          1. Throw a *TypeError* exception.
+        1. Let _fieldNamesList_ be ? CreateListFromArrayLike(_fieldNames_).
+        1. Append *"offset"* to _fieldNamesList_.
+        1. Set _fieldNames_ to ? CreateArrayFromList(_fieldNamesList_).
+        1. Let _result_ be ? PreparePartialTemporalFields(_temporalDateTimeLike_, _fieldNames_).
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -1227,89 +1224,14 @@
       <p>
         The abstract operation ToTemporalZonedDateTimeFields reads the relevant properties of an Object _temporalZonedDateTimeLike_, including the calendar-specific ones; ensures all the required properties are present; and creates a new Object with all the properties converted to the correct type, missing ones filled in with their default values.
       </p>
-      <emu-note>The value of ? ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. Assert: Type(_temporalZonedDateTimeLike_) is Object.
-        1. Let _result_ be ? OrdinaryObjectCreate(%Object.prototype%).
-        1. For each value _property_ of _fieldNames_, do
-          1. Let _value_ be ? Get(_temporalDateLike_, _property_).
-          1. If _property_ is one of *"day"*, *"month"*, or *"year"*, then
-            1. If _value_ is *undefined*, throw a *TypeError* exception.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. For each row of <emu-xref href="#table-temporal-temporalzoneddatetimelike-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _property_ be the Property value of the current row.
-          1. Let _value_ be ? Get(_temporalDateTimeLike_, _property_).
-          1. If _value_ is *undefined* and the Optional value of the current row is *false*, then
-            1. Throw a *TypeError* exception.
-          1. If the Type value of the current row is Integer, then
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
-          1. Else if the Type value of the current row is String, then
-            1. Set _value_ to ? ToString(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+        1. Let _fieldNamesList_ be ? CreateListFromArrayLike(_fieldNames_).
+        1. Append *"timeZone"* to _fieldNamesList_.
+        1. Set _fieldNames_ to ? CreateArrayFromList(_fieldNamesList_).
+        1. Let _result_ be ? PrepareTemporalFields(_temporalZonedDateTimeLike_, _fieldNames_, « *"_timeZone_"* »).
         1. Return _result_.
       </emu-alg>
-      <emu-table id="table-temporal-temporalzoneddatetimelike-properties">
-        <emu-caption>Non-calendar properties of a TemporalZonedDateTimeLike</emu-caption>
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Property</th>
-              <th>Type</th>
-              <th>Optional</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>*"hour"*</td>
-              <td>Integer</td>
-              <td>*true*</td>
-            </tr>
-
-            <tr>
-              <td>*"microsecond"*</td>
-              <td>Integer</td>
-              <td>*true*</td>
-            </tr>
-
-            <tr>
-              <td>*"millisecond"*</td>
-              <td>Integer</td>
-              <td>*true*</td>
-            </tr>
-
-            <tr>
-              <td>*"minute"*</td>
-              <td>Integer</td>
-              <td>*true*</td>
-            </tr>
-
-            <tr>
-              <td>*"nanosecond"*</td>
-              <td>Integer</td>
-              <td>*true*</td>
-            </tr>
-
-            <tr>
-              <td>*"offset"*</td>
-              <td>String</td>
-              <td>*true*</td>
-            </tr>
-
-            <tr>
-              <td>*"second"*</td>
-              <td>Integer</td>
-              <td>*true*</td>
-            </tr>
-
-            <tr>
-              <td>*"timeZone"*</td>
-              <td>Object</td>
-              <td>*false*</td>
-            </tr>
-          </tbody>
-        </table>
-      </emu-table>
     </emu-clause>
 
     <emu-clause id="sec-temporal-temporalzoneddatetimetostring" aoid="TemporalZonedDateTimeToString">


### PR DESCRIPTION
**Do not merge**; RFC only in this state

This change does a few other things as well:
- Implement `era`, `eraYear` for all remaining objects.
- Implement `eraYear`/`year` split behavior for `'gregory'` and `'japanese'` calendars (NB: choice of anchor/default era in 'japanese' should be revisited with more cultural context).

I only included the specification for the new `PrepareTemporalFields` abstract operation; I'm still refactoring the spec text into all the other `ToTemporal*Fields`, `ToRelativeTemporalObject`, etc abstract operations and that's messy / incomplete at the moment. However, `PrepareTemporalFields` closely matches how ES.ToRecord was used throughout the polyfill already, so this brings the specification and polyfill much closer together.

There are a number of questions and FIXME comments; I'm also uncertain if the language I used around abstract operation references in a table is valid specification. Bear with me :) Will finish this up over the next day and change.