### PR TITLE
Fix undefined / unused variables in spec text.

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3266,6 +3266,7 @@ export const ES = ObjectAssign({}, ES2020, {
     // not expected and so is avoided below via a fast path for time-only
     // arithmetic.
     // BTW, this behavior is similar in spirit to offset: 'prefer' in `with`.
+    const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
     if (ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0) === 0) {
       return ES.AddInstant(GetSlot(instant, EPOCHNANOSECONDS), h, min, s, ms, µs, ns);
     }
@@ -3275,7 +3276,8 @@ export const ES = ObjectAssign({}, ES2020, {
     let dt = ES.GetTemporalDateTimeFor(timeZone, instant, calendar);
     const TemporalDate = GetIntrinsic('%Temporal.PlainDate%');
     const datePart = new TemporalDate(GetSlot(dt, ISO_YEAR), GetSlot(dt, ISO_MONTH), GetSlot(dt, ISO_DAY), calendar);
-    const addedDate = ES.CalendarDateAdd(calendar, datePart, { years, months, weeks, days }, options, TemporalDate);
+    const dateDuration = new TemporalDuration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+    const addedDate = ES.CalendarDateAdd(calendar, datePart, dateDuration, options, TemporalDate);
     const TemporalDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
     const dtIntermediate = new TemporalDateTime(
       GetSlot(addedDate, ISO_YEAR),

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1314,7 +1314,7 @@
       1. Set _hours_ to ? ToIntegerOrInfinity(_hours_) × _factor_.
       1. Set _minutes_ to ? ToIntegerOrInfinity(_minutes_) × _factor_.
       1. Set _seconds_ to ? ToIntegerOrInfinity(_seconds_) × _factor_.
-      1. If _fraction_ is not undefined, then
+      1. If _fraction_ is not *undefined*, then
         1. Let _fraction_ be the part of _isoString_ produced by the |TimeFractionalPart| production.
         1. Set _fraction_ to the string-concatenation of the previous value of _fraction_ and the string *"000000000"*.
         1. Let _milliseconds_ be the String value equal to the substring of _fraction_ consisting of the code units with indices 0 (inclusive) through 3 (exclusive).

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -284,7 +284,7 @@
       1. Else,
         1. Assert: _smallestUnit_ is *"millisecond"*, *"microsecond"*, or *"nanosecond"*.
         1. Let _maximum_ be 1000.
-      1. Return ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+      1. Return ? ToTemporalRoundingIncrement(_normalizedOptions_, _maximum_, *false*).
     </emu-alg>
   </emu-clause>
 
@@ -589,7 +589,7 @@
       1. Else,
         1. Let _string_ be ? ToString(_value_).
         1. Let _result_ be ? ParseISODateTime(_string_).
-        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_record_.[[Calendar]]).
+        1. Let _calendar_ be ? ToOptionalTemporalCalendar(_result_.[[Calendar]]).
         1. Let _offset_ be _result_.[[TimeZoneOffset]].
         1. Let _timeZone_ be _result_.[[TimeZoneIANAName]].
       1. If _timeZone_ is not *undefined*, then
@@ -1273,7 +1273,7 @@
         [[Year]]: _result_.[[Year]],
         [[Month]]: _result_.[[Month]],
         [[Day]]: _result_.[[Day]],
-        [[Calendar]]: _calendar_
+        [[Calendar]]: _result_.[[Calendar]]
         }.
     </emu-alg>
   </emu-clause>
@@ -1302,7 +1302,7 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalDurationString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
-      1. Let _sign_, _years_, _months_, _weeks_, _days_, _hours_, _fHours_, _minutes_, _fMinutes_, _seconds_, and _fSeconds_ be the parts of _isoString_ produced respectively by the |Sign|, |DurationYears|, |DurationMonths|, |DurationWeeks|, |DurationDays|, |DurationHours|, |DurationHoursFraction|, |DurationMinutes|, |DurationMinutesFraction|, |DurationSeconds|, and |DurationSecondsFraction| productions, or *undefined* if not present.
+      1. Let _sign_, _years_, _months_, _weeks_, _days_, _hours_, _fHours_, _minutes_, _fMinutes_, _seconds_, and _fraction_ be the parts of _isoString_ produced respectively by the |Sign|, |DurationYears|, |DurationMonths|, |DurationWeeks|, |DurationDays|, |DurationHours|, |DurationHoursFraction|, |DurationMinutes|, |DurationMinutesFraction|, |DurationSeconds|, and |TimeFractionalPart| productions, or *undefined* if not present.
       1. If _sign_ is the code unit 0x002D (HYPHEN-MINUS) or 0x2212 (MINUS SIGN), then
         1. Let _factor_ be −1.
       1. Else,
@@ -1314,7 +1314,7 @@
       1. Set _hours_ to ? ToIntegerOrInfinity(_hours_) × _factor_.
       1. Set _minutes_ to ? ToIntegerOrInfinity(_minutes_) × _factor_.
       1. Set _seconds_ to ? ToIntegerOrInfinity(_seconds_) × _factor_.
-      1. If _isoString_ contains a |TimeFractionalPart| production, then
+      1. If _fraction_ is not undefined, then
         1. Let _fraction_ be the part of _isoString_ produced by the |TimeFractionalPart| production.
         1. Set _fraction_ to the string-concatenation of the previous value of _fraction_ and the string *"000000000"*.
         1. Let _milliseconds_ be the String value equal to the substring of _fraction_ consisting of the code units with indices 0 (inclusive) through 3 (exclusive).
@@ -1426,7 +1426,7 @@
           1. Set _sign_ to −1.
         1. Else,
           1. Set _sign_ to 1.
-        1. Set _minutes_ to ! ToIntegerOrInfinity(_minute_).
+        1. Set _minutes_ to ! ToIntegerOrInfinity(_minutes_).
         1. Set _seconds_ to ! ToIntegerOrInfinity(_seconds_).
         1. If _fraction_ is not *undefined*, then
           1. Set _fraction_ to the string-concatenation of the previous value of _fraction_ and the string *"000000000"*.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -318,7 +318,7 @@
         1. If _temporalDurationLike_.[[Years]] is not *undefined*, then
           1. Let _years_ be _temporalDurationLike_.[[Years]].
         1. Else,
-          1. Let _year_ be _duration_.[[Year]].
+          1. Let _years_ be _duration_.[[Years]].
         1. If _temporalDurationLike_.[[Months]] is not *undefined*, then
           1. Let _months_ be _temporalDurationLike_.[[Months]].
         1. Else,
@@ -435,7 +435,7 @@
         1. If _smallestUnit_ is *undefined*, then
           1. Set _smallestUnitPresent_ to *false*.
           1. Set _smallestUnit_ to *"nanoseconds"*.
-        1. Let _defaultLargestUnit_ be ! DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Let _defaultLargestUnit_ be ! DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
         1. Set _defaultLargestUnit_ to ! LargerOfTwoTemporalDurationUnits(_defaultLargestUnit_, _smallestUnit_).
         1. Let _largestUnit_ be ? ToLargestTemporalDurationUnit(_options_).
         1. If _largestUnit_ is *undefined*, then
@@ -450,8 +450,8 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _relativeTo_ be ? ToRelativeTemporalObject(_options_).
-        1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_years_, _months_, _weeks_, _days_, _largestUnit_, _relativeTo_).
-        1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
+        1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _relativeTo_).
+        1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_[[Seconds]], _duration_[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
         1. Let _adjustResult_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
         1. Let _balanceResult_ be ? BalanceDurationRelative(_adjustResult_.[[Years]], _adjustResult_.[[Months]], _adjustResult_.[[Weeks]], _adjustResult_.[[Days]], _largestUnit_, _relativeTo_).
         1. If _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
@@ -475,7 +475,7 @@
         1. Let _unit_ be ? ToTemporalDurationTotalUnit(_options_).
         1. If _unit_ is *undefined*, then
           1. Throw a *RangeError* exception.
-        1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_years_, _months_, _weeks_, _days_, _unit_, _relativeTo_).
+        1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _relativeTo_).
         1. Let _intermediate_ be *undefined*.
         1. If _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Set _intermediate_ to ? MoveRelativeZonedDateTime(_relativeTo_, _unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], 0).
@@ -759,7 +759,7 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-defaulttemporallargestunit" aoid="DefaultTemporalLargestUnit">
-      <h1>DefaultTemporalLargestUnit ( _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ )</h1>
+      <h1>DefaultTemporalLargestUnit ( _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_ )</h1>
       <p>
         The abstract operation DefaultTemporalLargestUnit implements the logic used in the `Temporal.Duration.prototype.round()` method and elsewhere, where the `largestUnit` option, if not given explicitly, is set to the largest non-zero unit in the input Temporal.Duration.
       </p>
@@ -995,13 +995,13 @@
           1. Repeat, while abs(_years_) &gt; 0,
             1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
-            1. Set _oneYearDays_ to _moveResult_.[[Days]].
+            1. Let _oneYearDays_ be _moveResult_.[[Days]].
             1. Set _years_ to _years_ − _sign_.
             1. Set _days_ to _days_ + _oneYearDays_.
           1. Repeat, while abs(_months_) &gt; 0,
             1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
-            1. Set _oneMonthDays_ to _moveResult_.[[Days]].
+            1. Let _oneMonthDays_ be _moveResult_.[[Days]].
             1. Set _months_ to _months_ − _sign_.
             1. Set _days_ to _days_ + _oneMonthDays_.
         1. Else,
@@ -1011,19 +1011,19 @@
             1. Repeat, while abs(_years_) &gt; 0,
               1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
-              1. Set _oneYearDays_ to _moveResult_.[[Days]].
+              1. Let _oneYearDays_ be _moveResult_.[[Days]].
               1. Set _years_ to _years_ − _sign_.
               1. Set _days_ to _days_ + _oneYearDays_.
             1. Repeat, while abs(_months_) &gt; 0,
               1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
-              1. Set _oneMonthDays_ to _moveResult_.[[Days]].
+              1. Let _oneMonthDays_ be _moveResult_.[[Days]].
               1. Set _months_ to _months_ − _sign_.
               1. Set _days_ to _days_ + _oneMonthDays_.
             1. Repeat, while abs(_weeks_) &gt; 0,
               1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
-              1. Set _oneWeekDays_ to _moveResult_.[[Days]].
+              1. Let _oneWeekDays_ be _moveResult_.[[Days]].
               1. Set _weeks_ to _weeks_ − _sign_.
               1. Set _days_ to _days_ + _oneWeekDays_.
         1. Return the new Record {
@@ -1126,8 +1126,8 @@
       </p>
       <emu-alg>
         1. Assert: _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_ are integer Number values.
-        1. Let _largestUnit1_ be ! DefaultTemporalLargestUnit(_y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
-        1. Let _largestUnit2_ be ! DefaultTemporalLargestUnit(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _largestUnit1_ be ! DefaultTemporalLargestUnit(_y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_).
+        1. Let _largestUnit2_ be ! DefaultTemporalLargestUnit(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_).
         1. Let _largestUnit_ be ! LargerOfTwoTemporalDurationUnits(_largestUnit1_, _largestUnit2_).
         1. If _relativeTo_ is *undefined*, then
           1. If _largestUnit_ is one of *"years"*, *"months"*, or *"weeks"*, then
@@ -1253,7 +1253,7 @@
       </p>
       <emu-alg>
         1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
-        1. Let _intermediate_ be ? CreateTemporalZonedDateTime(_intermediateNs_, _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]]).
+        1. Return ? CreateTemporalZonedDateTime(_intermediateNs_, _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -1511,7 +1511,7 @@
           1. If _precision_ is *"auto"*, then
             1. If _fraction_ ≠ 0, then
               1. Let _decimalPart_ be _fraction_ formatted as a nine-digit decimal number, padded to the left with zeroes if necessary.
-              1. Set _fractionString_ to the longest possible substring of _decimalPart_ starting at position 0 and not ending with the code unit 0x0030 (DIGIT ZERO).
+              1. Let _fractionString_ be the longest possible substring of _decimalPart_ starting at position 0 and not ending with the code unit 0x0030 (DIGIT ZERO).
           1. Else if _precision_ ≠ 0, then
             1. Let _decimalPart_ be _fraction_ formatted as a decimal number.
             1. Let _len_ be the length of _fractionString_.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -356,9 +356,10 @@
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
+        1. Let _balancedDuration_ be ? CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _constructor_ be ? SpeciesConstructor(_temporalDate_, %Temporal.PlainDate%).
-        1. Return ? CalendarDateAdd(_calendar_, _temporalDate_, _duration_, _options_, _constructor_).
+        1. Return ? CalendarDateAdd(_temporalDate_.[[Calendar]], _temporalDate_, _balancedDuration_, _options_, _constructor_).
       </emu-alg>
     </emu-clause>
 
@@ -375,9 +376,9 @@
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
-        1. Let _negatedDuration_ be ? CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_duration_.[[Days]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]]).
+        1. Let _negatedDuration_ be ? CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _constructor_ be ? SpeciesConstructor(_temporalDate_, %Temporal.PlainDate%).
-        1. Return ? CalendarDateAdd(_calendar_, _temporalDate_, _negatedDuration_, _options_, _constructor_).
+        1. Return ? CalendarDateAdd(_temporalDate_.[[Calendar]], _temporalDate_, _negatedDuration_, _options_, _constructor_).
       </emu-alg>
     </emu-clause>
 
@@ -723,7 +724,7 @@
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? ToTemporalDateFields(_item_, _fieldNames_).
           1. Return ? DateFromFields(_calendar_, _fields_, _constructor_, _options_).
-        1. Perform ? ToTemporalOverflow(_options_).
+        1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalDateString(_string_).
         1. If ! ValidateDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *false*, then
@@ -871,7 +872,6 @@
         1. Let _month_ be _balancedYearMonth_.[[Month]].
         1. Let _year_ be _balancedYearMonth_.[[Year]].
         1. NOTE: To deal with negative numbers of days whose absolute value is greater than the number of days in a year, the following section subtracts years and adds days until the number of days is greater than −366 or −365.
-        1. Let _daysInYear_ be 0.
         1. If _month_ &gt; 2, then
           1. Let _testYear_ be _year_.
         1. Else,

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -404,10 +404,10 @@
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
         1. Let _partialDateTime_ be ? PreparePartialTemporalFields(_temporalDateTimeLike_, _fieldNames_).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
-        1. Let _fields_ be ? ToTemporalDateTimeFields(_datetime_, _fieldNames_).
+        1. Let _fields_ be ? ToTemporalDateTimeFields(_dateTime_, _fieldNames_).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialDateTime_).
         1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
-        1. Assert: ! ValidateDateTime(_year_, _month_, _day_, _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
+        1. Assert: ! ValidateDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -358,6 +358,7 @@
       <emu-alg>
         1. If _constructor_ is not given, set it to %Temporal.PlainMonthDay%.
         1. If _options_ is not given, set it to ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _referenceISOYear_ be *1972*<sub>𝔽</sub>.
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalMonthDay]] internal slot, then
             1. Return _item_.
@@ -371,8 +372,9 @@
           1. Let _fields_ be ? ToTemporalMonthDayFields(_item_, _fieldNames_).
           1. Let _month_ be ? Get(_fields_, *"month"*).
           1. Let _monthCode_ be ? Get(_fields_, *"monthCode"*).
+          1. Let _year_ be ? Get(_fields_, *"year"*).
           1. If _calendarAbsent_ is *true*, and _month_ is not *undefined*, and _monthCode_ is *undefined* and _year_ is *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_fields_, *"year"*, *1972*<sub>𝔽</sub>).
+            1. Perform ! CreateDataPropertyOrThrow(_fields_, *"year"*, _referenceISOYear_).
           1. Return ? MonthDayFromFields(_calendar_, _fields_, _constructor_, _options_).
         1. Perform ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
@@ -392,12 +394,12 @@
     <emu-clause id="sec-temporal-createtemporalmonthday" aoid="CreateTemporalMonthDay">
       <h1>CreateTemporalMonthDay ( _isoMonth_, _isoDay_, _calendar_, _referenceISOYear_ [ , _newTarget_ ] )</h1>
       <emu-alg>
-        1. If ! ValidateDate(_referenceISOYear_, _month_, _day_) is *false*, then
+        1. If ! ValidateDate(_referenceISOYear_, _isoMonth_, _isoDay_) is *false*, then
           1. Throw a *RangeError* exception.
         1. If _newTarget_ is not given, set it to %Temporal.PlainMonthDay%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.PlainMonthDay.prototype%"*, « [[InitializedTemporalMonthDay]], [[ISOMonth]], [[ISODay]], [[ISOYear]], [[Calendar]] »).
-        1. Set _object_.[[ISOMonth]] to _month_.
-        1. Set _object_.[[ISODay]] to _day_.
+        1. Set _object_.[[ISOMonth]] to _isoMonth_.
+        1. Set _object_.[[ISODay]] to _isoDay_.
         1. Set _object_.[[Calendar]] to _calendar_.
         1. Set _object_.[[ISOYear]] to _referenceISOYear_.
         1. Return _object_.

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -238,7 +238,6 @@
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _result_ be ? AddTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]]).
         1. Set _result_ to ? RegulateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], *"reject"*).
         1. Return ? CreateTemporalTimeFromInstance(_temporalTime_, _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
@@ -262,7 +261,6 @@
         1. Let _timeZoneProperty_ be ? Get(_temporalTimeLike_, *"timeZone"*).
         1. If _timeZoneProperty_ is not *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _calendar_ be _temporalTime_.[[Calendar]].
         1. Let _partialTime_ be ? ToPartialTime(_temporalTimeLike_).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
@@ -419,7 +417,7 @@
         1. Let _temporalDateLike_ be ? Get(_item_, *"plainDate"*).
         1. If _temporalDateLike_ is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _temporalDate_ to ? ToTemporalTime(_temporalDateLike_).
+        1. Let _temporalDate_ be ? ToTemporalTime(_temporalDateLike_).
         1. Let _temporalTimeZoneLike_ be ? Get(_item_, *"timeZone"*).
         1. If _temporalTimeZoneLike_ is *undefined*, then
           1. Throw a *TypeError* exception.
@@ -462,7 +460,7 @@
         1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundResult_ be ? RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
-        1. Return ? TemporalTimeToString(_roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], _temporalTime_.[[Calendar]], _precision_.[[Precision]]).
+        1. Return ? TemporalTimeToString(_roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], _precision_.[[Precision]]).
       </emu-alg>
     </emu-clause>
 
@@ -478,7 +476,7 @@
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. Return ? TemporalTimeToString(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _temporalTime_.[[Calendar]], *"auto"*, *"auto"*).
+        1. Return ? TemporalTimeToString(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], *"auto"*, *"auto"*).
       </emu-alg>
     </emu-clause>
 
@@ -875,7 +873,7 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-temporaltimetostring" aoid="TemporalTimeToString">
-      <h1>TemporalTimeToString ( _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_, _precision_ )</h1>
+      <h1>TemporalTimeToString ( _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _precision_ )</h1>
       <emu-alg>
         1. Let _hour_ be _hour_ formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _hour_ be _minute_ formatted as a two-digit decimal number, padded to the left with a zero if necessary.

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -588,7 +588,7 @@
           1. If ! ValidateDate(_result_.[[Year]], _result_.[[Month]], 1) is *false*, then
             1. Throw a *RangeError* exception.
           1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _calendar_, *undefined*).
-        1. Set _result_ to ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _referenceISODay_).
+        1. Set _result_ to ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[Day]]).
         1. Let _canonicalYearMonthOptions_ be ! OrdinaryObjectCreate(%Object.prototype%).
         1. Return ? YearMonthFromFields(_calendar_, _result_, _constructor_, _canonicalYearMonthOptions_).
       </emu-alg>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -124,7 +124,7 @@
           1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_identifier_).
           1. Let _canonical_ be ? FormatTimeZoneOffsetString(_offsetNanoseconds_).
         1. Else,
-          1. If ! IsValidTimeZoneName(_id_) is *false*, then
+          1. If ! IsValidTimeZoneName(_identifier_) is *false*, then
             1. Throw a *RangeError* exception.
           1. Let _canonical_ be ! CanonicalizeTimeZoneName(_identifier_).
         1. Return ? CreateTemporalTimeZone(_canonical_, NewTarget).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -322,7 +322,7 @@
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalZonedDateTime]]).
+        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Let _ns_ be _zonedDateTime_.[[Nanoseconds]].
         1. Let _s_ be RoundTowardsZero(ℝ(_ns_) / 1,000,000,000<sub>ℝ</sub>).
         1. Return 𝔽(_s_).
@@ -337,7 +337,7 @@
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalZonedDateTime]]).
+        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Let _ns_ be _zonedDateTime_.[[Nanoseconds]].
         1. Let _ms_ be RoundTowardsZero(ℝ(_ns_) / 1,000,000<sub>ℝ</sub>).
         1. Return 𝔽(_ms_).
@@ -352,7 +352,7 @@
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalZonedDateTime]]).
+        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Let _ns_ be _zonedDateTime_.[[Nanoseconds]].
         1. Let _µs_ be RoundTowardsZero(ℝ(_ns_) / 1,000<sub>ℝ</sub>).
         1. Return ℤ(_µs_).
@@ -367,7 +367,7 @@
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalZonedDateTime]]).
+        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Return _zonedDateTime_.[[Nanoseconds]].
       </emu-alg>
     </emu-clause>
@@ -771,8 +771,8 @@
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_).
-        1. Let _roundResult_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
-        1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
+        1. Let _roundResult_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
+        1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
         1. Return ? CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], −_result_.[[Weeks]], −_result_.[[Days]], −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -799,7 +799,7 @@
         1. Let _dtStart_ be ? CreateTemporalDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], 0, 0, 0, 0, 0, 0, _isoCalendar_).
         1. Let _instantStart_ be ? GetTemporalInstantFor(_timeZone_, _dtStart_, *"compatible"*).
         1. Let _startNs_ be _instantStart_.[[Nanoseconds]].
-        1. Let _endNs_ be ? AddZonedDateTime(_startNs_, _timeZone_, _calendar_, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0).
+        1. Let _endNs_ be ? AddZonedDateTime(_startNs_, _timeZone_, _zonedDateTime_.[[Calendar]], 0, 0, 0, 1, 0, 0, 0, 0, 0, 0).
         1. Let _dayLengthNs_ be _endNs_ − _startNs_.
         1. Let _roundResult_ be ? RoundDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dayLengthNs_).
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
@@ -839,7 +839,7 @@
         1. Let _showCalendar_ be ? ToShowCalendarOption(_options_).
         1. Let _showTimeZone_ be ? ToShowTimeZoneNameOption(_options_).
         1. Let _showOffset_ be ? ToShowOffsetOption(_options_).
-        1. Return ? TemporalZonedDateTimeToString(_zonedDateTime_, _precision_.[[Precision]], _showCalendar_, _showTimeZone, _showOffset_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Return ? TemporalZonedDateTimeToString(_zonedDateTime_, _precision_.[[Precision]], _showCalendar_, _showTimeZone_, _showOffset_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
       </emu-alg>
     </emu-clause>
 
@@ -1002,7 +1002,7 @@
         1. Let _fields_ be ? ObjectCreate(%ObjectPrototype%).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ? CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _temporalDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_).
+        1. Let _dateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_).
         1. Let _offset_ be ? GetOffsetStringFor(_timeZone_, _instant_).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"calendar"*, _zonedDateTime_.[[Calendar]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"hour"*, _dateTime_.[[ISOHour]]).
@@ -1155,7 +1155,7 @@
         1. Let _fieldNamesList_ be ? CreateListFromArrayLike(_fieldNames_).
         1. Append *"offset"* to _fieldNamesList_.
         1. Set _fieldNames_ to ? CreateArrayFromList(_fieldNamesList_).
-        1. Let _result_ be ? PreparePartialTemporalFields(_temporalDateTimeLike_, _fieldNames_).
+        1. Let _result_ be ? PreparePartialTemporalFields(_temporalZonedDateTimeLike_, _fieldNames_).
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -1222,7 +1222,7 @@
         1. Let _fieldNamesList_ be ? CreateListFromArrayLike(_fieldNames_).
         1. Append *"timeZone"* to _fieldNamesList_.
         1. Set _fieldNames_ to ? CreateArrayFromList(_fieldNamesList_).
-        1. Let _result_ be ? PrepareTemporalFields(_temporalZonedDateTimeLike_, _fieldNames_, « *"_timeZone_"* »).
+        1. Let _result_ be ? PrepareTemporalFields(_temporalZonedDateTimeLike_, _fieldNames_, « *"timeZone"* »).
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -1271,7 +1271,7 @@
         1. Let _temporalDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _instant_, _calendar_).
         1. Let _datePart_ be ? CreateTemporalDate(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _calendar_).
         1. Let _dateDuration_ be ? CreateTemporalDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
-        1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _dateDuration_, _options_, %Temporal.PlainDate%).
+        1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _datePart_, _dateDuration_, _options_, %Temporal.PlainDate%).
         1. Let _intermediateDateTime_ be ? CreateTemporalDateTime(_addedDate_.[[ISOYear]], _addedDate_.[[ISOMonth]], _addedDate_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _calendar_).
         1. Let _intermediateInstant_ be ? GetTemporalInstantFor(_timeZone_, _intermediateDateTime_, *"compatible"*).
         1. Return ! AddInstant(_intermediateInstant_.[[Nanoseconds]], _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
@@ -1318,12 +1318,13 @@
             [[Nanoseconds]]: _nanoseconds_ modulo _dayLengthNs_,
             [[DayLength]]: _sign_ × _dayLengthNs_
             }.
-        1. Let _startInstant_ be ? CreateTemporalInstant(_relativeTo_.[[Nanoseconds]]).
-        1. Let _startDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _startInstant_, _calendar_).
-        1. Let _endNs_ be _relativeTo_.[[Nanoseconds]] + _nanoseconds_.
+        1. Let _startNs_ be ? _relativeTo_.[[Nanoseconds]].
+        1. Let _startInstant_ be ? CreateTemporalInstant(_startNs_).
+        1. Let _startDateTime_ be ? GetTemporalDateTimeFor(_relativeTo_.[[TimeZone]], _startInstant_, _relativeTo_.[[Calendar]]).
+        1. Let _endNs_ be _startNs_ + _nanoseconds_.
         1. Let _endInstant_ be ? CreateTemporalInstant(_endNs_).
-        1. Let _endDateTime_ be ? GetTemporalDateTimeFor(_timeZone_, _endInstant_, _calendar_).
-        1. Let _dateDifference_ be ? DifferenceDateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, *"days"*).
+        1. Let _endDateTime_ be ? GetTemporalDateTimeFor(_relativeTo_.[[TimeZone]], _endInstant_, _relativeTo_.[[Calendar]]).
+        1. Let _dateDifference_ be ? DifferenceDateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"days"*).
         1. Let _days_ be _dateDifference_.[[Days]].
         1. Let _intermediateNs_ be ? AddZonedDateTime(_startNs_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, 0, 0, 0, 0, 0, 0).
         1. If _sign_ = 1, then


### PR DESCRIPTION
Fix a number of small bugs where variables in spec text are used without being
defined, defined without being used; a wide range of small bugs exposed by a
quick-and-dirty linter I wrote. Common culprits look like:

- Referencing undefined _calendar_ instead of _someObject_.[[Calendar]]
- Set _thing_ to ? Create... instead of Let _thing_ be ? Create...