### PR TITLE
Correct + make runnable documentation code samples.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ For a human-readable local calendar date or clock time, use a `Temporal.TimeZone
 
 ```js
 const instant = Temporal.Instant.from('1969-07-20T20:17Z');
-instant.toString(); // => "1969-07-20T20:17:00Z"
+instant.toString(); // => '1969-07-20T20:17:00Z'
 instant.epochMilliseconds; // => -14182980000
 ```
 
@@ -88,7 +88,7 @@ const zonedDateTime = Temporal.ZonedDateTime.from({
   millisecond: 0,
   microsecond: 3,
   nanosecond: 500
-}); // => 1995-12-07T03:24:30.000003500+08:00[America/Los_Angeles]
+}); // => 1995-12-07T03:24:30.0000035-08:00[America/Los_Angeles]
 ```
 
 As the broadest `Temporal` type, `Temporal.ZonedDateTime` can be considered a combination of `Temporal.TimeZone`, `Temporal.Instant`, and `Temporal.PlainDateTime` (which includes `Temporal.Calendar`).
@@ -103,7 +103,7 @@ A `Temporal.PlainDate` object represents a calendar date that is not associated 
 const date = Temporal.PlainDate.from({ year: 2006, month: 8, day: 24 }); // => 2006-08-24
 date.year; // => 2006
 date.inLeapYear; // => false
-date.toString(); // => "2006-08-24"
+date.toString(); // => '2006-08-24'
 ```
 
 This can also be converted to partial dates such as `Temporal.PlainYearMonth` and `Temporal.PlainMonthDay`.
@@ -125,7 +125,7 @@ const time = Temporal.PlainTime.from({
 }); // => 19:39:09.068346205
 
 time.second; // => 9
-time.toString(); // => "19:39:09.068346205"
+time.toString(); // => '19:39:09.068346205'
 ```
 
 See [Temporal.PlainTime Documentation](./plaintime.md) for detailed documentation.

--- a/docs/ambiguity.md
+++ b/docs/ambiguity.md
@@ -75,18 +75,17 @@ formatOptions = {
 zdt = instant.toZonedDateTimeISO('Asia/Tokyo');
   // => 2019-09-03T17:34:05+09:00[Asia/Tokyo]
 zdt.toLocaleString('en-us', { ...formatOptions, calendar: zdt.calendar });
-  // => "Sep 3, 2019 AD, 5:34:05 PM"
+  // => 'Sep 3, 2019 AD, 5:34:05 PM'
 zdt.year;
   // => 2019
-zdt = instant.toZonedDateTime('Asia/Tokyo', 'iso8601').toLocaleString('ja-jp', formatOptions);
-  // => 2019-09-03T17:34:05+09:00[Asia/Tokyo]
-  // this is identical to the result of toZonedDateTime() above
+zdt = instant.toZonedDateTime({timeZone: 'Asia/Tokyo', calendar: 'iso8601'}).toLocaleString('ja-jp', formatOptions);
+  // => '西暦2019年9月3日 17:34:05'
 
-zdt = instant.toZonedDateTime('Asia/Tokyo', 'japanese');
+zdt = instant.toZonedDateTime({timeZone: 'Asia/Tokyo', calendar: 'japanese'});
   // => 2019-09-03T17:34:05+09:00[Asia/Tokyo][u-ca=japanese]
 zdt.toLocaleString('en-us', { ...formatOptions, calendar: zdt.calendar });
-  // => "Sep 3, 1 Reiwa, 5:34:05 PM"
-zdt.year;
+  // => 'Sep 3, 1 Reiwa, 5:34:05 PM'
+zdt.eraYear;
   // => 1
 ```
 <!-- prettier-ignore-end -->
@@ -99,15 +98,15 @@ Conversions from calendar date and/or wall clock time to exact time are also sup
 date = Temporal.PlainDate.from('2019-12-17');
 // If time is omitted, local time defaults to start of day
 zdt = date.toZonedDateTime('Asia/Tokyo');
-  // => 2019-12-17T00:00+09:00[Asia/Tokyo]
-zdt = date.toZonedDateTime({ timeZone: 'Asia/Tokyo', time: '10:00' });
-  // => 2019-12-17T10:00+09:00[Asia/Tokyo]
+  // => 2019-12-17T00:00:00+09:00[Asia/Tokyo]
+zdt = date.toZonedDateTime({ timeZone: 'Asia/Tokyo', plainTime: '10:00' });
+  // => 2019-12-17T10:00:00+09:00[Asia/Tokyo]
 time = Temporal.PlainTime.from('14:35');
-zdt = time.toZonedDateTime({ timeZone: 'Asia/Tokyo', date: Temporal.PlainDate.from('2020-08-27') });
-  // => 020-08-27T14:35+09:00[Asia/Tokyo]
+zdt = time.toZonedDateTime({ timeZone: 'Asia/Tokyo', plainDate: Temporal.PlainDate.from('2020-08-27') });
+  // => 2020-08-27T14:35:00+09:00[Asia/Tokyo]
 dateTime = Temporal.PlainDateTime.from('2019-12-17T07:48');
 zdt = dateTime.toZonedDateTime('Asia/Tokyo');
-  // => 2019-12-17T07:48+09:00[Asia/Tokyo]
+  // => 2019-12-17T07:48:00+09:00[Asia/Tokyo]
 
 // Get the exact time in seconds, milliseconds, or nanoseconds since the UNIX epoch.
 inst = zdt.toInstant();
@@ -173,11 +172,11 @@ zdt = dt.toZonedDateTime('America/Sao_Paulo'); // can be ambiguous
 
 // the offset is lost when converting from an exact type to a non-exact type
 zdt = Temporal.ZonedDateTime.from('2020-11-01T01:30-08:00[America/Los_Angeles]');
-  // => 2020-11-01T01:30-08:00[America/Los_Angeles]
+  // => 2020-11-01T01:30:00-08:00[America/Los_Angeles]
 dt = zdt.toPlainDateTime(); // offset is lost!
-  // => 2020-11-01T01:30
+  // => 2020-11-01T01:30:00
 zdtAmbiguous = dt.toZonedDateTime('America/Los_Angeles'); // can be ambiguous
-  // => 2020-11-01T01:30-07:00[America/Los_Angeles]
+  // => 2020-11-01T01:30:00-07:00[America/Los_Angeles]
   // note that the offset is now -07:00 (Pacific Daylight Time) which is the "first" 1:30AM
   // not -08:00 (Pacific Standard Time) like the original time which was the "second" 1:30AM
 ```
@@ -228,17 +227,22 @@ In `'compatible'` mode, the same time is returned as `'later'` mode, which match
 // Offset of -07:00 is Daylight Saving Time, while offset of -08:00 indicates Standard Time.
 props = { timeZone: 'America/Los_Angeles', year: 2020, month: 3, day: 8, hour: 2, minute: 30 };
 zdt = Temporal.ZonedDateTime.from(props, { disambiguation: 'compatible' });
-  // => 2020-03-08T03:30-07:00[America/Los_Angeles]
+  // => 2020-03-08T03:30:00-07:00[America/Los_Angeles]
 zdt = Temporal.ZonedDateTime.from(props);
-  // => 2020-03-08T03:30-07:00[America/Los_Angeles] ('compatible' is the default)
+  // => 2020-03-08T03:30:00-07:00[America/Los_Angeles]
+  // ('compatible' is the default)
 earlier = Temporal.ZonedDateTime.from(props, { disambiguation: 'earlier' });
-  // => 2020-03-08T01:30-08:00[America/Los_Angeles] (1:30 clock time; still in Standard Time)
+  // => 2020-03-08T01:30:00-08:00[America/Los_Angeles]
+  // (1:30 clock time; still in Standard Time)
 later = Temporal.ZonedDateTime.from(props, { disambiguation: 'later' });
-  // => 2020-03-08T03:30-07:00[America/Los_Angeles] ('later' is same as 'compatible' for backwards transitions)
+  // => 2020-03-08T03:30:00-07:00[America/Los_Angeles]
+  // ('later' is same as 'compatible' for backwards transitions)
 later.toPlainDateTime().since(earlier.toPlainDateTime());
-  // => PT2H  (2 hour difference in clock time...
+  // => PT2H
+  // (2 hour difference in clock time...
 later.since(earlier);
-  // => PT1H   ... but 1 hour later in real-world time)
+  // => PT1H
+  // ... but 1 hour later in real-world time)
 ```
 <!-- prettier-ignore-end -->
 
@@ -254,22 +258,22 @@ In `'compatible'` mode, the same time is returned as `'earlier'` mode, which mat
 // Offset of -07:00 is Daylight Saving Time, while offset of -08:00 indicates Standard Time.
 props = { timeZone: 'America/Los_Angeles', year: 2020, month: 11, day: 1, hour: 1, minute: 30 };
 zdt = Temporal.ZonedDateTime.from(props, { disambiguation: 'compatible' });
-  // => 2020-11-01T01:30-07:00[America/Los_Angeles]
+  // => 2020-11-01T01:30:00-07:00[America/Los_Angeles]
 zdt = Temporal.ZonedDateTime.from(props);
-  // => 2020-11-01T01:30-07:00[America/Los_Angeles]
+  // => 2020-11-01T01:30:00-07:00[America/Los_Angeles]
   // 'compatible' is the default.
 earlier = Temporal.ZonedDateTime.from(props, { disambiguation: 'earlier' });
-  // => 2020-11-01T01:30-07:00[America/Los_Angeles] 
+  // => 2020-11-01T01:30:00-07:00[America/Los_Angeles]
   // 'earlier' is same as 'compatible' for backwards transitions.
 later = Temporal.ZonedDateTime.from(props, { disambiguation: 'later' });
-  // => 2020-11-01T01:30-08:00[America/Los_Angeles] 
+  // => 2020-11-01T01:30:00-08:00[America/Los_Angeles]
   // Same clock time, but one hour later.
   // -08:00 offset indicates Standard Time.
 later.toPlainDateTime().since(earlier.toPlainDateTime());
-  // => PT0S  
+  // => PT0S
   // (same clock time...
 later.since(earlier);
-  // => PT1H   
+  // => PT1H
   // ... but 1 hour later in real-world time)
 ```
 <!-- prettier-ignore-end -->
@@ -319,7 +323,7 @@ Let's assume the stored future time was noon on January 15, 2020 in São Paulo:
 ```javascript
 zdt = Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 15, hour: 12, timeZone: 'America/Sao_Paulo' });
 zdt.toString();
-  // => "2020-01-15T12:00-02:00[America/Sao_Paulo]"
+  // => '2020-01-15T12:00:00-02:00[America/Sao_Paulo]'
   // Assume this string is saved in an external database.
   // Note that the offset is `-02:00` which is Daylight Saving Time
 
@@ -338,19 +342,19 @@ The `offset` option helps deal with this case.
 <!-- prettier-ignore-start -->
 ```javascript
 savedUsingOldTzDefinition = '2020-01-01T12:00-02:00[America/Sao_Paulo]'; // string that was saved earlier
-zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition);
+/* WRONG */ zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition);
   // => RangeError: Offset is invalid for '2020-01-01T12:00' in 'America/Sao_Paulo'. Provided: -02:00, expected: -03:00.
   // Default is to throw when the offset and time zone conflict.
-zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition, { offset: 'reject' });
+/* WRONG */ zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition, { offset: 'reject' });
   // => RangeError: Offset is invalid for '2020-01-01T12:00' in 'America/Sao_Paulo'. Provided: -02:00, expected: -03:00.
 zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition, { offset: 'use' });
-  // => 2020-01-15T11:00-03:00[America/Sao_Paulo]
+  // => 2020-01-01T11:00:00-03:00[America/Sao_Paulo]
   // Evaluate DateTime value using old offset, which keeps UTC time constant as local time changes to 11:00
 zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition, { offset: 'ignore' });
-  // => 2020-01-15T12:00-03:00[America/Sao_Paulo]
+  // => 2020-01-01T12:00:00-03:00[America/Sao_Paulo]
   // Use current time zone rules to calculate offset, ignoring any saved offset
 zdt = Temporal.ZonedDateTime.from(savedUsingOldTzDefinition, { offset: 'prefer' });
-  // => 2020-01-15T12:00-03:00[America/Sao_Paulo]
+  // => 2020-01-01T12:00:00-03:00[America/Sao_Paulo]
   // Saved offset is invalid for current time zone rules, so use time zone to to calculate offset.
 ```
 <!-- prettier-ignore-end -->

--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -32,7 +32,9 @@ By default, the largest unit in the input will be largest unit in the output.
 
 ```javascript
 d = Temporal.Duration.from({ minutes: 80, seconds: 30 }); // => PT80M30S
-d.round(); // => PT80M30S (unchanged)
+d.round({largestUnit: 'auto'});
+  // => PT80M30S
+  // (unchanged)
 ```
 
 However, `round()` will balance units smaller than the largest one.
@@ -40,14 +42,18 @@ This only matters in the rare case that an unbalanced duration isn't top-heavy.
 
 ```javascript
 d = Temporal.Duration.from({ minutes: 80, seconds: 90 }); // => PT80M90S
-d.round(); // => PT81M30S (seconds balance to minutes, but not minutes=>hours)
+d.round({largestUnit: 'auto'});
+  // => PT81M30S
+  // (seconds balance to minutes, but not minutes=>hours)
 ```
 
 To fully balance a duration, use the `largestUnit` option:
 
 ```javascript
 d = Temporal.Duration.from({ minutes: 80, seconds: 90 }); // => PT80M90S
-d.round({ largestUnit: 'hours' }); // => PT1H21M30S (fully balanced)
+d.round({ largestUnit: 'hours' });
+  // => PT1H21M30S
+  // (fully balanced)
 ```
 
 ## Balancing Relative to a Reference Point
@@ -64,9 +70,11 @@ To handle this potential ambiguity, the `relativeTo` option is used to provide a
 
 ```javascript
 d = Temporal.Duration.from({ days: 370 }); // => P370D
-d.round({ largestUnit: 'months' }); // => RangeError (`relativeTo` is required)
-d.round({ largestUnit: 'months', relativeTo: '2019-01-01' }); // => P1Y5D
-d.round({ largestUnit: 'months', relativeTo: '2020-01-01' }); // => P1Y4D (2020 is a leap year)
+/* WRONG */ d.round({ largestUnit: 'years' }); // => RangeError (`relativeTo` is required)
+d.round({ largestUnit: 'years', relativeTo: '2019-01-01' }); // => P1Y5D
+d.round({ largestUnit: 'years', relativeTo: '2020-01-01' });
+  // => P1Y4D
+  // (2020 is a leap year)
 ```
 
 `relativeTo` is optional when balancing to or from `days`, and if `relativeTo` is omitted then days are assumed to be 24 hours long.
@@ -78,7 +86,8 @@ d = Temporal.Duration.from({ hours: 48 }); // => PT48H
 d.round({ largestUnit: 'days' });
   // => P2D
 d.round({ largestUnit: 'days', relativeTo: '2020-03-08T00:00-08:00[America/Los_Angeles]' });
-  // => P2D1H (because one clock hour was skipped by DST starting)
+  // => P2DT1H
+  // (because one clock hour was skipped by DST starting)
 ```
 <!-- prettier-ignore-end -->
 
@@ -99,7 +108,9 @@ The `largestUnit` option can be used to balance to larger units than the inputs.
 ```javascript
 d1 = Temporal.Duration.from({ minutes: 80, seconds: 90 }); // => PT80M90S
 d2 = Temporal.Duration.from({ minutes: 100, seconds: 15 }); // => PT100M15S
-d1.add(d2, { largestUnit: 'hours' }); // => PT3H1M45S (fully balanced)
+d1.add(d2).round({ largestUnit: 'hours' });
+  // => PT3H1M45S
+  // (fully balanced)
 ```
 
 The `relativeTo` option can be used to balance to, or from, weeks, months or years (or days for timezone-aware durations).
@@ -109,10 +120,11 @@ The `relativeTo` option can be used to balance to, or from, weeks, months or yea
 ```javascript
 d1 = Temporal.Duration.from({ hours: 48 }); // => PT48H
 d2 = Temporal.Duration.from({ hours: 24 }); // => PT24H
-d1.add(d2, { largestUnit: 'days' });
+d1.add(d2).round({ largestUnit: 'days' });
   // => P3D
-d1.add(d2, { largestUnit: 'days', relativeTo: '2020-03-08T00:00-08:00[America/Los_Angeles]' });
-  // => P3D1H (because one clock hour was skipped by DST starting)
+d1.add(d2).round({ largestUnit: 'days', relativeTo: '2020-03-08T00:00-08:00[America/Los_Angeles]' });
+  // => P3DT1H
+  // (because one clock hour was skipped by DST starting)
 ```
 <!-- prettier-ignore-end -->
 

--- a/docs/calendar-review.md
+++ b/docs/calendar-review.md
@@ -111,14 +111,16 @@ For example:
 
 ```javascript
 date = Temporal.PlainDate.from('2019-02-28[u-ca=hebrew]');
-date.with({ day: 1 }); // => 1 Adar I 5779
+date.with({ day: 1 }); // => 2019-02-06[u-ca=hebrew]
+date.with({ day: 1 }).toLocaleString('en-US', { calendar: 'hebrew' }); // => '1 Adar I 5779'
 date.year; // => 5779
-date.monthCode; // => M05L
+date.monthCode; // => 'M05L'
 date.month; // => 6
-date.day; // => 2
+date.day; // => 23
 date.inLeapYear; // => true
-date.calendar.id; // => hebrew
-inFourMonths = date.add({ months: 4 }); // => 23 Sivan 5779
+date.calendar.id; // => 'hebrew'
+inFourMonths = date.add({ months: 4 });
+inFourMonths.toLocaleString('en-US', { calendar: 'hebrew' }); // => '23 Sivan 5779'
 inFourMonths.withCalendar('iso8601'); // => 2019-06-26
 date.until(inFourMonths, { largestUnit: 'months' }); // => P4M
 ```
@@ -161,7 +163,8 @@ hebrewNewYearsEve = Temporal.PlainDate.from({
   day: 29,
   calendar: 'hebrew'
 });
-isLastDayOfYear(hebrewNewYearsEve); // => expected: true, actual: false
+isLastDayOfYear(hebrewNewYearsEve); // => false
+// (desired: true)
 ```
 
 ### Mitigating the Unexpected Calendar Problem

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -124,7 +124,7 @@ Example usage:
 ```javascript
 cal = new Temporal.Calendar('iso8601');
 cal = new Temporal.Calendar('gregory');
-/*⚠️*/ cal = new Temporal.Calendar('discordian'); // not a built-in calendar, throws
+/* WRONG */ cal = new Temporal.Calendar('discordian'); // => throws, not a built-in calendar
 ```
 
 ## Static methods
@@ -166,10 +166,8 @@ cal = Temporal.Calendar.from('2020-01-13T16:31:00.065858086-08:00[America/Vancou
 cal2 = Temporal.Calendar.from(cal);
 
 // Custom calendar that is a plain object (this calendar does not do much)
-cal = Temporal.Calendar.from({ id: 'mycalendar' });
-
-/*⚠️*/ cal = Temporal.Calendar.from('discordian'); // not a built-in calendar, throws
-/*⚠️*/ cal = Temporal.Calendar.from('[u-ca=iso8601]'); // lone annotation not a valid ISO 8601 string
+/* WRONG */ cal = Temporal.Calendar.from('discordian'); // => throws, not a built-in calendar
+/* WRONG */ cal = Temporal.Calendar.from('[u-ca-iso8601]'); // => throws, lone annotation not a valid ISO 8601 string
 ```
 
 ## Properties
@@ -231,7 +229,7 @@ For example:
 const date = Temporal.PlainDate.from('2019-02-06').withCalendar('hebrew');
 date.year; // => 5779
 date.calendar.year(date); // same result, but calling the method directly
-date.monthCode; // => "M05L"
+date.monthCode; // => 'M05L'
 date.calendar.monthCode(date); // same result, but calling the method directly
 date.daysInYear; // => 385
 date.calendar.daysInYear(date); // same result, but calling the method directly
@@ -268,10 +266,10 @@ For example:
 date = Temporal.PlainDate.from({ year: 5779, monthCode: 'M05L', day: 18, calendar: 'hebrew' });
 date.year; // => 5779
 date.month; // => 6
-date.monthCode; // => "M05L"
+date.monthCode; // => 'M05L'
 date.day; // => 18
-date.toString(); // => 2019-02-23[u-ca=hebrew]
-date.toLocaleString('en-US', { calendar: 'hebrew' }); // => "18 Adar I 5779"
+date.toString(); // => '2019-02-23[u-ca=hebrew]'
+date.toLocaleString('en-US', { calendar: 'hebrew' }); // => '18 Adar I 5779'
 
 // same result, but calling the method directly and using month index instead of month code:
 date = Temporal.Calendar.from('hebrew').dateFromFields(
@@ -313,7 +311,7 @@ date = Temporal.PlainDate.from('2020-05-29')
 date.year; // => 1441
 date.month; // => 11
 date.day; // => 7
-date.toString(); // => 2020-06-28[u-ca=islamic]
+date.toString(); // => '2020-06-28[u-ca=islamic]'
 
 // same result, but calling the method directly:
 date = Temporal.Calendar.from('islamic').dateAdd(
@@ -324,7 +322,7 @@ date = Temporal.Calendar.from('islamic').dateAdd(
 date.year; // => 1441
 date.month; // => 11
 date.day; // => 7
-date.toString(); // => 2020-06-28[u-ca=islamic]
+date.toString(); // => '2020-06-28[u-ca=islamic]'
 ```
 
 ### calendar.**dateUntil**(_one_: Temporal.PlainDate | object | string, _two_: Temporal.PlainDate | object | string, _options_: object) : Temporal.Duration
@@ -391,7 +389,7 @@ Usage example:
 ```js
 // In the ISO calendar, this method just makes a copy of the input array
 Temporal.Calendar.from('iso8601').fields(['monthCode', 'day']);
-// => ['monthCode', 'day']
+// => [ 'monthCode', 'day' ]
 ```
 <!-- prettier-ignore-end -->
 
@@ -437,7 +435,7 @@ This method overrides `Object.prototype.toString()` and provides the calendar's 
 Example usage:
 
 ```javascript
-Temporal.PlainDate.from('2020-05-29[u-ca=gregory]').calendar.toString(); // => gregory
+Temporal.PlainDate.from('2020-05-29[u-ca=gregory]').calendar.toString(); // => 'gregory'
 ```
 
 ### calendar.**toJSON**() : string

--- a/docs/cookbook/getUtcOffsetStringAtInstant.mjs
+++ b/docs/cookbook/getUtcOffsetStringAtInstant.mjs
@@ -1,8 +1,8 @@
 const instant = Temporal.Instant.from('2020-01-09T00:00Z');
 const nyc = Temporal.TimeZone.from('America/New_York');
 
-nyc.getOffsetStringFor(instant); // => -05:00
+nyc.getOffsetStringFor(instant); // => '-05:00'
 
 // Can also be done with ZonedDateTime.offset:
 const source = instant.toZonedDateTimeISO(nyc);
-source.offset; // => -05:00
+source.offset; // => '-05:00'

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -99,14 +99,14 @@ Usage examples:
 d = Temporal.Duration.from({ years: 1, days: 1 }); // => P1Y1D
 d = Temporal.Duration.from({ days: -2, hours: -12 }); // => -P2DT12H
 
-Temporal.Duration.from(d) === d; // => true
+Temporal.Duration.from(d) === d; // => false
 
 d = Temporal.Duration.from('P1Y1D'); // => P1Y1D
 d = Temporal.Duration.from('-P2DT12H'); // => -P2DT12H
 d = Temporal.Duration.from('P0D'); // => PT0S
 
 // Mixed-sign values are never allowed, even if overall positive:
-d = Temporal.Duration.from({ hours: 1, minutes: -30 }); // throws
+/* WRONG */ d = Temporal.Duration.from({ hours: 1, minutes: -30 }); // => throws
 ```
 
 ### Temporal.Duration.**compare**(_one_: Temporal.Duration | object | string, _two_: Temporal.Duration | object | string, _options_?: object) : number
@@ -148,13 +148,13 @@ two = Temporal.Duration.from({ days: 3, hours: 7, seconds: 630 });
 three = Temporal.Duration.from({ days: 3, hours: 6, minutes: 50 });
 sorted = [one, two, three].sort(Temporal.Duration.compare);
 sorted.join(' ');
-// => P3DT6H50M PT79H10M P3DT7H630S
+// => 'P3DT6H50M PT79H10M P3DT7H630S'
 
 // Sorting relative to a date, taking DST changes into account:
 relativeTo = Temporal.ZonedDateTime.from('2020-11-01T00:00-07:00[America/Los_Angeles]');
 sorted = [one, two, three].sort((one, two) => Temporal.Duration.compare(one, two, {relativeTo}));
 sorted.join(' ');
-// => PT79H10M P3DT6H50M P3DT7H630S
+// => 'PT79H10M P3DT6H50M P3DT7H630S'
 ```
 
 ## Properties
@@ -289,17 +289,15 @@ hour.add({ minutes: 30 }); // => PT1H30M
 // Examples of balancing:
 one = Temporal.Duration.from({ hours: 1, minutes: 30 });
 two = Temporal.Duration.from({ hours: 2, minutes: 45 });
-result = one.add(two); // => PT3H75M
-result.with(result, { overflow: 'balance' }); // => PT4H15M
+result = one.add(two); // => PT4H15M
 
 fifty = Temporal.Duration.from('P50Y50M50DT50H50M50.500500500S');
-result = fifty.add(fifty); // => P100Y100M100DT100H100M101.001001S'
-Temporal.Duration.from(result, { overflow: 'balance' });
-// => P100Y100M104DT5H41M41.001001S
+/* WRONG */ result = fifty.add(fifty); // => throws, need relativeTo
+result = fifty.add(fifty, {relativeTo: '1900-01-01'}); // => P108Y7M12DT5H41M41.001001S
 
 // Example of converting ambiguous units relative to a start date
 oneAndAHalfMonth = Temporal.Duration.from({ months: 1, days: 15 });
-oneAndAHalfMonth.add(oneAndAHalfMonth); // throws
+/* WRONG */ oneAndAHalfMonth.add(oneAndAHalfMonth); // => throws
 oneAndAHalfMonth.add(oneAndAHalfMonth, { relativeTo: '2000-02-01' }); // => P3M
 oneAndAHalfMonth.add(oneAndAHalfMonth, { relativeTo: '2000-03-01' }); // => P2M30D
 ```
@@ -346,12 +344,12 @@ hourAndAHalf.subtract({ hours: 1 }); // => PT30M
 one = Temporal.Duration.from({ minutes: 180 });
 two = Temporal.Duration.from({ seconds: 30 });
 one.subtract(two); // => PT179M30S
-one.subtract(two, { overflow: 'balance' }); // => PT2H59M30S
+one.subtract(two).round({largestUnit: 'hours'}); // => PT2H59M30S
 
 // Example of converting ambiguous units relative to a start date
 threeMonths = Temporal.Duration.from({ months: 3 });
 oneAndAHalfMonth = Temporal.Duration.from({ months: 1, days: 15 });
-threeMonths.subtract(oneAndAHalfMonth); // throws
+/* WRONG */ threeMonths.subtract(oneAndAHalfMonth); // => throws
 threeMonths.subtract(oneAndAHalfMonth, { relativeTo: '2000-02-01' }); // => P1M16D
 threeMonths.subtract(oneAndAHalfMonth, { relativeTo: '2000-03-01' }); // => P1M15D
 ```
@@ -479,16 +477,18 @@ d = Temporal.Duration.from({ hours: 2756 });
 d.round({
    relativeTo: '2020-01-01T00:00+01:00[Europe/Rome]',
    largestUnit: 'years'
-}); // => P114DT21H (one hour longer because DST skipped an hour)
+}); // => P114DT21H
+    // (one hour longer because DST skipped an hour)
 d.round({
   relativeTo: '2020-01-01',
   largestUnit: 'years'
-}); // => P114DT20H (one hour shorter if ignoring DST)
+}); // => P114DT20H
+    // (one hour shorter if ignoring DST)
 
 // Normalize days into months or years
 d = Temporal.Duration.from({ days: 190 });
 refDate = Temporal.PlainDate.from('2020-01-01');
-d.round({ relativeTo: refDate, largestUnit: 'years' }); // => P6M6D
+d.round({ relativeTo: refDate, largestUnit: 'years' }); // => P6M8D
 
 // Same, but in a different calendar system
 d.round({
@@ -502,7 +502,7 @@ d.round({
   smallestUnit: 'minutes',
   roundingIncrement: 5,
   roundingMode: 'ceil'
-}); // ==> P10M
+}); // => PT10M
 
 // How many full 3-month quarters of this year, are in this duration?
 d = Temporal.Duration.from({ months: 10, days: 15 });
@@ -510,7 +510,7 @@ d = d.round({
   smallestUnit: 'months',
   roundingIncrement: 3,
   roundingMode: 'trunc',
-  relativeTo: Temporal.now.plainDate()
+  relativeTo: Temporal.now.plainDateISO()
 });
 quarters = d.months / 3;
 quarters; // => 3
@@ -607,9 +607,9 @@ d.toString(); // => PT1S
 // The output format always balances units under 1 s, even if the
 // underlying Temporal.Duration object doesn't.
 nobal = Temporal.Duration.from({ milliseconds: 3500 });
-console.log(`${nobal}`, nobal.seconds, nobal.milliseconds); // => PT3.500S 0 3500
-bal = Temporal.Duration.from({ milliseconds: 3500 }, { overflow: 'balance' });
-console.log(`${bal}`, bal.seconds, bal.milliseconds); // => PT3.500S 3 500
+console.log(`${nobal}`, nobal.seconds, nobal.milliseconds); // => 'PT3.5S 0 3500'
+bal = nobal.round({largestUnit: 'years'}); // balance through round
+console.log(`${bal}`, bal.seconds, bal.milliseconds); // => 'PT3.5S 3 500'
 
 d = Temporal.Duration.from('PT59.999999999S');
 d.toString({ smallestUnit: 'seconds' });   // => PT59S
@@ -671,14 +671,13 @@ The `locales` and `options` arguments are the same as in the constructor to [`In
 > **NOTE**: This method requires that your JavaScript environment supports `Intl.DurationFormat`.
 > That is still an early-stage proposal and at the time of writing it is not supported anywhere.
 > If `Intl.DurationFormat` is not available, then the output of this method is the same as that of `duration.toString()`, and the `locales` and `options` arguments are ignored.
-
 Usage examples:
 
 ```javascript
 d = Temporal.Duration.from('P1DT6H30M');
-d.toLocaleString(); // => 1 day 6 hours 30 minutes
-d.toLocaleString('de-DE'); // => 1 Tag 6 Stunden 30 Minuten
-d.toLocaleString('en-US', { day: 'numeric', hour: 'numeric' }); // => 1 day 6 hours
+d.toLocaleString(); // example output: '1 day 6 hours 30 minutes'
+d.toLocaleString('de-DE'); // example output: '1 Tag 6 Stunden 30 Minuten'
+d.toLocaleString('en-US', { day: 'numeric', hour: 'numeric' }); // example output: '1 day 6 hours'
 ```
 
 ### duration.**valueOf**()

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -43,9 +43,9 @@ Example usage:
 ```js
 instant = new Temporal.Instant(1553906700000000000n);
 // When was the Unix epoch?
-epoch = new Temporal.Instant(0n); // => 1970-01-01T00:00Z
+epoch = new Temporal.Instant(0n); // => 1970-01-01T00:00:00Z
 // Dates before the Unix epoch are negative
-turnOfTheCentury = new Temporal.Instant(-2208988800000000000n); // => 1900-01-01T00:00Z
+turnOfTheCentury = new Temporal.Instant(-2208988800000000000n); // => 1900-01-01T00:00:00Z
 ```
 
 ## Static methods
@@ -71,11 +71,11 @@ Example usage:
 instant = Temporal.Instant.from('2019-03-30T01:45:00+01:00[Europe/Berlin]');
 instant = Temporal.Instant.from('2019-03-30T01:45+01:00');
 instant = Temporal.Instant.from('2019-03-30T00:45Z');
-instant === Temporal.Instant.from(instant); // => true
+instant === Temporal.Instant.from(instant); // => false
 
 // Not enough information to denote an exact time:
-/* WRONG */ instant = Temporal.Instant.from('2019-03-30'); // no time; throws
-/* WRONG */ instant = Temporal.Instant.from('2019-03-30T01:45'); // no time zone; throws
+/* WRONG */ instant = Temporal.Instant.from('2019-03-30'); // => throws, no time
+/* WRONG */ instant = Temporal.Instant.from('2019-03-30T01:45'); // => throws, no time zone
 ```
 <!-- prettier-ignore-end -->
 
@@ -98,8 +98,8 @@ Example usage:
 ```js
 // Same examples as in new Temporal.Instant(), but with seconds precision
 instant = Temporal.Instant.fromEpochSeconds(1553906700);
-epoch = Temporal.Instant.fromEpochSeconds(0); // => 1970-01-01T00:00Z
-turnOfTheCentury = Temporal.Instant.fromEpochSeconds(-2208988800); // => 1900-01-01T00:00Z
+epoch = Temporal.Instant.fromEpochSeconds(0); // => 1970-01-01T00:00:00Z
+turnOfTheCentury = Temporal.Instant.fromEpochSeconds(-2208988800); // => 1900-01-01T00:00:00Z
 ```
 
 ### Temporal.Instant.**fromEpochMilliseconds**(_epochMilliseconds_: number) : Temporal.Instant
@@ -117,7 +117,7 @@ However, for conversion from legacy `Date` to `Temporal.Instant`, use `Date.prot
 
 ```js
 legacyDate = new Date('December 17, 1995 03:24:00 GMT');
-instant = Temporal.Instant.fromEpochMilliseconds(legacyDate.getTime()); // => 1995-12-17T03:24Z
+instant = Temporal.Instant.fromEpochMilliseconds(legacyDate.getTime()); // => 1995-12-17T03:24:00Z
 instant = Temporal.Instant.fromEpochMilliseconds(+legacyDate); // valueOf() called implicitly
 instant = legacyDate.toTemporalInstant(); // recommended
 
@@ -174,7 +174,7 @@ two = Temporal.Instant.fromEpochSeconds(1.1e9);
 three = Temporal.Instant.fromEpochSeconds(1.2e9);
 sorted = [three, one, two].sort(Temporal.Instant.compare);
 sorted.join(' ');
-// => 2001-09-09T01:46:40Z 2004-11-09T11:33:20Z 2008-01-10T21:20Z
+// => '2001-09-09T01:46:40Z 2004-11-09T11:33:20Z 2008-01-10T21:20:00Z'
 ```
 
 ## Properties
@@ -191,7 +191,7 @@ Example usage:
 
 ```js
 instant = Temporal.Instant.from('2019-03-30T01:45+01:00');
-instant.epochSeconds; // => 1554000300
+instant.epochSeconds; // => 1553906700
 ```
 
 ### instant.**epochMilliseconds** : number
@@ -244,9 +244,9 @@ Example usage:
 ```js
 // Converting a specific exact time to a calendar date / wall-clock time
 timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
-timestamp.toZonedDateTimeISO('Europe/Berlin'); // => 2019-03-31T01:45+02:00[Europe/Berlin]
-timestamp.toZonedDateTimeISO('UTC'); // => 2019-03-31T00:45+00:00[UTC]
-timestamp.toZonedDateTimeISO('-08:00'); // => 2019-03-30T16:45-08:00[-08:00]
+timestamp.toZonedDateTimeISO('Europe/Berlin'); // => 2019-03-31T01:45:00+01:00[Europe/Berlin]
+timestamp.toZonedDateTimeISO('UTC'); // => 2019-03-31T00:45:00+00:00[UTC]
+timestamp.toZonedDateTimeISO('-08:00'); // => 2019-03-30T16:45:00-08:00[-08:00]
 ```
 
 ### instant.**toZonedDateTime**(_item_: object) : Temporal.ZonedDateTime
@@ -274,15 +274,15 @@ Example usage:
 epoch = Temporal.Instant.fromEpochSeconds(0);
 timeZone = Temporal.TimeZone.from('America/New_York');
 epoch.toZonedDateTime({ timeZone, calendar: 'gregory' });
-  // => 1969-12-31T19:00-05:00[America/New_York][u-ca=gregory]
+  // => 1969-12-31T19:00:00-05:00[America/New_York][u-ca=gregory]
 
 // What time was the Unix epoch in Tokyo in the Japanese calendar?
 timeZone = Temporal.TimeZone.from('Asia/Tokyo');
 calendar = Temporal.Calendar.from('japanese');
 zdt = epoch.toZonedDateTime({ timeZone, calendar });
-  // => 1970-01-01T09:00+09:00[Asia/Tokyo][u-ca=japanese]
-console.log(zdt.year, zdt.era);
-  // => 45 showa
+  // => 1970-01-01T09:00:00+09:00[Asia/Tokyo][u-ca=japanese]
+console.log(zdt.eraYear, zdt.era);
+  // => '45 showa'
 ```
 <!-- prettier-ignore-end -->
 
@@ -403,7 +403,7 @@ Example usage:
 ```js
 startOfMoonMission = Temporal.Instant.from('1969-07-16T13:32:00Z');
 endOfMoonMission = Temporal.Instant.from('1969-07-24T16:50:35Z');
-missionLength = startOfMoonMission.until(endOfMoonMission, { largestUnit: 'days' });
+missionLength = startOfMoonMission.until(endOfMoonMission, { largestUnit: 'hours' });
   // => PT195H18M35S
 missionLength.toLocaleString();
   // example output: '195 hours 18 minutes 35 seconds'
@@ -413,24 +413,25 @@ approxMissionLength = startOfMoonMission.until(endOfMoonMission, {
   largestUnit: 'hours',
   smallestUnit: 'hours'
 });
-  // => P195H
+  // => PT195H
 
 // A billion (10^9) seconds since the epoch in different units
 epoch = Temporal.Instant.fromEpochSeconds(0);
 billion = Temporal.Instant.fromEpochSeconds(1e9);
 epoch.until(billion);
-  // =>    PT1000000000S
+  // => PT1000000000S
 epoch.until(billion, { largestUnit: 'hours' });
-  // =>  PT277777H46M40S
+  // => PT277777H46M40S
 ns = epoch.until(billion, { largestUnit: 'nanoseconds' });
-  // =>    PT1000000000S
+  // => PT1000000000S
 ns.add({ nanoseconds: 1 });
-  // =>    PT1000000000S (lost precision)
+  // => PT1000000000S
+  // (lost precision)
 
 // Calculate the difference in years, eliminating the ambiguity by
 // explicitly using the corresponding calendar date in UTC:
 epoch.toZonedDateTimeISO('UTC').until(
-  billion.toZonedDateTimeISO('UTC'), 
+  billion.toZonedDateTimeISO('UTC'),
   { largestUnit: 'years' }
 );
   // => P31Y8M8DT1H46M40S
@@ -517,13 +518,13 @@ Example usage:
 instant = Temporal.Instant.from('2019-03-30T02:45:59.999999999Z');
 
 // Round to a particular unit
-instant.round({ smallestUnit: 'second' }); // => 2019-03-30T02:46Z
+instant.round({ smallestUnit: 'second' }); // => 2019-03-30T02:46:00Z
 // Round to an increment of a unit, e.g. an hour:
 instant.round({ roundingIncrement: 60, smallestUnit: 'minute' });
-  // => 2019-03-30T03:00Z
+  // => 2019-03-30T03:00:00Z
 // Round to the same increment but round down instead:
 instant.round({ roundingIncrement: 60, smallestUnit: 'minute', roundingMode: 'floor' });
-  // => 2019-03-30T02:00Z
+  // => 2019-03-30T02:00:00Z
 ```
 <!-- prettier-ignore-end -->
 
@@ -587,20 +588,20 @@ Example usage:
 
 ```js
 instant = Temporal.Instant.fromEpochMilliseconds(1574074321816);
-instant.toString(); // => 2019-11-18T10:52:01.816Z
+instant.toString(); // => '2019-11-18T10:52:01.816Z'
 instant.toString({ timeZone: Temporal.TimeZone.from('UTC') });
-// => 2019-11-18T10:52:01.816+00:00
+// => '2019-11-18T10:52:01.816+00:00'
 instant.toString({ timeZone: 'Asia/Seoul' });
-// => 2019-11-18T19:52:01.816+09:00
+// => '2019-11-18T19:52:01.816+09:00'
 
 instant.toString({ smallestUnit: 'minute' });
-// => 2019-11-18T10:52Z
+// => '2019-11-18T10:52Z'
 instant.toString({ fractionalSecondDigits: 0 });
-// => 2019-11-18T10:52:01Z
+// => '2019-11-18T10:52:01Z'
 instant.toString({ fractionalSecondDigits: 4 });
-// => 2019-11-18T10:52:01.8160Z
+// => '2019-11-18T10:52:01.8160Z'
 instant.toString({ smallestUnit: 'second', roundingMode: 'halfExpand' });
-// => 2019-11-18T10:52:02Z
+// => '2019-11-18T10:52:02Z'
 ```
 
 ### instant.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
@@ -626,8 +627,8 @@ Example usage:
 
 ```js
 instant = Temporal.Instant.from('2019-11-18T11:00:00.000Z');
-instant.toLocaleString(); // => example output: 2019-11-18, 3:00:00 a.m.
-instant.toLocaleString('de-DE'); // => example output: 18.11.2019, 03:00:00
+instant.toLocaleString(); // example output: '2019-11-18, 3:00:00 a.m.'
+instant.toLocaleString('de-DE'); // example output: '18.11.2019, 03:00:00'
 instant.toLocaleString('de-DE', {
   timeZone: 'Europe/Berlin',
   year: 'numeric',
@@ -636,10 +637,10 @@ instant.toLocaleString('de-DE', {
   hour: 'numeric',
   minute: 'numeric',
   timeZoneName: 'long'
-}); // => 18.11.2019, 12:00 Mitteleuropäische Normalzeit
+}); // => '18.11.2019, 12:00 Mitteleuropäische Normalzeit'
 instant.toLocaleString('en-US-u-nu-fullwide-hc-h12', {
   timeZone: 'Asia/Kolkata'
-}); // => １１/１８/２０１９, ４:３０:００ PM
+}); // => '１１/１８/２０１９, ４:３０:００ PM'
 ```
 
 ### instant.**toJSON**() : string

--- a/docs/parse-draft.md
+++ b/docs/parse-draft.md
@@ -1,5 +1,5 @@
-This is a draft design document for a `Temporal.parse` API, which is not currently planned to be implemented for several reasons: 
-- `Temporal`'s approach to most operations&mdash;including parsing&mdash;is to encourage strong typing, e.g. `Temporal.Instant.from` vs. `Temporal.PlainDateTime.from`. A type-spanning "parse anything" API goes against that strongly-typed model. 
+This is a draft design document for a `Temporal.parse` API, which is not currently planned to be implemented for several reasons:
+- `Temporal`'s approach to most operations&mdash;including parsing&mdash;is to encourage strong typing, e.g. `Temporal.Instant.from` vs. `Temporal.PlainDateTime.from`. A type-spanning "parse anything" API goes against that strongly-typed model.
 - The main use case beyond type-specific parsing that was identified for a `parse` API was handling "partially correct" ISO strings, e.g. where only one unit was out of range. Most of these use cases were addressed via the `overflow` option in the `from` method of all types which which either clamps out-of-range values (`'constrain'`) to the nearest in-range value or throws (`'reject'`) in that case.
 - The final remaining case for a `parse` API was resolving the case where a time zone and a time zone offset can be in conflict, as would happen for future `Temporal.ZonedDateTime` values stored before a country permanently abolishes DST. This use case is now handled via the `offset` option of `Temporal.ZonedDateTime.from`.
 

--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -92,26 +92,28 @@ date = Temporal.PlainDate.from('2006-08-24T15:43:27'); // => 2006-08-24
 date = Temporal.PlainDate.from('2006-08-24T15:43:27Z'); // => 2006-08-24
 date = Temporal.PlainDate.from('2006-08-24T15:43:27+01:00[Europe/Brussels]');
   // => 2006-08-24
-date === Temporal.PlainDate.from(date) // => true
+date === Temporal.PlainDate.from(date); // => false
 
 date = Temporal.PlainDate.from({year: 2006, month: 8, day: 24}); // => 2006-08-24
 date = Temporal.PlainDate.from(Temporal.PlainDateTime.from('2006-08-24T15:43:27'));
-  // => same as above; Temporal.PlainDateTime has year, month, and day properties
+  // => 2006-08-24
+  // same as above; Temporal.PlainDateTime has year, month, and day properties
 
 calendar = Temporal.Calendar.from('islamic');
-date = Temporal.PlainDate.from({ year: 1427, month; 8, day: 1, calendar }); // => 2006-08-24[u-ca=islamic]
+date = Temporal.PlainDate.from({ year: 1427, month: 8, day: 1, calendar }); // => 2006-08-24[u-ca=islamic]
 date = Temporal.PlainDate.from({ year: 1427, month: 8, day: 1, calendar: 'islamic' });
-  // => same as above
+  // => 2006-08-24[u-ca=islamic]
+  // same as above
 
 // Different overflow modes
 date = Temporal.PlainDate.from({ year: 2001, month: 13, day: 1 }, { overflow: 'constrain' })
   // => 2001-12-01
-date = Temporal.PlainDate.from({ year: 2001, month: -1, day: 1 }, { overflow: 'constrain' })
-  // => 2001-01-01
+date = Temporal.PlainDate.from({ year: 2001, month: 1, day: 32 }, { overflow: 'constrain' })
+  // => 2001-01-31
 date = Temporal.PlainDate.from({ year: 2001, month: 13, day: 1 }, { overflow: 'reject' })
-  // throws
-date = Temporal.PlainDate.from({ year: 2001, month: -1, day: 1 }, { overflow: 'reject' })
-  // throws
+  // => throws
+date = Temporal.PlainDate.from({ year: 2001, month: 1, day: 32 }, { overflow: 'reject' })
+  // => throws
 ```
 
 ### Temporal.PlainDate.**compare**(_one_: Temporal.PlainDate | object | string, _two_: Temporal.PlainDate | object | string) : number
@@ -143,7 +145,7 @@ one = Temporal.PlainDate.from('2006-08-24');
 two = Temporal.PlainDate.from('2015-07-14');
 three = Temporal.PlainDate.from('1930-02-18');
 sorted = [one, two, three].sort(Temporal.PlainDate.compare);
-sorted.join(' '); // => 1930-02-18 2006-08-24 2015-07-14
+sorted.join(' '); // => '1930-02-18 2006-08-24 2015-07-14'
 ```
 
 ## Properties
@@ -182,13 +184,13 @@ Usage examples:
 date = Temporal.PlainDate.from('2006-08-24');
 date.year;      // => 2006
 date.month;     // => 8
-date.monthCode; // => "M08"
+date.monthCode; // => 'M08'
 date.day;       // => 24
 
 date = Temporal.PlainDate.from('2019-02-23[u-ca=hebrew]');
 date.year;      // => 5779
 date.month;     // => 6
-date.monthCode; // => "M05L"
+date.monthCode; // => 'M05L'
 date.day;       // => 18
 ```
 <!-- prettier-ignore-end -->
@@ -209,7 +211,7 @@ Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like t
 ```javascript
 date = Temporal.PlainDate.from('-000015-01-01[u-ca=gregory]');
 date.era;
-// => "bce"
+// => 'bce'
 date.eraYear;
 // => 16
 date.year;
@@ -226,7 +228,7 @@ Usage example:
 
 ```javascript
 date = Temporal.PlainDate.from('2006-08-24');
-['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'][date.dayOfWeek - 1]; // => THU
+['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'][date.dayOfWeek - 1]; // => 'THU'
 ```
 
 ### date.**dayOfYear** : number
@@ -239,7 +241,7 @@ Usage example:
 ```javascript
 date = Temporal.PlainDate.from('2006-08-24');
 // ISO ordinal date
-console.log(date.year, date.dayOfYear); // => 2006 236
+console.log(date.year, date.dayOfYear); // => '2006 236'
 ```
 
 ### date.**weekOfYear** : number
@@ -254,7 +256,7 @@ Usage example:
 ```javascript
 date = Temporal.PlainDate.from('2006-08-24');
 // ISO week date
-console.log(date.year, date.weekOfYear, date.dayOfWeek); // => 2006 34 4
+console.log(date.year, date.weekOfYear, date.dayOfWeek); // => '2006 34 4'
 ```
 
 ### date.**daysInWeek** : number
@@ -280,7 +282,7 @@ Usage example:
 // Attempt to write some mnemonic poetry
 const monthsByDays = {};
 for (let month = 1; month <= 12; month++) {
-  const date = Temporal.now.plainDate().with({ month });
+  const date = Temporal.now.plainDateISO().with({ month });
   monthsByDays[date.daysInMonth] = (monthsByDays[date.daysInMonth] || []).concat(date);
 }
 
@@ -301,7 +303,7 @@ For the ISO 8601 calendar, this is 365 or 366, depending on whether the year is 
 Usage example:
 
 ```javascript
-date = Temporal.now.plainDate();
+date = Temporal.now.plainDateISO();
 percent = date.dayOfYear / date.daysInYear;
 `The year is ${percent.toLocaleString('en', { style: 'percent' })} over!`;
 // example output: "The year is 10% over!"
@@ -328,7 +330,7 @@ Usage example:
 
 ```javascript
 // Is this year a leap year?
-date = Temporal.now.plainDate();
+date = Temporal.now.plainDateISO();
 date.inLeapYear; // example output: true
 // Is 2100 a leap year? (no, because it's divisible by 100 and not 400)
 date.with({ year: 2100 }).inLeapYear; // => false
@@ -620,7 +622,7 @@ Example usage:
 
 ```js
 date = Temporal.PlainDate.from('2006-08-24');
-date.toString(); // => 2006-08-24
+date.toString(); // => '2006-08-24'
 ```
 
 ### date.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
@@ -640,10 +642,10 @@ Example usage:
 
 ```js
 date = Temporal.PlainDate.from('2006-08-24');
-date.toLocaleString(); // => example output: 8/24/2006
-date.toLocaleString('de-DE'); // => example output: 24.8.2006
-date.toLocaleString('de-DE', { weekday: 'long' }); // => Donnerstag
-date.toLocaleString('en-US-u-nu-fullwide'); // => ８/２４/２００６
+date.toLocaleString(); // example output: 8/24/2006
+date.toLocaleString('de-DE'); // example output: '24.8.2006'
+date.toLocaleString('de-DE', { weekday: 'long' }); // => 'Donnerstag'
+date.toLocaleString('en-US-u-nu-fullwide'); // => '８/２４/２００６'
 ```
 
 ### date.**toJSON**() : string
@@ -729,7 +731,7 @@ plainTime = Temporal.PlainTime.from('15:23:30.003');
 plainDate.toZonedDateTime({ timeZone: 'America/Los_Angeles', plainTime });
 // => 2006-08-24T15:23:30.003-07:00[America/Los_Angeles]
 plainDate.toZonedDateTime({ timeZone: 'America/Los_Angeles' });
-// => 2006-08-24T00:00-07:00[America/Los_Angeles]
+// => 2006-08-24T00:00:00-07:00[America/Los_Angeles]
 ```
 
 ### date.**toPlainDateTime**(_time_?: Temporal.PlainTime | object | string) : Temporal.PlainDateTime
@@ -754,7 +756,7 @@ Usage example:
 date = Temporal.PlainDate.from('2006-08-24');
 time = Temporal.PlainTime.from('15:23:30.003');
 date.toPlainDateTime(time); // => 2006-08-24T15:23:30.003
-date.toPlainDateTime(); // => 2006-08-24T00:00
+date.toPlainDateTime(); // => 2006-08-24T00:00:00
 ```
 
 ### date.**toPlainYearMonth**() : Temporal.PlainYearMonth

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -71,7 +71,7 @@ Usage examples:
 
 ```javascript
 // Leet hour on pi day in 2020
-datetime = new Temporal.PlainDateTime(2020, 3, 14, 13, 37); // => 2020-03-14T13:37
+datetime = new Temporal.PlainDateTime(2020, 3, 14, 13, 37); // => 2020-03-14T13:37:00
 ```
 
 ## Static methods
@@ -125,8 +125,9 @@ Example usage:
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30');
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30Z'); // => 1995-12-07T03:24:30
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30+01:00[Europe/Brussels]');
-  // => same as above; time zone is ignored
-dt === Temporal.PlainDateTime.from(dt); // => true
+  // => 1995-12-07T03:24:30
+  // same as above; time zone is ignored
+dt === Temporal.PlainDateTime.from(dt); // => false
 
 dt = Temporal.PlainDateTime.from({
   year: 1995,
@@ -138,34 +139,34 @@ dt = Temporal.PlainDateTime.from({
   millisecond: 0,
   microsecond: 3,
   nanosecond: 500
-}); // => 1995-12-07T03:24:30.000003500
-dt = Temporal.PlainDateTime.from({ year: 1995, month: 12, day: 7 }); // => 1995-12-07T00:00
+}); // => 1995-12-07T03:24:30.0000035
+dt = Temporal.PlainDateTime.from({ year: 1995, month: 12, day: 7 }); // => 1995-12-07T00:00:00
 dt = Temporal.PlainDateTime.from(Temporal.PlainDate.from('1995-12-07T03:24:30'));
-  // => same as above; Temporal.PlainDate has year, month, and day properties
+  // => 1995-12-07T00:00:00
+  // same as above; Temporal.PlainDate has year, month, and day properties
 
 calendar = Temporal.Calendar.from('hebrew');
 dt = Temporal.PlainDateTime.from({ year: 5756, month: 3, day: 14, hour: 3, minute: 24, second: 30, calendar });
   // => 1995-12-07T03:24:30[u-ca=hebrew]
 dt = Temporal.PlainDateTime.from({ year: 5756, month: 3, day: 14, hour: 3, minute: 24, second: 30, calendar: 'hebrew' });
-  // => same as above
+  // => 1995-12-07T03:24:30[u-ca=hebrew]
+  // same as above
 
 // Different overflow modes
 dt = Temporal.PlainDateTime.from({ year: 2001, month: 13, day: 1 }, { overflow: 'constrain' });
-  // => 2001-12-01T00:00
-dt = Temporal.PlainDateTime.from({ year: 2001, month: -1, day: 1 }, { overflow: 'constrain' });
-  // => 2001-01-01T00:00
+  // => 2001-12-01T00:00:00
+dt = Temporal.PlainDateTime.from({ year: 2001, month: 1, day: 32 }, { overflow: 'constrain' });
+  // => 2001-01-31T00:00:00
 dt = Temporal.PlainDateTime.from({ year: 2001, month: 1, day: 1, hour: 25 }, { overflow: 'constrain' });
-  // => 2001-01-01T23:00
+  // => 2001-01-01T23:00:00
 dt = Temporal.PlainDateTime.from({ year: 2001, month: 1, day: 1, minute: 60 }, { overflow: 'constrain' });
-  // => 2001-01-01T00:59
-dt = Temporal.PlainDateTime.from({ year: 2001, month: 1, day: 1, minute: 60 }, { overflow: 'constrain' });
-  // => 2001-01-01T01:00
+  // => 2001-01-01T00:59:00
 dt = Temporal.PlainDateTime.from({ year: 2001, month: 13, day: 1 }, { overflow: 'reject' });
-  // throws
-dt = Temporal.PlainDateTime.from({ year: 2001, month: -1, day: 1 }, { overflow: 'reject' });
-  // throws
+  // => throws
+dt = Temporal.PlainDateTime.from({ year: 2001, month: 1, day: 32 }, { overflow: 'reject' });
+  // => throws
 dt = Temporal.PlainDateTime.from({ year: 2001, month: 1, day: 1, hour: 25 }, { overflow: 'reject' });
-  // throws
+  // => throws
 dt = Temporal.PlainDateTime.from({ year: 2001, month: 1, day: 1, minute: 60 }, { overflow: 'reject' });
   // => throws
 ```
@@ -201,7 +202,7 @@ two = Temporal.PlainDateTime.from('1995-12-07T01:24');
 three = Temporal.PlainDateTime.from('2015-12-07T01:24');
 sorted = [one, two, three].sort(Temporal.PlainDateTime.compare);
 sorted.join(' ');
-// => 1995-12-07T01:24 1995-12-07T03:24 2015-12-07T01:24
+// => '1995-12-07T01:24:00 1995-12-07T03:24:00 2015-12-07T01:24:00'
 ```
 
 ## Properties
@@ -268,7 +269,7 @@ Usage examples:
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt.year;        // => 1995
 dt.month;       // => 12
-dt.monthCode;   // => "M12"
+dt.monthCode;   // => 'M12'
 dt.day;         // => 7
 dt.hour;        // => 3
 dt.minute;      // => 24
@@ -277,10 +278,10 @@ dt.millisecond; // => 0
 dt.microsecond; // => 3
 dt.nanosecond;  // => 500
 
-dt = Temporal.PlainDate.from('2019-02-23T03:24:30.000003500[u-ca=hebrew]');
+dt = Temporal.PlainDateTime.from('2019-02-23T03:24:30.000003500[u-ca=hebrew]');
 dt.year;        // => 5779
 dt.month;       // => 6
-dt.monthCode;   // => "M05L"
+dt.monthCode;   // => 'M05L'
 dt.day;         // => 18
 dt.hour;        // => 3
 dt.minute;      // => 24
@@ -307,7 +308,7 @@ Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like t
 ```javascript
 date = Temporal.PlainDateTime.from('-000015-01-01T12:30[u-ca=gregory]');
 date.era;
-// => "bce"
+// => 'bce'
 date.eraYear;
 // => 16
 date.year;
@@ -324,7 +325,7 @@ Usage example:
 
 ```javascript
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
-['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'][dt.dayOfWeek - 1]; // => THU
+['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'][dt.dayOfWeek - 1]; // => 'THU'
 ```
 
 ### datetime.**dayOfYear** : number
@@ -337,7 +338,7 @@ Usage example:
 ```javascript
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 // ISO ordinal date
-console.log(dt.year, dt.dayOfYear); // => 1995 341
+console.log(dt.year, dt.dayOfYear); // => '1995 341'
 ```
 
 ### datetime.**weekOfYear** : number
@@ -352,7 +353,7 @@ Usage example:
 ```javascript
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 // ISO week date
-console.log(dt.year, dt.weekOfYear, dt.dayOfWeek); // => 1995 49 4
+console.log(dt.year, dt.weekOfYear, dt.dayOfWeek); // => '1995 49 4'
 ```
 
 ### datetime.**daysInWeek** : number
@@ -378,7 +379,7 @@ Usage example:
 // Attempt to write some mnemonic poetry
 const monthsByDays = {};
 for (let month = 1; month <= 12; month++) {
-  const dt = Temporal.now.plainDateTime().with({ month });
+  const dt = Temporal.now.plainDateTimeISO().with({ month });
   monthsByDays[dt.daysInMonth] = (monthsByDays[dt.daysInMonth] || []).concat(dt);
 }
 
@@ -399,7 +400,7 @@ For the ISO 8601 calendar, this is 365 or 366, depending on whether the year is 
 Usage example:
 
 ```javascript
-dt = Temporal.now.plainDateTime();
+dt = Temporal.now.plainDateTimeISO();
 percent = dt.dayOfYear / dt.daysInYear;
 `The year is ${percent.toLocaleString('en', { style: 'percent' })} over!`;
 // example output: "The year is 10% over!"
@@ -426,7 +427,7 @@ Usage example:
 
 ```javascript
 // Is this year a leap year?
-dt = Temporal.now.plainDateTime();
+dt = Temporal.now.plainDateTime('iso8601');
 dt.inLeapYear; // example output: true
 // Is 2100 a leap year? (no, because it's divisible by 100 and not 400)
 dt.with({ year: 2100 }).inLeapYear; // => false
@@ -462,7 +463,7 @@ Usage example:
 
 ```javascript
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
-dt.with({ year: 2015, second: 31 }); // => 2015-12-07T03:24:31.000003500
+dt.with({ year: 2015, second: 31 }); // => 2015-12-07T03:24:31.0000035
 ```
 
 ### datetime.**withPlainTime**(_plainTime_?: object | string) : Temporal.PlainDateTime
@@ -538,7 +539,7 @@ dt.add({ hours: 12 }).withPlainDate('2000-06-01'); // => 2000-06-01T15:24:30
 // result contains a non-ISO calendar if present in the input
 dt.withCalendar('japanese').withPlainDate('2008-09-06'); // => 2008-09-06T03:24:30[u-ca=japanese]
 dt.withPlainDate('2017-09-06[u-ca=japanese]'); // => 2017-09-06T03:24:30[u-ca=japanese]
-dt.withCalendar('japanese').withPlainDate('2017-09-06[u-ca=hebrew]'); // => RangeError (calendar conflict)
+/* WRONG */ dt.withCalendar('japanese').withPlainDate('2017-09-06[u-ca=hebrew]'); // => RangeError (calendar conflict)
 ```
 
 ### datetime.**withCalendar**(_calendar_: object | string) : Temporal.PlainDateTime
@@ -555,7 +556,7 @@ Usage example:
 
 ```javascript
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500[u-ca=japanese]');
-dt.withCalendar('iso8601'); // => 1995-12-07T03:24:30.000003500
+dt.withCalendar('iso8601'); // => 1995-12-07T03:24:30.0000035
 ```
 
 ### datetime.**add**(_duration_: Temporal.Duration | object | string, _options_?: object) : Temporal.PlainDateTime
@@ -594,7 +595,7 @@ dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt.add({ years: 20, months: 4, nanoseconds: 500 }); // => 2016-04-07T03:24:30.000004
 
 dt = Temporal.PlainDateTime.from('2019-01-31T15:30');
-dt.add({ months: 1 }); // => 2019-02-28T15:30
+dt.add({ months: 1 }); // => 2019-02-28T15:30:00
 dt.add({ months: 1 }, { overflow: 'reject' }); // => throws
 ```
 
@@ -634,8 +635,8 @@ dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt.subtract({ years: 20, months: 4, nanoseconds: 500 }); // => 1975-08-07T03:24:30.000003
 
 dt = Temporal.PlainDateTime.from('2019-03-31T15:30');
-dt.subtract({ months: 1 }, { overflow: 'constrain' }); // => 2019-02-28T15:30
-dt.subtract({ months: 1 }); // => throws
+dt.subtract({ months: 1 }); // => 2019-02-28T15:30:00
+dt.subtract({ months: 1 }, { overflow: 'reject' }); // => throws
 ```
 
 ### datetime.**until**(_other_: Temporal.PlainDateTime | object | string, _options_?: object) : Temporal.Duration
@@ -693,20 +694,21 @@ Usage example:
 dt1 = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt2 = Temporal.PlainDateTime.from('2019-01-31T15:30');
 dt1.until(dt2);
-  // =>    P8456DT12H5M29.999996500S
+  // => P8456DT12H5M29.9999965S
 dt1.until(dt2, { largestUnit: 'years' });
-  // => P23Y1M24DT12H5M29.999996500S
+  // => P23Y1M24DT12H5M29.9999965S
 dt2.until(dt1, { largestUnit: 'years' });
-  // => -P23Y1M24DT12H5M29.999996500S
+  // => -P23Y1M24DT12H5M29.9999965S
 dt1.until(dt2, { largestUnit: 'nanoseconds' });
-  // =>       PT730641929.999996544S (precision lost)
+  // => PT730641929.999996544S
+  // (precision lost)
 
 // Rounding, for example if you don't care about sub-seconds
 dt1.until(dt2, { smallestUnit: 'seconds' });
   // => P8456DT12H5M29S
 
 // Months and years can be different lengths
-[jan1, feb1, mar1] = [1, 2, 3].map((month) =>
+let [jan1, feb1, mar1] = [1, 2, 3].map((month) =>
   Temporal.PlainDateTime.from({ year: 2020, month, day: 1 }));
 jan1.until(feb1);                            // => P31D
 jan1.until(feb1, { largestUnit: 'months' }); // => P1M
@@ -749,7 +751,7 @@ Usage example:
 ```javascript
 dt1 = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt2 = Temporal.PlainDateTime.from('2019-01-31T15:30');
-dt2.since(dt1); // => P8456DT12H5M29.999996500S
+dt2.since(dt1); // => P8456DT12H5M29.9999965S
 ```
 
 ### datetime.**round**(_options_: object) : Temporal.PlainDateTime
@@ -799,13 +801,13 @@ Example usage:
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 
 // Round to a particular unit
-dt.round({ smallestUnit: 'hour' }); // => 1995-12-07T03:00
+dt.round({ smallestUnit: 'hour' }); // => 1995-12-07T03:00:00
 // Round to an increment of a unit, e.g. half an hour:
 dt.round({ roundingIncrement: 30, smallestUnit: 'minute' });
-  // => 1995-12-07T03:30
+  // => 1995-12-07T03:30:00
 // Round to the same increment but round down instead:
 dt.round({ roundingIncrement: 30, smallestUnit: 'minute', roundingMode: 'floor' });
-  // => 1995-12-07T03:00
+  // => 1995-12-07T03:00:00
 ```
 <!-- prettier-ignore-end -->
 
@@ -885,13 +887,13 @@ dt = Temporal.PlainDateTime.from({
   microsecond: 999,
   nanosecond: 999
 });
-dt.toString(); // => 1999-12-31T23:59:59.999999999
+dt.toString(); // => '1999-12-31T23:59:59.999999999'
 
-dt.toString({ smallestUnit: 'minute' });    // => 1999-12-31T23:59
-dt.toString({ fractionalSecondDigits: 0 }); // => 1999-12-31T23:59:59
-dt.toString({ fractionalSecondDigits: 4 }); // => 1999-12-31T23:59:59.9999
+dt.toString({ smallestUnit: 'minute' });    // => '1999-12-31T23:59'
+dt.toString({ fractionalSecondDigits: 0 }); // => '1999-12-31T23:59:59'
+dt.toString({ fractionalSecondDigits: 4 }); // => '1999-12-31T23:59:59.9999'
 dt.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' });
-// => 2000-01-01T00:00:00.00000000
+// => '2000-01-01T00:00:00.00000000'
 ```
 <!-- prettier-ignore-end -->
 
@@ -916,10 +918,10 @@ Example usage:
 
 ```js
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
-dt.toLocaleString(); // => example output: 1995-12-07, 3:24:30 a.m.
-dt.toLocaleString('de-DE'); // => example output: 7.12.1995, 03:24:30
-dt.toLocaleString('de-DE', { timeZone: 'Europe/Berlin', weekday: 'long' }); // => Donnerstag
-dt.toLocaleString('en-US-u-nu-fullwide-hc-h12'); // => １２/７/１９９５, ３:２４:３０ AM
+dt.toLocaleString(); // example output: 1995-12-07, 3:24:30 a.m.
+dt.toLocaleString('de-DE'); // example output: 7.12.1995, 03:24:30
+dt.toLocaleString('de-DE', { timeZone: 'Europe/Berlin', weekday: 'long' }); // => 'Donnerstag'
+dt.toLocaleString('en-US-u-nu-fullwide-hc-h12'); // => '１２/７/１９９５, ３:２４:３０ AM'
 ```
 
 ### datetime.**toJSON**() : string
@@ -1027,7 +1029,7 @@ dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt.toPlainDate(); // => 1995-12-07
 dt.toPlainYearMonth(); // => 1995-12
 dt.toPlainMonthDay(); // => 12-07
-dt.toPlainTime(); // => 03:24:30.000003500
+dt.toPlainTime(); // => 03:24:30.0000035
 ```
 
 ### datetime.**getISOFields**(): { isoYear: number, isoMonth: number, isoDay: number, isoHour: number, isoMinute: number, isoSecond: number, isoMillisecond: number, isoMicrosecond: number, isoNanosecond: number, calendar: object }

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -95,35 +95,37 @@ md = Temporal.PlainMonthDay.from('2006-08-24T15:43:27'); // => 08-24
 md = Temporal.PlainMonthDay.from('2006-08-24T15:43:27Z'); // => 08-24
 md = Temporal.PlainMonthDay.from('2006-08-24T15:43:27+01:00[Europe/Brussels]');
 // => 08-24
-md === Temporal.PlainMonthDay.from(md); // => true
+md === Temporal.PlainMonthDay.from(md); // => false
 
 md = Temporal.PlainMonthDay.from({ monthCode: 'M08', day: 24 }); // => 08-24
 md = Temporal.PlainMonthDay.from(Temporal.PlainDate.from('2006-08-24'));
-// => same as above; Temporal.PlainDate has month and day properties
+// => 08-24
+// (same as above; Temporal.PlainDate has month and day properties)
 
 // Different overflow modes
 md = Temporal.PlainMonthDay.from({ month: 13, day: 1, year: 2000 }, { overflow: 'constrain' });
 // => 12-01
-md = Temporal.PlainMonthDay.from({ month: -1, day: 1, year: 2000 }, { overflow: 'constrain' });
-// => 01-01
+md = Temporal.PlainMonthDay.from({ month: 1, day: 32, year: 2000 }, { overflow: 'constrain' });
+// => 01-31
 md = Temporal.PlainMonthDay.from({ month: 13, day: 1, year: 2000 }, { overflow: 'reject' });
-// throws
-md = Temporal.PlainMonthDay.from({ month: -1, day: 1, year: 2000 }, { overflow: 'reject' });
-// throws
+// => throws
+md = Temporal.PlainMonthDay.from({ month: 1, day: 32, year: 2000 }, { overflow: 'reject' });
+// => throws
 md = Temporal.PlainMonthDay.from({ month: 2, day: 29, year: 2001 }, { overflow: 'reject' });
-// throws (this year is not a leap year in the ISO calendar)
+// => throws (this year is not a leap year in the ISO calendar)
 
 // non-ISO calendars
 md = Temporal.PlainMonthDay.from({ monthCode: 'M05L', day: 15, calendar: 'hebrew' });
-// => 2019-02-20[u-ca=hebrew]
+// => 1970-02-21[u-ca=hebrew]
 md = Temporal.PlainMonthDay.from({ month: 6, day: 15, year: 5779, calendar: 'hebrew' });
-// => 2019-02-20[u-ca=hebrew]
-md = Temporal.PlainMonthDay.from({ month: 6, day: 15, calendar: 'hebrew' });
+// => 1970-02-21[u-ca=hebrew]
+/* WRONG */ md = Temporal.PlainMonthDay.from({ month: 6, day: 15, calendar: 'hebrew' });
 // => throws (either year or monthCode is required)
 md = Temporal.PlainMonthDay.from('2019-02-20[u-ca=hebrew]');
-md.monthCode; // => "M05L"
+md.monthCode; // => 'M05L'
 md.day; // => 15
-md.month; // undefined (month property is not present in this type; use monthCode instead)
+md.month; // undefined
+// (month property is not present in this type; use monthCode instead)
 ```
 
 ## Properties
@@ -147,14 +149,16 @@ Usage examples:
 
 ```javascript
 md = Temporal.PlainMonthDay.from('08-24');
-md.monthCode; // => "M08"
+md.monthCode; // => 'M08'
 md.day; // => 24
-md.month; // undefined (no `month` property; use `monthCode` instead)
+md.month; // => undefined
+// (no `month` property; use `monthCode` instead)
 
 md = Temporal.PlainMonthDay.from('2019-02-20[u-ca=hebrew]');
-md.monthCode; // => "M05L"
+md.monthCode; // => 'M05L'
 md.day; // => 15
-md.month; // undefined (no `month` property; use `monthCode` instead)
+md.month; // => undefined
+// (no `month` property; use `monthCode` instead)
 ```
 
 ### monthDay.**calendar** : object
@@ -254,7 +258,7 @@ Example usage:
 
 ```js
 md = Temporal.PlainMonthDay.from('08-24');
-md.toString(); // => 08-24
+md.toString(); // => '08-24'
 ```
 
 ### monthDay.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
@@ -286,15 +290,16 @@ monthDay.toLocaleString();
 Example usage:
 
 ```js
+let calendar;
 ({ calendar } = new Intl.DateTimeFormat().resolvedOptions());
 md = Temporal.PlainMonthDay.from({ monthCode: 'M08', day: 24, calendar });
-md.toLocaleString(); // => example output: 08-24
+md.toLocaleString(); // example output: '8/24'
 // Same as above, but explicitly specifying the calendar:
-md.toLocaleString(undefined, { calendar });
+md.toLocaleString(undefined, { calendar }); // example output: '8/24'
 
-md.toLocaleString('de-DE', { calendar }); // => example output: 24.8.
-md.toLocaleString('de-DE', { month: 'long', day: 'numeric', calendar }); // => 24. August
-md.toLocaleString(`en-US-u-nu-fullwide-u-ca-${calendar}`); // => ８/２４
+md.toLocaleString('de-DE', { calendar }); // => '24.8.'
+md.toLocaleString('de-DE', { month: 'long', day: 'numeric', calendar }); // => '24. August'
+md.toLocaleString(`en-US-u-nu-fullwide-ca-${calendar}`); // => '８/２４'
 ```
 
 ### monthDay.**toJSON**() : string
@@ -370,7 +375,7 @@ md = Temporal.PlainMonthDay.from({
   day: 1
 });
 
-date = md.toPlainDate({ era: 'reiwa', eraYear: 2 });
+date = md.toPlainDate({ era: 'reiwa', eraYear: 2 }); // => 2020-01-01[u-ca=japanese]
 ```
 
 ### monthDay.**getISOFields**(): { isoYear: number, isoMonth: number, isoDay: number, calendar: object }

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -37,7 +37,7 @@ Usage examples:
 
 ```javascript
 // Leet hour
-time = new Temporal.PlainTime(13, 37); // => 13:37
+time = new Temporal.PlainTime(13, 37); // => 13:37:00
 ```
 
 ## Static methods
@@ -85,8 +85,9 @@ time = Temporal.PlainTime.from('03:24:30'); // => 03:24:30
 time = Temporal.PlainTime.from('1995-12-07T03:24:30'); // => 03:24:30
 time = Temporal.PlainTime.from('1995-12-07T03:24:30Z'); // => 03:24:30
 time = Temporal.PlainTime.from('1995-12-07T03:24:30+01:00[Europe/Brussels]');
-  // => same as above; time zone is ignored
-time === Temporal.PlainTime.from(time); // => true
+  // => 03:24:30
+  // (same as above; time zone is ignored)
+time === Temporal.PlainTime.from(time); // => false
 
 time = Temporal.PlainTime.from({
   hour: 19,
@@ -98,17 +99,18 @@ time = Temporal.PlainTime.from({
 }); // => 19:39:09.068346205
 time = Temporal.PlainTime.from({ hour: 19, minute: 39, second: 9 }); // => 19:39:09
 time = Temporal.PlainTime.from(Temporal.PlainDateTime.from('2020-02-15T19:39:09'));
-  // => same as above; Temporal.PlainDateTime has hour, minute, etc. properties
+  // => 19:39:09
+  // (same as above; Temporal.PlainDateTime has hour, minute, etc. properties)
 
 // Different overflow modes
 time = Temporal.PlainTime.from({ hour: 15, minute: 60 }, { overflow: 'constrain' });
-  // => 15:59
+  // => 15:59:00
 time = Temporal.PlainTime.from({ hour: 15, minute: -1 }, { overflow: 'constrain' });
-  // => 15:00
+  // => 15:00:00
 time = Temporal.PlainTime.from({ hour: 15, minute: 60 }, { overflow: 'reject' });
-  // throws
+  // => throws
 time = Temporal.PlainTime.from({ hour: 15, minute: -1 }, { overflow: 'reject' });
-  // throws
+  // => throws
 ```
 <!-- prettier-ignore-end -->
 
@@ -138,7 +140,7 @@ one = Temporal.PlainTime.from('03:24');
 two = Temporal.PlainTime.from('01:24');
 three = Temporal.PlainTime.from('01:24:05');
 sorted = [one, two, three].sort(Temporal.PlainTime.compare);
-sorted.join(' '); // => 01:24 01:24:05 03:24
+sorted.join(' '); // => '01:24:00 01:24:05 03:24:00'
 ```
 
 ## Properties
@@ -208,7 +210,7 @@ time.add({ hours: 1 }).with({
   millisecond: 0,
   microsecond: 0,
   nanosecond: 0
-}); // => 20:00
+}); // => 20:00:00
 ```
 
 ### time.**add**(_duration_: Temporal.Duration | object | string) : Temporal.PlainTime
@@ -392,13 +394,13 @@ Example usage:
 time = Temporal.PlainTime.from('19:39:09.068346205');
 
 // Round to a particular unit
-time.round({ smallestUnit: 'hour' }); // => 20:00
+time.round({ smallestUnit: 'hour' }); // => 20:00:00
 // Round to an increment of a unit, e.g. half an hour:
 time.round({ roundingIncrement: 30, smallestUnit: 'minute' });
-  // => 19:30
+  // => 19:30:00
 // Round to the same increment but round up instead:
 time.round({ roundingIncrement: 30, smallestUnit: 'minute', roundingMode: 'ceil' });
-  // => 20:00
+  // => 20:00:00
 ```
 <!-- prettier-ignore-end -->
 
@@ -459,13 +461,13 @@ Example usage:
 <!-- prettier-ignore-start -->
 ```js
 time = Temporal.PlainTime.from('19:39:09.068346205');
-time.toString(); // => 19:39:09.068346205
+time.toString(); // => '19:39:09.068346205'
 
-time.toString({ smallestUnit: 'minute' }); // => 19:39
-time.toString({ fractionalSecondDigits: 0 }); // => 19:39:09
-time.toString({ fractionalSecondDigits: 4 }); // => 19:39:09.0683
+time.toString({ smallestUnit: 'minute' }); // => '19:39'
+time.toString({ fractionalSecondDigits: 0 }); // => '19:39:09'
+time.toString({ fractionalSecondDigits: 4 }); // => '19:39:09.0683'
 time.toString({ fractionalSecondDigits: 5, roundingMode: 'halfExpand' });
-  // => 19:39:09.06835
+  // => '19:39:09.06835'
 ```
 <!-- prettier-ignore-end -->
 
@@ -488,10 +490,10 @@ Example usage:
 
 ```js
 time = Temporal.PlainTime.from('19:39:09.068346205');
-time.toLocaleString(); // => example output: 7:39:09 p.m.
-time.toLocaleString('de-DE'); // => example output: 19:39:09
-time.toLocaleString('de-DE', { timeZone: 'Europe/Berlin' }); // => 19:39:09
-time.toLocaleString('en-US-u-nu-fullwide-hc-h24'); // => １９:３９:０９
+time.toLocaleString(); // example output: '7:39:09 PM'
+time.toLocaleString('de-DE'); // example output: '19:39:09'
+time.toLocaleString('de-DE', { timeZone: 'Europe/Berlin' }); // => '19:39:09'
+time.toLocaleString('en-US-u-nu-fullwide-hc-h24'); // => '１９:３９:０９'
 ```
 
 ### time.**toJSON**() : string

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -97,21 +97,18 @@ ym = Temporal.PlainYearMonth.from('2019-06-24T15:43:27'); // => 2019-06
 ym = Temporal.PlainYearMonth.from('2019-06-24T15:43:27Z'); // => 2019-06
 ym = Temporal.PlainYearMonth.from('2019-06-24T15:43:27+01:00[Europe/Brussels]');
   // => 2019-06
-ym === Temporal.PlainYearMonth.from(ym); // => true
+ym === Temporal.PlainYearMonth.from(ym); // => false
 
 ym = Temporal.PlainYearMonth.from({ year: 2019, month: 6 }); // => 2019-06
 ym = Temporal.PlainYearMonth.from(Temporal.PlainDate.from('2019-06-24'));
-  // => same as above; Temporal.PlainDate has year and month properties
+  // => 2019-06
+  // (same as above; Temporal.PlainDate has year and month properties)
 
 // Different overflow modes
 ym = Temporal.PlainYearMonth.from({ year: 2001, month: 13 }, { overflow: 'constrain' });
   // => 2001-12
-ym = Temporal.PlainYearMonth.from({ year: 2001, month: -1 }, { overflow: 'constrain' });
-  // => 2001-01
 ym = Temporal.PlainYearMonth.from({ year: 2001, month: 13 }, { overflow: 'reject' });
-  // throws
-ym = Temporal.PlainYearMonth.from({ year: 2001, month: -1 }, { overflow: 'reject' });
-  // throws
+  // => throws
 ```
 <!-- prettier-ignore-end -->
 
@@ -144,7 +141,7 @@ one = Temporal.PlainYearMonth.from('2006-08');
 two = Temporal.PlainYearMonth.from('2015-07');
 three = Temporal.PlainYearMonth.from('1930-02');
 sorted = [one, two, three].sort(Temporal.PlainYearMonth.compare);
-sorted.join(' '); // => 1930-02 2006-08 2015-07
+sorted.join(' '); // => '1930-02 2006-08 2015-07'
 ```
 
 ## Properties
@@ -179,13 +176,12 @@ Usage examples:
 ym = Temporal.PlainYearMonth.from('2019-06');
 ym.year; // => 2019
 ym.month; // => 6
-ym.monthCode; // => "M06"
+ym.monthCode; // => 'M06'
 
 ym = Temporal.PlainYearMonth.from('2019-02-23[u-ca=hebrew]');
 ym.year; // => 5779
 ym.month; // => 6
-ym.monthCode; // => "M05L"
-ym.day; // => 18
+ym.monthCode; // => 'M05L'
 ```
 
 ### yearMonth.**calendar** : object
@@ -204,7 +200,7 @@ Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like t
 ```javascript
 ym = Temporal.PlainYearMonth.from('-000015-01-01[u-ca=gregory]');
 ym.era;
-// => "bce"
+// => 'bce'
 ym.eraYear;
 // => 16
 ym.year;
@@ -222,11 +218,11 @@ Usage example:
 // Attempt to write some mnemonic poetry
 const monthsByDays = {};
 for (let month = 1; month <= 12; month++) {
-  const ym = Temporal.PlainYearMonth.from({ year: 2020, month });
+  const ym = Temporal.PlainYearMonth.from({ year: 2020, calendar: 'iso8601', month });
   monthsByDays[ym.daysInMonth] = (monthsByDays[ym.daysInMonth] || []).concat(ym);
 }
 
-const strings = monthsByDays[30].map((ym) => ym.toLocaleString('en', { month: 'long' }));
+const strings = monthsByDays[30].map((ym) => ym.toLocaleString('en', { month: 'long', calendar: 'iso8601' }));
 // Shuffle to improve poem as determined empirically
 strings.unshift(strings.pop());
 const format = new Intl.ListFormat('en');
@@ -244,10 +240,10 @@ Usage example:
 
 <!-- prettier-ignore-start -->
 ```javascript
-ym = Temporal.PlainYearMonth.from('2019-06');
+ym = Temporal.PlainYearMonth.from({ year: 2019, month: 6, calendar: 'iso8601' });
 percent = ym.daysInMonth / ym.daysInYear;
-`${ym.toLocaleString('en', {month: 'long', year: 'numeric'})} was ${percent.toLocaleString('en', {style: 'percent'})} of the year!`
-  // => example output: "June 2019 was 8% of the year!"
+`${ym.toLocaleString('en', {month: 'long', year: 'numeric', calendar: 'iso8601' })} was ${percent.toLocaleString('en', {style: 'percent'})} of the year!`
+  // => 'June 2019 was 8% of the year!'
 ```
 <!-- prettier-ignore-end -->
 
@@ -259,7 +255,7 @@ For the ISO 8601 calendar, this is always 12, but in other calendar systems it m
 Usage example:
 
 ```javascript
-ym = Temporal.PlainDate.from('1900-01');
+ym = Temporal.PlainYearMonth.from('1900-01');
 ym.monthsInYear; // => 12
 ```
 
@@ -526,7 +522,7 @@ Example usage:
 
 ```js
 ym = Temporal.PlainYearMonth.from('2019-06');
-ym.toString(); // => 2019-06
+ym.toString(); // => '2019-06'
 ```
 
 ### yearMonth.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string
@@ -560,13 +556,13 @@ Example usage:
 ```js
 ({ calendar } = new Intl.DateTimeFormat().resolvedOptions());
 ym = Temporal.PlainYearMonth.from({ year: 2019, month: 6, calendar });
-ym.toLocaleString(); // => example output: 2019-06
+ym.toLocaleString(); // example output: '6/2019'
 // Same as above, but explicitly specifying the calendar:
 ym.toLocaleString(undefined, { calendar });
 
-ym.toLocaleString('de-DE', { calendar }); // => example output: 6.2019
-ym.toLocaleString('de-DE', { month: 'long', year: 'numeric', calendar }); // => Juni 2019
-ym.toLocaleString(`en-US-u-nu-fullwide-u-ca-${calendar}`); // => ６/２０１９
+ym.toLocaleString('de-DE', { calendar }); // example output: '6.2019'
+ym.toLocaleString('de-DE', { month: 'long', year: 'numeric', calendar }); // => 'Juni 2019'
+ym.toLocaleString(`en-US-u-nu-fullwide-ca-${calendar}`); // => '６/２０１９'
 ```
 
 ### yearMonth.**toJSON**() : string

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -63,7 +63,7 @@ tz = new Temporal.TimeZone('america/VANCOUVER');
 tz = new Temporal.TimeZone('Asia/Katmandu'); // alias of Asia/Kathmandu
 tz = new Temporal.TimeZone('-04:00');
 tz = new Temporal.TimeZone('+0645');
-/* WRONG */ tz = new Temporal.TimeZone('local'); // not a time zone, throws
+/* WRONG */ tz = new Temporal.TimeZone('local'); // => throws, not a time zone
 ```
 
 #### Difference between IANA time zones and UTC offsets
@@ -76,8 +76,8 @@ For example:
 tz1 = new Temporal.TimeZone('-08:00');
 tz2 = new Temporal.TimeZone('America/Vancouver');
 inst = Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: tz2 }).toInstant();
+tz2.getPreviousTransition(inst); // => 2019-11-03T09:00:00Z
 tz1.getNextTransition(inst); // => null
-tz2.getPreviousTransition(inst); // => 2020-03-08T10:00Z
 ```
 
 ## Static methods
@@ -122,9 +122,9 @@ tz = Temporal.TimeZone.from('2020-01-13T16:31:00.065858086-08:00[America/Vancouv
 // Existing TimeZone object
 tz2 = Temporal.TimeZone.from(tz);
 
-/* WRONG */ tz = Temporal.TimeZone.from('local'); // not a time zone, throws
-/* WRONG */ tz = Temporal.TimeZone.from('2020-01-14T00:31:00'); // ISO 8601 string without time zone offset part, throws
-/* WRONG */ tz = Temporal.TimeZone.from('-08:00[America/Vancouver]'); // ISO 8601 string without date-time part, throws
+/* WRONG */ tz = Temporal.TimeZone.from('local'); // => throws, not a time zone
+/* WRONG */ tz = Temporal.TimeZone.from('2020-01-14T00:31:00'); // => throws, ISO 8601 string without time zone offset part
+/* WRONG */ tz = Temporal.TimeZone.from('-08:00[America/Vancouver]'); // => throws, ISO 8601 string without date-time part
 ```
 
 ## Properties
@@ -196,11 +196,11 @@ Example usage:
 // Getting the UTC offset for a time zone at a particular time
 timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
 tz = Temporal.TimeZone.from('Europe/Berlin');
-tz.getOffsetStringFor(timestamp); // => +01:00
+tz.getOffsetStringFor(timestamp); // => '+01:00'
 
 // TimeZone with a fixed UTC offset
 tz = Temporal.TimeZone.from('-08:00');
-tz.getOffsetStringFor(timestamp); // => -08:00
+tz.getOffsetStringFor(timestamp); // => '-08:00'
 ```
 
 ### timeZone.**getPlainDateTimeFor**(_instant_: Temporal.Instant | string, _calendar_?: object | string) : Temporal.PlainDateTime
@@ -225,12 +225,12 @@ Example usage:
 // Converting an exact time to a calendar date / wall-clock time
 timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
 tz = Temporal.TimeZone.from('Europe/Berlin');
-tz.getPlainDateTimeFor(timestamp); // => 2019-03-31T01:45
+tz.getPlainDateTimeFor(timestamp); // => 2019-03-31T01:45:00
 
 // What time was the Unix Epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA)?
 epoch = Temporal.Instant.fromEpochSeconds(0);
 tz = Temporal.TimeZone.from('America/New_York');
-tz.getPlainDateTimeFor(epoch); // => 1969-12-31T19:00
+tz.getPlainDateTimeFor(epoch); // => 1969-12-31T19:00:00
 ```
 
 ### timeZone.**getInstantFor**(_dateTime_: Temporal.PlainDateTime | object | string, _options_?: object) : Temporal.Instant

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -126,7 +126,7 @@ export class PlainMonthDay {
     let fields = ES.ToTemporalMonthDayFields(this, receiverFieldNames);
 
     const inputFieldNames = ES.CalendarFields(calendar, ['year']);
-    const inputEntries = [['year']];
+    const inputEntries = [['year', undefined]];
     // Add extra fields from the calendar at the end
     inputFieldNames.forEach((fieldName) => {
       if (!inputEntries.some(([name]) => name === fieldName)) {


### PR DESCRIPTION
Running all the code samples in the docs through a tolerant markdown snippet parser + execution environment revealed many errors. #1395, #1391, #1380, and this patch's one-line fix in plainmonthday.mjs were all bugs revealed by the documentation code samples. Many of the changes in this patch are slight syntactic changes to make the samples testable and more clear.

Common classes of smaller issues fixed:
- Examples did not include seconds in string representations
- Examples contained extra zeroes of precision when not requested
- Old calling conventions used; arguments needed to be changed
- Some options bags are now used in dedicated places rather than alongside other methods

Though the documentation tester I wrote isn't included in this patch, because it's messy, one-off, and would be needless work to maintain for auditing every pull request, I'll keep it around for periodic audits of the documentation.

Fixes #921 .