### PR TITLE
Ensure that implementation-defined Intl operations access properties …

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -38,22 +38,19 @@ export class Calendar {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     if (ES.Type(fields) !== 'Object') throw new TypeError('invalid fields');
     options = ES.NormalizeOptionsObject(options);
-    const overflow = ES.ToTemporalOverflow(options);
-    return impl[GetSlot(this, CALENDAR_ID)].dateFromFields(fields, overflow, constructor, this);
+    return impl[GetSlot(this, CALENDAR_ID)].dateFromFields(fields, options, constructor, this);
   }
   yearMonthFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     if (ES.Type(fields) !== 'Object') throw new TypeError('invalid fields');
     options = ES.NormalizeOptionsObject(options);
-    const overflow = ES.ToTemporalOverflow(options);
-    return impl[GetSlot(this, CALENDAR_ID)].yearMonthFromFields(fields, overflow, constructor, this);
+    return impl[GetSlot(this, CALENDAR_ID)].yearMonthFromFields(fields, options, constructor, this);
   }
   monthDayFromFields(fields, options, constructor) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     if (ES.Type(fields) !== 'Object') throw new TypeError('invalid fields');
     options = ES.NormalizeOptionsObject(options);
-    const overflow = ES.ToTemporalOverflow(options);
-    return impl[GetSlot(this, CALENDAR_ID)].monthDayFromFields(fields, overflow, constructor, this);
+    return impl[GetSlot(this, CALENDAR_ID)].monthDayFromFields(fields, options, constructor, this);
   }
   fields(fields) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
@@ -91,46 +88,58 @@ export class Calendar {
   }
   year(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].year(date);
   }
   month(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (ES.IsTemporalMonthDay(date)) throw new TypeError('use monthCode on PlainMonthDay instead');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].month(date);
   }
   monthCode(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].monthCode(date);
   }
   day(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].day(date);
   }
   era(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].era(date);
   }
   eraYear(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].eraYear(date);
   }
   dayOfWeek(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].dayOfWeek(date);
   }
   dayOfYear(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].dayOfYear(date);
   }
   weekOfYear(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].weekOfYear(date);
   }
   daysInWeek(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].daysInWeek(date);
   }
   daysInMonth(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].daysInMonth(date);
   }
   daysInYear(date) {
@@ -139,6 +148,7 @@ export class Calendar {
   }
   monthsInYear(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return impl[GetSlot(this, CALENDAR_ID)].monthsInYear(date);
   }
   inLeapYear(date) {
@@ -175,21 +185,24 @@ MakeIntrinsicClass(Calendar, 'Temporal.Calendar');
 DefineIntrinsic('Temporal.Calendar.from', Calendar.from);
 
 impl['iso8601'] = {
-  dateFromFields(fields, overflow, constructor, calendar) {
+  dateFromFields(fields, options, constructor, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
     fields = ES.PrepareTemporalFields(fields, [['day'], ['month', undefined], ['monthCode', undefined], ['year']]);
     fields = resolveNonLunisolarMonth(fields);
     let { year, month, day } = fields;
     ({ year, month, day } = ES.RegulateISODate(year, month, day, overflow));
     return new constructor(year, month, day, calendar);
   },
-  yearMonthFromFields(fields, overflow, constructor, calendar) {
+  yearMonthFromFields(fields, options, constructor, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
     fields = ES.PrepareTemporalFields(fields, [['month', undefined], ['monthCode', undefined], ['year']]);
     fields = resolveNonLunisolarMonth(fields);
     let { year, month } = fields;
     ({ year, month } = ES.RegulateISOYearMonth(year, month, overflow));
     return new constructor(year, month, calendar, /* referenceISODay */ 1);
   },
-  monthDayFromFields(fields, overflow, constructor, calendar) {
+  monthDayFromFields(fields, options, constructor, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
     fields = ES.PrepareTemporalFields(fields, [
       ['day'],
       ['month', undefined],
@@ -238,58 +251,43 @@ impl['iso8601'] = {
     );
   },
   year(date) {
-    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return GetSlot(date, ISO_YEAR);
   },
-  era(date) {
-    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+  era() {
     return undefined;
   },
-  eraYear(date) {
-    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+  eraYear() {
     return undefined;
   },
   month(date) {
-    if (ES.IsTemporalMonthDay(date)) throw new TypeError('use monthCode on PlainMonthDay instead');
-    if (!HasSlot(date, ISO_MONTH)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return GetSlot(date, ISO_MONTH);
   },
   monthCode(date) {
-    if (!HasSlot(date, ISO_MONTH)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return buildMonthCode(GetSlot(date, ISO_MONTH));
   },
   day(date) {
-    if (!HasSlot(date, ISO_DAY)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return GetSlot(date, ISO_DAY);
   },
   dayOfWeek(date) {
-    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return ES.DayOfWeek(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
   },
   dayOfYear(date) {
-    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return ES.DayOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
   },
   weekOfYear(date) {
-    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return ES.WeekOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
   },
-  daysInWeek(date) {
-    ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+  daysInWeek() {
     return 7;
   },
   daysInMonth(date) {
-    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH)) {
-      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    }
     return ES.ISODaysInMonth(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH));
   },
   daysInYear(date) {
     if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     return ES.LeapYear(GetSlot(date, ISO_YEAR)) ? 366 : 365;
   },
-  monthsInYear(date) {
-    if (!HasSlot(date, ISO_YEAR)) ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
+  monthsInYear() {
     return 12;
   },
   inLeapYear(date) {
@@ -1779,7 +1777,8 @@ const helperDangi = ObjectAssign({}, { ...helperChinese, id: 'dangi' });
  * ISO and non-ISO implementations vs. code that was very different.
  */
 const nonIsoGeneralImpl = {
-  dateFromFields(fields, overflow, constructor, calendar) {
+  dateFromFields(fields, options, constructor, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
     const cache = new OneObjectCache();
     // Intentionally alphabetical
     fields = ES.PrepareTemporalFields(fields, [
@@ -1795,7 +1794,8 @@ const nonIsoGeneralImpl = {
     cache.setObject(result);
     return result;
   },
-  yearMonthFromFields(fields, overflow, constructor, calendar) {
+  yearMonthFromFields(fields, options, constructor, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
     const cache = new OneObjectCache();
     // Intentionally alphabetical
     fields = ES.PrepareTemporalFields(fields, [
@@ -1810,7 +1810,8 @@ const nonIsoGeneralImpl = {
     cache.setObject(result);
     return result;
   },
-  monthDayFromFields(fields, overflow, constructor, calendar) {
+  monthDayFromFields(fields, options, constructor, calendar) {
+    const overflow = ES.ToTemporalOverflow(options);
     // All built-in calendars require `day`, but some allow other fields to be
     // substituted for `month`. And for lunisolar calendars, either `monthCode`
     // or `year` must be provided because `month` is ambiguous without a year or
@@ -1818,11 +1819,11 @@ const nonIsoGeneralImpl = {
     const cache = new OneObjectCache();
     fields = ES.PrepareTemporalFields(fields, [
       ['day'],
-      ['month', undefined],
-      ['year', undefined],
-      ['monthCode', undefined],
       ['era', undefined],
-      ['eraYear', undefined]
+      ['eraYear', undefined],
+      ['month', undefined],
+      ['monthCode', undefined],
+      ['year', undefined]
     ]);
     const { year, month, day } = this.helper.monthDayFromFields(fields, overflow, cache);
     // `year` is a reference year where this month/day exists in this calendar
@@ -1876,45 +1877,33 @@ const nonIsoGeneralImpl = {
     return result;
   },
   year(date) {
-    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
-      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    }
     const cache = OneObjectCache.getCacheForObject(date);
     const calendarDate = this.helper.temporalToCalendarDate(date, cache);
     return calendarDate.year;
   },
   month(date) {
-    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
-      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    }
     const cache = OneObjectCache.getCacheForObject(date);
     const calendarDate = this.helper.temporalToCalendarDate(date, cache);
     return calendarDate.month;
   },
   day(date) {
-    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH) || !HasSlot(date, ISO_DAY)) {
-      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    }
     const cache = OneObjectCache.getCacheForObject(date);
     const calendarDate = this.helper.temporalToCalendarDate(date, cache);
     return calendarDate.day;
   },
   era(date) {
-    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     if (!this.helper.hasEra) return undefined;
     const cache = OneObjectCache.getCacheForObject(date);
     const calendarDate = this.helper.temporalToCalendarDate(date, cache);
     return calendarDate.era;
   },
   eraYear(date) {
-    if (!HasSlot(date, ISO_YEAR)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     if (!this.helper.hasEra) return undefined;
     const cache = OneObjectCache.getCacheForObject(date);
     const calendarDate = this.helper.temporalToCalendarDate(date, cache);
     return calendarDate.eraYear;
   },
   monthCode(date) {
-    if (!HasSlot(date, ISO_MONTH)) date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     const cache = OneObjectCache.getCacheForObject(date);
     const calendarDate = this.helper.temporalToCalendarDate(date, cache);
     return calendarDate.monthCode;
@@ -1924,7 +1913,6 @@ const nonIsoGeneralImpl = {
   },
   dayOfYear(date) {
     const cache = OneObjectCache.getCacheForObject(date);
-    date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     const calendarDate = this.helper.isoToCalendarDate(date, cache);
     const startOfYear = this.helper.startOfCalendarYear(calendarDate);
     const diffDays = this.helper.calendarDaysUntil(startOfYear, calendarDate, cache);
@@ -1937,9 +1925,6 @@ const nonIsoGeneralImpl = {
     return impl['iso8601'].daysInWeek(date);
   },
   daysInMonth(date) {
-    if (!HasSlot(date, ISO_YEAR) || !HasSlot(date, ISO_MONTH)) {
-      date = ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
-    }
     const cache = OneObjectCache.getCacheForObject(date);
     const calendarDate = this.helper.temporalToCalendarDate(date, cache);
 
@@ -1966,7 +1951,6 @@ const nonIsoGeneralImpl = {
     return result;
   },
   monthsInYear(date) {
-    if (!HasSlot(date, ISO_YEAR)) ES.ToTemporalDate(date, GetIntrinsic('%Temporal.PlainDate%'));
     const cache = OneObjectCache.getCacheForObject(date);
     const calendarDate = this.helper.temporalToCalendarDate(date, cache);
     const result = this.helper.monthsInYear(calendarDate, cache);

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -524,7 +524,7 @@
         The ISOYear abstract operation implements the calendar-specific logic in the `Temporal.Calendar.year` method for the ISO 8601 calendar.
       </p>
       <emu-alg>
-        1. If _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+        1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
           1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(_dateOrDateTime_.[[ISOYear]]).
       </emu-alg>
@@ -536,9 +536,7 @@
         The ISOMonth abstract operation implements the calendar-specific logic in the `Temporal.Calendar.month` method for the ISO 8601 calendar.
       </p>
       <emu-alg>
-        1. If _dateOrDateTime_ has an [[InitializedTemporalMonthDay]] internal slot, then
-          1. Throw a *TypeError* exception.
-        1. If _dateOrDateTime_ does not have an [[ISOMonth]] internal slot, then
+        1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOMonth]] internal slot, then
           1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(_dateOrDateTime_.[[ISOMonth]]).
       </emu-alg>
@@ -550,7 +548,7 @@
         The ISOMonthCode abstract operation implements the calendar-specific logic in the `Temporal.Calendar.monthCode` method for the ISO 8601 calendar.
       </p>
       <emu-alg>
-        1. If _dateOrDateTime_ does not have an [[ISOMonth]] internal slot, then
+        1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOMonth]] internal slot, then
           1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Let _monthCode_ be the String representation of _dateOrDateTime_.[[ISOMonth]], formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
         1. Return the string-concatenation of *"M"* and _monthCode_.
@@ -563,7 +561,7 @@
         The ISODay abstract operation implements the calendar-specific logic in the `Temporal.Calendar.day` method for the ISO 8601 calendar.
       </p>
       <emu-alg>
-        1. If _dateOrDateTime_ does not have an [[ISODay]] internal slot, then
+        1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISODay]] internal slot, then
           1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
         1. Return 𝔽(_dateOrDateTime_.[[ISODay]]).
       </emu-alg>
@@ -854,6 +852,8 @@
       <emu-alg>
         1. Let _calendar_ be the *this* value.
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
+        1. If Type(_dateOrDateTime_) is Object and _dateOrDateTime_ has an [[InitializedTemporalMonthDay]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Return ? ISOMonth(_dateOrDateTime_).
       </emu-alg>
@@ -1024,7 +1024,7 @@
         1. Let _calendar_ be the *this* value.
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
-        1. Perform ? ToTemporalDateTime(_dateOrDateTime_).
+        1. Perform ? ToTemporalDate(_dateOrDateTime_).
         1. Return *12*<sub>𝔽</sub>.
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1144,7 +1144,9 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ? ISODateFromFields(_fields_, _options_).
             1. Else,
-              1. Let _result_ be a Record with [[Year]], [[Month]], and [[Day]] fields, that is the result of implementation-defined processing of _fields_, _options_, and the value of _calendar_.[[Identifier]].
+              1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
+              1. Let _result_ be a Record with [[Year]], [[Month]], and [[Day]] fields, that is the result of implementation-defined processing of _fields_, _overflow_, and the value of _calendar_.[[Identifier]].
             1. Return ? CreateTemporalDateFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
           </emu-alg>
         </emu-clause>
@@ -1164,7 +1166,9 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _options_).
             1. Else,
-              1. Let _result_ be a Record with [[Year]], [[Month]], and [[ReferenceISODay]] fields, that is the result of implementation-defined processing of _fields_, _options_, and the value of _calendar_.[[Identifier]].
+              1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « »).
+              1. Let _result_ be a Record with [[Year]], [[Month]], and [[ReferenceISODay]] fields, that is the result of implementation-defined processing of _fields_, _overflow_, and the value of _calendar_.[[Identifier]].
             1. Return ? CreateTemporalYearMonthFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[ReferenceISODay]]).
           </emu-alg>
         </emu-clause>
@@ -1184,7 +1188,9 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _options_).
             1. Else,
-              1. Let _result_ be a Record with [[Month]], [[Day]], and [[ReferenceISOYear]] fields, that is the result of implementation-defined processing of _fields_, _options_, and the value of _calendar_.[[Identifier]].
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
+              1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+              1. Let _result_ be a Record with [[Month]], [[Day]], and [[ReferenceISOYear]] fields, that is the result of implementation-defined processing of _fields_, _overflow_, and the value of _calendar_.[[Identifier]].
             1. Return ? CreateTemporalMonthDayFromStatic(_constructor_, _result_.[[Month]], _result_.[[Day]], _calendar_, _result_.[[ReferenceISOYear]]).
           </emu-alg>
         </emu-clause>
@@ -1202,11 +1208,11 @@
             1. Set _date_ to ? ToTemporalDate(_date_).
             1. Set _duration_ to ? ToTemporalDuration(_duration_).
             1. Set _options_ to ? NormalizeOptionsObject(_options_).
+            1. Let _overflow_ be ? ToTemporalOverflow(_options_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _overflow_).
             1. Else,
-              1. Let _result_ be a Record with [[Year]], [[Month]], and [[Day]] fields, that is the result of implementation-defined processing of _date_, _duration_, _options_, and the value of _calendar_.[[Identifier]].
+              1. Let _result_ be a Record with [[Year]], [[Month]], and [[Day]] fields, that is the result of implementation-defined processing of _date_, _duration_, _overflow_, and the value of _calendar_.[[Identifier]].
             1. Return ? CreateTemporalDateFromStatic(_constructor_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
           </emu-alg>
         </emu-clause>
@@ -1224,11 +1230,11 @@
             1. Set _one_ to ? ToTemporalDate(_one_).
             1. Set _two_ to ? ToTemporalDate(_two_).
             1. Set _options_ to ? NormalizeOptionsObject(_options_).
+            1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
               1. Let _result_ be ? DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
             1. Else,
-              1. Let _result_ be a Record with [[Years]], [[Months]], [[Weeks]], and [[Days]] fields, that is the result of implementation-defined processing of _one_, _two_, _options_, and the value of _calendar_.[[Identifier]].
+              1. Let _result_ be a Record with [[Years]], [[Months]], [[Weeks]], and [[Days]] fields, that is the result of implementation-defined processing of _one_, _two_, _largestUnit_, and the value of _calendar_.[[Identifier]].
             1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
           </emu-alg>
         </emu-clause>
@@ -1242,6 +1248,8 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
+            1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+              1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return *undefined*.
             1. Let _era_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
@@ -1258,6 +1266,8 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
+            1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+              1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return *undefined*.
             1. Let _eraYear_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
@@ -1278,6 +1288,8 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _year_ be ? ISOYear(_dateOrDateTime_).
             1. Else,
+              1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+                1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
               1. Let _year_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_year_).
           </emu-alg>
@@ -1293,9 +1305,13 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
+            1. If Type(_dateOrDateTime_) is Object and _dateOrDateTime_ has an [[InitializedTemporalMonthDay]] internal slot, then
+              1. Throw a *TypeError* exception.
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _month_ be ? ISOMonth(_dateOrDateTime_).
             1. Else,
+              1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+                1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
               1. Let _month_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_month_).
           </emu-alg>
@@ -1314,6 +1330,8 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _monthCode_ be ? ISOMonthCode(_dateOrDateTime_).
             1. Else,
+              1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+                1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
               1. Let _monthCode_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return _monthCode_.
           </emu-alg>
@@ -1332,6 +1350,8 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _day_ be ? ISODay(_dateOrDateTime_).
             1. Else,
+              1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+                1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
               1. Let _day_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_day_).
           </emu-alg>
@@ -1347,11 +1367,12 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-            1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
+            1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+              1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _dayOfWeek_ be ! ToISODayOfWeek(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]]).
+              1. Let _dayOfWeek_ be ! ToISODayOfWeek(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]], _dateOrDateTime_.[[ISODay]]).
             1. Else,
-              1. Let _dayOfWeek_ be the result of implementation-defined processing of _date_ and the value of _calendar_.[[Identifier]].
+              1. Let _dayOfWeek_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_dayOfWeek_).
           </emu-alg>
         </emu-clause>
@@ -1366,11 +1387,12 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-            1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
+            1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+              1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _dayOfYear_ be ! ToISODayOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]]).
+              1. Let _dayOfYear_ be ! ToISODayOfYear(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]], _dateOrDateTime_.[[ISODay]]).
             1. Else,
-              1. Let _dayOfYear_ be the result of implementation-defined processing of _date_ and the value of _calendar_.[[Identifier]].
+              1. Let _dayOfYear_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_dayOfYear_).
           </emu-alg>
         </emu-clause>
@@ -1385,11 +1407,12 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-            1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
+            1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+              1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _weekOfYear_ be ! ToISOWeekOfYear(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]]).
+              1. Let _weekOfYear_ be ! ToISOWeekOfYear(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]], _dateOrDateTime_.[[ISODay]]).
             1. Else,
-              1. Let _weekOfYear_ be the result of implementation-defined processing of _date_ and the value of _calendar_.[[Identifier]].
+              1. Let _weekOfYear_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_weekOfYear_).
           </emu-alg>
         </emu-clause>
@@ -1404,11 +1427,12 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-            1. Let _date_ be ? ToTemporalDate(_dateOrDateTime_).
+            1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+              1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _daysInWeek_ be 7.
             1. Else,
-              1. Let _daysInWeek_ be the result of implementation-defined processing of _date_ and the value of _calendar_.[[Identifier]].
+              1. Let _daysInWeek_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_daysInWeek_).
           </emu-alg>
         </emu-clause>
@@ -1423,9 +1447,9 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
+            1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+              1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. If _dateOrDateTime_ does not have [[ISOYear]] and [[ISOMonth]] internal slots, then
-                1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
               1. Let _daysInMonth_ be ! ISODaysInMonth(_dateOrDateTime_.[[ISOYear]], _dateOrDateTime_.[[ISOMonth]]).
             1. Else,
               1. Let _daysInMonth_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
@@ -1447,6 +1471,8 @@
               1. Let _year_ be ? ISOYear(_dateOrDateTime_).
               1. Let _daysInYear_ be ! ISODaysInYear(_year_).
             1. Else,
+              1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+                1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
               1. Let _daysInYear_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return 𝔽(_daysInYear_).
           </emu-alg>
@@ -1462,7 +1488,8 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-            1. Let _date_ be ? ToTemporalDateTime(_dateOrDateTime_).
+            1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+              1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _monthsInYear_ be 12.
             1. Else,
@@ -1485,6 +1512,8 @@
               1. Let _year_ be ? ISOYear(_dateOrDateTime_).
               1. Let _inLeapYear_ be ! IsISOLeapYear(_year_).
             1. Else,
+              1. If Type(_dateOrDateTime_) is not Object or _dateOrDateTime_ does not have an [[ISOYear]] internal slot, then
+                1. Set _dateOrDateTime_ to ? ToTemporalDate(_dateOrDateTime_).
               1. Let _inLeapYear_ be the result of implementation-defined processing of _dateOrDateTime_ and the value of _calendar_.[[Identifier]].
             1. Return _inLeapYear_.
           </emu-alg>
@@ -1524,7 +1553,19 @@
             1. Set _additionalFields_ to ? ToObject(_additionalFields_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return ? ISOMergeFields(_fields_, _additionalFields_).
-            1. Return the result of implementation-defined processing of _fields_, _additionalFields_, and the value of _calendar_.[[Identifier]].
+            1. Let _fieldsKeys_ be ? EnumerableOwnPropertyNames(_fields_, ~key~).
+            1. Let _fieldsCopied_ be ! OrdinaryObjectCreate(%Object.prototype%).
+            1. For each element _key_ of _fieldsKeys_, do
+              1. Let _propValue_ be ? Get(_fields_, _key_).
+              1. If _propValue_ is not *undefined*, then
+                1. Perform ! CreateDataPropertyOrThrow(_fieldsCopied_, _key_, _propValue_).
+            1. Let _additionalFieldsKeys_ be ? EnumerableOwnPropertyNames(_additionalFields_, ~key~).
+            1. Let _additionalFieldsCopied_ be ! OrdinaryObjectCreate(%Object.prototype%).
+            1. For each element _key_ of _additionalFieldsKeys_, do
+              1. Let _propValue_ be ? Get(_additionalFields_, _key_).
+              1. If _propValue_ is not *undefined*, then
+                1. Perform ! CreateDataPropertyOrThrow(_additionalFieldsCopied_, _key_, _propValue_).
+            1. Return the result of implementation-defined processing of _fieldsCopied_, _additionalFieldsCopied_, and the value of _calendar_.[[Identifier]].
           </emu-alg>
         </emu-clause>
       </emu-clause>


### PR DESCRIPTION
…in consistent order and only call getters once.

Fixes #1388.