### PR TITLE
Docs: show clipped content at right edge of persistence-model.svg

### DIFF
--- a/docs/persistence-model.svg
+++ b/docs/persistence-model.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"
-  viewBox="-12 -155 1339 770"
+  viewBox="-12 -155 1378 770"
   width="100%"
   height="100%"
   fill="none"


### PR DESCRIPTION
This PR fixes the size of persistence-model.svg so the right edge of the diagram won't be clipped in the docs home page.

Current: 
![image](https://user-images.githubusercontent.com/277214/107269856-0ff19680-69ff-11eb-880d-5d695abec327.png)

Fixed: 
![image](https://user-images.githubusercontent.com/277214/107269892-1bdd5880-69ff-11eb-9ae2-686279a2b4dc.png)
