### PR TITLE
Sync calendar annotation format with the IETF draft

### DIFF
--- a/docs/ambiguity.md
+++ b/docs/ambiguity.md
@@ -83,7 +83,7 @@ zdt = instant.toZonedDateTime('Asia/Tokyo', 'iso8601').toLocaleString('ja-jp', f
   // this is identical to the result of toZonedDateTime() above
 
 zdt = instant.toZonedDateTime('Asia/Tokyo', 'japanese');
-  // => 2019-09-03T17:34:05+09:00[Asia/Tokyo][u-ca-japanese]
+  // => 2019-09-03T17:34:05+09:00[Asia/Tokyo][u-ca=japanese]
 zdt.toLocaleString('en-us', { ...formatOptions, calendar: zdt.calendar });
   // => "Sep 3, 1 Reiwa, 5:34:05 PM"
 zdt.year;

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -117,7 +117,7 @@ For a list of calendar identifiers, see the documentation for [Intl.DateTimeForm
 If `calendarIdentifier` is not a built-in calendar, then a `RangeError` is thrown.
 
 Use this constructor directly if you have a string that is known to be a correct built-in calendar identifier.
-If you have an ISO 8601 date-time string with a `[u-ca-identifier]` annotation, then `Temporal.Calendar.from()` is more convenient than parsing the identifier out of the string, and also the only way to parse strings annotated with a non-built-in calendar.
+If you have an ISO 8601 date-time string with a `[u-ca=identifier]` annotation, then `Temporal.Calendar.from()` is more convenient than parsing the identifier out of the string, and also the only way to parse strings annotated with a non-built-in calendar.
 
 Example usage:
 
@@ -146,7 +146,7 @@ Any other value is converted to a string, which is expected to be either:
 - a string that is accepted by `new Temporal.Calendar()`; or
 - a string in the ISO 8601 format.
 
-Note that the ISO 8601 string can be extended with a `[u-ca-identifier]` annotation in square brackets appended to it.
+Note that the ISO 8601 string can be extended with a `[u-ca=identifier]` annotation in square brackets appended to it.
 Without such an annotation, the calendar is taken to be `iso8601`.
 
 This function is often more convenient to use than `new Temporal.Calendar()` because it handles a wider range of input.
@@ -160,7 +160,7 @@ cal = Temporal.Calendar.from('gregory');
 
 // ISO 8601 string with or without calendar annotation
 cal = Temporal.Calendar.from('2020-01-13T16:31:00.065858086');
-cal = Temporal.Calendar.from('2020-01-13T16:31:00.065858086-08:00[America/Vancouver][u-ca-iso8601]');
+cal = Temporal.Calendar.from('2020-01-13T16:31:00.065858086-08:00[America/Vancouver][u-ca=iso8601]');
 
 // Existing calendar object
 cal2 = Temporal.Calendar.from(cal);
@@ -169,7 +169,7 @@ cal2 = Temporal.Calendar.from(cal);
 cal = Temporal.Calendar.from({ id: 'mycalendar' });
 
 /*⚠️*/ cal = Temporal.Calendar.from('discordian'); // not a built-in calendar, throws
-/*⚠️*/ cal = Temporal.Calendar.from('[u-ca-iso8601]'); // lone annotation not a valid ISO 8601 string
+/*⚠️*/ cal = Temporal.Calendar.from('[u-ca=iso8601]'); // lone annotation not a valid ISO 8601 string
 ```
 
 ## Properties
@@ -273,7 +273,7 @@ date.year; // => 5779
 date.month; // => 6
 date.monthCode; // => "M05L"
 date.day; // => 18
-date.toString(); // => 2019-02-23[u-ca-hebrew]
+date.toString(); // => 2019-02-23[u-ca=hebrew]
 date.toLocaleString('en-US', { calendar: 'hebrew' }); // => "18 Adar I 5779"
 
 // same result, but calling the method directly and using month index instead of month code:
@@ -320,7 +320,7 @@ date = Temporal.PlainDate.from('2020-05-29')
 date.year; // => 1441
 date.month; // => 11
 date.day; // => 7
-date.toString(); // => 2020-06-28[u-ca-islamic]
+date.toString(); // => 2020-06-28[u-ca=islamic]
 
 // same result, but calling the method directly:
 date = Temporal.Calendar.from('islamic').dateAdd(
@@ -332,7 +332,7 @@ date = Temporal.Calendar.from('islamic').dateAdd(
 date.year; // => 1441
 date.month; // => 11
 date.day; // => 7
-date.toString(); // => 2020-06-28[u-ca-islamic]
+date.toString(); // => 2020-06-28[u-ca=islamic]
 ```
 
 ### calendar.**dateUntil**(_one_: Temporal.PlainDate | object | string, _two_: Temporal.PlainDate | object | string, _options_: object) : Temporal.Duration
@@ -445,7 +445,7 @@ This method overrides `Object.prototype.toString()` and provides the calendar's 
 Example usage:
 
 ```javascript
-Temporal.PlainDate.from('2020-05-29[u-ca-gregory]').calendar.toString(); // => gregory
+Temporal.PlainDate.from('2020-05-29[u-ca=gregory]').calendar.toString(); // => gregory
 ```
 
 ### calendar.**toJSON**() : string

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -274,13 +274,13 @@ Example usage:
 epoch = Temporal.Instant.fromEpochSeconds(0);
 timeZone = Temporal.TimeZone.from('America/New_York');
 epoch.toZonedDateTime({ timeZone, calendar: 'gregory' });
-  // => 1969-12-31T19:00-05:00[America/New_York][u-ca-gregory]
+  // => 1969-12-31T19:00-05:00[America/New_York][u-ca=gregory]
 
 // What time was the Unix epoch in Tokyo in the Japanese calendar?
 timeZone = Temporal.TimeZone.from('Asia/Tokyo');
 calendar = Temporal.Calendar.from('japanese');
 zdt = epoch.toZonedDateTime({ timeZone, calendar });
-  // => 1970-01-01T09:00+09:00[Asia/Tokyo][u-ca-japanese]
+  // => 1970-01-01T09:00+09:00[Asia/Tokyo][u-ca=japanese]
 console.log(zdt.year, zdt.era);
   // => 45 showa
 ```

--- a/docs/iso-string-ext.md
+++ b/docs/iso-string-ext.md
@@ -55,7 +55,7 @@ _Calendar-specific dates are expressed as their equivalent date in the ISO calen
 For example, when parsed, the following string would represent the date **28 Iyar 5780** in the Hebrew calendar:
 
 ```
-2020-05-22[u-ca-hebrew]
+2020-05-22[u-ca=hebrew]
 ```
 
 The syntax of the calendar suffix is currently being proposed for standardization with the CalConnect and IETF Calsify standards bodies.
@@ -86,7 +86,7 @@ The list of calendar identifiers currently supported by CLDR is:
 Example of a maximal length string containing both an IANA time zone name and a calendar system:
 
 ```
-2020-05-22T07:19:35.356-04:00[America/Indiana/Indianapolis][u-ca-islamic-umalqura]
+2020-05-22T07:19:35.356-04:00[America/Indiana/Indianapolis][u-ca=islamic-umalqura]
 ```
 
 ### Calendar-dependent YearMonth and MonthDay

--- a/docs/persistence-model.svg
+++ b/docs/persistence-model.svg
@@ -41,7 +41,7 @@
       font-size: 35px;
     }
   ]]></style>
-  <text fill="#000" style="font-size: 55px">2020-08-05T20:06:13+09:00[Asia/Tokyo][u-ca-japanese]</text>
+  <text fill="#000" style="font-size: 55px">2020-08-05T20:06:13+09:00[Asia/Tokyo][u-ca=japanese]</text>
   <rect x="-10" y="-150" stroke="#70AD47" fill="none" width="698" height="170"/>
   <text x="170" y="-100" style="font-size: 35px; stroke: #70AD47; fill: #70AD47">ISO 8601 / RFC 3339</text>
 
@@ -49,7 +49,7 @@
   <text x="770" y="-100" style="font-size: 35px; stroke: #ED7D31; fill: #ED7D31">Time Zone</text>
   <text x="777" y="-60" style="font-size: 35px; stroke: #ED7D31; fill: #ED7D31">Extension</text>
 
-  <rect x="998" y="-150" stroke="#F4B5BC" fill="none" width="366" height="170"/>
+  <rect x="998" y="-150" stroke="#F4B5BC" fill="none" width="380" height="170"/>
   <text x="1120" y="-100" style="font-size: 35px; stroke: #CC0000; fill: #CC0000">Calendar</text>
   <text x="1114" y="-60" style="font-size: 35px; stroke: #CC0000; fill: #CC0000">Extension</text>
 

--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -99,7 +99,7 @@ date = Temporal.PlainDate.from(Temporal.PlainDateTime.from('2006-08-24T15:43:27'
   // => same as above; Temporal.PlainDateTime has year, month, and day properties
 
 calendar = Temporal.Calendar.from('islamic');
-date = Temporal.PlainDate.from({ year: 1427, month; 8, day: 1, calendar }); // => 2006-08-24[u-ca-islamic]
+date = Temporal.PlainDate.from({ year: 1427, month; 8, day: 1, calendar }); // => 2006-08-24[u-ca=islamic]
 date = Temporal.PlainDate.from({ year: 1427, month: 8, day: 1, calendar: 'islamic' });
   // => same as above
 
@@ -185,7 +185,7 @@ date.month;     // => 8
 date.monthCode; // => "M08"
 date.day;       // => 24
 
-date = Temporal.PlainDate.from('2019-02-23[u-ca-hebrew]');
+date = Temporal.PlainDate.from('2019-02-23[u-ca=hebrew]');
 date.year;      // => 5779
 date.month;     // => 6
 date.monthCode; // => "M05L"
@@ -207,7 +207,7 @@ As inputs to `from` or `with`, `era` and `eraYear` can be used instead of `year`
 Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.
 
 ```javascript
-date = Temporal.PlainDate.from('-000015-01-01[u-ca-gregory]');
+date = Temporal.PlainDate.from('-000015-01-01[u-ca=gregory]');
 date.era;
 // => "bce"
 date.eraYear;
@@ -384,7 +384,7 @@ This method is the same as `date.with({ calendar })`, but may be more efficient.
 Usage example:
 
 ```javascript
-date = Temporal.PlainDate.from('2006-08-24[u-ca-japanese]');
+date = Temporal.PlainDate.from('2006-08-24[u-ca=japanese]');
 date.withCalendar('iso8601'); // => 2006-08-24
 ```
 

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -145,7 +145,7 @@ dt = Temporal.PlainDateTime.from(Temporal.PlainDate.from('1995-12-07T03:24:30'))
 
 calendar = Temporal.Calendar.from('hebrew');
 dt = Temporal.PlainDateTime.from({ year: 5756, month: 3, day: 14, hour: 3, minute: 24, second: 30, calendar });
-  // => 1995-12-07T03:24:30[u-ca-hebrew]
+  // => 1995-12-07T03:24:30[u-ca=hebrew]
 dt = Temporal.PlainDateTime.from({ year: 5756, month: 3, day: 14, hour: 3, minute: 24, second: 30, calendar: 'hebrew' });
   // => same as above
 
@@ -277,7 +277,7 @@ dt.millisecond; // => 0
 dt.microsecond; // => 3
 dt.nanosecond;  // => 500
 
-dt = Temporal.PlainDate.from('2019-02-23T03:24:30.000003500[u-ca-hebrew]');
+dt = Temporal.PlainDate.from('2019-02-23T03:24:30.000003500[u-ca=hebrew]');
 dt.year;        // => 5779
 dt.month;       // => 6
 dt.monthCode;   // => "M05L"
@@ -305,7 +305,7 @@ As inputs to `from` or `with`, `era` and `eraYear` can be used instead of `year`
 Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.
 
 ```javascript
-date = Temporal.PlainDateTime.from('-000015-01-01T12:30[u-ca-gregory]');
+date = Temporal.PlainDateTime.from('-000015-01-01T12:30[u-ca=gregory]');
 date.era;
 // => "bce"
 date.eraYear;
@@ -536,9 +536,9 @@ dt.withPlainDate('2018-09-15'); // => 2018-09-15T03:24:30
 dt.add({ hours: 12 }).withPlainDate('2000-06-01'); // => 2000-06-01T15:24:30
 
 // result contains a non-ISO calendar if present in the input
-dt.withCalendar('japanese').withPlainDate('2008-09-06'); // => 2008-09-06T03:24:30[u-ca-japanese]
-dt.withPlainDate('2017-09-06[u-ca-japanese]'); // => 2017-09-06T03:24:30[u-ca-japanese]
-dt.withCalendar('japanese').withPlainDate('2017-09-06[u-ca-hebrew]'); // => RangeError (calendar conflict)
+dt.withCalendar('japanese').withPlainDate('2008-09-06'); // => 2008-09-06T03:24:30[u-ca=japanese]
+dt.withPlainDate('2017-09-06[u-ca=japanese]'); // => 2017-09-06T03:24:30[u-ca=japanese]
+dt.withCalendar('japanese').withPlainDate('2017-09-06[u-ca=hebrew]'); // => RangeError (calendar conflict)
 ```
 
 ### datetime.**withCalendar**(_calendar_: object | string) : Temporal.PlainDateTime
@@ -554,7 +554,7 @@ This method is the same as `datetime.with({ calendar })`, but may be more effici
 Usage example:
 
 ```javascript
-dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500[u-ca-japanese]');
+dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500[u-ca=japanese]');
 dt.withCalendar('iso8601'); // => 1995-12-07T03:24:30.000003500
 ```
 

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -115,12 +115,12 @@ md = Temporal.PlainMonthDay.from({ month: 2, day: 29, year: 2001 }, { overflow: 
 
 // non-ISO calendars
 md = Temporal.PlainMonthDay.from({ monthCode: 'M05L', day: 15, calendar: 'hebrew' });
-// => 2019-02-20[u-ca-hebrew]
+// => 2019-02-20[u-ca=hebrew]
 md = Temporal.PlainMonthDay.from({ month: 6, day: 15, year: 5779, calendar: 'hebrew' });
-// => 2019-02-20[u-ca-hebrew]
+// => 2019-02-20[u-ca=hebrew]
 md = Temporal.PlainMonthDay.from({ month: 6, day: 15, calendar: 'hebrew' });
 // => throws (either year or monthCode is required)
-md = Temporal.PlainMonthDay.from('2019-02-20[u-ca-hebrew]');
+md = Temporal.PlainMonthDay.from('2019-02-20[u-ca=hebrew]');
 md.monthCode; // => "M05L"
 md.day; // => 15
 md.month; // undefined (month property is not present in this type; use monthCode instead)
@@ -151,7 +151,7 @@ md.monthCode; // => "M08"
 md.day; // => 24
 md.month; // undefined (no `month` property; use `monthCode` instead)
 
-md = Temporal.PlainMonthDay.from('2019-02-20[u-ca-hebrew]');
+md = Temporal.PlainMonthDay.from('2019-02-20[u-ca=hebrew]');
 md.monthCode; // => "M05L"
 md.day; // => 15
 md.month; // undefined (no `month` property; use `monthCode` instead)

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -181,7 +181,7 @@ ym.year; // => 2019
 ym.month; // => 6
 ym.monthCode; // => "M06"
 
-ym = Temporal.PlainYearMonth.from('2019-02-23[u-ca-hebrew]');
+ym = Temporal.PlainYearMonth.from('2019-02-23[u-ca=hebrew]');
 ym.year; // => 5779
 ym.month; // => 6
 ym.monthCode; // => "M05L"
@@ -202,7 +202,7 @@ As inputs to `from` or `with`, `era` and `eraYear` can be used instead of `year`
 Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.
 
 ```javascript
-ym = Temporal.PlainYearMonth.from('-000015-01-01[u-ca-gregory]');
+ym = Temporal.PlainYearMonth.from('-000015-01-01[u-ca=gregory]');
 ym.era;
 // => "bce"
 ym.eraYear;

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -88,7 +88,7 @@ Any non-object value is converted to a string, which is expected to be an ISO 86
 For example:
 
 ```
-2020-08-05T20:06:13+09:00[Asia/Tokyo][u-ca-japanese]
+2020-08-05T20:06:13+09:00[Asia/Tokyo][u-ca=japanese]
 ```
 
 If the string isn't valid, then a `RangeError` will be thrown regardless of the value of `overflow`.
@@ -179,7 +179,7 @@ Example usage:
 <!-- prettier-ignore-start -->
 ```javascript
 zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00[Africa/Cairo]');
-zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00[Africa/Cairo][u-ca-islamic]');
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00[Africa/Cairo][u-ca=islamic]');
 zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30');  // RangeError; time zone ID required
 zdt = Temporal.ZonedDateTime.from('1995-12-07T01:24:30Z');  // RangeError; time zone ID required
 zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00');  // RangeError; time zone ID required
@@ -337,7 +337,7 @@ dt.millisecond; // => 0
 dt.microsecond; // => 3
 dt.nanosecond;  // => 500
 
-dt = Temporal.ZonedDateTime.from('2019-02-23T03:24:30.000003500[Europe/Rome][u-ca-hebrew]');
+dt = Temporal.ZonedDateTime.from('2019-02-23T03:24:30.000003500[Europe/Rome][u-ca=hebrew]');
 dt.year;        // => 5779
 dt.month;       // => 6
 dt.monthCode;   // => "M05L"
@@ -466,7 +466,7 @@ As inputs to `from` or `with`, `era` and `eraYear` can be used instead of `year`
 Unlike `year`, `eraYear` may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.
 
 ```javascript
-date = Temporal.ZonedDateTime.from('-000015-01-01T12:30[Europe/Rome][u-ca-gregory]');
+date = Temporal.ZonedDateTime.from('-000015-01-01T12:30[Europe/Rome][u-ca=gregory]');
 date.era;
 // => "bce"
 date.eraYear;
@@ -825,9 +825,9 @@ zdt.withPlainDate('2018-09-15'); // => 2018-09-15T03:24:30-07:00[America/Los_Ang
 zdt.add({ hours: 12 }).withPlainDate('2000-06-01'); // => 2000-06-01T15:24:30-07:00[America/Los_Angeles]
 
 // result contains a non-ISO calendar if present in the input
-zdt.withCalendar('japanese').withPlainDate('2008-09-06'); // => 2008-09-06T03:24:30-07:00[America/Los_Angeles][u-ca-japanese]
-zdt.withPlainDate('2017-09-06[u-ca-japanese]'); // => 2017-09-06T03:24:30-07:00[America/Los_Angeles][u-ca-japanese]
-zdt.withCalendar('japanese').withPlainDate('2017-09-06[u-ca-hebrew]'); // => RangeError (calendar conflict)
+zdt.withCalendar('japanese').withPlainDate('2008-09-06'); // => 2008-09-06T03:24:30-07:00[America/Los_Angeles][u-ca=japanese]
+zdt.withPlainDate('2017-09-06[u-ca=japanese]'); // => 2017-09-06T03:24:30-07:00[America/Los_Angeles][u-ca=japanese]
+zdt.withCalendar('japanese').withPlainDate('2017-09-06[u-ca=hebrew]'); // => RangeError (calendar conflict)
 ```
 
 ### zonedDateTime.**withTimeZone**(_timeZone_: object | string) : Temporal.ZonedDateTime
@@ -857,7 +857,7 @@ zdt.withTimeZone('Africa/Accra').toString(); // => "1995-12-06T18:24:30+00:00[Af
 Usage example:
 
 ```javascript
-zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+09:00[Asia/Tokyo][u-ca-japanese]');
+zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+09:00[Asia/Tokyo][u-ca=japanese]');
 `${zdt.era} ${zdt.year}`; // => "heisei 7"
 zdt.withCalendar('iso8601').year; // => 1995
 ```
@@ -1246,7 +1246,7 @@ zdt1.equals(zdt1); // => true
 Examples:
 
 - `2011-12-03T10:15:30+01:00[Europe/Paris]`
-- `2011-12-03T10:15:30+09:00[Asia/Tokyo][u-ca-japanese]`
+- `2011-12-03T10:15:30+09:00[Asia/Tokyo][u-ca=japanese]`
 
 This method overrides the `Object.prototype.toString()` method and provides a convenient, unambiguous string representation of `zonedDateTime`.
 The string is "round-trippable".
@@ -1273,7 +1273,7 @@ Example usage:
 zdt = Temporal.ZonedDateTime.from({ year: 2019, month: 12, day: 1, hour: 12, timeZone: 'Africa/Lagos' });
 zdt.toString(); // => 2019-12-01T12:00+01:00[Africa/Lagos]
 zdt.withCalendar('japanese');
-zdt.toString(); // => 2019-12-01T12:00+01:00[Africa/Lagos][u-ca-japanese]
+zdt.toString(); // => 2019-12-01T12:00+01:00[Africa/Lagos][u-ca=japanese]
 ```
 
 ### zonedDateTime.**toLocaleString**(_locales_?: string | array&lt;string&gt;, _options_?: object) : string

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -166,7 +166,7 @@ export const ES = ObjectAssign({}, ES2020, {
   FormatCalendarAnnotation: (id, showCalendar) => {
     if (showCalendar === 'never') return '';
     if (showCalendar === 'auto' && id === 'iso8601') return '';
-    return `[u-ca-${id}]`;
+    return `[u-ca=${id}]`;
   },
   ParseISODateTime: (isoString, { zoneRequired }) => {
     const regex = zoneRequired ? PARSE.instant : PARSE.datetime;

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -1,30 +1,7 @@
-// Per specification,
-//   TZLeadingChar TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar?
-//     TZChar? TZChar? TZChar? TZChar? TZChar? TZChar?
-//   but not one of `.` or `..` or
-//     CalChar `-` CalChar CalChar `-` CalendarNameComponent
-// In plain words, 1 to 14 letters, periods, underscores, or dashes, but not
-// starting with a dash, and not consisting only of one or two periods, and not
-// of the form (letter)-(2 letters)-(3 or more letters) which conflicts with
-// calComponent
-const tzComponentNotBCP47 = new RegExp(
-  [
-    '\\.\\.[-A-Za-z._]{1,12}',
-    '\\.[-A-Za-z_][-A-Za-z._]{0,12}',
-    '_[-A-Za-z._]{0,13}',
-    '[a-zA-Z](?:[A-Za-z._][-A-Za-z._]{0,12})?',
-    '[a-zA-Z]-(?:[-._][-A-Za-z._]{0,11})?',
-    '[a-zA-Z]-[a-zA-Z](?:[-._][-A-Za-z._]{0,10})?',
-    '[a-zA-Z]-[a-zA-Z][a-zA-Z](?:[A-Za-z._][-A-Za-z._]{0,9})?',
-    '[a-zA-Z]-[a-zA-Z][a-zA-Z]-(?:[-._][-A-Za-z._]{0,8})?',
-    '[a-zA-Z]-[a-zA-Z][a-zA-Z]-[a-zA-Z](?:[-._][-A-Za-z._]{0,7})?',
-    '[a-zA-Z]-[a-zA-Z][a-zA-Z]-[a-zA-Z][a-zA-Z](?:[-._][-A-Za-z._]{0,6})?'
-  ].join('|')
-);
 const tzComponent = /\.[-A-Za-z_]|\.\.[-A-Za-z._]{1,12}|\.[-A-Za-z_][-A-Za-z._]{0,12}|[A-Za-z_][-A-Za-z._]{0,13}/;
 const offsetNoCapture = /(?:[+\u2212-][0-2][0-9](?::?[0-5][0-9](?::?[0-5][0-9](?:[.,]\d{1,9})?)?)?)/;
 export const timeZoneID = new RegExp(
-  `(?:(?:${tzComponentNotBCP47.source})(?:\\/(?:${tzComponent.source}))*|Etc/GMT[-+]\\d{1,2}|${offsetNoCapture.source})`
+  `(?:(?:${tzComponent.source})(?:\\/(?:${tzComponent.source}))*|Etc/GMT[-+]\\d{1,2}|${offsetNoCapture.source})`
 );
 
 const calComponent = /[A-Za-z0-9]{3,8}/;
@@ -35,7 +12,7 @@ export const datesplit = new RegExp(`(${yearpart.source})(?:-(\\d{2})-(\\d{2})|(
 const timesplit = /(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?|(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?/;
 export const offset = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5][0-9])(?:[.,](\d{1,9}))?)?)?/;
 const zonesplit = new RegExp(`(?:([zZ])|(?:${offset.source})?)(?:\\[(${timeZoneID.source})\\])?`);
-const calendar = new RegExp(`\\[u-ca-(${calendarID.source})\\]`);
+const calendar = new RegExp(`\\[u-ca=(${calendarID.source})\\]`);
 
 export const instant = new RegExp(
   `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?${zonesplit.source}(?:${calendar.source})?$`,

--- a/polyfill/test/PlainDate/prototype/toString/options-undefined.js
+++ b/polyfill/test/PlainDate/prototype/toString/options-undefined.js
@@ -11,7 +11,7 @@ const calendar = {
 const date = new Temporal.PlainDate(2000, 5, 2, calendar);
 
 const explicit = date.toString(undefined);
-assert.sameValue(explicit, "2000-05-02[u-ca-custom]", "default show-calendar option is auto");
+assert.sameValue(explicit, "2000-05-02[u-ca=custom]", "default show-calendar option is auto");
 
 const implicit = date.toString();
-assert.sameValue(implicit, "2000-05-02[u-ca-custom]", "default show-calendar option is auto");
+assert.sameValue(implicit, "2000-05-02[u-ca=custom]", "default show-calendar option is auto");

--- a/polyfill/test/PlainDateTime/prototype/toString/options-undefined.js
+++ b/polyfill/test/PlainDateTime/prototype/toString/options-undefined.js
@@ -13,13 +13,13 @@ const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 650, 0,
 const explicit = datetime.toString(undefined);
 assert.sameValue(
   explicit,
-  "2000-05-02T12:34:56.98765[u-ca-custom]",
+  "2000-05-02T12:34:56.98765[u-ca=custom]",
   "default show-calendar option is auto, precision is auto, and rounding is trunc"
 );
 
 const implicit = datetime.toString();
 assert.sameValue(
   implicit,
-  "2000-05-02T12:34:56.98765[u-ca-custom]",
+  "2000-05-02T12:34:56.98765[u-ca=custom]",
   "default show-calendar option is auto, precision is auto, and rounding is trunc"
 );

--- a/polyfill/test/PlainMonthDay/prototype/toString/options-undefined.js
+++ b/polyfill/test/PlainMonthDay/prototype/toString/options-undefined.js
@@ -11,7 +11,7 @@ const calendar = {
 const monthday = new Temporal.PlainMonthDay(5, 2, calendar);
 
 const explicit = monthday.toString(undefined);
-assert.sameValue(explicit, "1972-05-02[u-ca-custom]", "default show-calendar option is auto");
+assert.sameValue(explicit, "1972-05-02[u-ca=custom]", "default show-calendar option is auto");
 
 const implicit = monthday.toString();
-assert.sameValue(implicit, "1972-05-02[u-ca-custom]", "default show-calendar option is auto");
+assert.sameValue(implicit, "1972-05-02[u-ca=custom]", "default show-calendar option is auto");

--- a/polyfill/test/PlainYearMonth/prototype/toString/options-undefined.js
+++ b/polyfill/test/PlainYearMonth/prototype/toString/options-undefined.js
@@ -11,7 +11,7 @@ const calendar = {
 const yearmonth = new Temporal.PlainYearMonth(2000, 5, calendar);
 
 const explicit = yearmonth.toString(undefined);
-assert.sameValue(explicit, "2000-05-01[u-ca-custom]", "default show-calendar option is auto");
+assert.sameValue(explicit, "2000-05-01[u-ca=custom]", "default show-calendar option is auto");
 
 const implicit = yearmonth.toString();
-assert.sameValue(implicit, "2000-05-01[u-ca-custom]", "default show-calendar option is auto");
+assert.sameValue(implicit, "2000-05-01[u-ca=custom]", "default show-calendar option is auto");

--- a/polyfill/test/ZonedDateTime/prototype/toString/options-undefined.js
+++ b/polyfill/test/ZonedDateTime/prototype/toString/options-undefined.js
@@ -13,13 +13,13 @@ const datetime = new Temporal.ZonedDateTime(957270896_987_650_000n, "UTC", calen
 const explicit = datetime.toString(undefined);
 assert.sameValue(
   explicit,
-  "2000-05-02T12:34:56.98765+00:00[UTC][u-ca-custom]",
+  "2000-05-02T12:34:56.98765+00:00[UTC][u-ca=custom]",
   "default show options are auto, precision is auto, and rounding is trunc"
 );
 
 const implicit = datetime.toString();
 assert.sameValue(
   implicit,
-  "2000-05-02T12:34:56.98765+00:00[UTC][u-ca-custom]",
+  "2000-05-02T12:34:56.98765+00:00[UTC][u-ca=custom]",
   "default show options are auto, precision is auto, and rounding is trunc"
 );

--- a/polyfill/test/calendar.mjs
+++ b/polyfill/test/calendar.mjs
@@ -103,10 +103,10 @@ describe('Calendar', () => {
       }
       it('other types with a calendar are accepted', () => {
         [
-          Temporal.PlainDate.from('1976-11-18[u-ca-gregory]'),
-          Temporal.PlainDateTime.from('1976-11-18[u-ca-gregory]'),
-          Temporal.PlainMonthDay.from('1972-11-18[u-ca-gregory]'),
-          Temporal.PlainYearMonth.from('1976-11-01[u-ca-gregory]')
+          Temporal.PlainDate.from('1976-11-18[u-ca=gregory]'),
+          Temporal.PlainDateTime.from('1976-11-18[u-ca=gregory]'),
+          Temporal.PlainMonthDay.from('1972-11-18[u-ca=gregory]'),
+          Temporal.PlainYearMonth.from('1976-11-01[u-ca=gregory]')
         ].forEach((obj) => {
           const calFrom = Calendar.from(obj);
           assert(calFrom instanceof Calendar);
@@ -132,7 +132,7 @@ describe('Calendar', () => {
       it('throws with bad identifier', () => {
         throws(() => Calendar.from('local'), RangeError);
         throws(() => Calendar.from('iso-8601'), RangeError);
-        throws(() => Calendar.from('[u-ca-iso8601]'), RangeError);
+        throws(() => Calendar.from('[u-ca=iso8601]'), RangeError);
       });
       it('throws with bad value in property bag', () => {
         throws(() => Calendar.from({ calendar: 'local' }), RangeError);
@@ -141,8 +141,8 @@ describe('Calendar', () => {
     });
     describe('Calendar.from(ISO string)', () => {
       test('1994-11-05T08:15:30-05:00', 'iso8601');
-      test('1994-11-05T08:15:30-05:00[u-ca-gregory]', 'gregory');
-      test('1994-11-05T13:15:30Z[u-ca-japanese]', 'japanese');
+      test('1994-11-05T08:15:30-05:00[u-ca=gregory]', 'gregory');
+      test('1994-11-05T13:15:30Z[u-ca=japanese]', 'japanese');
       function test(isoString, id) {
         const calendar = Calendar.from(isoString);
         it(`Calendar.from(${isoString}) is a calendar`, () => assert(calendar instanceof Calendar));
@@ -384,28 +384,28 @@ describe('Calendar', () => {
 describe('Built-in calendars (not standardized yet)', () => {
   describe('gregory', () => {
     it('era CE', () => {
-      const date = Temporal.PlainDate.from('1999-12-31[u-ca-gregory]');
+      const date = Temporal.PlainDate.from('1999-12-31[u-ca=gregory]');
       equal(date.era, 'ce');
       equal(date.eraYear, 1999);
       equal(date.year, 1999);
     });
     it('era BCE', () => {
-      const date = Temporal.PlainDate.from('-000001-12-31[u-ca-gregory]');
+      const date = Temporal.PlainDate.from('-000001-12-31[u-ca=gregory]');
       equal(date.era, 'bce');
       equal(date.eraYear, 2);
       equal(date.year, -1);
     });
     it('can create from fields with era CE', () => {
       const date = Temporal.PlainDate.from({ era: 'ce', eraYear: 1999, month: 12, day: 31, calendar: 'gregory' });
-      equal(`${date}`, '1999-12-31[u-ca-gregory]');
+      equal(`${date}`, '1999-12-31[u-ca=gregory]');
     });
     it('era CE is the default', () => {
       const date = Temporal.PlainDate.from({ year: 1999, month: 12, day: 31, calendar: 'gregory' });
-      equal(`${date}`, '1999-12-31[u-ca-gregory]');
+      equal(`${date}`, '1999-12-31[u-ca=gregory]');
     });
     it('can create from fields with era BCE', () => {
       const date = Temporal.PlainDate.from({ era: 'bce', eraYear: 2, month: 12, day: 31, calendar: 'gregory' });
-      equal(`${date}`, '-000001-12-31[u-ca-gregory]');
+      equal(`${date}`, '-000001-12-31[u-ca=gregory]');
     });
   });
 });

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -464,7 +464,7 @@ describe('Instant', () => {
       equal(`${Instant.from('1976-11-18T15Z')}`, '1976-11-18T15:00:00Z');
     });
     it('ignores any specified calendar', () =>
-      equal(`${Instant.from('1976-11-18T15:23:30.123456789Z[u-ca-discord]')}`, '1976-11-18T15:23:30.123456789Z'));
+      equal(`${Instant.from('1976-11-18T15:23:30.123456789Z[u-ca=discord]')}`, '1976-11-18T15:23:30.123456789Z'));
     it('no junk at end of string', () => throws(() => Instant.from('1976-11-18T15:23:30.123456789Zjunk'), RangeError));
   });
   describe('Instant.add works', () => {
@@ -1392,13 +1392,13 @@ describe('Instant', () => {
       const timeZone = Temporal.TimeZone.from('UTC');
       const zdt = inst.toZonedDateTime({ timeZone, calendar: 'gregory' });
       equal(inst.epochNanoseconds, zdt.epochNanoseconds);
-      equal(`${zdt}`, '1976-11-18T14:23:30.123456789+00:00[UTC][u-ca-gregory]');
+      equal(`${zdt}`, '1976-11-18T14:23:30.123456789+00:00[UTC][u-ca=gregory]');
     });
     it('time zone parameter non-UTC', () => {
       const timeZone = Temporal.TimeZone.from('America/New_York');
       const zdt = inst.toZonedDateTime({ timeZone, calendar: 'gregory' });
       equal(inst.epochNanoseconds, zdt.epochNanoseconds);
-      equal(`${zdt}`, '1976-11-18T09:23:30.123456789-05:00[America/New_York][u-ca-gregory]');
+      equal(`${zdt}`, '1976-11-18T09:23:30.123456789-05:00[America/New_York][u-ca=gregory]');
     });
   });
 });

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -925,7 +925,7 @@ describe('Intl', () => {
       }
     });
     it('handles leap days', () => {
-      const leapYearFirstDay = Temporal.PlainDate.from('2004-03-21[u-ca-indian]');
+      const leapYearFirstDay = Temporal.PlainDate.from('2004-03-21[u-ca=indian]');
       equal(leapYearFirstDay.year, 2004 - 78);
       equal(leapYearFirstDay.month, 1);
       equal(leapYearFirstDay.day, 1);
@@ -936,7 +936,7 @@ describe('Intl', () => {
       equal(leapYearLastDay.day, 31);
     });
     it('handles non-leap years', () => {
-      const nonLeapYearFirstDay = Temporal.PlainDate.from('2005-03-22[u-ca-indian]');
+      const nonLeapYearFirstDay = Temporal.PlainDate.from('2005-03-22[u-ca=indian]');
       equal(nonLeapYearFirstDay.year, 2005 - 78);
       equal(nonLeapYearFirstDay.month, 1);
       equal(nonLeapYearFirstDay.day, 1);
@@ -953,43 +953,43 @@ describe('Intl', () => {
   describe('Japanese eras', () => {
     it('Reiwa (2019-)', () => {
       let date = Temporal.PlainDate.from({ era: 'reiwa', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '2020-01-01[u-ca-japanese]');
+      equal(`${date}`, '2020-01-01[u-ca=japanese]');
     });
     it('Heisei (1989-2019)', () => {
       let date = Temporal.PlainDate.from({ era: 'heisei', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '1990-01-01[u-ca-japanese]');
+      equal(`${date}`, '1990-01-01[u-ca=japanese]');
     });
     it('Showa (1926-1989)', () => {
       let date = Temporal.PlainDate.from({ era: 'showa', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '1927-01-01[u-ca-japanese]');
+      equal(`${date}`, '1927-01-01[u-ca=japanese]');
     });
     it('Taisho (1912-1926)', () => {
       let date = Temporal.PlainDate.from({ era: 'taisho', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '1913-01-01[u-ca-japanese]');
+      equal(`${date}`, '1913-01-01[u-ca=japanese]');
     });
     it('Meiji (1868-1912)', () => {
       let date = Temporal.PlainDate.from({ era: 'meiji', eraYear: 2, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '1869-01-01[u-ca-japanese]');
+      equal(`${date}`, '1869-01-01[u-ca=japanese]');
     });
     it('Dates in same year before Japanese era starts will resolve to previous era', () => {
       let date = Temporal.PlainDate.from({ era: 'reiwa', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '2019-01-01[u-ca-japanese]');
+      equal(`${date}`, '2019-01-01[u-ca=japanese]');
       equal(date.era, 'heisei');
       equal(date.eraYear, 31);
       date = Temporal.PlainDate.from({ era: 'heisei', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '1989-01-01[u-ca-japanese]');
+      equal(`${date}`, '1989-01-01[u-ca=japanese]');
       equal(date.era, 'showa');
       equal(date.eraYear, 64);
       date = Temporal.PlainDate.from({ era: 'showa', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '1926-01-01[u-ca-japanese]');
+      equal(`${date}`, '1926-01-01[u-ca=japanese]');
       equal(date.era, 'taisho');
       equal(date.eraYear, 15);
       date = Temporal.PlainDate.from({ era: 'taisho', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '1912-01-01[u-ca-japanese]');
+      equal(`${date}`, '1912-01-01[u-ca=japanese]');
       equal(date.era, 'meiji');
       equal(date.eraYear, 45);
       date = Temporal.PlainDate.from({ era: 'meiji', eraYear: 1, month: 1, day: 1, calendar: 'japanese' });
-      equal(`${date}`, '1868-01-01[u-ca-japanese]');
+      equal(`${date}`, '1868-01-01[u-ca=japanese]');
       equal(date.era, 'ce');
       equal(date.eraYear, 1868);
       throws(
@@ -997,7 +997,7 @@ describe('Intl', () => {
         RangeError
       );
       // uncomment & revise `throws` above if https://bugs.chromium.org/p/chromium/issues/detail?id=1173158 is resolved
-      // equal(`${date}`, '+000000-01-01[u-ca-japanese]');
+      // equal(`${date}`, '+000000-01-01[u-ca=japanese]');
       // equal(date.era, 'bce');
       // equal(date.eraYear, 1);
     });

--- a/polyfill/test/plaindate.mjs
+++ b/polyfill/test/plaindate.mjs
@@ -879,17 +879,17 @@ describe('Date', () => {
     const d = new PlainDate(1976, 11, 18);
     it('shows only non-ISO calendar if calendarName = auto', () => {
       equal(d.toString({ calendarName: 'auto' }), '1976-11-18');
-      equal(d.withCalendar('gregory').toString({ calendarName: 'auto' }), '1976-11-18[u-ca-gregory]');
+      equal(d.withCalendar('gregory').toString({ calendarName: 'auto' }), '1976-11-18[u-ca=gregory]');
     });
     it('shows ISO calendar if calendarName = always', () => {
-      equal(d.toString({ calendarName: 'always' }), '1976-11-18[u-ca-iso8601]');
+      equal(d.toString({ calendarName: 'always' }), '1976-11-18[u-ca=iso8601]');
     });
     it('omits non-ISO calendar if calendarName = never', () => {
       equal(d.withCalendar('gregory').toString({ calendarName: 'never' }), '1976-11-18');
     });
     it('default is calendar = auto', () => {
       equal(d.toString(), '1976-11-18');
-      equal(d.withCalendar('gregory').toString(), '1976-11-18[u-ca-gregory]');
+      equal(d.withCalendar('gregory').toString(), '1976-11-18[u-ca=gregory]');
     });
     it('throws on invalid calendar', () => {
       ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -370,13 +370,13 @@ describe('DateTime', () => {
       equal(`${dt.withPlainDate('2018-09-15')}`, '2018-09-15T03:24:30');
     });
     it('result contains a non-ISO calendar if present in the input', () => {
-      equal(`${dt.withCalendar('japanese').withPlainDate('2008-09-06')}`, '2008-09-06T03:24:30[u-ca-japanese]');
+      equal(`${dt.withCalendar('japanese').withPlainDate('2008-09-06')}`, '2008-09-06T03:24:30[u-ca=japanese]');
     });
     it('calendar is unchanged if input has ISO calendar', () => {
-      equal(`${dt.withPlainDate('2008-09-06[u-ca-japanese]')}`, '2008-09-06T03:24:30[u-ca-japanese]');
+      equal(`${dt.withPlainDate('2008-09-06[u-ca=japanese]')}`, '2008-09-06T03:24:30[u-ca=japanese]');
     });
     it('throws if both `this` and `other` have a non-ISO calendar', () => {
-      throws(() => dt.withCalendar('gregory').withPlainDate('2008-09-06[u-ca-japanese]'), RangeError);
+      throws(() => dt.withCalendar('gregory').withPlainDate('2008-09-06[u-ca=japanese]'), RangeError);
     });
     it('object must contain at least one correctly-spelled property', () => {
       throws(() => dt.withPlainDate({}), TypeError);
@@ -1674,17 +1674,17 @@ describe('DateTime', () => {
     });
     it('shows only non-ISO calendar if calendarName = auto', () => {
       equal(dt1.toString({ calendarName: 'auto' }), '1976-11-18T15:23:00');
-      equal(dt1.withCalendar('gregory').toString({ calendarName: 'auto' }), '1976-11-18T15:23:00[u-ca-gregory]');
+      equal(dt1.withCalendar('gregory').toString({ calendarName: 'auto' }), '1976-11-18T15:23:00[u-ca=gregory]');
     });
     it('shows ISO calendar if calendarName = always', () => {
-      equal(dt1.toString({ calendarName: 'always' }), '1976-11-18T15:23:00[u-ca-iso8601]');
+      equal(dt1.toString({ calendarName: 'always' }), '1976-11-18T15:23:00[u-ca=iso8601]');
     });
     it('omits non-ISO calendar if calendarName = never', () => {
       equal(dt1.withCalendar('gregory').toString({ calendarName: 'never' }), '1976-11-18T15:23:00');
     });
     it('default is calendar = auto', () => {
       equal(dt1.toString(), '1976-11-18T15:23:00');
-      equal(dt1.withCalendar('gregory').toString(), '1976-11-18T15:23:00[u-ca-gregory]');
+      equal(dt1.withCalendar('gregory').toString(), '1976-11-18T15:23:00[u-ca=gregory]');
     });
     it('throws on invalid calendar', () => {
       ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {

--- a/polyfill/test/plainmonthday.mjs
+++ b/polyfill/test/plainmonthday.mjs
@@ -85,13 +85,13 @@ describe('MonthDay', () => {
       it('MonthDay.from({year, month, day}) allowed in other calendar', () => {
         equal(
           `${PlainMonthDay.from({ year: 1970, month: 11, day: 18, calendar: 'gregory' })}`,
-          '1972-11-18[u-ca-gregory]'
+          '1972-11-18[u-ca=gregory]'
         );
       });
       it('MonthDay.from({era, eraYear, month, day}) allowed in other calendar', () => {
         equal(
           `${PlainMonthDay.from({ era: 'ce', eraYear: 1970, month: 11, day: 18, calendar: 'gregory' })}`,
-          '1972-11-18[u-ca-gregory]'
+          '1972-11-18[u-ca=gregory]'
         );
       });
       it('MonthDay.from({ day: 15 }) throws', () => throws(() => PlainMonthDay.from({ day: 15 }), TypeError));
@@ -310,10 +310,10 @@ describe('MonthDay', () => {
     const md2 = PlainMonthDay.from({ monthCode: 'M11', day: 18, calendar: 'gregory' });
     it('shows only non-ISO calendar if calendarName = auto', () => {
       equal(md1.toString({ calendarName: 'auto' }), '11-18');
-      equal(md2.toString({ calendarName: 'auto' }), '1972-11-18[u-ca-gregory]');
+      equal(md2.toString({ calendarName: 'auto' }), '1972-11-18[u-ca=gregory]');
     });
     it('shows ISO calendar if calendarName = always', () => {
-      equal(md1.toString({ calendarName: 'always' }), '11-18[u-ca-iso8601]');
+      equal(md1.toString({ calendarName: 'always' }), '11-18[u-ca=iso8601]');
     });
     it('omits non-ISO calendar, but not year, if calendarName = never', () => {
       equal(md1.toString({ calendarName: 'never' }), '11-18');
@@ -321,7 +321,7 @@ describe('MonthDay', () => {
     });
     it('default is calendar = auto', () => {
       equal(md1.toString(), '11-18');
-      equal(md2.toString(), '1972-11-18[u-ca-gregory]');
+      equal(md2.toString(), '1972-11-18[u-ca=gregory]');
     });
     it('throws on invalid calendar', () => {
       ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {

--- a/polyfill/test/plainyearmonth.mjs
+++ b/polyfill/test/plainyearmonth.mjs
@@ -778,10 +778,10 @@ describe('YearMonth', () => {
     const ym2 = PlainYearMonth.from({ year: 1976, month: 11, calendar: 'gregory' });
     it('shows only non-ISO calendar if calendarName = auto', () => {
       equal(ym1.toString({ calendarName: 'auto' }), '1976-11');
-      equal(ym2.toString({ calendarName: 'auto' }), '1976-11-01[u-ca-gregory]');
+      equal(ym2.toString({ calendarName: 'auto' }), '1976-11-01[u-ca=gregory]');
     });
     it('shows ISO calendar if calendarName = always', () => {
-      equal(ym1.toString({ calendarName: 'always' }), '1976-11[u-ca-iso8601]');
+      equal(ym1.toString({ calendarName: 'always' }), '1976-11[u-ca=iso8601]');
     });
     it('omits non-ISO calendar, but not day, if calendarName = never', () => {
       equal(ym1.toString({ calendarName: 'never' }), '1976-11');
@@ -789,7 +789,7 @@ describe('YearMonth', () => {
     });
     it('default is calendar = auto', () => {
       equal(ym1.toString(), '1976-11');
-      equal(ym2.toString(), '1976-11-01[u-ca-gregory]');
+      equal(ym2.toString(), '1976-11-01[u-ca=gregory]');
     });
     it('throws on invalid calendar', () => {
       ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -142,7 +142,7 @@ describe('fromString regex', () => {
     test('1976-11-18', [1976, 11, 18]);
     // Representations with calendar
     ['', 'Z', '+01:00[Europe/Vienna]', '+01:00[Custom/Vienna]', '[Europe/Vienna]'].forEach((zoneString) =>
-      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca-iso8601]`, [1976, 11, 18, 15, 23, 30, 123, 456, 789])
+      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [1976, 11, 18, 15, 23, 30, 123, 456, 789])
     );
   });
 
@@ -205,9 +205,9 @@ describe('fromString regex', () => {
     test('15121118', [1512, 11, 18]);
     // Representations with calendar
     ['', 'Z', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
-      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca-iso8601]`, [1976, 11, 18])
+      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [1976, 11, 18])
     );
-    test('1976-11-18[u-ca-iso8601]', [1976, 11, 18]);
+    test('1976-11-18[u-ca=iso8601]', [1976, 11, 18]);
   });
 
   describe('time', () => {
@@ -269,9 +269,9 @@ describe('fromString regex', () => {
     );
     // Representations with calendar
     ['', 'Z', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
-      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca-iso8601]`, [15, 23, 30, 123, 456, 789])
+      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [15, 23, 30, 123, 456, 789])
     );
-    test('15:23:30.123456789[u-ca-iso8601]', [15, 23, 30, 123, 456, 789]);
+    test('15:23:30.123456789[u-ca=iso8601]', [15, 23, 30, 123, 456, 789]);
   });
 
   describe('yearmonth', () => {
@@ -342,9 +342,9 @@ describe('fromString regex', () => {
     test('151211', [1512, 11]);
     // Representations with calendar
     ['', 'Z', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
-      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca-iso8601]`, [1976, 11])
+      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [1976, 11])
     );
-    test('1976-11-01[u-ca-iso8601]', [1976, 11]);
+    test('1976-11-01[u-ca=iso8601]', [1976, 11]);
   });
 
   describe('monthday', () => {
@@ -418,9 +418,9 @@ describe('fromString regex', () => {
     test('--1118', [11, 18]);
     // Representations with calendar
     ['', 'Z', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
-      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca-iso8601]`, [11, 18])
+      test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [11, 18])
     );
-    test('1972-11-18[u-ca-iso8601]', [11, 18]);
+    test('1972-11-18[u-ca=iso8601]', [11, 18]);
   });
 
   describe('timezone', () => {
@@ -502,10 +502,10 @@ describe('fromString regex', () => {
     test('-03:00:00.000000000', '-03:00');
     test('-030000.0', '-03:00');
     // Representations with calendar
-    test('1976-11-18T15:23:30.123456789Z[u-ca-iso8601]', 'UTC');
-    test('1976-11-18T15:23:30.123456789-04:00[u-ca-iso8601]', '-04:00');
-    test('1976-11-18T15:23:30.123456789[Europe/Vienna][u-ca-iso8601]', 'Europe/Vienna');
-    test('1976-11-18T15:23:30.123456789+01:00[Europe/Vienna][u-ca-iso8601]', 'Europe/Vienna');
+    test('1976-11-18T15:23:30.123456789Z[u-ca=iso8601]', 'UTC');
+    test('1976-11-18T15:23:30.123456789-04:00[u-ca=iso8601]', '-04:00');
+    test('1976-11-18T15:23:30.123456789[Europe/Vienna][u-ca=iso8601]', 'Europe/Vienna');
+    test('1976-11-18T15:23:30.123456789+01:00[Europe/Vienna][u-ca=iso8601]', 'Europe/Vienna');
   });
 
   describe('duration', () => {
@@ -672,7 +672,7 @@ describe('fromString regex', () => {
       };
     });
     function testCalendarID(id) {
-      return Temporal.PlainDateTime.from(`1970-01-01T00:00+00:00[UTC][u-ca-${id}]`);
+      return Temporal.PlainDateTime.from(`1970-01-01T00:00+00:00[UTC][u-ca=${id}]`);
     }
     describe('valid', () => {
       ['aaa', 'aaa-aaa', 'eightZZZ', 'eightZZZ-eightZZZ'].forEach((id) => {

--- a/polyfill/test/usercalendar.mjs
+++ b/polyfill/test/usercalendar.mjs
@@ -71,9 +71,9 @@ describe('Userland calendar', () => {
     // FIXME: what should happen in Temporal.Calendar.from(obj)?
     it('.id is not available in from()', () => {
       throws(() => Temporal.Calendar.from('two-based'), RangeError);
-      throws(() => Temporal.Calendar.from('2020-06-05T09:34-07:00[America/Vancouver][u-ca-two-based]'), RangeError);
+      throws(() => Temporal.Calendar.from('2020-06-05T09:34-07:00[America/Vancouver][u-ca=two-based]'), RangeError);
     });
-    it('Temporal.PlainDate.from()', () => equal(`${date}`, '2020-04-05[u-ca-two-based]'));
+    it('Temporal.PlainDate.from()', () => equal(`${date}`, '2020-04-05[u-ca=two-based]'));
     it('Temporal.PlainDate fields', () => {
       equal(date.year, 2020);
       equal(date.month, 5);
@@ -87,7 +87,7 @@ describe('Userland calendar', () => {
       const date2 = Temporal.PlainDate.from('2020-04-05');
       assert(date2.withCalendar(obj).equals(date));
     });
-    it('Temporal.PlainDateTime.from()', () => equal(`${dt}`, '2020-04-05T12:00:00[u-ca-two-based]'));
+    it('Temporal.PlainDateTime.from()', () => equal(`${dt}`, '2020-04-05T12:00:00[u-ca=two-based]'));
     it('Temporal.PlainDateTime fields', () => {
       equal(dt.year, 2020);
       equal(dt.month, 5);
@@ -107,7 +107,7 @@ describe('Userland calendar', () => {
       const dt2 = Temporal.PlainDateTime.from('2020-04-05T12:00');
       assert(dt2.withCalendar(obj).equals(dt));
     });
-    it('Temporal.PlainYearMonth.from()', () => equal(`${ym}`, '2020-04-01[u-ca-two-based]'));
+    it('Temporal.PlainYearMonth.from()', () => equal(`${ym}`, '2020-04-01[u-ca=two-based]'));
     it('Temporal.PlainYearMonth fields', () => {
       equal(dt.year, 2020);
       equal(dt.month, 5);
@@ -116,7 +116,7 @@ describe('Userland calendar', () => {
       const ym2 = ym.with({ month: 2 });
       equal(ym2.month, 2);
     });
-    it('Temporal.PlainMonthDay.from()', () => equal(`${md}`, '1972-04-05[u-ca-two-based]'));
+    it('Temporal.PlainMonthDay.from()', () => equal(`${md}`, '1972-04-05[u-ca=two-based]'));
     it('Temporal.PlainMonthDay fields', () => {
       equal(md.monthCode, 'M05');
       equal(md.day, 5);
@@ -217,9 +217,9 @@ describe('Userland calendar', () => {
     // FIXME: what should happen in Temporal.Calendar.from(obj)?
     it('.id is not available in from()', () => {
       throws(() => Temporal.Calendar.from('decimal'), RangeError);
-      throws(() => Temporal.Calendar.from('2020-06-05T09:34-07:00[America/Vancouver][u-ca-decimal]'), RangeError);
+      throws(() => Temporal.Calendar.from('2020-06-05T09:34-07:00[America/Vancouver][u-ca=decimal]'), RangeError);
     });
-    it('Temporal.PlainDate.from()', () => equal(`${date}`, '2020-06-05[u-ca-decimal]'));
+    it('Temporal.PlainDate.from()', () => equal(`${date}`, '2020-06-05[u-ca=decimal]'));
     it('Temporal.PlainDate fields', () => {
       equal(date.year, 184);
       equal(date.month, 2);
@@ -233,7 +233,7 @@ describe('Userland calendar', () => {
       const date2 = Temporal.PlainDate.from('2020-06-05T12:00');
       assert(date2.withCalendar(obj).equals(date));
     });
-    it('Temporal.PlainDateTime.from()', () => equal(`${dt}`, '2020-06-05T12:00:00[u-ca-decimal]'));
+    it('Temporal.PlainDateTime.from()', () => equal(`${dt}`, '2020-06-05T12:00:00[u-ca=decimal]'));
     it('Temporal.PlainDateTime fields', () => {
       equal(dt.year, 184);
       equal(dt.month, 2);
@@ -253,7 +253,7 @@ describe('Userland calendar', () => {
       const dt2 = Temporal.PlainDateTime.from('2020-06-05T12:00');
       assert(dt2.withCalendar(obj).equals(dt));
     });
-    it('Temporal.PlainYearMonth.from()', () => equal(`${ym}`, '2020-05-28[u-ca-decimal]'));
+    it('Temporal.PlainYearMonth.from()', () => equal(`${ym}`, '2020-05-28[u-ca=decimal]'));
     it('Temporal.PlainYearMonth fields', () => {
       equal(dt.year, 184);
       equal(dt.month, 2);
@@ -262,7 +262,7 @@ describe('Userland calendar', () => {
       const ym2 = ym.with({ year: 0 });
       equal(ym2.year, 0);
     });
-    it('Temporal.PlainMonthDay.from()', () => equal(`${md}`, '1970-01-19[u-ca-decimal]'));
+    it('Temporal.PlainMonthDay.from()', () => equal(`${md}`, '1970-01-19[u-ca=decimal]'));
     it('Temporal.PlainMonthDay fields', () => {
       equal(md.monthCode, 'M02');
       equal(md.day, 9);
@@ -371,38 +371,38 @@ describe('Userland calendar', () => {
     it('accepts season in from()', () => {
       equal(
         `${Temporal.PlainDateTime.from({ year: 2019, season: 3, month: 3, day: 15, calendar })}`,
-        '2019-09-15T00:00:00[u-ca-season]'
+        '2019-09-15T00:00:00[u-ca=season]'
       );
       equal(
         `${Temporal.PlainDate.from({ year: 2019, season: 3, month: 3, day: 15, calendar })}`,
-        '2019-09-15[u-ca-season]'
+        '2019-09-15[u-ca=season]'
       );
       equal(
         `${Temporal.PlainYearMonth.from({ year: 2019, season: 3, month: 3, calendar })}`,
-        '2019-09-01[u-ca-season]'
+        '2019-09-01[u-ca=season]'
       );
       equal(
         `${Temporal.PlainMonthDay.from({ season: 3, monthCode: 'M03', day: 15, calendar })}`,
-        '1972-09-15[u-ca-season]'
+        '1972-09-15[u-ca=season]'
       );
       equal(
         `${Temporal.ZonedDateTime.from({ year: 2019, season: 3, month: 3, day: 15, timeZone: 'UTC', calendar })}`,
-        '2019-09-15T00:00:00+00:00[UTC][u-ca-season]'
+        '2019-09-15T00:00:00+00:00[UTC][u-ca=season]'
       );
     });
     it('accepts season in with()', () => {
-      equal(`${datetime.with({ season: 2 })}`, '2019-06-15T00:00:00[u-ca-season]');
-      equal(`${date.with({ season: 2 })}`, '2019-06-15[u-ca-season]');
-      equal(`${yearmonth.with({ season: 2 })}`, '2019-06-01[u-ca-season]');
-      equal(`${monthday.with({ season: 2 })}`, '1972-06-15[u-ca-season]');
-      equal(`${zoned.with({ season: 2 })}`, '2019-06-15T00:00:00+00:00[UTC][u-ca-season]');
+      equal(`${datetime.with({ season: 2 })}`, '2019-06-15T00:00:00[u-ca=season]');
+      equal(`${date.with({ season: 2 })}`, '2019-06-15[u-ca=season]');
+      equal(`${yearmonth.with({ season: 2 })}`, '2019-06-01[u-ca=season]');
+      equal(`${monthday.with({ season: 2 })}`, '1972-06-15[u-ca=season]');
+      equal(`${zoned.with({ season: 2 })}`, '2019-06-15T00:00:00+00:00[UTC][u-ca=season]');
     });
     it('translates month correctly in with()', () => {
-      equal(`${datetime.with({ month: 2 })}`, '2019-08-15T00:00:00[u-ca-season]');
-      equal(`${date.with({ month: 2 })}`, '2019-08-15[u-ca-season]');
-      equal(`${yearmonth.with({ month: 2 })}`, '2019-08-01[u-ca-season]');
-      equal(`${monthday.with({ monthCode: 'M02' })}`, '1972-08-15[u-ca-season]');
-      equal(`${zoned.with({ month: 2 })}`, '2019-08-15T00:00:00+00:00[UTC][u-ca-season]');
+      equal(`${datetime.with({ month: 2 })}`, '2019-08-15T00:00:00[u-ca=season]');
+      equal(`${date.with({ month: 2 })}`, '2019-08-15[u-ca=season]');
+      equal(`${yearmonth.with({ month: 2 })}`, '2019-08-01[u-ca=season]');
+      equal(`${monthday.with({ monthCode: 'M02' })}`, '1972-08-15[u-ca=season]');
+      equal(`${zoned.with({ month: 2 })}`, '2019-08-15T00:00:00+00:00[UTC][u-ca=season]');
     });
     after(() => {
       delete Temporal.PlainDateTime.prototype.season;
@@ -512,22 +512,22 @@ describe('Userland calendar', () => {
       equal(zoned.centuryYear, 19);
     });
     it('correctly resolves century in with()', () => {
-      equal(`${datetime.with({ century: 20 })}`, '1919-09-15T00:00:00[u-ca-century]');
-      equal(`${date.with({ century: 20 })}`, '1919-09-15[u-ca-century]');
-      equal(`${yearmonth.with({ century: 20 })}`, '1919-09-01[u-ca-century]');
-      equal(`${zoned.with({ century: 20 })}`, '1919-09-15T00:00:00+00:00[UTC][u-ca-century]');
+      equal(`${datetime.with({ century: 20 })}`, '1919-09-15T00:00:00[u-ca=century]');
+      equal(`${date.with({ century: 20 })}`, '1919-09-15[u-ca=century]');
+      equal(`${yearmonth.with({ century: 20 })}`, '1919-09-01[u-ca=century]');
+      equal(`${zoned.with({ century: 20 })}`, '1919-09-15T00:00:00+00:00[UTC][u-ca=century]');
     });
     it('correctly resolves centuryYear in with()', () => {
-      equal(`${datetime.with({ centuryYear: 5 })}`, '2005-09-15T00:00:00[u-ca-century]');
-      equal(`${date.with({ centuryYear: 5 })}`, '2005-09-15[u-ca-century]');
-      equal(`${yearmonth.with({ centuryYear: 5 })}`, '2005-09-01[u-ca-century]');
-      equal(`${zoned.with({ centuryYear: 5 })}`, '2005-09-15T00:00:00+00:00[UTC][u-ca-century]');
+      equal(`${datetime.with({ centuryYear: 5 })}`, '2005-09-15T00:00:00[u-ca=century]');
+      equal(`${date.with({ centuryYear: 5 })}`, '2005-09-15[u-ca=century]');
+      equal(`${yearmonth.with({ centuryYear: 5 })}`, '2005-09-01[u-ca=century]');
+      equal(`${zoned.with({ centuryYear: 5 })}`, '2005-09-15T00:00:00+00:00[UTC][u-ca=century]');
     });
     it('correctly resolves year in with()', () => {
-      equal(`${datetime.with({ year: 1974 })}`, '1974-09-15T00:00:00[u-ca-century]');
-      equal(`${date.with({ year: 1974 })}`, '1974-09-15[u-ca-century]');
-      equal(`${yearmonth.with({ year: 1974 })}`, '1974-09-01[u-ca-century]');
-      equal(`${zoned.with({ year: 1974 })}`, '1974-09-15T00:00:00+00:00[UTC][u-ca-century]');
+      equal(`${datetime.with({ year: 1974 })}`, '1974-09-15T00:00:00[u-ca=century]');
+      equal(`${date.with({ year: 1974 })}`, '1974-09-15[u-ca=century]');
+      equal(`${yearmonth.with({ year: 1974 })}`, '1974-09-01[u-ca=century]');
+      equal(`${zoned.with({ year: 1974 })}`, '1974-09-15T00:00:00+00:00[UTC][u-ca=century]');
     });
     after(() => {
       delete Temporal.PlainDateTime.prototype.century;

--- a/polyfill/test/usertimezone.mjs
+++ b/polyfill/test/usertimezone.mjs
@@ -55,7 +55,7 @@ describe('Userland time zone', () => {
     it('has offset string +00:00', () => equal(obj.getOffsetStringFor(inst), '+00:00'));
     it('converts to DateTime', () => {
       equal(`${obj.getPlainDateTimeFor(inst)}`, '1970-01-01T00:00:00');
-      equal(`${obj.getPlainDateTimeFor(inst, 'gregory')}`, '1970-01-01T00:00:00[u-ca-gregory]');
+      equal(`${obj.getPlainDateTimeFor(inst, 'gregory')}`, '1970-01-01T00:00:00[u-ca=gregory]');
     });
     it('converts to Instant', () => {
       equal(`${obj.getInstantFor(dt)}`, '1976-11-18T15:23:30.123456789Z');
@@ -102,7 +102,7 @@ describe('Userland time zone', () => {
       equal(`${Temporal.TimeZone.prototype.getPlainDateTimeFor.call(obj, inst)}`, '1970-01-01T00:00:00');
       equal(
         `${Temporal.TimeZone.prototype.getPlainDateTimeFor.call(obj, inst, 'gregory')}`,
-        '1970-01-01T00:00:00[u-ca-gregory]'
+        '1970-01-01T00:00:00[u-ca=gregory]'
       );
     });
     it('converts to Instant', () => {
@@ -161,7 +161,7 @@ describe('Userland time zone', () => {
     it('has offset string -00:00:01.111111111', () => equal(obj.getOffsetStringFor(inst), '-00:00:01.111111111'));
     it('converts to DateTime', () => {
       equal(`${obj.getPlainDateTimeFor(inst)}`, '1969-12-31T23:59:58.888888889');
-      equal(`${obj.getPlainDateTimeFor(inst, 'gregory')}`, '1969-12-31T23:59:58.888888889[u-ca-gregory]');
+      equal(`${obj.getPlainDateTimeFor(inst, 'gregory')}`, '1969-12-31T23:59:58.888888889[u-ca=gregory]');
     });
     it('converts to Instant', () => {
       equal(`${obj.getInstantFor(dt)}`, '1976-11-18T15:23:31.2345679Z');

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -286,7 +286,7 @@ const temporalTimeZoneIdentifier = withCode(choice(timeZoneNumericUTCOffset, tim
   if (!('offset' in data)) data.offset = undefined;
 });
 const calendarName = withCode(choice(...calendarNames), (data, result) => (data.calendar = result));
-const calendar = seq('[u-ca-', calendarName, ']');
+const calendar = seq('[u-ca=', calendarName, ']');
 const timeSpec = seq(
   timeHour,
   choice([':', timeMinute, [':', timeSecond, [timeFraction]]], seq(timeMinute, [timeSecond, [timeFraction]]))

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -262,8 +262,8 @@ describe('ZonedDateTime', () => {
       it('zdt.inLeapYear is true', () => equal(zdt.inLeapYear, true));
       it('zdt.offset is +01:00', () => equal(zdt.offset, '+01:00'));
       it('zdt.offsetNanoseconds is 3600e9', () => equal(zdt.offsetNanoseconds, 3600e9));
-      it('string output is 1976-11-18T16:23:30.123456789+01:00[Europe/Vienna][u-ca-gregory]', () =>
-        equal(`${zdt}`, '1976-11-18T16:23:30.123456789+01:00[Europe/Vienna][u-ca-gregory]'));
+      it('string output is 1976-11-18T16:23:30.123456789+01:00[Europe/Vienna][u-ca=gregory]', () =>
+        equal(`${zdt}`, '1976-11-18T16:23:30.123456789+01:00[Europe/Vienna][u-ca=gregory]'));
     });
 
     it('casts time zone', () => {
@@ -1000,18 +1000,18 @@ describe('ZonedDateTime', () => {
     it('result contains a non-ISO calendar if present in the input', () => {
       equal(
         `${zdt.withCalendar('japanese').withPlainDate('2008-09-06')}`,
-        '2008-09-06T03:24:30-07:00[America/Los_Angeles][u-ca-japanese]'
+        '2008-09-06T03:24:30-07:00[America/Los_Angeles][u-ca=japanese]'
       );
     });
     it('calendar is unchanged if input has ISO calendar', () => {
       equal(
-        `${zdt.withPlainDate('2008-09-06[u-ca-japanese]')}`,
-        '2008-09-06T03:24:30-07:00[America/Los_Angeles][u-ca-japanese]'
+        `${zdt.withPlainDate('2008-09-06[u-ca=japanese]')}`,
+        '2008-09-06T03:24:30-07:00[America/Los_Angeles][u-ca=japanese]'
       );
     });
     it('throws if both `this` and `other` have a non-ISO calendar', () => {
       throws(
-        () => zdt.withCalendar('gregory').withPlainDate('2008-09-06-07:00[America/Los_Angeles][u-ca-japanese]'),
+        () => zdt.withCalendar('gregory').withPlainDate('2008-09-06-07:00[America/Los_Angeles][u-ca=japanese]'),
         RangeError
       );
     });
@@ -1037,7 +1037,7 @@ describe('ZonedDateTime', () => {
       equal(`${zdt.withTimeZone('America/Los_Angeles')}`, '2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles]');
     });
     it('keeps instant and calendar the same', () => {
-      const zdt = ZonedDateTime.from('2019-11-18T15:23:30.123456789+01:00[Europe/Madrid][u-ca-gregory]');
+      const zdt = ZonedDateTime.from('2019-11-18T15:23:30.123456789+01:00[Europe/Madrid][u-ca=gregory]');
       const zdt2 = zdt.withTimeZone('America/Vancouver');
       equal(zdt.epochNanoseconds, zdt2.epochNanoseconds);
       equal(zdt2.calendar.id, 'gregory');
@@ -1049,16 +1049,16 @@ describe('ZonedDateTime', () => {
     const zdt = ZonedDateTime.from('2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles]');
     it('zonedDateTime.withCalendar(japanese) works', () => {
       const cal = Temporal.Calendar.from('japanese');
-      equal(`${zdt.withCalendar(cal)}`, '2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles][u-ca-japanese]');
+      equal(`${zdt.withCalendar(cal)}`, '2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles][u-ca=japanese]');
     });
     it('casts its argument', () => {
       equal(
         `${zdt.withCalendar('japanese')}`,
-        '2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles][u-ca-japanese]'
+        '2019-11-18T15:23:30.123456789-08:00[America/Los_Angeles][u-ca=japanese]'
       );
     });
     it('keeps instant and time zone the same', () => {
-      const zdt = ZonedDateTime.from('2019-11-18T15:23:30.123456789+01:00[Europe/Madrid][u-ca-gregory]');
+      const zdt = ZonedDateTime.from('2019-11-18T15:23:30.123456789+01:00[Europe/Madrid][u-ca=gregory]');
       const zdt2 = zdt.withCalendar('japanese');
       equal(zdt.epochNanoseconds, zdt2.epochNanoseconds);
       equal(zdt2.calendar.id, 'japanese');
@@ -2076,7 +2076,7 @@ describe('ZonedDateTime', () => {
     const cal = Temporal.Calendar.from('gregory');
     const zdt = new ZonedDateTime(0n, tz, cal);
     it('constructed from equivalent parameters are equal', () => {
-      const zdt2 = ZonedDateTime.from('1969-12-31T19:00-05:00[America/New_York][u-ca-gregory]');
+      const zdt2 = ZonedDateTime.from('1969-12-31T19:00-05:00[America/New_York][u-ca=gregory]');
       assert(zdt.equals(zdt2));
       assert(zdt2.equals(zdt));
     });
@@ -2093,7 +2093,7 @@ describe('ZonedDateTime', () => {
       assert(!zdt.equals(zdt2));
     });
     it('casts its argument', () => {
-      assert(zdt.equals('1969-12-31T19:00-05:00[America/New_York][u-ca-gregory]'));
+      assert(zdt.equals('1969-12-31T19:00-05:00[America/New_York][u-ca=gregory]'));
       assert(
         zdt.equals({
           year: 1969,
@@ -2130,11 +2130,11 @@ describe('ZonedDateTime', () => {
       equal(zdt1.toString({ calendarName: 'auto' }), '1976-11-18T15:23:00+01:00[Europe/Vienna]');
       equal(
         zdt1.withCalendar('gregory').toString({ calendarName: 'auto' }),
-        '1976-11-18T15:23:00+01:00[Europe/Vienna][u-ca-gregory]'
+        '1976-11-18T15:23:00+01:00[Europe/Vienna][u-ca=gregory]'
       );
     });
     it('shows ISO calendar if calendarName = always', () => {
-      equal(zdt1.toString({ calendarName: 'always' }), '1976-11-18T15:23:00+01:00[Europe/Vienna][u-ca-iso8601]');
+      equal(zdt1.toString({ calendarName: 'always' }), '1976-11-18T15:23:00+01:00[Europe/Vienna][u-ca=iso8601]');
     });
     it('omits non-ISO calendar if calendarName = never', () => {
       equal(
@@ -2144,7 +2144,7 @@ describe('ZonedDateTime', () => {
     });
     it('default is calendar = auto', () => {
       equal(zdt1.toString(), '1976-11-18T15:23:00+01:00[Europe/Vienna]');
-      equal(zdt1.withCalendar('gregory').toString(), '1976-11-18T15:23:00+01:00[Europe/Vienna][u-ca-gregory]');
+      equal(zdt1.withCalendar('gregory').toString(), '1976-11-18T15:23:00+01:00[Europe/Vienna][u-ca=gregory]');
     });
     it('throws on invalid calendar', () => {
       ['ALWAYS', 'sometimes', false, 3, null].forEach((calendarName) => {
@@ -2167,7 +2167,7 @@ describe('ZonedDateTime', () => {
       const zdt = zdt1.withCalendar('gregory');
       equal(zdt.toString({ timeZoneName: 'never', calendarName: 'never' }), '1976-11-18T15:23:00+01:00');
       equal(zdt.toString({ offset: 'never', calendarName: 'never' }), '1976-11-18T15:23:00[Europe/Vienna]');
-      equal(zdt.toString({ offset: 'never', timeZoneName: 'never' }), '1976-11-18T15:23:00[u-ca-gregory]');
+      equal(zdt.toString({ offset: 'never', timeZoneName: 'never' }), '1976-11-18T15:23:00[u-ca=gregory]');
       equal(zdt.toString({ offset: 'never', timeZoneName: 'never', calendarName: 'never' }), '1976-11-18T15:23:00');
     });
     it('truncates to minute', () => {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -983,14 +983,11 @@
           `-`
           `_`
 
-      TimeZoneIANANameComponentNotBCP47 :
-          TZLeadingChar TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? but not one of `.` or `..` or CalChar `-` CalChar CalChar `-` CalendarNameComponent
-
       TimeZoneIANANameComponent :
           TZLeadingChar TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? TZChar? but not one of `.` or `..`
 
       TimeZoneIANAName :
-          TimeZoneIANANameComponentNotBCP47
+          TimeZoneIANANameComponent
           TimeZoneIANAName `/` TimeZoneIANANameComponent
 
       TimeZoneBracketedName :
@@ -1021,7 +1018,7 @@
           CalendarNameComponent `-` CalendarName
 
       Calendar :
-          `[u-ca-` CalendarName `]`
+          `[u-ca=` CalendarName `]`
 
       TimeSpec :
           TimeHour

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -322,13 +322,13 @@
         Depending on the given _id_ and value of _showCalendar_, the string may be empty if no calendar annotation need be included.
       </p>
       <emu-note type="editor">
-        The exact form this annotation will take is unknown, and the *"u-ca-"* format is tentative; it is being discussed in <a href="https://ryzokuken.dev/draft-ryzokuken-datetime-extended/documents/rfc-3339.html#name-internet-date-time-format">Date and Time on the Internet: Timestamps with additional information</a>, a draft update to <a href="https://tools.ietf.org/html/rfc3339#appendix-A">RFC 3339</a>.
+        The exact form this annotation will take is undergoing a standardization process in the IETF; it is being discussed in the Internet Draft <a href="https://ryzokuken.dev/draft-ryzokuken-datetime-extended/documents/rfc-3339.html#name-internet-date-time-format">Date and Time on the Internet: Timestamps with additional information</a>.
       </emu-note>
       <emu-alg>
         1. Assert: _showCalendar_ is *"auto"*, *"always"*, or *"never"*.
         1. If _showCalendar_ is *"never"*, return the empty String.
         1. If _showCalendar_ is *"auto"* and _id_ is *"iso8601"*, return the empty String.
-        1. Return the string-concatenation of *"[u-ca-"*, _id_, and *"]"*.
+        1. Return the string-concatenation of *"[u-ca="*, _id_, and *"]"*.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
IETF is moving forward with [n-kk=vvvvv] (n=namespace, k=key, v=value)
rather than [n-kk-vvvvv]. By definition, Temporal uses the format that is
being standardized within IETF.

Update the note in the spec text as well to remove the text saying that
the format is tentative. This is the format that IETF is moving forward
with.

Closes: #1409
Closes: #1412