### PR TITLE
Normative: Use singular unit names throughout

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -299,9 +299,7 @@
       The precision may be an integer 0 through 9 signifying a number of digits after the decimal point in the seconds, the string *"minute"* signifying not to print seconds at all, or the string *"auto"* signifying to drop trailing zeroes after the decimal point.
     </p>
     <emu-alg>
-      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *undefined*).
-      1. If the value of _smallestUnit_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
-        1. Set _smallestUnit_ to the corresponding Singular value of the same row.
+      1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_normalizedOptions_, « *"year"*, *"month"*, *"week"*, *"day"*, *"hour"* », *undefined*).
       1. If _smallestUnit_ is *"minute"*, then
         1. Return the new Record {
             [[Precision]]: *"minute"*,
@@ -367,110 +365,42 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-todurationsecondsstringprecision" aoid="ToDurationSecondsStringPrecision">
-    <h1>ToDurationSecondsStringPrecision ( _normalizedOptions_ )</h1>
-    <p>
-      The abstract operation ToDurationSecondsStringPrecision combines the values of the options `smallestUnit` and `fractionalSecondDigits` to yield a precision for printing seconds to a string, and a rounding unit and increment.
-      The precision may be an integer 0 through 9 signifying a number of digits after the decimal point in the seconds, or the string *"auto"* signifying to drop trailing zeroes after the decimal point.
-    </p>
-    <p>
-      This operation differs from ToSecondsStringPrecision in that it is intended to be used with `Temporal.Duration`.
-      It returns plural unit strings and does not support minutes.
-    </p>
-    <emu-alg>
-      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* », *undefined*).
-      1. If the value of _smallestUnit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
-        1. Set _smallestUnit_ to the corresponding Plural value of the same row.
-      1. If _smallestUnit_ is *"seconds"*, then
-        1. Return the new Record {
-            [[Precision]]: 0,
-            [[Unit]]: *"seconds"*,
-            [[Increment]]: 1
-          }.
-      1. If _smallestUnit_ is *"milliseconds"*, then
-        1. Return the new Record {
-            [[Precision]]: 3,
-            [[Unit]]: *"milliseconds"*,
-            [[Increment]]: 1
-          }.
-      1. If _smallestUnit_ is *"microseconds"*, then
-        1. Return the new Record {
-            [[Precision]]: 6,
-            [[Unit]]: *"microseconds"*,
-            [[Increment]]: 1
-          }.
-      1. If _smallestUnit_ is *"nanoseconds"*, then
-        1. Return the new Record {
-            [[Precision]]: 9,
-            [[Unit]]: *"nanoseconds"*,
-            [[Increment]]: 1
-          }.
-      1. Assert: _smallestUnit_ is *undefined*.
-      1. Let _digits_ be ? GetStringOrNumberOption(_normalizedOptions_, *"fractionalSecondDigits"*, « *"auto"* », 0, 9, *"auto"*).
-      1. If _digits_ is *"auto"*, then
-        1. Return the new Record {
-            [[Precision]]: *"auto"*,
-            [[Unit]]: *"nanoseconds"*,
-            [[Increment]]: 1
-          }.
-      1. If _digits_ is 0, then
-        1. Return the new Record {
-            [[Precision]]: 0,
-            [[Unit]]: *"seconds"*,
-            [[Increment]]: 1
-          }.
-      1. If _digits_ is 1, 2, or 3, then
-        1. Return the new Record {
-            [[Precision]]: _digits_,
-            [[Unit]]: *"milliseconds"*,
-            [[Increment]]: 10<sup>3 − _digits_</sup>
-          }.
-      1. If _digits_ is 4, 5, or 6, then
-        1. Return the new Record {
-            [[Precision]]: _digits_,
-            [[Unit]]: *"microseconds"*,
-            [[Increment]]: 10<sup>6 − _digits_</sup>
-          }.
-      1. Assert: _digits_ is 7, 8, or 9.
-      1. Return the new Record {
-          [[Precision]]: _digits_,
-          [[Unit]]: *"nanoseconds"*,
-          [[Increment]]: 10<sup>9 − _digits_</sup>
-        }.
-    </emu-alg>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-tolargesttemporalunit" aoid="ToLargestTemporalUnit">
-    <h1>ToLargestTemporalUnit ( _normalizedOptions_, _disallowedUnits_, _defaultUnit_ )</h1>
+    <h1>ToLargestTemporalUnit ( _normalizedOptions_, _disallowedUnits_, _fallback_ [ , _autoValue_ ] )</h1>
+    <p>
+      The abstract operation ToLargestTemporalUnit consults the `largestUnit` property of the Object _normalizedOptions_, and checks that it is a valid unit and not one of a List of _disallowedUnits_.
+      It returns a _fallback_ value if the property is not present.
+      Optionally, if an _autoValue_ is provided, then a value of *"auto"* is replaced with this value.
+    </p>
+    <p>
+      Both singular and plural unit names are accepted, but only the singular form is returned.
+    </p>
     <emu-alg>
-      1. Assert: _disallowedUnits_ does not contain _defaultUnit_ or *"auto"*.
-      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, *"string"*, « *"auto"*, *"year"*, *"years"*, *"month"*, *"months"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *"auto"*).
-      1. If _largestUnit_ is *"auto"*, then
-        1. Return _defaultUnit_.
-      1. If the value of _largestUnit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
-        1. Set _largestUnit_ to the corresponding Plural value of the same row.
+      1. Assert: _disallowedUnits_ does not contain _fallback_ or *"auto"*.
+      1. Assert: If _autoValue_ is present, _fallback_ is *"auto"*, and _disallowedUnits_ does not contain _autoValue_.
+      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, *"string"*, « *"auto"*, *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
+      1. If _largestUnit_ is *"auto"* and _autoValue_ is present, then
+        1. Return _autoValue_.
+      1. If the value of _largestUnit_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
+        1. Set _largestUnit_ to the corresponding Singular value of the same row.
       1. If _disallowedUnits_ contains _largestUnit_, then
         1. Throw a *RangeError* exception.
       1. Return _largestUnit_.
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-tolargesttemporaldurationunit" aoid="ToLargestTemporalDurationUnit">
-    <h1>ToLargestTemporalDurationUnit ( _normalizedOptions_ )</h1>
-    <emu-alg>
-      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, *"string"*, « *"auto"*, *"year"*, *"years"*, *"month"*, *"months"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *undefined*).
-      1. If the value of _largestUnit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
-        1. Set _largestUnit_ to the corresponding Plural value of the same row.
-      1. Return _largestUnit_.
-    </emu-alg>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-tosmallesttemporalunit" aoid="ToSmallestTemporalUnit">
-    <h1>ToSmallestTemporalUnit ( _normalizedOptions_, _disallowedUnits_ )</h1>
+    <h1>ToSmallestTemporalUnit ( _normalizedOptions_, _disallowedUnits_, _fallback_ )</h1>
+    <p>
+      The abstract operation ToSmallestTemporalUnit consults the `smallestUnit` property of the Object _normalizedOptions_, and checks that it is a valid unit and not one of a List of _disallowedUnits_.
+      It returns a _fallback_ value if the property is not present.
+    </p>
+    <p>
+      Both singular and plural unit names are accepted, but only the singular form is returned.
+    </p>
     <emu-alg>
-      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *undefined*).
-      1. If _smallestUnit_ is *undefined*, then
-        1. Throw a *RangeError* exception.
+      1. Assert: _disallowedUnits_ does not contain _fallback_.
+      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
       1. If the value of _smallestUnit_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
         1. Set _smallestUnit_ to the corresponding Singular value of the same row.
       1. If _disallowedUnits_ contains _smallestUnit_, then
@@ -479,24 +409,19 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-tosmallesttemporaldurationunit" aoid="ToSmallestTemporalDurationUnit">
-    <h1>ToSmallestTemporalDurationUnit ( _normalizedOptions_, _disallowedUnits_, _fallback_ )</h1>
-    <emu-alg>
-      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
-      1. If the value of _smallestUnit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
-        1. Set _smallestUnit_ to the corresponding Plural value of the same row.
-      1. If _disallowedUnits_ contains _smallestUnit_, then
-        1. Throw a *RangeError* exception.
-      1. Return _smallestUnit_.
-    </emu-alg>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-totemporaldurationtotalunit" aoid="ToTemporalDurationTotalUnit">
     <h1>ToTemporalDurationTotalUnit ( _normalizedOptions_ )</h1>
+    <p>
+      The abstract operation ToTemporalDurationTotalUnit consults the `unit` property of the Object _normalizedOptions_, and checks that it is a valid unit.
+      It returns *undefined* if the property is not present.
+    </p>
+    <p>
+      Both singular and plural unit names are accepted, but only the singular form is returned.
+    </p>
     <emu-alg>
-      1. Let _unit_ be ? GetOption(_normalizedOptions_, *"unit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *undefined*).
-      1. If the value of _unit_ is in the Singular column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref> ("weeks" has no singular equivalent), then
-        1. Set _unit_ to the corresponding Plural value of the same row.
+      1. Let _unit_ be ? GetOption(_normalizedOptions_, *"unit"*, *"string"*, « *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *undefined*).
+      1. If the value of _unit_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
+        1. Set _unit_ to the corresponding Singular value of the same row.
       1. Return _unit_.
     </emu-alg>
   </emu-clause>
@@ -504,8 +429,8 @@
   <emu-clause id="sec-temporal-singular-and-plural-units">
     <h1>Singular and plural units</h1>
     <p>
-      Where possible, the `smallestUnit` and `largestUnit` options accept both singular and plural forms.
-      As an exception, *"week"* is not accepted, because there is no property named that on any Temporal object.
+      Where possible, the `smallestUnit`, `largestUnit`, and `unit` options accept both singular and plural forms.
+      Only the singular form is used internally.
     </p>
     <emu-table id="table-temporal-singular-and-plural-units">
       <emu-caption>Singular and plural units</emu-caption>
@@ -525,6 +450,11 @@
           <tr>
             <td>*"month"*</td>
             <td>*"months"*</td>
+          </tr>
+
+          <tr>
+            <td>*"week"*</td>
+            <td>*"weeks"*</td>
           </tr>
 
           <tr>
@@ -614,43 +544,43 @@
   <emu-clause id="sec-temporal-validatetemporalunitrange" aoid="ValidateTemporalUnitRange">
     <h1>ValidateTemporalUnitRange ( _largestUnit_, _smallestUnit_ )</h1>
     <emu-alg>
-      1. If _smallestUnit_ is *"years"* and _largestUnit_ is not *"years"*, then
+      1. If _smallestUnit_ is *"year"* and _largestUnit_ is not *"year"*, then
         1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"months"* and _largestUnit_ is not *"years"* or *"months"*, then
+      1. If _smallestUnit_ is *"month"* and _largestUnit_ is not *"year"* or *"month"*, then
         1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"weeks"* and _largestUnit_ is not one of *"years"*, *"months"*, or *"weeks"*, then
+      1. If _smallestUnit_ is *"week"* and _largestUnit_ is not one of *"year"*, *"month"*, or *"week"*, then
         1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"days"* and _largestUnit_ is not one of *"years"*, *"months"*, *"weeks"*, or *"days"*, then
+      1. If _smallestUnit_ is *"day"* and _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
         1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"hours"* and _largestUnit_ is not one of *"years"*, *"months"*, *"weeks"*, *"days"*, or *"hours"*, then
+      1. If _smallestUnit_ is *"hour"* and _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, *"day"*, or *"hour"*, then
         1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"minutes"* and _largestUnit_ is *"seconds"*, *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*, then
+      1. If _smallestUnit_ is *"minute"* and _largestUnit_ is *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*, then
         1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"seconds"* and _largestUnit_ is *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*, then
+      1. If _smallestUnit_ is *"second"* and _largestUnit_ is *"millisecond"*, *"microsecond"*, or *"nanosecond"*, then
         1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"milliseconds"* and _largestUnit_ is *"microseconds"* or *"nanoseconds"*, then
+      1. If _smallestUnit_ is *"millisecond"* and _largestUnit_ is *"microsecond"* or *"nanosecond"*, then
         1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"microseconds"* and _largestUnit_ is *"nanoseconds"*, then
+      1. If _smallestUnit_ is *"microsecond"* and _largestUnit_ is *"nanosecond"*, then
         1. Throw a *RangeError* exception.
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-largeroftwotemporaldurationunits" aoid="LargerOfTwoTemporalDurationUnits">
-    <h1>LargerOfTwoTemporalDurationUnits ( _u1_, _u2_ )</h1>
+  <emu-clause id="sec-temporal-largeroftwotemporalunits" aoid="LargerOfTwoTemporalUnits">
+    <h1>LargerOfTwoTemporalUnits ( _u1_, _u2_ )</h1>
     <p>
-      The abstract operation LargerOfTwoTemporalDurationUnits, given two strings representing the units of a Temporal.Duration, returns the string representing the larger of the two units.
+      The abstract operation LargerOfTwoTemporalUnits, given two strings representing units of time, returns the string representing the larger of the two units.
     </p>
     <emu-alg>
-      1. If either _u1_ or _u2_ is *"years"*, return *"years"*.
-      1. If either _u1_ or _u2_ is *"months"*, return *"months"*.
-      1. If either _u1_ or _u2_ is *"weeks"*, return *"weeks"*.
-      1. If either _u1_ or _u2_ is *"days"*, return *"days"*.
-      1. If either _u1_ or _u2_ is *"hours"*, return *"hours"*.
-      1. If either _u1_ or _u2_ is *"minutes"*, return *"minutes"*.
-      1. If either _u1_ or _u2_ is *"seconds"*, return *"seconds"*.
-      1. If either _u1_ or _u2_ is *"milliseconds"*, return *"milliseconds"*.
-      1. If either _u1_ or _u2_ is *"microseconds"*, return *"microseconds"*.
-      1. Return *"nanoseconds"*.
+      1. If either _u1_ or _u2_ is *"year"*, return *"year"*.
+      1. If either _u1_ or _u2_ is *"month"*, return *"month"*.
+      1. If either _u1_ or _u2_ is *"week"*, return *"week"*.
+      1. If either _u1_ or _u2_ is *"day"*, return *"day"*.
+      1. If either _u1_ or _u2_ is *"hour"*, return *"hour"*.
+      1. If either _u1_ or _u2_ is *"minute"*, return *"minute"*.
+      1. If either _u1_ or _u2_ is *"second"*, return *"second"*.
+      1. If either _u1_ or _u2_ is *"millisecond"*, return *"millisecond"*.
+      1. If either _u1_ or _u2_ is *"microsecond"*, return *"microsecond"*.
+      1. Return *"nanosecond"*.
     </emu-alg>
   </emu-clause>
 
@@ -673,13 +603,13 @@
   <emu-clause id="sec-temporal-maximumtemporaldurationroundingincrement" aoid="MaximumTemporalDurationRoundingIncrement">
     <h1>MaximumTemporalDurationRoundingIncrement ( _unit_ )</h1>
     <emu-alg>
-      1. If _unit_ is *"years"*, *"months"*, *"weeks"*, or *"days"*, then
+      1. If _unit_ is *"year"*, *"month"*, *"week"*, or *"day"*, then
         1. Return *undefined*.
-      1. If _unit_ is *"hours"*, then
+      1. If _unit_ is *"hour"*, then
         1. Return 24.
-      1. Else if _unit_ is *"minutes"* or *"seconds"*, then
+      1. Else if _unit_ is *"minute"* or *"second"*, then
         1. Return 60.
-      1. Assert: _unit_ is one of *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*.
+      1. Assert: _unit_ is one of *"millisecond"*, *"microsecond"*, or *"nanosecond"*.
       1. Return 1000.
     </emu-alg>
   </emu-clause>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -798,7 +798,7 @@
         1. Set _one_ to ? ToTemporalDate(_one_).
         1. Set _two_ to ? ToTemporalDate(_two_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* », *"auto"*, *"day"*).
         1. Let _result_ be ? DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
         1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -94,8 +94,8 @@
         1. Let _shift1_ be ! CalculateOffsetShift(_relativeTo_, _one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], _one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]]).
         1. Let _shift2_ be ! CalculateOffsetShift(_relativeTo_, _two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], _two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]]).
         1. If any of _one_.[[Years]], _two_.[[Years]], _one_.[[Months]], _two_.[[Months]], _one_.[[Weeks]], or _two_.[[Weeks]] are not 0, then
-          1. Let _balanceResult1_ be ? UnbalanceDurationRelative(_one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], *"days"*, _relativeTo_).
-          1. Let _balanceResult2_ be ? UnbalanceDurationRelative(_two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], *"days"*, _relativeTo_).
+          1. Let _balanceResult1_ be ? UnbalanceDurationRelative(_one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], *"day"*, _relativeTo_).
+          1. Let _balanceResult2_ be ? UnbalanceDurationRelative(_two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], *"day"*, _relativeTo_).
           1. Let _days1_ be _balanceResult1_.[[Days]].
           1. Let _days2_ be _balanceResult2_.[[Days]].
         1. Else,
@@ -415,13 +415,13 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnitPresent_ be *true*.
         1. Let _largestUnitPresent_ be *true*.
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « », *undefined*).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *undefined*).
         1. If _smallestUnit_ is *undefined*, then
           1. Set _smallestUnitPresent_ to *false*.
-          1. Set _smallestUnit_ to *"nanoseconds"*.
+          1. Set _smallestUnit_ to *"nanosecond"*.
         1. Let _defaultLargestUnit_ be ! DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
-        1. Set _defaultLargestUnit_ to ! LargerOfTwoTemporalDurationUnits(_defaultLargestUnit_, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalDurationUnit(_options_).
+        1. Set _defaultLargestUnit_ to ! LargerOfTwoTemporalUnits(_defaultLargestUnit_, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *undefined*).
         1. If _largestUnit_ is *undefined*, then
           1. Set _largestUnitPresent_ to *false*.
           1. Set _largestUnit_ to _defaultLargestUnit_.
@@ -465,23 +465,23 @@
           1. Set _intermediate_ to ? MoveRelativeZonedDateTime(_relativeTo_, _unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], 0).
         1. Let _balanceResult_ be ? BalanceDuration(_unbalanceResult_.[[Days]], _unbalanceResult_.[[Hours]], _unbalanceResult_.[[Minutes]], _unbalanceResult_.[[Seconds]], _unbalanceResult_.[[Milliseconds]], _unbalanceResult_.[[Microseconds]], _unbalanceResult_.[[Nanoseconds]], _unit_, _intermediate_).
         1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], 1, _unit_, *"trunc"*, _relativeTo_).
-        1. If _unit_ is *"years"*, then
+        1. If _unit_ is *"year"*, then
           1. Let _whole_ be _roundResult_.[[Years]].
-        1. If _unit_ is *"months"*, then
+        1. If _unit_ is *"month"*, then
           1. Let _whole_ be _roundResult_.[[Months]].
-        1. If _unit_ is *"weeks"*, then
+        1. If _unit_ is *"week"*, then
           1. Let _whole_ be _roundResult_.[[Weeks]].
-        1. If _unit_ is *"days"*, then
+        1. If _unit_ is *"day"*, then
           1. Let _whole_ be _roundResult_.[[Days]].
-        1. If _unit_ is *"hours"*, then
+        1. If _unit_ is *"hour"*, then
           1. Let _whole_ be _roundResult_.[[Hours]].
-        1. If _unit_ is *"minutes"*, then
+        1. If _unit_ is *"minute"*, then
           1. Let _whole_ be _roundResult_.[[Minutes]].
-        1. If _unit_ is *"seconds"*, then
+        1. If _unit_ is *"second"*, then
           1. Let _whole_ be _roundResult_.[[Seconds]].
-        1. If _unit_ is *"milliseconds"*, then
+        1. If _unit_ is *"millisecond"*, then
           1. Let _whole_ be _roundResult_.[[Milliseconds]].
-        1. If _unit_ is *"microseconds"*, then
+        1. If _unit_ is *"microsecond"*, then
           1. Let _whole_ be _roundResult_.[[Microseconds]].
         1. Return _whole_ + _roundResult_.[[Remainder]].
       </emu-alg>
@@ -497,7 +497,8 @@
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _precision_ be ? ToDurationSecondsStringPrecision(_options_).
+        1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
+        1. If _precision_.[[Unit]] is *"minute"*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _result_ be ? RoundDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ! TemporalDurationToString(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _precision_.[[Precision]]).
@@ -746,16 +747,16 @@
         The abstract operation DefaultTemporalLargestUnit implements the logic used in the `Temporal.Duration.prototype.round()` method and elsewhere, where the `largestUnit` option, if not given explicitly, is set to the largest non-zero unit in the input Temporal.Duration.
       </p>
       <emu-alg>
-        1. If _years_ is not zero, return *"years"*.
-        1. If _months_ is not zero, return *"months"*.
-        1. If _weeks_ is not zero, return *"weeks"*.
-        1. If _days_ is not zero, return *"days"*.
-        1. If _hours_ is not zero, return *"hours"*.
-        1. If _minutes_ is not zero, return *"minutes"*.
-        1. If _seconds_ is not zero, return *"seconds"*.
-        1. If _milliseconds_ is not zero, return *"milliseconds"*.
-        1. If _microseconds_ is not zero, return *"microseconds"*.
-        1. Return *"nanoseconds"*.
+        1. If _years_ is not zero, return *"year"*.
+        1. If _months_ is not zero, return *"month"*.
+        1. If _weeks_ is not zero, return *"week"*.
+        1. If _days_ is not zero, return *"day"*.
+        1. If _hours_ is not zero, return *"hour"*.
+        1. If _minutes_ is not zero, return *"minute"*.
+        1. If _seconds_ is not zero, return *"second"*.
+        1. If _milliseconds_ is not zero, return *"millisecond"*.
+        1. If _microseconds_ is not zero, return *"microsecond"*.
+        1. Return *"nanosecond"*.
       </emu-alg>
     </emu-clause>
 
@@ -853,7 +854,7 @@
           1. Set _nanoseconds_ to _endNs_ − _relativeTo_.[[Nanoseconds]].
         1. Else,
           1. Set _nanoseconds_ to ! TotalDurationNanoseconds(_days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, 0).
-        1. If _largestUnit_ is one of *"years"*, *"months"*, *"weeks"*, or *"days"*, then
+        1. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
           1. Set _days_ to _result_.[[Days]].
           1. Set _nanoseconds_ to _result_.[[Nanoseconds]].
@@ -862,7 +863,7 @@
         1. Set _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ to 0.
         1. If _nanoseconds_ &lt; 0, let _sign_ be −1; else, let _sign_ be 1.
         1. Set _nanoseconds_ to abs(_nanoseconds_).
-        1. If _largestUnit_ is *"years"*, *"months"*, *"weeks"*, *"days"*, or *"hours"*, then
+        1. If _largestUnit_ is *"year"*, *"month"*, *"week"*, *"day"*, or *"hour"*, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
           1. Set _milliseconds_ to floor(_microseconds_ / 1000).
@@ -873,7 +874,7 @@
           1. Set _seconds_ to _seconds_ modulo 60.
           1. Set _hours_ to floor(_minutes_ / 60).
           1. Set _minutes_ to _minutes_ modulo 60.
-        1. Else if _largestUnit_ is *"minutes"*, then
+        1. Else if _largestUnit_ is *"minute"*, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
           1. Set _milliseconds_ to floor(_microseconds_ / 1000).
@@ -882,23 +883,23 @@
           1. Set _milliseconds_ to _milliseconds_ modulo 1000.
           1. Set _minutes_ to floor(_seconds_ / 60).
           1. Set _seconds_ to _seconds_ modulo 60.
-        1. Else if _largestUnit_ is *"seconds"*, then
+        1. Else if _largestUnit_ is *"second"*, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
           1. Set _milliseconds_ to floor(_microseconds_ / 1000).
           1. Set _microseconds_ to _microseconds_ modulo 1000.
           1. Set _seconds_ to floor(_milliseconds_ / 1000).
           1. Set _milliseconds_ to _milliseconds_ modulo 1000.
-        1. Else if _largestUnit_ is *"milliseconds"*, then
+        1. Else if _largestUnit_ is *"millisecond"*, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
           1. Set _milliseconds_ to floor(_microseconds_ / 1000).
           1. Set _microseconds_ to _microseconds_ modulo 1000.
-        1. Else if _largestUnit_ is *"microseconds"*, then
+        1. Else if _largestUnit_ is *"microsecond"*, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
         1. Else,
-          1. Assert: _largestUnit_ is *"nanoseconds"*.
+          1. Assert: _largestUnit_ is *"nanosecond"*.
         1. Return the new Record {
           [[Days]]: 𝔽(_days_),
           [[Hours]]: 𝔽(_hours_) × _sign_,
@@ -915,7 +916,7 @@
       <h1>UnbalanceDurationRelative ( _years_, _months_, _weeks_, _days_, _largestUnit_ [ , _relativeTo_ ] )</h1>
       <p>The abstract operation UnbalanceDurationRelative converts the calendar units of a Temporal.Duration into a form where no unit is larger than _largestUnit_.</p>
       <emu-alg>
-        1. If _largestUnit_ is *"years"*, or _years_, _months_, _weeks_, and _days_ are all 0, then
+        1. If _largestUnit_ is *"year"*, or _years_, _months_, _weeks_, and _days_ are all 0, then
           1. Return the new Record {
             [[Years]]: _years_,
             [[Months]]: _months_,
@@ -932,7 +933,7 @@
           1. Let _calendar_ be _relativeTo_.[[Calendar]].
         1. Else,
           1. Let _calendar_ be *undefined*.
-        1. If _largestUnit_ is *"months"*, then
+        1. If _largestUnit_ is *"month"*, then
           1. If _calendar_is *undefined*, then
             1. Throw a *RangeError* exception.
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
@@ -941,13 +942,13 @@
             1. Let _addOptions_ be ! OrdinaryObjectCreate(*null*).
             1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, _addOptions_, _dateAdd_).
             1. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
-            1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"months"*).
+            1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
             1. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
             1. Let _oneYearMonths_ be ? Get(_untilResult_, *"months"*).
             1. Set _relativeTo_ to _newRelativeTo_.
             1. Set _years_ to _years_ − _sign_.
             1. Set _months_ to _months_ + _oneYearMonths_.
-        1. Else if _largestUnit_ is *"weeks"*, then
+        1. Else if _largestUnit_ is *"week"*, then
           1. If _calendar_ is *undefined*, then
             1. Throw a *RangeError* exception.
           1. Repeat, while abs(_years_) &gt; 0,
@@ -997,7 +998,7 @@
       <h1>BalanceDurationRelative ( _years_, _months_, _weeks_, _days_, _largestUnit_, _relativeTo_ )</h1>
       <p>The abstract operation BalanceDurationRelative converts the calendar units of a duration into a form where lower units are converted into higher units as much as possible, up to _largestUnit_.</p>
       <emu-alg>
-        1. If _largestUnit_ is not one of *"years"*, *"months"*, or *"weeks"*, or _years_, _months_, _weeks_, and _days_ are all 0, then
+        1. If _largestUnit_ is not one of *"year"*, *"month"*, or *"week"*, or _years_, _months_, _weeks_, and _days_ are all 0, then
           1. Return the new Record {
             [[Years]]: _years_,
             [[Months]]: _months_,
@@ -1011,7 +1012,7 @@
         1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, _sign_, 0, 0, 0, 0, 0, 0, 0).
         1. Set _relativeTo_ to ? ToTemporalDateTime(_relativeTo_).
         1. Let _calendar_ be _relativeTo_.[[Calendar]].
-        1. If _largestUnit_ is *"years"*, then
+        1. If _largestUnit_ is *"year"*, then
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo, _oneYear_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
@@ -1035,7 +1036,7 @@
           1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, _addOptions_, _dateAdd_).
           1. Let _dateUntil_ be ? GetMethod(_calendar_, *"dateUntil"*).
           1. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"months"*).
+          1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
           1. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
           1. Let _oneYearMonths_ be ? Get(_untilResult_, *"months"*).
           1. Repeat, while abs(_months_) ≥ abs(_oneYearMonths_),
@@ -1045,10 +1046,10 @@
             1. Let _addOptions_ be ! OrdinaryObjectCreate(*null*).
             1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, _addOptions_, _dateAdd_).
             1. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
-            1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"months"*).
+            1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
             1. Set _untilResult_ to ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
             1. Set _oneYearMonths_ to ? Get(_untilResult_, *"months"*).
-        1. Else if _largestUnit_ is *"months"*, then
+        1. Else if _largestUnit_ is *"month"*, then
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo, _oneMonth_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
@@ -1059,7 +1060,7 @@
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
         1. Else,
-          1. Assert: _largestUnit_ is *"weeks"*.
+          1. Assert: _largestUnit_ is *"week"*.
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo, _oneWeek_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneWeekDays_ be _moveResult_.[[Days]].
@@ -1087,9 +1088,9 @@
         1. Assert: _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_ are integer Number values.
         1. Let _largestUnit1_ be ! DefaultTemporalLargestUnit(_y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_).
         1. Let _largestUnit2_ be ! DefaultTemporalLargestUnit(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_).
-        1. Let _largestUnit_ be ! LargerOfTwoTemporalDurationUnits(_largestUnit1_, _largestUnit2_).
+        1. Let _largestUnit_ be ! LargerOfTwoTemporalUnits(_largestUnit1_, _largestUnit2_).
         1. If _relativeTo_ is *undefined*, then
-          1. If _largestUnit_ is one of *"years"*, *"months"*, or *"weeks"*, then
+          1. If _largestUnit_ is one of *"year"*, *"month"*, or *"week"*, then
             1. Throw a *RangeError* exception.
           1. Let _result_ be ! BalanceDuration(_d1_ + _d2_, _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
           1. Let _years_ be 0.
@@ -1112,7 +1113,7 @@
           1. Let _intermediate_ be ? CalendarDateAdd(_calendar_, _datePart_, _dateDuration1_, _firstAddOptions_, _dateAdd_).
           1. Let _secondAddOptions_ be ! OrdinaryObjectCreate(*null*).
           1. Let _end_ be ? CalendarDateAdd(_calendar_, _intermediate_, _dateDuration2_, _secondAddOptions_, _dateAdd_).
-          1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"days"*, _largestUnit_).
+          1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
           1. Let _differenceOptions_ be ! OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_differenceOptions_, *"largestUnit"*, _dateLargestUnit_).
           1. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _datePart_, _end_, _differenceOptions_).
@@ -1133,8 +1134,8 @@
           1. Let _calendar_ be _relativeTo_.[[Calendar]].
           1. Let _intermediateNs_ be ? AddZonedDateTime(_relativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
           1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZone_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
-          1. If _largestUnit_ is not one of *"years"*, *"months"*, *"weeks"*, or *"days"*, then
-            1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanoseconds"*, *"halfExpand"*).
+          1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+            1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, *"halfExpand"*).
             1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _diffNs_, _largestUnit_).
             1. Let _years_ be 0.
             1. Let _months_ be 0.
@@ -1183,7 +1184,7 @@
       </p>
       <emu-alg>
         1. Assert: _earlier_ and _later_ both have [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots.
-        1. Let _difference_ be ? DifferenceISODate(_earlier_.[[ISOYear]], _earlier_.[[ISOMonth]], _earlier_.[[ISODay]], _later_.[[ISOYear]], _later_.[[ISOMonth]], _later_.[[ISODay]], *"days"*).
+        1. Let _difference_ be ? DifferenceISODate(_earlier_.[[ISOYear]], _earlier_.[[ISOMonth]], _earlier_.[[ISODay]], _later_.[[ISOYear]], _later_.[[ISOMonth]], _later_.[[ISODay]], *"day"*).
         1. Return _difference_.[[Days]].
       </emu-alg>
     </emu-clause>
@@ -1221,7 +1222,7 @@
       <h1>RoundDuration ( _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _increment_, _unit_, _roundingMode_ [ , _relativeTo_ ] )</h1>
       <emu-alg>
         1. Let _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, and _increment_ each be the mathematical values of themselves.
-        1. If _unit_ is *"years"*, *"months"*, or *"weeks"*, and _relativeTo_ is *undefined*, then
+        1. If _unit_ is *"year"*, *"month"*, or *"week"*, and _relativeTo_ is *undefined*, then
           1. Throw a *RangeError* exception.
         1. Let _zonedRelativeTo_ be *undefined*.
         1. If _relativeTo_ is not *undefined*, then
@@ -1232,7 +1233,7 @@
           1. Else,
             1. Perform ? RequireInternalSlot(_relativeTo_, [[InitializedTemporalDateTime]]).
           1. Let _calendar_ be _relativeTo_.[[Calendar]].
-        1. If _unit_ is one of *"years"*, *"months"*, *"weeks"*, or *"days"*, then
+        1. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _nanoseconds_ be ! TotalDurationNanoseconds(0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, 0).
           1. Let _intermediate_ be *undefined*.
           1. If _zonedRelativeTo_ is not *undefined*, then
@@ -1243,7 +1244,7 @@
         1. Else,
           1. Let _fractionalSeconds_ be _nanoseconds_ × 10<sup>−9</sup> + _microseconds_ × 10<sup>−6</sup> + _milliseconds_ × 10<sup>−3</sup> + _seconds_.
         1. Let _remainder_ be *undefined*.
-        1. If _unit_ is *"years"*, then
+        1. If _unit_ is *"year"*, then
           1. Let _yearsDuration_ be ? CreateTemporalDuration(_years_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
           1. Let _firstAddOptions_ be ! OrdinaryObjectCreate(*null*).
@@ -1258,7 +1259,7 @@
           1. Let _thirdAddOptions_ be ! OrdinaryObjectCreate(*null*).
           1. Let _daysLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _daysDuration_, _thirdAddOptions_, _dateAdd_).
           1. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"years"*).
+          1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"year"*).
           1. Let _timePassed_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _daysLater_, _untilOptions_).
           1. Let _yearsPassed_ be _timePassed_.[[Years]].
           1. Set _years_ to _years_ + _yearsPassed_.
@@ -1277,7 +1278,7 @@
           1. Set _years_ to ? RoundNumberToIncrement(_fractionalYears_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalYears_ - _years_.
           1. Set _months_, _weeks_, and _days_ to 0.
-        1. Else if _unit_ is *"months"*, then
+        1. Else if _unit_ is *"month"*, then
           1. Let _yearsMonths_ be ? CreateTemporalDuration(_years_, _months_, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
           1. Let _firstAddOptions_ be ! OrdinaryObjectCreate(*null*).
@@ -1304,7 +1305,7 @@
           1. Set _months_ to ? RoundNumberToIncrement(_fractionalMonths_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalMonths_ - _months_.
           1. Set _weeks_ and _days_ to 0.
-        1. Else if _unit_ is *"weeks"*, then
+        1. Else if _unit_ is *"week"*, then
           1. Let _sign_ be ! Sign(_days_).
           1. If _sign_ is 0, set _sign_ to 1.
           1. Let _oneWeek_ be ? CreateTemporalDuration(0, 0, _sign_, 0, 0, 0, 0, 0, 0, 0).
@@ -1321,36 +1322,36 @@
           1. Set _weeks_ to ? RoundNumberToIncrement(_fractionalWeeks_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalWeeks_ - _weeks_.
           1. Set _days_ to 0.
-        1. Else if _unit_ is *"days"*, then
+        1. Else if _unit_ is *"day"*, then
           1. Let _fractionalDays_ be _days_.
           1. Set _days_ to ? RoundNumberToIncrement(_days_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalDays_ - _days_.
-        1. Else if _unit_ is *"hours"*, then
+        1. Else if _unit_ is *"hour"*, then
           1. Let _fractionalHours_ be (_fractionalSeconds_ / 60 + _minutes_) / 60 + _hours_.
           1. Set _hours_ to ? RoundNumberToIncrement(_fractionalHours_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalHours_ - _hours_.
           1. Set _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
-        1. Else if _unit_ is *"minutes"*, then
+        1. Else if _unit_ is *"minute"*, then
           1. Let _fractionalMinutes_ be _fractionalSeconds_ / 60 + _minutes_.
           1. Set _minutes_ to ? RoundNumberToIncrement(_fractionalMinutes_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalMinutes_ - _minutes_.
           1. Set _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
-        1. Else if _unit_ is *"seconds"*, then
+        1. Else if _unit_ is *"second"*, then
           1. Set _seconds_ to ? RoundNumberToIncrement(_fractionalSeconds_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalSeconds_ - _seconds_.
           1. Set _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
-        1. Else if _unit_ is *"milliseconds"*, then
+        1. Else if _unit_ is *"millisecond"*, then
           1. Let _fractionalMilliseconds_ be _nanoseconds_ × 10<sup>−6</sup> + _microseconds_ × 10<sup>−3</sup> + _milliseconds_.
           1. Set _milliseconds_ to ? RoundNumberToIncrement(_fractionalMilliseconds_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalMilliseconds_ - _milliseconds_.
           1. Set _microseconds_ and _nanoseconds_ to 0.
-        1. Else if _unit_ is *"microseconds"*, then
+        1. Else if _unit_ is *"microsecond"*, then
           1. Let _fractionalMicroseconds_ be _nanoseconds_ × 10<sup>−3</sup> + _microseconds_.
           1. Set _microseconds_ to ? RoundNumberToIncrement(_fractionalMicroseconds_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalMicroseconds_ - _microseconds_.
           1. Set _nanoseconds_ to 0.
         1. Else,
-          1. Assert: _unit_ is *"nanoseconds"*.
+          1. Assert: _unit_ is *"nanosecond"*.
           1. Set _remainder_ to _nanoseconds_.
           1. Set _nanoseconds_ to ? RoundNumberToIncrement(_nanoseconds_, _increment_, _roundingMode_).
           1. Set _remainder_ to _remainder_ − _nanoseconds_.
@@ -1378,7 +1379,7 @@
         In this case, the days part of the duration is adjusted by one, and the time part is re-rounded.
       </p>
       <emu-alg>
-        1. If _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot; or _unit_ is one of *"years"*, *"months"*, *"weeks"*, or *"days"*; or _unit_ is *"nanoseconds"* and _increment_ is 1, then
+        1. If _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot; or _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*; or _unit_ is *"nanosecond"* and _increment_ is 1, then
           1. Return the new Record {
             [[Years]]: _years_,
             [[Months]]: _months_,
@@ -1411,7 +1412,7 @@
             }.
         1. Set _timeRemainderNs_ to ? RoundTemporalInstant(_timeRemainderNs_ − _dayLengthNs_, _increment_, _unit_, _roundingMode_).
         1. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, _relativeTo_).
-        1. Let _adjustedTimeDuration_ be ? BalanceDuration(0, 0, 0, 0, 0, 0, _timeRemainderNs_, *"hours"*).
+        1. Let _adjustedTimeDuration_ be ? BalanceDuration(0, 0, 0, 0, 0, 0, _timeRemainderNs_, *"hour"*).
         1. Return the new Record {
           [[Years]]: _adjustedDateDuration_.[[Years]],
           [[Months]]: _adjustedDateDuration_.[[Months]],

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -253,9 +253,9 @@
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _other_ to ? ToTemporalInstant(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"seconds"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », _defaultLargestUnit_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
@@ -277,9 +277,9 @@
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _other_ to ? ToTemporalInstant(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"seconds"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », _defaultLargestUnit_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
@@ -300,7 +300,8 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"* »).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
+        1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
           1. Let _maximum_ be 24.
@@ -578,18 +579,18 @@
         The abstract operation DifferenceInstant computes the difference between two exact times expressed in nanoseconds since the Unix epoch, and rounds the result according to the given parameters.
       </p>
       <emu-alg>
-        1. If _smallestUnit_ is *"hours"*, then
+        1. If _smallestUnit_ is *"hour"*, then
           1. Let _incrementNs_ be _roundingIncrement_ × 3.6 × 10<sup>12</sup>.
-        1. If _smallestUnit_ is *"minutes"*, then
+        1. If _smallestUnit_ is *"minute"*, then
           1. Let _incrementNs_ be _roundingIncrement_ × 6 × 10<sup>10</sup>.
-        1. Else if _smallestUnit_ is *"seconds"*, then
+        1. Else if _smallestUnit_ is *"second"*, then
           1. Let _incrementNs_ be _roundingIncrement_ × 10<sup>9</sup>.
-        1. Else if _smallestUnit_ is *"milliseconds"*, then
+        1. Else if _smallestUnit_ is *"millisecond"*, then
           1. Let _incrementNs_ be _roundingIncrement_ × 10<sup>6</sup>.
-        1. Else if _smallestUnit_ is *"microseconds"*, then
+        1. Else if _smallestUnit_ is *"microsecond"*, then
           1. Let _incrementNs_ be _roundingIncrement_ × 10<sup>3</sup>.
         1. Else,
-          1. Assert: _smallestUnit_ is *"nanoseconds"*.
+          1. Assert: _smallestUnit_ is *"nanosecond"*.
           1. Let _incrementNs_ be _roundingIncrement_.
         1. Let _diff_ be _ns2_ − _ns1_.
         1. Return ? RoundNumberToIncrement(_diff_, _incrementNs_, _roundingMode_).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1334,7 +1334,7 @@
             1. Set _one_ to ? ToTemporalDate(_one_).
             1. Set _two_ to ? ToTemporalDate(_two_).
             1. Set _options_ to ? GetOptionsObject(_options_).
-            1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* », *"days"*).
+            1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* », *"auto"*, *"day"*).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ? DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
             1. Else,

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -338,7 +338,7 @@
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
+        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
         1. Let _balancedDuration_ be ? CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Return ? CalendarDateAdd(_temporalDate_.[[Calendar]], _temporalDate_, _balancedDuration_, _options_).
@@ -356,7 +356,7 @@
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
+        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _negatedDuration_ be ? CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Return ? CalendarDateAdd(_temporalDate_.[[Calendar]], _temporalDate_, _negatedDuration_, _options_).
@@ -418,14 +418,15 @@
         1. Set _other_ to ? ToTemporalDate(_other_).
         1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, _disallowedUnits_, *"days"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"days"*).
+        1. Let _disallowedUnits_ be « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"day"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"day"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
-        1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _options_).
-        1. If _smallestUnit_ is not *"days"* or _roundingIncrement_ ≠ 1, then
+        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+        1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
+        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ ≠ 1, then
           1. Let _relativeTo_ be ! CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], 0, 0, 0, 0, 0, 0, _temporalDate_.[[Calendar]]).
           1. Set _result_ to ? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
         1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
@@ -444,15 +445,16 @@
         1. Set _other_ to ? ToTemporalDate(_other_).
         1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, _disallowedUnits_, *"days"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"days"*).
+        1. Let _disallowedUnits_ be « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"day"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"day"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
-        1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _other_, _temporalDate_, _options_).
-        1. If _smallestUnit_ is *"days"* and _roundingIncrement_ = 1, then
+        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+        1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _other_, _temporalDate_, _untilOptions_).
+        1. If _smallestUnit_ is *"day"* and _roundingIncrement_ = 1, then
           1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _relativeTo_ be ! CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], 0, 0, 0, 0, 0, 0, _temporalDate_.[[Calendar]]).
         1. Set _result_ to ? RoundDuration(−_result_.[[Years]], −_result_.[[Months]], −_result_.[[Weeks]], −_result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
@@ -699,8 +701,8 @@
     <emu-clause id="sec-temporal-differenceisodate" aoid="DifferenceISODate">
       <h1>DifferenceISODate ( _y1_, _m1_, _d1_, _y2_, _m2_, _d2_, _largestUnit_ )</h1>
       <emu-alg>
-        1. Assert: _largestUnit_ is one of *"years"*, *"months"*, *"weeks"*, or *"days"*.
-        1. If _largestUnit_ is *"years"* or *"months"*, then
+        1. Assert: _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*.
+        1. If _largestUnit_ is *"year"* or *"month"*, then
           1. Let _sign_ be -(! CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_)).
           1. If _sign_ is 0, return the new Record { [[Years]]: 0, [[Months]]: 0, [[Weeks]]: 0, [[Days]]: 0 }.
           1. Let _start_ be the new Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
@@ -709,7 +711,7 @@
           1. Let _mid_ be ? AddISODate(_y1_, _m1_, _d1_, _years_, 0, 0, *"constrain"*).
           1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
-            1. If _largestUnit_ is *"years"*, return the new Record { [[Years]]: _years_, [[Months]]: 0, [[Weeks]]: 0, [[Days]]: 0 }.
+            1. If _largestUnit_ is *"year"*, return the new Record { [[Years]]: _years_, [[Months]]: 0, [[Weeks]]: 0, [[Days]]: 0 }.
             1. Else, return the new Record { [[Years]]: 0, [[Months]]: _years_ × 12, [[Weeks]]: 0, [[Days]]: 0 }.
           1. Let _months_ be _end_.[[Month]] − _start_.[[Month]].
           1. If _midSign_ is not equal to _sign_, then
@@ -718,7 +720,7 @@
           1. Set _mid_ be ? AddISODate(_y1_, _m1_, _d1_, _years_, _months_, 0, *"constrain"*).
           1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
-            1. If _largestUnit_ is *"years"*, return the new Record { [[Years]]: _years_, [[Months]]: _months_, [[Weeks]]: 0, [[Days]]: 0 }.
+            1. If _largestUnit_ is *"year"*, return the new Record { [[Years]]: _years_, [[Months]]: _months_, [[Weeks]]: 0, [[Days]]: 0 }.
             1. Else, return the new Record { [[Years]]: 0, [[Months]]: _months_ + _years_ × 12, [[Weeks]]: 0, [[Days]]: 0 }.
           1. If _midSign_ is not equal to _sign_, then
             1. Set _months_ to _months_ - _sign_.
@@ -731,11 +733,11 @@
           1. If _mid_.[[Month]] is equal to _end_.[[Month]] and _mid_.[[Year]] is equal to _mid_.[[Year]], set _days_ to _end_.[[Day]] - _mid_.[[Day]].
           1. Else if _sign_ &lt; 0, set _days_ to -_mid_.[[Day]] - (! ISODaysInMonth(_end_.[[Year]], _end_.[[Month]]) - _end_.[[Day]]).
           1. Else, set _days_ to _end_.[[Day]] + (! ISODaysInMonth(_mid_.[[Year]], _mid_.[[Month]]) - _mid_.[[Day]]).
-          1. If _largestUnit_ is *"months"*, then
+          1. If _largestUnit_ is *"month"*, then
             1. Set _months_ to _months_ + _years_ × 12.
             1. Set _years_ to 0.
           1. Return the new Record { [[Years]]: _years_, [[Months]]: _months_, [[Weeks]]: 0, [[Days]]: _days_ }.
-        1. If _largestUnit_ is *"days"* or *"weeks"*, then
+        1. If _largestUnit_ is *"day"* or *"week"*, then
           1. If ! CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_) &lt; 0, then
             1. Let _smaller_ be the new Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
             1. Let _greater_ be the new Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
@@ -751,7 +753,7 @@
             1. Set _days_ to _days_ + ! ISODaysInYear(_smaller_.[[Year]] + _years_ − 1).
             1. Set _years_ to _years_ − 1.
           1. Let _weeks_ be 0.
-          1. If _largestUnit_ is *"weeks"*, then
+          1. If _largestUnit_ is *"week"*, then
             1. Set _weeks_ to floor(_days_ / 7).
             1. Set _days_ to _days_ mod 7.
           1. Return the Record {

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -489,9 +489,9 @@
         1. Set _other_ to ? ToTemporalDateTime(_other_).
         1. If ? CalendarEquals(_dateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « », *"nanoseconds"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"days"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », _defaultLargestUnit_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
@@ -515,9 +515,9 @@
         1. Set _other_ to ? ToTemporalDateTime(_other_).
         1. If ? CalendarEquals(_dateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « », *"nanoseconds"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"days"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », _defaultLargestUnit_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
@@ -542,7 +542,8 @@
         1. If _options_ is *undefined*, then
           1. Throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « »).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"* », *undefined*).
+        1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_options_, _smallestUnit_).
         1. Let _result_ be ? RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
@@ -1068,7 +1069,7 @@
           1. Set _timeDifference_ to ? BalanceDuration(-_timeSign_, _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
         1. Let _date1_ be ? CreateTemporalDate(_balanceResult_.[[Year]], _balanceResult_.[[Month]], _balanceResult_.[[Day]]).
         1. Let _date2_ be ? CreateTemporalDate(_y2_, _mon2_, _d2_).
-        1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"days"*, _largestUnit_).
+        1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
         1. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
         1. Return ? BalanceDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -289,8 +289,8 @@
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Set _other_ to ? ToTemporalTime(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"hours"*).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, *"hour"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
@@ -313,8 +313,8 @@
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Set _other_ to ? ToTemporalTime(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"nanoseconds"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"years"*, *"months"*, *"weeks"*, *"days"* », *"hours"*).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, *"hour"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
@@ -339,7 +339,8 @@
         1. If _options_ is *undefined*, then
           1. Throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"day"* »).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
+        1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
           1. Let _maximum_ be 24.

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -251,7 +251,7 @@
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
+        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
@@ -279,7 +279,7 @@
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
         1. Perform ? RejectDurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"days"*).
+        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
@@ -309,9 +309,9 @@
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"weeks"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, _disallowedUnits_, *"months"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"years"*).
+        1. Let _disallowedUnits_ be « *"week"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"month"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"year"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
@@ -324,7 +324,7 @@
         1. Let _thisDate_ be ? DateFromFields(_calendar_, _thisFields_).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
-        1. If _smallestUnit_ is *"months"* and _roundingIncrement_ = 1, then
+        1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
           1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0).
         1. Let _relativeTo_ be ? CreateTemporalDateTime(_thisDate_.[[ISOYear]], _thisDate_.[[ISOMonth]], _thisDate_.[[ISODay]], 0, 0, 0, 0, 0, 0, _calendar_).
         1. Let _result_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
@@ -345,9 +345,9 @@
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"weeks"*, *"days"*, *"hours"*, *"minutes"*, *"seconds"*, *"milliseconds"*, *"microseconds"*, *"nanoseconds"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, _disallowedUnits_, *"months"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"years"*).
+        1. Let _disallowedUnits_ be « *"week"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"month"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"year"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
@@ -361,7 +361,7 @@
         1. Let _thisDate_ be ? DateFromFields(_calendar_, _thisFields_).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
-        1. If _smallestUnit_ is *"months"* and _roundingIncrement_ = 1, then
+        1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
           1. Return ? CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0).
         1. Let _relativeTo_ be ? CreateTemporalDateTime(_thisDate_.[[ISOYear]], _thisDate_.[[ISOMonth]], _thisDate_.[[ISODay]], 0, 0, 0, 0, 0, 0, _calendar_).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -711,14 +711,14 @@
         1. If ? CalendarEquals(_zonedDateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « », *"nanoseconds"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"hours"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », _defaultLargestUnit_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"hour"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. If _largestUnit_ is not one of *"years"*, *"months"*, *"weeks"*, or *"days"*, then
+        1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ? DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
           1. Return ? CreateTemporalDuration(0, 0, 0, 0, _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
@@ -744,15 +744,15 @@
         1. If ? CalendarEquals(_zonedDateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalDurationUnit(_options_, « », *"nanoseconds"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalDurationUnits(*"hours"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », _defaultLargestUnit_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"hour"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. If _largestUnit_ is not one of *"years"*, *"months"*, *"weeks"*, or *"days"*, then
+        1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ? DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
           1. Return ? CreateTemporalDuration(0, 0, 0, 0, −_balanceResult_.[[Hours]], −_balanceResult_.[[Minutes]], −_balanceResult_.[[Seconds]], −_balanceResult_.[[Milliseconds]], −_balanceResult_.[[Microseconds]], −_balanceResult_.[[Nanoseconds]]).
@@ -777,7 +777,8 @@
         1. If _options_ is *undefined*, then
           1. Throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « »).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"* », *undefined*).
+        1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_options_, _smallestUnit_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
@@ -1218,7 +1219,7 @@
         1. Let _timeRemainderNs_ be _ns2_ − _intermediateNs_.
         1. Let _intermediate_ be ? CreateTemporalZonedDateTime(_intermediateNs_, _timeZone_, _calendar_).
         1. Let _result_ be ? NanosecondsToDays(_timeRemainderNs_, _intermediate_).
-        1. Let _timeDifference_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], *"hours"*).
+        1. Let _timeDifference_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], *"hour"*).
         1. Return the new Record { [[Years]]: _dateDifference_.[[Years]], [[Months]]: _dateDifference_.[[Months]], [[Weeks]]: _dateDifference_.[[Weeks]], [[Days]]: _result_.[[Days]], [[Hours]]: _timeDifference_.[[Hours]], [[Minutes]]: _timeDifference_.[[Minutes]], [[Seconds]]: _timeDifference_.[[Seconds]], [[Milliseconds]]: _timeDifference_.[[Milliseconds]], [[Microseconds]]: _timeDifference_.[[Microseconds]], [[Nanoseconds]]: _timeDifference_.[[Nanoseconds]] }.
       </emu-alg>
     </emu-clause>
@@ -1246,7 +1247,7 @@
         1. Let _endNs_ be _startNs_ + _nanoseconds_.
         1. Let _endInstant_ be ? CreateTemporalInstant(_endNs_).
         1. Let _endDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_relativeTo_.[[TimeZone]], _endInstant_, _relativeTo_.[[Calendar]]).
-        1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"days"*).
+        1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*).
         1. Let _days_ be _dateDifference_.[[Days]].
         1. Let _intermediateNs_ be ? AddZonedDateTime(_startNs_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, 0, 0, 0, 0, 0, 0).
         1. If _sign_ = 1, then


### PR DESCRIPTION
Both singular and plural names remain accepted everywhere, and 'week' is
now accepted where previously only 'weeks' was. However, the singular form
is now preferred for Temporal.Duration as well, and the spec text should
reflect this.

Ensure that options objects passed to user code have the correct singular
unit strings on them.

Closes: #1491