### PR TITLE
polyfill: Fix iso week number

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2028,7 +2028,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const week = MathFloor((doy - dow + 10) / 7);
 
     if (week < 1) {
-      if (doj === (ES.LeapYear(year) ? 5 : 6)) {
+      if (doj === 5 || (doj === 6 && ES.LeapYear(year - 1))) {
         return 53;
       } else {
         return 52;

--- a/polyfill/test/calendar.mjs
+++ b/polyfill/test/calendar.mjs
@@ -261,6 +261,10 @@ describe('Calendar', () => {
       throws(() => iso.weekOfYear({ year: 2000 }), TypeError);
     });
   });
+  describe('edge cases for Calendar.weekOfYear()', () => {
+    it('week 1 from next year', () => equal(iso.weekOfYear(Temporal.PlainDate.from('2019-12-31')), 1));
+    it('week 53 from previous year', () => equal(iso.weekOfYear(Temporal.PlainDate.from('2021-01-01')), 53));
+  });
   describe('Calendar.daysInWeek()', () => {
     const res = 7;
     it('accepts Date', () => equal(iso.daysInWeek(Temporal.PlainDate.from('1994-11-05')), res));


### PR DESCRIPTION
The current algorithm for calculating the ISO week number is wrong for dates that belong to an ISO week from the previous year. For example `Temporal.Calendar.from("iso8601").weekOfYear("2021-01-01")` returns 52 but the correct answer is 53.

The problem is in the function `ES.WeekOfYear`: This function computes first the expression `const week = MathFloor((doy - dow + 10) / 7);` and then, if the answer is 0, this means that the day belongs to the last ISO week of the previous year. So the result of the function must be the number of ISO weeks of the *previous* year, which is 53 if the previous year ends on a Thursday (regardless if its a leap or not) or if ends on a Friday and is a leap. Otherwise the result must be 52 ([source](https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year)).