### PR TITLE
polyfill: fix Instant precision bug

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1671,7 +1671,7 @@ export const ES = ObjectAssign({}, ES2020, {
       while (fraction[fraction.length - 1] === '0') fraction = fraction.slice(0, -1);
     } else {
       if (precision === 0) return secs;
-      fraction = `${fraction}`.slice(0, precision).padStart(precision, '0');
+      fraction = `${fraction}`.padStart(9, '0').slice(0, precision);
     }
     return `${secs}.${fraction}`;
   },

--- a/polyfill/test/Instant/prototype/toString/precision.js
+++ b/polyfill/test/Instant/prototype/toString/precision.js
@@ -1,0 +1,12 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+const { Instant } = Temporal;
+
+const isoString = '2020-01-01T23:58:57.012034Z';
+const instant = Instant.from(isoString);
+const instantIsoStrMicros = instant.toString({
+  smallestUnit: 'microseconds'
+});
+
+assert.sameValue(instantIsoStrMicros, isoString);


### PR DESCRIPTION
Fix a bug where Instant.prototype.toString produced the incorrect result
where the fractional part included leading zeroes and precision was not
auto or 0. Includes test262 test for the same.

Fixes: https://github.com/tc39/proposal-temporal/issues/1336