### PR TITLE
Convert "bc"/"ad" eras to "bce"/"ce" in Gregorian calendar

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -200,12 +200,12 @@ The `calendar` read-only property gives the calendar that the `year`, `month`, a
 In calendars that use eras, the `era` and `eraYear` read-only properties can be used together to resolve an era-relative year.
 Both properties are `undefined` when using the ISO 8601 calendar.
 As inputs to `from` or `with`, `era` and `eraYear` can be used instead of `year`.
-Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BC era in the Gregorian calendar) count years backwards.
+Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.
 
 ```javascript
 date = Temporal.PlainDate.from('-000015-01-01[u-ca-gregory]');
 date.era;
-// => "bc"
+// => "bce"
 date.eraYear;
 // => 16
 date.year;

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -285,12 +285,12 @@ The `calendar` read-only property gives the calendar that the `year`, `month`, `
 In calendars that use eras, the `era` and `eraYear` read-only properties can be used together to resolve an era-relative year.
 Both properties are `undefined` when using the ISO 8601 calendar.
 As inputs to `from` or `with`, `era` and `eraYear` can be used instead of `year`.
-Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BC era in the Gregorian calendar) count years backwards.
+Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.
 
 ```javascript
 date = Temporal.PlainDateTime.from('-000015-01-01T12:30[u-ca-gregory]');
 date.era;
-// => "bc"
+// => "bce"
 date.eraYear;
 // => 16
 date.year;

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -195,12 +195,12 @@ The `calendar` read-only property gives the calendar that the `year` and `month`
 In calendars that use eras, the `era` and `eraYear` read-only properties can be used together to resolve an era-relative year.
 Both properties are `undefined` when using the ISO 8601 calendar.
 As inputs to `from` or `with`, `era` and `eraYear` can be used instead of `year`.
-Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BC era in the Gregorian calendar) count years backwards.
+Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.
 
 ```javascript
 ym = Temporal.PlainYearMonth.from('-000015-01-01[u-ca-gregory]');
 ym.era;
-// => "bc"
+// => "bce"
 ym.eraYear;
 // => 16
 ym.year;

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -459,12 +459,12 @@ zdt.withTimeZone('GMT').timeZone;
 In calendars that use eras, the `era` and `eraYear` read-only properties can be used together to resolve an era-relative year.
 Both properties are `undefined` when using the ISO 8601 calendar.
 As inputs to `from` or `with`, `era` and `eraYear` can be used instead of `year`.
-Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BC era in the Gregorian calendar) count years backwards.
+Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.
 
 ```javascript
 date = Temporal.ZonedDateTime.from('-000015-01-01T12:30[Europe/Rome][u-ca-gregory]');
 date.era;
-// => "bc"
+// => "bce"
 date.eraYear;
 // => 16
 date.year;

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -333,7 +333,7 @@ function resolveNonLunisolarMonth(calendarDate) {
 // Implementation details for Gregorian calendar
 const gre = {
   isoYear(eraYear, era) {
-    return era === 'bc' ? -(eraYear - 1) : eraYear;
+    return era === 'bce' ? -(eraYear - 1) : eraYear;
   },
   validateFields(fields) {
     if ((fields.era === undefined || fields.eraYear === undefined) && fields.year === undefined) {
@@ -359,11 +359,11 @@ const gre = {
 
 // 'iso8601' calendar is equivalent to 'gregory' except for ISO 8601 week
 // numbering rules, which we do not currently use in Temporal, and the addition
-// of BC/AD eras which means no negative years or year 0.
+// of BCE/CE eras which means no negative years or year 0.
 impl['gregory'] = ObjectAssign({}, impl['iso8601'], {
   era(date) {
     if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    return GetSlot(date, ISO_YEAR) < 1 ? 'bc' : 'ad';
+    return GetSlot(date, ISO_YEAR) < 1 ? 'bce' : 'ce';
   },
   eraYear(date) {
     if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));

--- a/polyfill/test/calendar.mjs
+++ b/polyfill/test/calendar.mjs
@@ -379,28 +379,28 @@ describe('Calendar', () => {
 });
 describe('Built-in calendars (not standardized yet)', () => {
   describe('gregory', () => {
-    it('era AD', () => {
+    it('era CE', () => {
       const date = Temporal.PlainDate.from('1999-12-31[u-ca-gregory]');
-      equal(date.era, 'ad');
+      equal(date.era, 'ce');
       equal(date.eraYear, 1999);
       equal(date.year, 1999);
     });
-    it('era BC', () => {
+    it('era BCE', () => {
       const date = Temporal.PlainDate.from('-000001-12-31[u-ca-gregory]');
-      equal(date.era, 'bc');
+      equal(date.era, 'bce');
       equal(date.eraYear, 2);
       equal(date.year, -1);
     });
-    it('can create from fields with era AD', () => {
-      const date = Temporal.PlainDate.from({ era: 'ad', eraYear: 1999, month: 12, day: 31, calendar: 'gregory' });
+    it('can create from fields with era CE', () => {
+      const date = Temporal.PlainDate.from({ era: 'ce', eraYear: 1999, month: 12, day: 31, calendar: 'gregory' });
       equal(`${date}`, '1999-12-31[u-ca-gregory]');
     });
-    it('era AD is the default', () => {
+    it('era CE is the default', () => {
       const date = Temporal.PlainDate.from({ year: 1999, month: 12, day: 31, calendar: 'gregory' });
       equal(`${date}`, '1999-12-31[u-ca-gregory]');
     });
-    it('can create from fields with era BC', () => {
-      const date = Temporal.PlainDate.from({ era: 'bc', eraYear: 2, month: 12, day: 31, calendar: 'gregory' });
+    it('can create from fields with era BCE', () => {
+      const date = Temporal.PlainDate.from({ era: 'bce', eraYear: 2, month: 12, day: 31, calendar: 'gregory' });
       equal(`${date}`, '-000001-12-31[u-ca-gregory]');
     });
   });

--- a/polyfill/test/plainmonthday.mjs
+++ b/polyfill/test/plainmonthday.mjs
@@ -50,8 +50,8 @@ describe('MonthDay', () => {
         equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
       });
       it('ignores era/eraYear when determining the ISO reference year from month/day', () => {
-        const one = PlainMonthDay.from({ era: 'ad', eraYear: 2019, month: 11, day: 18, calendar: 'gregory' });
-        const two = PlainMonthDay.from({ era: 'ad', eraYear: 1979, month: 11, day: 18, calendar: 'gregory' });
+        const one = PlainMonthDay.from({ era: 'ce', eraYear: 2019, month: 11, day: 18, calendar: 'gregory' });
+        const two = PlainMonthDay.from({ era: 'ce', eraYear: 1979, month: 11, day: 18, calendar: 'gregory' });
         equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
       });
       it('ignores year when determining the ISO reference year from monthCode/day', () => {
@@ -60,8 +60,8 @@ describe('MonthDay', () => {
         equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
       });
       it('ignores era/eraYear when determining the ISO reference year from monthCode/day', () => {
-        const one = PlainMonthDay.from({ era: 'ad', eraYear: 2019, monthCode: '11', day: 18, calendar: 'gregory' });
-        const two = PlainMonthDay.from({ era: 'ad', eraYear: 1979, monthCode: '11', day: 18, calendar: 'gregory' });
+        const one = PlainMonthDay.from({ era: 'ce', eraYear: 2019, monthCode: '11', day: 18, calendar: 'gregory' });
+        const two = PlainMonthDay.from({ era: 'ce', eraYear: 1979, monthCode: '11', day: 18, calendar: 'gregory' });
         equal(one.getISOFields().isoYear, two.getISOFields().isoYear);
       });
       it('MonthDay.from(11-18) is not the same object', () => {
@@ -90,7 +90,7 @@ describe('MonthDay', () => {
       });
       it('MonthDay.from({era, eraYear, month, day}) allowed in other calendar', () => {
         equal(
-          `${PlainMonthDay.from({ era: 'ad', eraYear: 1970, month: 11, day: 18, calendar: 'gregory' })}`,
+          `${PlainMonthDay.from({ era: 'ce', eraYear: 1970, month: 11, day: 18, calendar: 'gregory' })}`,
           '1972-11-18[u-ca-gregory]'
         );
       });

--- a/polyfill/test/plainyearmonth.mjs
+++ b/polyfill/test/plainyearmonth.mjs
@@ -88,13 +88,13 @@ describe('YearMonth', () => {
         equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
       });
       it('ignores day when determining the ISO reference day from era/eraYear/month', () => {
-        const one = PlainYearMonth.from({ era: 'ad', eraYear: 2019, month: 11, day: 1, calendar: 'gregory' });
-        const two = PlainYearMonth.from({ era: 'ad', eraYear: 2019, month: 11, day: 2, calendar: 'gregory' });
+        const one = PlainYearMonth.from({ era: 'ce', eraYear: 2019, month: 11, day: 1, calendar: 'gregory' });
+        const two = PlainYearMonth.from({ era: 'ce', eraYear: 2019, month: 11, day: 2, calendar: 'gregory' });
         equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
       });
       it('ignores day when determining the ISO reference day from era/eraYear/monthCode', () => {
-        const one = PlainYearMonth.from({ era: 'ad', eraYear: 2019, monthCode: '11', day: 1, calendar: 'gregory' });
-        const two = PlainYearMonth.from({ era: 'ad', eraYear: 2019, monthCode: '11', day: 2, calendar: 'gregory' });
+        const one = PlainYearMonth.from({ era: 'ce', eraYear: 2019, monthCode: '11', day: 1, calendar: 'gregory' });
+        const two = PlainYearMonth.from({ era: 'ce', eraYear: 2019, monthCode: '11', day: 2, calendar: 'gregory' });
         equal(one.getISOFields().isoDay, two.getISOFields().isoDay);
       });
       it('YearMonth.from(2019-11) is not the same object', () => {

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -237,7 +237,7 @@ describe('ZonedDateTime', () => {
         assert(zdt);
         equal(typeof zdt, 'object');
       });
-      it('zdt.era is ad', () => equal(zdt.era, 'ad'));
+      it('zdt.era is ce', () => equal(zdt.era, 'ce'));
       it('zdt.year is 1976', () => equal(zdt.year, 1976));
       it('zdt.month is 11', () => equal(zdt.month, 11));
       it('zdt.monthCode is "11"', () => equal(zdt.monthCode, '11'));


### PR DESCRIPTION
This PR changes the `bc` and `ad` eras in the `gregory` calendar to `ce` and `bce`, respectively, per   
https://github.com/unicode-org/icu4x/issues/470#issuecomment-772735333.