### PR TITLE
Version bump in preparation for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+## 0.7.0
+
+- New APIs:
+  - Temporal.Calendar.era
+  - Temporal.Calendar.eraYear
+  - Temporal.Calendar.mergeFields
+  - Temporal.Calendar.monthCode
+  - Temporal.Calendar.toJSON
+  - Temporal.PlainDate.era
+  - Temporal.PlainDate.eraYear
+  - Temporal.PlainDate.monthCode
+  - Temporal.PlainDateTime.era
+  - Temporal.PlainDateTime.eraYear
+  - Temporal.PlainDateTime.monthCode
+  - Temporal.PlainMonthDay.monthCode
+  - Temporal.PlainYearMonth.era
+  - Temporal.PlainYearMonth.eraYear
+  - Temporal.PlainYearMonth.monthCode
+  - Temporal.PlainZonedDateTime.era
+  - Temporal.PlainZonedDateTime.eraYear
+  - Temporal.PlainZonedDateTime.monthCode
+- Removals:
+  - Temporal.Duration.getFields
+  - Temporal.PlainDate.getFields
+  - Temporal.PlainDateTime.getFields
+  - Temporal.PlainMonthDay.getFields
+  - Temporal.PlainTime.getFields
+  - Temporal.PlainYearMonth.getFields
+  - Temporal.ZonedDateTime.getFields
+- Removed the options argument from Temporal.PlainTime.add() and Temporal.PlainTime.subtract().
+- Temporal.Duration.toString() gains `fractionalSecondDigits`,
+  `smallestUnit`, and `roundingMode` options to control the precision
+  used in the output string.
+- The form of the calendar annotation in ISO strings is changed from `[c=calendar]` to `[u-ca-calendar]`.
+
 ## 0.6.0
 
 - API renames:

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proposal-temporal",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Experimental polyfill for the TC39 Temporal proposal",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
We should cut a release of the polyfill now that the API is frozen.