### PR TITLE
compare methods should not include calendar

### DIFF
--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -438,7 +438,7 @@ export class PlainDate {
   static compare(one, two) {
     one = ES.ToTemporalDate(one, PlainDate);
     two = ES.ToTemporalDate(two, PlainDate);
-    const result = ES.CompareISODate(
+    return ES.CompareISODate(
       GetSlot(one, ISO_YEAR),
       GetSlot(one, ISO_MONTH),
       GetSlot(one, ISO_DAY),
@@ -446,8 +446,6 @@ export class PlainDate {
       GetSlot(two, ISO_MONTH),
       GetSlot(two, ISO_DAY)
     );
-    if (result !== 0) return result;
-    return ES.CalendarCompare(GetSlot(one, CALENDAR), GetSlot(two, CALENDAR));
   }
 }
 

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -794,7 +794,7 @@ export class PlainDateTime {
       const val2 = GetSlot(two, slot);
       if (val1 !== val2) return ES.ComparisonResult(val1 - val2);
     }
-    return ES.CalendarCompare(GetSlot(one, CALENDAR), GetSlot(two, CALENDAR));
+    return 0;
   }
 }
 

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -396,12 +396,14 @@ export class PlainYearMonth {
   static compare(one, two) {
     one = ES.ToTemporalYearMonth(one, PlainYearMonth);
     two = ES.ToTemporalYearMonth(two, PlainYearMonth);
-    for (const slot of [ISO_YEAR, ISO_MONTH, ISO_DAY]) {
-      const val1 = GetSlot(one, slot);
-      const val2 = GetSlot(two, slot);
-      if (val1 !== val2) return ES.ComparisonResult(val1 - val2);
-    }
-    return ES.CalendarCompare(GetSlot(one, CALENDAR), GetSlot(two, CALENDAR));
+    return ES.CompareISODate(
+      GetSlot(one, ISO_YEAR),
+      GetSlot(one, ISO_MONTH),
+      GetSlot(one, ISO_DAY),
+      GetSlot(two, ISO_YEAR),
+      GetSlot(two, ISO_MONTH),
+      GetSlot(two, ISO_DAY)
+    );
   }
 }
 

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -861,8 +861,6 @@ export class ZonedDateTime {
     const ns2 = GetSlot(two, EPOCHNANOSECONDS);
     if (bigInt(ns1).lesser(ns2)) return -1;
     if (bigInt(ns1).greater(ns2)) return 1;
-    const calendarResult = ES.CalendarCompare(GetSlot(one, CALENDAR), GetSlot(two, CALENDAR));
-    if (calendarResult) return calendarResult;
     return ES.TimeZoneCompare(GetSlot(one, TIME_ZONE), GetSlot(two, TIME_ZONE));
   }
 }

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -861,7 +861,7 @@ export class ZonedDateTime {
     const ns2 = GetSlot(two, EPOCHNANOSECONDS);
     if (bigInt(ns1).lesser(ns2)) return -1;
     if (bigInt(ns1).greater(ns2)) return 1;
-    return ES.TimeZoneCompare(GetSlot(one, TIME_ZONE), GetSlot(two, TIME_ZONE));
+    return 0;
   }
 }
 

--- a/polyfill/test/PlainDate/constructor/compare/use-internal-slots.js
+++ b/polyfill/test/PlainDate/constructor/compare/use-internal-slots.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-comparetemporaldate
+esid: sec-temporal-compareisodate
 ---*/
 
 function CustomError() {}

--- a/polyfill/test/PlainDateTime/constructor/compare/use-internal-slots.js
+++ b/polyfill/test/PlainDateTime/constructor/compare/use-internal-slots.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal-comparetemporaldatetime
+esid: sec-temporal-compareisodatetime
 ---*/
 
 function CustomError() {}

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -2810,8 +2810,8 @@ describe('ZonedDateTime', () => {
         TypeError
       );
     });
-    it('compares time zone IDs if exact times are equal', () => {
-      equal(ZonedDateTime.compare(zdt1, zdt1.withTimeZone('Asia/Kolkata')), 1);
+    it('disregards time zone IDs if exact times are equal', () => {
+      equal(ZonedDateTime.compare(zdt1, zdt1.withTimeZone('Asia/Kolkata')), 0);
     });
     it('disregards calendar IDs if exact times and time zones are equal', () => {
       equal(ZonedDateTime.compare(zdt1, zdt1.withCalendar('japanese')), 0);

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -2813,8 +2813,8 @@ describe('ZonedDateTime', () => {
     it('compares time zone IDs if exact times are equal', () => {
       equal(ZonedDateTime.compare(zdt1, zdt1.withTimeZone('Asia/Kolkata')), 1);
     });
-    it('compares calendar IDs if exact times and time zones are equal', () => {
-      equal(ZonedDateTime.compare(zdt1, zdt1.withCalendar('japanese')), -1);
+    it('disregards calendar IDs if exact times and time zones are equal', () => {
+      equal(ZonedDateTime.compare(zdt1, zdt1.withCalendar('japanese')), 0);
     });
     it('compares exact time, not clock time', () => {
       const clockBefore = ZonedDateTime.from('1999-12-31T23:30-08:00[America/Vancouver]');

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -83,8 +83,7 @@
       <emu-alg>
         1. Set _one_ to ? ToTemporalDate(_one_).
         1. Set _two_ to ? ToTemporalDate(_two_).
-        1. Return 𝔽(? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]],
-            _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]])).
+        1. Return 𝔽(! CompareISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]])).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -740,13 +739,13 @@
         1. If _largestUnit_ is not *"years"*, *"months"*, or *"weeks"*, then
           1. Set _largestUnit_ to *"days"*.
         1. If _largestUnit_ is *"years"* or *"months"*, then
-          1. Let _sign_ be -(! ES.CompareTemporalDate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_)).
+          1. Let _sign_ be -(! CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_)).
           1. If _sign_ is 0, return the new Record { [[Years]]: 0, [[Months]]: 0, [[Weeks]]: 0, [[Days]]: 0 }.
           1. Let _start_ be the new Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
           1. Let _end_ be the new Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
           1. Let _years_ be _end_.[[Year]] − _start_.[[Year]].
           1. Let _mid_ be ? AddISODate(_y1_, _m1_, _d1_, _years_, 0, 0, *"constrain"*).
-          1. Let _midSign_ be -(! ES.CompareTemporalDate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
+          1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
             1. If _largestUnit_ is *"years"*, return the new Record { [[Years]]: _years_, [[Months]]: 0, [[Weeks]]: 0, [[Days]]: 0 }.
             1. Else, return the new Record { [[Years]]: 0, [[Months]]: _years_ × 12, [[Weeks]]: 0, [[Days]]: 0 }.
@@ -755,7 +754,7 @@
             1. Set _years_ to _years_ - _sign_.
             1. Set _months_ to _months_ + _sign_ × 12.
           1. Set _mid_ be ? AddISODate(_y1_, _m1_, _d1_, _years_, _months_, 0, *"constrain"*).
-          1. Let _midSign_ be -(! ES.CompareTemporalDate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
+          1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
             1. If _largestUnit_ is *"years"*, return the new Record { [[Years]]: _years_, [[Months]]: _months_, [[Weeks]]: 0, [[Days]]: 0 }.
             1. Else, return the new Record { [[Years]]: 0, [[Months]]: _months_ + _years_ × 12, [[Weeks]]: 0, [[Days]]: 0 }.
@@ -765,7 +764,7 @@
               1. Set _years_ to _years_ - _sign_.
               1. Set _months_ to 11 × _sign_.
             1. Set _mid_ be ? AddISODate(_y1_, _m1_, _d1_, _years_, _months_, 0, *"constrain"*).
-            1. Let _midSign_ be -(! ES.CompareTemporalDate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
+            1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. Let _days_ be 0.
           1. If _mid_.[[Month]] is equal to _end_.[[Month]] and _mid_.[[Year]] is equal to _mid_.[[Year]], set _days_ to _end_.[[Day]] - _mid_.[[Day]].
           1. Else if _sign_ &lt; 0, set _days_ to -_mid_.[[Day]] - (! ISODaysInMonth(_end_.[[Year]], _end_.[[Month]]) - _end_.[[Day]]).
@@ -956,16 +955,6 @@
         1. If _d1_ &gt; _d2_, return 1.
         1. If _d1_ &lt; _d2_, return -1.
         1. Return 0.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-comparetemporaldatecalendar" aoid="CompareTemporalDateCalendar">
-      <h1>CompareTemporalDateCalendar ( _y1_, _m1_, _d1_, _y2_, _m2_, _d2_, _c1_, _c2_ )</h1>
-      <emu-alg>
-        1. Let _result_ be ! CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_).
-        1. If _result_ ≠ 0, then
-          1. Return _result_.
-        1. Return ? CompareCalendar(_c1_, _c2_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -89,10 +89,7 @@
       <emu-alg>
         1. Set _one_ to ? ToTemporalDateTime(_one_).
         1. Set _two_ to ? ToTemporalDateTime(_two_).
-        1. Let _result_ be ! CompareISODateTime(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[ISOHour]], _one_.[[ISOMinute]], _one_.[[ISOSecond]], _one_.[[ISOMillisecond]], _one_.[[ISOMicrosecond]], _one_.[[ISONanosecond]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[ISOHour]], _two_.[[ISOMinute]], _two_.[[ISOSecond]], _two_.[[ISOMillisecond]], _two_.[[ISOMicrosecond]], _two_.[[ISONanosecond]]).
-        1. If _result_ ≠ 0, then
-          1. Return 𝔽(_result_).
-        1. Return 𝔽(? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]])).
+        1. Return 𝔽(! CompareISODateTime(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[ISOHour]], _one_.[[ISOMinute]], _one_.[[ISOSecond]], _one_.[[ISOMillisecond]], _one_.[[ISOMicrosecond]], _one_.[[ISONanosecond]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[ISOHour]], _two_.[[ISOMinute]], _two_.[[ISOSecond]], _two_.[[ISOMillisecond]], _two_.[[ISOMicrosecond]], _two_.[[ISONanosecond]])).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -84,8 +84,7 @@
       <emu-alg>
         1. Set _one_ to ? ToTemporalYearMonth(_one_).
         1. Set _two_ to ? ToTemporalYearMonth(_two_).
-        1. Return 𝔽(? CompareTemporalDateCalendar(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _one_.[[Calendar]],
-            _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _two_.[[Calendar]])).
+        1. Return 𝔽(? CompareISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]])).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -89,9 +89,6 @@
         1. Let _result_ be ! CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]]).
         1. If _result_ ≠ 0, then
           1. Return 𝔽(_result_).
-        1. Set _result_ to ? CompareCalendar(_one_.[[Calendar]], _two_.[[Calendar]]).
-        1. If _result_ ≠ 0, then
-          1. Return 𝔽(_result_).
         1. Return 𝔽(? CompareTimeZone(_one_.[[TimeZone]], _two_.[[TimeZone]]).
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -86,10 +86,7 @@
       <emu-alg>
         1. Set _one_ to ? ToTemporalZonedDateTime(_one_).
         1. Set _two_ to ? ToTemporalZonedDateTime(_two_).
-        1. Let _result_ be ! CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]]).
-        1. If _result_ ≠ 0, then
-          1. Return 𝔽(_result_).
-        1. Return 𝔽(? CompareTimeZone(_one_.[[TimeZone]], _two_.[[TimeZone]]).
+        1. Return 𝔽(! CompareEpochNanoseconds(_one_.[[Nanoseconds]], _two_.[[Nanoseconds]])).
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This commit changes different compare methods on types that include
calendars to not take them into account. With this, two instances that
have different calendars attached but map to the same points in the ISO
calendar are compared to be "equal".

Fixes: https://github.com/tc39/proposal-temporal/issues/1431

/cc @bakkot