### PR TITLE
Handle opposite date/time signs in DifferenceISODateTime.

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3290,7 +3290,35 @@ export const ES = ObjectAssign({}, ES2020, {
       µs2,
       ns2
     );
+
+    const timeSign = ES.DurationSign(
+      0,
+      0,
+      0,
+      deltaDays,
+      hours,
+      minutes,
+      seconds,
+      milliseconds,
+      microseconds,
+      nanoseconds
+    );
     ({ year: y1, month: mon1, day: d1 } = ES.BalanceISODate(y1, mon1, d1 + deltaDays));
+    const dateSign = ES.CompareISODate(y2, mon2, d2, y1, mon1, d1);
+    if (dateSign === -timeSign) {
+      ({ year: y1, month: mon1, day: d1 } = ES.BalanceISODate(y1, mon1, d1 - timeSign));
+      ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
+        -timeSign,
+        hours,
+        minutes,
+        seconds,
+        milliseconds,
+        microseconds,
+        nanoseconds,
+        largestUnit
+      ));
+    }
+
     const date1 = ES.CreateTemporalDate(y1, mon1, d1, calendar);
     const date2 = ES.CreateTemporalDate(y2, mon2, d2, calendar);
     const dateLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', largestUnit);

--- a/polyfill/test/PlainDateTime/prototype/until/balance.js
+++ b/polyfill/test/PlainDateTime/prototype/until/balance.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+---*/
+
+const a = Temporal.PlainDateTime.from('2017-10-05T08:07:14+00:00[UTC]');
+const b = Temporal.PlainDateTime.from('2021-03-05T03:32:45+00:00[UTC]');
+const c = Temporal.PlainDateTime.from('2021-03-05T09:32:45+00:00[UTC]');
+
+const r1 = a.until(b, { largestUnit: 'months' });
+assert.sameValue(r1.toString(), "P40M27DT19H25M31S", "r1");
+assert.sameValue(a.add(r1).toString(), b.toString(), "a.add(r1)");
+
+const r2 = b.until(a, { largestUnit: 'months' });
+assert.sameValue(r2.toString(), "-P40M30DT19H25M31S", "r2");
+assert.sameValue(b.add(r2).toString(), a.toString(), "b.add(r2)");
+
+const r3 = c.until(a, { largestUnit: 'months' });
+assert.sameValue(r3.toString(), "-P41MT1H25M31S", "r3");
+assert.sameValue(c.add(r3).toString(), a.toString(), "c.add(r3)");

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1121,7 +1121,12 @@
       <emu-alg>
         1. If _options_ is not given, set it to ! OrdinaryObjectCreate(%Object.prototype%).
         1. Let _timeDifference_ be ? DifferenceTime(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _timeSign_ be ! DurationSign(0, 0, 0, _timeDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]]).
+        1. Let _dateSign_ be ! CompareISODate(_y2_, _mon2_, _d2_, _y1_, _mon1_, _d1_).
         1. Let _balanceResult_ be ? BalanceISODate(_y1_, _mon1_, _d1_ + _timeDifference_.[[Days]]).
+        1. If _timeSign_ is -_dateSign_, then
+          1. Set _balanceResult_ be ? BalanceISODate(_balanceResult_.[[Year]], _balanceResult_.[[Month]], _balanceResult_.[[Day]] - _timeSign_).
+          1. Set _timeDifference_ to ? BalanceDuration(-_timeSign_, _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
         1. Let _date1_ be ? CreateTemporalDate(_balanceResult_.[[Year]], _balanceResult_.[[Month]], _balanceResult_.[[Day]]).
         1. Let _date2_ be ? CreateTemporalDate(_y2_, _mon2_, _d2_).
         1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"days"*, _largestUnit_).


### PR DESCRIPTION
This ensures cases such as months=1, hours=-1 are balanced correctly.

Fixes #1415.