### PR TITLE
Minor fixups to two docs pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,6 @@ Temporal provides a number of separate types, in order to
 - Avoid buggy pattern of filling in 0 or UTC for missing info
 - Do appropriate calculations based on type
 
-
 ## Cookbook
 
 A cookbook to help you get started and learn the ins and outs of Temporal is available [here](./cookbook.md).
@@ -52,10 +51,7 @@ Read more about [handling time zones, DST, and ambiguity in `Temporal`](./ambigu
 - `Temporal.now.plainDateTimeISO()` - same as above, but return the DateTime in the ISO-8601 calendar
 
 ```js
-console.log(
-  "Initialization complete",
-  Temporal.now.instant()
-);
+console.log('Initialization complete', Temporal.now.instant());
 // example output:
 // Initialization complete 2021-01-13T20:57:01.500944804Z
 ```
@@ -68,9 +64,9 @@ A `Temporal.Instant` represents a fixed point in time (called **"exact time"**),
 For a human-readable local calendar date or clock time, use a `Temporal.TimeZone` and `Temporal.Calendar` to obtain a `Temporal.ZonedDateTime` or `Temporal.PlainDateTime`.
 
 ```js
-const instant = Temporal.Instant.from("1969-07-20T20:17Z");
-instant.toString() // => "1969-07-20T20:17:00Z"
-instant.epochMilliseconds // => -14182980000
+const instant = Temporal.Instant.from('1969-07-20T20:17Z');
+instant.toString(); // => "1969-07-20T20:17:00Z"
+instant.epochMilliseconds; // => -14182980000
 ```
 
 See [Temporal.Instant Documentation](./instant.md) for detailed documentation.
@@ -82,16 +78,16 @@ This type is optimized for use cases that require a time zone, including DST-saf
 
 ```js
 const zonedDateTime = Temporal.ZonedDateTime.from({
-    timeZone: 'America/Los_Angeles',
-    year: 1995,
-    month: 12,
-    day: 7,
-    hour: 3,
-    minute: 24,
-    second: 30,
-    millisecond: 0,
-    microsecond: 3,
-    nanosecond: 500
+  timeZone: 'America/Los_Angeles',
+  year: 1995,
+  month: 12,
+  day: 7,
+  hour: 3,
+  minute: 24,
+  second: 30,
+  millisecond: 0,
+  microsecond: 3,
+  nanosecond: 500
 }); // => 1995-12-07T03:24:30.000003500+08:00[America/Los_Angeles]
 ```
 
@@ -104,10 +100,10 @@ See [Temporal.ZonedDateTime Documentation](./zoneddatetime.md) for detailed docu
 A `Temporal.PlainDate` object represents a calendar date that is not associated with a particular time or time zone, e.g. August 24th, 2006.
 
 ```js
-const date = Temporal.PlainDate.from({year: 2006, month: 8, day: 24}); // => 2006-08-24
-date.year // => 2006
-date.inLeapYear // => false
-date.toString() // => "2006-08-24"
+const date = Temporal.PlainDate.from({ year: 2006, month: 8, day: 24 }); // => 2006-08-24
+date.year; // => 2006
+date.inLeapYear; // => false
+date.toString(); // => "2006-08-24"
 ```
 
 This can also be converted to partial dates such as `Temporal.PlainYearMonth` and `Temporal.PlainMonthDay`.
@@ -128,8 +124,8 @@ const time = Temporal.PlainTime.from({
   nanosecond: 205
 }); // => 19:39:09.068346205
 
-time.second // => 9
-time.toString() // => "19:39:09.068346205"
+time.second; // => 9
+time.toString(); // => "19:39:09.068346205"
 ```
 
 See [Temporal.PlainTime Documentation](./plaintime.md) for detailed documentation.
@@ -163,8 +159,8 @@ This is useful to express things like "the October 2020 meeting".
 
 ```js
 const yearMonth = Temporal.PlainYearMonth.from({ year: 2020, month: 10 }); // => 2020-10
-yearMonth.daysInMonth // => 31
-yearMonth.daysInYear // => 366
+yearMonth.daysInMonth; // => 31
+yearMonth.daysInYear; // => 366
 ```
 
 See [Temporal.PlainYearMonth Documentation](./plainyearmonth.md) for detailed documentation.
@@ -176,8 +172,8 @@ This is useful to express things like "Bastille Day is on the 14th of July".
 
 ```js
 const monthDay = Temporal.PlainMonthDay.from({ month: 7, day: 14 }); // => 07-14
-const date = monthDay.toPlainDate({ year: 2030 });  // => 2030-07-14
-date.dayOfWeek // => 7
+const date = monthDay.toPlainDate({ year: 2030 }); // => 2030-07-14
+date.dayOfWeek; // => 7
 ```
 
 See [Temporal.PlainMonthDay Documentation](./plainmonthday.md) for detailed documentation.
@@ -214,10 +210,10 @@ It is also possible to implement your own time zones.
 
 ```js
 const timeZone = Temporal.TimeZone.from('Africa/Cairo');
-timeZone.getInstantFor('2000-01-01T00:00') // => 1999-12-31T22:00:00Z
-timeZone.getPlainDateTimeFor('2000-01-01T00:00Z') // => 2000-01-01T02:00:00
-timeZone.getPreviousTransition(Temporal.now.instant()) // => 2014-09-25T21:00:00Z
-timeZone.getNextTransition(Temporal.now.instant()) // => null
+timeZone.getInstantFor('2000-01-01T00:00'); // => 1999-12-31T22:00:00Z
+timeZone.getPlainDateTimeFor('2000-01-01T00:00Z'); // => 2000-01-01T02:00:00
+timeZone.getPreviousTransition(Temporal.now.instant()); // => 2014-09-25T21:00:00Z
+timeZone.getNextTransition(Temporal.now.instant()); // => null
 ```
 
 See [Temporal.TimeZone Documentation](./timezone.md) for detailed documentation.
@@ -234,10 +230,10 @@ Under the hood, this math is done by methods on the calendars.
 It is also possible to implement your own calendars.
 
 ```js
-const calendar = Temporal.Calendar.from('iso8601');
-const date = calendar.dateFromFields({ year: 1999, month: 12, day: 31 }, {}, Temporal.PlainDate);
-date.monthsInYear // => 12
-date.daysInYear // => 365
+const cal = Temporal.Calendar.from('iso8601');
+const date = cal.dateFromFields({ year: 1999, month: 12, day: 31 }, {}, Temporal.PlainDate);
+date.monthsInYear; // => 12
+date.daysInYear; // => 365
 ```
 
 See [Temporal.Calendar Documentation](./calendar.md) for detailed documentation.
@@ -261,5 +257,5 @@ For more information about extensions to the ISO 8601 / RFC 3339 standards that 
 - [Ambiguity](./ambiguity.md) &mdash; Explanation of missing times and double times due to daylight saving and time zone changes.
 - [Balancing](./balancing.md) &mdash; Explanation of when `Temporal.Duration` units wrap around to 0 and when they don't.
 - [ISO String Extensions](./iso-string-ext.md) &mdash; Discussion of extensions to the ISO 8601 and/or RFC 3339 standards which are used by `Temporal`.
+- [Why do Temporal instances have a Calendar?](./calendar-review.md) &mdash; Background about why types like `Temporal.PlainDate` or `Temporal.PlainDate` contain a calendar.
   These extensions are being actively worked on with IETF to get them on a standards track.
-

--- a/docs/calendar-review.md
+++ b/docs/calendar-review.md
@@ -1,48 +1,67 @@
 # Supporting Calendar Systems in Temporal
 
-[ECMAScript Temporal](https://github.com/tc39/proposal-temporal/) is the new date and time API for ECMAScript.  Because ECMAScript is designed for global audiences, high-quality internationalization is a design goal.
+[ECMAScript Temporal](https://github.com/tc39/proposal-temporal/) is the new date and time API for ECMAScript.
+Because ECMAScript is designed for global audiences, high-quality internationalization is a design goal.
 
-This document discusses why and how calendar systems are included in the Temporal API, explains problems we expect developers to encounter with calendars, and outlines how to avoid those problems. A final section explains alternative designs for using calendar systems in Temporal, along with an explanation of why the current approach was chosen instead.
+This document discusses why and how calendar systems are included in the Temporal API, explains problems we expect developers to encounter with calendars, and outlines how to avoid those problems.
+A final section explains alternative designs for using calendar systems in Temporal, along with an explanation of why the current approach was chosen instead.
 
 ## Background and Motivation
 
 Calendar systems provide a way to assign human-readable numbers, such as year, month, and day, to a particular period of time.
 
-Much of the world uses the Gregorian calendar system, which uses solar years, months, and days: over time, it remains synchronized with the cycle of the seasons.  However, there are other calendar systems used throughout much of the world.  Some popular calendar systems include Hebrew, Islamic, Buddhist, Hindu, Chinese, Japanese, and Ethiopic.
+Much of the world uses the Gregorian calendar system, which uses solar years, months, and days: over time, it remains synchronized with the cycle of the seasons.
+However, there are other calendar systems used throughout much of the world.
+Some popular calendar systems include Hebrew, Islamic, Buddhist, Hindu, Chinese, Japanese, and Ethiopic.
 
-Today's date is March 4, 2021 in the Gregorian calendar.  Here are several other representations of that date:
+Today's date is March 4, 2021 in the Gregorian calendar.
+Here are several other representations of that date:
 
-*   20 Adar 5781 (Hebrew)
-*   Rajab 20, 1442 AH (Islamic, Umm al-Qura)
-*   March 4, 2564 BE (Thai Buddhist)
-*   令和3年3月4日 == March 4, 3 Reiwa (Japanese)
+<!-- prettier-ignore-start -->
 
-Non-Gregorian calendar systems are used in day-to-day life in several countries, particularly those with weaker cultural and economic ties to Gregorian-dominant Western countries, as well as in religious, cultural, and academic applications.  For example, several countries including Japan, China, Iran, Afghanistan, Saudi Arabia, and Taiwan use non-Gregorian calendars for at least some official government purposes. Beyond those official uses, a majority of the world's population lives in countries that use non-Gregorian calendars to determine the dates of religious or cultural holidays. 
+- 20 Adar 5781 (Hebrew)
+- Rajab 20, 1442 AH (Islamic, Umm al-Qura)
+- March 4, 2564 BE (Thai Buddhist)
+- 令和3年3月4日 == March 4, 3 Reiwa (Japanese)
+
+<!-- prettier-ignore-end -->
+
+Non-Gregorian calendar systems are used in day-to-day life in several countries, particularly those with weaker cultural and economic ties to Gregorian-dominant Western countries, as well as in religious, cultural, and academic applications.
+For example, several countries including Japan, China, Iran, Afghanistan, Saudi Arabia, and Taiwan use non-Gregorian calendars for at least some official government purposes.
+Beyond those official uses, a majority of the world's population lives in countries that use non-Gregorian calendars to determine the dates of religious or cultural holidays.
 
 ### Calendars in Business Logic (Not Only String Localization)
 
-Calendar systems play an important role in localization (l10n).  They enable a human-friendly display representation of timestamps, dates, and times.
+Calendar systems play an important role in localization (l10n).
+They enable a human-friendly display representation of timestamps, dates, and times.
 
-However, calendar systems also play an important role in the business logic of an application.  Applications involving dates intended for human consumption must consider the calendar system when performing arithmetic or any other business-logic operation that uses months and years.  Examples of calendar-sensitive operations include:
+However, calendar systems also play an important role in the business logic of an application.
+Applications involving dates intended for human consumption must consider the calendar system when performing arithmetic or any other business-logic operation that uses months and years.
+Examples of calendar-sensitive operations include:
 
-*   What is the date one month from today?
-*   What is the first day of the month?
-*   On what month and day do I celebrate my birthday or anniversary?
-*   On what day do I celebrate a religious or cultural holiday, like Ramadan, Passover, Easter, or the Chinese Lunar New Year?
+- What is the date one month from today?
+- What is the first day of the month?
+- On what month and day do I celebrate my birthday or anniversary?
+- On what day do I celebrate a religious or cultural holiday, like Ramadan, Passover, Easter, or the Chinese Lunar New Year?
 
-In other words, units of time greater than a solar day are inherently dependent on the calendar system.  The only universal solution to date arithmetic would be to omit the concept of months and years, but a date API without months and years would be insufficient for many use cases.
+In other words, units of time greater than a solar day are inherently dependent on the calendar system.
+The only universal solution to date arithmetic would be to omit the concept of months and years, but a date API without months and years would be insufficient for many use cases.
 
 ### Intl-First Design
 
-ECMAScript supports internationalization (i18n) as a primary feature. The i18n subcommittee, TC39-TG2, evangelizes "Intl-first design." Two principles of Intl-first design are (1) language- and region-dependent operations should be data-driven, and (2) user preferences should be an explicit input to APIs. These principles help ensure that APIs work well for developers targeting a wide range of end-users around the world.
+ECMAScript supports internationalization (i18n) as a primary feature. The i18n subcommittee, TC39-TG2, evangelizes "Intl-first design."
+Two principles of Intl-first design are (1) language- and region-dependent operations should be data-driven, and (2) user preferences should be an explicit input to APIs.
+These principles help ensure that APIs work well for developers targeting a wide range of end-users around the world.
 
-Temporal applies these design principles by abstracting calendar-specific logic and by making the calendar an explicit choice when constructing objects. The result is an API that supports use cases like the ones listed above for regions that use only Gregorian and for those that have other calendar systems in common use.
+Temporal applies these design principles by abstracting calendar-specific logic and by making the calendar an explicit choice when constructing objects.
+The result is an API that supports use cases like the ones listed above for regions that use only Gregorian and for those that have other calendar systems in common use.
 
 ### Using Calendars in Temporal Code
 
-The following section shows how calendar systems are exposed in Temporal code. For a more thorough discussion, see the [documentation](https://tc39.es/proposal-temporal/docs/calendar.html). 
+The following section shows how calendar systems are exposed in Temporal code. For a more thorough discussion, see the [documentation](https://tc39.es/proposal-temporal/docs/calendar.html).
 
-In Temporal, every object that includes date fields also has a calendar field. For example, both of the following lines result in a `Temporal.PlainDate` instance that represents 23 Adar I 5779 in the Hebrew calendar: 
+In Temporal, every object that includes date fields also has a calendar field.
+For example, both of the following lines result in a `Temporal.PlainDate` instance that represents 23 Adar I 5779 in the Hebrew calendar:
 
 ```javascript
 // Create a Hebrew date from a bag of fields
@@ -57,7 +76,9 @@ Temporal.PlainDate.from({
 Temporal.PlainDate.from('2019-02-28').withCalendar('hebrew');
 ```
 
-Internally, the day is always represented in the ISO calendar, meaning that if the calendar annotation gets dropped, the day remains the same.  This is true for both the internal slots of Temporal types and the string representation.  Thus, the following two lines also result in the same 23 Adar I 5779 instance:
+Internally, the day is always represented in the ISO calendar, meaning that if the calendar annotation gets dropped, the day remains the same.
+This is true for both the internal slots of Temporal types and the string representation.
+Thus, the following two lines also result in the same 23 Adar I 5779 instance:
 
 ```javascript
 // Parse from an annotated ISO string (IETF RFC pending)
@@ -67,7 +88,8 @@ Temporal.PlainDate.from('2019-02-28[u-ca=hebrew]');
 new Temporal.PlainDate(2019, 2, 28, 'hebrew');
 ```
 
-Operations on Temporal instances interpret all month, day, and year values in context of the calendar system. For example: 
+Operations on Temporal instances interpret all month, day, and year values in context of the calendar system.
+For example:
 
 ```javascript
 date = Temporal.PlainDate.from('2019-02-28[u-ca=hebrew]');
@@ -83,7 +105,8 @@ inFourMonths.withCalendar('iso8601'); // => 2019-06-26
 date.until(inFourMonths, { largestUnit: 'months' }); // => P4M
 ```
 
-By definition, creating a bag of fields with year, month, and day requires choosing a calendar system. We elide the ISO calendar if no other calendar system is specified in this situation, and it is the only place Temporal performs calendar elision:
+By definition, creating a bag of fields with year, month, and day requires choosing a calendar system.
+We elide the ISO calendar if no other calendar system is specified in this situation, and it is the only place Temporal performs calendar elision:
 
 ```javascript
 Temporal.PlainDate.from({ year: 2019, month: 2, day: 28 });
@@ -93,13 +116,15 @@ The following Temporal types all carry a calendar: `Temporal.ZonedDateTime`, `Te
 
 ## The Unexpected Calendar Problem
 
-Integrating calendar awareness into many Temporal operations is essential for a global audience, but it introduces a new problem: if code is written to assume one calendar system, bugs may result if a different calendar system is introduced instead. Introducing unexpected calendars could also be a vector for malicious activity.
+Integrating calendar awareness into many Temporal operations is essential for a global audience, but it introduces a new problem: if code is written to assume one calendar system, bugs may result if a different calendar system is introduced instead.
+Introducing unexpected calendars could also be a vector for malicious activity.
 
 This section describes this problem, which we call the "Unexpected Calendar Problem," and how to mitigate it in userland Temporal code.
 
 ### Problem Definition
 
-Below is a canonical example of this problem: a function which tests whether a particular date is the last day of the year. It assumes a calendar with 12 months and whose last month is 31 days long.
+Below is a canonical example of this problem: a function which tests whether a particular date is the last day of the year.
+It assumes a calendar with 12 months and whose last month is 31 days long.
 
 ```javascript
 function isLastDayOfYear(date) {
@@ -112,8 +137,12 @@ isLastDayOfYear(Temporal.PlainDate.from('2019-12-31')); // => true
 isLastDayOfYear(Temporal.PlainDate.from('2020-01-01')); // => false
 
 // fails for some non-ISO calendars
-hebrewNewYearsEve = Temporal.PlainDate.from(
-  { year: 5780, monthCode: 'M12', day: 29, calendar: 'hebrew' });
+hebrewNewYearsEve = Temporal.PlainDate.from({
+  year: 5780,
+  monthCode: 'M12',
+  day: 29,
+  calendar: 'hebrew'
+});
 isLastDayOfYear(hebrewNewYearsEve); // => expected: true, actual: false
 ```
 
@@ -123,20 +152,35 @@ There are two ways to avoid the Unexpected Calendar Problem: the preferred solut
 
 #### Writing Calendar-Safe Code
 
-The best way to mitigate the Unexpected Calendar Problem is to write "calendar-safe" code that works for all built-in calendars. For example, the function above can easily be written to be calendar-safe by using the `monthsInYear` and `daysInMonth` properties instead of hard-coding ISO constants. Developers who follow documented [best practices for writing calendar-safe Temporal code](https://tc39.es/proposal-temporal/docs/calendar.html#writing-cross-calendar-code) will be able to use the same code for all built-in calendars.
+The best way to mitigate the Unexpected Calendar Problem is to write "calendar-safe" code that works for all built-in calendars.
+For example, the function above can easily be written to be calendar-safe by using the `monthsInYear` and `daysInMonth` properties instead of hard-coding ISO constants.
+Developers who follow documented [best practices for writing calendar-safe Temporal code](https://tc39.es/proposal-temporal/docs/calendar.html#writing-cross-calendar-code) will be able to use the same code for all built-in calendars.
 
-Beyond documentation, the Temporal API itself has been designed to make it easier to write calendar-safe code. For example:
+Beyond documentation, the Temporal API itself has been designed to make it easier to write calendar-safe code.
+For example:
 
-*   All built-in calendars (including ISO) use the same set of date fields: `year`, `month`, `day`, and `monthCode`. These fields act the same way in all built-in calendars.
-*   The `month` property is a continuous (no gaps), 1-based index of the month in the current year. This aligns with ISO behavior and avoids unexpected behavior from lunisolar calendars where each year may have a different set of months.  A separate `monthCode` string field is used for a year-independent month identifier.
-*   The `year` property is a signed value that's relative to a specific "default era" for each calendar. This matches ISO calendar behavior and prevents bugs from, for example, eras like B.C. where years count backwards.  Separate `eraYear` and `era` fields are used for measuring years within the context of other eras.
-*   Differences between calendars are exposed via convenience properties available in every calendar, e.g. `monthsInYear`, `daysInMonth`, `inLeapYear`, etc. Userland code can completely avoid the use of calendar-specific constants (e.g. 12 months per year) by using these properties. 
-*   There is never an implicit default calendar system. Developers must explicitly decide whether they're using the ISO calendar or another calendar. For example, shortcut methods on the `Temporal.now` object are named with an ISO prefix to avoid ambiguity, such as `Temporal.now.zonedDateTimeISO()`.
-*   Temporal never infers a calendar from the user's environment.  Introducing a calendar system into a program requires a conscious, opt-in decision on the part of the developer of the app, library, or input source.
+- All built-in calendars (including ISO) use the same set of date fields: `year`, `month`, `day`, and `monthCode`.
+  These fields act the same way in all built-in calendars.
+- The `month` property is a continuous (no gaps), 1-based index of the month in the current year.
+  This aligns with ISO behavior and avoids unexpected behavior from lunisolar calendars where each year may have a different set of months.
+  A separate `monthCode` string field is used for a year-independent month identifier.
+- The `year` property is a signed value that's relative to a specific "default era" for each calendar.
+  This matches ISO calendar behavior and prevents bugs from, for example, eras like B.C. where years count backwards.
+  Separate `eraYear` and `era` fields are used for measuring years within the context of non-default eras.
+- Differences between calendars are exposed via convenience properties available in every calendar, e.g. `monthsInYear`, `daysInMonth`, `inLeapYear`, etc.
+  Userland code can completely avoid the use of calendar-specific constants (e.g. 12 months per year) by using these properties.
+- There is never an implicit default calendar system.
+  Developers must explicitly decide whether they're using the ISO calendar or another calendar.
+  For example, shortcut methods on the `Temporal.now` object are named with an ISO prefix to avoid ambiguity, such as `Temporal.now.zonedDateTimeISO()`.
+- Temporal never infers a calendar from the user's environment.
+  Introducing a calendar system into a program requires a conscious, opt-in decision on the part of the developer of the app, library, or input source.
 
 #### Validating or Coercing Inputs
 
-Even though Temporal makes it straightforward to write calendar-safe code, doing so still requires work from developers. Some developers won't do this work. Sometimes this will be because they don't know about or don't understand non-ISO calendars. In other cases, developers won't bother to follow best practices because they expect to only be dealing with ISO-calendar data. Even if a developer conscientiously follows best practices in their own code, most ECMAScript apps have many library dependencies that may not do so. Or they may have to interoperate with existing code that cannot be changed due to time constraints.
+Even though Temporal makes it straightforward to write calendar-safe code, doing so still requires work from developers. Some developers won't do this work.
+Sometimes this will be because they don't know about or don't understand non-ISO calendars. In other cases, developers won't bother to follow best practices because they expect to only be dealing with ISO-calendar data.
+Even if a developer conscientiously follows best practices in their own code, most ECMAScript apps have many library dependencies that may not do so.
+Or they may have to interoperate with existing code that cannot be changed due to time constraints.
 
 In these situations, the developer should ensure that inputs to that code are either (a) validated to ensure the input is in the expected calendar system, or (b) coerced to that system. Whether to validate or coerce depends on the use case.
 
@@ -149,63 +193,89 @@ date = date.withCalendar('iso8601');
 To validate:
 
 ```javascript
-if (date.calendar.id !== 'iso8601') throw new Error ('invalid calendar');
+if (date.calendar.id !== 'iso8601') throw new Error('invalid calendar');
 ```
 
-Note that "inputs" are not only external data. Inputs could include values returned from library dependencies, e.g. date pickers. Unless the library or input source guarantees a certain calendar system, defensive code should assume Temporal objects (or strings or objects that will be converted into a Temporal object) to be "external" and subject to validation or coercion to the ISO calendar if the code that will use that data is not calendar-safe.
+Note that "inputs" are not only external data. Inputs could include values returned from library dependencies, e.g. date pickers.
+Unless the library or input source guarantees a certain calendar system, defensive code should assume Temporal objects (or strings or objects that will be converted into a Temporal object) to be "external" and subject to validation or coercion to the ISO calendar if the code that will use that data is not calendar-safe.
 
 ## Alternatives Considered
 
-Integrating calendars into Temporal was one of the most challenging parts of designing the API. Below is a quick discussion about alternative calendar APIs we considered before adopting the current design. Note that none of the options considered (including the current Temporal design) are ideal; they all have known flaws that require workarounds for some cases. We believe that the current design is the best option overall, relative to the alternatives below.
+Integrating calendars into Temporal was one of the most challenging parts of designing the API.
+Below is a quick discussion about alternative calendar APIs we considered before adopting the current design.
+Note that none of the options considered (including the current Temporal design) are ideal; they all have known flaws that require workarounds for some cases.
+We believe that the current design is the best option overall, relative to the alternatives below.
 
 ### Alternative 1: No Calendar in the Data Model
 
-An alternative approach to the current Temporal design would have been to store calendar information separately from Temporal instances. This approach would have the advantage of avoiding the Unexpected Calendar Problem, but at significant ergonomic cost:
+An alternative approach to the current Temporal design would have been to store calendar information separately from Temporal instances.
+This approach would have the advantage of avoiding the Unexpected Calendar Problem, but at significant ergonomic cost:
 
-*   Calendar-specific fields (e.g. `month`, `day`, `year`) and convenience properties (e.g. `daysInMonth`, `inLeapYear`) could not be parameterless getters anymore. Instead, users would have to call methods to get calendar-specific values, e.g. `date.calendarMonth('chinese')`
-*   Many methods (`add`, `subtract`, `round`, `until`, `since`, `with`, maybe `toPlainMonthDay`) would require a calendar option to be able to use calendar-specific months, days, or years. Example: \
-`date.add({months: 2}, {calendar: 'chinese'})`
-*   Chaining multiple operations (e.g. `.add({months: 2}).with({day: 1})`) gets less ergonomic and more bug-prone because the same calendar value must be used in all chained calls. 
-*   The `Temporal.PlainMonthDay` type would become challenging to reason about without a calendar attached because month/day values like birthdays and holidays are inherently calendar-specific and have no ISO counterpart. This is especially true in lunisolar calendars like Hebrew and Chinese where ordinal month numbers vary from year to year for the same month. (Current Temporal uses a string <code>[monthCode](https://tc39.es/proposal-temporal/docs/plaindate.html#monthCode)</code> field to describe year-independent months.) For example, a birthday on 12 Adar I in the Hebrew calendar is currently modelled as \
-<code>  Temporal.PlainMonthDay.from( \
-    { monthCode: 'M05L', day: 12, calendar: 'hebrew' } \
-  ); \
-</code>
+- Calendar-specific fields (e.g. `month`, `day`, `year`) and convenience properties (e.g. `daysInMonth`, `inLeapYear`) could not be parameterless getters anymore.
+  Instead, users would have to call methods to get calendar-specific values, e.g. `date.calendarMonth('chinese')`
+- Most methods (`add`, `subtract`, `round`, `until`, `since`, `with`, maybe `toPlainMonthDay`, `compare`, `equals`, and a few others too) would require a calendar option to be able to use calendar-specific months, days, or years.
+  Example: `date.add({months: 2}, {calendar: 'chinese'})`
+- Chaining multiple operations (e.g. `.add({months: 2}).with({day: 1})`) gets less ergonomic and more bug-prone because the same calendar value must be used in all chained calls.
+- The `Temporal.PlainMonthDay` type would become challenging to reason about without a calendar attached because month/day values like birthdays and holidays are inherently calendar-specific and have no ISO counterpart.
+  This is especially true in lunisolar calendars like Hebrew and Chinese where ordinal month numbers vary from year to year for the same month.
+  (Current Temporal uses a string [`monthCode`](./docs/plaindate.md#monthCode) field to describe year-independent months.)
+  For example, a birthday on 12 Adar I in the Hebrew calendar is currently modelled as
 
-It's not clear how we'd model holidays if the calendar isn't stored in the instance.
-*   Code that wants to return a date along with its calendar can no longer return a single Temporal instance. Instead, it must return a compound object or serialized string. For example, a date picker that returned a date in the user's preferred calendar could no longer return a <code>Temporal.PlainDate</code>. Instead, it'd have to return a tuple or compound object like <code>{date, calendar}</code>.  Passing around compound objects (or extra calendar parameters) would complicate all calendar-using Temporal code.
+  ```javascript
+  Temporal.PlainMonthDay.from({ monthCode: 'M05L', day: 12, calendar: 'hebrew' });
+  ```
 
-The Temporal champions believe that the ergonomic challenges of this alternative are worse than the work required to mitigate the Unexpected Calendar Problem. 
+  It's not clear how we'd model holidays in these calendars if the calendar isn't stored in the instance.
+
+- Code that wants to return a date along with its calendar can no longer return a single Temporal instance.
+  Instead, it must return a compound object or serialized string.
+  For example, a date picker that returned a date in the user's preferred calendar could no longer return a `Temporal.PlainDate`.
+  Instead, it'd have to return a tuple or compound object like `{date, calendar}`.
+  Passing around compound objects (or extra calendar parameters) would complicate all calendar-using Temporal code.
+
+The Temporal champions believe that the ergonomic challenges of this alternative are worse than the work required to mitigate the Unexpected Calendar Problem.
 
 ### Alternative 2: Separate ISO and Calendar Properties
 
-It would be possible to retain the calendar in Temporal objects' data model without being vulnerable to the Unexpected Calendar Problem, but doing so would involve a significant increase in Temporal surface area. Below is one way it could be done. 
+It would be possible to retain the calendar in Temporal objects' data model without being vulnerable to the Unexpected Calendar Problem, but doing so would involve a significant increase in Temporal surface area.
+Below is one way it could be done.
 
-*   Offer two sets of fields, e.g. `.isoMonth` vs. `.calendarMonth` (or `month` vs. `calendarMonth` for brevity and to encourage developers who are unfamiliar with calendars to be nudged to use ISO fields?)
-    *   The number and types of `calendar*` fields are completely up to the calendar implementation.  Built-in calendars will all offer `calendarDay`, `calendarMonth`, `calendarMonthCode`, `calendarYear`, and sometimes `calendarEra` and `calendarEraYear` too.
-    *   Temporal APIs that accept property bag parameters will accept either calendar fields or ISO fields, BUT NOT BOTH. `date.with({calendarYear: 5780, isoMonth: 12}) `should throw. BTW, this may be enforceable via TS and ESLint for a nice design-time DX.
-    *   Trying to read `calendar*` fields would throw if the calendar is ISO because there is no human calendar defined.
-    *   Non-field convenience properties (e.g. `dayOfYear`, `inLeapYear`, etc.) would also be duplicated. The non-`calendar` variants of these fields would report the ISO values.
-*   `Temporal.Duration` would gain a `calendar` field.  
-    *   Instances using the ISO calendar would only support ISO fields: `days`, `weeks`, `months`, and `years`. 
-    *   Instances using a non-ISO calendar would only support calendar fields: `calendarDays`, `calendarWeeks`, `calendarMonths`, and `calendarYears`. 
-    *   String parsing and serialization would use calendar annotations like other Temporal types, e.g. `'P2D[u-ca=chinese]'`. Strings without an annotation would assume the ISO calendar.
-    *   `until` and `since` are now ambiguous, so they’d need a way to indicate whether the output should be an ISO duration or a non-ISO one. Options include:
-        *   Split each method into "iso" and "calendar" variants, e.g. `isoUntil` vs. `calendarUntil` or `untilISO` vs. `untilCalendar`
-        *   Always return both flavors, e.g. `foo.until(bar).isoDuration` and `foo.until(bar).calendarDuration`.
-        *   Use an option, e.g. `{ resultFields: 'iso' | 'calendar' }`. FWIW, I'm not sure that this option would work well with TS in cases where options are not specified as a literal in the API call.
-    *   There would NOT be a `withCalendar` method on durations, because durations don't have the ability to convert between calendar and ISO data. Instead, they would either have ISO fields or calendar fields, but not both.
+- Offer two sets of fields, e.g. `.isoMonth` vs. `.calendarMonth` (or `month` vs. `calendarMonth` for brevity and to encourage developers who are unfamiliar with calendars to be nudged to use ISO fields?)
+  - The number and types of `calendar*` fields are completely up to the calendar implementation.
+    Built-in calendars will all offer `calendarDay`, `calendarMonth`, `calendarMonthCode`, `calendarYear`, and sometimes `calendarEra` and `calendarEraYear` too.
+  - Temporal APIs that accept property bag parameters will accept either calendar fields or ISO fields, BUT NOT BOTH.
+    `date.with({calendarYear: 5780, isoMonth: 12}) `should throw.
+    BTW, this may be enforceable via TS and ESLint for design-time DX.
+  - Trying to read `calendar*` fields would throw if the calendar is ISO because there is no human calendar defined.
+  - Non-field convenience properties (e.g. `dayOfYear`, `inLeapYear`, etc.) would also be duplicated.
+    The non-`calendar` variants of these fields would report the ISO values.
+- `Temporal.Duration` would gain a `calendar` field.
+  - Instances using the ISO calendar would only support ISO fields: `days`, `weeks`, `months`, and `years`.
+  - Instances using a non-ISO calendar would only support calendar fields: `calendarDays`, `calendarWeeks`, `calendarMonths`, and `calendarYears`.
+  - String parsing and serialization would use calendar annotations like other Temporal types, e.g. `'P2D[u-ca=chinese]'`.
+    Strings without an annotation would assume the ISO calendar.
+  - `until` and `since` are now ambiguous, so they’d need a way to indicate whether the output should be an ISO duration or a non-ISO one.
+    Options include:
+    - Split each method into "iso" and "calendar" variants, e.g. `isoUntil` vs. `calendarUntil` or `untilISO` vs. `untilCalendar`
+    - Always return both flavors, e.g. `foo.until(bar).isoDuration` and `foo.until(bar).calendarDuration`.
+    - Use an option, e.g. `{ resultFields: 'iso' | 'calendar' }`.
+      FWIW, I'm not sure that this option would work well with TS in cases where options are not specified as a literal in the API call.
+  - There would NOT be a `withCalendar` method on durations, because durations don't have the ability to convert between calendar and ISO data.
+    Instead, they would either have ISO fields or calendar fields, but not both.
 
-After considering this and similar options, the champions decided that the additional complexity wasn't worth it. In particular, we were concerned that the dual-property approach would be more confusing and would result in more bugs than teaching users to validate or coerce inputs. 
+After considering this and similar options, the champions decided that the additional complexity wasn't worth it.
+In particular, we were concerned that the dual-property approach would be more confusing and would result in more bugs than teaching users to validate or coerce inputs.
 
 ### Alternative 3: Subclasses
 
-Instead of having the calendar system be a slot of the PlainDate type, we considered keeping PlainDate as an ISO-only type, with subclasses for all other calendar systems, such as PlainHebrewDate, PlainChineseDate, and so on.  Read more in the [discussion on calendar subclassing](https://github.com/tc39/proposal-temporal/blob/main/docs/calendar-subclass.md).
+Instead of having the calendar system be a slot of the PlainDate type, we considered keeping PlainDate as an ISO-only type, with subclasses for all other calendar systems, such as PlainHebrewDate, PlainChineseDate, and so on.
+Read more in the [discussion on calendar subclassing](https://github.com/tc39/proposal-temporal/blob/main/docs/calendar-subclass.md).
 
 We decided against the calendar subclassing approach because:
 
-*   If each subclass has its own unique set of methods, trans-calendar code becomes difficult to write, and benefits of polymorphism and subclassing are lost.  On the other hand, if each subclass has the same set of methods as PlainDate, the external behavior is the same as if the calendar were a pluggable slot.
-*   The space of possible calendar systems is large (and, theoretically, unbounded), resulting in a large number of PlainDate subclasses.
-*   Each individual subclass would need to define its own data model, increasing the surface of the specification.
+- If each subclass has its own unique set of methods, trans-calendar code becomes difficult to write, and benefits of polymorphism and subclassing are lost.
+  On the other hand, if each subclass has the same set of methods as PlainDate, the external behavior is the same as if the calendar were a pluggable slot.
+- The space of possible calendar systems is large (and, theoretically, unbounded), resulting in a large number of PlainDate subclasses.
+- Each individual subclass would need to define its own data model, increasing the surface of the specification.
 
 In the end, the champions decided that the subclassing approach brought a high cost with no clear benefit over the other approaches, and that keeping all calendar-sensitive operations neatly organized into the Temporal.Calendar object resulted in a cleaner model.


### PR DESCRIPTION
This PR fixes some code sample formatting issues on the new calendar design document and adds a link to it from the "other documentation" section on the docs home page. 

* Fixed the formatting of one code sample in the calendar review page
* Added a link to the calendar review page from the docs home page
* Fixed a too-wide docs homepage code sample (was horizontal scrolling)
* Split paragraphs into separate lines, which will make subsequent PRs easier
* Prettier made a bunch of other harmless changes