### PR TITLE
Add missing parameter in Duration.p.toString

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -516,7 +516,7 @@ export namespace Temporal {
     total(options: DurationTotalOptions): number;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
-    toString(): string;
+    toString(options?: ToStringPrecisionOptions): string;
   }
 
   /**


### PR DESCRIPTION
Pulling this one-line fix out of #1497. 