### PR TITLE
Fix abstract operation names

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -613,8 +613,8 @@
       </p>
       <emu-alg>
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. Let _result_ be ! GetPartsFromEpoch(_instant_.[[Nanoseconds]]).
-        1. Set _result_ to ? BalanceDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).
+        1. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+        1. Set _result_ to ? BalanceISODateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>
@@ -641,7 +641,7 @@
         1. Assert: _n_ = 0.
         1. If _disambiguation_ is *"reject"*, then
           1. Throw a *RangeError* exception.
-        1. Let _epochNanoseconds_ be ! GetEpochFromParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
+        1. Let _epochNanoseconds_ be ! GetEpochFromISOParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
         1. Let _dayBefore_ be ? CreateTemporalInstant(_epochNanoseconds_ − 8.64 × 10<sup>13</sup>).
         1. Let _dayAfter_ be ? CreateTemporalInstant(_epochNanoseconds_ + 8.64 × 10<sup>13</sup>).
         1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayBefore_).


### PR DESCRIPTION
These operations were renamed to have "ISO" in the name while I was
working on the patch that defined the operations in which they were
called.

Closes: #1416