### PR TITLE
Use singular unit names in polyfill

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -79,14 +79,12 @@ export class Calendar {
     one = ES.ToTemporalDate(one);
     two = ES.ToTemporalDate(two);
     options = ES.GetOptionsObject(options);
-    const largestUnit = ES.ToLargestTemporalUnit(options, 'days', [
-      'hours',
-      'minutes',
-      'seconds',
-      'milliseconds',
-      'microseconds',
-      'nanoseconds'
-    ]);
+    const largestUnit = ES.ToLargestTemporalUnit(
+      options,
+      'auto',
+      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'],
+      'day'
+    );
     const { years, months, weeks, days } = impl[GetSlot(this, CALENDAR_ID)].dateUntil(one, two, largestUnit);
     const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
@@ -793,22 +791,22 @@ const nonIsoHelperBase = {
     let months = 0;
     let years = 0;
     switch (largestUnit) {
-      case 'days':
+      case 'day':
         days = this.calendarDaysUntil(calendarOne, calendarTwo, cache);
         break;
-      case 'weeks': {
+      case 'week': {
         const totalDays = this.calendarDaysUntil(calendarOne, calendarTwo, cache);
         days = totalDays % 7;
         weeks = (totalDays - days) / 7;
         break;
       }
-      case 'months':
-      case 'years': {
+      case 'month':
+      case 'year': {
         const diffYears = calendarTwo.year - calendarOne.year;
         const diffMonths = calendarTwo.month - calendarOne.month;
         const diffDays = calendarTwo.day - calendarOne.day;
         const sign = this.compareCalendarDates(calendarTwo, calendarOne);
-        if (largestUnit === 'years' && diffYears) {
+        if (largestUnit === 'year' && diffYears) {
           const isOneFurtherInYear = diffMonths * sign < 0 || (diffMonths === 0 && diffDays * sign < 0);
           years = isOneFurtherInYear ? diffYears - sign : diffYears;
         }
@@ -898,7 +896,7 @@ const nonIsoHelperBase = {
       twoIso.year,
       twoIso.month,
       twoIso.day,
-      'days'
+      'day'
     );
     return duration.days;
   },

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -323,14 +323,14 @@ export class Duration {
       nanoseconds
     );
     options = ES.GetOptionsObject(options);
-    let smallestUnit = ES.ToSmallestTemporalDurationUnit(options, undefined);
+    let smallestUnit = ES.ToSmallestTemporalUnit(options, undefined);
     let smallestUnitPresent = true;
     if (!smallestUnit) {
       smallestUnitPresent = false;
-      smallestUnit = 'nanoseconds';
+      smallestUnit = 'nanosecond';
     }
-    defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits(defaultLargestUnit, smallestUnit);
-    let largestUnit = ES.ToLargestTemporalDurationUnit(options);
+    defaultLargestUnit = ES.LargerOfTwoTemporalUnits(defaultLargestUnit, smallestUnit);
+    let largestUnit = ES.ToLargestTemporalUnit(options, undefined);
     let largestUnitPresent = true;
     if (!largestUnit) {
       largestUnitPresent = false;
@@ -342,19 +342,7 @@ export class Duration {
     }
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
-    const maximumIncrements = {
-      years: undefined,
-      months: undefined,
-      weeks: undefined,
-      days: undefined,
-      hours: 24,
-      minutes: 60,
-      seconds: 60,
-      milliseconds: 1000,
-      microseconds: 1000,
-      nanoseconds: 1000
-    };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+    const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
     let relativeTo = ES.ToRelativeTemporalObject(options);
 
     ({ years, months, weeks, days } = ES.UnbalanceDurationRelative(
@@ -495,7 +483,8 @@ export class Duration {
   toString(options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
-    const { precision, unit, increment } = ES.ToDurationSecondsStringPrecision(options);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    if (precision === 'minute') throw new RangeError('smallestUnit must not be "minute"');
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     return ES.TemporalDurationToString(this, precision, { unit, increment, roundingMode });
   }
@@ -559,8 +548,8 @@ export class Duration {
     const shift1 = ES.CalculateOffsetShift(relativeTo, y1, mon1, w1, d1, h1, min1, s1, ms1, µs1, ns1);
     const shift2 = ES.CalculateOffsetShift(relativeTo, y2, mon2, w2, d2, h2, min2, s2, ms2, µs2, ns2);
     if (y1 !== 0 || y2 !== 0 || mon1 !== 0 || mon2 !== 0 || w1 !== 0 || w2 !== 0) {
-      ({ days: d1 } = ES.UnbalanceDurationRelative(y1, mon1, w1, d1, 'days', relativeTo));
-      ({ days: d2 } = ES.UnbalanceDurationRelative(y2, mon2, w2, d2, 'days', relativeTo));
+      ({ days: d1 } = ES.UnbalanceDurationRelative(y1, mon1, w1, d1, 'day', relativeTo));
+      ({ days: d2 } = ES.UnbalanceDurationRelative(y2, mon2, w2, d2, 'day', relativeTo));
     }
     ns1 = ES.TotalDurationNanoseconds(d1, h1, min1, s1, ms1, µs1, ns1, shift1);
     ns2 = ES.TotalDurationNanoseconds(d2, h2, min2, s2, ms2, µs2, ns2, shift2);

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -18,6 +18,8 @@ import {
   HasSlot
 } from './slots.mjs';
 
+const DISALLOWED_UNITS = ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'];
+
 export class PlainDate {
   constructor(isoYear, isoMonth, isoDay, calendar = ES.GetISO8601Calendar()) {
     isoYear = ES.ToInteger(isoYear);
@@ -134,7 +136,7 @@ export class PlainDate {
     options = ES.GetOptionsObject(options);
 
     let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
-    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'days'));
+    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'day'));
     duration = { years, months, weeks, days };
     return ES.CalendarDateAdd(GetSlot(this, CALENDAR), this, duration, options);
   }
@@ -145,7 +147,7 @@ export class PlainDate {
     options = ES.GetOptionsObject(options);
 
     let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
-    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'days'));
+    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'day'));
     duration = { years: -years, months: -months, weeks: -weeks, days: -days };
     return ES.CalendarDateAdd(GetSlot(this, CALENDAR), this, duration, options);
   }
@@ -161,16 +163,16 @@ export class PlainDate {
     }
 
     options = ES.GetOptionsObject(options);
-    const disallowedUnits = ['hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'days', disallowedUnits);
-    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
-    const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit, disallowedUnits);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'day', DISALLOWED_UNITS);
+    const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('day', smallestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', DISALLOWED_UNITS, defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
 
-    const result = ES.CalendarDateUntil(calendar, this, other, options);
-    if (smallestUnit === 'days' && roundingIncrement === 1) return result;
+    const untilOptions = { ...options, largestUnit };
+    const result = ES.CalendarDateUntil(calendar, this, other, untilOptions);
+    if (smallestUnit === 'day' && roundingIncrement === 1) return result;
 
     let { years, months, weeks, days } = result;
     const relativeTo = ES.CreateTemporalDateTime(
@@ -217,17 +219,17 @@ export class PlainDate {
     }
 
     options = ES.GetOptionsObject(options);
-    const disallowedUnits = ['hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'days', disallowedUnits);
-    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
-    const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit, disallowedUnits);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'day', DISALLOWED_UNITS);
+    const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('day', smallestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', DISALLOWED_UNITS, defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
 
-    let { years, months, weeks, days } = ES.CalendarDateUntil(calendar, this, other, options);
+    const untilOptions = { ...options, largestUnit };
+    let { years, months, weeks, days } = ES.CalendarDateUntil(calendar, this, other, untilOptions);
     const Duration = GetIntrinsic('%Temporal.Duration%');
-    if (smallestUnit === 'days' && roundingIncrement === 1) {
+    if (smallestUnit === 'day' && roundingIncrement === 1) {
       return new Duration(-years, -months, -weeks, -days, 0, 0, 0, 0, 0, 0);
     }
     const relativeTo = ES.CreateTemporalDateTime(

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -379,9 +379,9 @@ export class PlainDateTime {
       throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
     }
     options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
-    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
-    const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond');
+    const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('day', smallestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', [], defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
@@ -473,9 +473,9 @@ export class PlainDateTime {
       throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
     }
     options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
-    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('days', smallestUnit);
-    const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond');
+    const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('day', smallestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', [], defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
@@ -571,7 +571,8 @@ export class PlainDateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     if (options === undefined) throw new TypeError('options parameter is required');
     options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week']);
+    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       day: 1,

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -25,6 +25,16 @@ import {
 
 const ObjectAssign = Object.assign;
 
+const DISALLOWED_UNITS = ['year', 'month', 'week', 'day'];
+const MAX_INCREMENTS = {
+  hour: 24,
+  minute: 60,
+  second: 60,
+  millisecond: 1000,
+  microsecond: 1000,
+  nanosecond: 1000
+};
+
 function TemporalTimeToString(time, precision, options = undefined) {
   let hour = GetSlot(time, ISO_HOUR);
   let minute = GetSlot(time, ISO_MINUTE);
@@ -228,19 +238,11 @@ export class PlainTime {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     other = ES.ToTemporalTime(other);
     options = ES.GetOptionsObject(options);
-    const largestUnit = ES.ToLargestTemporalUnit(options, 'hours', ['years', 'months', 'weeks', 'days']);
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', DISALLOWED_UNITS, 'hour');
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond', DISALLOWED_UNITS);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
-    const maximumIncrements = {
-      hours: 24,
-      minutes: 60,
-      seconds: 60,
-      milliseconds: 1000,
-      microseconds: 1000,
-      nanoseconds: 1000
-    };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, MAX_INCREMENTS[smallestUnit], false);
     let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(
       GetSlot(this, ISO_HOUR),
       GetSlot(this, ISO_MINUTE),
@@ -287,19 +289,11 @@ export class PlainTime {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     other = ES.ToTemporalTime(other);
     options = ES.GetOptionsObject(options);
-    const largestUnit = ES.ToLargestTemporalUnit(options, 'hours', ['years', 'months', 'weeks', 'days']);
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', DISALLOWED_UNITS, 'hour');
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond', DISALLOWED_UNITS);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
-    const maximumIncrements = {
-      hours: 24,
-      minutes: 60,
-      seconds: 60,
-      milliseconds: 1000,
-      microseconds: 1000,
-      nanoseconds: 1000
-    };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, MAX_INCREMENTS[smallestUnit], false);
     let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(
       GetSlot(other, ISO_HOUR),
       GetSlot(other, ISO_MINUTE),
@@ -352,17 +346,10 @@ export class PlainTime {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     if (options === undefined) throw new TypeError('options parameter is required');
     options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, ['day']);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, DISALLOWED_UNITS);
+    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
-    const maximumIncrements = {
-      hour: 24,
-      minute: 60,
-      second: 60,
-      millisecond: 1000,
-      microsecond: 1000,
-      nanosecond: 1000
-    };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, MAX_INCREMENTS[smallestUnit], false);
 
     let hour = GetSlot(this, ISO_HOUR);
     let minute = GetSlot(this, ISO_MINUTE);

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -5,6 +5,8 @@ import { ISO_YEAR, ISO_MONTH, ISO_DAY, CALENDAR, TIME_ZONE, GetSlot, HasSlot } f
 
 const ObjectCreate = Object.create;
 
+const DISALLOWED_UNITS = ['week', 'day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'];
+
 export class PlainYearMonth {
   constructor(isoYear, isoMonth, calendar = ES.GetISO8601Calendar(), referenceISODay = 1) {
     isoYear = ES.ToInteger(isoYear);
@@ -94,7 +96,7 @@ export class PlainYearMonth {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     const duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
     let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
-    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'days'));
+    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'day'));
 
     options = ES.GetOptionsObject(options);
 
@@ -125,7 +127,7 @@ export class PlainYearMonth {
       nanoseconds: -duration.nanoseconds
     };
     let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
-    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'days'));
+    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'day'));
 
     options = ES.GetOptionsObject(options);
 
@@ -153,18 +155,8 @@ export class PlainYearMonth {
       );
     }
     options = ES.GetOptionsObject(options);
-    const disallowedUnits = [
-      'weeks',
-      'days',
-      'hours',
-      'minutes',
-      'seconds',
-      'milliseconds',
-      'microseconds',
-      'nanoseconds'
-    ];
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'months', disallowedUnits);
-    const largestUnit = ES.ToLargestTemporalUnit(options, 'years', disallowedUnits);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'month', DISALLOWED_UNITS);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', DISALLOWED_UNITS, 'year');
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
@@ -177,7 +169,7 @@ export class PlainYearMonth {
 
     const untilOptions = { ...options, largestUnit };
     const result = ES.CalendarDateUntil(calendar, thisDate, otherDate, untilOptions);
-    if (smallestUnit === 'months' && roundingIncrement === 1) return result;
+    if (smallestUnit === 'month' && roundingIncrement === 1) return result;
 
     let { years, months } = result;
     const relativeTo = ES.CreateTemporalDateTime(
@@ -225,18 +217,8 @@ export class PlainYearMonth {
       );
     }
     options = ES.GetOptionsObject(options);
-    const disallowedUnits = [
-      'weeks',
-      'days',
-      'hours',
-      'minutes',
-      'seconds',
-      'milliseconds',
-      'microseconds',
-      'nanoseconds'
-    ];
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'months', disallowedUnits);
-    const largestUnit = ES.ToLargestTemporalUnit(options, 'years', disallowedUnits);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'month', DISALLOWED_UNITS);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', DISALLOWED_UNITS, 'year');
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
@@ -250,7 +232,7 @@ export class PlainYearMonth {
     const untilOptions = { ...options, largestUnit };
     let { years, months } = ES.CalendarDateUntil(calendar, thisDate, otherDate, untilOptions);
     const Duration = GetIntrinsic('%Temporal.Duration%');
-    if (smallestUnit === 'months' && roundingIncrement === 1) {
+    if (smallestUnit === 'month' && roundingIncrement === 1) {
       return new Duration(-years, -months, 0, 0, 0, 0, 0, 0, 0, 0);
     }
     const relativeTo = ES.CreateTemporalDateTime(

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -358,9 +358,9 @@ export class ZonedDateTime {
       throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
     }
     options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
-    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('hours', smallestUnit);
-    const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond');
+    const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('hour', smallestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', [], defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
@@ -368,7 +368,7 @@ export class ZonedDateTime {
     const ns1 = GetSlot(this, EPOCHNANOSECONDS);
     const ns2 = GetSlot(other, EPOCHNANOSECONDS);
     let years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
-    if (largestUnit !== 'years' && largestUnit !== 'months' && largestUnit !== 'weeks' && largestUnit !== 'days') {
+    if (largestUnit !== 'year' && largestUnit !== 'month' && largestUnit !== 'week' && largestUnit !== 'day') {
       // The user is only asking for a time difference, so return difference of instants.
       years = 0;
       months = 0;
@@ -482,9 +482,9 @@ export class ZonedDateTime {
       throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
     }
     options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalDurationUnit(options, 'nanoseconds');
-    const defaultLargestUnit = ES.LargerOfTwoTemporalDurationUnits('hours', smallestUnit);
-    const largestUnit = ES.ToLargestTemporalUnit(options, defaultLargestUnit);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond');
+    const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('hour', smallestUnit);
+    const largestUnit = ES.ToLargestTemporalUnit(options, 'auto', [], defaultLargestUnit);
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     let roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
@@ -493,7 +493,7 @@ export class ZonedDateTime {
     const ns1 = GetSlot(this, EPOCHNANOSECONDS);
     const ns2 = GetSlot(other, EPOCHNANOSECONDS);
     let years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
-    if (largestUnit !== 'years' && largestUnit !== 'months' && largestUnit !== 'weeks' && largestUnit !== 'days') {
+    if (largestUnit !== 'year' && largestUnit !== 'month' && largestUnit !== 'week' && largestUnit !== 'day') {
       // The user is only asking for a time difference, so return difference of instants.
       years = 0;
       months = 0;
@@ -611,7 +611,8 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     if (options === undefined) throw new TypeError('options parameter is required');
     options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week']);
+    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       day: 1,

--- a/polyfill/test/Calendar/prototype/dateUntil/largestunit-plurals-accepted.js
+++ b/polyfill/test/Calendar/prototype/dateUntil/largestunit-plurals-accepted.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateuntil
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainDate(2000, 5, 2);
+const later = new Temporal.PlainDate(2001, 6, 12);
+const calendar = new Temporal.Calendar("iso8601");
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => calendar.dateUntil(earlier, later, { largestUnit }), validUnits);

--- a/polyfill/test/Duration/prototype/add/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/Duration/prototype/add/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,77 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.duration.prototype.add step 6:
+      6. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _other_.[[Years]], _other_.[[Months]], _other_.[[Weeks]], _other_.[[Days]], _other_.[[Hours]], _other_.[[Minutes]], _other_.[[Seconds]], _other_.[[Milliseconds]], _other_.[[Microseconds]], _other_.[[Nanoseconds]], _relativeTo_).
+    sec-temporal-addduration steps 6-7:
+      6. If _relativeTo_ has an [[InitializedTemporalPlainDateTime]] internal slot, then
+        ...
+        j. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+        k. Let _differenceOptions_ be ! OrdinaryObjectCreate(*null*).
+        l. Perform ! CreateDataPropertyOrThrow(_differenceOptions_, *"largestUnit"*, _dateLargestUnit_).
+        m. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _datePart_, _end_, _differenceOptions_).
+        ...
+      7. Else,
+        a. Assert: _relativeTo_ has an [[IntializedTemporalZonedDateTime]] internal slot.
+        ...
+        f. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+          ...
+        g. Else,
+          i. Let _result_ be ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_).
+    sec-temporal-differencezoneddatetime steps 7 and 11:
+      7. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
+      11. Let _result_ be ? NanosecondsToDays(_timeRemainderNs_, _intermediate_).
+    sec-temporal-nanosecondstodays step 11:
+      11. 1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*).
+    sec-temporal-differenceisodatetime steps 9–11:
+      9. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+      10. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
+      11. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit, index) => {
+    const one = new Temporal.Duration(...[...Array(index).fill(0), ...Array(10 - index).fill(1)]);
+    const two = new Temporal.Duration(...[...Array(index).fill(0), ...Array(10 - index).fill(2)]);
+    const relativeTo = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+    one.add(two, { relativeTo, largestUnit });
+  },
+  {
+    years: ["year"],
+    months: ["month"],
+    weeks: ["week"],
+    days: ["day"],
+    hours: ["day"],
+    minutes: ["day"],
+    seconds: ["day"],
+    milliseconds: ["day"],
+    microseconds: ["day"],
+    nanoseconds: ["day"]
+  }
+);
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit, index) => {
+    const one = new Temporal.Duration(...[...Array(index).fill(0), ...Array(10 - index).fill(1)]);
+    const two = new Temporal.Duration(...[...Array(index).fill(0), ...Array(10 - index).fill(2)]);
+    const relativeTo = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC", calendar);
+    one.add(two, { relativeTo, largestUnit });
+  },
+  {
+    years: ["year", "day"],
+    months: ["month", "day"],
+    weeks: ["week", "day"],
+    days: ["day", "day"],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);

--- a/polyfill/test/Duration/prototype/round/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/Duration/prototype/round/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,159 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.duration.prototype.round steps 20–25:
+      20. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _relativeTo_).
+      21. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_[[Seconds]], _duration_[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
+      22. Let _adjustResult_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
+      23. Let _balanceResult_ be ? BalanceDurationRelative(_adjustResult_.[[Years]], _adjustResult_.[[Months]], _adjustResult_.[[Weeks]], _adjustResult_.[[Days]], _largestUnit_, _relativeTo_).
+      24. ...
+      25. Let _result_ be ? BalanceDuration(_balanceResult_.[[Days]], _adjustResult_.[[Hours]], _adjustResult_.[[Minutes]], _adjustResult_.[[Seconds]], _adjustResult_.[[Milliseconds]], _adjustResult_.[[Microseconds]], _adjustResult.[[Nanoseconds]], _largestUnit_, _relativeTo_).
+    sec-temporal-unbalancedurationrelative steps 1 and 9.d.iii–v:
+      1. If _largestUnit_ is *"year"*, or _years_, _months_, _weeks_, and _days_ are all 0, then
+        a. Return ...
+      ...
+      9. If _largestUnit_ is *"month"*, then
+        ...
+        d. Repeat, while abs(_years_) > 0,
+          ...
+          iii. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
+          iv. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
+          v. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
+    sec-temporal-roundduration steps 5.d and 8.n–p:
+      5. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+        d. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_).
+      ...
+      8. If _unit_ is *"year"*, then
+        ...
+        n. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
+        o. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"year"*).
+        p. Let _timePassed_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _daysLater_, _untilOptions_)
+    sec-temporal-adjustroundeddurationdays steps 1 and 9:
+      1. If _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot; or _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*; or _unit_ is *"nanosecond"* and _increment_ is 1, then
+        a. Return ...
+      ...
+      9. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, _relativeTo_).
+    sec-temporal-addduration step 7.a–g:
+      a. Assert: _relativeTo_ has an [[IntializedTemporalZonedDateTime]] internal slot.
+      ...
+      f. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+      g. Else,
+        i. Let _result_ be ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_).
+    sec-temporal-balancedurationrelative steps 1, 9.m–o, and 9.q.vi–viii:
+      1. If _largestUnit_ is not one of *"year"*, *"month"*, or *"week"*, or _years_, _months_, _weeks_, and _days_ are all 0, then
+        a. Return ...
+      ...
+      9. If _largestUnit_ is *"year"*, then
+        ...
+        m. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
+        n. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
+        o. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
+        p. ...
+        q. Repeat, while abs(_months_) ≥ abs(_oneYearMonths_),
+          ...
+          vi. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
+          vii. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
+          viii. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
+    sec-temporal-balanceduration step 3.a:
+      3. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        a. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
+    sec-temporal-differencezoneddatetime steps 7 and 11:
+      7. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
+      11. Let _result_ be ? NanosecondsToDays(_timeRemainderNs_, _intermediate_).
+    sec-temporal-nanosecondstodays step 11:
+      11. 1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*).
+    sec-temporal-differenceisodatetime steps 9–11:
+      9. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+      10. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
+      11. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+// Check with smallestUnit nanoseconds but roundingIncrement > 1; each call
+// should result in two calls to dateUntil() originating from
+// AdjustRoundedDurationDays, one with largestUnit equal to the largest unit in
+// the duration higher than "day", and one with largestUnit: "day".
+// Additionally one call with largestUnit: "month" in BalanceDurationRelative
+// when the largestUnit given to round() is "year", and one call with
+// largestUnit: "day" when the largestUnit given to round() is "year", "month",
+// "week", or "day".
+
+const durations = [
+  [1, 0, 0, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+  [0, 1, 0, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+  [0, 0, 1, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 86399_999_999_999],
+].map((args) => new Temporal.Duration(...args));
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit, index) => {
+    const duration = durations[index];
+    const relativeTo = new Temporal.ZonedDateTime(0n, "UTC", calendar);
+    duration.round({ largestUnit, roundingIncrement: 2, roundingMode: 'ceil', relativeTo });
+  },
+  {
+    years: ["year", "day", "month", "day"],
+    months: ["month", "day", "day"],
+    weeks: ["week", "day", "day"],
+    days: ["day", "day", "day"],
+    hours: ["day", "day"],
+    minutes: ["day", "day"],
+    seconds: ["day", "day"],
+    milliseconds: ["day", "day"],
+    microseconds: ["day", "day"],
+    nanoseconds: ["day", "day"]
+  }
+);
+
+// Check the path that converts months to years and vice versa in
+// BalanceDurationRelative and UnbalanceDurationRelative.
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const duration = new Temporal.Duration(5, 60);
+    const relativeTo = new Temporal.PlainDateTime(2000, 5, 2, 0, 0, 0, 0, 0, 0, calendar);
+    duration.round({ largestUnit, relativeTo });
+  },
+  {
+    years: ["month", "month", "month", "month", "month", "month"],
+    months: ["month", "month", "month", "month", "month"],
+    weeks: [],
+    days: [],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);
+
+// Check the paths that call dateUntil() in RoundDuration. These paths do not
+// call dateUntil() in AdjustRoundedDurationDays. Note that there is no
+// largestUnit: "month" call in BalanceDurationRelative and no largestUnit:
+// "day" call in BalanceDuration, because the durations have rounded down to 0.
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const duration = new Temporal.Duration(0, 0, 0, 0, 1, 1, 1, 1, 1, 1);
+    const relativeTo = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", calendar);
+    duration.round({ largestUnit, smallestUnit: largestUnit, relativeTo });
+  }, {
+    years: ["day", "year"],
+    months: ["day"],
+    weeks: ["day"],
+    days: ["day"]
+  }
+);

--- a/polyfill/test/Duration/prototype/round/largestunit-plurals-accepted.js
+++ b/polyfill/test/Duration/prototype/round/largestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const relativeTo = new Temporal.PlainDate(2000, 1, 1);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => duration.round({ largestUnit, relativeTo }), validUnits);

--- a/polyfill/test/Duration/prototype/round/smallestunit-plurals-accepted.js
+++ b/polyfill/test/Duration/prototype/round/smallestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const relativeTo = new Temporal.PlainDate(2000, 1, 1);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => duration.round({ smallestUnit, relativeTo }), validUnits);

--- a/polyfill/test/Duration/prototype/subtract/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/Duration/prototype/subtract/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,77 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.duration.prototype.subtract step 6:
+      6. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], −_other_.[[Years]], −_other_.[[Months]], −_other_.[[Weeks]], −_other_.[[Days]], −_other_.[[Hours]], −_other_.[[Minutes]], −_other_.[[Seconds]], −_other_.[[Milliseconds]], −_other_.[[Microseconds]], −_other_.[[Nanoseconds]], _relativeTo_).
+    sec-temporal-addduration steps 6-7:
+      6. If _relativeTo_ has an [[InitializedTemporalPlainDateTime]] internal slot, then
+        ...
+        j. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+        k. Let _differenceOptions_ be ! OrdinaryObjectCreate(*null*).
+        l. Perform ! CreateDataPropertyOrThrow(_differenceOptions_, *"largestUnit"*, _dateLargestUnit_).
+        m. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _datePart_, _end_, _differenceOptions_).
+        ...
+      7. Else,
+        a. Assert: _relativeTo_ has an [[IntializedTemporalZonedDateTime]] internal slot.
+        ...
+        f. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+          ...
+        g. Else,
+          i. Let _result_ be ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_).
+    sec-temporal-differencezoneddatetime steps 7 and 11:
+      7. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
+      11. Let _result_ be ? NanosecondsToDays(_timeRemainderNs_, _intermediate_).
+    sec-temporal-nanosecondstodays step 11:
+      11. 1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*).
+    sec-temporal-differenceisodatetime steps 9–11:
+      9. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+      10. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
+      11. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit, index) => {
+    const one = new Temporal.Duration(...[...Array(index).fill(0), ...Array(10 - index).fill(1)]);
+    const two = new Temporal.Duration(...[...Array(index).fill(0), ...Array(10 - index).fill(2)]);
+    const relativeTo = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+    two.subtract(one, { relativeTo });
+  },
+  {
+    years: ["year"],
+    months: ["month"],
+    weeks: ["week"],
+    days: ["day"],
+    hours: ["day"],
+    minutes: ["day"],
+    seconds: ["day"],
+    milliseconds: ["day"],
+    microseconds: ["day"],
+    nanoseconds: ["day"]
+  }
+);
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit, index) => {
+    const one = new Temporal.Duration(...[...Array(index).fill(0), ...Array(10 - index).fill(1)]);
+    const two = new Temporal.Duration(...[...Array(index).fill(0), ...Array(10 - index).fill(2)]);
+    const relativeTo = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC", calendar);
+    two.subtract(one, { relativeTo });
+  },
+  {
+    years: ["year", "day"],
+    months: ["month", "day"],
+    weeks: ["week", "day"],
+    days: ["day", "day"],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);

--- a/polyfill/test/Duration/prototype/toString/smallestunit-plurals-accepted.js
+++ b/polyfill/test/Duration/prototype/toString/smallestunit-plurals-accepted.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const validUnits = [
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => duration.toString({ smallestUnit }), validUnits);

--- a/polyfill/test/Duration/prototype/total/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/Duration/prototype/total/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,92 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.duration.prototype.total steps 7–11:
+        7. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _relativeTo_).
+        ...
+        10. Let _balanceResult_ be ? BalanceDuration(_unbalanceResult_.[[Days]], _unbalanceResult_.[[Hours]], _unbalanceResult_.[[Minutes]], _unbalanceResult_.[[Seconds]], _unbalanceResult_.[[Milliseconds]], _unbalanceResult_.[[Microseconds]], _unbalanceResult_.[[Nanoseconds]], _unit_, _intermediate_).
+        11. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], 1, _unit_, *"trunc"*, _relativeTo_).
+    sec-temporal-unbalancedurationrelative steps 1 and 9.d.iii–v:
+      1. If _largestUnit_ is *"year"*, or _years_, _months_, _weeks_, and _days_ are all 0, then
+        a. Return ...
+      ...
+      9. If _largestUnit_ is *"month"*, then
+        ...
+        d. Repeat, while abs(_years_) > 0,
+          ...
+          iii. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
+          iv. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
+          v. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
+    sec-temporal-balanceduration step 3.a:
+      3. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        a. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
+    sec-temporal-roundduration steps 5.d and 8.n–p:
+      5. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+        d. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_).
+      ...
+      8. If _unit_ is *"year"*, then
+        ...
+        n. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
+        o. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"year"*).
+        p. Let _timePassed_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _daysLater_, _untilOptions_)
+    sec-temporal-nanosecondstodays step 11:
+      11. 1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*).
+    sec-temporal-differenceisodatetime steps 9–11:
+      9. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+      10. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
+      11. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+// Check the paths that go through NanosecondsToDays: one call to dateUntil() in
+// BalanceDuration and one in RoundDuration with largestUnit: "day" when the
+// unit is "year", "month", "week", or "day", and one extra call with
+// largestUnit: "year" in RoundDuration when the unit is "year".
+
+const duration = new Temporal.Duration(0, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, unit) => {
+    const relativeTo = new Temporal.ZonedDateTime(0n, "UTC", calendar);
+    duration.total({ unit, relativeTo });
+  },
+  {
+    years: ["day", "day", "year"],
+    months: ["day", "day"],
+    weeks: ["day", "day"],
+    days: ["day", "day"],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);
+
+// Check the path that converts years to months in UnbalanceDurationRelative.
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, unit) => {
+    const duration = new Temporal.Duration(5);
+    const relativeTo = new Temporal.PlainDateTime(2000, 5, 2, 0, 0, 0, 0, 0, 0, calendar);
+    duration.total({ unit, relativeTo });
+  },
+  {
+    years: ["year"],
+    months: ["month", "month", "month", "month", "month"],
+    weeks: [],
+    days: [],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);

--- a/polyfill/test/Duration/prototype/total/unit-plurals-accepted.js
+++ b/polyfill/test/Duration/prototype/total/unit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: Plural units are accepted as well for the unit option
+includes: [temporalHelpers.js]
+---*/
+
+const duration = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const relativeTo = new Temporal.PlainDate(2000, 1, 1);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((unit) => duration.total({ unit, relativeTo }), validUnits);

--- a/polyfill/test/Instant/prototype/round/smallestunit-plurals-accepted.js
+++ b/polyfill/test/Instant/prototype/round/smallestunit-plurals-accepted.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.round
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const instant = new Temporal.Instant(1_000_000_000_987_654_321n);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => instant.round({ smallestUnit }), validUnits);

--- a/polyfill/test/Instant/prototype/since/largestunit-plurals-accepted.js
+++ b/polyfill/test/Instant/prototype/since/largestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.Instant(1_000_000_000_987_654_321n);
+const later = new Temporal.Instant(1_086_403_661_988_655_322n);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => later.since(earlier, { largestUnit }), validUnits);

--- a/polyfill/test/Instant/prototype/since/smallestunit-plurals-accepted.js
+++ b/polyfill/test/Instant/prototype/since/smallestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.since
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.Instant(1_000_000_000_987_654_321n);
+const later = new Temporal.Instant(1_086_403_661_988_655_322n);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => later.since(earlier, { smallestUnit }), validUnits);

--- a/polyfill/test/Instant/prototype/toString/smallestunit-plurals-accepted.js
+++ b/polyfill/test/Instant/prototype/toString/smallestunit-plurals-accepted.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const instant = new Temporal.Instant(1_000_000_000_123_456_789n);
+const validUnits = [
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => instant.toString({ smallestUnit }), validUnits);

--- a/polyfill/test/Instant/prototype/until/largestunit-plurals-accepted.js
+++ b/polyfill/test/Instant/prototype/until/largestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.Instant(1_000_000_000_987_654_321n);
+const later = new Temporal.Instant(1_086_403_661_988_655_322n);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => earlier.until(later, { largestUnit }), validUnits);

--- a/polyfill/test/Instant/prototype/until/smallestunit-plurals-accepted.js
+++ b/polyfill/test/Instant/prototype/until/smallestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.until
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.Instant(1_000_000_000_987_654_321n);
+const later = new Temporal.Instant(1_086_403_661_988_655_322n);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => earlier.until(later, { smallestUnit }), validUnits);

--- a/polyfill/test/PlainDate/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/PlainDate/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.plaindate.prototype.since steps 13–14:
+      13. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+      14. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _other_, _temporalDate_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.PlainDate(2000, 5, 2, calendar);
+    const later = new Temporal.PlainDate(2001, 6, 3, calendar);
+    later.since(earlier, { largestUnit });
+  },
+  {
+    years: ["year"],
+    months: ["month"],
+    weeks: ["week"],
+    days: ["day"]
+  }
+);

--- a/polyfill/test/PlainDate/prototype/since/largestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDate/prototype/since/largestunit-plurals-accepted.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainDate(2000, 5, 2);
+const later = new Temporal.PlainDate(2001, 6, 12);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => later.since(earlier, { largestUnit }), validUnits);

--- a/polyfill/test/PlainDate/prototype/since/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDate/prototype/since/smallestunit-plurals-accepted.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.since
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainDate(2000, 5, 2);
+const later = new Temporal.PlainDate(2001, 6, 12);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => later.since(earlier, { smallestUnit }), validUnits);

--- a/polyfill/test/PlainDate/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/PlainDate/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.plaindate.prototype.until steps 12–13:
+      13. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+      14. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.PlainDate(2000, 5, 2, calendar);
+    const later = new Temporal.PlainDate(2001, 6, 3, calendar);
+    earlier.until(later, { largestUnit });
+  },
+  {
+    years: ["year"],
+    months: ["month"],
+    weeks: ["week"],
+    days: ["day"]
+  }
+);

--- a/polyfill/test/PlainDate/prototype/until/largestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDate/prototype/until/largestunit-plurals-accepted.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainDate(2000, 5, 2);
+const later = new Temporal.PlainDate(2001, 6, 12);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => earlier.until(later, { largestUnit }), validUnits);

--- a/polyfill/test/PlainDate/prototype/until/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDate/prototype/until/smallestunit-plurals-accepted.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.until
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainDate(2000, 5, 2);
+const later = new Temporal.PlainDate(2001, 6, 12);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => earlier.until(later, { smallestUnit }), validUnits);

--- a/polyfill/test/PlainDateTime/prototype/round/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDateTime/prototype/round/smallestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.round
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 789, 999, 999);
+const validUnits = [
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => datetime.round({ smallestUnit }), validUnits);

--- a/polyfill/test/PlainDateTime/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/PlainDateTime/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.plaindatetime.prototype.since step 14:
+      14. Let _diff_ be ? DifferenceISODateTime(_other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
+    sec-temporal-differenceisodatetime steps 9–11:
+      9. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+      10. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
+      11. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+    const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 988, 655, 322, calendar);
+    later.since(earlier, { largestUnit });
+  },
+  {
+    years: ["year"],
+    months: ["month"],
+    weeks: ["week"],
+    days: ["day"],
+    hours: ["day"],
+    minutes: ["day"],
+    seconds: ["day"],
+    milliseconds: ["day"],
+    microseconds: ["day"],
+    nanoseconds: ["day"]
+  }
+);

--- a/polyfill/test/PlainDateTime/prototype/since/largestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDateTime/prototype/since/largestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const later = new Temporal.PlainDateTime(2001, 6, 12, 13, 35, 57, 988, 655, 322);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => later.since(earlier, { largestUnit }), validUnits);

--- a/polyfill/test/PlainDateTime/prototype/since/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDateTime/prototype/since/smallestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const later = new Temporal.PlainDateTime(2001, 6, 12, 13, 35, 57, 988, 655, 322);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => later.since(earlier, { smallestUnit }), validUnits);

--- a/polyfill/test/PlainDateTime/prototype/toString/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDateTime/prototype/toString/smallestunit-plurals-accepted.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tostring
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 789, 999, 999);
+const validUnits = [
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => datetime.toString({ smallestUnit }), validUnits);

--- a/polyfill/test/PlainDateTime/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/PlainDateTime/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.plaindatetime.prototype.until step 13:
+      13. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
+    sec-temporal-differenceisodatetime steps 9–11:
+      9. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+      10. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
+      11. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+    const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 988, 655, 322, calendar);
+    earlier.until(later, { largestUnit });
+  },
+  {
+    years: ["year"],
+    months: ["month"],
+    weeks: ["week"],
+    days: ["day"],
+    hours: ["day"],
+    minutes: ["day"],
+    seconds: ["day"],
+    milliseconds: ["day"],
+    microseconds: ["day"],
+    nanoseconds: ["day"]
+  }
+);

--- a/polyfill/test/PlainDateTime/prototype/until/largestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDateTime/prototype/until/largestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const later = new Temporal.PlainDateTime(2001, 6, 12, 13, 35, 57, 988, 655, 322);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => earlier.until(later, { largestUnit }), validUnits);

--- a/polyfill/test/PlainDateTime/prototype/until/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainDateTime/prototype/until/smallestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321);
+const later = new Temporal.PlainDateTime(2001, 6, 12, 13, 35, 57, 988, 655, 322);
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => earlier.until(later, { smallestUnit }), validUnits);

--- a/polyfill/test/PlainTime/prototype/round/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainTime/prototype/round/smallestunit-plurals-accepted.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.round
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const time = new Temporal.PlainTime(12, 34, 56, 789, 999, 999);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => time.round({ smallestUnit }), validUnits);

--- a/polyfill/test/PlainTime/prototype/since/largestunit-plurals-accepted.js
+++ b/polyfill/test/PlainTime/prototype/since/largestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const later = new Temporal.PlainTime(13, 35, 57, 988, 655, 322);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => later.since(earlier, { largestUnit }), validUnits);

--- a/polyfill/test/PlainTime/prototype/since/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainTime/prototype/since/smallestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const later = new Temporal.PlainTime(13, 35, 57, 988, 655, 322);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => later.since(earlier, { smallestUnit }), validUnits);

--- a/polyfill/test/PlainTime/prototype/toString/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainTime/prototype/toString/smallestunit-plurals-accepted.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tostring
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const time = new Temporal.PlainTime(12, 34, 56, 789, 999, 999);
+const validUnits = [
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => time.toString({ smallestUnit }), validUnits);

--- a/polyfill/test/PlainTime/prototype/until/largestunit-plurals-accepted.js
+++ b/polyfill/test/PlainTime/prototype/until/largestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const later = new Temporal.PlainTime(13, 35, 57, 988, 655, 322);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => earlier.until(later, { largestUnit }), validUnits);

--- a/polyfill/test/PlainTime/prototype/until/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainTime/prototype/until/smallestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainTime(12, 34, 56, 987, 654, 321);
+const later = new Temporal.PlainTime(13, 35, 57, 988, 655, 322);
+const validUnits = [
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => earlier.until(later, { smallestUnit }), validUnits);

--- a/polyfill/test/PlainYearMonth/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/PlainYearMonth/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.plainyearmonth.prototype.since steps 21–22:
+      21. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+      22. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _options_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.PlainYearMonth(2000, 5, calendar);
+    const later = new Temporal.PlainYearMonth(2001, 6, calendar);
+    later.since(earlier, { largestUnit });
+  },
+  {
+    years: ["year"],
+    months: ["month"]
+  }
+);

--- a/polyfill/test/PlainYearMonth/prototype/since/largestunit-plurals-accepted.js
+++ b/polyfill/test/PlainYearMonth/prototype/since/largestunit-plurals-accepted.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainYearMonth(2000, 5);
+const later = new Temporal.PlainYearMonth(2001, 6);
+const validUnits = [
+  "year",
+  "month",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => later.since(earlier, { largestUnit }), validUnits);

--- a/polyfill/test/PlainYearMonth/prototype/since/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainYearMonth/prototype/since/smallestunit-plurals-accepted.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.since
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainYearMonth(2000, 5);
+const later = new Temporal.PlainYearMonth(2001, 6);
+const validUnits = [
+  "year",
+  "month",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => later.since(earlier, { smallestUnit }), validUnits);

--- a/polyfill/test/PlainYearMonth/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/PlainYearMonth/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.plainyearmonth.prototype.until steps 20–21:
+      20. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+      21. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _options_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.PlainYearMonth(2000, 5, calendar);
+    const later = new Temporal.PlainYearMonth(2001, 6, calendar);
+    earlier.until(later, { largestUnit });
+  },
+  {
+    years: ["year"],
+    months: ["month"]
+  }
+);

--- a/polyfill/test/PlainYearMonth/prototype/until/largestunit-plurals-accepted.js
+++ b/polyfill/test/PlainYearMonth/prototype/until/largestunit-plurals-accepted.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainYearMonth(2000, 5);
+const later = new Temporal.PlainYearMonth(2001, 6);
+const validUnits = [
+  "year",
+  "month",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => earlier.until(later, { largestUnit }), validUnits);

--- a/polyfill/test/PlainYearMonth/prototype/until/smallestunit-plurals-accepted.js
+++ b/polyfill/test/PlainYearMonth/prototype/until/smallestunit-plurals-accepted.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.until
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.PlainYearMonth(2000, 5);
+const later = new Temporal.PlainYearMonth(2001, 6);
+const validUnits = [
+  "year",
+  "month",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => earlier.until(later, { smallestUnit }), validUnits);

--- a/polyfill/test/ZonedDateTime/prototype/round/smallestunit-plurals-accepted.js
+++ b/polyfill/test/ZonedDateTime/prototype/round/smallestunit-plurals-accepted.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.round
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+const validUnits = [
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => datetime.round({ smallestUnit }), validUnits);

--- a/polyfill/test/ZonedDateTime/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/ZonedDateTime/prototype/since/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,113 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.zoneddatetime.prototype.since steps 14–18:
+      14. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+        c. Return ...
+      15. ...
+      16. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_).
+      17. Let _roundResult_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
+      18. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
+    sec-temporal-differencezoneddatetime steps 7 and 11:
+      7. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
+      11. Let _result_ be ? NanosecondsToDays(_timeRemainderNs_, _intermediate_).
+    sec-temporal-roundduration steps 5.d and 8.n–p:
+      5. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+        d. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_).
+      ...
+      8. If _unit_ is *"year"*, then
+        ...
+        n. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
+        o. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"year"*).
+        p. Let _timePassed_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _daysLater_, _untilOptions_)
+    sec-temporal-adjustroundeddurationdays steps 1 and 9:
+      1. If _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot; or _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*; or _unit_ is *"nanosecond"* and _increment_ is 1, then
+        a. Return ...
+      ...
+      9. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, _relativeTo_).
+    sec-temporal-addduration step 7.a–g:
+      a. Assert: _relativeTo_ has an [[IntializedTemporalZonedDateTime]] internal slot.
+      ...
+      f. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+      g. Else,
+        i. Let _result_ be ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_).
+    sec-temporal-nanosecondstodays step 11:
+      11. 1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*).
+    sec-temporal-differenceisodatetime steps 9–11:
+      9. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+      10. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
+      11. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC", calendar);
+    const later = new Temporal.ZonedDateTime(1_086_403_661_988_655_322n, "UTC", calendar);
+    later.since(earlier, { largestUnit });
+  },
+  {
+    years: ["year", "day"],
+    months: ["month", "day"],
+    weeks: ["week", "day"],
+    days: ["day", "day"],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);
+
+// Additionally check the path that goes through AdjustRoundedDurationDays
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.ZonedDateTime(0n, "UTC", calendar);
+    const later = new Temporal.ZonedDateTime(86_399_999_999_999n, "UTC", calendar);
+    later.since(earlier, { largestUnit, roundingIncrement: 2, roundingMode: 'ceil' });
+  },
+  {
+    years: ["year", "day", "day", "day"],
+    months: ["month", "day", "day", "day"],
+    weeks: ["week", "day", "day", "day"],
+    days: ["day", "day", "day", "day"],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);
+
+// Also check the path that goes through RoundDuration when smallestUnit is
+// given
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, smallestUnit) => {
+    const earlier = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC", calendar);
+    const later = new Temporal.ZonedDateTime(1_086_403_661_988_655_322n, "UTC", calendar);
+    later.since(earlier, { smallestUnit });
+  },
+  {
+    years: ["year", "day", "day", "year"],
+    months: ["month", "day", "day"],
+    weeks: ["week", "day", "day"],
+    days: ["day", "day", "day"],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);

--- a/polyfill/test/ZonedDateTime/prototype/since/largestunit-plurals-accepted.js
+++ b/polyfill/test/ZonedDateTime/prototype/since/largestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+const later = new Temporal.ZonedDateTime(1_086_403_661_988_655_322n, "UTC");
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => later.since(earlier, { largestUnit }), validUnits);

--- a/polyfill/test/ZonedDateTime/prototype/since/smallestunit-plurals-accepted.js
+++ b/polyfill/test/ZonedDateTime/prototype/since/smallestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+const later = new Temporal.ZonedDateTime(1_086_403_661_988_655_322n, "UTC");
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => later.since(earlier, { smallestUnit }), validUnits);

--- a/polyfill/test/ZonedDateTime/prototype/toString/smallestunit-plurals-accepted.js
+++ b/polyfill/test/ZonedDateTime/prototype/toString/smallestunit-plurals-accepted.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(1_000_000_000_123_456_789n, "UTC");
+const validUnits = [
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => datetime.toString({ smallestUnit }), validUnits);

--- a/polyfill/test/ZonedDateTime/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
+++ b/polyfill/test/ZonedDateTime/prototype/until/calendar-dateuntil-called-with-singular-largestunit.js
@@ -1,0 +1,113 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: The options object passed to calendar.dateUntil has a largestUnit property with its value in the singular form
+info: |
+    sec-temporal.zoneddatetime.prototype.until steps 13–17:
+      13. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+        c. Return ...
+      14. ...
+      15. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_).
+      16. Let _roundResult_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
+      17. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
+    sec-temporal-differencezoneddatetime steps 7 and 11:
+      7. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
+      11. Let _result_ be ? NanosecondsToDays(_timeRemainderNs_, _intermediate_).
+    sec-temporal-roundduration steps 5.d and 8.n–p:
+      5. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+        d. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_).
+      ...
+      8. If _unit_ is *"year"*, then
+        ...
+        n. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
+        o. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"year"*).
+        p. Let _timePassed_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _daysLater_, _untilOptions_)
+    sec-temporal-adjustroundeddurationdays steps 1 and 9:
+      1. If _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot; or _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*; or _unit_ is *"nanosecond"* and _increment_ is 1, then
+        a. Return ...
+      ...
+      9. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, _relativeTo_).
+    sec-temporal-addduration step 7.a–g:
+      a. Assert: _relativeTo_ has an [[IntializedTemporalZonedDateTime]] internal slot.
+      ...
+      f. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+      g. Else,
+        i. Let _result_ be ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_).
+    sec-temporal-nanosecondstodays step 11:
+      11. 1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*).
+    sec-temporal-differenceisodatetime steps 9–11:
+      9. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+      10. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
+      11. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
+includes: [compareArray.js, temporalHelpers.js]
+---*/
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC", calendar);
+    const later = new Temporal.ZonedDateTime(1_086_403_661_988_655_322n, "UTC", calendar);
+    earlier.until(later, { largestUnit });
+  },
+  {
+    years: ["year", "day"],
+    months: ["month", "day"],
+    weeks: ["week", "day"],
+    days: ["day", "day"],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);
+
+// Additionally check the path that goes through AdjustRoundedDurationDays
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, largestUnit) => {
+    const earlier = new Temporal.ZonedDateTime(0n, "UTC", calendar);
+    const later = new Temporal.ZonedDateTime(86_399_999_999_999n, "UTC", calendar);
+    earlier.until(later, { largestUnit, roundingIncrement: 2, roundingMode: 'ceil' });
+  },
+  {
+    years: ["year", "day", "day", "day"],
+    months: ["month", "day", "day", "day"],
+    weeks: ["week", "day", "day", "day"],
+    days: ["day", "day", "day", "day"],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);
+
+// Also check the path that goes through RoundDuration when smallestUnit is
+// given
+
+TemporalHelpers.checkCalendarDateUntilLargestUnitSingular(
+  (calendar, smallestUnit) => {
+    const earlier = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC", calendar);
+    const later = new Temporal.ZonedDateTime(1_086_403_661_988_655_322n, "UTC", calendar);
+    earlier.until(later, { smallestUnit });
+  },
+  {
+    years: ["year", "day", "day", "year"],
+    months: ["month", "day", "day"],
+    weeks: ["week", "day", "day"],
+    days: ["day", "day", "day"],
+    hours: [],
+    minutes: [],
+    seconds: [],
+    milliseconds: [],
+    microseconds: [],
+    nanoseconds: []
+  }
+);

--- a/polyfill/test/ZonedDateTime/prototype/until/largestunit-plurals-accepted.js
+++ b/polyfill/test/ZonedDateTime/prototype/until/largestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Plural units are accepted as well for the largestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+const later = new Temporal.ZonedDateTime(1_086_403_661_988_655_322n, "UTC");
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((largestUnit) => earlier.until(later, { largestUnit }), validUnits);

--- a/polyfill/test/ZonedDateTime/prototype/until/smallestunit-plurals-accepted.js
+++ b/polyfill/test/ZonedDateTime/prototype/until/smallestunit-plurals-accepted.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: Plural units are accepted as well for the smallestUnit option
+includes: [temporalHelpers.js]
+---*/
+
+const earlier = new Temporal.ZonedDateTime(1_000_000_000_987_654_321n, "UTC");
+const later = new Temporal.ZonedDateTime(1_086_403_661_988_655_322n, "UTC");
+const validUnits = [
+  "year",
+  "month",
+  "week",
+  "day",
+  "hour",
+  "minute",
+  "second",
+  "millisecond",
+  "microsecond",
+  "nanosecond",
+];
+TemporalHelpers.checkPluralUnitsAccepted((smallestUnit) => earlier.until(later, { smallestUnit }), validUnits);


### PR DESCRIPTION
This is the implementation of the normative changes in #1509 in the
polyfill, accompanied by test262 tests to ensure that passing plural and
singular values for largestUnit, smallestUnit, and unit behaves the same;
and also that Calendar.dateUntil() is only ever called with options bags
that contain singular values for largestUnit.

See: #1491