### PR TITLE
Move assert down in CreateTemporalTimeZone

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -414,6 +414,7 @@
         1. If _identifier_ satisfies the syntax of a |TimeZoneNumericUTCOffset| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
           1. Set _object_.[[OffsetNanoseconds]] to ! ParseTimeZoneOffsetString(_identifier_).
         1. Else,
+          1. Assert: ! CanonicalizeTimeZoneName(_identifier_) is _identifier_.
           1. Set _object_.[[OffsetNanoseconds]] to *undefined*.
         1. Return _object_.
       </emu-alg>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -408,7 +408,6 @@
     <emu-clause id="sec-temporal-createtemporaltimezone" aoid="CreateTemporalTimeZone">
       <h1>CreateTemporalTimeZone ( _identifier_ [ , _newTarget_ ] )</h1>
       <emu-alg>
-        1. Assert: ! CanonicalizeTimeZoneName(_identifier_) is _identifier_.
         1. If _newTarget_ is not present, set it to %Temporal.TimeZone%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.TimeZone.prototype%"*, « [[InitializedTemporalTimeZone]], [[Identifier]], [[OffsetNanoseconds]] »).
         1. Set _object_.[[Identifier]] to _identifier_.


### PR DESCRIPTION
I think we have some problem with current logic in the TimeZone

First of all, let's assume the spec support only the "minimum implementation", which mean
IsValidTimeZoneName only return true if the timeZone is a case-insiitive verison of "UTC" and CanonicalizeTimeZoneName only return "UTC".
https://tc39.es/proposal-temporal/#sec-isvalidtimezonename
https://tc39.es/proposal-temporal/#sec-canonicalizetimezonename

Now, we can see some issue in the rest of the spec

https://tc39.es/proposal-temporal/#sec-temporal.timezone
notice if the identifier is something like "+12", "-12:34" "+12:34:56" it will then satisfied 
"3.  If identifier satisfies the syntax of a TimeZoneNumericUTCOffset (see 13.33), then"
and step 3.b will be run
b. Let canonical be ! FormatTimeZoneOffsetString(offsetNanoseconds).
so canonical will be "+12:00:00", "-12:34:00" "+12:34:56", etc

But now in step 4
5. Return ? CreateTemporalTimeZone(canonical, NewTarget).

but in 
https://tc39.es/proposal-temporal/#sec-temporal-createtemporaltimezone

1. Assert: ! CanonicalizeTimeZoneName(identifier) is identifier.
and that could not always be true

Also that assertion conflict with
5. If identifier satisfies the syntax of a TimeZoneNumericUTCOffset (see 13.33), then

because if identifier in the minimum implementaiton is always "UTC" it will never satisfies the syntax of a TimeZoneNumericUTCOffset


@justingrant @ptomato @sffc @ryzokuken 