### PR TITLE
Normative: Remove extra "secondsPart"

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1487,7 +1487,7 @@
         1. Let _signPart_ be the code unit 0x002D (HYPHEN-MINUS) if _sign_ &lt; 0, and otherwise the empty String.
         1. Let _result_ be the string concatenation of _signPart_, the code unit 0x0050 (LATIN CAPITAL LETTER P) and _datePart_.
         1. If _timePart_ is not *""*, then
-          1. Set _result_ to the string concatenation of _result_, the code unit 0x0054 (LATIN CAPITAL LETTER T), and _timePart__.
+          1. Set _result_ to the string concatenation of _result_, the code unit 0x0054 (LATIN CAPITAL LETTER T), and _timePart_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1487,7 +1487,7 @@
         1. Let _signPart_ be the code unit 0x002D (HYPHEN-MINUS) if _sign_ &lt; 0, and otherwise the empty String.
         1. Let _result_ be the string concatenation of _signPart_, the code unit 0x0050 (LATIN CAPITAL LETTER P) and _datePart_.
         1. If _timePart_ is not *""*, then
-          1. Set _result_ to the string concatenation of _result_, the code unit 0x0054 (LATIN CAPITAL LETTER T), _timePart_, and _secondsPart_.
+          1. Set _result_ to the string concatenation of _result_, the code unit 0x0054 (LATIN CAPITAL LETTER T), and _timePart__.
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
_secondsPart_ is already concatated into _timePart_ 4 lines above and should not be concancated again.

@ptomato @justingrant @sffc @Ms2ger 