### PR TITLE
Fix docs header on iPhone devices

### DIFF
--- a/docs/head.html.part
+++ b/docs/head.html.part
@@ -138,5 +138,5 @@
   <body>
     <div class="banner">
       This Stage 3 proposal is <strong><a href="https://blogs.igalia.com/compilers/2020/06/23/dates-and-times-in-javascript/">experimental.</a></strong>
-      <strong>Do</strong> try it out and <a href="https://github.com/tc39/proposal-temporal/issues">report bugs</a>; <strong>don't</strong> use it in production!
+      <strong>Do</strong> try it and <a href="https://github.com/tc39/proposal-temporal/issues">report bugs</a>; <strong>don't</strong> use it in production!
     </div>


### PR DESCRIPTION
On my iPhone X, the docs header text wraps to three lines and obscures the H1 title. This commit removes an unnecessary word to limit the header to 2 lines.