### PR TITLE
Normative: Fix inconsistent property names/order returned by `getISOFields()`

### DIFF
--- a/polyfill/test/PlainDate/prototype/getISOFields/field-names.js
+++ b/polyfill/test/PlainDate/prototype/getISOFields/field-names.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.getisofields
+description: Correct field names on the object returned from getISOFields
+---*/
+
+const date = new Temporal.PlainDate(2000, 5, 2);
+
+const result = date.getISOFields();
+assert.sameValue(result.isoYear, 2000, "isoYear result");
+assert.sameValue(result.isoMonth, 5, "isoMonth result");
+assert.sameValue(result.isoDay, 2, "isoDay result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");

--- a/polyfill/test/PlainDate/prototype/getISOFields/field-traversal-order.js
+++ b/polyfill/test/PlainDate/prototype/getISOFields/field-traversal-order.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.getisofields
+description: Properties added in correct order to object returned from getISOFields
+includes: [compareArray.js]
+---*/
+
+const expected = [
+  "calendar",
+  "isoDay",
+  "isoMonth",
+  "isoYear",
+];
+
+const date = new Temporal.PlainDate(2000, 5, 2);
+const result = date.getISOFields();
+
+assert.compareArray(Object.keys(result), expected);

--- a/polyfill/test/PlainDateTime/prototype/getISOFields/field-names.js
+++ b/polyfill/test/PlainDateTime/prototype/getISOFields/field-names.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.getisofields
+description: Correct field names on the object returned from getISOFields
+---*/
+
+const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+
+const result = datetime.getISOFields();
+assert.sameValue(result.isoYear, 2000, "isoYear result");
+assert.sameValue(result.isoMonth, 5, "isoMonth result");
+assert.sameValue(result.isoDay, 2, "isoDay result");
+assert.sameValue(result.isoHour, 12, "isoHour result");
+assert.sameValue(result.isoMinute, 34, "isoMinute result");
+assert.sameValue(result.isoSecond, 56, "isoSecond result");
+assert.sameValue(result.isoMillisecond, 987, "isoMillisecond result");
+assert.sameValue(result.isoMicrosecond, 654, "isoMicrosecond result");
+assert.sameValue(result.isoNanosecond, 321, "isoNanosecond result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");

--- a/polyfill/test/PlainDateTime/prototype/getISOFields/field-traversal-order.js
+++ b/polyfill/test/PlainDateTime/prototype/getISOFields/field-traversal-order.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.getisofields
+description: Properties added in correct order to object returned from getISOFields
+includes: [compareArray.js]
+---*/
+
+const expected = [
+  "calendar",
+  "isoDay",
+  "isoHour",
+  "isoMicrosecond",
+  "isoMillisecond",
+  "isoMinute",
+  "isoMonth",
+  "isoNanosecond",
+  "isoSecond",
+  "isoYear",
+];
+
+const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const result = datetime.getISOFields();
+
+assert.compareArray(Object.keys(result), expected);

--- a/polyfill/test/PlainMonthDay/prototype/getISOFields/field-names.js
+++ b/polyfill/test/PlainMonthDay/prototype/getISOFields/field-names.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.getisofields
+description: Correct field names on the object returned from getISOFields
+---*/
+
+const md = new Temporal.PlainMonthDay(5, 2);
+
+const result = md.getISOFields();
+assert.sameValue(result.isoYear, 1972, "isoYear result");
+assert.sameValue(result.isoMonth, 5, "isoMonth result");
+assert.sameValue(result.isoDay, 2, "isoDay result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");

--- a/polyfill/test/PlainMonthDay/prototype/getISOFields/field-traversal-order.js
+++ b/polyfill/test/PlainMonthDay/prototype/getISOFields/field-traversal-order.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.getisofields
+description: Properties added in correct order to object returned from getISOFields
+includes: [compareArray.js]
+---*/
+
+const expected = [
+  "calendar",
+  "isoDay",
+  "isoMonth",
+  "isoYear",
+];
+
+const md = new Temporal.PlainMonthDay(5, 2);
+const result = md.getISOFields();
+
+assert.compareArray(Object.keys(result), expected);

--- a/polyfill/test/PlainTime/prototype/getISOFields/field-names.js
+++ b/polyfill/test/PlainTime/prototype/getISOFields/field-names.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.getisofields
+description: Correct field names on the object returned from getISOFields
+---*/
+
+const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+
+const result = time.getISOFields();
+assert.sameValue(result.isoHour, 12, "isoHour result");
+assert.sameValue(result.isoMinute, 34, "isoMinute result");
+assert.sameValue(result.isoSecond, 56, "isoSecond result");
+assert.sameValue(result.isoMillisecond, 987, "isoMillisecond result");
+assert.sameValue(result.isoMicrosecond, 654, "isoMicrosecond result");
+assert.sameValue(result.isoNanosecond, 321, "isoNanosecond result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");

--- a/polyfill/test/PlainTime/prototype/getISOFields/field-traversal-order.js
+++ b/polyfill/test/PlainTime/prototype/getISOFields/field-traversal-order.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.getisofields
+description: Properties added in correct order to object returned from getISOFields
+includes: [compareArray.js]
+---*/
+
+const expected = [
+  "calendar",
+  "isoHour",
+  "isoMicrosecond",
+  "isoMillisecond",
+  "isoMinute",
+  "isoNanosecond",
+  "isoSecond",
+];
+
+const time = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const result = time.getISOFields();
+
+assert.compareArray(Object.keys(result), expected);

--- a/polyfill/test/PlainYearMonth/prototype/getISOFields/field-names.js
+++ b/polyfill/test/PlainYearMonth/prototype/getISOFields/field-names.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.getisofields
+description: Correct field names on the object returned from getISOFields
+---*/
+
+const ym = new Temporal.PlainYearMonth(2000, 5);
+
+const result = ym.getISOFields();
+assert.sameValue(result.isoYear, 2000, "isoYear result");
+assert.sameValue(result.isoMonth, 5, "isoMonth result");
+assert.sameValue(result.isoDay, 1, "isoDay result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");

--- a/polyfill/test/PlainYearMonth/prototype/getISOFields/field-traversal-order.js
+++ b/polyfill/test/PlainYearMonth/prototype/getISOFields/field-traversal-order.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.getisofields
+description: Properties added in correct order to object returned from getISOFields
+includes: [compareArray.js]
+---*/
+
+const expected = [
+  "calendar",
+  "isoDay",
+  "isoMonth",
+  "isoYear",
+];
+
+const ym = new Temporal.PlainYearMonth(2000, 5);
+const result = ym.getISOFields();
+
+assert.compareArray(Object.keys(result), expected);

--- a/polyfill/test/ZonedDateTime/prototype/getISOFields/field-names.js
+++ b/polyfill/test/ZonedDateTime/prototype/getISOFields/field-names.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.getisofields
+description: Correct field names on the object returned from getISOFields
+---*/
+
+const datetime = new Temporal.ZonedDateTime(1_000_086_400_987_654_321n, "UTC");
+
+const result = datetime.getISOFields();
+assert.sameValue(result.isoYear, 2001, "isoYear result");
+assert.sameValue(result.isoMonth, 9, "isoMonth result");
+assert.sameValue(result.isoDay, 10, "isoDay result");
+assert.sameValue(result.isoHour, 1, "isoHour result");
+assert.sameValue(result.isoMinute, 46, "isoMinute result");
+assert.sameValue(result.isoSecond, 40, "isoSecond result");
+assert.sameValue(result.isoMillisecond, 987, "isoMillisecond result");
+assert.sameValue(result.isoMicrosecond, 654, "isoMicrosecond result");
+assert.sameValue(result.isoNanosecond, 321, "isoNanosecond result");
+assert.sameValue(result.offset, "+00:00", "offset result");
+assert.sameValue(result.calendar.id, "iso8601", "calendar result");
+assert.sameValue(result.timeZone.id, "UTC", "timeZone result");

--- a/polyfill/test/ZonedDateTime/prototype/getISOFields/field-traversal-order.js
+++ b/polyfill/test/ZonedDateTime/prototype/getISOFields/field-traversal-order.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.getisofields
+description: Properties added in correct order to object returned from getISOFields
+includes: [compareArray.js]
+---*/
+
+const expected = [
+  "calendar",
+  "isoDay",
+  "isoHour",
+  "isoMicrosecond",
+  "isoMillisecond",
+  "isoMinute",
+  "isoMonth",
+  "isoNanosecond",
+  "isoSecond",
+  "isoYear",
+  "offset",
+  "timeZone",
+];
+
+const datetime = new Temporal.ZonedDateTime(1_000_086_400_987_654_321n, "UTC");
+const result = datetime.getISOFields();
+
+assert.compareArray(Object.keys(result), expected);

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -712,10 +712,10 @@
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"calendar"*, _dateTime_.[[Calendar]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoDay"*, 𝔽(_dateTime_.[[ISODay]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoHour"*, 𝔽(_dateTime_.[[ISOHour]])).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMonth"*, 𝔽(_dateTime_.[[ISOMonth]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMicrosecond"*, 𝔽(_dateTime_.[[ISOMicrosecond]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMillisecond"*, 𝔽(_dateTime_.[[ISOMillisecond]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMinute"*, 𝔽(_dateTime_.[[ISOMinute]])).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMonth"*, 𝔽(_dateTime_.[[ISOMonth]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoNanosecond"*, 𝔽(_dateTime_.[[ISONanosecond]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoSecond"*, 𝔽(_dateTime_.[[Second]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoYear"*, 𝔽(_dateTime_.[[ISOYear]])).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -997,16 +997,16 @@
         1. Let _dateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
         1. Let _offset_ be ? BuiltinTimeZoneGetOffsetStringFor(_timeZone_, _instant_).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"calendar"*, _calendar_).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"hour"*, _dateTime_.[[ISOHour]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoDay"*, _dateTime_.[[ISODay]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoHour"*, _dateTime_.[[ISOHour]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMicrosecond"*, _dateTime_.[[ISOMicrosecond]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMillisecond"*, _dateTime_.[[ISOMillisecond]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMinute"*, _dateTime_.[[ISOMinute]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMonth"*, _dateTime_.[[ISOMonth]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoNanosecond"*, _dateTime_.[[ISONanosecond]]).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoSecond"*, _dateTime_.[[ISOSecond]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoYear"*, _dateTime_.[[ISOYear]]).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"microsecond"*, _dateTime_.[[ISOMicrosecond]]).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"millisecond"*, _dateTime_.[[ISOMillisecond]]).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"minute"*, _dateTime_.[[ISOMinute]]).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"nanosecond"*, _dateTime_.[[ISONanosecond]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"offset"*, _offset_).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"second"*, _dateTime_.[[ISOSecond]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"timeZone"*, _timeZone_).
         1. Return _fields_.
       </emu-alg>


### PR DESCRIPTION
Fixes the names of properties on the return value from ZonedDateTime.getISOFields, which were missing the `iso` prefix.

Fixes the definition order of properties on the return value from PlainDateTime.getISOFields, which was incorrectly alphabetized.

Adds test262 tests for these fixes to all getISOFields methods.

Closes: #1508