### PR TITLE
Clarify names of abstract operations applying to internal ISO data model

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -357,19 +357,29 @@ export const ES = ObjectAssign({}, ES2020, {
       offset
     } = ES.ParseTemporalInstantString(isoString);
 
-    const epochNs = ES.GetEpochFromParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    const epochNs = ES.GetEpochFromISOParts(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond
+    );
     if (epochNs === null) throw new RangeError('DateTime outside of supported range');
     if (!offset) throw new RangeError('Temporal.Instant requires a time zone offset');
     const offsetNs = ES.ParseOffsetString(offset);
     return epochNs.subtract(offsetNs);
   },
-  RegulateDateTime: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, overflow) => {
+  RegulateISODateTime: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, overflow) => {
     switch (overflow) {
       case 'reject':
         ES.RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
         break;
       case 'constrain':
-        ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.ConstrainDateTime(
+        ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.ConstrainISODateTime(
           year,
           month,
           day,
@@ -384,13 +394,13 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
   },
-  RegulateDate: (year, month, day, overflow) => {
+  RegulateISODate: (year, month, day, overflow) => {
     switch (overflow) {
       case 'reject':
-        ES.RejectDate(year, month, day);
+        ES.RejectISODate(year, month, day);
         break;
       case 'constrain':
-        ({ year, month, day } = ES.ConstrainDate(year, month, day));
+        ({ year, month, day } = ES.ConstrainISODate(year, month, day));
         break;
     }
     return { year, month, day };
@@ -413,14 +423,14 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     return { hour, minute, second, millisecond, microsecond, nanosecond };
   },
-  RegulateYearMonth: (year, month, overflow) => {
+  RegulateISOYearMonth: (year, month, overflow) => {
     const referenceISODay = 1;
     switch (overflow) {
       case 'reject':
-        ES.RejectDate(year, month, referenceISODay);
+        ES.RejectISODate(year, month, referenceISODay);
         break;
       case 'constrain':
-        ({ year, month } = ES.ConstrainDate(year, month));
+        ({ year, month } = ES.ConstrainISODate(year, month));
         break;
     }
     return { year, month };
@@ -894,7 +904,7 @@ export const ES = ObjectAssign({}, ES2020, {
       timeZone = ES.ToTemporalTimeZone(timeZone);
       let offsetNs = null;
       if (offset) offsetNs = ES.ParseOffsetString(ES.ToString(offset));
-      const epochNanoseconds = ES.InterpretTemporalZonedDateTimeOffset(
+      const epochNanoseconds = ES.InterpretISODateTimeOffset(
         year,
         month,
         day,
@@ -1140,7 +1150,7 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     ES.ToTemporalOverflow(options); // validate and ignore
     let { year, month, day, calendar } = ES.ParseTemporalDateString(ES.ToString(item));
-    ES.RejectDate(year, month, day);
+    ES.RejectISODate(year, month, day);
     if (calendar === undefined) calendar = ES.GetISO8601Calendar();
     calendar = ES.ToTemporalCalendar(calendar);
     let result = new constructor(year, month, day, calendar);
@@ -1297,7 +1307,7 @@ export const ES = ObjectAssign({}, ES2020, {
     calendar = ES.ToTemporalCalendar(calendar);
 
     if (referenceISOYear === undefined) {
-      ES.RejectDate(1972, month, day);
+      ES.RejectISODate(1972, month, day);
       const result = new constructor(month, day, calendar);
       if (!ES.IsTemporalMonthDay(result)) throw new TypeError('invalid result');
       return result;
@@ -1357,7 +1367,7 @@ export const ES = ObjectAssign({}, ES2020, {
     calendar = ES.ToTemporalCalendar(calendar);
 
     if (referenceISODay === undefined) {
-      ES.RejectDate(year, month, 1);
+      ES.RejectISODate(year, month, 1);
       const result = new constructor(year, month, calendar);
       if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
       return result;
@@ -1366,7 +1376,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const result = new PlainYearMonth(year, month, calendar, referenceISODay);
     return ES.YearMonthFromFields(calendar, result, constructor, {});
   },
-  InterpretTemporalZonedDateTimeOffset: (
+  InterpretISODateTimeOffset: (
     year,
     month,
     day,
@@ -1396,7 +1406,7 @@ export const ES = ObjectAssign({}, ES2020, {
     // for this timezone and date/time.
     if (offsetOpt === 'use') {
       // Calculate the instant for the input's date/time and offset
-      const epochNs = ES.GetEpochFromParts(
+      const epochNs = ES.GetEpochFromISOParts(
         year,
         month,
         day,
@@ -1479,7 +1489,7 @@ export const ES = ObjectAssign({}, ES2020, {
     if (offset) offsetNs = ES.ParseOffsetString(offset);
     const disambiguation = ES.ToTemporalDisambiguation(options);
     const offsetOpt = ES.ToTemporalOffset(options, 'reject');
-    const epochNanoseconds = ES.InterpretTemporalZonedDateTimeOffset(
+    const epochNanoseconds = ES.InterpretISODateTimeOffset(
       year,
       month,
       day,
@@ -1923,7 +1933,7 @@ export const ES = ObjectAssign({}, ES2020, {
       microsecond,
       nanosecond
     } = ES.GetIANATimeZoneDateTimeParts(epochNanoseconds, id);
-    const utc = ES.GetEpochFromParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    const utc = ES.GetEpochFromISOParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
     if (utc === null) throw new RangeError('Date outside of supported range');
     return +utc.minus(epochNanoseconds);
   },
@@ -1948,7 +1958,7 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     return `${sign}${hourString}:${minuteString}${post}`;
   },
-  GetEpochFromParts: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
+  GetEpochFromISOParts: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
     // Note: Date.UTC() interprets one and two-digit years as being in the
     // 20th century, so don't use it
     const legacyDate = new Date();
@@ -1962,7 +1972,7 @@ export const ES = ObjectAssign({}, ES2020, {
     if (ns.lesser(NS_MIN) || ns.greater(NS_MAX)) return null;
     return ns;
   },
-  GetPartsFromEpoch: (epochNanoseconds) => {
+  GetISOPartsFromEpoch: (epochNanoseconds) => {
     const { quotient, remainder } = bigInt(epochNanoseconds).divmod(1e6);
     let epochMilliseconds = +quotient;
     let nanos = +remainder;
@@ -1985,9 +1995,9 @@ export const ES = ObjectAssign({}, ES2020, {
     return { epochMilliseconds, year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
   },
   GetIANATimeZoneDateTimeParts: (epochNanoseconds, id) => {
-    const { epochMilliseconds, millisecond, microsecond, nanosecond } = ES.GetPartsFromEpoch(epochNanoseconds);
+    const { epochMilliseconds, millisecond, microsecond, nanosecond } = ES.GetISOPartsFromEpoch(epochNanoseconds);
     const { year, month, day, hour, minute, second } = ES.GetFormatterParts(id, epochMilliseconds);
-    return ES.BalanceDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    return ES.BalanceISODateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   },
   GetIANATimeZoneNextTransition: (epochNanoseconds, id) => {
     const uppercap = ES.SystemUTCEpochNanoSeconds() + 366 * DAYMILLIS * 1e6;
@@ -2063,7 +2073,7 @@ export const ES = ObjectAssign({}, ES2020, {
     };
   },
   GetIANATimeZoneEpochValue: (id, year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
-    let ns = ES.GetEpochFromParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    let ns = ES.GetEpochFromISOParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
     if (ns === null) throw new RangeError('DateTime outside of supported range');
     const dayNanos = bigInt(DAYMILLIS).multiply(1e6);
     let nsEarlier = ns.minus(dayNanos);
@@ -2101,7 +2111,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const isDiv400 = year % 400 === 0;
     return isDiv4 && (!isDiv100 || isDiv400);
   },
-  DaysInMonth: (year, month) => {
+  ISODaysInMonth: (year, month) => {
     const DoM = {
       standard: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
       leapyear: [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
@@ -2128,7 +2138,7 @@ export const ES = ObjectAssign({}, ES2020, {
   DayOfYear: (year, month, day) => {
     let days = day;
     for (let m = month - 1; m > 0; m--) {
-      days += ES.DaysInMonth(year, m);
+      days += ES.ISODaysInMonth(year, m);
     }
     return days;
   },
@@ -2161,7 +2171,7 @@ export const ES = ObjectAssign({}, ES2020, {
     return 0;
   },
 
-  BalanceYearMonth: (year, month) => {
+  BalanceISOYearMonth: (year, month) => {
     if (!NumberIsFinite(year) || !NumberIsFinite(month)) throw new RangeError('infinity is out of range');
     month -= 1;
     year += MathFloor(month / 12);
@@ -2170,9 +2180,9 @@ export const ES = ObjectAssign({}, ES2020, {
     month += 1;
     return { year, month };
   },
-  BalanceDate: (year, month, day) => {
+  BalanceISODate: (year, month, day) => {
     if (!NumberIsFinite(day)) throw new RangeError('infinity is out of range');
-    ({ year, month } = ES.BalanceYearMonth(year, month));
+    ({ year, month } = ES.BalanceISOYearMonth(year, month));
     let daysInYear = 0;
     let testYear = month > 2 ? year : year - 1;
     while (((daysInYear = ES.LeapYear(testYear) ? 366 : 365), day < -daysInYear)) {
@@ -2188,17 +2198,17 @@ export const ES = ObjectAssign({}, ES2020, {
     }
 
     while (day < 1) {
-      ({ year, month } = ES.BalanceYearMonth(year, month - 1));
-      day += ES.DaysInMonth(year, month);
+      ({ year, month } = ES.BalanceISOYearMonth(year, month - 1));
+      day += ES.ISODaysInMonth(year, month);
     }
-    while (day > ES.DaysInMonth(year, month)) {
-      day -= ES.DaysInMonth(year, month);
-      ({ year, month } = ES.BalanceYearMonth(year, month + 1));
+    while (day > ES.ISODaysInMonth(year, month)) {
+      day -= ES.ISODaysInMonth(year, month);
+      ({ year, month } = ES.BalanceISOYearMonth(year, month + 1));
     }
 
     return { year, month, day };
   },
-  BalanceDateTime: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
+  BalanceISODateTime: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
     let deltaDays;
     ({ deltaDays, hour, minute, second, millisecond, microsecond, nanosecond } = ES.BalanceTime(
       hour,
@@ -2208,7 +2218,7 @@ export const ES = ObjectAssign({}, ES2020, {
       microsecond,
       nanosecond
     ));
-    ({ year, month, day } = ES.BalanceDate(year, month, day + deltaDays));
+    ({ year, month, day } = ES.BalanceISODate(year, month, day + deltaDays));
     return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
   },
   BalanceTime: (hour, minute, second, millisecond, microsecond, nanosecond) => {
@@ -2275,7 +2285,7 @@ export const ES = ObjectAssign({}, ES2020, {
     // Find the difference in days only.
     const dtStart = ES.GetTemporalDateTimeFor(timeZone, start, calendar);
     const dtEnd = ES.GetTemporalDateTimeFor(timeZone, end, calendar);
-    let { days } = ES.DifferenceDateTime(
+    let { days } = ES.DifferenceISODateTime(
       GetSlot(dtStart, ISO_YEAR),
       GetSlot(dtStart, ISO_MONTH),
       GetSlot(dtStart, ISO_DAY),
@@ -2614,9 +2624,9 @@ export const ES = ObjectAssign({}, ES2020, {
   },
 
   ConstrainToRange: (value, min, max) => MathMin(max, MathMax(min, value)),
-  ConstrainDate: (year, month, day) => {
+  ConstrainISODate: (year, month, day) => {
     month = ES.ConstrainToRange(month, 1, 12);
-    day = ES.ConstrainToRange(day, 1, ES.DaysInMonth(year, month));
+    day = ES.ConstrainToRange(day, 1, ES.ISODaysInMonth(year, month));
     return { year, month, day };
   },
   ConstrainTime: (hour, minute, second, millisecond, microsecond, nanosecond) => {
@@ -2628,8 +2638,8 @@ export const ES = ObjectAssign({}, ES2020, {
     nanosecond = ES.ConstrainToRange(nanosecond, 0, 999);
     return { hour, minute, second, millisecond, microsecond, nanosecond };
   },
-  ConstrainDateTime: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
-    ({ year, month, day } = ES.ConstrainDate(year, month, day));
+  ConstrainISODateTime: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
+    ({ year, month, day } = ES.ConstrainISODate(year, month, day));
     ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.ConstrainTime(
       hour,
       minute,
@@ -2644,9 +2654,9 @@ export const ES = ObjectAssign({}, ES2020, {
   RejectToRange: (value, min, max) => {
     if (value < min || value > max) throw new RangeError(`value out of range: ${min} <= ${value} <= ${max}`);
   },
-  RejectDate: (year, month, day) => {
+  RejectISODate: (year, month, day) => {
     ES.RejectToRange(month, 1, 12);
-    ES.RejectToRange(day, 1, ES.DaysInMonth(year, month));
+    ES.RejectToRange(day, 1, ES.ISODaysInMonth(year, month));
   },
   RejectDateRange: (year, month, day) => {
     // Noon avoids trouble at edges of DateTime range (excludes midnight)
@@ -2661,7 +2671,7 @@ export const ES = ObjectAssign({}, ES2020, {
     ES.RejectToRange(nanosecond, 0, 999);
   },
   RejectDateTime: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
-    ES.RejectDate(year, month, day);
+    ES.RejectISODate(year, month, day);
     ES.RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
   },
   RejectDateTimeRange: (year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
@@ -2670,10 +2680,20 @@ export const ES = ObjectAssign({}, ES2020, {
     if (
       (year === YEAR_MIN &&
         null ==
-          ES.GetEpochFromParts(year, month, day + 1, hour, minute, second, millisecond, microsecond, nanosecond - 1)) ||
+          ES.GetEpochFromISOParts(
+            year,
+            month,
+            day + 1,
+            hour,
+            minute,
+            second,
+            millisecond,
+            microsecond,
+            nanosecond - 1
+          )) ||
       (year === YEAR_MAX &&
         null ==
-          ES.GetEpochFromParts(year, month, day - 1, hour, minute, second, millisecond, microsecond, nanosecond + 1))
+          ES.GetEpochFromISOParts(year, month, day - 1, hour, minute, second, millisecond, microsecond, nanosecond + 1))
     ) {
       throw new RangeError('DateTime outside of supported range');
     }
@@ -2707,19 +2727,19 @@ export const ES = ObjectAssign({}, ES2020, {
     }
   },
 
-  DifferenceDate: (y1, m1, d1, y2, m2, d2, largestUnit = 'days') => {
+  DifferenceISODate: (y1, m1, d1, y2, m2, d2, largestUnit = 'days') => {
     switch (largestUnit) {
       case 'years':
       case 'months': {
-        const sign = -ES.CompareTemporalDate(y1, m1, d1, y2, m2, d2);
+        const sign = -ES.CompareISODate(y1, m1, d1, y2, m2, d2);
         if (sign === 0) return { years: 0, months: 0, weeks: 0, days: 0 };
 
         const start = { year: y1, month: m1, day: d1 };
         const end = { year: y2, month: m2, day: d2 };
 
         let years = end.year - start.year;
-        let mid = ES.AddDate(y1, m1, d1, years, 0, 0, 0, 'constrain');
-        let midSign = -ES.CompareTemporalDate(mid.year, mid.month, mid.day, y2, m2, d2);
+        let mid = ES.AddISODate(y1, m1, d1, years, 0, 0, 0, 'constrain');
+        let midSign = -ES.CompareISODate(mid.year, mid.month, mid.day, y2, m2, d2);
         if (midSign === 0) {
           return largestUnit === 'years'
             ? { years, months: 0, weeks: 0, days: 0 }
@@ -2730,8 +2750,8 @@ export const ES = ObjectAssign({}, ES2020, {
           years -= sign;
           months += sign * 12;
         }
-        mid = ES.AddDate(y1, m1, d1, years, months, 0, 0, 'constrain');
-        midSign = -ES.CompareTemporalDate(mid.year, mid.month, mid.day, y2, m2, d2);
+        mid = ES.AddISODate(y1, m1, d1, years, months, 0, 0, 'constrain');
+        midSign = -ES.CompareISODate(mid.year, mid.month, mid.day, y2, m2, d2);
         if (midSign === 0) {
           return largestUnit === 'years'
             ? { years, months, weeks: 0, days: 0 }
@@ -2745,8 +2765,8 @@ export const ES = ObjectAssign({}, ES2020, {
             years -= sign;
             months = 11 * sign;
           }
-          mid = ES.AddDate(y1, m1, d1, years, months, 0, 0, 'constrain');
-          midSign = -ES.CompareTemporalDate(y1, m1, d1, mid.year, mid.month, mid.day);
+          mid = ES.AddISODate(y1, m1, d1, years, months, 0, 0, 'constrain');
+          midSign = -ES.CompareISODate(y1, m1, d1, mid.year, mid.month, mid.day);
         }
 
         let days = 0;
@@ -2762,11 +2782,11 @@ export const ES = ObjectAssign({}, ES2020, {
         } else if (sign < 0) {
           // 2) end is previous month from intermediate (negative duration)
           // Example: intermediate: Feb 1, end: Jan 30, DaysInMonth = 31, days = -2
-          days = -mid.day - (ES.DaysInMonth(end.year, end.month) - end.day);
+          days = -mid.day - (ES.ISODaysInMonth(end.year, end.month) - end.day);
         } else {
           // 3) end is next month from intermediate (positive duration)
           // Example: intermediate: Jan 29, end: Feb 1, DaysInMonth = 31, days = 3
-          days = end.day + (ES.DaysInMonth(mid.year, mid.month) - mid.day);
+          days = end.day + (ES.ISODaysInMonth(mid.year, mid.month) - mid.day);
         }
 
         if (largestUnit === 'months') {
@@ -2778,7 +2798,7 @@ export const ES = ObjectAssign({}, ES2020, {
       case 'weeks':
       case 'days': {
         let larger, smaller, sign;
-        if (ES.CompareTemporalDate(y1, m1, d1, y2, m2, d2) < 0) {
+        if (ES.CompareISODate(y1, m1, d1, y2, m2, d2) < 0) {
           smaller = { year: y1, month: m1, day: d1 };
           larger = { year: y2, month: m2, day: d2 };
           sign = 1;
@@ -2858,7 +2878,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const seconds = +roundedDiff.divide(1e9);
     return { seconds, milliseconds, microseconds, nanoseconds };
   },
-  DifferenceDateTime: (
+  DifferenceISODateTime: (
     y1,
     mon1,
     d1,
@@ -2896,7 +2916,7 @@ export const ES = ObjectAssign({}, ES2020, {
       µs2,
       ns2
     );
-    ({ year: y1, month: mon1, day: d1 } = ES.BalanceDate(y1, mon1, d1 + deltaDays));
+    ({ year: y1, month: mon1, day: d1 } = ES.BalanceISODate(y1, mon1, d1 + deltaDays));
     const date1 = new TemporalDate(y1, mon1, d1, calendar);
     const date2 = new TemporalDate(y2, mon2, d2, calendar);
     const dateLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', largestUnit);
@@ -2938,7 +2958,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const end = new TemporalInstant(ns2);
     const dtStart = ES.GetTemporalDateTimeFor(timeZone, start, calendar);
     const dtEnd = ES.GetTemporalDateTimeFor(timeZone, end, calendar);
-    let { years, months, weeks, days } = ES.DifferenceDateTime(
+    let { years, months, weeks, days } = ES.DifferenceISODateTime(
       GetSlot(dtStart, ISO_YEAR),
       GetSlot(dtStart, ISO_MONTH),
       GetSlot(dtStart, ISO_DAY),
@@ -2981,14 +3001,14 @@ export const ES = ObjectAssign({}, ES2020, {
     );
     return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
   },
-  AddDate: (year, month, day, years, months, weeks, days, overflow) => {
+  AddISODate: (year, month, day, years, months, weeks, days, overflow) => {
     year += years;
     month += months;
-    ({ year, month } = ES.BalanceYearMonth(year, month));
-    ({ year, month, day } = ES.RegulateDate(year, month, day, overflow));
+    ({ year, month } = ES.BalanceISOYearMonth(year, month));
+    ({ year, month, day } = ES.RegulateISODate(year, month, day, overflow));
     days += 7 * weeks;
     day += days;
-    ({ year, month, day } = ES.BalanceDate(year, month, day));
+    ({ year, month, day } = ES.BalanceISODate(year, month, day));
     return { year, month, day };
   },
   AddTime: (
@@ -3025,11 +3045,11 @@ export const ES = ObjectAssign({}, ES2020, {
   SubtractDate: (year, month, day, years, months, weeks, days, overflow) => {
     days += 7 * weeks;
     day -= days;
-    ({ year, month, day } = ES.BalanceDate(year, month, day));
+    ({ year, month, day } = ES.BalanceISODate(year, month, day));
     month -= months;
     year -= years;
-    ({ year, month } = ES.BalanceYearMonth(year, month));
-    ({ year, month, day } = ES.RegulateDate(year, month, day, overflow));
+    ({ year, month } = ES.BalanceISOYearMonth(year, month));
+    ({ year, month, day } = ES.RegulateISODate(year, month, day, overflow));
     return { year, month, day };
   },
   AddDuration: (
@@ -3327,7 +3347,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const roundedRemainder = ES.RoundNumberToIncrement(remainder, nsPerTimeUnit[unit] * increment, roundingMode);
     return wholeDays.plus(roundedRemainder);
   },
-  RoundDateTime: (
+  RoundISODateTime: (
     year,
     month,
     day,
@@ -3355,7 +3375,7 @@ export const ES = ObjectAssign({}, ES2020, {
       roundingMode,
       dayLengthNs
     ));
-    ({ year, month, day } = ES.BalanceDate(year, month, day + deltaDays));
+    ({ year, month, day } = ES.BalanceISODate(year, month, day + deltaDays));
     return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
   },
   RoundTime: (
@@ -3412,7 +3432,7 @@ export const ES = ObjectAssign({}, ES2020, {
     }
   },
   DaysUntil: (earlier, later) => {
-    return ES.DifferenceDate(
+    return ES.DifferenceISODate(
       GetSlot(earlier, ISO_YEAR),
       GetSlot(earlier, ISO_MONTH),
       GetSlot(earlier, ISO_DAY),
@@ -3807,7 +3827,7 @@ export const ES = ObjectAssign({}, ES2020, {
     return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, total };
   },
 
-  CompareTemporalDate: (y1, m1, d1, y2, m2, d2) => {
+  CompareISODate: (y1, m1, d1, y2, m2, d2) => {
     for (const [x, y] of [
       [y1, y2],
       [m1, m2],

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -43,7 +43,7 @@ export class PlainDate {
       throw new RangeError('missing argument: isoYear, isoMonth and isoDay are required');
     }
 
-    ES.RejectDate(isoYear, isoMonth, isoDay);
+    ES.RejectISODate(isoYear, isoMonth, isoDay);
     ES.RejectDateRange(isoYear, isoMonth, isoDay);
     CreateSlots(this);
     SetSlot(this, ISO_YEAR, isoYear);
@@ -438,7 +438,7 @@ export class PlainDate {
   static compare(one, two) {
     one = ES.ToTemporalDate(one, PlainDate);
     two = ES.ToTemporalDate(two, PlainDate);
-    const result = ES.CompareTemporalDate(
+    const result = ES.CompareISODate(
       GetSlot(one, ISO_YEAR),
       GetSlot(one, ISO_MONTH),
       GetSlot(one, ISO_DAY),

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -34,7 +34,7 @@ function DateTimeToString(dateTime, precision, showCalendar = 'auto', options = 
 
   if (options) {
     const { unit, increment, roundingMode } = options;
-    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundDateTime(
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundISODateTime(
       year,
       month,
       day,
@@ -440,7 +440,7 @@ export class PlainDateTime {
       milliseconds,
       microseconds,
       nanoseconds
-    } = ES.DifferenceDateTime(
+    } = ES.DifferenceISODateTime(
       GetSlot(this, ISO_YEAR),
       GetSlot(this, ISO_MONTH),
       GetSlot(this, ISO_DAY),
@@ -534,7 +534,7 @@ export class PlainDateTime {
       milliseconds,
       microseconds,
       nanoseconds
-    } = ES.DifferenceDateTime(
+    } = ES.DifferenceISODateTime(
       GetSlot(this, ISO_YEAR),
       GetSlot(this, ISO_MONTH),
       GetSlot(this, ISO_DAY),
@@ -636,7 +636,7 @@ export class PlainDateTime {
     let millisecond = GetSlot(this, ISO_MILLISECOND);
     let microsecond = GetSlot(this, ISO_MICROSECOND);
     let nanosecond = GetSlot(this, ISO_NANOSECOND);
-    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundDateTime(
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundISODateTime(
       year,
       month,
       day,

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -35,7 +35,7 @@ export class PlainMonthDay {
       throw new RangeError('missing argument: isoMonth and isoDay are required');
     }
 
-    ES.RejectDate(referenceISOYear, isoMonth, isoDay);
+    ES.RejectISODate(referenceISOYear, isoMonth, isoDay);
     ES.RejectDateRange(referenceISOYear, isoMonth, isoDay);
 
     CreateSlots(this);

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -35,7 +35,7 @@ export class PlainYearMonth {
       throw new RangeError('missing argument: isoYear and isoMonth are required');
     }
 
-    ES.RejectDate(isoYear, isoMonth, referenceISODay);
+    ES.RejectISODate(isoYear, isoMonth, referenceISODay);
     ES.RejectYearMonthRange(isoYear, isoMonth);
     CreateSlots(this);
     SetSlot(this, ISO_YEAR, isoYear);

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -64,8 +64,8 @@ export class TimeZone {
 
     const ns = GetSlot(instant, EPOCHNANOSECONDS);
     const offsetNs = ES.GetOffsetNanosecondsFor(this, instant);
-    let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.GetPartsFromEpoch(ns);
-    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.BalanceDateTime(
+    let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.GetISOPartsFromEpoch(ns);
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.BalanceISODateTime(
       year,
       month,
       day,
@@ -103,7 +103,7 @@ export class TimeZone {
       }
     }
 
-    const utcns = ES.GetEpochFromParts(
+    const utcns = ES.GetEpochFromISOParts(
       GetSlot(dateTime, ISO_YEAR),
       GetSlot(dateTime, ISO_MONTH),
       GetSlot(dateTime, ISO_DAY),
@@ -146,7 +146,7 @@ export class TimeZone {
 
     const offsetNs = ES.ParseOffsetString(id);
     if (offsetNs !== null) {
-      const epochNs = ES.GetEpochFromParts(
+      const epochNs = ES.GetEpochFromISOParts(
         GetSlot(dateTime, ISO_YEAR),
         GetSlot(dateTime, ISO_MONTH),
         GetSlot(dateTime, ISO_DAY),

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -154,7 +154,7 @@ export class ZonedDateTime {
     const month = GetSlot(dt, ISO_MONTH);
     const day = GetSlot(dt, ISO_DAY);
     const today = new DateTime(year, month, day, 0, 0, 0, 0, 0, 0);
-    const tomorrowFields = ES.AddDate(year, month, day, 0, 0, 0, 1, 'reject');
+    const tomorrowFields = ES.AddISODate(year, month, day, 0, 0, 0, 1, 'reject');
     const tomorrow = new DateTime(tomorrowFields.year, tomorrowFields.month, tomorrowFields.day, 0, 0, 0, 0, 0, 0);
     const timeZone = GetSlot(this, TIME_ZONE);
     const todayNs = GetSlot(ES.GetTemporalInstantFor(timeZone, today, 'compatible'), EPOCHNANOSECONDS);
@@ -238,7 +238,7 @@ export class ZonedDateTime {
       nanosecond
     } = ES.InterpretTemporalDateTimeFields(calendar, fields, options);
     const offsetNs = ES.ParseOffsetString(fields.offset);
-    const epochNanoseconds = ES.InterpretTemporalZonedDateTimeOffset(
+    const epochNanoseconds = ES.InterpretISODateTimeOffset(
       year,
       month,
       day,
@@ -701,7 +701,7 @@ export class ZonedDateTime {
     const instantStart = ES.GetTemporalInstantFor(timeZone, dtStart, 'compatible');
     const endNs = ES.AddZonedDateTime(instantStart, timeZone, calendar, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0);
     const dayLengthNs = endNs.subtract(GetSlot(instantStart, EPOCHNANOSECONDS));
-    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundDateTime(
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundISODateTime(
       year,
       month,
       day,
@@ -723,7 +723,7 @@ export class ZonedDateTime {
     // new date/time values. If DST disambiguation is required, the `compatible`
     // disambiguation algorithm will be used.
     const offsetNs = ES.GetOffsetNanosecondsFor(timeZone, GetSlot(this, INSTANT));
-    const epochNanoseconds = ES.InterpretTemporalZonedDateTimeOffset(
+    const epochNanoseconds = ES.InterpretISODateTimeOffset(
       year,
       month,
       day,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -599,7 +599,7 @@
           1. Let _offsetNs_ be ? ParseTimeZoneOffsetString(_offset_).
         1. Else,
           1. Let _offsetNs_ be *null*.
-        1. Let _epochNanoseconds_ be ? InterpretTemporalZonedDateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetNs_, _timeZone_, *"compatible"*, *"reject"*).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetNs_, _timeZone_, *"compatible"*, *"reject"*).
         1. Return ? CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
     </emu-alg>
@@ -1167,7 +1167,7 @@
         1. Let _millisecond_ be 0.
         1. Let _microsecond_ be 0.
         1. Let _nanosecond_ be 0.
-      1. If ! ValidateDate(_year_, _month_, _day_) is *false*, then
+      1. If ! ValidateISODate(_year_, _month_, _day_) is *false*, then
         1. Throw a *RangeError* exception.
       1. If ! ValidateTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *false*, then
         1. Throw a *RangeError* exception.

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -354,8 +354,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-isleapyear" aoid="IsLeapYear">
-      <h1>IsLeapYear ( _year_ )</h1>
+    <emu-clause id="sec-temporal-isisoleapyear" aoid="IsISOLeapYear">
+      <h1>IsISOLeapYear ( _year_ )</h1>
       <emu-alg>
         1. Assert: _year_ is an integer.
         1. If _year_ modulo 4 ≠ 0, return *false*.
@@ -365,30 +365,30 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-daysinyear" aoid="DaysInYear">
-      <h1>DaysInYear ( _year_ )</h1>
+    <emu-clause id="sec-temporal-isodaysinyear" aoid="ISODaysInYear">
+      <h1>ISODaysInYear ( _year_ )</h1>
       <emu-alg>
         1. Assert: _year_ is an integer.
-        1. If ! IsLeapYear(_year_) is *true*, then
+        1. If ! IsISOLeapYear(_year_) is *true*, then
           1. Return 366.
         1. Return 365.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-daysinmonth" aoid="DaysInMonth">
-      <h1>DaysInMonth ( _year_, _month_ )</h1>
+    <emu-clause id="sec-temporal-isodaysinmonth" aoid="ISODaysInMonth">
+      <h1>ISODaysInMonth ( _year_, _month_ )</h1>
       <emu-alg>
         1. Assert: _year_ is an integer.
         1. Assert: _month_ is an integer, _month_ ≥ 1, and _month_ ≤ 12.
         1. If _month_ is 1, 3, 5, 7, 8, 10, or 12, return 31.
         1. If _month_ is 4, 6, 9, or 11, return 30.
-        1. If ! IsLeapYear(_year_) is *true*, return 29.
+        1. If ! IsISOLeapYear(_year_) is *true*, return 29.
         1. Return 28.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-todayofweek" aoid="ToDayOfWeek">
-      <h1>ToDayOfWeek ( _year_, _month_, _day_ )</h1>
+    <emu-clause id="sec-temporal-toisodayofweek" aoid="ToISODayOfWeek">
+      <h1>ToISODayOfWeek ( _year_, _month_, _day_ )</h1>
       <emu-alg>
         1. Assert: _year_ is an integer.
         1. Assert: _month_ is an integer.
@@ -399,8 +399,8 @@
       <emu-note>Monday is 1 and Sunday is 7.</emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-todayofyear" aoid="ToDayOfYear">
-      <h1>ToDayOfYear ( _year_, _month_, _day_ )</h1>
+    <emu-clause id="sec-temporal-toisodayofyear" aoid="ToISODayOfYear">
+      <h1>ToISODayOfYear ( _year_, _month_, _day_ )</h1>
       <emu-alg>
         1. Assert: _year_ is an integer.
         1. Assert: _month_ is an integer.
@@ -410,8 +410,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-toweekofyear" aoid="ToWeekOfYear">
-      <h1>ToWeekOfYear ( _year_, _month_, _day_ )</h1>
+    <emu-clause id="sec-temporal-toisoweekofyear" aoid="ToISOWeekOfYear">
+      <h1>ToISOWeekOfYear ( _year_, _month_, _day_ )</h1>
       <emu-alg>
         1. Assert: _year_ is an integer.
         1. Assert: _month_ is an integer.
@@ -462,7 +462,7 @@
         1. Let _month_ be ? ResolveISOMonth(_fields_).
         1. Let _day_ be ? Get(_fields_, *"day"*).
         1. If _day_ is *undefined*, throw a *TypeError* exception.
-        1. Return ? RegulateDate(_year_, _month_, _day_, _overflow_).
+        1. Return ? RegulateISODate(_year_, _month_, _day_, _overflow_).
       </emu-alg>
     </emu-clause>
 
@@ -478,7 +478,7 @@
         1. Let _year_ be ? Get(_fields_, *"year"*).
         1. If _year_ is *undefined*, throw a *TypeError* exception.
         1. Let _month_ be ? ResolveISOMonth(_fields_).
-        1. Let _result_ be ? RegulateYearMonth(_year_, _month_, _overflow_).
+        1. Let _result_ be ? RegulateISOYearMonth(_year_, _month_, _overflow_).
         1. Return the new Record {
             [[Year]]: _result_.[[Year]],
             [[Month]]: _result_.[[Month]],
@@ -507,9 +507,9 @@
         1. Let _referenceISOYear_ be the first leap year after the Unix epoch (1972).
         1. Let _result_ be *undefined*.
         1. If _monthCode_ is *undefined*, then
-          1. Set _result_ to ? RegulateDate(_year_, _month_, _day_, _overflow_).
+          1. Set _result_ to ? RegulateISODate(_year_, _month_, _day_, _overflow_).
         1. Else,
-          1. Set _result_ to ? RegulateDate(_referenceISOYear_, _month_, _day_, _overflow_).
+          1. Set _result_ to ? RegulateISODate(_referenceISOYear_, _month_, _day_, _overflow_).
         1. Return the new Record {
             [[Month]]: _result_.[[Month]],
             [[Day]]: _result_.[[Day]],
@@ -795,7 +795,7 @@
         1. Set _duration_ to ? ToTemporalDuration(_duration_).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Let _result_ be ? AddDate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _overflow_).
+        1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _overflow_).
         1. Return ? CreateTemporalDateFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       </emu-alg>
     </emu-clause>
@@ -818,7 +818,7 @@
         1. Set _two_ to ? ToTemporalDate(_two_).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
-        1. Let _result_ be ? DifferenceDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
+        1. Let _result_ be ? DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
         1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
@@ -910,7 +910,7 @@
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
-        1. Return 𝔽(! ToDayOfWeek(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]])).
+        1. Return 𝔽(! ToISODayOfWeek(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]])).
       </emu-alg>
     </emu-clause>
 
@@ -929,7 +929,7 @@
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
-        1. Return 𝔽(! ToDayOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]])).
+        1. Return 𝔽(! ToISODayOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]])).
       </emu-alg>
     </emu-clause>
 
@@ -948,7 +948,7 @@
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
-        1. Return 𝔽(! ToWeekOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]])).
+        1. Return 𝔽(! ToISOWeekOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]])).
       </emu-alg>
     </emu-clause>
 
@@ -987,7 +987,7 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If _dateOrDateTime_ does not have [[ISOYear]] and [[ISOMonth]] internal slots, then
           1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
-        1. Return 𝔽(! DaysInMonth(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]])).
+        1. Return 𝔽(! ISODaysInMonth(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]])).
       </emu-alg>
     </emu-clause>
 
@@ -1006,7 +1006,7 @@
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _year_ be ? ISOYear(_dateOrDateTime_).
-        1. Return 𝔽(! DaysInYear(_year_)).
+        1. Return 𝔽(! ISODaysInYear(_year_)).
       </emu-alg>
     </emu-clause>
 
@@ -1044,7 +1044,7 @@
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _year_ be ? ISOYear(_dateOrDateTime_).
-        1. Return ! IsLeapYear(_year_).
+        1. Return ! IsISOLeapYear(_year_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1223,7 +1223,7 @@
       </p>
       <emu-alg>
         1. Assert: _earlier_ and _later_ both have [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots.
-        1. Let _difference_ be ? DifferenceDate(_earlier_.[[ISOYear]], _earlier_.[[ISOMonth]], _earlier_.[[ISODay]], _later_.[[ISOYear]], _later_.[[ISOMonth]], _later_.[[ISODay]], *"days"*).
+        1. Let _difference_ be ? DifferenceISODate(_earlier_.[[ISOYear]], _earlier_.[[ISOMonth]], _earlier_.[[ISODay]], _later_.[[ISOYear]], _later_.[[ISOMonth]], _later_.[[ISODay]], *"days"*).
         1. Return _difference_.[[Days]].
       </emu-alg>
     </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -580,7 +580,7 @@
         1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
         1. If _offsetString_ is *undefined*, then
           1. Throw a *RangeError* exception.
-        1. Let _utc_ be ? GetEpochFromParts(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+        1. Let _utc_ be ? GetEpochFromISOParts(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
         1. If _utc_ &lt; −8.64 × 10<sup>21</sup><sub>ℝ</sub> or _utc_ &gt; 8.64 × 10<sup>21</sup><sub>ℝ</sub>, then
           1. Throw a *RangeError* exception.
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1203,7 +1203,7 @@
             1. Set _options_ to ? NormalizeOptionsObject(_options_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-              1. Let _result_ be ? AddDate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _overflow_).
+              1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _overflow_).
             1. Else,
               1. Let _result_ be a Record with [[Year]], [[Month]], and [[Day]] fields, that is the result of implementation-defined processing of _date_, _duration_, _options_, and the value of _calendar_.[[Identifier]].
             1. Return ? CreateTemporalDateFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
@@ -1225,7 +1225,7 @@
             1. Set _options_ to ? NormalizeOptionsObject(_options_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
-              1. Let _result_ be ? DifferenceDate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
+              1. Let _result_ be ? DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
             1. Else,
               1. Let _result_ be a Record with [[Years]], [[Months]], [[Weeks]], and [[Days]] fields, that is the result of implementation-defined processing of _one_, _two_, _options_, and the value of _calendar_.[[Identifier]].
             1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
@@ -1348,7 +1348,7 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _dayOfWeek_ be ! ToDayOfWeek(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]]).
+              1. Let _dayOfWeek_ be ! ToISODayOfWeek(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]]).
             1. Else,
               1. Let _dayOfWeek_ be the result of implementation-defined processing of _date_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_dayOfWeek_).
@@ -1367,7 +1367,7 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _dayOfYear_ be ! ToDayOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]]).
+              1. Let _dayOfYear_ be ! ToISODayOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]]).
             1. Else,
               1. Let _dayOfYear_ be the result of implementation-defined processing of _date_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_dayOfYear_).
@@ -1386,7 +1386,7 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _weekOfYear_ be ! ToWeekOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]]).
+              1. Let _weekOfYear_ be ! ToISOWeekOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]]).
             1. Else,
               1. Let _weekOfYear_ be the result of implementation-defined processing of _date_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_weekOfYear_).
@@ -1425,7 +1425,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. If _dateOrDateTime_ does not have [[ISOYear]] and [[ISOMonth]] internal slots, then
                 1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
-              1. Let _daysInMonth_ be ! DaysInMonth(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]]).
+              1. Let _daysInMonth_ be ! ISODaysInMonth(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]]).
             1. Else,
               1. Let _daysInMonth_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_daysInMonth_).
@@ -1444,7 +1444,7 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _year_ be ? ISOYear(_dateOrDateTime_).
-              1. Let _daysInYear_ be ! DaysInYear(_year_).
+              1. Let _daysInYear_ be ! ISODaysInYear(_year_).
             1. Else,
               1. Let _daysInYear_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_daysInYear_).
@@ -1482,7 +1482,7 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _year_ be ? ISOYear(_dateOrDateTime_).
-              1. Let _inLeapYear_ be ! IsLeapYear(_year_).
+              1. Let _inLeapYear_ be ! IsISOLeapYear(_year_).
             1. Else,
               1. Let _inLeapYear_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return _inLeapYear_.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -644,7 +644,7 @@
               [[ISODay]]
             </td>
             <td>
-              An integer between 1 and DaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing the day of the month in the ISO 8601 calendar.
+              An integer between 1 and ISODaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing the day of the month in the ISO 8601 calendar.
             </td>
           </tr>
           <tr>
@@ -669,8 +669,8 @@
         1. Assert: _isoYear_ is an integer.
         1. Assert: _isoMonth_ is an integer.
         1. Assert: _isoDay_ is an integer.
-        1. Perform ? RejectDate(_isoYear_, _isoMonth_, _isoDay_).
-        1. If ! DateTimeWithinLimits(_isoYear_, _isoMonth_, _isoDay_, 12, 0, 0, 0, 0, 0) is not ~in range~, throw a *RangeError* exception.
+        1. Perform ? RejectISODate(_isoYear_, _isoMonth_, _isoDay_).
+        1. If ! ISODateTimeWithinLimits(_isoYear_, _isoMonth_, _isoDay_, 12, 0, 0, 0, 0, 0) is not ~in range~, throw a *RangeError* exception.
         1. If Type(_calendar_) is not Object, throw a *RangeError* exception.
         1. If _newTarget_ is not given, set it to %Temporal.PlainDate%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.PlainDate.prototype%"*, « [[InitializedTemporalDate]], [[ISOYear]], [[ISOMonth]], [[ISODay]], [[Calendar]] »).
@@ -681,7 +681,7 @@
         1. Return _object_.
       </emu-alg>
       <emu-note>
-        <p>Deferring to DateTimeWithinLimits with an hour of 12 avoids trouble at the extremes of the representable range of dates, which stop just before midnight on each end.</p>
+        <p>Deferring to ISODateTimeWithinLimits with an hour of 12 avoids trouble at the extremes of the representable range of dates, which stop just before midnight on each end.</p>
       </emu-note>
     </emu-clause>
 
@@ -689,7 +689,7 @@
       <h1>CreateTemporalDateFromInstance ( _temporalDate_, _isoYear_, _isoMonth_, _isoDay_, _calendar_ )</h1>
       <emu-alg>
         1. Assert: Type(_temporalDate_) is Object and _temporalDate_ has an [[InitializedTemporalDate]] internal slot.
-        1. Assert: ! ValidateDate(_isoYear_, _isoMonth_, _isoDay_) is *true*.
+        1. Assert: ! ValidateISODate(_isoYear_, _isoMonth_, _isoDay_) is *true*.
         1. Let _constructor_ be ? SpeciesConstructor(_temporalDate_, %Temporal.PlainDate%).
         1. Let _result_ be ? Construct(_constructor_, « _isoYear_, _isoMonth_, _isoDay_, _calendar_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalDate]]).
@@ -700,7 +700,7 @@
     <emu-clause id="sec-temporal-createtemporaldatefromstatic" aoid="CreateTemporalDateFromStatic">
       <h1>CreateTemporalDateFromStatic ( _constructor_, _isoYear_, _isoMonth_, _isoDay_, _calendar_ )</h1>
       <emu-alg>
-        1. Assert: ! ValidateDate(_isoYear_, _isoMonth_, _isoDay_) is *true*.
+        1. Assert: ! ValidateISODate(_isoYear_, _isoMonth_, _isoDay_) is *true*.
         1. If ! IsConstructor(_constructor_) is *false*, then
           1. Throw a *TypeError* exception.
         1. Let _result_ be ? Construct(_constructor_, « _isoYear_, _isoMonth_, _isoDay_, _calendar_ »).
@@ -727,16 +727,16 @@
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalDateString(_string_).
-        1. If ! ValidateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *false*, then
+        1. If ! ValidateISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
-        1. Set _result_ to ? RegulateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _overflow_).
+        1. Set _result_ to ? RegulateISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _overflow_).
         1. Return ? CreateTemporalDateFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-differencedate" aoid="DifferenceDate">
-      <h1>DifferenceDate ( _y1_, _m1_, _d1_, _y2_, _m2_, _d2_, _largestUnit_ )</h1>
+    <emu-clause id="sec-temporal-differenceisodate" aoid="DifferenceISODate">
+      <h1>DifferenceISODate ( _y1_, _m1_, _d1_, _y2_, _m2_, _d2_, _largestUnit_ )</h1>
       <emu-alg>
         1. Assert: _largestUnit_ is one of *"years"*, *"months"*, *"weeks"*, *"days"*, *"hours"*, *"minutes"*, or *"seconds"*.
         1. If _largestUnit_ is not *"years"*, *"months"*, or *"weeks"*, then
@@ -747,7 +747,7 @@
           1. Let _start_ be the new Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
           1. Let _end_ be the new Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
           1. Let _years_ be _end_.[[Year]] − _start_.[[Year]].
-          1. Let _mid_ be ? AddDate(_y1_, _m1_, _d1_, _years_, 0, 0, *"constrain"*).
+          1. Let _mid_ be ? AddISODate(_y1_, _m1_, _d1_, _years_, 0, 0, *"constrain"*).
           1. Let _midSign_ be -(! ES.CompareTemporalDate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
             1. If _largestUnit_ is *"years"*, return the new Record { [[Years]]: _years_, [[Months]]: 0, [[Weeks]]: 0, [[Days]]: 0 }.
@@ -756,7 +756,7 @@
           1. If _midSign_ is not equal to _sign_, then
             1. Set _years_ to _years_ - _sign_.
             1. Set _months_ to _months_ + _sign_ × 12.
-          1. Set _mid_ be ? AddDate(_y1_, _m1_, _d1_, _years_, _months_, 0, *"constrain"*).
+          1. Set _mid_ be ? AddISODate(_y1_, _m1_, _d1_, _years_, _months_, 0, *"constrain"*).
           1. Let _midSign_ be -(! ES.CompareTemporalDate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
             1. If _largestUnit_ is *"years"*, return the new Record { [[Years]]: _years_, [[Months]]: _months_, [[Weeks]]: 0, [[Days]]: 0 }.
@@ -766,18 +766,18 @@
             1. If _months_ is equal to -_sign_, then
               1. Set _years_ to _years_ - _sign_.
               1. Set _months_ to 11 × _sign_.
-            1. Set _mid_ be ? AddDate(_y1_, _m1_, _d1_, _years_, _months_, 0, *"constrain"*).
+            1. Set _mid_ be ? AddISODate(_y1_, _m1_, _d1_, _years_, _months_, 0, *"constrain"*).
             1. Let _midSign_ be -(! ES.CompareTemporalDate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. Let _days_ be 0.
           1. If _mid_.[[Month]] is equal to _end_.[[Month]] and _mid_.[[Year]] is equal to _mid_.[[Year]], set _days_ to _end_.[[Day]] - _mid_.[[Day]].
-          1. Else if _sign_ &lt; 0, set _days_ to -_mid_.[[Day]] - (! DaysInMonth(_end_.[[Year]], _end_.[[Month]]) - _end_.[[Day]]).
-          1. Else, set _days_ to _end_.[[Day]] + (! DaysInMonth(_mid_.[[Year]], _mid_.[[Month]]) - _mid_.[[Day]]).
+          1. Else if _sign_ &lt; 0, set _days_ to -_mid_.[[Day]] - (! ISODaysInMonth(_end_.[[Year]], _end_.[[Month]]) - _end_.[[Day]]).
+          1. Else, set _days_ to _end_.[[Day]] + (! ISODaysInMonth(_mid_.[[Year]], _mid_.[[Month]]) - _mid_.[[Day]]).
           1. If _largestUnit_ is *"months"*, then
             1. Set _months_ to _months_ + _years_ × 12.
             1. Set _years_ to 0.
           1. Return the new Record { [[Years]]: _years_, [[Months]]: _months_, [[Weeks]]: 0, [[Days]]: _days_ }.
         1. If _largestUnit_ is *"days"* or *"weeks"*, then
-          1. If ! CompareTemporalDate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_) &lt; 0, then
+          1. If ! CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_) &lt; 0, then
             1. Let _smaller_ be the new Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
             1. Let _greater_ be the new Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
             1. Let _sign_ be 1.
@@ -786,10 +786,10 @@
             1. Let _greater_ be the new Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
             1. Let _sign_ be −1.
           1. Let _years_ be _greater_.[[Year]] − _smaller_.[[Year]].
-          1. Let _days_ be ! ToDayOfYear(_greater_.[[Year]], _greater_.[[Month]], _greater_.[[Day]]) − ! ToDayOfYear(_smaller_.[[Year]], _smaller_.[[Month]], _smaller_.[[Day]]).
+          1. Let _days_ be ! ToISODayOfYear(_greater_.[[Year]], _greater_.[[Month]], _greater_.[[Day]]) − ! ToISODayOfYear(_smaller_.[[Year]], _smaller_.[[Month]], _smaller_.[[Day]]).
           1. Assert: _years_ ≥ 0.
           1. Repeat, while _years_ &gt; 0,
-            1. Set _days_ to _days_ + ! DaysInYear(_smaller_.[[Year]] + _years_ − 1).
+            1. Set _days_ to _days_ + ! ISODaysInYear(_smaller_.[[Year]] + _years_ − 1).
             1. Set _years_ to _years_ − 1.
           1. Let _weeks_ be 0.
           1. If _largestUnit_ is *"weeks"*, then
@@ -811,50 +811,50 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-regulatedate" aoid="RegulateDate">
-      <h1>RegulateDate ( _year_, _month_, _day_, _overflow_ )</h1>
+    <emu-clause id="sec-temporal-regulateisodate" aoid="RegulateISODate">
+      <h1>RegulateISODate ( _year_, _month_, _day_, _overflow_ )</h1>
       <emu-alg>
         1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. If _overflow_ is *"reject"*, then
-          1. Perform ? RejectDate(_year_, _month_, _day_).
+          1. Perform ? RejectISODate(_year_, _month_, _day_).
           1. Return the Record {
             [[Year]]: _year_,
             [[Month]]: _month_,
             [[Day]]: _day_
             }.
         1. If _overflow_ is *"constrain"*, then
-          1. Return ! ConstrainDate(_year_, _month_, _day_).
+          1. Return ! ConstrainISODate(_year_, _month_, _day_).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-validatedate" aoid="ValidateDate">
-      <h1>ValidateDate ( _year_, _month_, _day_ )</h1>
+    <emu-clause id="sec-temporal-validateisodate" aoid="ValidateISODate">
+      <h1>ValidateISODate ( _year_, _month_, _day_ )</h1>
       <emu-alg>
         1. Assert: _year_, _month_, and _day_ are integers.
         1. If _month_ &lt; 1 or _month_ &gt; 12, then
           1. Return *false*.
-        1. Let _daysInMonth_ be ! DaysInMonth(_year_, _month_).
+        1. Let _daysInMonth_ be ! ISODaysInMonth(_year_, _month_).
         1. If _day_ &lt; 1 or _day_ &gt; _daysInMonth_, then
           1. Return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-rejectdate" aoid="RejectDate">
-      <h1>RejectDate ( _year_, _month_, _day_ )</h1>
+    <emu-clause id="sec-temporal-rejectisodate" aoid="RejectISODate">
+      <h1>RejectISODate ( _year_, _month_, _day_ )</h1>
       <emu-alg>
         1. Assert: _year_, _month_, and _day_ are integers.
-        1. If ! ValidateDate(_year_, _month_, _day_) is *false*, then
+        1. If ! ValidateISODate(_year_, _month_, _day_) is *false*, then
           1. Throw a *RangeError* exception.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-constraindate" aoid="ConstrainDate">
-      <h1>ConstrainDate ( _year_, _month_, _day_ )</h1>
+    <emu-clause id="sec-temporal-constrainisodate" aoid="ConstrainISODate">
+      <h1>ConstrainISODate ( _year_, _month_, _day_ )</h1>
       <emu-alg>
         1. Assert: _year_, _month_, and _day_ are integers.
         1. Set _month_ to ! ConstrainToRange(_month_, 1, 12).
-        1. Set _day_ to ! ConstrainToRange(_day_, 1, ! DaysInMonth(_year_, _month_)).
+        1. Set _day_ to ! ConstrainToRange(_day_, 1, ! ISODaysInMonth(_year_, _month_)).
         1. Return the Record {
           [[Year]]: _year_,
           [[Month]]: _month_,
@@ -863,12 +863,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-balancedate" aoid="BalanceDate">
-      <h1>BalanceDate ( _year_, _month_, _day_ )</h1>
+    <emu-clause id="sec-temporal-balanceisodate" aoid="BalanceISODate">
+      <h1>BalanceISODate ( _year_, _month_, _day_ )</h1>
       <emu-alg>
         1. If _day_ is *+∞* or *−∞*, then
           1. Throw a *RangeError* exception.
-        1. Let _balancedYearMonth_ be ? BalanceYearMonth(_year_, _month_).
+        1. Let _balancedYearMonth_ be ? BalanceISOYearMonth(_year_, _month_).
         1. Let _month_ be _balancedYearMonth_.[[Month]].
         1. Let _year_ be _balancedYearMonth_.[[Year]].
         1. NOTE: To deal with negative numbers of days whose absolute value is greater than the number of days in a year, the following section subtracts years and adds days until the number of days is greater than −366 or −365.
@@ -876,26 +876,26 @@
           1. Let _testYear_ be _year_.
         1. Else,
           1. Let _testYear_ be _year_ − 1.
-        1. Repeat, while _day_ &lt; −1 × ! DaysInYear(_testYear_),
-          1. Set _day_ to _day_ + ! DaysInYear(_testYear_).
+        1. Repeat, while _day_ &lt; −1 × ! ISODaysInYear(_testYear_),
+          1. Set _day_ to _day_ + ! ISODaysInYear(_testYear_).
           1. Set _year_ to _year_ − 1.
           1. Set _testYear_ to _testYear_ − 1.
         1. NOTE: To deal with numbers of days greater than the number of days in a year, the following section adds years and subtracts days until the number of days is less than 366 or 365.
         1. Let _testYear_ be _year_ + 1.
-        1. Repeat, while _day_ &gt; ! DaysInYear(_testYear_),
-          1. Set _day_ to _day_ − ! DaysInYear(_testYear_).
+        1. Repeat, while _day_ &gt; ! ISODaysInYear(_testYear_),
+          1. Set _day_ to _day_ − ! ISODaysInYear(_testYear_).
           1. Set _year_ to _year_ + 1.
           1. Set _testYear_ to _testYear_ + 1.
         1. NOTE: To deal with negative numbers of days whose absolute value is greater than the number of days in the current month, the following section subtracts months and adds days until the number of days is greater than 0.
         1. Repeat, while _day_ &lt; 1,
-          1. Set _balancedYearMonth_ be ? BalanceYearMonth(_year_, _month_ − 1).
+          1. Set _balancedYearMonth_ be ? BalanceISOYearMonth(_year_, _month_ − 1).
           1. Set _year_ to _balancedYearMonth_.[[Year]].
           1. Set _month_ to _balancedYearMonth_.[[Month]].
-          1. Set _day_ to _day_ + ! DaysInMonth(_year_, _month_).
+          1. Set _day_ to _day_ + ! ISODaysInMonth(_year_, _month_).
         1. NOTE: To deal with numbers of days greater than the number of days in the current month, the following section adds months and subtracts days until the number of days is less than the number of days in the month.
-        1. Repeat, while _day_ &gt; ! DaysInMonth(_year_, _month_),
-          1. Set _day_ to _day_ − ! DaysInMonth(_year_, _month_).
-          1. Set _balancedYearMonth_ be ? BalanceYearMonth(_year_, _month_ + 1).
+        1. Repeat, while _day_ &gt; ! ISODaysInMonth(_year_, _month_),
+          1. Set _day_ to _day_ − ! ISODaysInMonth(_year_, _month_).
+          1. Set _balancedYearMonth_ be ? BalanceISOYearMonth(_year_, _month_ + 1).
           1. Set _year_ to _balancedYearMonth_.[[Year]].
           1. Set _month_ to _balancedYearMonth_.[[Month]].
         1. Return the new Record {
@@ -906,8 +906,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-padyear" aoid="PadYear">
-      <h1>PadYear ( _y_ )</h1>
+    <emu-clause id="sec-temporal-padisoyear" aoid="PadISOYear">
+      <h1>PadISOYear ( _y_ )</h1>
       <emu-alg>
         1. Assert: _y_ is an integer.
         1. If _y_ &gt; 999 and _y_ ≤ 9999, then
@@ -923,7 +923,7 @@
       <emu-alg>
         1. Assert: Type(_temporalDate_) is Object.
         1. Assert: _temporalDate_ has an [[InitializedTemporalDate]] internal slot.
-        1. Let _year_ be ! PadYear(_temporalDate_.[[ISOYear]]).
+        1. Let _year_ be ! PadISOYear(_temporalDate_.[[ISOYear]]).
         1. Let _month_ be _temporalDate_.[[ISOMonth]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _day_ be _temporalDate_.[[ISODay]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _calendarID_ be ? ToString(_temporalDate_.[[Calendar]]).
@@ -932,24 +932,24 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-adddate" aoid="AddDate">
-      <h1>AddDate ( _year_, _month_, _day_, _years_, _months_, _weeks_, _days_, _overflow_ )</h1>
+    <emu-clause id="sec-temporal-addisodate" aoid="AddISODate">
+      <h1>AddISODate ( _year_, _month_, _day_, _years_, _months_, _weeks_, _days_, _overflow_ )</h1>
       <emu-alg>
         1. Assert: _year_, _month_, _day_, _years_, _months_, _weeks_, and _days_ are integer Number values.
         1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. Let _y_ be _year_ + _years_.
         1. Let _m_ be _month_ + _months_.
-        1. Let _intermediate_ be ? BalanceYearMonth(_y_, _m_).
-        1. Let _intermediate_ be ? RegulateDate(_intermediate_.[[Year]], _intermediate_.[[Month]], _day_, _overflow_).
+        1. Let _intermediate_ be ? BalanceISOYearMonth(_y_, _m_).
+        1. Let _intermediate_ be ? RegulateISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _day_, _overflow_).
         1. Set _days_ to _days_ + 7 × _weeks_.
         1. Let _d_ be _intermediate_.[[Day]] + _days_.
-        1. Let _intermediate_ be ? BalanceDate(_intermediate_.[[Year]], _intermediate_.[[Month]], _d_).
-        1. Return ? RegulateDate(_intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]], _overflow_).
+        1. Let _intermediate_ be ? BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _d_).
+        1. Return ? RegulateISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]], _overflow_).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-comparetemporaldate" aoid="CompareTemporalDate">
-      <h1>CompareTemporalDate ( _y1_, _m1_, _d1_, _y2_, _m2_, _d2_ )</h1>
+    <emu-clause id="sec-temporal-compareisodate" aoid="CompareISODate">
+      <h1>CompareISODate ( _y1_, _m1_, _d1_, _y2_, _m2_, _d2_ )</h1>
       <emu-alg>
         1. If _y1_ &gt; _y2_, return 1.
         1. If _y1_ &lt; _y2_, return -1.
@@ -964,7 +964,7 @@
     <emu-clause id="sec-temporal-comparetemporaldatecalendar" aoid="CompareTemporalDateCalendar">
       <h1>CompareTemporalDateCalendar ( _y1_, _m1_, _d1_, _y2_, _m2_, _d2_, _c1_, _c2_ )</h1>
       <emu-alg>
-        1. Let _result_ be ! CompareTemporalDate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_).
+        1. Let _result_ be ! CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_).
         1. If _result_ ≠ 0, then
           1. Return _result_.
         1. Return ? CompareCalendar(_c1_, _c2_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -90,7 +90,7 @@
       <emu-alg>
         1. Set _one_ to ? ToTemporalDateTime(_one_).
         1. Set _two_ to ? ToTemporalDateTime(_two_).
-        1. Let _result_ be ! CompareTemporalDateTime(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[ISOHour]], _one_.[[ISOMinute]], _one_.[[ISOSecond]], _one_.[[ISOMillisecond]], _one_.[[ISOMicrosecond]], _one_.[[ISONanosecond]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[ISOHour]], _two_.[[ISOMinute]], _two_.[[ISOSecond]], _two_.[[ISOMillisecond]], _two_.[[ISOMicrosecond]], _two_.[[ISONanosecond]]).
+        1. Let _result_ be ! CompareISODateTime(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[ISOHour]], _one_.[[ISOMinute]], _one_.[[ISOSecond]], _one_.[[ISOMillisecond]], _one_.[[ISOMicrosecond]], _one_.[[ISONanosecond]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[ISOHour]], _two_.[[ISOMinute]], _two_.[[ISOSecond]], _two_.[[ISOMillisecond]], _two_.[[ISOMicrosecond]], _two_.[[ISONanosecond]]).
         1. If _result_ ≠ 0, then
           1. Return 𝔽(_result_).
         1. Return 𝔽(? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]])).
@@ -407,7 +407,7 @@
         1. Let _fields_ be ? ToTemporalDateTimeFields(_dateTime_, _fieldNames_).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialDateTime_).
         1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
-        1. Assert: ! ValidateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
+        1. Assert: ! ValidateISODateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>
@@ -470,7 +470,7 @@
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _result_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _options_).
-        1. Assert: ! ValidateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
+        1. Assert: ! ValidateISODateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -488,7 +488,7 @@
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _result_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], −_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_duration_.[[Days]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]], _options_).
-        1. Assert: ! ValidateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
+        1. Assert: ! ValidateISODateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -512,7 +512,7 @@
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _diff_ be ? DifferenceDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
+        1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
         1. Let _roundResult_ be ? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dateTime_).
         1. Let _result_ be ! BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
         1. Return ? CreateTemporalDuration(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
@@ -539,7 +539,7 @@
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _diff_ be ? DifferenceDateTime(_other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
+        1. Let _diff_ be ? DifferenceISODateTime(_other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
         1. Let _roundResult_ be ? RoundDuration(−_diff_.[[Years]], −_diff_.[[Months]], −_diff_.[[Weeks]], −_diff_.[[Days]], −_diff_.[[Hours]], −_diff_.[[Minutes]], −_diff_.[[Seconds]], −_diff_.[[Milliseconds]], −_diff_.[[Microseconds]], −_diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dateTime_).
         1. Let _result_ be ! BalanceDuration(−_roundResult_.[[Days]], −_roundResult_.[[Hours]], −_roundResult_.[[Minutes]], −_roundResult_.[[Seconds]], −_roundResult_.[[Milliseconds]], −_roundResult_.[[Microseconds]], −_roundResult_.[[Nanoseconds]], _largestUnit_).
         1. Return ? CreateTemporalDuration(−_roundResult_.[[Years]], −_roundResult_.[[Months]], −_roundResult_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
@@ -561,7 +561,7 @@
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_options_, _smallestUnit_).
-        1. Let _result_ be ? RoundDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Let _result_ be ? RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -602,7 +602,7 @@
         1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _showCalendar_ be ? ToShowCalendarOption(_options_).
-        1. Let _result_ be ? RoundDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Let _result_ be ? RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ? TemporalDateTimeToString(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]], _precision_.[[Precision]], _showCalendar_).
       </emu-alg>
     </emu-clause>
@@ -786,7 +786,7 @@
               [[ISODay]]
             </td>
             <td>
-              An integer Number value between 1 and DaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing the day of the month in the ISO 8601 calendar.
+              An integer Number value between 1 and ISODaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing the day of the month in the ISO 8601 calendar.
             </td>
           </tr>
           <tr>
@@ -853,12 +853,12 @@
   <emu-clause id="sec-temporal-plaindatetime-abstract-ops">
     <h1>Abstract operations</h1>
 
-    <emu-clause id="sec-temporal-getepochfromparts" aoid="GetEpochFromParts">
-      <h1>GetEpochFromParts ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
+    <emu-clause id="sec-temporal-getepochfromisoparts" aoid="GetEpochFromISOParts">
+      <h1>GetEpochFromISOParts ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
       <emu-alg>
         1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integer Number values.
         1. Assert: _month_ ≥ 1 and _month_ ≤ 12.
-        1. Assert: _day_ ≥ 1 and _day_ ≤ ! DaysInMonth(_year_, _month_).
+        1. Assert: _day_ ≥ 1 and _day_ ≤ ! ISODaysInMonth(_year_, _month_).
         1. Assert: ! ValidateTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
         1. Let _date_ be ! MakeDay(_year_, _month_, _day_).
         1. Let _time_ be ! MakeTime(_hour_, _minute_, _second_, _millisecond_).
@@ -868,8 +868,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-datetimewithinlimits" aoid="DateTimeWithinLimits">
-      <h1>DateTimeWithinLimits ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
+    <emu-clause id="sec-temporal-isodatetimewithinlimits" aoid="ISODateTimeWithinLimits">
+      <h1>ISODateTimeWithinLimits ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
       <emu-note>
         <p>
           Temporal.PlainDateTime objects can represent points in time within 24 hours (8.64 × 10<sup>16</sup> nanoseconds) of the Temporal.Instant boundaries
@@ -877,7 +877,7 @@
         </p>
       </emu-note>
       <emu-alg>
-        1. Let _ns_ be ! GetEpochFromParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+        1. Let _ns_ be ! GetEpochFromISOParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. If _ns_ ≤ -8.64 × 10<sup>21</sup><sub>ℝ</sub> - 8.64 × 10<sup>16</sup><sub>ℝ</sub>, then
           1. Return ~too early~.
         1. If _ns_ ≥ 8.64 × 10<sup>21</sup><sub>ℝ</sub> + 8.64 × 10<sup>16</sup><sub>ℝ</sub>, then
@@ -929,21 +929,21 @@
           1. Perform ? ToTemporalOverflow(_options_).
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalDateTimeString(_string_).
-          1. If ! ValidateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *false*, then
+          1. If ! ValidateISODateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *false*, then
             1. Throw a *RangeError* exception.
         1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. Return ? CreateTemporalDateTimeFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-regulatedatetime" aoid="RegulateDateTime">
-      <h1>RegulateDateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _overflow_ )</h1>
+    <emu-clause id="sec-temporal-regulateisodatetime" aoid="RegulateISODateTime">
+      <h1>RegulateISODateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _overflow_ )</h1>
       <emu-alg>
         1. Assert: _overflow_ is one of *"constrain"* or *"reject"*.
         1. If _overflow_ is *"constrain"*, then
-          1. Return ! ConstrainDateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+          1. Return ! ConstrainISODateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. If _overflow_ is *"reject"*, then
-          1. If ! ValidateDateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *false*, then
+          1. If ! ValidateISODateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *false*, then
             1. Throw a *RangeError* exception.
           1. Return the Record {
             [[Year]]: _year_,
@@ -959,13 +959,13 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-validatedatetime" aoid="ValidateDateTime">
-      <h1>ValidateDateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
+    <emu-clause id="sec-temporal-validateisodatetime" aoid="ValidateISODateTime">
+      <h1>ValidateISODateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
       <emu-alg>
         1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integer Number values.
         1. If _month_ &lt; 1 or _month_ &gt; 12, then
           1. Return *false*.
-        1. Let _maxDay_ be ! DaysInMonth(_year_, _month_).
+        1. Let _maxDay_ be ! ISODaysInMonth(_year_, _month_).
         1. If _day_ &lt; 1 or _day_ &gt; _maxDay_, then
           1. Return *false*.
         1. If ! ValidateTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *false*, then
@@ -974,12 +974,12 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-constraindatetime" aoid="ConstrainDateTime">
-      <h1>ConstrainDateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
+    <emu-clause id="sec-temporal-constrainisodatetime" aoid="ConstrainISODateTime">
+      <h1>ConstrainISODateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
       <emu-alg>
         1. Assert: _year_, _month_, and _day_ are integer Number values.
         1. Set _month_ to ! ConstrainToRange(_month_, 1, 12).
-        1. Set _day_ to ! ConstrainToRange(_day_, 1, ! DaysInMonth(_year_, _month_)).
+        1. Set _day_ to ! ConstrainToRange(_day_, 1, ! ISODaysInMonth(_year_, _month_)).
         1. Let _constrainedTime_ be ! ConstrainTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. Return the Record {
             [[Year]]: _year_,
@@ -995,11 +995,11 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-balancedatetime" aoid="BalanceDateTime">
-      <h1>BalanceDateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
+    <emu-clause id="sec-temporal-balanceisodatetime" aoid="BalanceISODateTime">
+      <h1>BalanceISODateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
       <emu-alg>
         1. Let _balancedTime_ be ? BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
-        1. Let _balancedDate_ be ? BalanceDate(_year_, _month_, _day_ + _balancedTime_.[[Days]]).
+        1. Let _balancedDate_ be ? BalanceISODate(_year_, _month_, _day_ + _balancedTime_.[[Days]]).
         1. Return the Record {
             [[Year]]: _balancedDate_.[[Year]],
             [[Month]]: _balancedDate_.[[Month]],
@@ -1017,9 +1017,9 @@
     <emu-clause id="sec-temporal-createtemporaldatetime" aoid="CreateTemporalDateTime">
       <h1>CreateTemporalDateTime ( _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ [ , _newTarget_ ] )</h1>
       <emu-alg>
-        1. If ! ValidateDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *false*, then
+        1. If ! ValidateISODateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *false*, then
           1. Throw a *RangeError* exception.
-        1. If ! DateTimeWithinLimits(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is not ~in range~, then
+        1. If ! ISODateTimeWithinLimits(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is not ~in range~, then
           1. Throw a *RangeError* exception.
         1. If _newTarget_ is not given, set it to %Temporal.PlainDateTime%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.PlainDateTime.prototype%"*, « [[InitializedTemporalDateTime]], [[ISOYear]], [[ISOMonth]], [[ISODay]], [[ISOHour]], [[ISOMinute]], [[ISOSecond]], [[ISOMillisecond]], [[ISOMicrosecond]], [[ISONanosecond]], [[Calendar]] »).
@@ -1041,7 +1041,7 @@
       <h1>CreateTemporalDateTimeFromInstance ( _dateTime_, _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ )</h1>
       <emu-alg>
         1. Assert: Type(_dateTime_) is Object and _dateTime_ has an [[InitializedTemporalDateTime]] internal slot.
-        1. Assert: ! ValidateDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
+        1. Assert: ! ValidateISODateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
         1. Let _constructor_ be ? SpeciesConstructor(_dateTime_, %Temporal.PlainDateTime%).
         1. Let _result_ be ? Construct(_constructor_, « _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ »).
         1. Perform ? RequireInternalSlot(_result_, [[InitializedTemporalDateTime]]).
@@ -1052,7 +1052,7 @@
     <emu-clause id="sec-temporal-createtemporaldatetimefromstatic" aoid="CreateTemporalDateTimeFromStatic">
       <h1>CreateTemporalDateTimeFromStatic ( _constructor_, _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ )</h1>
       <emu-alg>
-        1. Assert: ! ValidateDateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
+        1. Assert: ! ValidateISODateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
         1. If ! IsConstructor(_constructor_) is *false*, then
           1. Throw a *TypeError* exception.
         1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_ »).
@@ -1071,7 +1071,7 @@
     <emu-clause id="sec-temporal-temporaldatetimetostring" aoid="TemporalDateTimeToString">
       <h1>TemporalDateTimeToString ( _isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_, _precision_, _showCalendar_ )</h1>
       <emu-alg>
-        1. Let _year_ be ! PadYear(_isoYear_).
+        1. Let _year_ be ! PadISOYear(_isoYear_).
         1. Let _month_ be _isoMonth_ formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _day_ be _isoDay_ formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _hour_ be _hour_ formatted as a two-digit decimal number, padded to the left with a zero if necessary.
@@ -1083,8 +1083,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-comparetemporaldatetime" aoid="CompareTemporalDateTime">
-      <h1>CompareTemporalDateTime ( _y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_ )</h1>
+    <emu-clause id="sec-temporal-compareisodatetime" aoid="CompareISODateTime">
+      <h1>CompareISODateTime ( _y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_ )</h1>
       <emu-alg>
         1. If _y1_ &gt; _y2_, return 1.
         1. If _y1_ &lt; _y2_, return -1.
@@ -1132,14 +1132,14 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-rounddatetime" aoid="RoundDateTime">
-      <h1>RoundDateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_ [ , _dayLength_ ] )</h1>
+    <emu-clause id="sec-temporal-roundisodatetime" aoid="RoundISODateTime">
+      <h1>RoundISODateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_ [ , _dayLength_ ] )</h1>
       <p>
-        The abstract operation RoundDateTime rounds the time part of a combined date and time, carrying over any excess into the date part.
+        The abstract operation RoundISODateTime rounds the time part of a combined date and time, carrying over any excess into the date part.
       </p>
       <emu-alg>
         1. Let _roundedTime_ be ? RoundTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_, _dayLength_).
-        1. Let _balanceResult_ be ? BalanceDate(_year_, _month_, _day_ + _roundedTime_.[[Days]]).
+        1. Let _balanceResult_ be ? BalanceISODate(_year_, _month_, _day_ + _roundedTime_.[[Days]]).
         1. Return the new Record {
             [[Year]]: _balanceResult_.[[Year]],
             [[Month]]: _balanceResult_.[[Month]],
@@ -1154,17 +1154,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-differencedatetime" aoid="DifferenceDateTime">
-      <h1>DifferenceDateTime ( _y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_, _calendar_, _largestUnit_ [ , _options_ ] )</h1>
+    <emu-clause id="sec-temporal-differenceisodatetime" aoid="DifferenceISODateTime">
+      <h1>DifferenceISODateTime ( _y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_, _calendar_, _largestUnit_ [ , _options_ ] )</h1>
       <p>
-        The abstract operation DifferenceDateTime returns a Record with the elapsed duration from a first date and time, until a second date and time, according to the reckoning of the given _calendar_.
+        The abstract operation DifferenceISODateTime returns a Record with the elapsed duration from a first date and time, until a second date and time, according to the reckoning of the given _calendar_.
         The given date and time units are all in the ISO 8601 calendar.
         The _largestUnit_ and _options_ arguments are used in _calendar_'s `dateUntil` method.
       </p>
       <emu-alg>
         1. If _options_ is not given, set it to ! OrdinaryObjectCreate(%Object.prototype%).
         1. Let _timeDifference_ be ? DifferenceTime(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
-        1. Let _balanceResult_ be ? BalanceDate(_y1_, _mon1_, _d1_ + _timeDifference_.[[Days]]).
+        1. Let _balanceResult_ be ? BalanceISODate(_y1_, _mon1_, _d1_ + _timeDifference_.[[Days]]).
         1. Let _date1_ be ? CreateTemporalDate(_balanceResult_.[[Year]], _balanceResult_.[[Month]], _balanceResult_.[[Day]]).
         1. Let _date2_ be ? CreateTemporalDate(_y2_, _mon2_, _d2_).
         1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"days"*, _largestUnit_).

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -331,7 +331,7 @@
               [[ISODay]]
             </td>
             <td>
-              An integer Number value between 1 and DaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing the day of the month in the ISO 8601 calendar.
+              An integer Number value between 1 and ISODaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing the day of the month in the ISO 8601 calendar.
             </td>
           </tr>
           <tr>
@@ -382,7 +382,7 @@
         1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. If _result_.[[Year]] is *undefined*, then
           1. Let _validateYear_ be the first leap year after the Unix epoch (1972).
-          1. If ! ValidateDate(_validateYear_, _result_.[[Month]], _result_.[[Day]]) is *false*, then
+          1. If ! ValidateISODate(_validateYear_, _result_.[[Month]], _result_.[[Day]]) is *false*, then
             1. Throw a *RangeError* exception.
           1. Return ? CreateTemporalMonthDayFromStatic(_constructor_, _result_.[[Month]], _result_.[[Day]], _calendar_, *undefined*).
         1. Set _result_ to ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _referenceISOYear_, _calendar_).
@@ -394,7 +394,7 @@
     <emu-clause id="sec-temporal-createtemporalmonthday" aoid="CreateTemporalMonthDay">
       <h1>CreateTemporalMonthDay ( _isoMonth_, _isoDay_, _calendar_, _referenceISOYear_ [ , _newTarget_ ] )</h1>
       <emu-alg>
-        1. If ! ValidateDate(_referenceISOYear_, _isoMonth_, _isoDay_) is *false*, then
+        1. If ! ValidateISODate(_referenceISOYear_, _isoMonth_, _isoDay_) is *false*, then
           1. Throw a *RangeError* exception.
         1. If _newTarget_ is not given, set it to %Temporal.PlainMonthDay%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.PlainMonthDay.prototype%"*, « [[InitializedTemporalMonthDay]], [[ISOMonth]], [[ISODay]], [[ISOYear]], [[Calendar]] »).
@@ -409,7 +409,7 @@
     <emu-clause id="sec-temporal-createtemporalmonthdayfromstatic" aoid="CreateTemporalMonthDayFromStatic">
       <h1>CreateTemporalMonthDayFromStatic ( _constructor_, _month_, _day_, _referenceISOYear_ )</h1>
       <emu-alg>
-        1. Assert: ! ValidateDate(_referenceISOYear_, _month_, _day_) is *true*.
+        1. Assert: ! ValidateISODate(_referenceISOYear_, _month_, _day_) is *true*.
         1. If ! IsConstructor(_constructor_) is *false*, then
           1. Throw a *TypeError* exception.
         1. Let _result_ be ? Construct(_constructor_, « _month_, _day_, _referenceISOYear_ »).
@@ -435,7 +435,7 @@
         1. Let _result_ be the string-concatenation of _month_, the code unit 0x002D (HYPHEN-MINUS), and _day_.
         1. Let _calendarID_ be ? ToString(_monthDay_.[[Calendar]]).
         1. If _calendarID_ is not *"iso8601"*, then
-          1. Let _year_ be ! PadYear(_monthDay_.[[ISOYear]]).
+          1. Let _year_ be ! PadISOYear(_monthDay_.[[ISOYear]]).
           1. Set _result_ to the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _result_.
         1. Let _calendarString_ be ? FormatCalendarAnnotation(_calendarID_, _showCalendar_).
         1. If _calendarString_ is not the empty String, then

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -545,7 +545,7 @@
               [[ISODay]]
             </td>
             <td>
-              An integer Number value between 1 and DaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing a reference day of the month in the ISO 8601 calendar.
+              An integer Number value between 1 and ISODaysInMonth([[ISOYear]], [[ISOMonth]]), inclusive, representing a reference day of the month in the ISO 8601 calendar.
               This slot is used by the calendar object in the [[Calendar]] slot to disambiguate if the [[ISOYear]] and [[ISOMonth]] slots are not enough to uniquely identify a year and month in that calendar.
             </td>
           </tr>
@@ -585,7 +585,7 @@
         1. Let _result_ be ? ParseTemporalYearMonthString(_string_).
         1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. If _result_.[[Day]] is *undefined*, then
-          1. If ! ValidateDate(_result_.[[Year]], _result_.[[Month]], 1) is *false*, then
+          1. If ! ValidateISODate(_result_.[[Year]], _result_.[[Month]], 1) is *false*, then
             1. Throw a *RangeError* exception.
           1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _calendar_, *undefined*).
         1. Set _result_ to ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[Day]]).
@@ -594,15 +594,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-regulateyearmonth" aoid="RegulateYearMonth">
-      <h1>RegulateYearMonth ( _year_, _month_, _overflow_ )</h1>
+    <emu-clause id="sec-temporal-regulateisoyearmonth" aoid="RegulateISOYearMonth">
+      <h1>RegulateISOYearMonth ( _year_, _month_, _overflow_ )</h1>
       <emu-alg>
         1. Assert: _year_ and _month_ are integer Number values.
         1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. If _overflow_ is *"constrain"*, then
-          1. Return ! ConstrainYearMonth(_year_, _month_).
+          1. Return ! ConstrainISOYearMonth(_year_, _month_).
         1. If _overflow_ is *"reject"*, then
-          1. If ! ValidateYearMonth(_year_, _month_) is *false*, then
+          1. If ! ValidateISOYearMonth(_year_, _month_) is *false*, then
             1. Throw a *RangeError* exception.
           1. Return the new Record {
               [[Year]]: _year_,
@@ -611,8 +611,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-validateyearmonth" aoid="ValidateYearMonth">
-      <h1>ValidateYearMonth ( _year_, _month_ )</h1>
+    <emu-clause id="sec-temporal-validateisoyearmonth" aoid="ValidateISOYearMonth">
+      <h1>ValidateISOYearMonth ( _year_, _month_ )</h1>
       <emu-alg>
         1. Assert: _year_ and _month_ are integer Number values.
         1. If _month_ &lt; 1 or _month_ &gt; 12, then
@@ -621,8 +621,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-validateyearmonthrange" aoid="ValidateYearMonthRange">
-      <h1>ValidateYearMonthRange ( _year_, _month_ )</h1>
+    <emu-clause id="sec-temporal-validateisoyearmonthrange" aoid="ValidateISOYearMonthRange">
+      <h1>ValidateISOYearMonthRange ( _year_, _month_ )</h1>
       <emu-alg>
         1. Assert: _year_ and _month_ are integer Number values.
         1. If _year_ &lt; −271821 or _year_ &gt; 275760, then
@@ -635,8 +635,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-balanceyearmonth" aoid="BalanceYearMonth">
-      <h1>BalanceYearMonth ( _year_, _month_ )</h1>
+    <emu-clause id="sec-temporal-balanceisoyearmonth" aoid="BalanceISOYearMonth">
+      <h1>BalanceISOYearMonth ( _year_, _month_ )</h1>
       <emu-alg>
         1. Assert: _year_ and _month_ are integer Number values.
         1. If _year_ is *+∞* or *−∞*, or _month_ is *+∞* or *−∞*, then
@@ -650,8 +650,8 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-constrainyearmonth" aoid="ConstrainYearMonth">
-      <h1>ConstrainYearMonth ( _year_, _month_ )</h1>
+    <emu-clause id="sec-temporal-constrainisoyearmonth" aoid="ConstrainISOYearMonth">
+      <h1>ConstrainISOYearMonth ( _year_, _month_ )</h1>
       <emu-alg>
         1. Assert: _year_ and _month_ are integer Number values.
         1. Set _month_ to ! ConstrainToRange(_month_, 1, 12).
@@ -665,9 +665,9 @@
     <emu-clause id="sec-temporal-createtemporalyearmonth" aoid="CreateTemporalYearMonth">
       <h1>CreateTemporalYearMonth ( _isoYear_, _isoMonth_, _calendar_, _referenceISODay_ [ , _newTarget_ ] )</h1>
       <emu-alg>
-        1. If ! ValidateDate(_isoYear_, _isoMonth_, _referenceISODay_) is *false*, then
+        1. If ! ValidateISODate(_isoYear_, _isoMonth_, _referenceISODay_) is *false*, then
           1. Throw a *RangeError* exception.
-        1. If ! ValidateYearMonthRange(_isoYear_, _isoMonth_) is *false*, then
+        1. If ! ValidateISOYearMonthRange(_isoYear_, _isoMonth_) is *false*, then
           1. Throw a *RangeError* exception.
         1. If _newTarget_ is not given, set it to %Temporal.PlainYearMonth%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.PlainYearMonth.prototype%"*, « [[InitializedTemporalYearMonth]], [[ISOYear]], [[ISOMonth]], [[ISODay]], [[Calendar]] »).
@@ -682,7 +682,7 @@
     <emu-clause id="sec-temporal-createtemporalyearmonthfromstatic" aoid="CreateTemporalYearMonthFromStatic">
       <h1>CreateTemporalYearMonthFromStatic ( _constructor_, _year_, _month_, _calendar_, _referenceISODay_ )</h1>
       <emu-alg>
-        1. Assert: ! ValidateDate(_year_, _month_, _referenceISODay_) is *true*.
+        1. Assert: ! ValidateISODate(_year_, _month_, _referenceISODay_) is *true*.
         1. If ! IsConstructor(_constructor_) is *false*, then
           1. Throw a *TypeError* exception.
         1. Let _result_ be ? Construct(_constructor_, « _year_, _month_, _calendar_, _referenceISODay_ »).
@@ -703,7 +703,7 @@
       <emu-alg>
         1. Assert: Type(_yearMonth_) is Object.
         1. Assert: _yearMonth_ has an [[InitializedTemporalYearMonth]] internal slot.
-        1. Let _year_ be ! PadYear(_yearMonth_.[[ISOYear]]).
+        1. Let _year_ be ! PadISOYear(_yearMonth_.[[ISOYear]]).
         1. Let _month_ be _yearMonth_.[[ISOMonth]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _result_ be the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _month_.
         1. Let _calendarID_ be ? ToString(_yearMonth_.[[Calendar]]).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -263,8 +263,8 @@
         1. Set _instant_ to ? ToTemporalInstant(_instant_).
         1. Let _calendar_ be ? ToOptionalTemporalCalendar(_calendarLike_).
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. Let _result_ be ! GetPartsFromEpoch(_instant_.[[Nanoseconds]]).
-        1. Set _result_ to ? BalanceDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).
+        1. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+        1. Set _result_ to ? BalanceISODateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
       </emu-alg>
       <p>
@@ -298,7 +298,7 @@
         1. Assert: _n_ = 0.
         1. If _disambiguation_ is *"reject"*, then
           1. Throw a *RangeError* exception.
-        1. Let _epochNanoseconds_ be ! GetEpochFromParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
+        1. Let _epochNanoseconds_ be ! GetEpochFromISOParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
         1. Let _dayBefore_ be ? CreateTemporalInstant(_epochNanoseconds_ − 8.64 × 10<sup>13</sup>).
         1. Let _dayAfter_ be ? CreateTemporalInstant(_epochNanoseconds_ + 8.64 × 10<sup>13</sup>).
         1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayBefore_).
@@ -332,7 +332,7 @@
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimezone]]).
         1. Set _dateTime_ to ? ToTemporalDateTime(_dateTime_).
         1. If _timeZone_.[[OffsetNanoseconds]] is not *undefined*, then
-          1. Let _epochNanoseconds_ be ! GetEpochFromParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
+          1. Let _epochNanoseconds_ be ! GetEpochFromISOParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
           1. Let _instant_ be ? CreateTemporalInstant(_epochNanoseconds_ − _timeZone_.[[OffsetNanoseconds]]).
           1. Return ? CreateArrayFromList(« _instant_ »).
         1. Let _possibleEpochNanoseconds_ be ? GetIANATimeZoneEpochValue(_timeZone_.[[Identifier]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
@@ -491,10 +491,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-getpartsfromepoch" aoid="GetPartsFromEpoch">
-      <h1>GetPartsFromEpoch ( _epochNanoseconds_ )</h1>
+    <emu-clause id="sec-temporal-getisopartsfromepoch" aoid="GetISOPartsFromEpoch">
+      <h1>GetISOPartsFromEpoch ( _epochNanoseconds_ )</h1>
       <p>
-        The abstract operation GetPartsFromEpoch returns the components of a date corresponding to the given number of nanoseconds since the Unix epoch in UTC.
+        The abstract operation GetISOPartsFromEpoch returns the components of a date corresponding to the given number of nanoseconds since the Unix epoch in UTC.
       </p>
       <emu-alg>
         1. Let _remainderNs_ be ! NonNegativeModulo(_epochNanoseconds_, 1,000,000<sub>ℝ</sub>).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -440,7 +440,7 @@
         1. Let _day_ be _temporalDateTime_.[[ISODay]].
         1. Let _isoCalendar_ be ? GetISO8601Calendar().
         1. Let _today_ be ? CreateTemporalDateTime(_year_, _month_, _day_, 0, 0, 0, 0, 0, 0, _isoCalendar_).
-        1. Let _tomorrowFields_ be ? AddDate(_year_, _month_, _day_, 0, 0, 0, 1, *"reject"*).
+        1. Let _tomorrowFields_ be ? AddISODate(_year_, _month_, _day_, 0, 0, 0, 1, *"reject"*).
         1. Let _tomorrow_ be ? CreateTemporalDateTime(_tomorrowFields_.[[Year]], _tomorrowFields_.[[Month]], _tomorrowFields_.[[Day]], 0, 0, 0, 0, 0, 0, _isoCalendar_).
         1. Let _todayInstant_ be ? GetTemporalInstantFor(_timeZone_, _today_, *"compatible"*).
         1. Let _tomorrowInstant_ be ? GetTemporalInstantFor(_timeZone_, _tomorrow_, *"compatible"*).
@@ -596,7 +596,7 @@
           1. Set _offsetString_ to ? Get(_fields_, *"offset"*).
         1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
-        1. Let _epochNanoseconds_ be ? InterpretTemporalZonedDateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).
         1. Return ? CreateTemporalZonedDateTimeFromInstance(_zonedDateTime_, _epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -801,9 +801,9 @@
         1. Let _startNs_ be _instantStart_.[[Nanoseconds]].
         1. Let _endNs_ be ? AddZonedDateTime(_startNs_, _timeZone_, _zonedDateTime_.[[Calendar]], 0, 0, 0, 1, 0, 0, 0, 0, 0, 0).
         1. Let _dayLengthNs_ be _endNs_ − _startNs_.
-        1. Let _roundResult_ be ? RoundDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dayLengthNs_).
+        1. Let _roundResult_ be ? RoundISODateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dayLengthNs_).
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. Let _epochNanoseconds_ be ? InterpretTemporalZonedDateTimeOffset(_roundResult_.[[Year]], _roundResult_.[[Month]], _roundResult_.[[Day]], _roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], _offsetNanoseconds_, _timeZone_, *"compatible"*, *"prefer"*).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_.[[Year]], _roundResult_.[[Month]], _roundResult_.[[Day]], _roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], _offsetNanoseconds_, _timeZone_, *"compatible"*, *"prefer"*).
         1. Return ? CreateTemporalZonedDateTimeFromInstance(_zonedDateTime_, _epochNanoseconds_, _timeZone_, _zonedDateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -1078,10 +1078,10 @@
   <emu-clause id="sec-temporal-zoneddatetime-abstract-ops">
     <h1>Abstract operations</h1>
 
-    <emu-clause id="sec-temporal-interprettemporalzoneddatetimeoffset" aoid="InterpretTemporalZonedDateTimeOffset">
-      <h1>InterpretTemporalZonedDateTimeOffset ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_ )</h1>
+    <emu-clause id="sec-temporal-interpretisodatetimeoffset" aoid="InterpretISODateTimeOffset">
+      <h1>InterpretISODateTimeOffset ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_ )</h1>
       <p>
-        The abstract operation InterpretTemporalZonedDateTimeOffset determines the exact time in _timeZone_ corresponding to the given calendar date and time, and the given UTC offset in nanoseconds.
+        The abstract operation InterpretISODateTimeOffset determines the exact time in _timeZone_ corresponding to the given calendar date and time, and the given UTC offset in nanoseconds.
         In the case of more than one possible exact time, or no possible exact time, an answer is determined using _disambiguation_ and _offset_.
       </p>
       <emu-alg>
@@ -1092,7 +1092,7 @@
           1. Let _instant_ be ? GetTemporalInstantFor(_timeZone_, _dateTime_, _disambiguation_).
           1. Return _instant_.[[Nanoseconds]].
         1. If _offset_ is *"use"*, then
-          1. Let _epochNanoseconds_ be ? GetEpochFromParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+          1. Let _epochNanoseconds_ be ? GetEpochFromISOParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
           1. Return _epochNanoseconds_ − _offsetNanoseconds_.
         1. Assert: _offset_ is *"prefer"* or *"reject"*.
         1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
@@ -1135,7 +1135,7 @@
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
         1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
         1. Let _offset_ be ? ToTemporalOffset(_options_, *"reject"*).
-        1. Let _epochNanoseconds_ be ? InterpretTemporalZonedDateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).
         1. Return ? CreateTemporalZonedDateTimeFromStatic(_constructor_, _epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -1291,7 +1291,7 @@
         1. Let _startDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _startInstant_, _calendar_).
         1. Let _endInstant_ be ? CreateInstant(_ns2_).
         1. Let _endDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _endInstant_, _calendar_).
-        1. Let _dateDifference_ be ? DifferenceDateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
+        1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
         1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZone_, _calendar_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], 0, 0, 0, 0, 0, 0, 0).
         1. Let _timeRemainderNs_ be _ns2_ − _intermediateNs_.
         1. Let _intermediate_ be ? CreateTemporalZonedDateTime(_intermediateNs_, _timeZone_, _calendar_).
@@ -1324,7 +1324,7 @@
         1. Let _endNs_ be _startNs_ + _nanoseconds_.
         1. Let _endInstant_ be ? CreateTemporalInstant(_endNs_).
         1. Let _endDateTime_ be ? GetTemporalDateTimeFor(_relativeTo_.[[TimeZone]], _endInstant_, _relativeTo_.[[Calendar]]).
-        1. Let _dateDifference_ be ? DifferenceDateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"days"*).
+        1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"days"*).
         1. Let _days_ be _dateDifference_.[[Days]].
         1. Let _intermediateNs_ be ? AddZonedDateTime(_startNs_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, 0, 0, 0, 0, 0, 0).
         1. If _sign_ = 1, then


### PR DESCRIPTION
For all abstract operations that operate exclusively on ISO-valued or ISO-named
fields/slots, rename them to prepend ISO to the relevant part of the operation
name. E.g. "RegulateDate" => "RegulateISODate".

Fixes #1389.