### PR TITLE
Documentation changes for non-ISO calendars

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -38,7 +38,7 @@ date.withCalendar(calendar).add({ months: 1 });
 
 ### Invariants Across Calendars
 
-The following "invariants" (statements that are always true) hold for all built-in calendars, and SHOULD hold for properly-authored custom calendars:
+The following "invariants" (statements that are always true) hold for all built-in calendars, and should also hold for any properly-authored custom calendar that supports years, months, and days units:
 
 - `year` is always an integer that increases as time goes forward
 - `month` and `day` are always positive integers that increase as time goes forward, except they reset at the boundary of a year or month, respectively

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -18,7 +18,7 @@ Some places use another calendar system as the main calendar, or have a separate
 > **NOTE:** The Temporal polyfill currently only includes the ISO 8601 calendar, but the Temporal proposal will eventually provide all the calendars supported by Intl.
 > See [issue #541](https://github.com/tc39/proposal-temporal/issues/541).
 
-### When to use the `Temporal.Calendar`
+### When to use `Temporal.Calendar`
 
 It is best practice to specify a calendar system when performing calendar-sensitive operations, which are those involving arithmetic or other calculation in months or years.
 
@@ -35,6 +35,46 @@ To perform arithmetic consistently with the `toLocaleString()` calendar system:
 const calendar = new Intl.DateTimeFormat().resolvedOptions().calendar;
 date.withCalendar(calendar).add({ months: 1 });
 ```
+
+### Invariants Across Calendars
+
+The following "invariants" (statements that are always true) hold for all built-in calendars, and SHOULD hold for properly-authored custom calendars:
+
+- `year`, `month`, `day` are always integers that increase as time goes forward
+- `month` and `day` are always positive integers
+- `date.month === 1` during the first month of any year
+- `date.month === date.monthsInYear` during the last month of any year
+- `month` is always continuous (no gaps)
+- Any date can be serialized to an object using only four properties: `{ year, month, day, calendar }`
+
+### Writing Cross-Calendar Code
+
+Here are best practices for writing code that will work regardless of the calendar used:
+
+- Validate or coerce the calendar of all external input. If your code receives date data from an external source, you should validate that its calendar is what you expect or coerce it to a known calendar via the `withCalendar` method. Otherwise, a sophisticated attacker could change the behavior of your app or introduce security or performance issues by introducing an unexpected calendar.
+- Use `compare` methods (e.g. `Temporal.PlainDate.compare(date1, '2000-01-01')`) instead of manually comparing individual properties (e.g. `date.year > 2000`) whose meaning may vary across calendars.
+- Never compare field values in different calendars. A `month` or `year` in one calendar is unrelated to the same property values in another calendar. If dates in different calendars must be compared, use `compare`.
+- When comparing dates for equality that might be in different calendars, convert them both to the same calendar using `withCalendar`. The same ISO date in different calendars will return `false` from the `equals` method and will return a non-zero value from `compare` because the calendars are not equal.
+- When looping through all months in a year, use `monthsPerYear` as the upper bound instead of assuming that every year has 12 months.
+- Don't assume that `date.month===12` is the last month of the year. Instead, use `date.month===date.monthsInYear`.
+- Use `until` or `since` to count years, months, or days between dates. Manually calculating differences (e.g. `Math.floor(months/12)`) will fail for some calendars.
+- Use `daysPerMonth` instead of assuming that each month has the same number of days in every year.
+- Days in a month are not always continuous. There can be gaps due to political changes in calendars and/or time zones. For this reason, instead of looping through a month from 1 to `date.daysInMonth`, it's better to start a loop with the first day of the month (`.with({day: 1})`) and `add` one day at a time until the `month` property returns a different value.
+- Use `daysInYear` instead of assuming that every year has 365 days (366 in a leap year).
+- Don't assume that `inLeapYear===true` implies that the year is one day longer than a regular year. Some calendars add leap months, making the year 29 or 30 days longer than a normal year!
+- Use `toLocaleString` to format dates to users. DO NOT localize manually with code like `${month}/${day}/${year}`.
+- Don't assume that `month` has the same name in every year. Some calendars like Hebrew or Chinese have leap months that cause months to vary across years.
+- Use the correct property to refer to months. If you care about the order of the month in a particular year (e..g. when looping through all the months in a year) use `month`. If you care about the month regardless of what year it is (e.g. storing a birthday), use the `monthCode` string property.
+- When using the `Temporal.PlainMonthDay` type (e.g. for birthdays or holidays), use its `monthCode` property only. The `month` property is not present on this type because some calendars' month indexes vary from year to year.
+- When calling `Temporal.PlainMonthDay.prototype.toPlainDate(year)`, be prepared for the resulting date to have a different day of the month and/or a different month, because leap days and leap months are not present in every year.
+- Use `toLocaleString` to fetch month names instead instead of caching an array of names. Example: `date.toLocaleString('en-US', { calendar: date.calendar, month: 'long' })`. If you absolutely must cache month names, a string key like `${date.calendar.id}|{date.monthCode}|{date.inLeapYear}` will work for all built-in calendars.
+- Don't assume that `era` or `eraYear` properties are always present. They are not present in some calendars.
+- `era` and `eraYear` should always be used as a pair. Don't use one property without also using the other.
+- Don't combine `month` and `monthCode` in the same property bag. Pick one month representation and use it consistently.
+- Don't combine `year` and `era`/`eraYear` in the same property bag. Pick one year representation and use it consistently.
+- Read the documentation of your calendar to determine the meaning of `monthCode` and `era`.
+- Don't show `monthCode` and `era` values in a UI. Instead, use `toLocaleString` to convert these values into localized strings.
+- Don't assume that the year before `{ eraYear: 1 }` is the last year of the previous era. Some calendars have a "year zero", and the oldest era in era-using calendars typically allows negative `eraYear` values.
 
 ### Custom calendars
 
@@ -137,9 +177,15 @@ When subclassing `Temporal.Calendar`, this property doesn't need to be overridde
 
 ## Methods
 
+### calendar.**era**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.PlainYearMonth | object | string) : string | undefined
+
+### calendar.**eraYear**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.PlainYearMonth | object | string) : number | undefined
+
 ### calendar.**year**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.PlainYearMonth | object | string) : number
 
-### calendar.**month**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.PlainYearMonth | Temporal.PlainMonthDay | object | string) : number
+### calendar.**month**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.PlainYearMonth | object | string) : number
+
+### calendar.**monthCode**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.PlainYearMonth | Temporal.PlainMonthDay | object | string) : string
 
 ### calendar.**day**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.PlainMonthDay | object | string) : number
 
@@ -176,10 +222,12 @@ They are called indirectly when reading the various properties of `Temporal.Zone
 For example:
 
 ```javascript
-const date = Temporal.PlainDate.from('2020-05-29').withCalendar('hebrew');
-date.year; // => 5780
+const date = Temporal.PlainDate.from('2019-02-06').withCalendar('hebrew');
+date.year; // => 5779
 date.calendar.year(date); // same result, but calling the method directly
-date.daysInYear; // => 355
+date.monthCode; // => "5L"
+date.calendar.monthCode(date); // same result, but calling the method directly
+date.daysInYear; // => 385
 date.calendar.daysInYear(date); // same result, but calling the method directly
 ```
 
@@ -214,22 +262,20 @@ A custom implementation of these methods would convert the calendar-space argume
 For example:
 
 ```javascript
-date = Temporal.PlainDate.from({ year: 5780, month: 9, day: 6, calendar: 'hebrew' }, { overflow: 'reject' });
-date.year; // => 5780
-date.month; // => 9
-date.day; // => 6
-date.toString(); // => 2020-05-29[c=hebrew]
+date = Temporal.PlainDate.from({ year: 5779, monthCode: '5L', day: 18, calendar: 'hebrew' });
+date.year; // => 5779
+date.month; // => 6
+date.monthCode; // => "5L"
+date.day; // => 18
+date.toString(); // => 2019-02-23[c=hebrew]
+date.toLocaleString('en-US', { calendar: 'hebrew' }); // => "18 Adar I 5779"
 
-// same result, but calling the method directly:
+// same result, but calling the method directly and using month index instead of month code:
 date = Temporal.Calendar.from('hebrew').dateFromFields(
-  { year: 5780, month: 9, day: 6 },
-  { overflow: 'reject' },
+  { year: 5779, month: 6, day: 18 },
+  { overflow: 'constrain' },
   Temporal.PlainDate
 );
-date.year; // => 5780
-date.month; // => 9
-date.day; // => 6
-date.toString(); // => 2020-05-29[c=hebrew]
 ```
 
 ### calendar.**dateAdd**(_date_: Temporal.PlainDate | object | string, _duration_: Temporal.Duration | object | string, _options_: object, _constructor_: function) : Temporal.PlainDate
@@ -332,8 +378,9 @@ Temporal.Calendar.from('chinese').dateUntil(
 This method does not need to be called directly except in specialized code.
 It is called indirectly when using the `from()` static methods and `with()` methods of `Temporal.PlainDateTime`, `Temporal.PlainDate`, and `Temporal.PlainYearMonth`.
 
-Custom calendars should override this method if they require more fields with which to denote the date than the standard `year`, `month`, and `day` (for example, `era`).
-The input array contains the field names that are necessary for a particular operation (for example, `'month'` and `'day'` for `Temporal.PlainMonthDay.prototype.with()`), and the method should make a copy of the array and add whichever extra fields are necessary.
+Custom calendars should override this method if they accept fields in `from()` or `with()` other than the standard set of built-in calendar fields: `year`, `month`, `monthCode`, and `day`.
+The input array contains the field names that are necessary for a particular operation (for example, `'monthCode'`, and `'day'` for `Temporal.PlainMonthDay.prototype.with()`).
+The method should make a copy of the array and add additional fields as needed.
 
 When subclassing `Temporal.Calendar`, this method doesn't need to be overridden, unless your calendar requires extra fields, because the default implementation returns a copy of `fields`.
 
@@ -342,8 +389,8 @@ Usage example:
 <!-- prettier-ignore-start -->
 ```js
 // In built-in calendars, this method just makes a copy of the input array
-Temporal.Calendar.from('iso8601').fields(['month', 'day']);
-// => ['month', 'day']
+Temporal.Calendar.from('iso8601').fields(['monthCode', 'day']);
+// => ['monthCode', 'day']
 ```
 <!-- prettier-ignore-end -->
 
@@ -358,6 +405,7 @@ Example usage:
 ```javascript
 Temporal.PlainDate.from('2020-05-29[c=gregory]').calendar.toString(); // => gregory
 ```
+
 ### calendar.**toJSON**() : string
 
 **Returns:** The string given by `calendar.id`.

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -27,8 +27,8 @@ A `Temporal.PlainMonthDay` can be converted into a `Temporal.PlainDate` by combi
 
 **Returns:** a new `Temporal.PlainMonthDay` object.
 
-> The `calendar` and `referenceISOYear` parameters should be avoided because `equals` or `compare` will consider these two objects unequal: `new Temporal.PlainMonthDay(3, 14, 'iso8601', 1970)` and `new Temporal.PlainMonthDay(3, 14, 'iso8601`, 2000)`.
-> When creating instances for non-ISO-8601 calendars (other than when implementing a custom calendar) use the `from()` method which will automatically set a valid and consistent reference year for all calendars.
+> The `calendar` and `referenceISOYear` parameters should be avoided because `equals` or `compare` will consider `new Temporal.PlainMonthDay(3, 14, 'iso8601', 1977)` and `new Temporal.PlainMonthDay(3, 14, 'iso8601', 2000)` unequal even though they refer to the same month and day.
+> When creating instances for non-ISO-8601 calendars (except when implementing a custom calendar) use the `from()` method which will automatically set a valid and `equals`-compatible reference year.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 
@@ -44,12 +44,6 @@ Usage examples:
 md = new Temporal.PlainMonthDay(3, 14); // => 03-14
 // Leap day
 md = new Temporal.PlainMonthDay(2, 29); // => 02-29
-
-// 1 Adar I (first day of a leap month) in the Hebrew calendar
-md = new Temporal.PlainYearMonth(2, 6, Temporal.Calendar.from('hebrew'), 2019);
-// => 2019-02-06[c=hebrew]
-md.monthCode; // => "5L"
-md.day; // => 1
 ```
 
 ## Static methods
@@ -72,11 +66,9 @@ If the value is a `Temporal.PlainMonthDay`, `Temporal.PlainDate`, `Temporal.Plai
 If the value is any other object, it:
 
 - Must have a `day` property
-- Must have either a string `monthCode` property OR both `month` and `year` integer number properties.
+- Must have either a string `monthCode` or `month` property.
+  If `month` is used and `calendar` is provided, then `year` must be provided as well because `month` is ambiguous in some calendars without knowing the year.
 - May have a `calendar` property. If omitted, the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates) will be used by default.
-
-Some calendars like Hebrew or Chinese have leap months which causes `month` to be ambiguous without knowing the year.
-Therefore, if neither `monthCode` nor `year` is provided, a `RangeError` will be thrown (regardless of calendar used) to encourage calendar-independent code.
 
 Any non-object value will be converted to a string, which is expected to be in ISO 8601 format.
 For the ISO 8601 calendar, only the month and day will be parsed from the string.
@@ -178,8 +170,8 @@ The `calendar` read-only property gives the calendar that the `monthCode` and `d
     Allowed values are `constrain` and `reject`.
     The default is `constrain`.
 
-Note that there are two ways to change the month: providing `monthCode` or providing both `month` and `year`.
-If only `month` is provided, then a `RangeError` will be thrown because `month` is ambiguous in some calendars without knowing the year.
+There are two ways to change the month: providing `monthCode` or `month`.
+If `month` is used and `calendar` is provided, then `year` must be provided as well because `month` is ambiguous in some calendars without knowing the year.
 If `monthCode` is provided in addition to `month` and/or `year`, then the properties must not conflict or a `RangeError` will be thrown.
 
 **Returns:** a new `Temporal.PlainMonthDay` object.

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -23,14 +23,12 @@ A `Temporal.PlainMonthDay` can be converted into a `Temporal.PlainDate` by combi
 - `referenceISOYear` (optional for ISO 8601 calendar; required for other calendars):
   A reference year in the ISO 8601 calendar for disambiguation when implementing calendar systems.
   The default for the ISO 8601 calendar is the first leap year after the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
-  This value is required for other calendar systems, but can cause serious problems if not set correctly.
+  This value is required for other calendar systems. If you don't know what to put here, use the `from` method instead.
 
 **Returns:** a new `Temporal.PlainMonthDay` object.
 
-> NOTE: To avoid infinite recursion, the `referenceISOYear` is accepted as-is without validating that the year contains the specified month and day in the desired calendar and without replacing the year with a canonical value like `from` and `with` will do.
-> These limitations mean that `equals` or `compare` may return `false` for `Temporal.PlainMonthDay` instances where the month and day are identical, but the reference years don't match.
-> For this reason, it is STRONGLY recommended that this constructor SHOULD NOT be used except when implementing a custom calendar or when only using the ISO 8601 calendar.
-> For other calendars, use the `from` method which will always set the same reference year for the same month, day, and calendar.
+> The `calendar` and `referenceISOYear` parameters should be avoided because `equals` or `compare` will consider these two objects unequal: `new Temporal.PlainMonthDay(3, 14, 'iso8601', 1970)` and `new Temporal.PlainMonthDay(3, 14, 'iso8601`, 2000)`.
+> When creating instances for non-ISO-8601 calendars (other than when implementing a custom calendar) use the `from()` method which will automatically set a valid and consistent reference year for all calendars.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -22,7 +22,10 @@ A `Temporal.PlainYearMonth` can be converted into a `Temporal.PlainDate` by comb
 - `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the month into.
 - `referenceISODay` (optional for ISO 8601 calendar; required for other calendars): A reference day, used for disambiguation when implementing calendar systems.
   For the ISO 8601 calendar, this parameter will default to 1 if omitted.
-  For other calendars, it's the callers responsibility to set this parameter to the ISO-calendar day corresponding to the first day of the desired calendar year and month.
+  For other calendars, the must set this parameter to the ISO-calendar day corresponding to the first day of the desired calendar year and month.
+
+> The `calendar` and `referenceISODay` parameters should be avoided because `equals` or `compare` will consider `new Temporal.PlainYearMonth(2000, 3, 'iso8601', 14)` and `PlainYearMonth(2000, 3, 'iso8601', 1)` unequal even though they refer to the same year and month.
+> When creating instances for non-ISO-8601 calendars (except when implementing a custom calendar) use the `from()` method which will automatically set a valid and `equals`-compatible reference day.
 
 > NOTE: To avoid infinite recursion, `referenceISODay` is accepted as-is without validating that the day provided is actually the first day of the month in the desired calendar system.
 > This lack of validation means that `equals` or `compare` may return `false` for `Temporal.PlainYearMonth` instances where the year and month and day are identical, but the reference days don't match.
@@ -44,13 +47,6 @@ Usage examples:
 // The June 2019 meeting
 ym = new Temporal.PlainYearMonth(2019, 6);
 // => 2019-06
-
-// Non-ISO calendar
-ym = new Temporal.PlainYearMonth(2019, 2, Temporal.Calendar.from('hebrew'), 6);
-// => 2019-02-06[c=hebrew]
-ym.monthCode; // => "5L"
-ym.month; // => 6
-ym.year; // => 5779
 ```
 
 ## Static methods


### PR DESCRIPTION
This PR:
* Documents new `monthCode` and `eraYear` properties across all Temporal types where these properties are used, including docs for the getters themselves and also where they're used (esp. in `from` methods)
* Adds additional details about date field getters. For consistency, time field getters too in PlainDateTime/ZonedDateTime also get a little more detail.
* Clarifies PlainYearMonth/PlainMonthDay behavior with non-ISO calendars
* Documents which invariants hold across calendars (currently it's a short list; I assume we'll add to this list later as we realize what other invariants also hold)
* Documents best practices for writing cross-calendar code. This could be broken out into a new page if needed, but calendar.md is already a fairly specialized page for experts so it might be appropriate there. LMK how we should handle this content.
* Adds non-ISO calendar code examples in a few places. I probably should have added more (e.g. PDT/ZDT `from`) but ran out of time.

This PR doesn't cover docs for all other non-ISO-calendar changes happening this week, but hopefully should lighten the documentation load on @ptomato and @cjtenny who are doing the heavy lifting of wrapping up actual code and spec fixes for non-ISO calendars.
