### PR TITLE
Documentation fixes for monthCode

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -165,7 +165,7 @@ The above read-only properties allow accessing each component of a date individu
   The last month of every year has `month` equal to the `monthsInYear` property.
   `month` values start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 - `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
-  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For common (non-leap) months, `monthCode` should be `` `M${month}` ``.
   For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
   Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
   - `day` is a positive integer representing the day of the month.
@@ -180,13 +180,13 @@ Usage examples:
 date = Temporal.PlainDate.from('2006-08-24');
 date.year;      // => 2006
 date.month;     // => 8
-date.monthCode; // => "8"
+date.monthCode; // => "M8"
 date.day;       // => 24
 
 date = Temporal.PlainDate.from('2019-02-23[u-ca-hebrew]');
 date.year;      // => 5779
 date.month;     // => 6
-date.monthCode; // => "5L"
+date.monthCode; // => "M5L"
 date.day;       // => 18
 ```
 <!-- prettier-ignore-end -->

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -241,7 +241,7 @@ Date unit details:
   The last month of every year has `month` equal to the `monthsInYear` property.
   `month` values start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 - `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
-  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For common (non-leap) months, `monthCode` should be `` `M${month}` ``.
   For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
   Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
 - `day` is a positive integer representing the day of the month.
@@ -266,7 +266,7 @@ Usage examples:
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt.year;        // => 1995
 dt.month;       // => 12
-dt.monthCode;   // => "12"
+dt.monthCode;   // => "M12"
 dt.day;         // => 7
 dt.hour;        // => 3
 dt.minute;      // => 24
@@ -278,7 +278,7 @@ dt.nanosecond;  // => 500
 dt = Temporal.PlainDate.from('2019-02-23T03:24:30.000003500[u-ca-hebrew]');
 dt.year;        // => 5779
 dt.month;       // => 6
-dt.monthCode;   // => "5L"
+dt.monthCode;   // => "M5L"
 dt.day;         // => 18
 dt.hour;        // => 3
 dt.minute;      // => 24

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -133,7 +133,7 @@ md.month; // undefined (month property is not present in this type; use monthCod
 The above read-only properties allow accessing each component of the date individually.
 
 - `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
-  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For common (non-leap) months, `monthCode` should be ` ` `M${month}` ` `.
   For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
   Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
 - `day` is a positive integer representing the day of the month.
@@ -145,14 +145,14 @@ Usage examples:
 
 ```javascript
 md = Temporal.PlainMonthDay.from('08-24');
-md.monthCode; // => "8"
+md.monthCode; // => "M8"
 md.day; // => 24
-md.month; // undefined (month property is not present in this type; use monthCode instead)
+md.month; // undefined (no `month` property; use `monthCode` instead)
 
 md = Temporal.PlainMonthDay.from('2019-02-20[u-ca-hebrew]');
-md.monthCode; // => "5L"
+md.monthCode; // => "M5L"
 md.day; // => 15
-md.month; // undefined (month property is not present in this type; use monthCode instead)
+md.month; // undefined (no `month` property; use `monthCode` instead)
 ```
 
 ### monthDay.**calendar** : object

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -164,7 +164,7 @@ The above read-only properties allow accessing the year or month individually.
   The last month of every year has `month` equal to the `monthsInYear` property.
   `month` values start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 - `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
-  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For common (non-leap) months, `monthCode` should be `` `M${month}` ``.
   For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
   Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
 
@@ -177,12 +177,12 @@ Usage examples:
 ym = Temporal.PlainYearMonth.from('2019-06');
 ym.year; // => 2019
 ym.month; // => 6
-ym.monthCode; // => "6"
+ym.monthCode; // => "M6"
 
 ym = Temporal.PlainYearMonth.from('2019-02-23[u-ca-hebrew]');
 ym.year; // => 5779
 ym.month; // => 6
-ym.monthCode; // => "5L"
+ym.monthCode; // => "M5L"
 ym.day; // => 18
 ```
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -301,7 +301,7 @@ Date unit details:
   The last month of every year has `month` equal to the `monthsInYear` property.
   `month` values start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 - `monthCode` is a calendar-specific string that identifies the month in a year-independent way.
-  For common (non-leap) months, `monthCode` should be `M${month}`.
+  For common (non-leap) months, `monthCode` should be `` `M${month}` ``.
   For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with with an "L" suffix appended.
   Examples: `'M2'` => February; `'M8L'` => repeated 8th month in the Chinese calendar; `'M5L'` => Adar I in the Hebrew calendar.
 - `day` is a positive integer representing the day of the month.
@@ -326,7 +326,7 @@ Usage examples:
 dt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500[Europe/Rome]');
 dt.year;        // => 1995
 dt.month;       // => 12
-dt.monthCode;   // => "12"
+dt.monthCode;   // => "M12"
 dt.day;         // => 7
 dt.hour;        // => 3
 dt.minute;      // => 24
@@ -338,7 +338,7 @@ dt.nanosecond;  // => 500
 dt = Temporal.ZonedDateTime.from('2019-02-23T03:24:30.000003500[Europe/Rome][u-ca-hebrew]');
 dt.year;        // => 5779
 dt.month;       // => 6
-dt.monthCode;   // => "5L"
+dt.monthCode;   // => "M5L"
 dt.day;         // => 18
 dt.hour;        // => 3
 dt.minute;      // => 24


### PR DESCRIPTION
This PR is a few minor monthCode-related fixes for the docs: 

* Add missing "M" prefix in a few docs code examples that I missed in #1321
* Fix missing backticks
* Cut out a few words that weren't needed