### PR TITLE
Run polyfill & cookbook tests in Node v[15|14|12]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 jobs:
-  test-polyfill:
+  test-polyfill-node15:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -13,6 +13,26 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 15.x
+    - run: npm ci
+    - run: npm run codecov:tests
+  test-polyfill-node14:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: use node.js v14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - run: npm ci
+    - run: npm run codecov:tests
+  test-polyfill-node12:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: use node.js v12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
     - run: npm ci
     - run: npm run codecov:tests
   test-test262:
@@ -25,7 +45,7 @@ jobs:
         node-version: 15.x
     - run: npm ci
     - run: npm run codecov:test262
-  test-cookbook:
+  test-cookbook-node15:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -33,5 +53,25 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 15.x
+    - run: npm ci
+    - run: npm run test-cookbook
+  test-cookbook-node14:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: use node.js v14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - run: npm ci
+    - run: npm run test-cookbook
+  test-cookbook-node12:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: use node.js v12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
     - run: npm ci
     - run: npm run test-cookbook


### PR DESCRIPTION
Fixes #1335.  This PR changes CI to run polyfill and cookbook tests in Node 12.x, 14.x, and 15.x. 

I didn't add Test262 to this list because my assumption was that those tests were primarily used by platform (browsers, Node, etc.) to test against new versions so backwards-compat is less of an issue. If this is an incorrect assumption, it'd be easy to add 262 to multi-version testing too.