### PR TITLE
Remove all references to immutability.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Temporal fixes these problems by:
 
 - Providing easy-to-use APIs for date and time computations
 - First-class support for all time zones, including DST-safe arithmetic
-- Dealing only with immutable objects
+- Dealing only with objects representing fixed dates and times
 - Parsing a strictly specified string format
 - Supporting non-Gregorian calendars
 

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -5,7 +5,7 @@
 <!-- toc -->
 </details>
 
-A `Temporal.Duration` represents an immutable duration of time which can be used in date/time arithmetic.
+A `Temporal.Duration` represents a duration of time which can be used in date/time arithmetic.
 
 `Temporal.Duration` can be constructed directly or returned from `Temporal.Duration.from()`.
 It can also be obtained from the `since()` method of any other `Temporal` type that supports arithmetic, and is used in those types' `add()` and `subtract()` methods.
@@ -230,7 +230,7 @@ d.blank; // => true
 
 This method creates a new `Temporal.Duration` which is a copy of `duration`, but any properties present on `durationLike` override the ones already present on `duration`.
 
-Since `Temporal.Duration` objects are immutable, use this method instead of modifying one.
+Since `Temporal.Duration` objects each represent a fixed duration, use this method instead of modifying one.
 
 All non-zero properties of `durationLike` must have the same sign, and they must additionally have the same sign as the non-zero properties of `duration`, unless they override all of these non-zero properties.
 If a property of `durationLike` is infinity, then this function will throw a `RangeError`.

--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -351,7 +351,7 @@ date.with({ year: 2100 }).inLeapYear; // => false
 
 This method creates a new `Temporal.PlainDate` which is a copy of `date`, but any properties present on `dateLike` override the ones already present on `date`.
 
-Since `Temporal.PlainDate` objects are immutable, use this method instead of modifying one.
+Since `Temporal.PlainDate` objects each represent a fixed date, use this method instead of modifying one.
 
 If the result is earlier or later than the range of dates that `Temporal.PlainDate` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
 

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -449,7 +449,7 @@ dt.with({ year: 2100 }).inLeapYear; // => false
 
 This method creates a new `Temporal.PlainDateTime` which is a copy of `datetime`, but any properties present on `dateTimeLike` override the ones already present on `datetime`.
 
-Since `Temporal.PlainDateTime` objects are immutable, use this method instead of modifying one.
+Since `Temporal.PlainDateTime` objects each represent a fixed date and time, use this method instead of modifying one.
 
 If the result is earlier or later than the range of dates that `Temporal.PlainDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
 

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -191,7 +191,7 @@ The `overflow` option tells what should happen when out-of-range values are give
 
 > **NOTE**: The allowed values for the `monthDayLike.month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
-Since `Temporal.PlainMonthDay` objects are immutable, use this method instead of modifying one.
+Since `Temporal.PlainMonthDay` objects each represent a fixed month and day, use this method instead of modifying one.
 
 > **NOTE**: `calendar` and `timeZone` properties are not allowed on `monthDayLike`.
 > It is not possible to convert a `Temporal.PlainMonthDay` to another calendar system without knowing the year.

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -192,7 +192,7 @@ The value of the `calendar` read-only property is always the ISO 8601 calendar, 
 
 This method creates a new `Temporal.PlainTime` which is a copy of `time`, but any properties present on `timeLike` override the ones already present on `time`.
 
-Since `Temporal.PlainTime` objects are immutable, use this method instead of modifying one.
+Since `Temporal.PlainTime` objects each represent a fixed time, use this method instead of modifying one.
 
 > **NOTE**: `calendar` and `timeZone` properties are not allowed on `timeLike`.
 > See the `toPlainDateTime` and `toZonedDateTime` methods instead.

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -295,7 +295,7 @@ ym.with({ year: 2100 }).inLeapYear; // => false
 
 This method creates a new `Temporal.PlainYearMonth` which is a copy of `yearMonth`, but any properties present on `yearMonthLike` override the ones already present on `yearMonth`.
 
-Since `Temporal.PlainYearMonth` objects are immutable, use this method instead of modifying one.
+Since `Temporal.PlainYearMonth` objects each represent a fixed year and month, use this method instead of modifying one.
 
 If the result is earlier or later than the range of dates that `Temporal.PlainYearMonth` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -714,7 +714,7 @@ repeated0130 = daylightTime0130.with({ offset: minus8Hours });
 
 This method creates a new `Temporal.ZonedDateTime` which is a copy of `zonedDateTime`, but any properties present on `zonedDateTimeLike` override the ones already present on `zonedDateTime`.
 
-Since `Temporal.ZonedDateTime` objects are immutable, this method will create a new instance instead of modifying the existing instance.
+Since `Temporal.ZonedDateTime` objects each represent a fixed date and time, this method will create a new instance instead of modifying the existing instance.
 
 If the result is earlier or later than the range of dates that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -3,7 +3,7 @@
 
 <emu-clause id="sec-temporal-calendar-objects">
   <h1>Temporal.Calendar Objects</h1>
-  <p>A Temporal.Calendar object is an immutable Object representing a calendar.</p>
+  <p>A Temporal.Calendar object is an Object representing a calendar.</p>
 
   <emu-clause id="sec-temporal-calendar-abstract-ops">
     <h1>Abstract Operations for Temporal.Calendar Objects</h1>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -3,7 +3,7 @@
 
 <emu-clause id="sec-temporal-instant-objects">
   <h1>Temporal.Instant Objects</h1>
-  <p>A Temporal.Instant object is an immutable Object referencing a point in time with nanoseconds precision.</p>
+  <p>A Temporal.Instant object is an Object referencing a fixed point in time with nanoseconds precision.</p>
 
   <emu-clause id="sec-temporal-instant-constructor">
     <h1>The Temporal.Instant Constructor</h1>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -3,7 +3,7 @@
 
 <emu-clause id="sec-temporal-plaindate-objects">
   <h1>Temporal.PlainDate Objects</h1>
-  <p>A Temporal.PlainDate object is an immutable Object that contains integers corresponding to a
+  <p>A Temporal.PlainDate object is an Object that contains integers corresponding to a
     particular year, month, and day in the ISO8601 calendar, as well as an Object value used to
     interpret those integers in a particular calendar.</p>
 

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -3,7 +3,7 @@
 
 <emu-clause id="sec-temporal-plaindatetime-objects">
   <h1>Temporal.PlainDateTime Objects</h1>
-  <p>A Temporal.PlainDateTime object is an immutable Object that contains integers corresponding to a particular year, month, day, hour, minute, second, millisecond, microsecond, and nanosecond.</p>
+  <p>A Temporal.PlainDateTime object is an Object that contains integers corresponding to a particular year, month, day, hour, minute, second, millisecond, microsecond, and nanosecond.</p>
 
   <emu-clause id="sec-temporal-plaindatetime-constructor">
     <h1>The Temporal.PlainDateTime Constructor</h1>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -3,7 +3,7 @@
 
 <emu-clause id="sec-temporal-plainmonthday-objects">
   <h1>Temporal.PlainMonthDay Objects</h1>
-  <p>A Temporal.PlainMonthDay object is an immutable Object that contains Number values corresponding to a particular year and month.</p>
+  <p>A Temporal.PlainMonthDay object is an Object that contains Number values corresponding to a particular year and month.</p>
 
   <emu-clause id="sec-temporal-plainmonthday-constructor">
     <h1>The Temporal.PlainMonthDay Constructor</h1>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -3,7 +3,7 @@
 
 <emu-clause id="sec-temporal-plaintime-objects">
   <h1>Temporal.PlainTime Objects</h1>
-  <p>A Temporal.PlainTime object is an immutable Object that contains integers corresponding to a particular hour, minute,
+  <p>A Temporal.PlainTime object is an Object that contains integers corresponding to a particular hour, minute,
     second, millisecond, microsecond, and nanosecond.</p>
 
   <emu-clause id="sec-temporal-plaintime-constructor">

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -3,7 +3,7 @@
 
 <emu-clause id="sec-temporal-plainyearmonth-objects">
   <h1>Temporal.PlainYearMonth Objects</h1>
-  <p>A Temporal.PlainYearMonth object is an immutable Object that contains Number values corresponding to a particular year and month.</p>
+  <p>A Temporal.PlainYearMonth object is an Object that contains Number values corresponding to a particular year and month.</p>
 
   <emu-clause id="sec-temporal-plainyearmonth-constructor">
     <h1>The Temporal.PlainYearMonth Constructor</h1>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -3,7 +3,7 @@
 
 <emu-clause id="sec-temporal-timezone-objects">
   <h1>Temporal.TimeZone Objects</h1>
-  <p>A Temporal.TimeZone object is an immutable Object referencing a time zone.</p>
+  <p>A Temporal.TimeZone object is an Object referencing a time zone.</p>
 
   <emu-clause id="sec-time-zone-names">
     <h1>Time Zone Names</h1>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -4,7 +4,7 @@
 <emu-clause id="sec-temporal-zoneddatetime-objects">
   <h1>Temporal.ZonedDateTime Objects</h1>
   <p>
-    A Temporal.ZonedDateTime object is an immutable Object referencing a point in time with nanoseconds precision, and containing Object values corresponding to a particular time zone and calendar system.
+    A Temporal.ZonedDateTime object is an Object referencing a fixed point in time with nanoseconds precision, and containing Object values corresponding to a particular time zone and calendar system.
   </p>
 
   <emu-clause id="sec-temporal-zoneddatetime-constructor">


### PR DESCRIPTION
'Immutable' is not the correct word to describe Temporal JavaScript
objects. Change documentation to refer to Temporal objects representing fixed
moments in time, and strike all uses of immutability from the spec text.

Fixes #1387.