### PR TITLE
Add "M" prefix to monthCode

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -234,7 +234,7 @@ For example:
 const date = Temporal.PlainDate.from('2019-02-06').withCalendar('hebrew');
 date.year; // => 5779
 date.calendar.year(date); // same result, but calling the method directly
-date.monthCode; // => "5L"
+date.monthCode; // => "M5L"
 date.calendar.monthCode(date); // same result, but calling the method directly
 date.daysInYear; // => 385
 date.calendar.daysInYear(date); // same result, but calling the method directly
@@ -271,10 +271,10 @@ A custom implementation of these methods would convert the calendar-space argume
 For example:
 
 ```javascript
-date = Temporal.PlainDate.from({ year: 5779, monthCode: '5L', day: 18, calendar: 'hebrew' });
+date = Temporal.PlainDate.from({ year: 5779, monthCode: 'M5L', day: 18, calendar: 'hebrew' });
 date.year; // => 5779
 date.month; // => 6
-date.monthCode; // => "5L"
+date.monthCode; // => "M5L"
 date.day; // => 18
 date.toString(); // => 2019-02-23[u-ca-hebrew]
 date.toLocaleString('en-US', { calendar: 'hebrew' }); // => "18 Adar I 5779"
@@ -433,9 +433,9 @@ Usage example:
 // and `monthCode` into account
 Temporal.Calendar.from('iso8601').mergeFields(
   { year: 2006, month: 7, day: 31 },
-  { monthCode: '8' }
+  { monthCode: 'M8' }
 );
-// => { year: 2006, monthCode: '8', day: 31 }
+// => { year: 2006, monthCode: 'M8', day: 31 }
 ```
 <!-- prettier-ignore-end -->
 

--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -164,9 +164,11 @@ The above read-only properties allow accessing each component of a date individu
   The first month in every year has `month` equal to `1`.
   The last month of every year has `month` equal to the `monthsInYear` property.
   `month` values start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
-- `monthCode` is a calendar-specific, non-empty string which identifies the month in a year-independent way.
-  For calendars that do not use leap months, `monthCode` is the same as `month.toString()`.
-- `day` is a positive integer representing the day of the month.
+- `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
+  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
+  Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
+  - `day` is a positive integer representing the day of the month.
 
 Either `month` or `monthCode` can be used in `from` or `with` to refer to the month.
 Similarly, in calendars that user eras an `era`/`eraYear` pair can be used in place of `year` when calling `from` or `with`.

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -227,8 +227,10 @@ Date unit details:
   The first month in every year has `month` equal to `1`.
   The last month of every year has `month` equal to the `monthsInYear` property.
   `month` values start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
-- `monthCode` is a calendar-specific, non-empty string which identifies the month in a year-independent way.
-  For calendars that do not use leap months, `monthCode` is the same as `month.toString()`.
+- `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
+  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
+  Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
 - `day` is a positive integer representing the day of the month.
 
 Either `month` or `monthCode` can be used in `from` or `with` to refer to the month.

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -95,7 +95,7 @@ md = Temporal.PlainMonthDay.from('2006-08-24T15:43:27+01:00[Europe/Brussels]');
 // => 08-24
 md === Temporal.PlainMonthDay.from(md); // => true
 
-md = Temporal.PlainMonthDay.from({ monthCode: '8', day: 24 }); // => 08-24
+md = Temporal.PlainMonthDay.from({ monthCode: 'M8', day: 24 }); // => 08-24
 md = Temporal.PlainMonthDay.from(Temporal.PlainDate.from('2006-08-24'));
 // => same as above; Temporal.PlainDate has month and day properties
 
@@ -112,14 +112,14 @@ md = Temporal.PlainMonthDay.from({ month: 2, day: 29, year: 2001 }, { overflow: 
 // throws (this year is not a leap year in the ISO calendar)
 
 // non-ISO calendars
-md = Temporal.PlainMonthDay.from({ monthCode: '5L', day: 15, calendar: 'hebrew' });
+md = Temporal.PlainMonthDay.from({ monthCode: 'M5L', day: 15, calendar: 'hebrew' });
 // => 2019-02-20[u-ca-hebrew]
 md = Temporal.PlainMonthDay.from({ month: 6, day: 15, year: 5779, calendar: 'hebrew' });
 // => 2019-02-20[u-ca-hebrew]
 md = Temporal.PlainMonthDay.from({ month: 6, day: 15, calendar: 'hebrew' });
 // => throws (either year or monthCode is required)
 md = Temporal.PlainMonthDay.from('2019-02-20[u-ca-hebrew]');
-md.monthCode; // => "5L"
+md.monthCode; // => "M5L"
 md.day; // => 15
 md.month; // undefined (month property is not present in this type; use monthCode instead)
 ```
@@ -132,8 +132,10 @@ md.month; // undefined (month property is not present in this type; use monthCod
 
 The above read-only properties allow accessing each component of the date individually.
 
-- `monthCode` is a calendar-specific, non-empty string which identifies the month in a year-independent way.
-  For example, `'2'` is the `monthCode` for February in the ISO calendar, while `'8L'` is the month code for a leap month in the Chinese calendar when the leap month repeats the 8th month.
+- `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
+  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
+  Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
 - `day` is a positive integer representing the day of the month.
 
 Note that this type has no `month` property, because `month` is ambiguous for some calendars without knowing the year.
@@ -283,7 +285,7 @@ Example usage:
 
 ```js
 ({ calendar } = new Intl.DateTimeFormat().resolvedOptions());
-md = Temporal.PlainMonthDay.from({ monthCode: '8', day: 24, calendar });
+md = Temporal.PlainMonthDay.from({ monthCode: 'M8', day: 24, calendar });
 md.toLocaleString(); // => example output: 08-24
 // Same as above, but explicitly specifying the calendar:
 md.toLocaleString(undefined, { calendar });
@@ -309,7 +311,7 @@ Example usage:
 ```js
 const holiday = {
   name: 'Canada Day',
-  holidayMonthDay: Temporal.PlainMonthDay.from({ monthCode: '7', day: 1 })
+  holidayMonthDay: Temporal.PlainMonthDay.from({ monthCode: 'M7', day: 1 })
 };
 const str = JSON.stringify(holiday, null, 2);
 console.log(str);
@@ -362,7 +364,7 @@ Example:
 ```javascript
 md = Temporal.PlainMonthDay.from({
   calendar: 'japanese',
-  monthCode: '1',
+  monthCode: 'M1',
   day: 1
 });
 

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -163,8 +163,10 @@ The above read-only properties allow accessing the year or month individually.
   The first month in every year has `month` equal to `1`.
   The last month of every year has `month` equal to the `monthsInYear` property.
   `month` values start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
-- `monthCode` is a calendar-specific, non-empty string which identifies the month in a year-independent way.
-  For calendars that do not use leap months, `monthCode` is the same as `month.toString()`.
+- `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
+  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
+  Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
 
 Either `month` or `monthCode` can be used in `from` or `with` to refer to the month.
 Similarly, in calendars that user eras an `era`/`eraYear` pair can be used in place of `year` when calling `from` or `with`.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -300,8 +300,10 @@ Date unit details:
   The first month in every year has `month` equal to `1`.
   The last month of every year has `month` equal to the `monthsInYear` property.
   `month` values start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
-- `monthCode` is a calendar-specific, non-empty string which identifies the month in a year-independent way.
-  For calendars that do not use leap months, `monthCode` is the same as `month.toString()`.
+- `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
+  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
+  Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
 - `day` is a positive integer representing the day of the month.
 
 Either `month` or `monthCode` can be used in `from` or `with` to refer to the month.

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -255,7 +255,7 @@ impl['iso8601'] = {
   },
   monthCode(date) {
     if (!HasSlot(date, ISO_MONTH)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    return ES.ToString(GetSlot(date, ISO_MONTH));
+    return `M${ES.ToString(GetSlot(date, ISO_MONTH))}`;
   },
   day(date) {
     if (!HasSlot(date, ISO_DAY)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
@@ -302,7 +302,10 @@ impl['iso8601'] = {
 // ECMA-402.
 
 function monthCodeNumberPart(monthCode) {
-  const month = +monthCode;
+  if (!monthCode.startsWith('M')) {
+    throw new RangeError(`Invalid month code: ${monthCode}.  Month codes must start with M.`);
+  }
+  const month = +monthCode.slice(1);
   if (isNaN(month)) throw new RangeError(`Invalid month code: ${monthCode}`);
   return month;
 }
@@ -316,14 +319,14 @@ function resolveNonLunisolarMonth(calendarDate) {
   let { month, monthCode } = calendarDate;
   if (monthCode === undefined) {
     if (month === undefined) throw new TypeError('Either month or monthCode are required');
-    monthCode = `${month}`;
+    monthCode = `M${month}`;
   } else {
     const numberPart = monthCodeNumberPart(monthCode);
     if (month !== undefined && month !== numberPart) {
       throw new RangeError(`monthCode ${monthCode} and month ${month} must match if both are present`);
     }
-    if (monthCode !== `${numberPart}`) {
-      throw new RangeError(`Invalid month code: ${monthCode}. Expected numeric string`);
+    if (monthCode !== `M${numberPart}`) {
+      throw new RangeError(`Invalid month code: ${monthCode}`);
     }
     month = numberPart;
   }

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1280,7 +1280,7 @@ export const ES = ObjectAssign({}, ES2020, {
       const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);
       const fields = ES.ToTemporalMonthDayFields(item, fieldNames);
       if (calendarAbsent && fields.month !== undefined && fields.monthCode === undefined) {
-        fields.monthCode = ES.ToString(fields.month);
+        fields.monthCode = `M${ES.ToString(fields.month)}`;
       }
       return ES.MonthDayFromFields(calendar, fields, constructor, options);
     }

--- a/polyfill/test/PlainDate/constructor/from/order-of-operations.js
+++ b/polyfill/test/PlainDate/constructor/from/order-of-operations.js
@@ -21,7 +21,7 @@ const actual = [];
 const fields = {
   year: 1.7,
   month: 1.7,
-  monthCode: "1",
+  monthCode: "M1",
   day: 1.7,
 };
 const argument = new Proxy(fields, {
@@ -49,7 +49,7 @@ const result = Temporal.PlainDate.from(argument);
 assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
-assert.sameValue(result.monthCode, "1", "monthCode result");
+assert.sameValue(result.monthCode, "M1", "monthCode result");
 assert.sameValue(result.day, 1, "day result");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/PlainDate/prototype/with/order-of-operations.js
+++ b/polyfill/test/PlainDate/prototype/with/order-of-operations.js
@@ -23,7 +23,7 @@ const actual = [];
 const fields = {
   year: 1.7,
   month: 1.7,
-  monthCode: "1",
+  monthCode: "M1",
   day: 1.7,
 };
 const argument = new Proxy(fields, {
@@ -53,7 +53,7 @@ const result = instance.with(argument);
 assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
-assert.sameValue(result.monthCode, "1", "monthCode result");
+assert.sameValue(result.monthCode, "M1", "monthCode result");
 assert.sameValue(result.day, 1, "day result");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/PlainDateTime/constructor/from/order-of-operations.js
+++ b/polyfill/test/PlainDateTime/constructor/from/order-of-operations.js
@@ -33,7 +33,7 @@ const actual = [];
 const fields = {
   year: 1.7,
   month: 1.7,
-  monthCode: "1",
+  monthCode: "M1",
   day: 1.7,
   hour: 1.7,
   minute: 1.7,
@@ -67,7 +67,7 @@ const result = Temporal.PlainDateTime.from(argument);
 assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
-assert.sameValue(result.monthCode, "1", "monthCode result");
+assert.sameValue(result.monthCode, "M1", "monthCode result");
 assert.sameValue(result.day, 1, "day result");
 assert.sameValue(result.hour, 1, "hour result");
 assert.sameValue(result.minute, 1, "minute result");

--- a/polyfill/test/PlainDateTime/prototype/with/order-of-operations.js
+++ b/polyfill/test/PlainDateTime/prototype/with/order-of-operations.js
@@ -35,7 +35,7 @@ const actual = [];
 const fields = {
   year: 1.7,
   month: 1.7,
-  monthCode: "1",
+  monthCode: "M1",
   day: 1.7,
   hour: 1.7,
   minute: 1.7,
@@ -71,7 +71,7 @@ const result = instance.with(argument);
 assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
-assert.sameValue(result.monthCode, "1", "monthCode result");
+assert.sameValue(result.monthCode, "M1", "monthCode result");
 assert.sameValue(result.day, 1, "day result");
 assert.sameValue(result.hour, 1, "hour result");
 assert.sameValue(result.minute, 1, "minute result");

--- a/polyfill/test/PlainMonthDay/constructor/from/infinity-handled.js
+++ b/polyfill/test/PlainMonthDay/constructor/from/infinity-handled.js
@@ -9,10 +9,10 @@ esid: sec-temporal.plainmonthday.from
 // constrain
 
 let result = Temporal.PlainMonthDay.from({ month: Infinity, day: 1 }, { overflow: 'constrain' });
-assert.sameValue(result.monthCode, "12");
+assert.sameValue(result.monthCode, "M12");
 assert.sameValue(result.day, 1);
 result = Temporal.PlainMonthDay.from({ month: 1, day: Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.monthCode, "1");
+assert.sameValue(result.monthCode, "M1");
 assert.sameValue(result.day, 31);
 
 // reject

--- a/polyfill/test/PlainMonthDay/constructor/from/options-undefined.js
+++ b/polyfill/test/PlainMonthDay/constructor/from/options-undefined.js
@@ -8,9 +8,9 @@ esid: sec-temporal.plainmonthday.from
 const fields = { month: 2, day: 31 };
 
 const explicit = Temporal.PlainMonthDay.from(fields, undefined);
-assert.sameValue(explicit.monthCode, "2", "default overflow is constrain");
+assert.sameValue(explicit.monthCode, "M2", "default overflow is constrain");
 assert.sameValue(explicit.day, 29, "default overflow is constrain");
 
 const implicit = Temporal.PlainMonthDay.from(fields);
-assert.sameValue(implicit.monthCode, "2", "default overflow is constrain");
+assert.sameValue(implicit.monthCode, "M2", "default overflow is constrain");
 assert.sameValue(implicit.day, 29, "default overflow is constrain");

--- a/polyfill/test/PlainMonthDay/constructor/from/order-of-operations.js
+++ b/polyfill/test/PlainMonthDay/constructor/from/order-of-operations.js
@@ -20,7 +20,7 @@ const expected = [
 const actual = [];
 const fields = {
   month: 1.7,
-  monthCode: "1",
+  monthCode: "M1",
   day: 1.7,
   year: 1.7,
 };
@@ -46,7 +46,7 @@ const argument = new Proxy(fields, {
   },
 });
 const result = Temporal.PlainMonthDay.from(argument);
-assert.sameValue(result.monthCode, "1", "monthCode result");
+assert.sameValue(result.monthCode, "M1", "monthCode result");
 assert.sameValue(result.day, 1, "day result");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/PlainMonthDay/constructor/from/subclass.js
+++ b/polyfill/test/PlainMonthDay/constructor/from/subclass.js
@@ -17,7 +17,7 @@ class MyMonthDay extends Temporal.PlainMonthDay {
 }
 
 const result = MyMonthDay.from("05-02");
-assert.sameValue(result.monthCode, "5", "monthCode result");
+assert.sameValue(result.monthCode, "M5", "monthCode result");
 assert.sameValue(result.day, 2, "day result");
 assert.sameValue(called, true);
 assert.sameValue(Object.getPrototypeOf(result), MyMonthDay.prototype);

--- a/polyfill/test/PlainMonthDay/prototype/with/infinity-handled.js
+++ b/polyfill/test/PlainMonthDay/prototype/with/infinity-handled.js
@@ -11,7 +11,7 @@ const instance = new Temporal.PlainMonthDay(5, 2);
 // constrain
 
 let result = instance.with({ day: Infinity }, { overflow: 'constrain' });
-assert.sameValue(result.monthCode, "5");
+assert.sameValue(result.monthCode, "M5");
 assert.sameValue(result.day, 31);
 
 // reject

--- a/polyfill/test/PlainMonthDay/prototype/with/order-of-operations.js
+++ b/polyfill/test/PlainMonthDay/prototype/with/order-of-operations.js
@@ -22,7 +22,7 @@ const expected = [
 const actual = [];
 const fields = {
   month: 1.7,
-  monthCode: "1",
+  monthCode: "M1",
   day: 1.7,
   year: 1.7,
 };
@@ -50,6 +50,6 @@ const argument = new Proxy(fields, {
   },
 });
 const result = instance.with(argument);
-assert.sameValue(result.monthCode, "1", "monthCode result");
+assert.sameValue(result.monthCode, "M1", "monthCode result");
 assert.sameValue(result.day, 1, "day result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/PlainMonthDay/prototype/with/subclass-constructor-undefined.js
+++ b/polyfill/test/PlainMonthDay/prototype/with/subclass-constructor-undefined.js
@@ -22,7 +22,7 @@ assert.sameValue(called, 1);
 MyMonthDay.prototype.constructor = undefined;
 
 const result = instance.with({ day: 20 });
-assert.sameValue(result.monthCode, "5", "monthCode result");
+assert.sameValue(result.monthCode, "M5", "monthCode result");
 assert.sameValue(result.day, 20, "day result");
 assert.sameValue(called, 1);
 assert.sameValue(Object.getPrototypeOf(result), Temporal.PlainMonthDay.prototype);

--- a/polyfill/test/PlainMonthDay/prototype/with/subclass-out-of-range.js
+++ b/polyfill/test/PlainMonthDay/prototype/with/subclass-out-of-range.js
@@ -20,7 +20,7 @@ const instance = MyMonthDay.from("11-30");
 assert.sameValue(called, 1);
 
 const result = instance.with({ day: 31 });
-assert.sameValue(result.monthCode, "11", "monthCode result");
+assert.sameValue(result.monthCode, "M11", "monthCode result");
 assert.sameValue(result.day, 30, "day result");
 assert.sameValue(called, 2);
 

--- a/polyfill/test/PlainMonthDay/prototype/with/subclass-species-null.js
+++ b/polyfill/test/PlainMonthDay/prototype/with/subclass-species-null.js
@@ -25,7 +25,7 @@ MyMonthDay.prototype.constructor = {
 };
 
 const result = instance.with({ day: 20 });
-assert.sameValue(result.monthCode, "5", "monthCode result");
+assert.sameValue(result.monthCode, "M5", "monthCode result");
 assert.sameValue(result.day, 20, "day result");
 assert.sameValue(called, 1);
 assert.sameValue(Object.getPrototypeOf(result), Temporal.PlainMonthDay.prototype);

--- a/polyfill/test/PlainMonthDay/prototype/with/subclass-species-undefined.js
+++ b/polyfill/test/PlainMonthDay/prototype/with/subclass-species-undefined.js
@@ -25,7 +25,7 @@ MyMonthDay.prototype.constructor = {
 };
 
 const result = instance.with({ day: 20 });
-assert.sameValue(result.monthCode, "5", "monthCode result");
+assert.sameValue(result.monthCode, "M5", "monthCode result");
 assert.sameValue(result.day, 20, "day result");
 assert.sameValue(called, 1);
 assert.sameValue(Object.getPrototypeOf(result), Temporal.PlainMonthDay.prototype);

--- a/polyfill/test/PlainMonthDay/prototype/with/subclass.js
+++ b/polyfill/test/PlainMonthDay/prototype/with/subclass.js
@@ -25,7 +25,7 @@ const instance = MyMonthDay.from("05-02");
 assert.sameValue(called, 1);
 
 const result = instance.with({ day: 20 });
-assert.sameValue(result.monthCode, "5", "monthCode result");
+assert.sameValue(result.monthCode, "M5", "monthCode result");
 assert.sameValue(result.day, 20, "day result");
 assert.sameValue(called, 2);
 assert.sameValue(Object.getPrototypeOf(result), MyMonthDay.prototype);

--- a/polyfill/test/PlainYearMonth/constructor/from/order-of-operations.js
+++ b/polyfill/test/PlainYearMonth/constructor/from/order-of-operations.js
@@ -19,7 +19,7 @@ const actual = [];
 const fields = {
   year: 1.7,
   month: 1.7,
-  monthCode: "1",
+  monthCode: "M1",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
@@ -46,6 +46,6 @@ const result = Temporal.PlainYearMonth.from(argument);
 assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
-assert.sameValue(result.monthCode, "1", "monthCode result");
+assert.sameValue(result.monthCode, "M1", "monthCode result");
 assert.sameValue(result.calendar.id, "iso8601", "calendar result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/PlainYearMonth/prototype/with/order-of-operations.js
+++ b/polyfill/test/PlainYearMonth/prototype/with/order-of-operations.js
@@ -21,7 +21,7 @@ const actual = [];
 const fields = {
   year: 1.7,
   month: 1.7,
-  monthCode: "1",
+  monthCode: "M1",
 };
 const argument = new Proxy(fields, {
   get(target, key) {
@@ -50,5 +50,5 @@ const result = instance.with(argument);
 assert.sameValue(result.era, undefined, "era result");
 assert.sameValue(result.year, 1, "year result");
 assert.sameValue(result.month, 1, "month result");
-assert.sameValue(result.monthCode, "1", "monthCode result");
+assert.sameValue(result.monthCode, "M1", "monthCode result");
 assert.compareArray(actual, expected, "order of operations");

--- a/polyfill/test/calendar.mjs
+++ b/polyfill/test/calendar.mjs
@@ -199,7 +199,7 @@ describe('Calendar', () => {
     });
   });
   describe('Calendar.monthCode()', () => {
-    const res = '11';
+    const res = 'M11';
     it('accepts Date', () => equal(iso.monthCode(Temporal.PlainDate.from('1994-11-05')), res));
     it('accepts DateTime', () => equal(iso.monthCode(Temporal.PlainDateTime.from('1994-11-05T08:15:30')), res));
     it('accepts YearMonth', () => equal(iso.monthCode(Temporal.PlainYearMonth.from('1994-11')), res));

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -190,7 +190,7 @@ describe('Intl', () => {
   });
   describe('monthday.toLocaleString()', () => {
     const calendar = new Intl.DateTimeFormat('en').resolvedOptions().calendar;
-    const monthday = Temporal.PlainMonthDay.from({ monthCode: '11', day: 18, calendar });
+    const monthday = Temporal.PlainMonthDay.from({ monthCode: 'M11', day: 18, calendar });
     it(`(${monthday.toString()}).toLocaleString('en-US', { timeZone: 'America/New_York' })`, () =>
       equal(`${monthday.toLocaleString('en', { timeZone: 'America/New_York' })}`, '11/18'));
     it(`(${monthday.toString()}).toLocaleString('de-AT', { timeZone: 'Europe/Vienna' })`, () =>
@@ -204,7 +204,7 @@ describe('Intl', () => {
       equal(monthday.toLocaleString('en', { weekday: 'long' }), '11/18');
     });
     it("works when the object's calendar is the same as the locale's calendar", () => {
-      const md = Temporal.PlainMonthDay.from({ monthCode: '11', day: 18, calendar: 'japanese' });
+      const md = Temporal.PlainMonthDay.from({ monthCode: 'M11', day: 18, calendar: 'japanese' });
       equal(`${md.toLocaleString('en-US-u-ca-japanese')}`, '11/18');
     });
     it('throws when the calendar is not equal to the locale calendar', () => {

--- a/polyfill/test/plaindate.mjs
+++ b/polyfill/test/plaindate.mjs
@@ -111,7 +111,7 @@ describe('Date', () => {
     });
     it('date.year is 1976', () => equal(date.year, 1976));
     it('date.month is 11', () => equal(date.month, 11));
-    it('date.monthCode is "11"', () => equal(date.monthCode, '11'));
+    it('date.monthCode is "M11"', () => equal(date.monthCode, 'M11'));
     it('date.day is 18', () => equal(date.day, 18));
     it('date.calendar is the object', () => equal(date.calendar, calendar));
     it('date.dayOfWeek is 4', () => equal(date.dayOfWeek, 4));
@@ -123,7 +123,7 @@ describe('Date', () => {
   });
   describe('date fields', () => {
     const date = new PlainDate(2019, 10, 6);
-    const datetime = { year: 2019, month: 10, monthCode: '10', day: 1, hour: 14, minute: 20, second: 36 };
+    const datetime = { year: 2019, month: 10, monthCode: 'M10', day: 1, hour: 14, minute: 20, second: 36 };
     const fromed = new PlainDate(2019, 10, 1);
     it(`(${date}).dayOfWeek === 7`, () => equal(date.dayOfWeek, 7));
     it(`Temporal.PlainDate.from(${date}) is not the same object)`, () => notEqual(PlainDate.from(date), date));
@@ -142,11 +142,11 @@ describe('Date', () => {
       const date = original.with({ month: 5 });
       equal(`${date}`, '1976-05-18');
     });
-    it('date.with({ monthCode: "5" }) works', () => {
-      equal(`${original.with({ monthCode: '5' })}`, '1976-05-18');
+    it('date.with({ monthCode: "M5" }) works', () => {
+      equal(`${original.with({ monthCode: 'M5' })}`, '1976-05-18');
     });
     it('month and monthCode must agree', () => {
-      throws(() => original.with({ month: 5, monthCode: '6' }), RangeError);
+      throws(() => original.with({ month: 5, monthCode: 'M6' }), RangeError);
     });
     it('date.with({ day: 17 } works', () => {
       const date = original.with({ day: 17 });
@@ -938,9 +938,9 @@ describe('Date', () => {
     it('can be constructed with month and without monthCode', () =>
       equal(`${PlainDate.from({ year: 1976, month: 11, day: 18 })}`, '1976-11-18'));
     it('can be constructed with monthCode and without month', () =>
-      equal(`${PlainDate.from({ year: 1976, monthCode: '11', day: 18 })}`, '1976-11-18'));
+      equal(`${PlainDate.from({ year: 1976, monthCode: 'M11', day: 18 })}`, '1976-11-18'));
     it('month and monthCode must agree', () =>
-      throws(() => PlainDate.from({ year: 1976, month: 11, monthCode: '12', day: 18 }), RangeError));
+      throws(() => PlainDate.from({ year: 1976, month: 11, monthCode: 'M12', day: 18 }), RangeError));
     it('Date.from({ year: 2019, day: 15 }) throws', () =>
       throws(() => PlainDate.from({ year: 2019, day: 15 }), TypeError));
     it('Date.from({ month: 12 }) throws', () => throws(() => PlainDate.from({ month: 12 }), TypeError));

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -130,7 +130,7 @@ describe('DateTime', () => {
       });
       it('datetime.year is 1976', () => equal(datetime.year, 1976));
       it('datetime.month is 11', () => equal(datetime.month, 11));
-      it('datetime.monthCode is "11"', () => equal(datetime.monthCode, '11'));
+      it('datetime.monthCode is "M11"', () => equal(datetime.monthCode, 'M11'));
       it('datetime.day is 18', () => equal(datetime.day, 18));
       it('datetime.hour is 15', () => equal(datetime.hour, 15));
       it('datetime.minute is 23', () => equal(datetime.minute, 23));
@@ -155,7 +155,7 @@ describe('DateTime', () => {
       });
       it('datetime.year is 1976', () => equal(datetime.year, 1976));
       it('datetime.month is 11', () => equal(datetime.month, 11));
-      it('datetime.monthCode is "11"', () => equal(datetime.monthCode, '11'));
+      it('datetime.monthCode is "M11"', () => equal(datetime.monthCode, 'M11'));
       it('datetime.day is 18', () => equal(datetime.day, 18));
       it('datetime.hour is 15', () => equal(datetime.hour, 15));
       it('datetime.minute is 23', () => equal(datetime.minute, 23));
@@ -179,7 +179,7 @@ describe('DateTime', () => {
       });
       it('datetime.year is 1976', () => equal(datetime.year, 1976));
       it('datetime.month is 11', () => equal(datetime.month, 11));
-      it('datetime.monthCode is "11"', () => equal(datetime.monthCode, '11'));
+      it('datetime.monthCode is "M11"', () => equal(datetime.monthCode, 'M11'));
       it('datetime.day is 18', () => equal(datetime.day, 18));
       it('datetime.hour is 15', () => equal(datetime.hour, 15));
       it('datetime.minute is 23', () => equal(datetime.minute, 23));
@@ -203,7 +203,7 @@ describe('DateTime', () => {
       });
       it('datetime.year is 1976', () => equal(datetime.year, 1976));
       it('datetime.month is 11', () => equal(datetime.month, 11));
-      it('datetime.monthCode is "11"', () => equal(datetime.monthCode, '11'));
+      it('datetime.monthCode is "M11"', () => equal(datetime.monthCode, 'M11'));
       it('datetime.day is 18', () => equal(datetime.day, 18));
       it('datetime.hour is 15', () => equal(datetime.hour, 15));
       it('datetime.minute is 23', () => equal(datetime.minute, 23));
@@ -227,7 +227,7 @@ describe('DateTime', () => {
       });
       it('datetime.year is 1976', () => equal(datetime.year, 1976));
       it('datetime.month is 11', () => equal(datetime.month, 11));
-      it('datetime.monthCode is "11"', () => equal(datetime.monthCode, '11'));
+      it('datetime.monthCode is "M11"', () => equal(datetime.monthCode, 'M11'));
       it('datetime.day is 18', () => equal(datetime.day, 18));
       it('datetime.hour is 15', () => equal(datetime.hour, 15));
       it('datetime.minute is 23', () => equal(datetime.minute, 23));
@@ -270,11 +270,11 @@ describe('DateTime', () => {
     it('datetime.with({ month: 5 } works', () => {
       equal(`${datetime.with({ month: 5 })}`, '1976-05-18T15:23:30.123456789');
     });
-    it('datetime.with({ monthCode: "5" } works', () => {
-      equal(`${datetime.with({ monthCode: '5' })}`, '1976-05-18T15:23:30.123456789');
+    it('datetime.with({ monthCode: "M5" } works', () => {
+      equal(`${datetime.with({ monthCode: 'M5' })}`, '1976-05-18T15:23:30.123456789');
     });
     it('month and monthCode must agree', () => {
-      throws(() => datetime.with({ month: 5, monthCode: '6' }), RangeError);
+      throws(() => datetime.with({ month: 5, monthCode: 'M6' }), RangeError);
     });
     it('datetime.with({ day: 5 } works', () => {
       equal(`${datetime.with({ day: 5 })}`, '1976-11-05T15:23:30.123456789');
@@ -1353,13 +1353,13 @@ describe('DateTime', () => {
       notEqual(actual, orig);
     });
     it('DateTime.from({ year: 1976, month: 11, day: 18 }) == 1976-11-18T00:00:00', () =>
-      equal(`${PlainDateTime.from({ year: 1976, month: 11, monthCode: '11', day: 18 })}`, '1976-11-18T00:00:00'));
+      equal(`${PlainDateTime.from({ year: 1976, month: 11, monthCode: 'M11', day: 18 })}`, '1976-11-18T00:00:00'));
     it('can be constructed with month and without monthCode', () =>
       equal(`${PlainDateTime.from({ year: 1976, month: 11, day: 18 })}`, '1976-11-18T00:00:00'));
     it('can be constructed with monthCode and without month', () =>
-      equal(`${PlainDateTime.from({ year: 1976, monthCode: '11', day: 18 })}`, '1976-11-18T00:00:00'));
+      equal(`${PlainDateTime.from({ year: 1976, monthCode: 'M11', day: 18 })}`, '1976-11-18T00:00:00'));
     it('month and monthCode must agree', () =>
-      throws(() => PlainDateTime.from({ year: 1976, month: 11, monthCode: '12', day: 18 }), RangeError));
+      throws(() => PlainDateTime.from({ year: 1976, month: 11, monthCode: 'M12', day: 18 }), RangeError));
     it('DateTime.from({ year: 1976, month: 11, day: 18, millisecond: 123 }) == 1976-11-18T00:00:00.123', () =>
       equal(`${PlainDateTime.from({ year: 1976, month: 11, day: 18, millisecond: 123 })}`, '1976-11-18T00:00:00.123'));
     it('DateTime.from({ year: 1976, day: 18, hour: 15, minute: 23, second: 30, millisecond: 123 }) throws', () =>

--- a/polyfill/test/plainmonthday.mjs
+++ b/polyfill/test/plainmonthday.mjs
@@ -42,8 +42,8 @@ describe('MonthDay', () => {
         equal(`${PlainMonthDay.from('2019-10-01T09:00:00Z')}`, '10-01'));
       it("MonthDay.from('11-18') == (11-18)", () => equal(`${PlainMonthDay.from('11-18')}`, '11-18'));
       it("MonthDay.from('1976-11-18') == (11-18)", () => equal(`${PlainMonthDay.from('1976-11-18')}`, '11-18'));
-      it('MonthDay.from({ monthCode: "11", day: 18 }) == 11-18', () =>
-        equal(`${PlainMonthDay.from({ monthCode: '11', day: 18 })}`, '11-18'));
+      it('MonthDay.from({ monthCode: "M11", day: 18 }) == 11-18', () =>
+        equal(`${PlainMonthDay.from({ monthCode: 'M11', day: 18 })}`, '11-18'));
       it('ignores year when determining the ISO reference year from month/day', () => {
         const one = PlainMonthDay.from({ year: 2019, month: 11, day: 18 });
         const two = PlainMonthDay.from({ year: 1979, month: 11, day: 18 });
@@ -55,13 +55,13 @@ describe('MonthDay', () => {
         equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
       });
       it('ignores year when determining the ISO reference year from monthCode/day', () => {
-        const one = PlainMonthDay.from({ year: 2019, monthCode: '11', day: 18 });
-        const two = PlainMonthDay.from({ year: 1979, monthCode: '11', day: 18 });
+        const one = PlainMonthDay.from({ year: 2019, monthCode: 'M11', day: 18 });
+        const two = PlainMonthDay.from({ year: 1979, monthCode: 'M11', day: 18 });
         equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
       });
       it('ignores era/eraYear when determining the ISO reference year from monthCode/day', () => {
-        const one = PlainMonthDay.from({ era: 'ce', eraYear: 2019, monthCode: '11', day: 18, calendar: 'gregory' });
-        const two = PlainMonthDay.from({ era: 'ce', eraYear: 1979, monthCode: '11', day: 18, calendar: 'gregory' });
+        const one = PlainMonthDay.from({ era: 'ce', eraYear: 2019, monthCode: 'M11', day: 18, calendar: 'gregory' });
+        const two = PlainMonthDay.from({ era: 'ce', eraYear: 1979, monthCode: 'M11', day: 18, calendar: 'gregory' });
         equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
       });
       it('MonthDay.from(11-18) is not the same object', () => {
@@ -95,8 +95,8 @@ describe('MonthDay', () => {
         );
       });
       it('MonthDay.from({ day: 15 }) throws', () => throws(() => PlainMonthDay.from({ day: 15 }), TypeError));
-      it('MonthDay.from({ monthCode: "12" }) throws', () =>
-        throws(() => PlainMonthDay.from({ monthCode: '12' }), TypeError));
+      it('MonthDay.from({ monthCode: "M12" }) throws', () =>
+        throws(() => PlainMonthDay.from({ monthCode: 'M12' }), TypeError));
       it('MonthDay.from({}) throws', () => throws(() => PlainMonthDay.from({}), TypeError));
       it('MonthDay.from(required prop undefined) throws', () =>
         throws(() => PlainMonthDay.from({ monthCode: undefined, day: 15 }), TypeError));
@@ -178,7 +178,7 @@ describe('MonthDay', () => {
     describe('getters', () => {
       let md = new PlainMonthDay(1, 15);
       it("(1-15).monthCode === '1'", () => {
-        equal(md.monthCode, '1');
+        equal(md.monthCode, 'M1');
       });
       it("(1-15).day === '15'", () => {
         equal(`${md.day}`, '15');
@@ -187,19 +187,19 @@ describe('MonthDay', () => {
     });
     describe('.with()', () => {
       const md = PlainMonthDay.from('01-22');
-      it('with(12-)', () => equal(`${md.with({ monthCode: '12' })}`, '12-22'));
+      it('with(12-)', () => equal(`${md.with({ monthCode: 'M12' })}`, '12-22'));
       it('with(-15)', () => equal(`${md.with({ day: 15 })}`, '01-15'));
     });
   });
   describe('MonthDay.with()', () => {
     const md = PlainMonthDay.from('01-15');
-    it('with({monthCode})', () => equal(`${md.with({ monthCode: '12' })}`, '12-15'));
+    it('with({monthCode})', () => equal(`${md.with({ monthCode: 'M12' })}`, '12-15'));
     it('with({month}) not accepted', () => {
       throws(() => md.with({ month: 12 }), TypeError);
     });
-    it('with({month, monthCode}) accepted', () => equal(`${md.with({ month: 12, monthCode: '12' })}`, '12-15'));
+    it('with({month, monthCode}) accepted', () => equal(`${md.with({ month: 12, monthCode: 'M12' })}`, '12-15'));
     it('month and monthCode must agree', () => {
-      throws(() => md.with({ month: 12, monthCode: '11' }), RangeError);
+      throws(() => md.with({ month: 12, monthCode: 'M11' }), RangeError);
     });
     it('with({year, month}) accepted', () => equal(`${md.with({ year: 2000, month: 12 })}`, '12-15'));
     it('throws on bad overflow', () => {
@@ -224,7 +224,7 @@ describe('MonthDay', () => {
       throws(() => md.with({ months: 12 }), TypeError);
     });
     it('incorrectly-spelled properties are ignored', () => {
-      equal(`${md.with({ monthCode: '12', days: 1 })}`, '12-15');
+      equal(`${md.with({ monthCode: 'M12', days: 1 })}`, '12-15');
     });
     it('year is ignored when determining ISO reference year', () => {
       equal(md.with({ year: 1900 }).getISOFields().isoYear, md.getISOFields().isoYear);
@@ -281,7 +281,7 @@ describe('MonthDay', () => {
   });
   describe('MonthDay.toString()', () => {
     const md1 = PlainMonthDay.from('11-18');
-    const md2 = PlainMonthDay.from({ monthCode: '11', day: 18, calendar: 'gregory' });
+    const md2 = PlainMonthDay.from({ monthCode: 'M11', day: 18, calendar: 'gregory' });
     it('shows only non-ISO calendar if calendarName = auto', () => {
       equal(md1.toString({ calendarName: 'auto' }), '11-18');
       equal(md2.toString({ calendarName: 'auto' }), '1972-11-18[u-ca-gregory]');

--- a/polyfill/test/plainyearmonth.mjs
+++ b/polyfill/test/plainyearmonth.mjs
@@ -61,7 +61,7 @@ describe('YearMonth', () => {
     });
     it('ym.year is 1976', () => equal(ym.year, 1976));
     it('ym.month is 11', () => equal(ym.month, 11));
-    it('ym.monthCode is "11"', () => equal(ym.monthCode, '11'));
+    it('ym.monthCode is "M11"', () => equal(ym.monthCode, 'M11'));
     it('ym.daysInMonth is 30', () => equal(ym.daysInMonth, 30));
     it('ym.daysInYear is 366', () => equal(ym.daysInYear, 366));
     it('ym.monthsInYear is 12', () => equal(ym.monthsInYear, 12));
@@ -72,19 +72,19 @@ describe('YearMonth', () => {
       it("YearMonth.from('1976-11') == (1976-11)", () => equal(`${PlainYearMonth.from('1976-11')}`, '1976-11'));
       it("YearMonth.from('1976-11-18') == (1976-11)", () => equal(`${PlainYearMonth.from('1976-11-18')}`, '1976-11'));
       it('can be constructed with monthCode and without month', () =>
-        equal(`${PlainYearMonth.from({ year: 2019, monthCode: '11' })}`, '2019-11'));
+        equal(`${PlainYearMonth.from({ year: 2019, monthCode: 'M11' })}`, '2019-11'));
       it('can be constructed with month and without monthCode', () =>
         equal(`${PlainYearMonth.from({ year: 2019, month: 11 })}`, '2019-11'));
       it('month and monthCode must agree', () =>
-        throws(() => PlainYearMonth.from({ year: 2019, month: 11, monthCode: '12' }), RangeError));
+        throws(() => PlainYearMonth.from({ year: 2019, month: 11, monthCode: 'M12' }), RangeError));
       it('ignores day when determining the ISO reference day from year/month', () => {
         const one = PlainYearMonth.from({ year: 2019, month: 11, day: 1 });
         const two = PlainYearMonth.from({ year: 2019, month: 11, day: 2 });
         equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
       });
       it('ignores day when determining the ISO reference day from year/monthCode', () => {
-        const one = PlainYearMonth.from({ year: 2019, monthCode: '11', day: 1 });
-        const two = PlainYearMonth.from({ year: 2019, monthCode: '11', day: 2 });
+        const one = PlainYearMonth.from({ year: 2019, monthCode: 'M11', day: 1 });
+        const two = PlainYearMonth.from({ year: 2019, monthCode: 'M11', day: 2 });
         equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
       });
       it('ignores day when determining the ISO reference day from era/eraYear/month', () => {
@@ -93,8 +93,8 @@ describe('YearMonth', () => {
         equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
       });
       it('ignores day when determining the ISO reference day from era/eraYear/monthCode', () => {
-        const one = PlainYearMonth.from({ era: 'ce', eraYear: 2019, monthCode: '11', day: 1, calendar: 'gregory' });
-        const two = PlainYearMonth.from({ era: 'ce', eraYear: 2019, monthCode: '11', day: 2, calendar: 'gregory' });
+        const one = PlainYearMonth.from({ era: 'ce', eraYear: 2019, monthCode: 'M11', day: 1, calendar: 'gregory' });
+        const two = PlainYearMonth.from({ era: 'ce', eraYear: 2019, monthCode: 'M11', day: 2, calendar: 'gregory' });
         equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
       });
       it('YearMonth.from(2019-11) is not the same object', () => {
@@ -111,8 +111,8 @@ describe('YearMonth', () => {
       });
       it('YearMonth.from({ year: 2019 }) throws', () => throws(() => PlainYearMonth.from({ year: 2019 }), TypeError));
       it('YearMonth.from({ month: 6 }) throws', () => throws(() => PlainYearMonth.from({ month: 6 }), TypeError));
-      it('YearMonth.from({ monthCode: "6" }) throws', () =>
-        throws(() => PlainYearMonth.from({ monthCode: '6' }), TypeError));
+      it('YearMonth.from({ monthCode: "M6" }) throws', () =>
+        throws(() => PlainYearMonth.from({ monthCode: 'M6' }), TypeError));
       it('YearMonth.from({}) throws', () => throws(() => PlainYearMonth.from({}), TypeError));
       it('YearMonth.from(required prop undefined) throws', () =>
         throws(() => PlainYearMonth.from({ year: undefined, month: 6 }), TypeError));
@@ -191,8 +191,8 @@ describe('YearMonth', () => {
       const ym = PlainYearMonth.from('2019-10');
       it('with(2020)', () => equal(`${ym.with({ year: 2020 })}`, '2020-10'));
       it('with(09)', () => equal(`${ym.with({ month: 9 })}`, '2019-09'));
-      it('with(monthCode)', () => equal(`${ym.with({ monthCode: '9' })}`, '2019-09'));
-      it('month and monthCode must agree', () => throws(() => ym.with({ month: 9, monthCode: '10' }), RangeError));
+      it('with(monthCode)', () => equal(`${ym.with({ monthCode: 'M9' })}`, '2019-09'));
+      it('month and monthCode must agree', () => throws(() => ym.with({ month: 9, monthCode: 'M10' }), RangeError));
     });
   });
   describe('YearMonth.with() works', () => {

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -352,7 +352,7 @@ describe('fromString regex', () => {
       it(isoString, () => {
         const [m, d, cid = 'iso8601'] = components;
         const monthDay = Temporal.PlainMonthDay.from(isoString);
-        equal(monthDay.monthCode, `${m}`);
+        equal(monthDay.monthCode, `M${m}`);
         equal(monthDay.day, d);
         equal(monthDay.calendar.id, cid);
       });

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -27,24 +27,24 @@ describe('Userland calendar', () => {
       }
       dateFromFields(fields, options, constructor) {
         let { year, month, monthCode, day } = fields;
-        if (month === undefined) month = +monthCode;
-        return super.dateFromFields({ year, monthCode: `${month - 1}`, day }, options, constructor);
+        if (month === undefined) month = +monthCode.slice(1);
+        return super.dateFromFields({ year, monthCode: `M${month - 1}`, day }, options, constructor);
       }
       yearMonthFromFields(fields, options, constructor) {
         let { year, month, monthCode } = fields;
-        if (month === undefined) month = +monthCode;
-        return super.yearMonthFromFields({ year, monthCode: `${month - 1}` }, options, constructor);
+        if (month === undefined) month = +monthCode.slice(1);
+        return super.yearMonthFromFields({ year, monthCode: `M${month - 1}` }, options, constructor);
       }
       monthDayFromFields(fields, options, constructor) {
         let { month, monthCode, day } = fields;
-        if (month === undefined) month = +monthCode;
-        return super.monthDayFromFields({ monthCode: `${month - 1}`, day }, options, constructor);
+        if (month === undefined) month = +monthCode.slice(1);
+        return super.monthDayFromFields({ monthCode: `M${month - 1}`, day }, options, constructor);
       }
       month(date) {
         return date.getISOFields().isoMonth + 1;
       }
       monthCode(date) {
-        return `${this.month(date)}`;
+        return `M${this.month(date)}`;
       }
     }
 
@@ -52,7 +52,7 @@ describe('Userland calendar', () => {
     const date = Temporal.PlainDate.from({ year: 2020, month: 5, day: 5, calendar: obj });
     const dt = Temporal.PlainDateTime.from({ year: 2020, month: 5, day: 5, hour: 12, calendar: obj });
     const ym = Temporal.PlainYearMonth.from({ year: 2020, month: 5, calendar: obj });
-    const md = Temporal.PlainMonthDay.from({ monthCode: '5', day: 5, calendar: obj });
+    const md = Temporal.PlainMonthDay.from({ monthCode: 'M5', day: 5, calendar: obj });
 
     it('is a calendar', () => equal(typeof obj, 'object'));
     it('.id property', () => equal(obj.id, 'two-based'));
@@ -106,12 +106,12 @@ describe('Userland calendar', () => {
     });
     it('Temporal.PlainMonthDay.from()', () => equal(`${md}`, '1972-04-05[u-ca-two-based]'));
     it('Temporal.PlainMonthDay fields', () => {
-      equal(md.monthCode, '5');
+      equal(md.monthCode, 'M5');
       equal(md.day, 5);
     });
     it('monthday.with()', () => {
-      const md2 = md.with({ monthCode: '2' });
-      equal(md2.monthCode, '2');
+      const md2 = md.with({ monthCode: 'M2' });
+      equal(md2.monthCode, 'M2');
     });
     it('timezone.getPlainDateTimeFor()', () => {
       const tz = Temporal.TimeZone.from('UTC');
@@ -188,7 +188,7 @@ describe('Userland calendar', () => {
         equal(`${md}`, '1972-01-01[u-ca-two-based]');
       });
       it('works for MonthDay.from(props)', () => {
-        const md = Temporal.PlainMonthDay.from({ monthCode: '2', day: 1, calendar: 'two-based' });
+        const md = Temporal.PlainMonthDay.from({ monthCode: 'M2', day: 1, calendar: 'two-based' });
         equal(`${md}`, '1972-01-01[u-ca-two-based]');
       });
       it('works for TimeZone.getPlainDateTimeFor', () => {
@@ -244,21 +244,21 @@ describe('Userland calendar', () => {
       dateFromFields(fields, options, constructor) {
         const { overflow = 'constrain' } = options ? options : {};
         let { month, monthCode } = fields;
-        if (month === undefined) month = +monthCode;
+        if (month === undefined) month = +monthCode.slice(1);
         const isoDate = decimalToISO(fields.year, month, fields.day, 0, 0, 0, overflow);
         return new constructor(isoDate.year, isoDate.month, isoDate.day, this);
       },
       yearMonthFromFields(fields, options, constructor) {
         const { overflow = 'constrain' } = options ? options : {};
         let { month, monthCode } = fields;
-        if (month === undefined) month = +monthCode;
+        if (month === undefined) month = +monthCode.slice(1);
         const isoDate = decimalToISO(fields.year, month, 1, 0, 0, 0, overflow);
         return new constructor(isoDate.year, isoDate.month, this, isoDate.day);
       },
       monthDayFromFields(fields, options, constructor) {
         const { overflow = 'constrain' } = options ? options : {};
         let { month, monthCode } = fields;
-        if (month === undefined) month = +monthCode;
+        if (month === undefined) month = +monthCode.slice(1);
         const isoDate = decimalToISO(0, month, fields.day, 0, 0, 0, overflow);
         return new constructor(isoDate.month, isoDate.day, this, isoDate.year);
       },
@@ -270,7 +270,7 @@ describe('Userland calendar', () => {
         return Math.floor(days / 10) + 1;
       },
       monthCode(date) {
-        return `${this.month(date)}`;
+        return `M${this.month(date)}`;
       },
       day(date) {
         const { days } = isoToDecimal(date);
@@ -281,7 +281,7 @@ describe('Userland calendar', () => {
     const date = Temporal.PlainDate.from({ year: 184, month: 2, day: 9, calendar: obj });
     const dt = Temporal.PlainDateTime.from({ year: 184, month: 2, day: 9, hour: 12, calendar: obj });
     const ym = Temporal.PlainYearMonth.from({ year: 184, month: 2, calendar: obj });
-    const md = Temporal.PlainMonthDay.from({ monthCode: '2', day: 9, calendar: obj });
+    const md = Temporal.PlainMonthDay.from({ monthCode: 'M2', day: 9, calendar: obj });
 
     it('is a calendar', () => equal(typeof obj, 'object'));
     // FIXME: what should happen in Temporal.Calendar.from(obj)?
@@ -334,12 +334,12 @@ describe('Userland calendar', () => {
     });
     it('Temporal.PlainMonthDay.from()', () => equal(`${md}`, '1970-01-19[u-ca-decimal]'));
     it('Temporal.PlainMonthDay fields', () => {
-      equal(md.monthCode, '2');
+      equal(md.monthCode, 'M2');
       equal(md.day, 9);
     });
     it('monthday.with()', () => {
-      const md2 = md.with({ monthCode: '1' });
-      equal(md2.monthCode, '1');
+      const md2 = md.with({ monthCode: 'M1' });
+      equal(md2.monthCode, 'M1');
     });
     it('timezone.getPlainDateTimeFor()', () => {
       const tz = Temporal.TimeZone.from('UTC');
@@ -416,7 +416,7 @@ describe('Userland calendar', () => {
         equal(`${md}`, '1970-01-01[u-ca-decimal]');
       });
       it('works for MonthDay.from(props)', () => {
-        const md = Temporal.PlainMonthDay.from({ monthCode: '1', day: 1, calendar: 'decimal' });
+        const md = Temporal.PlainMonthDay.from({ monthCode: 'M1', day: 1, calendar: 'decimal' });
         equal(`${md}`, '1970-01-01[u-ca-decimal]');
       });
       it('works for TimeZone.getPlainDateTimeFor', () => {
@@ -454,15 +454,15 @@ describe('Userland calendar', () => {
         return ((isoMonth - 1) % 3) + 1;
       }
       monthCode(date) {
-        return `${this.month(date)}`;
+        return `M${this.month(date)}`;
       }
       season(date) {
         const { isoMonth } = date.getISOFields();
         return Math.floor((isoMonth - 1) / 3) + 1;
       }
       _isoMonthCode(fields) {
-        const month = fields.month || +fields.monthCode;
-        return `${(fields.season - 1) * 3 + month}`;
+        const month = fields.month || +fields.monthCode.slice(1);
+        return `M${(fields.season - 1) * 3 + month}`;
       }
       dateFromFields(fields, options, constructor) {
         const monthCode = this._isoMonthCode(fields);
@@ -507,18 +507,18 @@ describe('Userland calendar', () => {
     it('property getter works', () => {
       equal(datetime.season, 3);
       equal(datetime.month, 3);
-      equal(datetime.monthCode, '3');
+      equal(datetime.monthCode, 'M3');
       equal(date.season, 3);
       equal(date.month, 3);
-      equal(date.monthCode, '3');
+      equal(date.monthCode, 'M3');
       equal(yearmonth.season, 3);
       equal(yearmonth.month, 3);
-      equal(yearmonth.monthCode, '3');
+      equal(yearmonth.monthCode, 'M3');
       equal(monthday.season, 3);
-      equal(monthday.monthCode, '3');
+      equal(monthday.monthCode, 'M3');
       equal(zoned.season, 3);
       equal(zoned.month, 3);
-      equal(zoned.monthCode, '3');
+      equal(zoned.monthCode, 'M3');
     });
     it('accepts season in from()', () => {
       equal(
@@ -534,7 +534,7 @@ describe('Userland calendar', () => {
         '2019-09-01[u-ca-season]'
       );
       equal(
-        `${Temporal.PlainMonthDay.from({ season: 3, monthCode: '3', day: 15, calendar })}`,
+        `${Temporal.PlainMonthDay.from({ season: 3, monthCode: 'M3', day: 15, calendar })}`,
         '1972-09-15[u-ca-season]'
       );
       equal(
@@ -553,7 +553,7 @@ describe('Userland calendar', () => {
       equal(`${datetime.with({ month: 2 })}`, '2019-08-15T00:00:00[u-ca-season]');
       equal(`${date.with({ month: 2 })}`, '2019-08-15[u-ca-season]');
       equal(`${yearmonth.with({ month: 2 })}`, '2019-08-01[u-ca-season]');
-      equal(`${monthday.with({ monthCode: '2' })}`, '1972-08-15[u-ca-season]');
+      equal(`${monthday.with({ monthCode: 'M2' })}`, '1972-08-15[u-ca-season]');
       equal(`${zoned.with({ month: 2 })}`, '2019-08-15T00:00:00+00:00[UTC][u-ca-season]');
     });
     after(() => {

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -202,7 +202,7 @@ describe('ZonedDateTime', () => {
       });
       it('zdt.year is 1976', () => equal(zdt.year, 1976));
       it('zdt.month is 11', () => equal(zdt.month, 11));
-      it('zdt.monthCode is "11"', () => equal(zdt.monthCode, '11'));
+      it('zdt.monthCode is "M11"', () => equal(zdt.monthCode, 'M11'));
       it('zdt.day is 18', () => equal(zdt.day, 18));
       it('zdt.hour is 15', () => equal(zdt.hour, 15));
       it('zdt.minute is 23', () => equal(zdt.minute, 23));
@@ -240,7 +240,7 @@ describe('ZonedDateTime', () => {
       it('zdt.era is ce', () => equal(zdt.era, 'ce'));
       it('zdt.year is 1976', () => equal(zdt.year, 1976));
       it('zdt.month is 11', () => equal(zdt.month, 11));
-      it('zdt.monthCode is "11"', () => equal(zdt.monthCode, '11'));
+      it('zdt.monthCode is "M11"', () => equal(zdt.monthCode, 'M11'));
       it('zdt.day is 18', () => equal(zdt.day, 18));
       it('zdt.hour is 16', () => equal(zdt.hour, 16));
       it('zdt.minute is 23', () => equal(zdt.minute, 23));
@@ -526,7 +526,7 @@ describe('ZonedDateTime', () => {
     const lagos = Temporal.TimeZone.from('Africa/Lagos');
     it('can be constructed with monthCode and without month', () => {
       equal(
-        `${ZonedDateTime.from({ year: 1976, monthCode: '11', day: 18, timeZone: lagos })}`,
+        `${ZonedDateTime.from({ year: 1976, monthCode: 'M11', day: 18, timeZone: lagos })}`,
         '1976-11-18T00:00:00+01:00[Africa/Lagos]'
       );
     });
@@ -538,7 +538,7 @@ describe('ZonedDateTime', () => {
     });
     it('month and monthCode must agree', () => {
       throws(
-        () => ZonedDateTime.from({ year: 1976, month: 11, monthCode: '12', day: 18, timeZone: lagos }),
+        () => ZonedDateTime.from({ year: 1976, month: 11, monthCode: 'M12', day: 18, timeZone: lagos }),
         RangeError
       );
     });
@@ -735,11 +735,11 @@ describe('ZonedDateTime', () => {
     it('zdt.with({ month: 5 } works', () => {
       equal(`${zdt.with({ month: 5 })}`, '1976-05-18T15:23:30.123456789+00:00[UTC]');
     });
-    it('zdt.with({ monthCode: "5" }) works', () => {
-      equal(`${zdt.with({ monthCode: '5' })}`, '1976-05-18T15:23:30.123456789+00:00[UTC]');
+    it('zdt.with({ monthCode: "M5" }) works', () => {
+      equal(`${zdt.with({ monthCode: 'M5' })}`, '1976-05-18T15:23:30.123456789+00:00[UTC]');
     });
     it('month and monthCode must agree', () => {
-      throws(() => zdt.with({ month: 5, monthCode: '6' }), RangeError);
+      throws(() => zdt.with({ month: 5, monthCode: 'M6' }), RangeError);
     });
     it('zdt.with({ day: 5 } works', () => {
       equal(`${zdt.with({ day: 5 })}`, '1976-11-05T15:23:30.123456789+00:00[UTC]');


### PR DESCRIPTION
The Temporal and ICU4X teams today decided on the month code format, which will be compatible with iCalendar's month codes but with a prefix of "M". This PR changes all Temporal usage of month codes to use the M prefix.  

I'll also update #1245 to use the M prefix and will rebase that PR on top of this one.

NOTE: this PR does not include spec changes because I didn't know the spec language for slicing or concatenating strings. ;-)

See https://docs.google.com/document/d/1_BvY40d2_QRnWDmVZRBpSndVZ4K_X1Ysp9P6ZAtT0AM/edit?ts=601316f4# for more discussion from @manishearth.

FYI @sffc 