### PR TITLE
Add polyfill types for Intl and Date.toTemporalInstant

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1637,3 +1637,79 @@ export namespace Temporal {
     export function timeZone(): Temporal.TimeZone;
   }
 }
+
+declare namespace IntlPolyfill {
+  type Formattable =
+    | Date
+    | Temporal.Instant
+    | Temporal.ZonedDateTime
+    | Temporal.PlainDate
+    | Temporal.PlainTime
+    | Temporal.PlainDateTime
+    | Temporal.PlainYearMonth
+    | Temporal.PlainMonthDay;
+
+  interface DateTimeFormatRangePart extends Intl.DateTimeFormatPart {
+    source: 'shared' | 'startRange' | 'endRange';
+  }
+
+  export interface DateTimeFormat extends Intl.DateTimeFormat {
+    /**
+     * Format a date into a string according to the locale and formatting
+     * options of this `Intl.DateTimeFormat` object.
+     *
+     * @param date The date to format.
+     */
+    format(date?: Formattable | number): string;
+
+    /**
+     * Allow locale-aware formatting of strings produced by
+     * `Intl.DateTimeFormat` formatters.
+     *
+     * @param date The date to format.
+     */
+    formatToParts(date?: Formattable | number): Intl.DateTimeFormatPart[];
+
+    /**
+     * Format a date range in the most concise way based on the locale and
+     * options provided when instantiating this `Intl.DateTimeFormat` object.
+     *
+     * @param startDate The start date of the range to format.
+     * @param endDate The start date of the range to format. Must be the same
+     * type as `startRange`.
+     */
+    formatRange<T extends Formattable>(startDate: T, endDate: T): string;
+    formatRange(startDate: Date | number, endDate: Date | number): string;
+
+    /**
+     * Allow locale-aware formatting of tokens representing each part of the
+     * formatted date range produced by `Intl.DateTimeFormat` formatters.
+     *
+     * @param startDate The start date of the range to format.
+     * @param endDate The start date of the range to format. Must be the same
+     * type as `startRange`.
+     */
+    formatRangeToParts<T extends Formattable>(startDate: T, endDate: T): DateTimeFormatRangePart[];
+    formatRangeToParts(startDate: Date | number, endDate: Date | number): DateTimeFormatRangePart[];
+  }
+
+  export const DateTimeFormat: {
+    /**
+     * Creates `Intl.DateTimeFormat` objects that enable language-sensitive
+     * date and time formatting.
+     */
+    new (locales?: string | string[], options?: Intl.DateTimeFormatOptions): DateTimeFormat;
+    (locales?: string | string[], options?: Intl.DateTimeFormatOptions): DateTimeFormat;
+
+    /**
+     * Get an array containing those of the provided locales that are supported
+     * in date and time formatting without having to fall back to the runtime's
+     * default locale.
+     */
+    supportedLocalesOf(locales: string | string[], options?: Intl.DateTimeFormatOptions): string[];
+  };
+}
+
+export { IntlPolyfill as Intl };
+
+export function toTemporalInstant(this: Date): Temporal.Instant;


### PR DESCRIPTION
The polyfill is missing TypeScript types for the Intl namespace and Date.toTemporalInstant.

This PR adds:
- A global type representing the result of `DateTimeFormat#formatRangeToParts`, since its currently missing from TypeScript's built-in lib.
- An `IntlPolyfill` namespace that is exported as `Intl`. The different name allows for the global `Intl` namespace to be referenced by other types, and doesn't affect the end result.
- A variant of `Intl.DateTimeFormat` that adds typing support for passing Temporal objects in.
- A variant of `formatRange` that enforces that the Temporal start and end types match each other.
- `toTemporalInstant` function that includes a `this` type.