### PR TITLE
Update samples on documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ This type is optimized for use cases that require a time zone, including DST-saf
 
 ```js
 const zonedDateTime = Temporal.ZonedDateTime.from({
-    timeZone: 'America/Los_Angeles'
+    timeZone: 'America/Los_Angeles',
     year: 1995,
     month: 12,
     day: 7,

--- a/docs/README.md
+++ b/docs/README.md
@@ -149,8 +149,8 @@ const dateTime = Temporal.PlainDateTime.from({
   hour: 15
 }); // => 1995-12-07T15:00:00
 const dateTime1 = dateTime.with({
-  minutes: 17,
-  seconds: 19
+  minute: 17,
+  second: 19
 }); // => 1995-12-07T15:17:19
 ```
 


### PR DESCRIPTION
A comma was missing from a code sample so I fixed that so it's copy and pastable.

The snippet

```js
const dateTIme1 = dateTime.with({
  minutes: 17,
  seconds: 19,
});
```

raised the error `Uncaught TypeError: invalid date-time-like` using the plurals. I assume that the docs should show what currently works, but if it should support `minutes` and `seconds` then I can change it back.