### PR TITLE
Rebase on top of DateTimeFormat.formatRange

### DIFF
--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -124,5 +124,12 @@
       "aoid": "PartitionDurationFormatPattern",
       "id": "sec-partitiondurationformatpattern"
     }
+  ],
+  "https://tc39.es/proposal-intl-DateTimeFormat-formatRange/": [
+    {
+      "type": "clause",
+      "number": 3,
+      "id": "table-datetimeformat-rangepatternfields"
+    }
   ]
 }

--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -116,6 +116,11 @@
       "type": "op",
       "aoid": "DateTimeStyleFormat",
       "id": "sec-date-time-style-format"
+    },
+    {
+      "type": "op",
+      "aoid": "PartitionPattern",
+      "id": "sec-partitionpattern"
     }
   ],
   "https://tc39.es/proposal-intl-duration-format/": [

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -528,12 +528,12 @@
                 1. Set _dateFieldsPracticallyEqual_ to *false*.
               1. Let _rangePattern_ be _rp_.
           1. Else,
-            1. Let _rp_ be _rangePatterns_.[[<_fieldName_>]].
+            1. Let _rp_ be _rangePatterns_.[[&lt;_fieldName&gt;>]].
             1. If _rangePattern_ is not *undefined* and _rp_ is *undefined*, then
               1. Set _patternContainsLargerDateField_ to *true*.
             1. Else,
-              1. Let _v1_ be _tm1_.[[<_fieldName_>]].
-              1. Let _v2_ be _tm2_.[[<_fieldName_>]].
+              1. Let _v1_ be _tm1_.[[&lt;_fieldName&gt;>]].
+              1. Let _v2_ be _tm2_.[[&lt;_fieldName_&gt;]].
               1. If _v1_ is not equal to _v2_, then
                 1. Set _dateFieldsPracticallyEqual_ to *false*.
               1. Let _rangePattern_ be _rp_.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -224,15 +224,6 @@
         1. <del>Else,</del>
           1. <del>Set _dateTimeFormat_.[[HourCycle]] to *undefined*.</del>
           1. <del>Let _pattern_ be _bestFormat_.[[pattern]].</del>
-        1. <ins>Let _expandedOptions_ be a copy of _opt_.</ins>
-        1. <ins>Let _needDefaults_ be *true*.</ins>
-        1. <ins>For each element _field_ of « *"weekday"*, *"year"*, *"month"*, *"day"*, *"hour"*, *"minute"*, *"second"* » in List order, do</ins>
-          1. <ins>If _expandedOptions_.[[&lt;_field_&gt;]] is not *undefined*, then</ins>
-            1. <ins>Set _needDefaults_ to *false*.</ins>
-        1. <ins>If _needDefaults_ is *true*, then</ins>
-          1. <ins>For each element _field_ of « *"year"*, *"month"*, *"day"*, *"hour"*, *"minute"*, *"second"* » in List order, do</ins>
-            1. <ins>Set _expandedOptions_.[[&lt;_field_&gt;]] to *"numeric"*.</ins>
-        1. <ins>Let _bestFormat_ be GetDateTimeFormatPattern(_matcher_, _expandedOptions_, _formats_, _hc_)</ins>.
         1. Set _dateTimeFormat_.[[Pattern]] to <del>_pattern_</del><ins>_bestFormat_.[[pattern]]</ins>.
         1. Set _dateTimeFormat_.[[RangePatterns]] to <del>_rangePatterns_</del><ins>_bestFormat_.[[rangePatterns]]</ins>.
         1. <ins>For each row in <emu-xref href="#table-temporal-patterns"></emu-xref>, except the header row, in table order, do</ins>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -232,7 +232,7 @@
         1. <ins>If _needDefaults_ is *true*, then</ins>
           1. <ins>For each element _field_ of « *"year"*, *"month"*, *"day"*, *"hour"*, *"minute"*, *"second"* » in List order, do</ins>
             1. <ins>Set _expandedOptions_.[[&lt;_field_&gt;]] to *"numeric"*.</ins>
-        1. <ins>Let _bestFormat_ be GetDateTimeFormatPattern(_matcher_, _limitedOptions_, _formats_, _hc_)</ins>.
+        1. <ins>Let _bestFormat_ be GetDateTimeFormatPattern(_matcher_, _expandedOptions_, _formats_, _hc_)</ins>.
         1. Set _dateTimeFormat_.[[Pattern]] to <del>_pattern_</del><ins>_bestFormat_.[[pattern]]</ins>.
         1. Set _dateTimeFormat_.[[RangePatterns]] to <del>_rangePatterns_</del><ins>_bestFormat_.[[rangePatterns]]</ins>.
         1. <ins>For each row in <emu-xref href="#table-temporal-patterns"></emu-xref>, except the header row, in table order, do</ins>
@@ -336,7 +336,7 @@
       <h1>FormatDateTimePattern ( _dateTimeFormat_, <ins>_pattern_</ins>, _patternParts_, <del>_x_</del><ins>_epochNanoseconds_</ins>, _rangeFormatOptions_ )</h1>
 
       <p>
-      The FormatDateTimePattern abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat), <ins>_pattern_ (with must be <mark>TODO: describe type</mark>),</ins> _patternParts_ (which is a list of Records as returned by PartitionPattern), <del>_x_</del><ins>_epochNanoseconds_</ins> (which must be a Number value), and _rangeFormatOptions_ (which is a range pattern Record as used in [[rangePattern]] or *undefined*), interprets _x_ as a time value as specified in ES2021, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according _pattern_ and to the effective locale and the formatting options of _dateTimeFormat_ and _rangeFormatOptions_. The following steps are taken:
+      The FormatDateTimePattern abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat), <ins>_pattern_ (which must be <mark>TODO: describe type</mark>),</ins> _patternParts_ (which is a list of Records as returned by PartitionPattern), <del>_x_</del><ins>_epochNanoseconds_</ins> (which must be a Number value), and _rangeFormatOptions_ (which is a range pattern Record as used in [[rangePattern]] or *undefined*), interprets _x_ as a time value as specified in ES2021, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according _pattern_ and to the effective locale and the formatting options of _dateTimeFormat_ and _rangeFormatOptions_. The following steps are taken:
       </p>
 
       <emu-alg>
@@ -418,7 +418,6 @@
       <emu-note>
         It is recommended that implementations use the time zone information of the IANA Time Zone Database.
       </emu-note>
-
     </emu-clause>
 
     <emu-clause id="sec-partitiondatetimepattern" aoid="PartitionDateTimePattern">
@@ -551,7 +550,7 @@
         1. For each _rangePatternPart_ in _rangePattern_.[[PatternParts]], do
           1. <mark>TODO: perhaps try to make the patterns play better with _rangePatternPart_.[[Pattern]].</mark>
           1. <del>Let _pattern_ be _rangePatternPart_.[[Pattern]].</del>
-          1. Let _source_ be _rangePatternPart_.[[Source]]
+          1. Let _source_ be _rangePatternPart_.[[Source]].
           1. If _source_ is *"startRange"* or *"shared"*, then
             1. Let _z_ be _x_<ins>.[[epochNanoseconds]]</ins>.
             1. <ins>Let _pattern_ be _x_.[[pattern]].</ins>
@@ -565,11 +564,10 @@
           1. Add all elements in _partResult_ to _result_ in order.
         1. Return _result_.
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sec-formatdatetimerange" aoid="FormatDateTimeRange">
-      <h1>FormatDateTimeRange( _dateTimeFormat_, _x_, _y_ )</h1>
+      <h1>FormatDateTimeRange ( _dateTimeFormat_, _x_, _y_ )</h1>
 
       <p>
         The FormatDateTimeRange abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat), _x_ (which must be <del>a Number</del><ins>an ECMAScript</ins> value) and _y_ (which must be <del>a Number</del><ins>an ECMAScript</ins> value), and performs the following steps:
@@ -582,7 +580,6 @@
           1. Set _result_ to a String value produced by concatenating _result_ and _part_.[[Value]].
         1. Return _result_.
       </emu-alg>
-
     </emu-clause>
 
     <emu-clause id="sec-formatdatetimerangetoparts" aoid="FormatDateTimeRangeToParts">
@@ -605,7 +602,6 @@
           1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>
-
     </emu-clause>
 
     <ins class="block">

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -429,69 +429,9 @@
       </p>
 
       <emu-alg>
-        1. <ins>If IsTemporalObject(_x_) is *true*, then</ins>
-          1. <mark>TODO: _era_, _dayPeriod_, _fractionalSecondDigits_.</mark>
-          1. <ins>If _x_ has an [[InitializedTemporalDate]] internal slot, then</ins>
-            1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainDatePattern]].</ins>
-            1. <ins>Let _calendar_ be ? ToString(_x_.[[Calendar]]).</ins>
-            1. <ins>If _calendar_ is _dateTimeFormat_.[[Calendar]], then</ins>
-              1. <ins>Let _calendarOverride_ be _x_.[[Calendar]].</ins>
-            1. <ins>Else if _calendar_ is *"iso8601"*, then</ins>
-              1. <ins>Let _calendarOverride_ be ? GetBuiltinCalendar(_dateTimeFormat_.[[Calendar]]).</ins>
-            1. <ins>Else,</ins>
-              1. <ins>Throw a *RangeError* exception.</ins>
-            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _calendarOverride_).</ins>
-            1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
-          1. <ins>If _x_ has an [[InitializedTemporalYearMonth]] internal slot, then</ins>
-            1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainYearMonthPattern]].</ins>
-            1. <ins>Let _calendar_ be ? ToString(_x_.[[Calendar]]).</ins>
-            1. <ins>If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then</ins>
-              1. <ins>Throw a *RangeError* exception.</ins>
-            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _x_.[[Calendar]]).</ins>
-            1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
-          1. <ins>If _x_ has an [[InitializedTemporalMonthDay]] internal slot, then</ins>
-            1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainMonthDayPattern]].</ins>
-            1. <ins>Let _calendar_ be ? ToString(_x_.[[Calendar]]).</ins>
-            1. <ins>If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then</ins>
-              1. <ins>Throw a *RangeError* exception.</ins>
-            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _x_.[[Calendar]]).</ins>
-            1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
-          1. <ins>If _x_ has an [[InitializedTemporalTime]] internal slot, then</ins>
-            1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainTimePattern]].</ins>
-            1. <ins>Let _isoCalendar_ be ? GetISO8601Calendar().</ins>
-            1. <ins>Let _plainDateTime_ be ? CreateTemporalDateTime(1970, 1, 1, _x_.[[ISOHour]], _x_.[[ISOMinute]], _x_.[[ISOSecond]], _x_.[[ISOMillisecond]], _x_.[[ISOMicrosecond]], _x_.[[ISONanosecond]], _isoCalendar_).</ins>
-            1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).</ins>
-          1. <ins>If _x_ has an [[InitializedTemporalDateTime]] internal slot, then</ins>
-            1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalPlainDateTimePattern]].</ins>
-            1. <ins>Let _calendar_ be ? ToString(_x_.[[Calendar]]).</ins>
-            1. <ins>If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then</ins>
-              1. <ins>Throw a *RangeError* exception.</ins>
-            1. <ins>Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _x_, *"reject"*).</ins>
-          1. <ins>If _x_ has an [[InitializedTemporalInstant]] internal slot, then</ins>
-            1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalInstantPattern]].</ins>
-            1. <ins>Let _instant_ be _x_.</ins>
-          1. <ins>If _x_ has an [[InitializedTemporalZonedDateTime]] internal slot, then</ins>
-            1. <ins>Let _pattern_ be _dateTimeFormat_.[[TemporalZonedDateTimePattern]].</ins>
-            1. <ins>Let _calendar_ be ? ToString(_x_.[[Calendar]]).</ins>
-            1. <ins>If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then</ins>
-              1. <ins>Throw a *RangeError* exception.</ins>
-            1. <ins>Let _timeZone_ be ? ToString(_x_.[[TimeZone]]).</ins>
-            1. <ins>If _dateTimeFormat_.[[TimeZone]] is not equal to DefaultTimeZone(), and _timeZone_ is not equal to _dateTimeFormat_.[[TimeZone]], then</ins>
-              1. <ins>Throw a *RangeError* exception.</ins>
-            1. <ins>Let _instant_ be ? CreateTemporalInstant(_x_.[[Nanoseconds]]).</ins>
-          1. <ins>If _pattern_ is *null*, throw a *TypeError* exception.</ins>
-          1. <ins>Let _epochNanoseconds_ be _instant_.[[Nanoseconds]].</ins>
-        1. <ins>Else,</ins>
-          1. <ins>Let _pattern_ be _dateTimeFormat_.[[Pattern]].</ins>
-          1. <ins>If _x_ is *undefined*, then</ins>
-            1. <ins>Set _x_ to Call(%Date.now%, *undefined*).</ins>
-          1. <ins>Else,</ins>
-            1. <ins>Set _x_ to ? ToNumber(_x_).</ins>
-          1. Set _x_ to TimeClip(_x_).
-          1. If _x_ is *NaN*, throw a *RangeError* exception.
-          1. <ins>Let _epochNanoseconds_ be ℤ(_x_) × 10<sup>6</sup>.</ins>
-        1. Let _patternParts_ be PartitionPattern(<del>_dateTimeFormat_.[[Pattern]]</del><ins>_pattern_</ins>).
-        1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, <ins>_pattern_</ins>, _patternParts_, <del>_x_</del><ins>_epochNanoseconds_</ins>, *undefined*).
+        1. <ins>Let _x_ be ? HandleDateTimeValue(_x_).</ins>
+        1. Let _patternParts_ be PartitionPattern(<del>_dateTimeFormat_.[[Pattern]]</del><ins>_x_.[[pattern]]</ins>).
+        1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, <ins>_x_.[[pattern]]</ins>, _patternParts_, <del>_x_</del><ins>_x_.[[epochNanoseconds]]</ins>, *undefined*).
         1. Return _result_.
       </emu-alg>
 
@@ -541,6 +481,133 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-partitiondatetimerangepattern" aoid="PartitionDateTimeRangePattern">
+      <h1>PartitionDateTimeRangePattern ( _dateTimeFormat_, _x_, _y_ )</h1>
+
+      <p>
+        The PartitionDateTimeRangePattern abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat), _x_ (which must be <del>a Number</del><ins>an ECMAScript</ins> value) and _y_ (which must be <del>a Number</del><ins>an ECMAScript</ins> value), <del>interprets _x_ and _y_ as time values as specified in ES2021, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>,</del> and creates the corresponding parts according to the effective locale and the formatting options of _dateTimeFormat_. The following steps are taken:
+      </p>
+      <emu-alg>
+        1. <del>Let _x_ be TimeClip(_x_).</del>
+        1. <del>If _x_ is *NaN*, throw a *RangeError* exception.</del>
+        1. <del>Let _y_ be TimeClip(_y_).</del>
+        1. <del>If _y_ is *NaN*, throw a *RangeError* exception.</del>
+        1. <ins>Let _x_ be ? HandleDateTimeValue(_x_).</ins>
+        1. <ins>Let _y_ be ? HandleDateTimeValue(_y_).</ins>
+        1. If _x_<ins>.[[epochNanoseconds]]</ins> is greater than _y_<ins>.[[epochNanoseconds]]</ins>, throw a *RangeError* exception.
+        1. Let _tm1_ be ToLocalTime(_x_<ins>.[[epochNanoseconds]]</ins>, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _tm2_ be ToLocalTime(_y_<ins>.[[epochNanoseconds]]</ins>, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _rangePatterns_ be _dateTimeFormat_.[[RangePatterns]].
+        1. Let _rangePattern_ be *undefined*.
+        1. Let _dateFieldsPracticallyEqual_ be *true*.
+        1. Let _patternContainsLargerDateField_ be *false*.
+        1. While _dateFieldsPracticallyEqual_ is *true* and _patternContainsLargerDateField_ is *false*, repeat for each row of <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref> in order, except the header row
+          1. Let _fieldName_ be the name given in the Range Pattern Field column of the row.
+          1. If _fieldName_ is equal to [[AmPm]], then
+            1. Let _rp_ be _rangePatterns_.[[AmPm]].
+            1. If _rangePattern_ is not *undefined* and _rp_ is *undefined*, then
+              1. Set _patternContainsLargerDateField_ to *true*.
+            1. Else,
+              1. Let _v1_ be _tm1_.[[Hour]].
+              1. Let _v2_ be _tm2_.[[Hour]].
+              1. If _v1_ is greater than 11 and _v2_ less or equal than 11, or _v1_ is less or equal than 11 and _v2_ is greater than 11, then
+                1. Set _dateFieldsPracticallyEqual_ to *false*.
+              1. Let _rangePattern_ be _rp_.
+          1. If _fieldName_ is equal to [[FractionalSecondDigits]], then
+            1. Let _rp_ be _rangePatterns_.[[FractionalSecondDigits]].
+            1. If _rangePattern_ is not *undefined* and _rp_ is *undefined*, then
+              1. Set _patternContainsLargerDateField_ to *true*.
+            1. Else,
+              1. Let _fractionalSecondDigits_ be _dateTimeFormat_.[[FractionalSecondDigits]].
+              1. If _fractionalSecondDigits_ is *undefined*, then
+                1. Set _fractionalSecondDigits_ to 3.
+              1. Let _v1_ be _tm1_.[[Millisecond]].
+              1. Let _v2_ be _tm2_.[[Millisecond]].
+              1. Let _v1_ be floor(_v1_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
+              1. Let _v2_ be floor(_v2_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
+              1. If _v1_ is not equal to _v2_, then
+                1. Set _dateFieldsPracticallyEqual_ to *false*.
+              1. Let _rangePattern_ be _rp_.
+          1. Else,
+            1. Let _rp_ be _rangePatterns_.[[<_fieldName_>]].
+            1. If _rangePattern_ is not *undefined* and _rp_ is *undefined*, then
+              1. Set _patternContainsLargerDateField_ to *true*.
+            1. Else,
+              1. Let _v1_ be _tm1_.[[<_fieldName_>]].
+              1. Let _v2_ be _tm2_.[[<_fieldName_>]].
+              1. If _v1_ is not equal to _v2_, then
+                1. Set _dateFieldsPracticallyEqual_ to *false*.
+              1. Let _rangePattern_ be _rp_.
+        1. If _dateFieldsPracticallyEqual_ is *true*, then
+          1. <del>Let _pattern_ be _dateTimeFormat_.[[Pattern]].</del>
+          1. Let _patternParts_ be PartitionPattern(<del>_pattern_</del><ins>_x_.[[pattern]]</ins>).
+          1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, <ins>_x_.[[pattern]] ,</ins> _patternParts_, _x_<ins>.[[epochNanoseconds]]</ins>, *undefined*).
+          1. For each _r_ in _result_ do
+            1. Set _r_.[[Source]] to *"shared"*.
+          1. Return _result_.
+        1. Let _result_ be a new empty List.
+        1. If _rangePattern_ is *undefined*, then
+          1. Let _rangePattern_ be _rangePatterns_.[[Default]].
+        1. For each _rangePatternPart_ in _rangePattern_.[[PatternParts]], do
+          1. <mark>TODO: perhaps try to make the patterns play better with _rangePatternPart_.[[Pattern]].</mark>
+          1. <del>Let _pattern_ be _rangePatternPart_.[[Pattern]].</del>
+          1. Let _source_ be _rangePatternPart_.[[Source]]
+          1. If _source_ is *"startRange"* or *"shared"*, then
+            1. Let _z_ be _x_<ins>.[[epochNanoseconds]]</ins>.
+            1. <ins>Let _pattern_ be _x_.[[pattern]].</ins>
+          1. Else,
+            1. Let _z_ be _y_<ins>.[[epochNanoseconds]]</ins>.
+            1. <ins>Let _pattern_ be _y_.[[pattern]].</ins>
+          1. Let _patternParts_ be PartitionPattern(_pattern_).
+          1. Let _partResult_ be ? FormatDateTimePattern(_dateTimeFormat_, <ins>_pattern_ ,</ins> _patternParts_, _z_, _rangePattern_).
+          1. For each _r_ in _partResult_, do
+            1. Set _r_.[[Source]] to _source_.
+          1. Add all elements in _partResult_ to _result_ in order.
+        1. Return _result_.
+      </emu-alg>
+
+    </emu-clause>
+
+    <emu-clause id="sec-formatdatetimerange" aoid="FormatDateTimeRange">
+      <h1>FormatDateTimeRange( _dateTimeFormat_, _x_, _y_ )</h1>
+
+      <p>
+        The FormatDateTimeRange abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat), _x_ (which must be <del>a Number</del><ins>an ECMAScript</ins> value) and _y_ (which must be <del>a Number</del><ins>an ECMAScript</ins> value), and performs the following steps:
+      </p>
+
+      <emu-alg>
+        1. Let _parts_ be ? PartitionDateTimeRangePattern(_dateTimeFormat_, _x_, _y_).
+        1. Let _result_ be the empty String.
+        1. For each Record _part_ in _parts_, do
+          1. Set _result_ to a String value produced by concatenating _result_ and _part_.[[Value]].
+        1. Return _result_.
+      </emu-alg>
+
+    </emu-clause>
+
+    <emu-clause id="sec-formatdatetimerangetoparts" aoid="FormatDateTimeRangeToParts">
+      <h1>FormatDateTimeRangeToParts ( _dateTimeFormat_, _x_, _y_ )</h1>
+
+      <p>
+        The FormatDateTimeRangeToParts abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat), _x_ (which must be <del>a Number</del><ins>an ECMAScript</ins> value) and _y_ (which must be <del>a Number</del><ins>an ECMAScript</ins> value), and performs the following steps:
+      </p>
+
+      <emu-alg>
+        1. Let _parts_ be ? PartitionDateTimeRangePattern(_dateTimeFormat_, _x_, _y_).
+        1. Let _result_ be ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. For each Record _part_ in _parts_, do
+          1. Let _O_ be ObjectCreate(%ObjectPrototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, *"value"*, _part_.[[Value]]).
+          1. Perform ! CreateDataPropertyOrThrow(_O_, *"source"*, _part_.[[Source]]).
+          1. Perform ! CreateDataProperty(_result_, ! ToString(_n_), _O_).
+          1. Increment _n_ by 1.
+        1. Return _result_.
+      </emu-alg>
+
+    </emu-clause>
+
     <ins class="block">
     <emu-clause id="sec-temporal-istemporalobject" aoid="IsTemporalObject">
       <h1>IsTemporalObject ( _value_ )</h1>
@@ -582,6 +649,82 @@
         1. Else,
           1. Set _bestFormat_.[[hourCycle]] to *undefined*.
         1. Return _bestFormat_.
+      </emu-alg>
+    </emu-clause>
+    </ins>
+
+    <ins class="block">
+    <emu-clause id="sec-temporal-handledatetimevalue" aoid="HandleDateTimeValue">
+      <h1>HandleDateTimeValue ( _x_ )</h1>
+
+      <p>
+        The abstract operation HandleDateTimeValue accepts the argument _x_ (which must be an ECMAScript value). It returns a record which contains the appropriate pattern and epochNanoseconds values for the input. This abstract operation functions as follows:
+      </p>
+
+      <emu-alg>
+      1. If IsTemporalObject(_x_) is *true*, then
+        1. <mark>TODO: _era_, _dayPeriod_, _fractionalSecondDigits_.</mark>
+        1. If _x_ has an [[InitializedTemporalDate]] internal slot, then
+          1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainDatePattern]].
+          1. Let _calendar_ be ? ToString(_x_.[[Calendar]]).
+          1. If _calendar_ is _dateTimeFormat_.[[Calendar]], then
+            1. Let _calendarOverride_ be _x_.[[Calendar]].
+          1. Else if _calendar_ is *"iso8601"*, then
+            1. Let _calendarOverride_ be ? GetBuiltinCalendar(_dateTimeFormat_.[[Calendar]]).
+          1. Else,
+            1. Throw a *RangeError* exception.
+          1. Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _calendarOverride_).
+          1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).
+        1. If _x_ has an [[InitializedTemporalYearMonth]] internal slot, then
+          1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainYearMonthPattern]].
+          1. Let _calendar_ be ? ToString(_x_.[[Calendar]]).
+          1. If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then
+            1. Throw a *RangeError* exception.
+          1. Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _x_.[[Calendar]]).
+          1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).
+        1. If _x_ has an [[InitializedTemporalMonthDay]] internal slot, then
+          1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainMonthDayPattern]].
+          1. Let _calendar_ be ? ToString(_x_.[[Calendar]]).
+          1. If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then
+            1. Throw a *RangeError* exception.
+          1. Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _x_.[[Calendar]]).
+          1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).
+        1. If _x_ has an [[InitializedTemporalTime]] internal slot, then
+          1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainTimePattern]].
+          1. Let _isoCalendar_ be ? GetISO8601Calendar().
+          1. Let _plainDateTime_ be ? CreateTemporalDateTime(1970, 1, 1, _x_.[[ISOHour]], _x_.[[ISOMinute]], _x_.[[ISOSecond]], _x_.[[ISOMillisecond]], _x_.[[ISOMicrosecond]], _x_.[[ISONanosecond]], _isoCalendar_).
+          1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _plainDateTime_, *"reject"*).
+        1. If _x_ has an [[InitializedTemporalDateTime]] internal slot, then
+          1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainDateTimePattern]].
+          1. Let _calendar_ be ? ToString(_x_.[[Calendar]]).
+          1. If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then
+            1. Throw a *RangeError* exception.
+          1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _x_, *"reject"*).
+        1. If _x_ has an [[InitializedTemporalInstant]] internal slot, then
+          1. Let _pattern_ be _dateTimeFormat_.[[TemporalInstantPattern]].
+          1. Let _instant_ be _x_.
+        1. If _x_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+          1. Let _pattern_ be _dateTimeFormat_.[[TemporalZonedDateTimePattern]].
+          1. Let _calendar_ be ? ToString(_x_.[[Calendar]]).
+          1. If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then
+            1. Throw a *RangeError* exception.
+          1. Let _timeZone_ be ? ToString(_x_.[[TimeZone]]).
+          1. If _dateTimeFormat_.[[TimeZone]] is not equal to DefaultTimeZone(), and _timeZone_ is not equal to _dateTimeFormat_.[[TimeZone]], then
+            1. Throw a *RangeError* exception.
+          1. Let _instant_ be ? CreateTemporalInstant(_x_.[[Nanoseconds]]).
+        1. If _pattern_ is *null*, throw a *TypeError* exception.
+        1. Let _epochNanoseconds_ be _instant_.[[Nanoseconds]].
+      1. Else,
+        1. Let _pattern_ be _dateTimeFormat_.[[Pattern]].
+        1. If _x_ is *undefined*, then
+          1. Set _x_ to Call(%Date.now%, *undefined*).
+        1. Else,
+          1. Set _x_ to ? ToNumber(_x_).
+        1. Set _x_ to TimeClip(_x_).
+        1. If _x_ is *NaN*, throw a *RangeError* exception.
+        1. Let _epochNanoseconds_ be ℤ(_x_) × 10<sup>6</sup>.
+      1. Let _result_ be the Record { [[pattern]]: _pattern_, [[epochNanoseconds]]: _epochNanoseconds_ }.
+      1. Return _result_.
       </emu-alg>
     </emu-clause>
     </ins>
@@ -726,6 +869,40 @@
         1. <del>Else,</del>
           1. <del>Let _x_ be ? ToNumber(_date_).</del>
         1. Return ? FormatDateTimeToParts(_dtf_, <del>_x_</del><ins>_date_</ins>).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-intl.datetimeformat.prototype.formatRange">
+      <h1>Intl.DateTimeFormat.prototype.formatRange ( _startDate_, _endDate_ )</h1>
+
+      <p>
+        When the `formatRange` method is called with an arguments _startDate_ and _endDate_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _dtf_ be *this* value.
+        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
+        1. If _startDate_ is *undefined* or _endDate_ is *undefined*, throw a *TypeError* exception.
+        1. <del>Let _x_ be ? ToNumber(_startDate_).</del>
+        1. <del>Let _y_ be ? ToNumber(_endDate_).</del>
+        1. Return ? FormatDateTimeRange(_dtf_, <del>_x_</del><ins>_startDate_</ins>, <del>_y_</del><ins>_endDate_</ins>).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DateTimeFormat.prototype.formatRangeToParts">
+      <h1>Intl.DateTimeFormat.prototype.formatRangeToParts ( _startDate_, _endDate_ )</h1>
+
+      <p>
+        When the `formatRangeToParts` method is called with an arguments _startDate_ and _endDate_, the following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _dtf_ be *this* value.
+        1. Perform ? RequireInternalSlot(_dtf_, [[InitializedDateTimeFormat]]).
+        1. If _startDate_ is *undefined* or _endDate_ is *undefined*, throw a *TypeError* exception.
+        1. <del>Let _x_ be ? ToNumber(_startDate_).</del>
+        1. <del>Let _y_ be ? ToNumber(_endDate_).</del>
+        1. Return ? FormatDateTimeRangeToParts(_dtf_, <del>_x_</del><ins>_startDate_</ins>, <del>_y_</del><ins>_endDate_</ins>).
       </emu-alg>
     </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -316,6 +316,95 @@
       </p>
     </emu-clause>
 
+    <emu-clause id="sec-formatdatetimepattern" aoid="FormatDateTimePattern">
+      <h1>FormatDateTimePattern ( _dateTimeFormat_, <ins>_pattern_</ins>, _patternParts_, <del>_x_</del><ins>_epochNanoseconds_</ins>, _rangeFormatOptions_ )</h1>
+
+      <p>
+      The FormatDateTimePattern abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat), <ins>_pattern_ (with must be <mark>TODO: describe type</mark>),</ins> _patternParts_ (which is a list of Records as returned by PartitionPattern), <del>_x_</del><ins>_epochNanoseconds_</ins> (which must be a Number value), and _rangeFormatOptions_ (which is a range pattern Record as used in [[rangePattern]] or *undefined*), interprets _x_ as a time value as specified in ES2021, <emu-xref href="#sec-time-values-and-time-range"></emu-xref>, and creates the corresponding parts according _pattern_ and to the effective locale and the formatting options of _dateTimeFormat_ and _rangeFormatOptions_. The following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. <del>Let _x_ be TimeClip(_x_).</del>
+        1. <del>If _x_ is *NaN*, throw a *RangeError* exception.</del>
+        1. Let _locale_ be _dateTimeFormat_.[[Locale]].
+        1. Let _nfOptions_ be ObjectCreate(*null*).
+        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"useGrouping"*, *false*).
+        1. Let _nf_ be ? Construct(%NumberFormat%, « _locale_, _nfOptions_ »).
+        1. Let _nf2Options_ be ObjectCreate(*null*).
+        1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"minimumIntegerDigits"*, 2).
+        1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"useGrouping"*, *false*).
+        1. Let _nf2_ be ? Construct(%NumberFormat%, « _locale_, _nf2Options_ »).
+        1. Let _fractionalSecondDigits_ be _dateTimeFormat_.[[FractionalSecondDigits]].
+        1. If _fractionalSecondDigits_ is not *undefined*, then
+          1. Let _nf3Options_ be ObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, _fractionalSecondDigits_).
+          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
+          1. Let _nf3_ be ? Construct(%NumberFormat%, « _locale_, _nf3Options_ »).
+        1. Let _tm_ be ToLocalTime(<del>_x_</del><ins>_epochNanoseconds_</ins>, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
+        1. Let _result_ be a new empty List.
+        1. Let _patternParts_ be PartitionPattern(<del>_dateTimeFormat_.[[Pattern]]</del><ins>_pattern_</ins>).
+        1. For each element _patternPart_ of _patternParts_, in List order, do
+          1. Let _p_ be _patternPart_.[[Type]].
+          1. If _p_ is *"literal"*, then
+            1. Append a new Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } as the last element of the list _result_.
+          1. Else if _p_ is equal to *"fractionalSecondDigits"*, then
+            1. Let _v_ be _tm_.[[Millisecond]].
+            1. Let _v_ be floor(_v_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
+            1. Let _fv_ be FormatNumeric(_nf3_, _v_).
+            1. Append a new Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _fv_ } as the last element of _result_.
+          1. Else if _p_ matches a Property column of the row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
+            1. If _rangeFormatOptions_ is not *undefined*, let _f_ be the value of _rangeFormatOptions_'s field whose name matches _p_.
+            1. Else, let _f_ be <del>the value of _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the matching row</del><ins>_pattern_.[[&lt;_p_&gt;]]</ins>.
+            1. Let _v_ be the value of _tm_'s field whose name is the Internal Slot column of the matching row.
+            1. If _p_ is *"year"* and _v_ ≤ 0, let _v_ be 1 - _v_.
+            1. If _p_ is *"month"*, increase _v_ by 1.
+            1. If _p_ is *"hour"* and <del>_dateTimeFormat_.[[HourCycle]]</del><ins>_pattern_.[[hourCycle]]</ins> is *"h11"* or *"h12"*, then
+              1. Let _v_ be _v_ modulo 12.
+              1. If _v_ is 0 and <del>_dateTimeFormat_.[[HourCycle]]</del><ins>_pattern_.[[hourCycle]]</ins> is *"h12"*, let _v_ be 12.
+            1. If _p_ is *"hour"* and <del>_dateTimeFormat_.[[HourCycle]]</del><ins>_pattern_.[[hourCycle]]</ins> is *"h24"*, then
+              1. If _v_ is 0, let _v_ be 24.
+            1. <ins>If _p_ is *timeZoneName*, then</ins>
+              1. <ins>If _tm_ has a [[timeZoneName]] field, then</ins>
+                1. <ins>Set _v_ to _tm_.[[timeZoneName]].</ins>
+              1. <ins>Else,</ins>
+                1. <ins>Set _v_ to _dateTimeFormat_.[[TimeZone]].</ins>
+            1. If _f_ is *"numeric"*, then
+              1. Let _fv_ be FormatNumeric(_nf_, _v_).
+            1. Else if _f_ is *"2-digit"*, then
+              1. Let _fv_ be FormatNumeric(_nf2_, _v_).
+              1. If the *"length"* property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
+            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether <del>_dateTimeFormat_.[[Day]]</del><ins>_pattern_.[[day]]</ins> is *undefined*. If _p_ is *"month"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[day]] is *undefined*.  If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[InDST]] field of _tm_. If _p_ is *"era"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether <del>_dateTimeFormat_.[[Era]]</del><ins>_pattern_.[[day]]</ins> is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[era]] is *undefined*. If the implementation does not have a localized representation of _f_, then use _f_ itself.
+            1. Append a new Record { [[Type]]: _p_, [[Value]]: _fv_ } as the last element of the list _result_.
+          1. Else if _p_ is equal to *"ampm"*, then
+            1. Let _v_ be _tm_.[[Hour]].
+            1. If _v_ is greater than 11, then
+              1. Let _fv_ be an implementation and locale dependent String value representing *"post meridiem"*.
+            1. Else,
+              1. Let _fv_ be an implementation and locale dependent String value representing *"ante meridiem"*.
+            1. Append a new Record { [[Type]]: *"dayPeriod"*, [[Value]]: _fv_ } as the last element of the list _result_.
+          1. Else if _p_ is equal to *"relatedYear"*, then
+            1. Let _v_ be _tm_.[[RelatedYear]].
+            1. Let _fv_ be FormatNumeric(_nf_, _v_).
+            1. Append a new Record { [[Type]]: *"relatedYear"*, [[Value]]: _fv_ } as the last element of the list _result_.
+          1. Else if _p_ is equal to *"yearName"*, then
+            1. Let _v_ be _tm_.[[YearName]].
+            1. Append a new Record { [[Type]]: *"yearName"*, [[Value]]: _v_ } as the last element of the list _result_.
+          1. Else,
+            1. Let _unknown_ be an implementation-, locale-, and numbering system-dependent String based on <del>_x_</del><ins>_epochNanoseconds_</ins> and _p_.
+            1. Append a new Record { [[Type]]: *"unknown"*, [[Value]]: _unknown_ } as the last element of _result_.
+        1. Return _result_.
+      </emu-alg>
+
+      <emu-note>
+        It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>), and use CLDR *"abbreviated"* strings for DateTimeFormat *"short"* strings, and CLDR *"wide"* strings for DateTimeFormat *"long"* strings.
+      </emu-note>
+
+      <emu-note>
+        It is recommended that implementations use the time zone information of the IANA Time Zone Database.
+      </emu-note>
+
+    </emu-clause>
+
     <emu-clause id="sec-partitiondatetimepattern" aoid="PartitionDateTimePattern">
       <h1>PartitionDateTimePattern ( _dateTimeFormat_, _x_ )</h1>
 
@@ -385,71 +474,8 @@
           1. Set _x_ to TimeClip(_x_).
           1. If _x_ is *NaN*, throw a *RangeError* exception.
           1. <ins>Let _epochNanoseconds_ be ℤ(_x_) × 10<sup>6</sup>.</ins>
-        1. Let _locale_ be _dateTimeFormat_.[[Locale]].
-        1. Let _nfOptions_ be ObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_nfOptions_, *"useGrouping"*, *false*).
-        1. Let _nf_ be ? Construct(%NumberFormat%, « _locale_, _nfOptions_ »).
-        1. Let _nf2Options_ be ObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"minimumIntegerDigits"*, 2).
-        1. Perform ! CreateDataPropertyOrThrow(_nf2Options_, *"useGrouping"*, *false*).
-        1. Let _nf2_ be ? Construct(%NumberFormat%, « _locale_, _nf2Options_ »).
-        1. Let _fractionalSecondDigits_ be _dateTimeFormat_.[[FractionalSecondDigits]].
-        1. If _fractionalSecondDigits_ is not *undefined*, then
-          1. Let _nf3Options_ be ObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"minimumIntegerDigits"*, _fractionalSecondDigits_).
-          1. Perform ! CreateDataPropertyOrThrow(_nf3Options_, *"useGrouping"*, *false*).
-          1. Let _nf3_ be ? Construct(%NumberFormat%, « _locale_, _nf3Options_ »).
-        1. Let _tm_ be ToLocalTime(<del>_x_</del><ins>_epochNanoseconds_</ins>, _dateTimeFormat_.[[Calendar]], _dateTimeFormat_.[[TimeZone]]).
-        1. Let _result_ be a new empty List.
         1. Let _patternParts_ be PartitionPattern(<del>_dateTimeFormat_.[[Pattern]]</del><ins>_pattern_</ins>).
-        1. For each element _patternPart_ of _patternParts_, in List order, do
-          1. Let _p_ be _patternPart_.[[Type]].
-          1. If _p_ is *"literal"*, then
-            1. Append a new Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } as the last element of the list _result_.
-          1. Else if _p_ is equal to *"fractionalSecondDigits"*, then
-            1. Let _v_ be _tm_.[[Millisecond]].
-            1. Let _v_ be floor(_v_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
-            1. Let _fv_ be FormatNumeric(_nf3_, _v_).
-            1. Append a new Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _fv_ } as the last element of _result_.
-          1. Else if _p_ matches a Property column of the row in <emu-xref href="#table-datetimeformat-components"></emu-xref>, then
-            1. Let _f_ be <del>the value of _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the matching row</del><ins>_pattern_.[[&lt;_p_&gt;]]</ins>.
-            1. Let _v_ be the value of _tm_'s field whose name is the Internal Slot column of the matching row.
-            1. If _p_ is *"year"* and _v_ ≤ 0, let _v_ be 1 - _v_.
-            1. If _p_ is *"month"*, increase _v_ by 1.
-            1. If _p_ is *"hour"* and <del>_dateTimeFormat_.[[HourCycle]]</del><ins>_pattern_.[[hourCycle]]</ins> is *"h11"* or *"h12"*, then
-              1. Let _v_ be _v_ modulo 12.
-              1. If _v_ is 0 and <del>_dateTimeFormat_.[[HourCycle]]</del><ins>_pattern_.[[hourCycle]]</ins> is *"h12"*, let _v_ be 12.
-            1. If _p_ is *"hour"* and <del>_dateTimeFormat_.[[HourCycle]]</del><ins>_pattern_.[[hourCycle]]</ins> is *"h24"*, then
-              1. If _v_ is 0, let _v_ be 24.
-            1. <ins>If _p_ is *timeZoneName*, then</ins>
-              1. <ins>If _tm_ has a [[timeZoneName]] field, then</ins>
-                1. <ins>Set _v_ to _tm_.[[timeZoneName]].</ins>
-              1. <ins>Else,</ins>
-                1. <ins>Set _v_ to _dateTimeFormat_.[[TimeZone]].</ins>
-            1. If _f_ is *"numeric"*, then
-              1. Let _fv_ be FormatNumeric(_nf_, _v_).
-            1. Else if _f_ is *"2-digit"*, then
-              1. Let _fv_ be FormatNumeric(_nf2_, _v_).
-              1. If the *"length"* property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
-            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"*, then the String value may also depend on whether <del>_dateTimeFormat_ has a [[Day]]</del><ins>_pattern_ has a [[day]]</ins> internal slot. If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[InDST]] field of _tm_. If _p_ is *"era"*, then the String value may also depend on whether <del>_dateTimeFormat_ has a [[Era]]</del><ins>_pattern_ has a [[era]]</ins> internal slot and if the implementation does not have a localized representation of _f_, then use _f_ itself.
-            1. Append a new Record { [[Type]]: _p_, [[Value]]: _fv_ } as the last element of the list _result_.
-          1. Else if _p_ is equal to *"ampm"*, then
-            1. Let _v_ be _tm_.[[Hour]].
-            1. If _v_ is greater than 11, then
-              1. Let _fv_ be an implementation and locale dependent String value representing *"post meridiem"*.
-            1. Else,
-              1. Let _fv_ be an implementation and locale dependent String value representing *"ante meridiem"*.
-            1. Append a new Record { [[Type]]: *"dayPeriod"*, [[Value]]: _fv_ } as the last element of the list _result_.
-          1. Else if _p_ is equal to *"relatedYear"*, then
-            1. Let _v_ be _tm_.[[RelatedYear]].
-            1. Let _fv_ be FormatNumeric(_nf_, _v_).
-            1. Append a new Record { [[Type]]: *"relatedYear"*, [[Value]]: _fv_ } as the last element of the list _result_.
-          1. Else if _p_ is equal to *"yearName"*, then
-            1. Let _v_ be _tm_.[[YearName]].
-            1. Append a new Record { [[Type]]: *"yearName"*, [[Value]]: _v_ } as the last element of the list _result_.
-          1. Else,
-            1. Let _unknown_ be an implementation-, locale-, and numbering system-dependent String based on <del>_x_</del><ins>_epochNanoseconds_</ins> and _p_.
-            1. Append a new Record { [[Type]]: *"unknown"*, [[Value]]: _unknown_ } as the last element of _result_.
+        1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, <ins>_pattern_</ins>, _patternParts_, <del>_x_</del><ins>_epochNanoseconds_</ins>, *undefined*).
         1. Return _result_.
       </emu-alg>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -196,6 +196,7 @@
         1. <del>If _dateTimeFormat_.[[Hour]] is *undefined*, then</del>
           1. <del>Set _dateTimeFormat_.[[HourCycle]] to *undefined*.</del>
           1. <del>Let _pattern_ be _bestFormat_.[[pattern]].</del>
+          1. <del>Let _rangePatterns_ be _bestFormat_.[[rangePatterns]].</del>
         1. <del>Else,</del>
           1. <del>Let _hcDefault_ be _dataLocaleData_.[[hourCycle]].</del>
           1. <del>Let _hc_ be _dateTimeFormat_.[[HourCycle]].</del>
@@ -216,9 +217,24 @@
           1. <del>Set _dateTimeFormat_.[[HourCycle]] to _hc_.</del>
           1. <del>If _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then</del>
             1. <del>Let _pattern_ be _bestFormat_.[[pattern12]].</del>
+            1. <del>Let _rangePatterns_ be _bestFormat_.[[rangePatterns12]].</del>
           1. <del>Else,</del>
             1. <del>Let _pattern_ be _bestFormat_.[[pattern]].</del>
+            1. <del>Let _rangePatterns_ be _bestFormat_.[[rangePatterns]].</del>
+        1. <del>Else,</del>
+          1. <del>Set _dateTimeFormat_.[[HourCycle]] to *undefined*.</del>
+          1. <del>Let _pattern_ be _bestFormat_.[[pattern]].</del>
+        1. <ins>Let _expandedOptions_ be a copy of _opt_.</ins>
+        1. <ins>Let _needDefaults_ be *true*.</ins>
+        1. <ins>For each element _field_ of « *"weekday"*, *"year"*, *"month"*, *"day"*, *"hour"*, *"minute"*, *"second"* » in List order, do</ins>
+          1. <ins>If _expandedOptions_.[[&lt;_field_&gt;]] is not *undefined*, then</ins>
+            1. <ins>Set _needDefaults_ to *false*.</ins>
+        1. <ins>If _needDefaults_ is *true*, then</ins>
+          1. <ins>For each element _field_ of « *"year"*, *"month"*, *"day"*, *"hour"*, *"minute"*, *"second"* » in List order, do</ins>
+            1. <ins>Set _expandedOptions_.[[&lt;_field_&gt;]] to *"numeric"*.</ins>
+        1. <ins>Let _bestFormat_ be GetDateTimeFormatPattern(_matcher_, _limitedOptions_, _formats_, _hc_)</ins>.
         1. Set _dateTimeFormat_.[[Pattern]] to <del>_pattern_</del><ins>_bestFormat_.[[pattern]]</ins>.
+        1. Set _dateTimeFormat_.[[RangePatterns]] to <del>_rangePatterns_</del><ins>_bestFormat_.[[rangePatterns]]</ins>.
         1. <ins>For each row in <emu-xref href="#table-temporal-patterns"></emu-xref>, except the header row, in table order, do</ins>
           1. <ins>Let _limitedOptions_ be a new Record.</ins>
           1. <ins>Let _needDefaults_ be *true*.</ins>
@@ -559,7 +575,9 @@
         1. If _bestFormat_.[[hour]] is not *undefined*, then
           1. If _hc_ is *"h11"* or *"h12"*, then
             1. Set _bestFormat_.[[pattern]] to _bestFormat_.[[pattern12]].
+            1. Set _bestFormat_.[[rangePatterns]] to _bestFormat_.[[rangePatterns12]].
           1. Remove the [[pattern12]] field from _bestFormat_.
+          1. Remove the [[rangePatterns12]] field from _bestFormat_.
           1. Set _bestFormat_.[[hourCycle]] to _hc_.
         1. Else,
           1. Set _bestFormat_.[[hourCycle]] to *undefined*.
@@ -891,6 +909,7 @@
       <li><del>[[HourCycle]] is a String value indicating whether the 12-hour format (*"h11"*, *"h12"*) or the 24-hour format (*"h23"*, *"h24"*) should be used. *"h11"* and *"h23"* start with hour 0 and go up to 11 and 23 respectively. *"h12"* and *"h24"* start with hour 1 and go up to 12 and 24. [[HourCycle]] is only used when [[Hour]] is not *undefined*.</del></li>
       <li>[[DateStyle]], [[TimeStyle]] are each either *undefined*, or a String value with values *"full"*, *"long"*, *"medium"*, or *"short"*.</li>
       <li>[[Pattern]]<ins>, [[TemporalPlainDatePattern]], [[TemporalPlainYearMonthPattern]], [[TemporalPlainMonthDayPattern]], [[TemporalPlainTimePattern]], [[TemporalPlainDateTimePattern]], [[TemporalInstantPattern]], and [[TemporalZonedDateTimePattern]] are</ins> <del>is a String value</del><ins>records containing at least a [[pattern]] field</ins> as described in <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>.</li>
+      <li>[[RangePatterns]] is a Record as described in <emu-xref href="#sec-intl.datetimeformat-internal-slots"></emu-xref>.</li>
     </ul>
 
     <p>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -389,7 +389,7 @@
             1. Else if _f_ is *"2-digit"*, then
               1. Let _fv_ be FormatNumeric(_nf2_, _v_).
               1. If the *"length"* property of _fv_ is greater than 2, let _fv_ be the substring of _fv_ containing the last two characters.
-            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether <del>_dateTimeFormat_.[[Day]]</del><ins>_pattern_.[[day]]</ins> is *undefined*. If _p_ is *"month"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[day]] is *undefined*.  If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[InDST]] field of _tm_. If _p_ is *"era"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether <del>_dateTimeFormat_.[[Era]]</del><ins>_pattern_.[[day]]</ins> is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[era]] is *undefined*. If the implementation does not have a localized representation of _f_, then use _f_ itself.
+            1. Else if _f_ is *"narrow"*, *"short"*, or *"long"*, then let _fv_ be a String value representing _v_ in the form given by _f_; the String value depends upon the implementation and the effective locale and calendar of _dateTimeFormat_. If _p_ is *"month"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether <del>_dateTimeFormat_.[[Day]]</del><ins>_pattern_.[[day]]</ins> is *undefined*. If _p_ is *"month"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[day]] is *undefined*. If _p_ is *"timeZoneName"*, then the String value may also depend on the value of the [[InDST]] field of _tm_. If _p_ is *"era"* and _rangeFormatOptions_ is *undefined*, then the String value may also depend on whether <del>_dateTimeFormat_.[[Era]]</del><ins>_pattern_.[[day]]</ins> is *undefined*. If _p_ is *"era"* and _rangeFormatOptions_ is not *undefined*, then the String value may also depend on whether _rangeFormatOptions_.[[era]] is *undefined*. If the implementation does not have a localized representation of _f_, then use _f_ itself.
             1. Append a new Record { [[Type]]: _p_, [[Value]]: _fv_ } as the last element of the list _result_.
           1. Else if _p_ is equal to *"ampm"*, then
             1. Let _v_ be _tm_.[[Hour]].
@@ -500,7 +500,7 @@
         1. Let _rangePattern_ be *undefined*.
         1. Let _dateFieldsPracticallyEqual_ be *true*.
         1. Let _patternContainsLargerDateField_ be *false*.
-        1. While _dateFieldsPracticallyEqual_ is *true* and _patternContainsLargerDateField_ is *false*, repeat for each row of <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref> in order, except the header row
+        1. While _dateFieldsPracticallyEqual_ is *true* and _patternContainsLargerDateField_ is *false*, repeat for each row of <emu-xref href="#table-datetimeformat-rangepatternfields"></emu-xref> in order, except the header row:
           1. Let _fieldName_ be the name given in the Range Pattern Field column of the row.
           1. If _fieldName_ is equal to [[AmPm]], then
             1. Let _rp_ be _rangePatterns_.[[AmPm]].
@@ -541,13 +541,13 @@
           1. <del>Let _pattern_ be _dateTimeFormat_.[[Pattern]].</del>
           1. Let _patternParts_ be PartitionPattern(<del>_pattern_</del><ins>_x_.[[pattern]]</ins>).
           1. Let _result_ be ? FormatDateTimePattern(_dateTimeFormat_, <ins>_x_.[[pattern]] ,</ins> _patternParts_, _x_<ins>.[[epochNanoseconds]]</ins>, *undefined*).
-          1. For each _r_ in _result_ do
+          1. For each element _r_ in _result_, do
             1. Set _r_.[[Source]] to *"shared"*.
           1. Return _result_.
         1. Let _result_ be a new empty List.
         1. If _rangePattern_ is *undefined*, then
           1. Let _rangePattern_ be _rangePatterns_.[[Default]].
-        1. For each _rangePatternPart_ in _rangePattern_.[[PatternParts]], do
+        1. For each element _rangePatternPart_ in _rangePattern_.[[PatternParts]], do
           1. <mark>TODO: perhaps try to make the patterns play better with _rangePatternPart_.[[Pattern]].</mark>
           1. <del>Let _pattern_ be _rangePatternPart_.[[Pattern]].</del>
           1. Let _source_ be _rangePatternPart_.[[Source]].
@@ -559,7 +559,7 @@
             1. <ins>Let _pattern_ be _y_.[[pattern]].</ins>
           1. Let _patternParts_ be PartitionPattern(_pattern_).
           1. Let _partResult_ be ? FormatDateTimePattern(_dateTimeFormat_, <ins>_pattern_ ,</ins> _patternParts_, _z_, _rangePattern_).
-          1. For each _r_ in _partResult_, do
+          1. For each element _r_ in _partResult_, do
             1. Set _r_.[[Source]] to _source_.
           1. Add all elements in _partResult_ to _result_ in order.
         1. Return _result_.


### PR DESCRIPTION
WIP series of commits rebasing the Temporal 402 spec on top of the spec from the DateTimeFormat.p.formatRange proposal.

Trying to make editorial cleanups or improvements where possible.

/cc @ptomato @Ms2ger 

Refs: https://github.com/tc39/ecma402/pull/532