### PR TITLE
ISOMonthDayFromFields: Reject leap day in appropriate cases when calendar is specified.

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -199,10 +199,12 @@ impl['iso8601'] = {
     if (fields.month !== undefined && fields.year === undefined && fields.monthCode === undefined) {
       throw new TypeError('either year or monthCode required with month');
     }
+    const useYear = fields.monthCode === undefined;
+    const referenceISOYear = 1972;
     fields = resolveNonLunisolarMonth(fields);
-    let { month, day } = fields;
-    ({ month, day } = ES.RegulateMonthDay(month, day, overflow));
-    return new constructor(month, day, calendar, /* referenceISOYear */ 1972);
+    let { month, day, year } = fields;
+    ({ month, day } = ES.RegulateDate(useYear ? year : referenceISOYear, month, day, overflow));
+    return new constructor(month, day, calendar, referenceISOYear);
   },
   fields(fields) {
     return fields;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -423,18 +423,6 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     return { year, month };
   },
-  RegulateMonthDay: (month, day, overflow) => {
-    const referenceISOYear = 1972;
-    switch (overflow) {
-      case 'reject':
-        ES.RejectDate(referenceISOYear, month, day);
-        break;
-      case 'constrain':
-        ({ month, day } = ES.ConstrainDate(referenceISOYear, month, day));
-        break;
-    }
-    return { month, day };
-  },
   DurationHandleFractions: (
     fHours,
     minutes,

--- a/polyfill/test/plainmonthday.mjs
+++ b/polyfill/test/plainmonthday.mjs
@@ -166,6 +166,32 @@ describe('MonthDay', () => {
         ['reject', 'constrain'].forEach((overflow) =>
           it(overflow, () => equal(`${PlainMonthDay.from({ month: 2, day: 29 }, { overflow })}`, '02-29'))
         );
+        it("rejects when year isn't a leap year", () =>
+          throws(() => PlainMonthDay.from({ month: 2, day: 29, year: 2001 }, { overflow: 'reject' }), RangeError));
+        it('constrains non-leap year', () =>
+          equal(`${PlainMonthDay.from({ month: 2, day: 29, year: 2001 }, { overflow: 'constrain' })}`, '02-28'));
+      });
+      describe('Leap day with calendar', () => {
+        it('requires year with calendar', () =>
+          throws(
+            () => PlainMonthDay.from({ month: 2, day: 29, calendar: 'iso8601' }, { overflow: 'reject' }),
+            TypeError
+          ));
+        it('rejects leap day with non-leap year', () =>
+          throws(
+            () => PlainMonthDay.from({ month: 2, day: 29, year: 2001, calendar: 'iso8601' }, { overflow: 'reject' }),
+            RangeError
+          ));
+        it('constrains leap day', () =>
+          equal(
+            `${PlainMonthDay.from({ month: 2, day: 29, year: 2001, calendar: 'iso8601' }, { overflow: 'constrain' })}`,
+            '02-28'
+          ));
+        it('accepts leap day with monthCode', () =>
+          equal(
+            `${PlainMonthDay.from({ monthCode: 'M02', day: 29, calendar: 'iso8601' }, { overflow: 'reject' })}`,
+            '02-29'
+          ));
       });
       it('object must contain at least the required correctly-spelled properties', () => {
         throws(() => PlainMonthDay.from({}), TypeError);

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -364,8 +364,12 @@
         1. Set _month_ to ? ResolveISOMonth(_fields_).
         1. Let _day_ be ? Get(_fields_, *"day"*).
         1. If _day_ is *undefined*, throw a *TypeError* exception.
-        1. Let _result_ be ? RegulateMonthDay(_month_, _day_, _overflow_).
         1. Let _referenceISOYear_ be the first leap year after the Unix epoch (1972).
+        1. Let _result_ be *undefined*.
+        1. If _monthCode_ is *undefined*, then
+          1. Set _result_ to ? RegulateDate(_year_, _month_, _day_, _overflow_).
+        1. Else,
+          1. Set _result_ to ? RegulateDate(_referenceISOYear_, _month_, _day_, _overflow_).
         1. Return the new Record {
             [[Month]]: _result_.[[Month]],
             [[Day]]: _result_.[[Day]],

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -393,57 +393,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-regulatemonthday" aoid="RegulateMonthDay">
-      <h1>RegulateMonthDay ( _month_, _day_, _overflow_ )</h1>
-      <emu-alg>
-        1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
-        1. If _overflow_ is *"reject"*, then
-          1. Perform ? RejectMonthDay(_month_, _day_).
-          1. Return the Record {
-              [[Month]]: _month_,
-              [[Day]]: _day_
-            }.
-        1. If _overflow_ is *"constrain"*, then
-          1. Return ! ConstrainMonthDay(_month_, _day_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-validatemonthday" aoid="ValidateMonthDay">
-      <h1>ValidateMonthDay ( _month_, _day_ )</h1>
-      <emu-alg>
-        1. Assert: _month_ and _day_ are integer Number values.
-        1. If _month_ &lt; 1 or _month_ &gt; 12, then
-          1. Return *false*.
-        1. Let _leapYear_ be the first leap year after the Unix epoch (1972).
-        1. Let _maxDay_ be ! DaysInMonth(_leapYear_, _m_).
-        1. If _d_ &lt; 1 or _d_ &gt; _maxDay_, then
-          1. Return *false*.
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-rejectmonthday" aoid="RejectMonthDay">
-      <h1>RejectMonthDay ( _month_, _day_ )</h1>
-      <emu-alg>
-        1. Assert: _month_ and _day_ are integer Number values.
-        1. If ! ValidateMonthDay(_month_, _day_) is *false*, then
-          1. Throw a *RangeError* exception.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-constrainmonthday" aoid="ConstrainMonthDay">
-      <h1>ConstrainMonthDay ( _month_, _day_ )</h1>
-      <emu-alg>
-        1. Assert: _month_ and _day_ are integer Number values.
-        1. Let _leapYear_ be the first leap year after the Unix epoch (1972).
-        1. Let _result_ be ! ConstrainDate(_leapYear_, _month_, _day_).
-        1. Return the new Record {
-            [[Month]]: _result_.[[Month]],
-            [[Day]]: _result_.[[Day]]
-          }.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-createtemporalmonthday" aoid="CreateTemporalMonthDay">
       <h1>CreateTemporalMonthDay ( _isoMonth_, _isoDay_, _calendar_, _referenceISOYear_ [ , _newTarget_ ] )</h1>
       <emu-alg>


### PR DESCRIPTION
ToTemporalMonthDay accepts 'month' without 'monthCode' or 'year' when no calendar has been specified, for users writing calendar-insensitive code. However, when a calendar has been specified, ISOMonthDayFromFields will still accept 2/29/2001 specified via month and year. This change makes ISOMonthDayFromFields reject or constrain 02-29 when month + year are specified, and keeps acceptance of 02-29 when only monthCode + day are specified. See the added test case for some examples.