### PR TITLE
Duration.toJSON() should not print unwanted zeroes

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1702,7 +1702,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const timeZoneString = timeZone === undefined ? 'Z' : ES.GetOffsetStringFor(outputTimeZone, instant);
     return `${year}-${month}-${day}T${hour}:${minute}${seconds}${timeZoneString}`;
   },
-  TemporalDurationToString: (duration, precision, options = undefined) => {
+  TemporalDurationToString: (duration, precision = 'auto', options = undefined) => {
     function formatNumber(num) {
       if (num <= NumberMaxSafeInteger) return num.toString(10);
       return bigInt(num).toString();

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -327,6 +327,12 @@ describe('Duration', () => {
       [{}, () => {}, undefined].forEach((options) => equal(d1.toString(options), 'PT15H23M'));
     });
   });
+  describe('toJSON()', () => {
+    it('is like toString but always with auto precision', () => {
+      const d = Duration.from({ hours: 1 });
+      equal(d.toJSON(), d.toString({ fractionalSecondDigits: 'auto' }));
+    });
+  });
   describe('toLocaleString()', () => {
     it('produces an implementation-defined string', () => {
       const duration = Duration.from({ hours: 12, minutes: 30 });


### PR DESCRIPTION
Due to a missing argument, Temporal.Duration.from({ hours: 1 }).toJSON()
would return "PT1H0.0S" instead of "PT1H". The same goes for
toLocaleString() in the absence of Intl.DurationFormat.

No change needed to the spec text or documentation, which are already
correct.

Closes: #1371 