### PR TITLE
Tidy up TypeScript descriptions for .now methods

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -190,7 +190,7 @@ export namespace Temporal {
      * `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`,
      * `'nanoseconds'` and `'auto'`, although some types may throw an exception
      * if a value is used that would produce an invalid result. For example,
-     * `hours` is not accepted by `Date.prototype.since()`.
+     * `hours` is not accepted by `Temporal.PlainDate.prototype.since()`.
      *
      * The default is always `'auto'`, though the meaning of this depends on the
      * type being used.
@@ -695,7 +695,7 @@ export namespace Temporal {
   /**
    * A `Temporal.Calendar` is a representation of a calendar system. It includes
    * information about how many days are in each year, how many months are in
-   * each year, how many days are in each month, and how to do arithmetic in\
+   * each year, how many days are in each month, and how to do arithmetic in
    * that calendar system.
    *
    * See https://tc39.es/proposal-temporal/docs/calendar.html for more details.

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1500,7 +1500,7 @@ export namespace Temporal {
      * The `calendar` parameter is required. When using the ISO 8601 calendar or
      * if you don't understand the need for or implications of a calendar, then
      * a more ergonomic alternative to this method is
-     * `Temporal.now.dateTimeISO()`.
+     * `Temporal.now.zonedDateTimeISO()`.
      *
      * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
      * a `Temporal.Calendar` instance, or an object implementing the calendar
@@ -1520,14 +1520,6 @@ export namespace Temporal {
      * Get the current calendar date and clock time in a specific time zone,
      * using the ISO 8601 calendar.
      *
-     * The `calendar` parameter is required. When using the ISO 8601 calendar or
-     * if you don't understand the need for or implications of a calendar, then
-     * a more ergonomic alternative to this method is
-     * `Temporal.now.zonedDateTimeISO()`.
-     *
-     * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
-     * a `Temporal.Calendar` instance, or an object implementing the calendar
-     * protocol.
      * @param {TimeZoneProtocol | string} [tzLike] -
      * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
      * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
@@ -1542,7 +1534,7 @@ export namespace Temporal {
      *
      * The calendar is required. When using the ISO 8601 calendar or if you
      * don't understand the need for or implications of a calendar, then a more
-     * ergonomic alternative to this method is `Temporal.now.zonedDateTimeISO`.
+     * ergonomic alternative to this method is `Temporal.now.plainDateTimeISO`.
      *
      * Note that the `Temporal.PlainDateTime` type does not persist the time zone,
      * but retaining the time zone is required for most time-zone-related use
@@ -1573,9 +1565,6 @@ export namespace Temporal {
      * cases. Therefore, it's usually recommended to use
      * `Temporal.now.zonedDateTimeISO` instead of this function.
      *
-     * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
-     * a `Temporal.Calendar` instance, or an object implementing the calendar
-     * protocol.
      * @param {TimeZoneProtocol | string} [tzLike] -
      * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
      * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
@@ -1585,7 +1574,11 @@ export namespace Temporal {
     export function plainDateTimeISO(tzLike?: TimeZoneProtocol | string): Temporal.PlainDateTime;
 
     /**
-     * Get the current calendar date in a specific time zone.
+     * Get the current calendar date in a specific calendar and time zone.
+     *
+     * The calendar is required. When using the ISO 8601 calendar or if you
+     * don't understand the need for or implications of a calendar, then a more
+     * ergonomic alternative to this method is `Temporal.now.plainDateISO`.
      *
      * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
      * a `Temporal.Calendar` instance, or an object implementing the calendar
@@ -1605,9 +1598,6 @@ export namespace Temporal {
      * Get the current date in a specific time zone, using the ISO 8601
      * calendar.
      *
-     * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
-     * a `Temporal.Calendar` instance, or an object implementing the calendar
-     * protocol.
      * @param {TimeZoneProtocol | string} [tzLike] -
      * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
      * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an


### PR DESCRIPTION
I noticed some of the TypeScript definitions for the `Temporal.now` methods had slightly incorrect descriptions (mostly looked like copy/paste errors).

This tidies up the descriptions to be consistent, and also fixes a couple of other typos I found elsewhere in the file.