### PR TITLE
Avoid constructing YearMonth/MonthDay twice if possible

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1286,13 +1286,18 @@ export const ES = ObjectAssign({}, ES2020, {
     }
 
     ES.ToTemporalOverflow(options); // validate and ignore
-    let { month, day, referenceISOYear = 1972, calendar } = ES.ParseTemporalMonthDayString(ES.ToString(item));
-    ES.RejectDate(referenceISOYear, month, day);
+    let { month, day, referenceISOYear, calendar } = ES.ParseTemporalMonthDayString(ES.ToString(item));
     if (calendar === undefined) calendar = ES.GetISO8601Calendar();
     calendar = ES.ToTemporalCalendar(calendar);
 
+    if (referenceISOYear === undefined) {
+      ES.RejectDate(1972, month, day);
+      const result = new constructor(month, day, calendar);
+      if (!ES.IsTemporalMonthDay(result)) throw new TypeError('invalid result');
+      return result;
+    }
     const PlainMonthDay = GetIntrinsic('%Temporal.PlainMonthDay%');
-    let result = new PlainMonthDay(month, day, calendar, referenceISOYear);
+    const result = new PlainMonthDay(month, day, calendar, referenceISOYear);
     return ES.MonthDayFromFields(calendar, result, constructor, {});
   },
   ToTemporalTime: (item, constructor, overflow = 'constrain') => {
@@ -1341,13 +1346,18 @@ export const ES = ObjectAssign({}, ES2020, {
     }
 
     ES.ToTemporalOverflow(options); // validate and ignore
-    let { year, month, referenceISODay = 1, calendar } = ES.ParseTemporalYearMonthString(ES.ToString(item));
-    ES.RejectDate(year, month, referenceISODay);
+    let { year, month, referenceISODay, calendar } = ES.ParseTemporalYearMonthString(ES.ToString(item));
     if (calendar === undefined) calendar = ES.GetISO8601Calendar();
     calendar = ES.ToTemporalCalendar(calendar);
 
+    if (referenceISODay === undefined) {
+      ES.RejectDate(year, month, 1);
+      const result = new constructor(year, month, calendar);
+      if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
+      return result;
+    }
     const PlainYearMonth = GetIntrinsic('%Temporal.PlainYearMonth%');
-    let result = new PlainYearMonth(year, month, calendar, referenceISODay);
+    const result = new PlainYearMonth(year, month, calendar, referenceISODay);
     return ES.YearMonthFromFields(calendar, result, constructor, {});
   },
   InterpretTemporalZonedDateTimeOffset: (

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -384,14 +384,12 @@
         1. Perform ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalMonthDayString(_string_).
-        1. If _result_.[[Year]] is *undefined*, then
-          1. Let _referenceISOYear_ be the first leap year after the Unix epoch (1972).
-        1. Else,
-          1. Let _referenceISOYear_ be _result_.[[Year]].
-        1. If ! ValidateDate(_referenceISOYear_, _result_.[[Month]], _result_.[[Day]]) is *false*, then
-          1. Throw a *RangeError* exception.
         1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
-        1. Set _result_ to ? RegulateMonthDay(_result_.[[Month]], _result_.[[Day]], _overflow_).
+        1. If _result_.[[Year]] is *undefined*, then
+          1. Let _validateYear_ be the first leap year after the Unix epoch (1972).
+          1. If ! ValidateDate(_validateYear_, _result_.[[Month]], _result_.[[Day]]) is *false*, then
+            1. Throw a *RangeError* exception.
+          1. Return ? CreateTemporalMonthDayFromStatic(_constructor_, _result_.[[Month]], _result_.[[Day]], _calendar_, *undefined*).
         1. Set _result_ to ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _referenceISOYear_, _calendar_).
         1. Let _canonicalMonthDayOptions_ be ! OrdinaryObjectCreate(%Object.prototype%).
         1. Return ? MonthDayFromFields(_calendar_, _result_, _constructor_, _canonicalMonthDayOptions_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -601,14 +601,11 @@
         1. Perform ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalYearMonthString(_string_).
-        1. If _result_.[[Day]] is *undefined*, then
-          1. Let _referenceISODay_ be 1.
-        1. Else,
-          1. Let _referenceISODay_ be _result_.[[Day]].
-        1. If ! ValidateDate(_result_.[[Year]], _result_.[[Month]], _referenceISODay_) is *false*, then
-          1. Throw a *RangeError* exception.
         1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
-        1. Set _result_ to ? RegulateYearMonth(_result_.[[Year]], _result_.[[Month]], _overflow_).
+        1. If _result_.[[Day]] is *undefined*, then
+          1. If ! ValidateDate(_result_.[[Year]], _result_.[[Month]], 1) is *false*, then
+            1. Throw a *RangeError* exception.
+          1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _calendar_, *undefined*).
         1. Set _result_ to ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _referenceISODay_).
         1. Let _canonicalYearMonthOptions_ be ! OrdinaryObjectCreate(%Object.prototype%).
         1. Return ? YearMonthFromFields(_calendar_, _result_, _constructor_, _canonicalYearMonthOptions_).


### PR DESCRIPTION
When reading a PlainYearMonth or PlainMonthDay from a string, if there is
no day or year (respectively) given (meaning also the calendar is ISO),
it's not necessary to construct an object twice in order to canonicalize
the reference day or year. This removes user-observable calls to calendar
methods in that case.

Follow up from #1316.