### PR TITLE
Prefer singular unit names in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -188,7 +188,7 @@ const duration = Temporal.Duration.from({
   minutes: 20
 });
 
-duration.total({ unit: 'seconds' }); // => 469200
+duration.total({ unit: 'second' }); // => 469200
 ```
 
 See [Temporal.Duration Documentation](./duration.md) for detailed documentation.

--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -32,28 +32,25 @@ By default, the largest unit in the input will be largest unit in the output.
 
 ```javascript
 d = Temporal.Duration.from({ minutes: 80, seconds: 30 }); // => PT80M30S
-d.round({largestUnit: 'auto'});
-  // => PT80M30S
-  // (unchanged)
+d.round({ largestUnit: 'auto' }); // => PT80M30S (unchanged)
 ```
 
 However, `round()` will balance units smaller than the largest one.
 This only matters in the rare case that an unbalanced duration isn't top-heavy.
 
+<!-- prettier-ignore-start -->
 ```javascript
 d = Temporal.Duration.from({ minutes: 80, seconds: 90 }); // => PT80M90S
-d.round({largestUnit: 'auto'});
-  // => PT81M30S
-  // (seconds balance to minutes, but not minutes=>hours)
+d.round({ largestUnit: 'auto' });
+  // => PT81M30S (seconds balance to minutes, but not minutes=>hours)
 ```
+<!-- prettier-ignore-end -->
 
 To fully balance a duration, use the `largestUnit` option:
 
 ```javascript
 d = Temporal.Duration.from({ minutes: 80, seconds: 90 }); // => PT80M90S
-d.round({ largestUnit: 'hours' });
-  // => PT1H21M30S
-  // (fully balanced)
+d.round({ largestUnit: 'hour' }); // => PT1H21M30S (fully balanced)
 ```
 
 ## Balancing Relative to a Reference Point
@@ -70,11 +67,9 @@ To handle this potential ambiguity, the `relativeTo` option is used to provide a
 
 ```javascript
 d = Temporal.Duration.from({ days: 370 }); // => P370D
-/* WRONG */ d.round({ largestUnit: 'years' }); // => RangeError (`relativeTo` is required)
-d.round({ largestUnit: 'years', relativeTo: '2019-01-01' }); // => P1Y5D
-d.round({ largestUnit: 'years', relativeTo: '2020-01-01' });
-  // => P1Y4D
-  // (2020 is a leap year)
+/* WRONG */ d.round({ largestUnit: 'year' }); // => RangeError (`relativeTo` is required)
+d.round({ largestUnit: 'year', relativeTo: '2019-01-01' }); // => P1Y5D
+d.round({ largestUnit: 'year', relativeTo: '2020-01-01' }); // => P1Y4D (leap year)
 ```
 
 `relativeTo` is optional when balancing to or from `days`, and if `relativeTo` is omitted then days are assumed to be 24 hours long.
@@ -83,9 +78,9 @@ However, if the duration is timezone-specific, then it's recommended to use a `T
 <!-- prettier-ignore-start -->
 ```javascript
 d = Temporal.Duration.from({ hours: 48 }); // => PT48H
-d.round({ largestUnit: 'days' });
+d.round({ largestUnit: 'day' });
   // => P2D
-d.round({ largestUnit: 'days', relativeTo: '2020-03-08T00:00-08:00[America/Los_Angeles]' });
+d.round({ largestUnit: 'day', relativeTo: '2020-03-08T00:00-08:00[America/Los_Angeles]' });
   // => P2DT1H
   // (because one clock hour was skipped by DST starting)
 ```
@@ -108,9 +103,7 @@ The `largestUnit` option can be used to balance to larger units than the inputs.
 ```javascript
 d1 = Temporal.Duration.from({ minutes: 80, seconds: 90 }); // => PT80M90S
 d2 = Temporal.Duration.from({ minutes: 100, seconds: 15 }); // => PT100M15S
-d1.add(d2).round({ largestUnit: 'hours' });
-  // => PT3H1M45S
-  // (fully balanced)
+d1.add(d2).round({ largestUnit: 'hour' }); // => PT3H1M45S (fully balanced)
 ```
 
 The `relativeTo` option can be used to balance to, or from, weeks, months or years (or days for timezone-aware durations).
@@ -120,9 +113,9 @@ The `relativeTo` option can be used to balance to, or from, weeks, months or yea
 ```javascript
 d1 = Temporal.Duration.from({ hours: 48 }); // => PT48H
 d2 = Temporal.Duration.from({ hours: 24 }); // => PT24H
-d1.add(d2).round({ largestUnit: 'days' });
+d1.add(d2).round({ largestUnit: 'day' });
   // => P3D
-d1.add(d2).round({ largestUnit: 'days', relativeTo: '2020-03-08T00:00-08:00[America/Los_Angeles]' });
+d1.add(d2).round({ largestUnit: 'day', relativeTo: '2020-03-08T00:00-08:00[America/Los_Angeles]' });
   // => P3DT1H
   // (because one clock hour was skipped by DST starting)
 ```

--- a/docs/calendar-review.md
+++ b/docs/calendar-review.md
@@ -122,7 +122,7 @@ date.calendar.id; // => 'hebrew'
 inFourMonths = date.add({ months: 4 });
 inFourMonths.toLocaleString('en-US', { calendar: 'hebrew' }); // => '23 Sivan 5779'
 inFourMonths.withCalendar('iso8601'); // => 2019-06-26
-date.until(inFourMonths, { largestUnit: 'months' }); // => P4M
+date.until(inFourMonths, { largestUnit: 'month' }); // => P4M
 ```
 
 By definition, creating a bag of fields with year, month, and day requires choosing a calendar system.

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -262,6 +262,7 @@ A custom implementation of these methods would convert the calendar-space argume
 
 For example:
 
+<!-- prettier-ignore-start -->
 ```javascript
 date = Temporal.PlainDate.from({ year: 5779, monthCode: 'M05L', day: 18, calendar: 'hebrew' });
 date.year; // => 5779
@@ -277,6 +278,7 @@ date = Temporal.Calendar.from('hebrew').dateFromFields(
   { overflow: 'constrain' }
 );
 ```
+<!-- prettier-ignore-end -->
 
 ### calendar.**dateAdd**(_date_: Temporal.PlainDate | object | string, _duration_: Temporal.Duration | object | string, _options_: object) : Temporal.PlainDate
 
@@ -334,7 +336,7 @@ date.toString(); // => '2020-06-28[u-ca=islamic]'
 - `options` (object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'`, `'months'`, and `'days'`.
+    Valid values are `'auto'`, `'year'`, `'month'`, and `'day'`.
     The default is `'auto'`.
 
 **Returns:** a `Temporal.Duration` representing the time elapsed after `one` and until `two`.
@@ -346,7 +348,7 @@ It is called indirectly when using the `until()` and `since()` methods of `Tempo
 
 If `one` is later than `two`, then the resulting duration should be negative.
 
-The default `largestUnit` value of `'auto'` is the same as `'days'`.
+The default `largestUnit` value of `'auto'` is the same as `'day'`.
 
 > **NOTE:** Unlike `Temporal.Calendar.dateAdd()`, the `options` object that this method receives is not always the same object passed to the respective `until()` or `since()` method.
 > Depending on the type, a copy may be made of the object.
@@ -356,13 +358,13 @@ For example:
 ```javascript
 d1 = Temporal.PlainDate.from('2020-07-29').withCalendar('chinese');
 d2 = Temporal.PlainDate.from('2020-08-29').withCalendar('chinese');
-d1.until(d2, { largestUnit: 'months' }); // => P1M2D
+d1.until(d2, { largestUnit: 'month' }); // => P1M2D
 
 // same result, but calling the method directly:
 Temporal.Calendar.from('chinese').dateUntil(
   Temporal.PlainDate.from('2020-07-29'),
   Temporal.PlainDate.from('2020-08-29'),
-  { largestUnit: 'months' }
+  { largestUnit: 'month' }
 ); // => P1M2D
 ```
 

--- a/docs/cookbook/futureDateForm.js
+++ b/docs/cookbook/futureDateForm.js
@@ -15,8 +15,8 @@ if (futuredateParam !== null) {
   const browserCalendar = new Intl.DateTimeFormat().resolvedOptions().calendar;
   const futureDate = Temporal.PlainDate.from(futuredateParam).withCalendar(browserCalendar);
   const today = Temporal.now.plainDate(browserCalendar);
-  const until = today.until(futureDate, { largestUnit: 'days' });
-  const untilMonths = until.round({ largestUnit: 'months', relativeTo: today });
+  const until = today.until(futureDate, { largestUnit: 'day' });
+  const untilMonths = until.round({ largestUnit: 'month', relativeTo: today });
 
   const dayString = englishPlural(until.days, 'day', 'days');
   const monthString =

--- a/docs/cookbook/getElapsedDurationSinceInstant.mjs
+++ b/docs/cookbook/getElapsedDurationSinceInstant.mjs
@@ -1,10 +1,10 @@
 const result = Temporal.Instant.from('2020-01-09T04:00Z').since(Temporal.Instant.from('2020-01-09T00:00Z'), {
-  largestUnit: 'hours'
+  largestUnit: 'hour'
 });
 assert.equal(`${result}`, 'PT4H');
 
 const result2 = Temporal.Instant.from('2020-01-09T00:00Z').until(Temporal.Instant.from('2020-01-09T04:00Z'), {
-  largestUnit: 'minutes'
+  largestUnit: 'minute'
 });
 assert.equal(`${result2}`, 'PT240M');
 

--- a/docs/cookbook/stockExchangeTimeZone.mjs
+++ b/docs/cookbook/stockExchangeTimeZone.mjs
@@ -121,7 +121,7 @@ class NYSETimeZone extends Temporal.TimeZone {
     instant = Temporal.Instant.from(instant);
     const zdt = instant.toZonedDateTimeISO(tz);
     const zdtWhenMarketIsOpen = isDuringMarketHours(zdt) ? zdt : getNextMarketOpen(zdt.toInstant());
-    const ns = zdt.offsetNanoseconds + zdt.until(zdtWhenMarketIsOpen, { largestUnit: 'nanoseconds' }).nanoseconds;
+    const ns = zdt.offsetNanoseconds + zdt.until(zdtWhenMarketIsOpen, { largestUnit: 'nanosecond' }).nanoseconds;
     return ns;
   }
   toString() {

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -152,7 +152,7 @@ sorted.join(' ');
 
 // Sorting relative to a date, taking DST changes into account:
 relativeTo = Temporal.ZonedDateTime.from('2020-11-01T00:00-07:00[America/Los_Angeles]');
-sorted = [one, two, three].sort((one, two) => Temporal.Duration.compare(one, two, {relativeTo}));
+sorted = [one, two, three].sort((one, two) => Temporal.Duration.compare(one, two, { relativeTo }));
 sorted.join(' ');
 // => 'PT79H10M P3DT6H50M P3DT7H630S'
 ```
@@ -293,7 +293,7 @@ result = one.add(two); // => PT4H15M
 
 fifty = Temporal.Duration.from('P50Y50M50DT50H50M50.500500500S');
 /* WRONG */ result = fifty.add(fifty); // => throws, need relativeTo
-result = fifty.add(fifty, {relativeTo: '1900-01-01'}); // => P108Y7M12DT5H41M41.001001S
+result = fifty.add(fifty, { relativeTo: '1900-01-01' }); // => P108Y7M12DT5H41M41.001001S
 
 // Example of converting ambiguous units relative to a start date
 oneAndAHalfMonth = Temporal.Duration.from({ months: 1, days: 15 });
@@ -344,7 +344,7 @@ hourAndAHalf.subtract({ hours: 1 }); // => PT30M
 one = Temporal.Duration.from({ minutes: 180 });
 two = Temporal.Duration.from({ seconds: 30 });
 one.subtract(two); // => PT179M30S
-one.subtract(two).round({largestUnit: 'hours'}); // => PT2H59M30S
+one.subtract(two).round({ largestUnit: 'hour' }); // => PT2H59M30S
 
 // Example of converting ambiguous units relative to a start date
 threeMonths = Temporal.Duration.from({ months: 3 });
@@ -393,11 +393,11 @@ d.abs(); // PT8H30M
 - `options` (object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'auto'`, `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `'nanoseconds'`, i.e. no rounding.
+    Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    The default is `'nanosecond'`, i.e. no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -412,18 +412,18 @@ Rounds and/or balances `duration` to the given largest and smallest units and ro
 
 The `largestUnit` determines the largest unit allowed in the result.
 It will cause units larger than `largestUnit` to be converted into smaller units, and units smaller than `largestUnit` to be converted into larger units as much as possible.
-For example, with `largestUnit: 'minutes'`, a duration of 1 hour and 125 seconds will be converted into a duration of 62 minutes and 5 seconds.
+For example, with `largestUnit: 'minute'`, a duration of 1 hour and 125 seconds will be converted into a duration of 62 minutes and 5 seconds.
 These durations are equally long, so no rounding takes place, but they are expressed differently.
 This operation is called "balancing."
 
 For usage examples and a more complete explanation of how balancing works, see [Duration balancing](./balancing.md).
 
 A `largestUnit` value of `'auto'`, which is the default if only `smallestUnit` is given, means that `largestUnit` should be the largest nonzero unit in the duration that is larger than `smallestUnit`.
-For example, in a duration of 3 days and 12 hours, `largestUnit: 'auto'` would mean the same as `largestUnit: 'days'`.
+For example, in a duration of 3 days and 12 hours, `largestUnit: 'auto'` would mean the same as `largestUnit: 'day'`.
 This behavior implies that the default balancing behaviour of this method to not 'grow' the duration beyond its current largest unit unless needed for rounding.
 
 The `smallestUnit` option determines the unit to round to.
-For example, to round to the nearest minute, use `smallestUnit: 'minutes'`.
+For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
 The default, if only `largestUnit` is given, is to do no rounding.
 
 At least one of `largestUnit` or `smallestUnit` is required.
@@ -432,10 +432,10 @@ Converting between years, months, weeks, and other units requires a reference po
 If `largestUnit` or `smallestUnit` is years, months, or weeks, or the duration has nonzero years, months, or weeks, then the `relativeTo` option is required.
 
 The `roundingIncrement` option allows rounding to an integer number of units.
-For example, to round to increments of a half hour, use `smallestUnit: 'minutes', roundingIncrement: 30`.
+For example, to round to increments of a half hour, use `smallestUnit: 'minute', roundingIncrement: 30`.
 
 Unless `smallestUnit` is years, months, weeks, or days, the value given as `roundingIncrement` must divide evenly into the next highest unit after `smallestUnit`, and must not be equal to it.
-For example, if `smallestUnit` is `'minutes'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
+For example, if `smallestUnit` is `'minute'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
 The valid values in this case are 1 (default), 2, 3, 4, 5, 6, 10, 12, 15, 20, and 30.
 Instead of 60 minutes, use 1 hour.
 
@@ -461,45 +461,45 @@ Example usage:
 ```javascript
 // Balance a duration as far as possible without knowing a starting point
 d = Temporal.Duration.from({ minutes: 130 });
-d.round({ largestUnit: 'days' }); // => PT2H10M
+d.round({ largestUnit: 'day' }); // => PT2H10M
 
 // Round to the nearest unit
 d = Temporal.Duration.from({ minutes: 10, seconds: 52 });
-d.round({ smallestUnit: 'minutes' }); // => PT11M
-d.round({ smallestUnit: 'minutes', roundingMode: 'trunc' }); // => PT10M
+d.round({ smallestUnit: 'minute' }); // => PT11M
+d.round({ smallestUnit: 'minute', roundingMode: 'trunc' }); // => PT10M
 
 // How many seconds in a multi-unit duration?
 d = Temporal.Duration.from('PT2H34M18S');
-d.round({ largestUnit: 'seconds' }).seconds; // => 9258
+d.round({ largestUnit: 'second' }).seconds; // => 9258
 
 // Normalize, with and without taking DST into account
 d = Temporal.Duration.from({ hours: 2756 });
 d.round({
-   relativeTo: '2020-01-01T00:00+01:00[Europe/Rome]',
-   largestUnit: 'years'
+  relativeTo: '2020-01-01T00:00+01:00[Europe/Rome]',
+  largestUnit: 'year'
 }); // => P114DT21H
-    // (one hour longer because DST skipped an hour)
+// (one hour longer because DST skipped an hour)
 d.round({
   relativeTo: '2020-01-01',
-  largestUnit: 'years'
+  largestUnit: 'year'
 }); // => P114DT20H
-    // (one hour shorter if ignoring DST)
+// (one hour shorter if ignoring DST)
 
 // Normalize days into months or years
 d = Temporal.Duration.from({ days: 190 });
 refDate = Temporal.PlainDate.from('2020-01-01');
-d.round({ relativeTo: refDate, largestUnit: 'years' }); // => P6M8D
+d.round({ relativeTo: refDate, largestUnit: 'year' }); // => P6M8D
 
 // Same, but in a different calendar system
 d.round({
   relativeTo: refDate.withCalendar('hebrew'),
-  largestUnit: 'years'
+  largestUnit: 'year'
 }); // => P6M13D
 
 // Round a duration up to the next 5-minute billing period
 d = Temporal.Duration.from({ minutes: 6 });
 d.round({
-  smallestUnit: 'minutes',
+  smallestUnit: 'minute',
   roundingIncrement: 5,
   roundingMode: 'ceil'
 }); // => PT10M
@@ -507,7 +507,7 @@ d.round({
 // How many full 3-month quarters of this year, are in this duration?
 d = Temporal.Duration.from({ months: 10, days: 15 });
 d = d.round({
-  smallestUnit: 'months',
+  smallestUnit: 'month',
   roundingIncrement: 3,
   roundingMode: 'trunc',
   relativeTo: Temporal.now.plainDateISO()
@@ -523,7 +523,7 @@ quarters; // => 3
 - `options` (object): An object with properties representing options for the operation.
   The following options are recognized:
   - `unit` (string): The unit of time that will be returned.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     There is no default; `unit` is required.
   - `relativeTo` (`Temporal.PlainDateTime`): The starting point to use when converting between years, months, weeks, and days.
     It must be a `Temporal.PlainDateTime`, or a value that can be passed to `Temporal.PlainDateTime.from()`.
@@ -535,7 +535,7 @@ If the duration IS NOT evenly divisible by the desired unit, then a fractional r
 If the duration IS evenly divisible by the desired unit, then the integer result will be identical to `duration.round({ smallestUnit: unit, largestUnit: unit, relativeTo })[unit]`.
 
 Interpreting years, months, or weeks requires a reference point.
-Therefore, `unit` is `'years'`, `'months'`, or `'weeks'`, or the duration has nonzero 'years', 'months', or 'weeks', then the `relativeTo` option is required.
+Therefore, `unit` is `'year'`, `'month'`, or `'week'`, or the duration has nonzero 'year', 'month', or 'week', then the `relativeTo` option is required.
 
 The `relativeTo` option gives the starting point used when converting between or rounding to years, months, weeks, or days.
 It is a `Temporal.PlainDateTime` instance.
@@ -547,20 +547,20 @@ Example usage:
 ```javascript
 // How many seconds in 18 hours and 20 minutes?
 d = Temporal.Duration.from({ hours: 130, minutes: 20 });
-d.total({ unit: 'seconds' }); // => 469200
+d.total({ unit: 'second' }); // => 469200
 
 // How many 24-hour days is 123456789 seconds?
 d = Temporal.Duration.from('PT123456789S');
-d.total({ unit: 'days' }); // 1428.8980208333332
+d.total({ unit: 'day' }); // 1428.8980208333332
 
 // Find totals in months, with and without taking DST into account
 d = Temporal.Duration.from({ hours: 2756 });
 d.total({
-   relativeTo: '2020-01-01T00:00+01:00[Europe/Rome]',
-   unit: 'months'
+  relativeTo: '2020-01-01T00:00+01:00[Europe/Rome]',
+  unit: 'month'
 }); // => 3.7958333333333334
 d.total({
-  unit: 'months',
+  unit: 'month',
   relativeTo: '2020-01-01'
 }); // => 3.7944444444444443
 ```
@@ -576,7 +576,7 @@ d.total({
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to include in the output string.
     This option overrides `fractionalSecondDigits` if both are given.
-    Valid values are `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
     Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
     The default is `'trunc'`.
@@ -608,11 +608,11 @@ d.toString(); // => PT1S
 // underlying Temporal.Duration object doesn't.
 nobal = Temporal.Duration.from({ milliseconds: 3500 });
 console.log(`${nobal}`, nobal.seconds, nobal.milliseconds); // => 'PT3.5S 0 3500'
-bal = nobal.round({largestUnit: 'years'}); // balance through round
+bal = nobal.round({ largestUnit: 'year' }); // balance through round
 console.log(`${bal}`, bal.seconds, bal.milliseconds); // => 'PT3.5S 3 500'
 
 d = Temporal.Duration.from('PT59.999999999S');
-d.toString({ smallestUnit: 'seconds' });   // => PT59S
+d.toString({ smallestUnit: 'second' }); // => PT59S
 d.toString({ fractionalSecondDigits: 0 }); // => PT59S
 d.toString({ fractionalSecondDigits: 4 }); // => PT59.9999S
 d.toString({ fractionalSecondDigits: 8, roundingMode: 'halfExpand' });
@@ -671,6 +671,7 @@ The `locales` and `options` arguments are the same as in the constructor to [`In
 > **NOTE**: This method requires that your JavaScript environment supports `Intl.DurationFormat`.
 > That is still an early-stage proposal and at the time of writing it is not supported anywhere.
 > If `Intl.DurationFormat` is not available, then the output of this method is the same as that of `duration.toString()`, and the `locales` and `options` arguments are ignored.
+
 Usage examples:
 
 ```javascript

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -356,11 +356,11 @@ Temporal.now.instant().subtract(oneHour);
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'auto'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
     Valid values are the same as for `largestUnit`.
-    The default is `'nanoseconds'`, i.e., no rounding.
+    The default is `'nanosecond'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -378,7 +378,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`, for example.
 However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `"hours"`.
-A value of `'auto'` means `'seconds'`, unless `smallestUnit` is `'hours'` or `'minutes'`, in which case `largestUnit` is equal to `smallestUnit`.
+A value of `'auto'` means `'second'`, unless `smallestUnit` is `'hour'` or `'minute'`, in which case `largestUnit` is equal to `smallestUnit`.
 
 By default, the largest unit in the result is seconds.
 Weeks, months, years, and days are not allowed, unlike the difference methods of the other Temporal types.
@@ -403,15 +403,15 @@ Example usage:
 ```js
 startOfMoonMission = Temporal.Instant.from('1969-07-16T13:32:00Z');
 endOfMoonMission = Temporal.Instant.from('1969-07-24T16:50:35Z');
-missionLength = startOfMoonMission.until(endOfMoonMission, { largestUnit: 'hours' });
+missionLength = startOfMoonMission.until(endOfMoonMission, { largestUnit: 'hour' });
   // => PT195H18M35S
 missionLength.toLocaleString();
   // example output: '195 hours 18 minutes 35 seconds'
 
 // Rounding, for example if you don't care about the minutes and seconds
 approxMissionLength = startOfMoonMission.until(endOfMoonMission, {
-  largestUnit: 'hours',
-  smallestUnit: 'hours'
+  largestUnit: 'hour',
+  smallestUnit: 'hour'
 });
   // => PT195H
 
@@ -420,9 +420,9 @@ epoch = Temporal.Instant.fromEpochSeconds(0);
 billion = Temporal.Instant.fromEpochSeconds(1e9);
 epoch.until(billion);
   // => PT1000000000S
-epoch.until(billion, { largestUnit: 'hours' });
+epoch.until(billion, { largestUnit: 'hour' });
   // => PT277777H46M40S
-ns = epoch.until(billion, { largestUnit: 'nanoseconds' });
+ns = epoch.until(billion, { largestUnit: 'nanosecond' });
   // => PT1000000000S
 ns.add({ nanoseconds: 1 });
   // => PT1000000000S
@@ -432,7 +432,7 @@ ns.add({ nanoseconds: 1 });
 // explicitly using the corresponding calendar date in UTC:
 epoch.toZonedDateTimeISO('UTC').until(
   billion.toZonedDateTimeISO('UTC'),
-  { largestUnit: 'years' }
+  { largestUnit: 'year' }
 );
   // => P31Y8M8DT1H46M40S
 ```
@@ -446,11 +446,11 @@ epoch.toZonedDateTimeISO('UTC').until(
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'auto'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
     Valid values are the same as for `largestUnit`.
-    The default is `'nanoseconds'`, i.e., no rounding.
+    The default is `'nanosecond'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.

--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -86,6 +86,7 @@ Additionally, if the result is earlier or later than the range of dates that `Te
 
 Example usage:
 
+<!-- prettier-ignore-start -->
 ```javascript
 date = Temporal.PlainDate.from('2006-08-24'); // => 2006-08-24
 date = Temporal.PlainDate.from('2006-08-24T15:43:27'); // => 2006-08-24
@@ -94,7 +95,7 @@ date = Temporal.PlainDate.from('2006-08-24T15:43:27+01:00[Europe/Brussels]');
   // => 2006-08-24
 date === Temporal.PlainDate.from(date); // => false
 
-date = Temporal.PlainDate.from({year: 2006, month: 8, day: 24}); // => 2006-08-24
+date = Temporal.PlainDate.from({ year: 2006, month: 8, day: 24 }); // => 2006-08-24
 date = Temporal.PlainDate.from(Temporal.PlainDateTime.from('2006-08-24T15:43:27'));
   // => 2006-08-24
   // same as above; Temporal.PlainDateTime has year, month, and day properties
@@ -102,19 +103,19 @@ date = Temporal.PlainDate.from(Temporal.PlainDateTime.from('2006-08-24T15:43:27'
 calendar = Temporal.Calendar.from('islamic');
 date = Temporal.PlainDate.from({ year: 1427, month: 8, day: 1, calendar }); // => 2006-08-24[u-ca=islamic]
 date = Temporal.PlainDate.from({ year: 1427, month: 8, day: 1, calendar: 'islamic' });
-  // => 2006-08-24[u-ca=islamic]
-  // same as above
+  // => 2006-08-24[u-ca=islamic] (same as above)
 
 // Different overflow modes
-date = Temporal.PlainDate.from({ year: 2001, month: 13, day: 1 }, { overflow: 'constrain' })
+date = Temporal.PlainDate.from({ year: 2001, month: 13, day: 1 }, { overflow: 'constrain' });
   // => 2001-12-01
-date = Temporal.PlainDate.from({ year: 2001, month: 1, day: 32 }, { overflow: 'constrain' })
+date = Temporal.PlainDate.from({ year: 2001, month: 1, day: 32 }, { overflow: 'constrain' });
   // => 2001-01-31
-date = Temporal.PlainDate.from({ year: 2001, month: 13, day: 1 }, { overflow: 'reject' })
+date = Temporal.PlainDate.from({ year: 2001, month: 13, day: 1 }, { overflow: 'reject' });
   // => throws
-date = Temporal.PlainDate.from({ year: 2001, month: 1, day: 32 }, { overflow: 'reject' })
+date = Temporal.PlainDate.from({ year: 2001, month: 1, day: 32 }, { overflow: 'reject' });
   // => throws
 ```
+<!-- prettier-ignore-end -->
 
 ### Temporal.PlainDate.**compare**(_one_: Temporal.PlainDate | object | string, _two_: Temporal.PlainDate | object | string) : number
 
@@ -478,11 +479,11 @@ date.subtract({ months: 1 }, { overflow: 'reject' }); // => throws
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, and `'days'`.
+    Valid values are `'auto'`, `'year'`, `'month'`, `'week'`, and `'day'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`.
-    The default is `'days'`, i.e., no rounding.
+    Valid values are `'year'`, `'month'`, `'week'`, `'day'`.
+    The default is `'day'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -501,7 +502,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two years will become 24 months when `largestUnit` is `"months"`, for example.
 However, a difference of two months will still be two months even if `largestUnit` is `"years"`.
-A value of `'auto'` means `'days'`, unless `smallestUnit` is `'years'`, `'months'`, or `'weeks'`, in which case `largestUnit` is equal to `smallestUnit`.
+A value of `'auto'` means `'day'`, unless `smallestUnit` is `'year'`, `'month'`, or `'week'`, in which case `largestUnit` is equal to `smallestUnit`.
 
 By default, the largest unit in the result is days.
 This is because months and years can be different lengths depending on which month is meant and whether the year is a leap year.
@@ -523,15 +524,15 @@ Usage example:
 earlier = Temporal.PlainDate.from('2006-08-24');
 later = Temporal.PlainDate.from('2019-01-31');
 earlier.until(later);                           // => P4543D
-earlier.until(later, { largestUnit: 'years' }); // => P12Y5M7D
-later.until(earlier, { largestUnit: 'years' }); // => -P12Y5M7D
+earlier.until(later, { largestUnit: 'year' }); // => P12Y5M7D
+later.until(earlier, { largestUnit: 'year' }); // => -P12Y5M7D
 
 // If you really need to calculate the difference between two Dates in
 // hours, you can eliminate the ambiguity by explicitly choosing the
 // point in time from which you want to reckon the difference. For
 // example, using noon:
 noon = Temporal.PlainTime.from('12:00');
-earlier.toPlainDateTime(noon).until(later.toPlainDateTime(noon), { largestUnit: 'hours' });
+earlier.toPlainDateTime(noon).until(later.toPlainDateTime(noon), { largestUnit: 'hour' });
   // => PT109032H
 ```
 <!-- prettier-ignore-end -->
@@ -544,11 +545,11 @@ earlier.toPlainDateTime(noon).until(later.toPlainDateTime(noon), { largestUnit: 
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (optional string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, and `'days'`.
+    Valid values are `'auto'`, `'year'`, `'month'`, `'week'`, and `'day'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`.
-    The default is `'days'`, i.e., no rounding.
+    Valid values are `'year'`, `'month'`, `'week'`, `'day'`.
+    The default is `'day'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -562,7 +563,7 @@ If `other` is later than `date` then the resulting duration will be negative.
 
 This method is similar to `Temporal.PlainDate.prototype.until()`, but reversed.
 The returned `Temporal.Duration`, when subtracted from `date` using the same `options`, will yield `other`.
-Using default options, `date1.since(date2)` yields the same result as `date1.until(date2).negated()`, but results may differ with options like `{ largestUnit: 'months' }`.
+Using default options, `date1.since(date2)` yields the same result as `date1.until(date2).negated()`, but results may differ with options like `{ largestUnit: 'month' }`.
 
 Usage example:
 

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -643,11 +643,11 @@ dt.subtract({ months: 1 }, { overflow: 'reject' }); // => throws
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'auto'`, `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `'nanoseconds'`, i.e., no rounding.
+    Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    The default is `'nanosecond'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -666,7 +666,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`, for example.
 However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `"hours"`.
-A value of `'auto'` means `'days'`, unless `smallestUnit` is `'years'`, `'months'`, or `'weeks'`, in which case `largestUnit` is equal to `smallestUnit`.
+A value of `'auto'` means `'day'`, unless `smallestUnit` is `'year'`, `'month'`, or `'week'`, in which case `largestUnit` is equal to `smallestUnit`.
 
 By default, the largest unit in the result is days.
 This is because months and years can be different lengths depending on which month is meant and whether the year is a leap year.
@@ -691,25 +691,25 @@ dt1 = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt2 = Temporal.PlainDateTime.from('2019-01-31T15:30');
 dt1.until(dt2);
   // => P8456DT12H5M29.9999965S
-dt1.until(dt2, { largestUnit: 'years' });
+dt1.until(dt2, { largestUnit: 'year' });
   // => P23Y1M24DT12H5M29.9999965S
-dt2.until(dt1, { largestUnit: 'years' });
+dt2.until(dt1, { largestUnit: 'year' });
   // => -P23Y1M24DT12H5M29.9999965S
-dt1.until(dt2, { largestUnit: 'nanoseconds' });
+dt1.until(dt2, { largestUnit: 'nanosecond' });
   // => PT730641929.999996544S
   // (precision lost)
 
 // Rounding, for example if you don't care about sub-seconds
-dt1.until(dt2, { smallestUnit: 'seconds' });
+dt1.until(dt2, { smallestUnit: 'second' });
   // => P8456DT12H5M29S
 
 // Months and years can be different lengths
 let [jan1, feb1, mar1] = [1, 2, 3].map((month) =>
   Temporal.PlainDateTime.from({ year: 2020, month, day: 1 }));
 jan1.until(feb1);                            // => P31D
-jan1.until(feb1, { largestUnit: 'months' }); // => P1M
+jan1.until(feb1, { largestUnit: 'month' }); // => P1M
 feb1.until(mar1);                            // => P29D
-feb1.until(mar1, { largestUnit: 'months' }); // => P1M
+feb1.until(mar1, { largestUnit: 'month' }); // => P1M
 jan1.until(mar1);                            // => P60D
 ```
 <!-- prettier-ignore-end -->
@@ -722,11 +722,11 @@ jan1.until(mar1);                            // => P60D
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'auto'`, `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `'nanoseconds'`, i.e., no rounding.
+    Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    The default is `'nanosecond'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -740,7 +740,7 @@ If `other` is later than `datetime` then the resulting duration will be negative
 
 This method is similar to `Temporal.PlainDateTime.prototype.until()`, but reversed.
 The returned `Temporal.Duration`, when subtracted from `datetime` using the same `options`, will yield `other`.
-Using default options, `dt1.since(dt2)` yields the same result as `dt1.until(dt2).negated()`, but results may differ with options like `{ largestUnit: 'months' }`.
+Using default options, `dt1.since(dt2)` yields the same result as `dt1.until(dt2).negated()`, but results may differ with options like `{ largestUnit: 'month' }`.
 
 Usage example:
 
@@ -776,7 +776,7 @@ The `roundingIncrement` option allows rounding to an integer number of units.
 For example, to round to increments of a half hour, use `smallestUnit: 'minute', roundingIncrement: 30`.
 
 The value given as `roundingIncrement` must divide evenly into the next highest unit after `smallestUnit`, and must not be equal to it.
-(For example, if `smallestUnit` is `'minutes'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
+(For example, if `smallestUnit` is `'minute'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
 The valid values in this case are 1 (default), 2, 3, 4, 5, 6, 10, 12, 15, 20, and 30.
 Instead of 60 minutes, use 1 hour.)
 

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -267,11 +267,11 @@ time.subtract({ minutes: 5, nanoseconds: 800 }); // => 19:34:09.068345405
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'auto'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `'nanoseconds'`, i.e., no rounding.
+    Valid values are `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    The default is `'nanosecond'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -288,9 +288,9 @@ If `other` is not a `Temporal.PlainTime` object, then it will be converted to on
 
 The `largestUnit` parameter controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
-A difference of two hours will become 7200 seconds when `largestUnit` is `'seconds'`, for example.
-However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `'hours'`.
-A value of `'auto'` means `'hours'`.
+A difference of two hours will become 7200 seconds when `largestUnit` is `'second'`, for example.
+However, a difference of 30 seconds will still be 30 seconds even if `largestUnit` is `'hour'`.
+A value of `'auto'` means `'hour'`.
 
 You can round the result using the `smallestUnit`, `roundingIncrement`, and `roundingMode` options.
 These behave as in the `Temporal.Duration.round()` method.
@@ -308,7 +308,7 @@ time.until(Temporal.PlainTime.from('22:39:09.068346205')); // => PT2H25M48.09694
 time.until(Temporal.PlainTime.from('19:39:09.068346205')); // => -PT34M11.903051894S
 
 // Rounding, for example if you don't care about sub-seconds
-time.until(Temporal.PlainTime.from('22:39:09.068346205'), { smallestUnit: 'seconds' });
+time.until(Temporal.PlainTime.from('22:39:09.068346205'), { smallestUnit: 'second' });
   // => PT2H25M48S
 ```
 <!-- prettier-ignore-end -->
@@ -321,11 +321,11 @@ time.until(Temporal.PlainTime.from('22:39:09.068346205'), { smallestUnit: 'secon
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'auto'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `'nanoseconds'`, i.e., no rounding.
+    Valid values are `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    The default is `'nanosecond'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -375,7 +375,7 @@ The `roundingIncrement` option allows rounding to an integer number of units.
 For example, to round to increments of a half hour, use `smallestUnit: 'minute', roundingIncrement: 30`.
 
 The value given as `roundingIncrement` must divide evenly into the next highest unit after `smallestUnit`, and must not be equal to it.
-(For example, if `smallestUnit` is `'minutes'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
+(For example, if `smallestUnit` is `'minute'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
 The valid values in this case are 1 (default), 2, 3, 4, 5, 6, 10, 12, 15, 20, and 30.
 Instead of 60 minutes, use 1 hour.)
 

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -383,11 +383,11 @@ ym.subtract({ years: 20, months: 4 }); // => 1999-02
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'` and `'months'`.
+    Valid values are `'auto'`, `'year'` and `'month'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'years'` and `'months'`.
-    The default is `'months'`, i.e., no rounding.
+    Valid values are `'year'` and `'month'`.
+    The default is `'month'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -406,7 +406,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 A difference of one year and two months will become 14 months when `largestUnit` is `"months"`, for example.
 However, a difference of one month will still be one month even if `largestUnit` is `"years"`.
-A value of `'auto'` means `'years'`.
+A value of `'auto'` means `'year'`.
 
 You can round the result using the `smallestUnit`, `roundingIncrement`, and `roundingMode` options.
 These behave as in the `Temporal.Duration.round()` method, but increments of months and larger are allowed.
@@ -424,15 +424,15 @@ Usage example:
 ym = Temporal.PlainYearMonth.from('2006-08');
 other = Temporal.PlainYearMonth.from('2019-06');
 ym.until(other);                            // => P12Y10M
-ym.until(other, { largestUnit: 'months' }); // => P154M
-other.until(ym, { largestUnit: 'months' }); // => -P154M
+ym.until(other, { largestUnit: 'month' }); // => P154M
+other.until(ym, { largestUnit: 'month' }); // => -P154M
 
 // If you really need to calculate the difference between two YearMonths
 // in days, you can eliminate the ambiguity by explicitly choosing the
 // day of the month (and if applicable, the time of that day) from which
 // you want to reckon the difference. For example, using the first of
 // the month to calculate a number of days:
-ym.toPlainDate({ day: 1 }).until(other.toPlainDate({ day: 1 }), { largestUnit: 'days' }); // => P4687D
+ym.toPlainDate({ day: 1 }).until(other.toPlainDate({ day: 1 }), { largestUnit: 'day' }); // => P4687D
 ```
 <!-- prettier-ignore-end -->
 
@@ -444,11 +444,11 @@ ym.toPlainDate({ day: 1 }).until(other.toPlainDate({ day: 1 }), { largestUnit: '
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'` and `'months'`.
+    Valid values are `'auto'`, `'year'` and `'month'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'years'` and `'months'`.
-    The default is `'months'`, i.e., no rounding.
+    Valid values are `'year'` and `'month'`.
+    The default is `'month'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -462,7 +462,7 @@ If `other` is later than `yearMonth` then the resulting duration will be negativ
 
 This method is similar to `Temporal.PlainYearMonth.prototype.until()`, but reversed.
 The returned `Temporal.Duration`, when subtracted from `yearMonth` using the same `options`, will yield `other`.
-Using default options, `ym1.since(ym2)` yields the same result as `ym1.until(ym2).negated()`, but results may differ with options like `{ largestUnit: 'months' }`.
+Using default options, `ym1.since(ym2)` yields the same result as `ym1.until(ym2).negated()`, but results may differ with options like `{ largestUnit: 'month' }`.
 
 Usage example:
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -926,7 +926,7 @@ zdt = Temporal.ZonedDateTime.from('2020-03-08T00:00-08:00[America/Los_Angeles]')
 laterDay = zdt.add({ days: 1 });
   // => 2020-03-09T00:00:00-07:00[America/Los_Angeles]
   // Note that the new offset is different, indicating the result is adjusted for DST.
-laterDay.since(zdt, { largestUnit: 'hours' }).hours;
+laterDay.since(zdt, { largestUnit: 'hour' }).hours;
   // => 23
   // because one clock hour lost to DST
 
@@ -934,7 +934,7 @@ laterHours = zdt.add({ hours: 24 });
   // => 2020-03-09T01:00:00-07:00[America/Los_Angeles]
   // Adding time units doesn't adjust for DST. Result is 1:00AM: 24 real-world
   // hours later because a clock hour was skipped by DST.
-laterHours.since(zdt, { largestUnit: 'hours' }).hours; // => 24
+laterHours.since(zdt, { largestUnit: 'hour' }).hours; // => 24
 ```
 <!-- prettier-ignore-end -->
 
@@ -991,7 +991,7 @@ zdt = Temporal.ZonedDateTime.from('2020-03-09T00:00-07:00[America/Los_Angeles]')
 earlierDay = zdt.subtract({ days: 1 });
   // => 2020-03-08T00:00:00-08:00[America/Los_Angeles]
   // Note that the new offset is different, indicating the result is adjusted for DST.
-earlierDay.since(zdt, { largestUnit: 'hours' }).hours;
+earlierDay.since(zdt, { largestUnit: 'hour' }).hours;
   // => -23
   // because one clock hour lost to DST
 
@@ -999,7 +999,7 @@ earlierHours = zdt.subtract({ hours: 24 });
   // => 2020-03-07T23:00:00-08:00[America/Los_Angeles]
   // Subtracting time units doesn't adjust for DST. Result is 11:00PM: 24 real-world
   // hours earlier because a clock hour was skipped by DST.
-earlierHours.since(zdt, { largestUnit: 'hours' }).hours; // => -24
+earlierHours.since(zdt, { largestUnit: 'hour' }).hours; // => -24
 ```
 <!-- prettier-ignore-end -->
 
@@ -1010,11 +1010,11 @@ earlierHours.since(zdt, { largestUnit: 'hours' }).hours; // => -24
 - `other` (`Temporal.LocalZonedDateTime`): Another date/time until when to compute the difference.
 - `options` (optional object): An object which may have some or all of the following properties:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'auto'`, `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `'nanoseconds'`, i.e., no rounding.
+    Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    The default is `'nanosecond'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -1031,7 +1031,7 @@ The `largestUnit` option controls how the resulting duration is expressed.
 The returned `Temporal.Duration` object will not have any nonzero fields that are larger than the unit in `largestUnit`.
 For example, a difference of two hours will become 7200 seconds when `largestUnit` is `"seconds"`.
 However, a difference of 30 seconds will still be 30 seconds if `largestUnit` is `"hours"`.
-A value of `'auto'` means `'hours'`, unless `smallestUnit` is `'years'`, `'months'`, `'weeks'`, or `'days'`, in which case `largestUnit` is equal to `smallestUnit`.
+A value of `'auto'` means `'hour'`, unless `smallestUnit` is `'year'`, `'month'`, `'week'`, or `'day'`, in which case `largestUnit` is equal to `smallestUnit`.
 
 You can round the result using the `smallestUnit`, `roundingIncrement`, and `roundingMode` options.
 These behave as in the `Temporal.Duration.round()` method, but increments of days and larger are allowed.
@@ -1050,15 +1050,15 @@ Examples:
 - Difference between 1:45AM on the day before DST starts and the "second" 1:15AM on the day DST ends => `PT24H30M`
   (because it hasn't been a full calendar day even though it's been 24.5 real-world hours).
 
-If `largestUnit` is `'hours'` or smaller, then the result will be the same as if `Temporal.Instant.prototype.until()` was used.
+If `largestUnit` is `'hour'` or smaller, then the result will be the same as if `Temporal.Instant.prototype.until()` was used.
 If both values have the same local time, then the result will be the same as if `Temporal.PlainDateTime.prototype.until()` was used.
 To calculate the difference between calendar dates only, use `.toPlainDate().until(other.toPlainDate())`.
 To calculate the difference between clock times only, use `.toPlainTime().until(other.toPlainTime())`.
 
 If the other `Temporal.ZonedDateTime` is in a different time zone, then the same days can be different lengths in each time zone, e.g. if only one of them observes DST.
-Therefore, a `RangeError` will be thrown if `largestUnit` is `'days'` or larger and the two instances' time zones have different `id` fields.
+Therefore, a `RangeError` will be thrown if `largestUnit` is `'day'` or larger and the two instances' time zones have different `id` fields.
 To work around this limitation, transform one of the instances to the other's time zone using `.withTimeZone(other.timeZone)` and then calculate the same-timezone difference.
-Because of the complexity and ambiguity involved in cross-timezone calculations involving days or larger units, `'hours'` is the default for `largestUnit`.
+Because of the complexity and ambiguity involved in cross-timezone calculations involving days or larger units, `'hour'` is the default for `largestUnit`.
 
 Take care when using milliseconds, microseconds, or nanoseconds as the largest unit.
 For some durations, the resulting value may overflow `Number.MAX_SAFE_INTEGER` and lose precision in its least significant digit(s).
@@ -1075,27 +1075,27 @@ zdt1 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+05:30[Asia/Kol
 zdt2 = Temporal.ZonedDateTime.from('2019-01-31T15:30+05:30[Asia/Kolkata]');
 zdt1.until(zdt2);
   // => PT202956H5M29.9999965S
-zdt1.until(zdt2, { largestUnit: 'years' });
+zdt1.until(zdt2, { largestUnit: 'year' });
   // => P23Y1M24DT12H5M29.9999965S
-zdt2.until(zdt1, { largestUnit: 'years' });
+zdt2.until(zdt1, { largestUnit: 'year' });
   // => -P23Y1M24DT12H5M29.9999965S
-zdt1.until(zdt2, { largestUnit: 'nanoseconds' });
+zdt1.until(zdt2, { largestUnit: 'nanosecond' });
   // => PT730641929.999996544S
   // (precision lost)
 
 // Rounding, for example if you don't care about sub-seconds
-zdt1.until(zdt2, { smallestUnit: 'seconds' });
+zdt1.until(zdt2, { smallestUnit: 'second' });
   // => PT202956H5M29S
 
 // Months and years can be different lengths
 [jan1, feb1, mar1] = [1, 2, 3].map((month) =>
   Temporal.ZonedDateTime.from({ year: 2020, month, day: 1, timeZone: 'Asia/Seoul' })
 );
-jan1.until(feb1, { largestUnit: 'days' }); // => P31D
-jan1.until(feb1, { largestUnit: 'months' }); // => P1M
-feb1.until(mar1, { largestUnit: 'days' }); // => P29D
-feb1.until(mar1, { largestUnit: 'months' }); // => P1M
-jan1.until(mar1, { largestUnit: 'days' }); // => P60D
+jan1.until(feb1, { largestUnit: 'day' }); // => P31D
+jan1.until(feb1, { largestUnit: 'month' }); // => P1M
+feb1.until(mar1, { largestUnit: 'day' }); // => P29D
+feb1.until(mar1, { largestUnit: 'month' }); // => P1M
+jan1.until(mar1, { largestUnit: 'day' }); // => P60D
 ```
 <!-- prettier-ignore-end -->
 
@@ -1106,11 +1106,11 @@ jan1.until(mar1, { largestUnit: 'days' }); // => P60D
 - `other` (`Temporal.LocalZonedDateTime`): Another date/time since when to compute the difference.
 - `options` (optional object): An object which may have some or all of the following properties:
   - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
+    Valid values are `'auto'`, `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
     The default is `'auto'`.
   - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'years'`, `'months'`, `'weeks'`, `'days'`, `'hours'`, `'minutes'`, `'seconds'`, `'milliseconds'`, `'microseconds'`, and `'nanoseconds'`.
-    The default is `'nanoseconds'`, i.e., no rounding.
+    Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    The default is `'nanosecond'`, i.e., no rounding.
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
@@ -1124,7 +1124,7 @@ If `other` is later than `zonedDateTime` then the resulting duration will be neg
 
 This method is similar to `Temporal.ZonedDateTime.prototype.until()`, but reversed.
 The returned `Temporal.Duration`, when subtracted from `zonedDateTime` using the same `options`, will yield `other`.
-Using default options, `zdt1.since(zdt2)` yields the same result as `zdt1.until(zdt2).negated()`, but results may differ with options like `{ largestUnit: 'days' }`.
+Using default options, `zdt1.since(zdt2)` yields the same result as `zdt1.until(zdt2).negated()`, but results may differ with options like `{ largestUnit: 'day' }`.
 
 Usage example:
 
@@ -1159,7 +1159,7 @@ The `roundingIncrement` option allows rounding to an integer number of units.
 For example, to round to increments of a half hour, use `{ smallestUnit: 'minute', roundingIncrement: 30 }`.
 
 The value given as `roundingIncrement` must divide evenly into the next highest unit after `smallestUnit`, and must not be equal to it.
-(For example, if `smallestUnit` is `'minutes'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
+(For example, if `smallestUnit` is `'minute'`, then the number of minutes given by `roundingIncrement` must divide evenly into 60 minutes, which is one hour.
 The valid values in this case are 1 (default), 2, 3, 4, 5, 6, 10, 12, 15, 20, and 30.
 Instead of 60 minutes, use 1 hour.)
 
@@ -1226,8 +1226,7 @@ Example usage:
 ```javascript
 zdt1 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Paris]');
 zdt2 = Temporal.ZonedDateTime.from('1995-12-07T03:24:30.000003500+01:00[Europe/Brussels]');
-zdt1.equals(zdt2); // => false
- // (same offset but different time zones)
+zdt1.equals(zdt2); // => false (same offset but different time zones)
 zdt1.equals(zdt1); // => true
 ```
 


### PR DESCRIPTION
Fixes #1486 to prefer singular names of units in `smallestUnit`/`largestUnit`/`unit` option values. 

Includes a few other minor changes (mostly whitespace) due to running prettier on docs code samples.