### PR TITLE
Duration.prototype.round: Throw on no largest or smallest unit provided.

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -378,12 +378,13 @@ export class Duration {
       smallestUnit = 'nanoseconds';
     }
     defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits(defaultLargestUnit, smallestUnit);
-    let largestUnit = ES.ToLargestTemporalUnit(options, undefined);
+    let largestUnit = ES.ToLargestTemporalDurationUnit(options);
     let largestUnitPresent = true;
     if (!largestUnit) {
       largestUnitPresent = false;
       largestUnit = defaultLargestUnit;
     }
+    if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
     if (!smallestUnitPresent && !largestUnitPresent) {
       throw new RangeError('at least one of smallestUnit or largestUnit is required');
     }

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -776,19 +776,7 @@ export const ES = ObjectAssign({}, ES2020, {
       ['microsecond', 'microseconds'],
       ['nanosecond', 'nanoseconds']
     ]);
-    const allowed = new Set([
-      'years',
-      'months',
-      'weeks',
-      'days',
-      'hours',
-      'minutes',
-      'seconds',
-      'milliseconds',
-      'microseconds',
-      'nanoseconds'
-    ]);
-    const retval = ES.GetOption(options, 'largestUnit', ['auto', ...allowed, ...plural.keys()]);
+    const retval = ES.GetOption(options, 'largestUnit', ['auto', ...plural.keys(), ...plural.values(), 'weeks']);
     if (plural.has(retval)) return plural.get(retval);
     return retval;
   },

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -764,6 +764,34 @@ export const ES = ObjectAssign({}, ES2020, {
     if (plural.has(retval)) return plural.get(retval);
     return retval;
   },
+  ToLargestTemporalDurationUnit: (options) => {
+    const plural = new Map([
+      ['year', 'years'],
+      ['month', 'months'],
+      ['day', 'days'],
+      ['hour', 'hours'],
+      ['minute', 'minutes'],
+      ['second', 'seconds'],
+      ['millisecond', 'milliseconds'],
+      ['microsecond', 'microseconds'],
+      ['nanosecond', 'nanoseconds']
+    ]);
+    const allowed = new Set([
+      'years',
+      'months',
+      'weeks',
+      'days',
+      'hours',
+      'minutes',
+      'seconds',
+      'milliseconds',
+      'microseconds',
+      'nanoseconds'
+    ]);
+    const retval = ES.GetOption(options, 'largestUnit', ['auto', ...allowed, ...plural.keys()]);
+    if (plural.has(retval)) return plural.get(retval);
+    return retval;
+  },
   ToSmallestTemporalUnit: (options, disallowedStrings = []) => {
     const singular = new Map(
       [

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -941,6 +941,12 @@ describe('Duration', () => {
     it('throws without parameter', () => {
       throws(() => d.round(), TypeError);
     });
+    it('throws with empty object', () => {
+      throws(() => d.round({}), RangeError);
+    });
+    it("succeeds with largestUnit: 'auto'", () => {
+      equal(`${Duration.from({ hours: 25 }).round({ largestUnit: 'auto' })}`, 'PT25H');
+    });
     it('throws on disallowed or invalid smallestUnit', () => {
       ['era', 'nonsense'].forEach((smallestUnit) => {
         throws(() => d.round({ smallestUnit }), RangeError);

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -476,7 +476,7 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-tosmallesttemporaldurationunit" aoid="ToSmallestTemporalDurationUnit">
-    <h1>ToSmallestTemporalDurationUnit ( _normalizedOptions_, _fallback_, _disallowedUnits_ )</h1>
+    <h1>ToSmallestTemporalDurationUnit ( _normalizedOptions_, _disallowedUnits_, _fallback_ )</h1>
     <emu-alg>
       1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
       1. If the value of _smallestUnit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -451,6 +451,16 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-tolargesttemporaldurationunit" aoid="ToLargestTemporalDurationUnit">
+    <h1>ToLargestTemporalDurationUnit ( _normalizedOptions_ )</h1>
+    <emu-alg>
+      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, *"string"*, « *"auto"*, *"year"*, *"years"*, *"month"*, *"months"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *undefined*).
+      1. If the value of _largestUnit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
+        1. Set _largestUnit_ to the corresponding Plural value of the same row.
+      1. Return _largestUnit_.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-tosmallesttemporalunit" aoid="ToSmallestTemporalUnit">
     <h1>ToSmallestTemporalUnit ( _normalizedOptions_, _disallowedUnits_ )</h1>
     <emu-alg>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -673,7 +673,7 @@
         1. Set _one_ to ? ToTemporalDate(_one_).
         1. Set _two_ to ? ToTemporalDate(_two_).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, *"days"*, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* »).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
         1. Let _result_ be ? DifferenceDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
         1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -443,7 +443,7 @@
           1. Set _largestUnit_ to _defaultLargestUnit_.
         1. Else if _largestUnit_ is *"auto"*, then
           1. Set _largestUnit_ to _defaultLargestUnit_.
-        1. If _smallestUnitPresent_ is *false* and -largestUnitPresent_ is *false*, then
+        1. If _smallestUnitPresent_ is *false* and _largestUnitPresent_ is *false*, then
           1. Throw a *RangeError* exception.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -431,16 +431,20 @@
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnitPresent_ be *true*.
         1. Let _largestUnitPresent_ be *true*.
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *undefined*).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *undefined*, « »).
         1. If _smallestUnit_ is *undefined*, then
           1. Set _smallestUnitPresent_ to *false*.
           1. Set _smallestUnit_ to *"nanoseconds"*.
         1. Let _defaultLargestUnit_ be ! DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Set _defaultLargestUnit_ to ! LargerOfTwoTemporalDurationUnits(_defaultLargestUnit_, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, *undefined*).
+        1. Let _largestUnit_ be ? ToLargestTemporalDurationUnit(_options_).
         1. If _largestUnit_ is *undefined*, then
           1. Set _largestUnitPresent_ to *false*.
           1. Set _largestUnit_ to _defaultLargestUnit_.
+        1. Else if _largestUnit_ is *"auto"*, then
+          1. Set _largestUnit_ to _defaultLargestUnit_.
+        1. If _smallestUnitPresent_ is *false* and -largestUnitPresent_ is *false*, then
+          1. Throw a *RangeError* exception.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
@@ -1452,7 +1456,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-tolimitedtemporalduration" aoid="ToLimitedTemporalDuration">
+    <emu-clause id="sec-temporal-tolimitedtemporalduration" aoid="ToiLmitedTemporalDuration">
       <h1>ToLimitedTemporalDuration ( _temporalDurationLike_, _disallowedFields_ )</h1>
       <emu-alg>
         1. If Type(_temporalDurationLike_) is not Object, then

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -431,7 +431,7 @@
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnitPresent_ be *true*.
         1. Let _largestUnitPresent_ be *true*.
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *undefined*, « »).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « », *undefined*).
         1. If _smallestUnit_ is *undefined*, then
           1. Set _smallestUnitPresent_ to *false*.
           1. Set _smallestUnit_ to *"nanoseconds"*.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1456,7 +1456,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-tolimitedtemporalduration" aoid="ToiLmitedTemporalDuration">
+    <emu-clause id="sec-temporal-tolimitedtemporalduration" aoid="ToLimitedTemporalDuration">
       <h1>ToLimitedTemporalDuration ( _temporalDurationLike_, _disallowedFields_ )</h1>
       <emu-alg>
         1. If Type(_temporalDurationLike_) is not Object, then

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1198,7 +1198,7 @@
             1. Set _two_ to ? ToTemporalDate(_two_).
             1. Set _options_ to ? NormalizeOptionsObject(_options_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, *"days"*, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* »).
+              1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
               1. Let _result_ be ? DifferenceDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
             1. Else,
               1. Let _result_ be a Record with [[Years]], [[Months]], [[Weeks]], and [[Days]] fields, that is the result of implementation-defined processing of _one_, _two_, _options_, and the value of _calendar_.[[Identifier]].

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -448,7 +448,7 @@
         1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _disallowedUnits_ be « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"days"*, _disallowedUnits_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, _disallowedUnits_, *"days"*).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"days"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
@@ -474,7 +474,7 @@
         1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _disallowedUnits_ be « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"days"*, _disallowedUnits_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, _disallowedUnits_, *"days"*).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"days"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -337,7 +337,7 @@
         1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _disallowedUnits_ be « *"weeks"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"months"*, _disallowedUnits_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, _disallowedUnits_, *"months"*).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"years"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
@@ -373,7 +373,7 @@
         1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _disallowedUnits_ be « *"weeks"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, *"months"*, _disallowedUnits_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, _disallowedUnits_, *"months"*).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"years"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).


### PR DESCRIPTION
Fix bug where largestUnit: 'auto' is considered to be no unit provided.

Fixes #1379.