### PR TITLE
Add DST warning to `PlainTime.p.compare()` docs

### DIFF
--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -143,6 +143,31 @@ sorted = [one, two, three].sort(Temporal.PlainTime.compare);
 sorted.join(' '); // => '01:24:00 01:24:05 03:24:00'
 ```
 
+Note that time zone offset transitions (like when Daylight Saving Time starts or ends ends) can produce unexpected results when comparing times, because clock times can be skipped or repeated.
+Therefore, `Temporal.ZonedDateTime.compare` (not `Temporal.PlainTime.compare`) should be used if the caller's actual intent is to compare specific instants, e.g. arrivals of two airplane flights.
+For example:
+
+```javascript
+// Backward transitions will repeat clock times
+zdtDst = Temporal.ZonedDateTime.from('2020-11-01T01:45-07:00[America/Los_Angeles]');
+zdtStandard = Temporal.ZonedDateTime.from('2020-11-01T01:30-08:00[America/Los_Angeles]');
+// The "first" 1:45 (in Daylight Time) is earlier than the "second" 1:30 (in Standard Time)
+Temporal.ZonedDateTime.compare(zdtDst, zdtStandard); // => -1
+// 1:45 is later than 1:30 when looking at a wall clock
+Temporal.PlainTime.compare(zdtDst, zdtStandard); // => 1
+
+// Forward transitions will skip clock times. Skipped times will be disambiguated.
+zdtBase = Temporal.ZonedDateTime.from('2020-03-08[America/Los_Angeles]');
+timeSkipped = Temporal.PlainTime.from('02:30');
+timeValid = Temporal.PlainTime.from('03:30');
+zdtSkipped = zdtBase.withPlainTime(timeSkipped);
+zdtValid = zdtBase.withPlainTime(timeValid);
+// The skipped time 2:30AM is disambiguated to 3:30AM, so the instants are equal
+Temporal.ZonedDateTime.compare(zdtSkipped, zdtValid); // => 0
+// 2:30 is earlier than 3:30 on a wall clock
+Temporal.PlainTime.compare(timeSkipped, timeValid); // => -1
+```
+
 ## Properties
 
 ### time.**hour**: number


### PR DESCRIPTION
Add a warning in the docs to provide guidance on comparing times on days where DST ends. 

See https://github.com/tc39/proposal-temporal/issues/1547#issuecomment-864291946