### PR TITLE
Ensure reference ISO year/day is always given by the calendar

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1290,10 +1290,10 @@ export const ES = ObjectAssign({}, ES2020, {
     ES.RejectDate(referenceISOYear, month, day);
     if (calendar === undefined) calendar = ES.GetISO8601Calendar();
     calendar = ES.ToTemporalCalendar(calendar);
-    if (referenceISOYear === undefined) referenceISOYear = 1972;
-    let result = new constructor(month, day, calendar, referenceISOYear);
-    if (!ES.IsTemporalMonthDay(result)) throw new TypeError('invalid result');
-    return result;
+
+    const PlainMonthDay = GetIntrinsic('%Temporal.PlainMonthDay%');
+    let result = new PlainMonthDay(month, day, calendar, referenceISOYear);
+    return ES.MonthDayFromFields(calendar, result, constructor, {});
   },
   ToTemporalTime: (item, constructor, overflow = 'constrain') => {
     let hour, minute, second, millisecond, microsecond, nanosecond, calendar;
@@ -1345,9 +1345,10 @@ export const ES = ObjectAssign({}, ES2020, {
     ES.RejectDate(year, month, referenceISODay);
     if (calendar === undefined) calendar = ES.GetISO8601Calendar();
     calendar = ES.ToTemporalCalendar(calendar);
-    let result = new constructor(year, month, calendar, referenceISODay);
-    if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
-    return result;
+
+    const PlainYearMonth = GetIntrinsic('%Temporal.PlainYearMonth%');
+    let result = new PlainYearMonth(year, month, calendar, referenceISODay);
+    return ES.YearMonthFromFields(calendar, result, constructor, {});
   },
   InterpretTemporalZonedDateTimeOffset: (
     year,

--- a/polyfill/test/plainmonthday.mjs
+++ b/polyfill/test/plainmonthday.mjs
@@ -44,10 +44,37 @@ describe('MonthDay', () => {
       it("MonthDay.from('1976-11-18') == (11-18)", () => equal(`${PlainMonthDay.from('1976-11-18')}`, '11-18'));
       it('MonthDay.from({ monthCode: "11", day: 18 }) == 11-18', () =>
         equal(`${PlainMonthDay.from({ monthCode: '11', day: 18 })}`, '11-18'));
+      it('ignores year when determining the ISO reference year from month/day', () => {
+        const one = PlainMonthDay.from({ year: 2019, month: 11, day: 18 });
+        const two = PlainMonthDay.from({ year: 1979, month: 11, day: 18 });
+        equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
+      });
+      it('ignores era/eraYear when determining the ISO reference year from month/day', () => {
+        const one = PlainMonthDay.from({ era: 'ad', eraYear: 2019, month: 11, day: 18, calendar: 'gregory' });
+        const two = PlainMonthDay.from({ era: 'ad', eraYear: 1979, month: 11, day: 18, calendar: 'gregory' });
+        equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
+      });
+      it('ignores year when determining the ISO reference year from monthCode/day', () => {
+        const one = PlainMonthDay.from({ year: 2019, monthCode: '11', day: 18 });
+        const two = PlainMonthDay.from({ year: 1979, monthCode: '11', day: 18 });
+        equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
+      });
+      it('ignores era/eraYear when determining the ISO reference year from monthCode/day', () => {
+        const one = PlainMonthDay.from({ era: 'ad', eraYear: 2019, monthCode: '11', day: 18, calendar: 'gregory' });
+        const two = PlainMonthDay.from({ era: 'ad', eraYear: 1979, monthCode: '11', day: 18, calendar: 'gregory' });
+        equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
+      });
       it('MonthDay.from(11-18) is not the same object', () => {
         const orig = new PlainMonthDay(11, 18);
         const actu = PlainMonthDay.from(orig);
         notEqual(actu, orig);
+      });
+      it('ignores year when determining the ISO reference year from other Temporal object', () => {
+        const plainDate1 = Temporal.PlainDate.from('2019-11-18');
+        const plainDate2 = Temporal.PlainDate.from('1976-11-18');
+        const one = PlainMonthDay.from(plainDate1);
+        const two = PlainMonthDay.from(plainDate2);
+        equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
       });
       it('MonthDay.from({month, day}) allowed if calendar absent', () =>
         equal(`${PlainMonthDay.from({ month: 11, day: 18 })}`, '11-18'));
@@ -102,6 +129,11 @@ describe('MonthDay', () => {
       it('RFC 3339 month-day syntax', () => {
         equal(`${PlainMonthDay.from('--11-18')}`, '11-18');
         equal(`${PlainMonthDay.from('--1118')}`, '11-18');
+      });
+      it('ignores year when determining the ISO reference year from string', () => {
+        const one = PlainMonthDay.from('2019-11-18');
+        const two = PlainMonthDay.from('1976-11-18');
+        equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
       });
       it('no junk at end of string', () => throws(() => PlainMonthDay.from('11-18junk'), RangeError));
       it('options may only be an object or undefined', () => {
@@ -193,6 +225,9 @@ describe('MonthDay', () => {
     });
     it('incorrectly-spelled properties are ignored', () => {
       equal(`${md.with({ monthCode: '12', days: 1 })}`, '12-15');
+    });
+    it('year is ignored when determining ISO reference year', () => {
+      equal(md.with({ year: 1900 }).getISOFields().isoYear, md.getISOFields().isoYear);
     });
   });
   describe('MonthDay.equals()', () => {

--- a/polyfill/test/plainyearmonth.mjs
+++ b/polyfill/test/plainyearmonth.mjs
@@ -77,10 +77,37 @@ describe('YearMonth', () => {
         equal(`${PlainYearMonth.from({ year: 2019, month: 11 })}`, '2019-11'));
       it('month and monthCode must agree', () =>
         throws(() => PlainYearMonth.from({ year: 2019, month: 11, monthCode: '12' }), RangeError));
+      it('ignores day when determining the ISO reference day from year/month', () => {
+        const one = PlainYearMonth.from({ year: 2019, month: 11, day: 1 });
+        const two = PlainYearMonth.from({ year: 2019, month: 11, day: 2 });
+        equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
+      });
+      it('ignores day when determining the ISO reference day from year/monthCode', () => {
+        const one = PlainYearMonth.from({ year: 2019, monthCode: '11', day: 1 });
+        const two = PlainYearMonth.from({ year: 2019, monthCode: '11', day: 2 });
+        equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
+      });
+      it('ignores day when determining the ISO reference day from era/eraYear/month', () => {
+        const one = PlainYearMonth.from({ era: 'ad', eraYear: 2019, month: 11, day: 1, calendar: 'gregory' });
+        const two = PlainYearMonth.from({ era: 'ad', eraYear: 2019, month: 11, day: 2, calendar: 'gregory' });
+        equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
+      });
+      it('ignores day when determining the ISO reference day from era/eraYear/monthCode', () => {
+        const one = PlainYearMonth.from({ era: 'ad', eraYear: 2019, monthCode: '11', day: 1, calendar: 'gregory' });
+        const two = PlainYearMonth.from({ era: 'ad', eraYear: 2019, monthCode: '11', day: 2, calendar: 'gregory' });
+        equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
+      });
       it('YearMonth.from(2019-11) is not the same object', () => {
         const orig = new PlainYearMonth(2019, 11);
         const actu = PlainYearMonth.from(orig);
         notEqual(actu, orig);
+      });
+      it('ignores day when determining the ISO reference day from other Temporal object', () => {
+        const plainDate1 = Temporal.PlainDate.from('1976-11-01');
+        const plainDate2 = Temporal.PlainDate.from('1976-11-18');
+        const one = PlainYearMonth.from(plainDate1);
+        const two = PlainYearMonth.from(plainDate2);
+        equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
       });
       it('YearMonth.from({ year: 2019 }) throws', () => throws(() => PlainYearMonth.from({ year: 2019 }), TypeError));
       it('YearMonth.from({ month: 6 }) throws', () => throws(() => PlainYearMonth.from({ month: 6 }), TypeError));
@@ -119,6 +146,11 @@ describe('YearMonth', () => {
         equal(`${PlainYearMonth.from('1976-11-18T15:23')}`, '1976-11');
         equal(`${PlainYearMonth.from('1976-11-18T15')}`, '1976-11');
         equal(`${PlainYearMonth.from('1976-11-18')}`, '1976-11');
+      });
+      it('ignores day when determining the ISO reference day from string', () => {
+        const one = PlainYearMonth.from('1976-11-01');
+        const two = PlainYearMonth.from('1976-11-18');
+        equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
       });
       it('no junk at end of string', () => throws(() => PlainYearMonth.from('1976-11junk'), RangeError));
       it('options may only be an object or undefined', () => {
@@ -183,6 +215,9 @@ describe('YearMonth', () => {
     });
     it('incorrectly-spelled properties are ignored', () => {
       equal(`${ym.with({ month: 1, years: 2020 })}`, '2019-01');
+    });
+    it('day is ignored when determining ISO reference day', () => {
+      equal(ym.with({ year: ym.year, day: 31 }).getISOFields().isoDay, ym.getISOFields().isoDay);
     });
   });
   describe('YearMonth.compare() works', () => {

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -185,7 +185,7 @@ describe('Userland calendar', () => {
       });
       it('works for MonthDay.from(iso)', () => {
         const md = Temporal.PlainMonthDay.from(iso);
-        equal(`${md}`, '1970-01-01[u-ca-two-based]');
+        equal(`${md}`, '1972-01-01[u-ca-two-based]');
       });
       it('works for MonthDay.from(props)', () => {
         const md = Temporal.PlainMonthDay.from({ monthCode: '2', day: 1, calendar: 'two-based' });

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -392,7 +392,9 @@
           1. Throw a *RangeError* exception.
         1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. Set _result_ to ? RegulateMonthDay(_result_.[[Month]], _result_.[[Day]], _overflow_).
-        1. Return ? CreateTemporalMonthDayFromStatic(_constructor_, _result_.[[Month]], _result_.[[Day]], _referenceISOYear_, _calendar_).
+        1. Set _result_ to ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _referenceISOYear_, _calendar_).
+        1. Let _canonicalMonthDayOptions_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Return ? MonthDayFromFields(_calendar_, _result_, _constructor_, _canonicalMonthDayOptions_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -609,7 +609,9 @@
           1. Throw a *RangeError* exception.
         1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. Set _result_ to ? RegulateYearMonth(_result_.[[Year]], _result_.[[Month]], _overflow_).
-        1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _calendar_, _referenceISODay_).
+        1. Set _result_ to ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _referenceISODay_).
+        1. Let _canonicalYearMonthOptions_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Return ? YearMonthFromFields(_calendar_, _result_, _constructor_, _canonicalYearMonthOptions_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
In PlainYearMonth and PlainMonthDay, when constructing via the from()
method, the reference ISO day or year should always be given by the
calendar ("canonicalized") and never by user code. This was already the
case when the argument to from() is a property bag or another Temporal
object, but was not the case when the argument is a string.

This requires, slightly weirdly, calling the intrinsic PMD/PYM constructor
and then calling calendar.monthDayFromFields/yearMonthFromFields on the
result of _that_, but it is more consistent this way.

The constructor functionality remains the same, where the reference ISO
day or year is used without any change.

Closes: #1316