### PR TITLE
polyfill: optimize rounding durations to years

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3715,20 +3715,16 @@ export const ES = ObjectAssign({}, ES2020, {
         relativeTo = yearsLater;
         days += monthsWeeksInDays;
 
-        // Years may be different lengths of days depending on the calendar, so
-        // we need to convert days to years in a loop. We get the number of days
-        // in the one-year period after (or preceding, depending on the sign of
-        // the duration) the relativeTo date, and convert that number of days to
-        // one year, repeating until the number of days is less than a year.
-        const sign = MathSign(days);
+        const daysLater = ES.CalendarDateAdd(calendar, relativeTo, { days }, {}, TemporalDate);
+        const yearsPassed = ES.CalendarDateUntil(calendar, relativeTo, daysLater, { largestUnit: 'years' }).years;
+        years += yearsPassed;
+        const oldRelativeTo = relativeTo;
+        relativeTo = ES.CalendarDateAdd(calendar, relativeTo, { years: yearsPassed }, {}, TemporalDate);
+        const daysPassed = ES.DaysUntil(oldRelativeTo, relativeTo);
+        days -= daysPassed;
         const oneYear = new TemporalDuration(days < 0 ? -1 : 1);
-        let oneYearDays;
-        ({ relativeTo, days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear));
-        while (MathAbs(days) >= MathAbs(oneYearDays)) {
-          years += sign;
-          days -= oneYearDays;
-          ({ relativeTo, days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear));
-        }
+        let { days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear);
+
         // Note that `nanoseconds` below (here and in similar code for months,
         // weeks, and days further below) isn't actually nanoseconds for the
         // full date range.  Instead, it's a BigInt representation of total

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1316,9 +1316,9 @@
           1. Set _months_, _weeks_, and _days_ to 0.
         1. Else if _unit_ is *"months"*, then
           1. Let _yearsMonths_ be ? CreateTemporalDuration(_years_, _months_, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _yearsMonthsLater_ be ? Call(_dateAdd_, _calendar_, « _relativeTo_, _yearsMonths_, _options_, %Temporal.PlainDate%).
+          1. Let _yearsMonthsLater_ be ? Call(_dateAdd_, _calendar_, « _relativeTo_, _yearsMonths_, _options_, %Temporal.PlainDate% »).
           1. Let _yearsMonthsWeeks_ be ? CreateTemporalDuration(_years_, _months_, _weeks_, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _yearsMonthsWeeksLater_ be ? Call(_dateAdd_, _calendar_, « _relativeTo_, _yearsMonthsWeeks_, _options_, %Temporal.PlainDate%).
+          1. Let _yearsMonthsWeeksLater_ be ? Call(_dateAdd_, _calendar_, « _relativeTo_, _yearsMonthsWeeks_, _options_, %Temporal.PlainDate% »).
           1. Let _weeksInDays_ be ? DaysUntil(_yearsMonthsLater_, _yearsMonthsWeeksLater_).
           1. Set _relativeTo_ to _yearsMonthsLater_.
           1. Let _days_ be _days_ + _weeksInDays_.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1293,18 +1293,23 @@
           1. Let _monthsWeeksInDays_ be ? DaysUntil(_yearsLater_, _yearsMonthsWeeksLater_).
           1. Set _relativeTo_ to _yearsLater_.
           1. Let _days_ be _days_ + _monthsWeeksInDays_..
+          1. Let _daysDuration_ be ? CreateTemporalDuration(0, 0, 0, _days_, 0, 0, 0, 0, 0, 0).
+          1. Let _daysLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _daysDuration_, _options_, %Temporal.PlainDate%).
+          1. Let _untilOptions_ be ! OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"years"*).
+          1. Let _timePassed_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _daysLater_, _untilOptions_).
+          1. Let _yearsPassed_ be _timePassed_.[[Years]].
+          1. Set _years_ to _years_ + _yearsPassed_.
+          1. Let _oldRelativeTo_ be _relativeTo_.
+          1. Let _yearsDuration_ be ? CreateTemporalDuration(_yearsPassed_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Set _relativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsDuration_, _options_, %Temporal.PlainDate%).
+          1. Let _daysPassed_ be ? DaysUntil(_oldRelativeTo_, _relativeTo_).
+          1. Set _days_ to _days_ - _daysPassed_.
           1. Let _sign_ be ! Sign(_days_).
           1. If _sign_ is 0, set _sign_ to 1.
           1. Let _oneYear_ be ? CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
-          1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
-          1. Repeat, while abs(_days_) ≥ abs(_oneYearDays_),
-            1. Set _years_ to _years_ + _sign_.
-            1. Set _days_ to _days_ − _oneYearDays_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
-            1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
-            1. Set _oneYearDays_ to _moveResult_.[[Days]].
           1. Let _fractionalYears_ be _years_ + _days_ / abs(_oneYearDays_).
           1. Set _years_ to ? RoundNumberToIncrement(_fractionalYears_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalYears_ - _years_.


### PR DESCRIPTION
Rounding durations to years was an operation that was previously of the
order O(Years), since it looped over the number of days. This commit
optimizes that logic by deferring that to calendar-specific PlainDate
arithmetic, essentially making it O(1).

Fixes: https://github.com/tc39/proposal-temporal/issues/1242

/cc @cjtenny @ptomato @justingrant 