### PR TITLE
Spec: Throw on undefined calendar in Temporal.now

### DIFF
--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -112,7 +112,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Return ? SystemDateTime(_temporalTimeZoneLike_).
+        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Return ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -134,7 +135,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_).
+        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_, _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -157,7 +159,8 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_).
+        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
         1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -215,7 +218,7 @@
           1. Let _timeZone_ be ? SystemTimeZone().
         1. Else,
           1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
-        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
         1. Let _instant_ be ? SystemInstant().
         1. Return ? GetTemporalDateTimeFor(_timeZone_, _instant_, _calendar_).
       </emu-alg>
@@ -228,7 +231,7 @@
           1. Let _timeZone_ be ? SystemTimeZone().
         1. Else,
           1. Let _timeZone_ be ? ToTemporalTimeZone(_temporalTimeZoneLike_).
-        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
+        1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
         1. Let _ns_ be ? SystemUTCEpochNanoseconds().
         1. Return ? CreateTemporalZonedDateTime(_ns_, _timeZone_, _calendar_).
       </emu-alg>


### PR DESCRIPTION
I found another spec discrepancy while auditing docs code samples, where the docs+polyfill disagree with spec.

`Temporal.now.{plainDate,plainDateTime,zonedDateTime}()` should accept undefined calendar because they all delegate to [SystemDateTime](https://tc39.es/proposal-temporal/#sec-temporal-systemdatetime) which uses `ToOptionalTemporalCalendar`. However, calendarLike isn't listed as an optional argument.

Which is the correct behavior? Assuming the spec is correct, this makes the polyfill match and adds some optionality-brackets to the spec for clarity.