### PR TITLE
Sync rounding mode names with Intl.NumberFormat v3

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -403,8 +403,8 @@ d.abs(); // PT8H30M
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    The default is `'halfExpand'`.
   - `relativeTo` (`Temporal.PlainDateTime`): The starting point to use when converting between years, months, weeks, and days.
     It must be a `Temporal.PlainDateTime`, or a value that can be passed to `Temporal.PlainDateTime.from()`.
 
@@ -443,7 +443,7 @@ Instead of 60 minutes, use 1 hour.
 
 The `roundingMode` option controls how the rounding is performed.
 
-- `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+- `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round away from zero like `ceil` for positive durations and like `floor` for negative durations.
 - `ceil`: Always round towards positive infinity.
   For negative durations this option will decrease the absolute value of the duration which may be unexpected.
@@ -578,7 +578,7 @@ d.total({
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
     The default is `'trunc'`.
 
 **Returns:** the duration as an ISO 8601 string.
@@ -615,7 +615,7 @@ d = Temporal.Duration.from('PT59.999999999S');
 d.toString({ smallestUnit: 'seconds' });   // => PT59S
 d.toString({ fractionalSecondDigits: 0 }); // => PT59S
 d.toString({ fractionalSecondDigits: 4 }); // => PT59.9999S
-d.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' });
+d.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' });
 // => PT60.00000000S
 ```
 

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -364,7 +364,7 @@ Temporal.now.instant().subtract(oneHour);
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the difference between `instant` and `other`.
@@ -453,7 +453,7 @@ epoch.toZonedDateTimeISO('UTC').until(
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the difference between `instant` and `other`.
@@ -484,8 +484,8 @@ billion.since(epoch); // => PT1000000000S
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    The default is `'halfExpand'`.
 
 **Returns:** a new `Temporal.Instant` object which is `instant` rounded to `roundingIncrement` of `smallestUnit`.
 
@@ -507,7 +507,7 @@ The `roundingMode` option controls how the rounding is performed.
 - `ceil`: Always round up, towards the end of time.
 - `floor`, `trunc`: Always round down, towards the beginning of time.
   (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
-- `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+- `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `ceil`.
 
 Example usage:
@@ -567,7 +567,7 @@ one.equals(one); // => true
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
     The default is `'trunc'`.
 
 **Returns:** a string in the ISO 8601 date format representing `instant`.
@@ -599,7 +599,7 @@ instant.toString({ fractionalSecondDigits: 0 });
 // => 2019-11-18T10:52:01Z
 instant.toString({ fractionalSecondDigits: 4 });
 // => 2019-11-18T10:52:01.8160Z
-instant.toString({ smallestUnit: 'second', roundingMode: 'nearest' });
+instant.toString({ smallestUnit: 'second', roundingMode: 'halfExpand' });
 // => 2019-11-18T10:52:02Z
 ```
 

--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -484,7 +484,7 @@ date.subtract({ months: 1 }, { overflow: 'reject' }); // => throws
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the time elapsed after `date` and until `other`.
@@ -550,7 +550,7 @@ earlier.toPlainDateTime(noon).until(later.toPlainDateTime(noon), { largestUnit: 
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the time elapsed before `date` and since `other`.

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -654,7 +654,7 @@ dt.subtract({ months: 1 }); // => throws
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `datetime` and until `other`.
@@ -732,7 +732,7 @@ jan1.until(mar1);                            // => P60D
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `datetime` and since `other`.
@@ -763,8 +763,8 @@ dt2.since(dt1); // => P8456DT12H5M29.999996500S
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    The default is `'halfExpand'`.
 
 **Returns:** a new `Temporal.PlainDateTime` object which is `datetime` rounded to `roundingIncrement` of `smallestUnit`.
 
@@ -789,7 +789,7 @@ The `roundingMode` option controls how the rounding is performed.
 - `ceil`: Always round up, towards the end of time.
 - `floor`, `trunc`: Always round down, towards the beginning of time.
   (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
-- `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+- `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `ceil`.
 
 Example usage:
@@ -852,7 +852,7 @@ dt1.equals(dt1); // => true
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
     The default is `'trunc'`.
 
 **Returns:** a string in the ISO 8601 date format representing `datetime`.
@@ -890,7 +890,7 @@ dt.toString(); // => 1999-12-31T23:59:59.999999999
 dt.toString({ smallestUnit: 'minute' });    // => 1999-12-31T23:59
 dt.toString({ fractionalSecondDigits: 0 }); // => 1999-12-31T23:59:59
 dt.toString({ fractionalSecondDigits: 4 }); // => 1999-12-31T23:59:59.9999
-dt.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' });
+dt.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' });
 // => 2000-01-01T00:00:00.00000000
 ```
 <!-- prettier-ignore-end -->

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -273,7 +273,7 @@ time.subtract({ minutes: 5, nanoseconds: 800 }); // => 19:34:09.068345405
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `time` and until `other`.
@@ -327,7 +327,7 @@ time.until(Temporal.PlainTime.from('22:39:09.068346205'), { smallestUnit: 'secon
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `time` and since `other`.
@@ -358,8 +358,8 @@ time.since(Temporal.PlainTime.from('22:39:09.068346205')); // => -PT2H25M48.0969
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    The default is `'halfExpand'`.
 
 **Returns:** a new `Temporal.PlainTime` object which is `time` rounded to `roundingIncrement` of `smallestUnit`.
 
@@ -382,7 +382,7 @@ The `roundingMode` option controls how the rounding is performed.
 - `ceil`: Always round up, towards 23:59:59.999999999.
 - `floor`, `trunc`: Always round down, 00:00.
   (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
-- `nearest`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+- `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `ceil`.
 
 Example usage:
@@ -440,7 +440,7 @@ time.equals(time); // => true
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
     The default is `'trunc'`.
 
 **Returns:** a string in the ISO 8601 time format representing `time`.
@@ -464,7 +464,7 @@ time.toString(); // => 19:39:09.068346205
 time.toString({ smallestUnit: 'minute' }); // => 19:39
 time.toString({ fractionalSecondDigits: 0 }); // => 19:39:09
 time.toString({ fractionalSecondDigits: 4 }); // => 19:39:09.0683
-time.toString({ fractionalSecondDigits: 5, roundingMode: 'nearest' });
+time.toString({ fractionalSecondDigits: 5, roundingMode: 'halfExpand' });
   // => 19:39:09.06835
 ```
 <!-- prettier-ignore-end -->

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -395,7 +395,7 @@ ym.subtract({ years: 20, months: 4 }); // => 1999-02
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `yearMonth` and until `other`.
@@ -456,7 +456,7 @@ ym.toPlainDate({ day: 1 }).until(other.toPlainDate({ day: 1 }), { largestUnit: '
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `yearMonth` and since `other`.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1005,7 +1005,7 @@ earlierHours.since(zdt, { largestUnit: 'hours' }).hours; // => -24
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `zonedDateTime` and until `other`.
@@ -1100,7 +1100,7 @@ jan1.until(mar1, { largestUnit: 'days' }); // => P60D
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `zonedDateTime` and since `other`.
@@ -1130,8 +1130,8 @@ zdt2.since(zdt1); // => PT202956H5M29.999996500S
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'nearest'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'nearest'`.
+    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    The default is `'halfExpand'`.
 
 **Returns:** a new `Temporal.ZonedDateTime` object which is `zonedDateTime` rounded to `roundingIncrement` of `smallestUnit`.
 
@@ -1156,7 +1156,7 @@ The `roundingMode` option controls how the rounding is performed.
 - `'ceil'`: Always round up, towards the end of time.
 - `'floor'`, `'trunc'`: Always round down, towards the beginning of time.
   (These two modes behave the same, but are both included for consistency with `Temporal.Duration.prototype.round()`, where they are not the same.)
-- `'nearest'`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+- `'halfExpand'`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `'ceil'`.
 
 Example usage:
@@ -1238,7 +1238,7 @@ zdt1.equals(zdt1); // => true
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'nearest'`.
+    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
     The default is `'trunc'`.
 
 **Returns:** a string containing an ISO 8601 date+time+offset format, a bracketed time zone suffix, and (if the calendar is not `iso8601`) a calendar suffix.

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1,6 +1,6 @@
 export namespace Temporal {
   export type ComparisonResult = -1 | 0 | 1;
-  type RoundingMode = 'nearest' | 'ceil' | 'trunc' | 'floor';
+  type RoundingMode = 'halfExpand' | 'ceil' | 'trunc' | 'floor';
   type ConstructorOf<T> = new (...args: unknown[]) => T;
 
   /**
@@ -144,7 +144,7 @@ export namespace Temporal {
 
     /**
      * Controls how rounding is performed:
-     * - `nearest`: Round to the nearest of the values allowed by
+     * - `halfExpand`: Round to the nearest of the values allowed by
      *   `roundingIncrement` and `smallestUnit`. When there is a tie, round up.
      *   This mode is the default.
      * - `ceil`: Always round up, towards the end of time.
@@ -213,7 +213,7 @@ export namespace Temporal {
 
     /**
      * Controls how rounding is performed:
-     * - `nearest`: Round to the nearest of the values allowed by
+     * - `halfExpand`: Round to the nearest of the values allowed by
      *   `roundingIncrement` and `smallestUnit`. When there is a tie, round away
      *   from zero like `ceil` for positive durations and like `floor` for
      *   negative durations.
@@ -249,7 +249,7 @@ export namespace Temporal {
 
     /**
      * Controls how rounding is performed:
-     * - `nearest`: Round to the nearest of the values allowed by
+     * - `halfExpand`: Round to the nearest of the values allowed by
      *   `roundingIncrement` and `smallestUnit`. When there is a tie, round up.
      *   This mode is the default.
      * - `ceil`: Always round up, towards the end of time.
@@ -261,7 +261,7 @@ export namespace Temporal {
      *   negative infinity which is usually unexpected. For this reason, `trunc`
      *   is recommended for most use cases.
      */
-    roundingMode?: 'nearest' | 'ceil' | 'trunc' | 'floor';
+    roundingMode?: RoundingMode;
   }
 
   export interface DurationRoundOptions {
@@ -335,7 +335,7 @@ export namespace Temporal {
 
     /**
      * Controls how rounding is performed:
-     * - `nearest`: Round to the nearest of the values allowed by
+     * - `halfExpand`: Round to the nearest of the values allowed by
      *   `roundingIncrement` and `smallestUnit`. When there is a tie, round away
      *   from zero like `ceil` for positive durations and like `floor` for
      *   negative durations. This mode is the default.
@@ -350,7 +350,7 @@ export namespace Temporal {
      *   For this reason, `trunc` is recommended for most "round down" use
      *   cases.
      */
-    roundingMode?: 'nearest' | 'ceil' | 'trunc' | 'floor';
+    roundingMode?: RoundingMode;
 
     /**
      * The starting point to use for rounding and conversions when

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -389,7 +389,7 @@ export class Duration {
       throw new RangeError('at least one of smallestUnit or largestUnit is required');
     }
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       years: undefined,
       months: undefined,

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -589,7 +589,7 @@ export const ES = ObjectAssign({}, ES2020, {
     return ES.GetOption(options, 'disambiguation', ['compatible', 'earlier', 'later', 'reject'], 'compatible');
   },
   ToTemporalRoundingMode: (options, fallback) => {
-    return ES.GetOption(options, 'roundingMode', ['ceil', 'floor', 'trunc', 'nearest'], fallback);
+    return ES.GetOption(options, 'roundingMode', ['ceil', 'floor', 'trunc', 'halfExpand'], fallback);
   },
   NegateTemporalRoundingMode: (roundingMode) => {
     switch (roundingMode) {
@@ -3232,7 +3232,7 @@ export const ES = ObjectAssign({}, ES2020, {
           endNs,
           1,
           'nanoseconds',
-          'nearest'
+          'halfExpand'
         ));
         ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
           0,
@@ -3391,7 +3391,7 @@ export const ES = ObjectAssign({}, ES2020, {
       case 'trunc':
         // no change needed, because divmod is a truncation
         break;
-      case 'nearest':
+      case 'halfExpand':
         // "half up away from zero"
         if (remainder.multiply(2).abs() >= increment) quotient = quotient.add(sign);
         break;

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -190,7 +190,7 @@ export class Instant {
     if (options === undefined) throw new TypeError('options parameter is required');
     options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalUnit(options, ['day']);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       hour: 24,
       minute: 1440,

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -615,7 +615,7 @@ export class PlainDateTime {
     if (options === undefined) throw new TypeError('options parameter is required');
     options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalUnit(options);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       day: 1,
       hour: 24,

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -359,7 +359,7 @@ export class PlainTime {
     if (options === undefined) throw new TypeError('options parameter is required');
     options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalUnit(options, ['day']);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       hour: 24,
       minute: 60,

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -670,7 +670,7 @@ export class ZonedDateTime {
     if (options === undefined) throw new TypeError('options parameter is required');
     options = ES.NormalizeOptionsObject(options);
     const smallestUnit = ES.ToSmallestTemporalUnit(options);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'nearest');
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       day: 1,
       hour: 24,

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -301,8 +301,8 @@ describe('Duration', () => {
       throws(() => d1.toString({ roundingMode: 'cile' }), RangeError);
     });
     it('rounds to nearest', () => {
-      equal(d3.toString({ smallestUnit: 'seconds', roundingMode: 'nearest' }), 'PT15H23M31S');
-      equal(d3.toString({ fractionalSecondDigits: 3, roundingMode: 'nearest' }), 'PT15H23M30.543S');
+      equal(d3.toString({ smallestUnit: 'seconds', roundingMode: 'halfExpand' }), 'PT15H23M31S');
+      equal(d3.toString({ fractionalSecondDigits: 3, roundingMode: 'halfExpand' }), 'PT15H23M30.543S');
     });
     it('rounds up', () => {
       equal(d3.toString({ smallestUnit: 'seconds', roundingMode: 'ceil' }), 'PT15H23M31S');
@@ -318,7 +318,7 @@ describe('Duration', () => {
     });
     it('rounding can affect units up to seconds', () => {
       const d4 = Duration.from('P1Y1M1W1DT23H59M59.999999999S');
-      equal(d4.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' }), 'P1Y1M1W1DT23H59M60.00000000S');
+      equal(d4.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' }), 'P1Y1M1W1DT23H59M60.00000000S');
     });
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
@@ -1246,7 +1246,7 @@ describe('Duration', () => {
       }
     }
     const roundingModeResults = {
-      nearest: ['P6Y', '-P6Y'],
+      halfExpand: ['P6Y', '-P6Y'],
       ceil: ['P6Y', '-P5Y'],
       floor: ['P5Y', '-P6Y'],
       trunc: ['P5Y', '-P5Y']
@@ -1257,7 +1257,7 @@ describe('Duration', () => {
         equal(`${d.negated().round({ smallestUnit: 'years', relativeTo, roundingMode })}`, negResult);
       });
     }
-    it('nearest is the default', () => {
+    it('halfExpand is the default', () => {
       equal(`${d.round({ smallestUnit: 'years', relativeTo })}`, 'P6Y');
       equal(`${d.negated().round({ smallestUnit: 'years', relativeTo })}`, '-P6Y');
     });

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -166,8 +166,8 @@ describe('Instant', () => {
       throws(() => i1.toString({ roundingMode: 'cile' }), RangeError);
     });
     it('rounds to nearest', () => {
-      equal(i2.toString({ smallestUnit: 'minute', roundingMode: 'nearest' }), '1976-11-18T15:24Z');
-      equal(i3.toString({ fractionalSecondDigits: 3, roundingMode: 'nearest' }), '1976-11-18T15:23:30.123Z');
+      equal(i2.toString({ smallestUnit: 'minute', roundingMode: 'halfExpand' }), '1976-11-18T15:24Z');
+      equal(i3.toString({ fractionalSecondDigits: 3, roundingMode: 'halfExpand' }), '1976-11-18T15:23:30.123Z');
     });
     it('rounds up', () => {
       equal(i2.toString({ smallestUnit: 'minute', roundingMode: 'ceil' }), '1976-11-18T15:24Z');
@@ -185,7 +185,7 @@ describe('Instant', () => {
     });
     it('rounding can affect all units', () => {
       const i5 = Instant.from('1999-12-31T23:59:59.999999999Z');
-      equal(i5.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' }), '2000-01-01T00:00:00.00000000Z');
+      equal(i5.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' }), '2000-01-01T00:00:00.00000000Z');
     });
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
@@ -651,8 +651,8 @@ describe('Instant', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than seconds', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'hours', roundingMode: 'nearest' })}`, 'PT376435H');
-      equal(`${later.since(earlier, { smallestUnit: 'minutes', roundingMode: 'nearest' })}`, 'PT22586123M');
+      equal(`${later.since(earlier, { smallestUnit: 'hours', roundingMode: 'halfExpand' })}`, 'PT376435H');
+      equal(`${later.since(earlier, { smallestUnit: 'minutes', roundingMode: 'halfExpand' })}`, 'PT22586123M');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => later.since(earlier, { roundingMode: 'cile' }), RangeError);
@@ -667,7 +667,7 @@ describe('Instant', () => {
       ['nanoseconds', 'PT376435H23M8.148529313S']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${later.since(earlier, { largestUnit, smallestUnit, roundingMode })}`, expected);
         equal(`${earlier.since(later, { largestUnit, smallestUnit, roundingMode })}`, `-${expected}`);
@@ -728,7 +728,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'hours',
           roundingIncrement: 3,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT376434H'
       );
@@ -739,7 +739,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'minutes',
           roundingIncrement: 30,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT376435H30M'
       );
@@ -750,7 +750,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'seconds',
           roundingIncrement: 15,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT376435H23M15S'
       );
@@ -761,7 +761,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'milliseconds',
           roundingIncrement: 10,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT376435H23M8.15S'
       );
@@ -772,7 +772,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'microseconds',
           roundingIncrement: 10,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT376435H23M8.14853S'
       );
@@ -783,7 +783,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'nanoseconds',
           roundingIncrement: 10,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT376435H23M8.14852931S'
       );
@@ -970,8 +970,8 @@ describe('Instant', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than seconds', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'hours', roundingMode: 'nearest' })}`, 'PT440610H');
-      equal(`${earlier.until(later, { smallestUnit: 'minutes', roundingMode: 'nearest' })}`, 'PT26436596M');
+      equal(`${earlier.until(later, { smallestUnit: 'hours', roundingMode: 'halfExpand' })}`, 'PT440610H');
+      equal(`${earlier.until(later, { smallestUnit: 'minutes', roundingMode: 'halfExpand' })}`, 'PT26436596M');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => earlier.until(later, { roundingMode: 'cile' }), RangeError);
@@ -986,7 +986,7 @@ describe('Instant', () => {
       ['nanoseconds', 'PT440609H56M3.148529313S']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${earlier.until(later, { largestUnit, smallestUnit, roundingMode })}`, expected);
         equal(`${later.until(earlier, { largestUnit, smallestUnit, roundingMode })}`, `-${expected}`);
@@ -1047,7 +1047,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'hours',
           roundingIncrement: 4,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT440608H'
       );
@@ -1058,7 +1058,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'minutes',
           roundingIncrement: 30,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT440610H'
       );
@@ -1069,7 +1069,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'seconds',
           roundingIncrement: 15,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT440609H56M'
       );
@@ -1080,7 +1080,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'milliseconds',
           roundingIncrement: 10,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT440609H56M3.15S'
       );
@@ -1091,7 +1091,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'microseconds',
           roundingIncrement: 10,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT440609H56M3.14853S'
       );
@@ -1102,7 +1102,7 @@ describe('Instant', () => {
           largestUnit,
           smallestUnit: 'nanoseconds',
           roundingIncrement: 10,
-          roundingMode: 'nearest'
+          roundingMode: 'halfExpand'
         })}`,
         'PT440609H56M3.14852931S'
       );
@@ -1240,7 +1240,7 @@ describe('Instant', () => {
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
       it(`rounds to nearest ${smallestUnit}`, () =>
-        equal(`${inst.round({ smallestUnit, roundingMode: 'nearest' })}`, expected));
+        equal(`${inst.round({ smallestUnit, roundingMode: 'halfExpand' })}`, expected));
     });
     const incrementOneCeil = [
       ['hour', '1976-11-18T15:00:00Z'],
@@ -1278,7 +1278,7 @@ describe('Instant', () => {
       equal(`${inst2.round({ smallestUnit, roundingMode: 'ceil' })}`, '1969-12-15T12:00:01Z');
       equal(`${inst2.round({ smallestUnit, roundingMode: 'floor' })}`, '1969-12-15T12:00:00Z');
       equal(`${inst2.round({ smallestUnit, roundingMode: 'trunc' })}`, '1969-12-15T12:00:00Z');
-      equal(`${inst2.round({ smallestUnit, roundingMode: 'nearest' })}`, '1969-12-15T12:00:01Z');
+      equal(`${inst2.round({ smallestUnit, roundingMode: 'halfExpand' })}`, '1969-12-15T12:00:01Z');
     });
     it('rounds to an increment of hours', () => {
       equal(`${inst.round({ smallestUnit: 'hour', roundingIncrement: 4 })}`, '1976-11-18T16:00:00Z');

--- a/polyfill/test/plaindate.mjs
+++ b/polyfill/test/plaindate.mjs
@@ -359,9 +359,9 @@ describe('Date', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
-      equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
-      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
+      equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
+      equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');
+      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingMode: 'halfExpand' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => earlier.until(later, { roundingMode: 'cile' }), RangeError);
@@ -373,7 +373,7 @@ describe('Date', () => {
       ['days', 'P973D']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${earlier.until(later, { smallestUnit, roundingMode })}`, expected);
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -423,23 +423,26 @@ describe('Date', () => {
       equal(`${later.until(earlier, { smallestUnit: 'years' })}`, '-P2Y');
     });
     it('rounds to an increment of years', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'nearest' })}`, 'P4Y');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'halfExpand' })}`,
+        'P4Y'
+      );
     });
     it('rounds to an increment of months', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'months', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'months', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'P30M'
       );
     });
     it('rounds to an increment of weeks', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'weeks', roundingIncrement: 12, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'weeks', roundingIncrement: 12, roundingMode: 'halfExpand' })}`,
         'P144W'
       );
     });
     it('rounds to an increment of days', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'days', roundingIncrement: 100, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'days', roundingIncrement: 100, roundingMode: 'halfExpand' })}`,
         'P1000D'
       );
     });
@@ -457,8 +460,8 @@ describe('Date', () => {
     it('rounds relative to the receiver', () => {
       const date1 = Temporal.PlainDate.from('2019-01-01');
       const date2 = Temporal.PlainDate.from('2019-02-15');
-      equal(`${date1.until(date2, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P2M');
-      equal(`${date2.until(date1, { smallestUnit: 'months', roundingMode: 'nearest' })}`, '-P1M');
+      equal(`${date1.until(date2, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P2M');
+      equal(`${date2.until(date1, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, '-P1M');
     });
   });
   describe('order of operations in until - TODO: add since', () => {
@@ -607,9 +610,9 @@ describe('Date', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
-      equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
-      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
+      equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
+      equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');
+      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingMode: 'halfExpand' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => later.since(earlier, { roundingMode: 'cile' }), RangeError);
@@ -621,7 +624,7 @@ describe('Date', () => {
       ['days', 'P973D']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${later.since(earlier, { smallestUnit, roundingMode })}`, expected);
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -671,23 +674,26 @@ describe('Date', () => {
       equal(`${earlier.since(later, { smallestUnit: 'years' })}`, '-P2Y');
     });
     it('rounds to an increment of years', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'nearest' })}`, 'P4Y');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'halfExpand' })}`,
+        'P4Y'
+      );
     });
     it('rounds to an increment of months', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'months', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'months', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'P30M'
       );
     });
     it('rounds to an increment of weeks', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'weeks', roundingIncrement: 12, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'weeks', roundingIncrement: 12, roundingMode: 'halfExpand' })}`,
         'P144W'
       );
     });
     it('rounds to an increment of days', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'days', roundingIncrement: 100, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'days', roundingIncrement: 100, roundingMode: 'halfExpand' })}`,
         'P1000D'
       );
     });
@@ -705,8 +711,8 @@ describe('Date', () => {
     it('rounds relative to the receiver', () => {
       const date1 = PlainDate.from('2019-01-01');
       const date2 = PlainDate.from('2019-02-15');
-      equal(`${date2.since(date1, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P1M');
-      equal(`${date1.since(date2, { smallestUnit: 'months', roundingMode: 'nearest' })}`, '-P2M');
+      equal(`${date2.since(date1, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P1M');
+      equal(`${date1.since(date2, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, '-P2M');
     });
   });
   describe('date.add() works', () => {

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -654,9 +654,9 @@ describe('DateTime', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
-      equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
-      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
+      equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
+      equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');
+      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingMode: 'halfExpand' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => earlier.until(later, { roundingMode: 'cile' }), RangeError);
@@ -674,7 +674,7 @@ describe('DateTime', () => {
       ['nanoseconds', 'P973DT4H17M4.864197532S']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${earlier.until(later, { smallestUnit, roundingMode })}`, expected);
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -743,37 +743,37 @@ describe('DateTime', () => {
     });
     it('rounds to an increment of hours', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'halfExpand' })}`,
         'P973DT3H'
       );
     });
     it('rounds to an increment of minutes', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'halfExpand' })}`,
         'P973DT4H30M'
       );
     });
     it('rounds to an increment of seconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'halfExpand' })}`,
         'P973DT4H17M'
       );
     });
     it('rounds to an increment of milliseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'P973DT4H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'P973DT4H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'P973DT4H17M4.86419753S'
       );
     });
@@ -871,8 +871,8 @@ describe('DateTime', () => {
     it('rounds relative to the receiver', () => {
       const dt1 = PlainDateTime.from('2019-01-01');
       const dt2 = PlainDateTime.from('2020-07-02');
-      equal(`${dt1.until(dt2, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P2Y');
-      equal(`${dt2.until(dt1, { smallestUnit: 'years', roundingMode: 'nearest' })}`, '-P1Y');
+      equal(`${dt1.until(dt2, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P2Y');
+      equal(`${dt2.until(dt1, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, '-P1Y');
     });
   });
   describe('DateTime.since()', () => {
@@ -975,9 +975,9 @@ describe('DateTime', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
-      equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
-      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
+      equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
+      equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');
+      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingMode: 'halfExpand' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => later.since(earlier, { roundingMode: 'cile' }), RangeError);
@@ -995,7 +995,7 @@ describe('DateTime', () => {
       ['nanoseconds', 'P973DT4H17M4.864197532S']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${later.since(earlier, { smallestUnit, roundingMode })}`, expected);
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -1064,37 +1064,37 @@ describe('DateTime', () => {
     });
     it('rounds to an increment of hours', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'halfExpand' })}`,
         'P973DT3H'
       );
     });
     it('rounds to an increment of minutes', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'halfExpand' })}`,
         'P973DT4H30M'
       );
     });
     it('rounds to an increment of seconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'halfExpand' })}`,
         'P973DT4H17M'
       );
     });
     it('rounds to an increment of milliseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'P973DT4H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'P973DT4H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'P973DT4H17M4.86419753S'
       );
     });
@@ -1192,8 +1192,8 @@ describe('DateTime', () => {
     it('rounds relative to the receiver', () => {
       const dt1 = PlainDateTime.from('2019-01-01');
       const dt2 = PlainDateTime.from('2020-07-02');
-      equal(`${dt2.since(dt1, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P1Y');
-      equal(`${dt1.since(dt2, { smallestUnit: 'years', roundingMode: 'nearest' })}`, '-P2Y');
+      equal(`${dt2.since(dt1, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P1Y');
+      equal(`${dt1.since(dt2, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, '-P2Y');
     });
   });
   describe('DateTime.round works', () => {
@@ -1224,7 +1224,7 @@ describe('DateTime', () => {
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
       it(`rounds to nearest ${smallestUnit}`, () =>
-        equal(`${dt.round({ smallestUnit, roundingMode: 'nearest' })}`, expected));
+        equal(`${dt.round({ smallestUnit, roundingMode: 'halfExpand' })}`, expected));
     });
     const incrementOneCeil = [
       ['day', '1976-11-19T00:00:00'],
@@ -1252,7 +1252,7 @@ describe('DateTime', () => {
         equal(`${dt.round({ smallestUnit, roundingMode: 'floor' })}`, expected));
       it(`truncates to ${smallestUnit}`, () => equal(`${dt.round({ smallestUnit, roundingMode: 'trunc' })}`, expected));
     });
-    it('nearest is the default', () => {
+    it('halfExpand is the default', () => {
       equal(`${dt.round({ smallestUnit: 'minute' })}`, '1976-11-18T14:24:00');
       equal(`${dt.round({ smallestUnit: 'second' })}`, '1976-11-18T14:23:30');
     });
@@ -1262,7 +1262,7 @@ describe('DateTime', () => {
       equal(`${dt2.round({ smallestUnit, roundingMode: 'ceil' })}`, '-000099-12-15T12:00:01');
       equal(`${dt2.round({ smallestUnit, roundingMode: 'floor' })}`, '-000099-12-15T12:00:00');
       equal(`${dt2.round({ smallestUnit, roundingMode: 'trunc' })}`, '-000099-12-15T12:00:00');
-      equal(`${dt2.round({ smallestUnit, roundingMode: 'nearest' })}`, '-000099-12-15T12:00:01');
+      equal(`${dt2.round({ smallestUnit, roundingMode: 'halfExpand' })}`, '-000099-12-15T12:00:01');
     });
     it('rounds to an increment of hours', () => {
       equal(`${dt.round({ smallestUnit: 'hour', roundingIncrement: 4 })}`, '1976-11-18T16:00:00');
@@ -1742,8 +1742,8 @@ describe('DateTime', () => {
       throws(() => dt1.toString({ roundingMode: 'cile' }), RangeError);
     });
     it('rounds to nearest', () => {
-      equal(dt2.toString({ smallestUnit: 'minute', roundingMode: 'nearest' }), '1976-11-18T15:24');
-      equal(dt3.toString({ fractionalSecondDigits: 3, roundingMode: 'nearest' }), '1976-11-18T15:23:30.123');
+      equal(dt2.toString({ smallestUnit: 'minute', roundingMode: 'halfExpand' }), '1976-11-18T15:24');
+      equal(dt3.toString({ fractionalSecondDigits: 3, roundingMode: 'halfExpand' }), '1976-11-18T15:23:30.123');
     });
     it('rounds up', () => {
       equal(dt2.toString({ smallestUnit: 'minute', roundingMode: 'ceil' }), '1976-11-18T15:24');
@@ -1761,7 +1761,7 @@ describe('DateTime', () => {
     });
     it('rounding can affect all units', () => {
       const dt5 = PlainDateTime.from('1999-12-31T23:59:59.999999999');
-      equal(dt5.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' }), '2000-01-01T00:00:00.00000000');
+      equal(dt5.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' }), '2000-01-01T00:00:00.00000000');
     });
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -361,7 +361,7 @@ describe('Time', () => {
       ['nanoseconds', 'PT4H17M4.864197532S']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${earlier.until(later, { smallestUnit, roundingMode })}`, expected);
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -418,37 +418,37 @@ describe('Time', () => {
     });
     it('rounds to an increment of hours', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'halfExpand' })}`,
         'PT3H'
       );
     });
     it('rounds to an increment of minutes', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'halfExpand' })}`,
         'PT4H30M'
       );
     });
     it('rounds to an increment of seconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'halfExpand' })}`,
         'PT4H17M'
       );
     });
     it('rounds to an increment of milliseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT4H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT4H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT4H17M4.86419753S'
       );
     });
@@ -629,7 +629,7 @@ describe('Time', () => {
       ['nanoseconds', 'PT4H17M4.864197532S']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${later.since(earlier, { smallestUnit, roundingMode })}`, expected);
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -686,37 +686,37 @@ describe('Time', () => {
     });
     it('rounds to an increment of hours', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'halfExpand' })}`,
         'PT3H'
       );
     });
     it('rounds to an increment of minutes', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'halfExpand' })}`,
         'PT4H30M'
       );
     });
     it('rounds to an increment of seconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'halfExpand' })}`,
         'PT4H17M'
       );
     });
     it('rounds to an increment of milliseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT4H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT4H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT4H17M4.86419753S'
       );
     });
@@ -832,7 +832,7 @@ describe('Time', () => {
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
       it(`rounds to nearest ${smallestUnit}`, () =>
-        equal(`${time.round({ smallestUnit, roundingMode: 'nearest' })}`, expected));
+        equal(`${time.round({ smallestUnit, roundingMode: 'halfExpand' })}`, expected));
     });
     const incrementOneCeil = [
       ['hour', '14:00:00'],
@@ -860,7 +860,7 @@ describe('Time', () => {
       it(`truncates to ${smallestUnit}`, () =>
         equal(`${time.round({ smallestUnit, roundingMode: 'trunc' })}`, expected));
     });
-    it('nearest is the default', () => {
+    it('halfExpand is the default', () => {
       equal(`${time.round({ smallestUnit: 'hour' })}`, '14:00:00');
       equal(`${time.round({ smallestUnit: 'minute' })}`, '13:46:00');
     });
@@ -1146,8 +1146,8 @@ describe('Time', () => {
       throws(() => t1.toString({ roundingMode: 'cile' }), RangeError);
     });
     it('rounds to nearest', () => {
-      equal(t2.toString({ smallestUnit: 'minute', roundingMode: 'nearest' }), '15:24');
-      equal(t3.toString({ fractionalSecondDigits: 3, roundingMode: 'nearest' }), '15:23:30.123');
+      equal(t2.toString({ smallestUnit: 'minute', roundingMode: 'halfExpand' }), '15:24');
+      equal(t3.toString({ fractionalSecondDigits: 3, roundingMode: 'halfExpand' }), '15:23:30.123');
     });
     it('rounds up', () => {
       equal(t2.toString({ smallestUnit: 'minute', roundingMode: 'ceil' }), '15:24');
@@ -1161,7 +1161,7 @@ describe('Time', () => {
     });
     it('rounding can affect all units', () => {
       const t4 = PlainTime.from('23:59:59.999999999');
-      equal(t4.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' }), '00:00:00.00000000');
+      equal(t4.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' }), '00:00:00.00000000');
     });
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>

--- a/polyfill/test/plainyearmonth.mjs
+++ b/polyfill/test/plainyearmonth.mjs
@@ -351,7 +351,7 @@ describe('YearMonth', () => {
       ['months', 'P2Y8M']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${earlier.until(later, { smallestUnit, roundingMode })}`, expected);
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -395,7 +395,10 @@ describe('YearMonth', () => {
       equal(`${later.until(earlier, { smallestUnit: 'years' })}`, '-P2Y');
     });
     it('rounds to an increment of years', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'nearest' })}`, 'P4Y');
+      equal(
+        `${earlier.until(later, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'halfExpand' })}`,
+        'P4Y'
+      );
     });
     it('rounds to an increment of months', () => {
       equal(`${earlier.until(later, { smallestUnit: 'months', roundingIncrement: 5 })}`, 'P2Y5M');
@@ -490,7 +493,7 @@ describe('YearMonth', () => {
       ['months', 'P2Y8M']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${later.since(earlier, { smallestUnit, roundingMode })}`, expected);
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -534,7 +537,10 @@ describe('YearMonth', () => {
       equal(`${earlier.since(later, { smallestUnit: 'years' })}`, '-P2Y');
     });
     it('rounds to an increment of years', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'nearest' })}`, 'P4Y');
+      equal(
+        `${later.since(earlier, { smallestUnit: 'years', roundingIncrement: 4, roundingMode: 'halfExpand' })}`,
+        'P4Y'
+      );
     });
     it('rounds to an increment of months', () => {
       equal(`${later.since(earlier, { smallestUnit: 'months', roundingIncrement: 5 })}`, 'P2Y5M');

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -1331,10 +1331,10 @@ describe('ZonedDateTime', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than hours', () => {
-      equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
-      equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
-      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
-      equal(`${earlier.until(later, { smallestUnit: 'days', roundingMode: 'nearest' })}`, 'P973D');
+      equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
+      equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');
+      equal(`${earlier.until(later, { smallestUnit: 'weeks', roundingMode: 'halfExpand' })}`, 'P139W');
+      equal(`${earlier.until(later, { smallestUnit: 'days', roundingMode: 'halfExpand' })}`, 'P973D');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => earlier.until(later, { roundingMode: 'cile' }), RangeError);
@@ -1352,7 +1352,7 @@ describe('ZonedDateTime', () => {
       ['nanoseconds', 'PT23356H17M4.864197532S']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${earlier.until(later, { smallestUnit, roundingMode })}`, expected);
         equal(`${later.until(earlier, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -1421,37 +1421,37 @@ describe('ZonedDateTime', () => {
     });
     it('rounds to an increment of hours', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'halfExpand' })}`,
         'PT23355H'
       );
     });
     it('rounds to an increment of minutes', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'halfExpand' })}`,
         'PT23356H30M'
       );
     });
     it('rounds to an increment of seconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'halfExpand' })}`,
         'PT23356H17M'
       );
     });
     it('rounds to an increment of milliseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT23356H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT23356H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${earlier.until(later, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT23356H17M4.86419753S'
       );
     });
@@ -1549,8 +1549,8 @@ describe('ZonedDateTime', () => {
     it('rounds relative to the receiver', () => {
       const dt1 = ZonedDateTime.from('2019-01-01T00:00+00:00[UTC]');
       const dt2 = ZonedDateTime.from('2020-07-02T00:00+00:00[UTC]');
-      equal(`${dt1.until(dt2, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P2Y');
-      equal(`${dt2.until(dt1, { smallestUnit: 'years', roundingMode: 'nearest' })}`, '-P1Y');
+      equal(`${dt1.until(dt2, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P2Y');
+      equal(`${dt2.until(dt1, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, '-P1Y');
     });
   });
   describe('ZonedDateTime.since()', () => {
@@ -1663,9 +1663,9 @@ describe('ZonedDateTime', () => {
       }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
-      equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P3Y');
-      equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'nearest' })}`, 'P32M');
-      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingMode: 'nearest' })}`, 'P139W');
+      equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
+      equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');
+      equal(`${later.since(earlier, { smallestUnit: 'weeks', roundingMode: 'halfExpand' })}`, 'P139W');
     });
     it('throws on invalid roundingMode', () => {
       throws(() => later.since(earlier, { roundingMode: 'cile' }), RangeError);
@@ -1683,7 +1683,7 @@ describe('ZonedDateTime', () => {
       ['nanoseconds', 'PT23356H17M4.864197532S']
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
-      const roundingMode = 'nearest';
+      const roundingMode = 'halfExpand';
       it(`rounds to nearest ${smallestUnit}`, () => {
         equal(`${later.since(earlier, { smallestUnit, roundingMode })}`, expected);
         equal(`${earlier.since(later, { smallestUnit, roundingMode })}`, `-${expected}`);
@@ -1752,37 +1752,37 @@ describe('ZonedDateTime', () => {
     });
     it('rounds to an increment of hours', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'hours', roundingIncrement: 3, roundingMode: 'halfExpand' })}`,
         'PT23355H'
       );
     });
     it('rounds to an increment of minutes', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'minutes', roundingIncrement: 30, roundingMode: 'halfExpand' })}`,
         'PT23356H30M'
       );
     });
     it('rounds to an increment of seconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'seconds', roundingIncrement: 15, roundingMode: 'halfExpand' })}`,
         'PT23356H17M'
       );
     });
     it('rounds to an increment of milliseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'milliseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT23356H17M4.86S'
       );
     });
     it('rounds to an increment of microseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'microseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT23356H17M4.8642S'
       );
     });
     it('rounds to an increment of nanoseconds', () => {
       equal(
-        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'nearest' })}`,
+        `${later.since(earlier, { smallestUnit: 'nanoseconds', roundingIncrement: 10, roundingMode: 'halfExpand' })}`,
         'PT23356H17M4.86419753S'
       );
     });
@@ -1880,8 +1880,8 @@ describe('ZonedDateTime', () => {
     it('rounds relative to the receiver', () => {
       const dt1 = ZonedDateTime.from('2019-01-01T00:00+00:00[UTC]');
       const dt2 = ZonedDateTime.from('2020-07-02T00:00+00:00[UTC]');
-      equal(`${dt2.since(dt1, { smallestUnit: 'years', roundingMode: 'nearest' })}`, 'P1Y');
-      equal(`${dt1.since(dt2, { smallestUnit: 'years', roundingMode: 'nearest' })}`, '-P2Y');
+      equal(`${dt2.since(dt1, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P1Y');
+      equal(`${dt1.since(dt2, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, '-P2Y');
     });
   });
 
@@ -1913,7 +1913,7 @@ describe('ZonedDateTime', () => {
     ];
     incrementOneNearest.forEach(([smallestUnit, expected]) => {
       it(`rounds to nearest ${smallestUnit}`, () =>
-        equal(`${zdt.round({ smallestUnit, roundingMode: 'nearest' })}`, expected));
+        equal(`${zdt.round({ smallestUnit, roundingMode: 'halfExpand' })}`, expected));
     });
     const incrementOneCeil = [
       ['day', '1976-11-19T00:00:00+01:00[Europe/Vienna]'],
@@ -1942,7 +1942,7 @@ describe('ZonedDateTime', () => {
       it(`truncates to ${smallestUnit}`, () =>
         equal(`${zdt.round({ smallestUnit, roundingMode: 'trunc' })}`, expected));
     });
-    it('nearest is the default', () => {
+    it('halfExpand is the default', () => {
       equal(`${zdt.round({ smallestUnit: 'minute' })}`, '1976-11-18T15:24:00+01:00[Europe/Vienna]');
       equal(`${zdt.round({ smallestUnit: 'second' })}`, '1976-11-18T15:23:30+01:00[Europe/Vienna]');
     });
@@ -1952,7 +1952,7 @@ describe('ZonedDateTime', () => {
       equal(`${zdt2.round({ smallestUnit, roundingMode: 'ceil' })}`, '1969-12-15T12:00:01+00:00[UTC]');
       equal(`${zdt2.round({ smallestUnit, roundingMode: 'floor' })}`, '1969-12-15T12:00:00+00:00[UTC]');
       equal(`${zdt2.round({ smallestUnit, roundingMode: 'trunc' })}`, '1969-12-15T12:00:00+00:00[UTC]');
-      equal(`${zdt2.round({ smallestUnit, roundingMode: 'nearest' })}`, '1969-12-15T12:00:01+00:00[UTC]');
+      equal(`${zdt2.round({ smallestUnit, roundingMode: 'halfExpand' })}`, '1969-12-15T12:00:01+00:00[UTC]');
     });
     it('rounding down is towards the Big Bang, not towards 1 BCE', () => {
       const zdt3 = ZonedDateTime.from('-000099-12-15T12:00:00.5+00:00[UTC]');
@@ -1960,7 +1960,7 @@ describe('ZonedDateTime', () => {
       equal(`${zdt3.round({ smallestUnit, roundingMode: 'ceil' })}`, '-000099-12-15T12:00:01+00:00[UTC]');
       equal(`${zdt3.round({ smallestUnit, roundingMode: 'floor' })}`, '-000099-12-15T12:00:00+00:00[UTC]');
       equal(`${zdt3.round({ smallestUnit, roundingMode: 'trunc' })}`, '-000099-12-15T12:00:00+00:00[UTC]');
-      equal(`${zdt3.round({ smallestUnit, roundingMode: 'nearest' })}`, '-000099-12-15T12:00:01+00:00[UTC]');
+      equal(`${zdt3.round({ smallestUnit, roundingMode: 'halfExpand' })}`, '-000099-12-15T12:00:01+00:00[UTC]');
     });
     it('rounds to an increment of hours', () => {
       equal(`${zdt.round({ smallestUnit: 'hour', roundingIncrement: 4 })}`, '1976-11-18T16:00:00+01:00[Europe/Vienna]');
@@ -2065,7 +2065,7 @@ describe('ZonedDateTime', () => {
     });
     it('rounding up to a nonexistent wall-clock time', () => {
       const almostSkipped = ZonedDateTime.from('2018-11-03T23:59:59.999999999-03:00[America/Sao_Paulo]');
-      const rounded = almostSkipped.round({ smallestUnit: 'microsecond', roundingMode: 'nearest' });
+      const rounded = almostSkipped.round({ smallestUnit: 'microsecond', roundingMode: 'halfExpand' });
       equal(`${rounded}`, '2018-11-04T01:00:00-02:00[America/Sao_Paulo]');
       equal(rounded.epochNanoseconds - almostSkipped.epochNanoseconds, 1n);
     });
@@ -2227,11 +2227,11 @@ describe('ZonedDateTime', () => {
     });
     it('rounds to nearest', () => {
       equal(
-        zdt2.toString({ smallestUnit: 'minute', roundingMode: 'nearest' }),
+        zdt2.toString({ smallestUnit: 'minute', roundingMode: 'halfExpand' }),
         '1976-11-18T15:24+01:00[Europe/Vienna]'
       );
       equal(
-        zdt3.toString({ fractionalSecondDigits: 3, roundingMode: 'nearest' }),
+        zdt3.toString({ fractionalSecondDigits: 3, roundingMode: 'halfExpand' }),
         '1976-11-18T15:23:30.123+01:00[Europe/Vienna]'
       );
     });
@@ -2258,13 +2258,13 @@ describe('ZonedDateTime', () => {
     it('rounding can affect all units', () => {
       const zdt5 = ZonedDateTime.from('1999-12-31T23:59:59.999999999+01:00[Europe/Berlin]');
       equal(
-        zdt5.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' }),
+        zdt5.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' }),
         '2000-01-01T00:00:00.00000000+01:00[Europe/Berlin]'
       );
     });
     it('rounding up to a nonexistent wall-clock time', () => {
       const zdt5 = ZonedDateTime.from('2018-11-03T23:59:59.999999999-03:00[America/Sao_Paulo]');
-      const roundedString = zdt5.toString({ fractionalSecondDigits: 8, roundingMode: 'nearest' });
+      const roundedString = zdt5.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' });
       equal(roundedString, '2018-11-04T01:00:00.00000000-02:00[America/Sao_Paulo]');
       const zdt6 = ZonedDateTime.from(roundedString);
       equal(zdt6.epochNanoseconds - zdt5.epochNanoseconds, 1n);
@@ -2598,7 +2598,7 @@ describe('ZonedDateTime', () => {
     it('Difference rounding (nearest day) is DST-aware', () => {
       const start = ZonedDateTime.from('2020-03-10T02:30-07:00[America/Los_Angeles]');
       const end = ZonedDateTime.from('2020-03-07T14:15-08:00[America/Los_Angeles]');
-      const diff = start.until(end, { smallestUnit: 'days', roundingMode: 'nearest' }); // roundingMode: 'nearest'
+      const diff = start.until(end, { smallestUnit: 'days', roundingMode: 'halfExpand' });
       equal(`${diff}`, '-P3D');
     });
 
@@ -2626,7 +2626,7 @@ describe('ZonedDateTime', () => {
     it('Difference rounding (nearest hour) is DST-aware', () => {
       const start = ZonedDateTime.from('2020-03-10T02:30-07:00[America/Los_Angeles]');
       const end = ZonedDateTime.from('2020-03-07T14:15-08:00[America/Los_Angeles]');
-      const diff = start.until(end, { largestUnit: 'days', smallestUnit: 'hours' }); // roundingMode: 'nearest'
+      const diff = start.until(end, { largestUnit: 'days', smallestUnit: 'hours', roundingMode: 'halfExpand' });
       equal(`${diff}`, '-P2DT12H');
     });
 
@@ -2668,14 +2668,14 @@ describe('ZonedDateTime', () => {
     it('Rounding up to hours causes one more day of overflow (positive)', () => {
       const start = ZonedDateTime.from('2020-01-01T00:00-08:00[America/Los_Angeles]');
       const end = ZonedDateTime.from('2020-01-03T23:59-08:00[America/Los_Angeles]');
-      const diff = start.until(end, { largestUnit: 'days', smallestUnit: 'hours', roundingMode: 'nearest' });
+      const diff = start.until(end, { largestUnit: 'days', smallestUnit: 'hours', roundingMode: 'halfExpand' });
       equal(`${diff}`, 'P3D');
     });
 
     it('Rounding up to hours causes one more day of overflow (negative)', () => {
       const start = ZonedDateTime.from('2020-01-01T00:00-08:00[America/Los_Angeles]');
       const end = ZonedDateTime.from('2020-01-03T23:59-08:00[America/Los_Angeles]');
-      const diff = end.until(start, { largestUnit: 'days', smallestUnit: 'hours', roundingMode: 'nearest' });
+      const diff = end.until(start, { largestUnit: 'days', smallestUnit: 'hours', roundingMode: 'halfExpand' });
       equal(`${diff}`, '-P3D');
     });
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -178,7 +178,7 @@
       </p>
     </emu-note>
     <emu-alg>
-      1. Return ? GetOption(_normalizedOptions_, *"roundingMode"*, *"string"*, « *"ceil"*, *"floor"*, *"trunc"*, *"nearest"* », _fallback_).
+      1. Return ? GetOption(_normalizedOptions_, *"roundingMode"*, *"string"*, « *"ceil"*, *"floor"*, *"trunc"*, *"halfExpand"* », _fallback_).
     </emu-alg>
   </emu-clause>
 
@@ -758,7 +758,7 @@
     </emu-note>
     <emu-alg>
       1. Assert: _x_ and _increment_ are mathematical values.
-      1. Assert: _roundingMode_ is *"ceil"*, *"floor"*, *"trunc"*, or *"nearest"*.
+      1. Assert: _roundingMode_ is *"ceil"*, *"floor"*, *"trunc"*, or *"halfExpand"*.
       1. Let _quotient_ be _x_ / _increment_.
       1. If _roundingMode_ is *"ceil"*, then
         1. Let _rounded_ be −floor(−_quotient_).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -446,7 +446,7 @@
         1. If _smallestUnitPresent_ is *false* and _largestUnitPresent_ is *false*, then
           1. Throw a *RangeError* exception.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _relativeTo_ be ? ToRelativeTemporalObject(_options_).
@@ -1174,7 +1174,7 @@
           1. Let _intermediateNs_ be ? AddZonedDateTime(_relativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
           1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZone_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
           1. If _largestUnit_ is not one of *"years"*, *"months"*, *"weeks"*, or *"days"*, then
-            1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanoseconds"*, *"nearest"*).
+            1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanoseconds"*, *"halfExpand"*).
             1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _diffNs_, _largestUnit_).
             1. Let _years_ be 0.
             1. Let _months_ be 0.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -321,7 +321,7 @@
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"* »).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
           1. Let _maximum_ be 24.
         1. Else if _smallestUnit_ is *"minute"*, then

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -559,7 +559,7 @@
           1. Throw a *TypeError* exception.
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « »).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_options_, _smallestUnit_).
         1. Let _result_ be ? RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTimeFromInstance(_dateTime_, _result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -355,7 +355,7 @@
           1. Throw a *TypeError* exception.
         1. Set _options_ to ? NormalizeOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"* »).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"nearest"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
           1. Let _maximum_ be 24.
         1. Else if _smallestUnit_ is *"minute"* or *"second"*, then


### PR DESCRIPTION
In the ECMA-402 meeting of 2021-02-11, 'nearest' was renamed to
'halfExpand'. By definition, Temporal uses the same names for rounding
modes as in that proposal.

See: #1038