### PR TITLE
Assert precision in TemporalDurationToString

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1446,6 +1446,7 @@
     <emu-clause id="sec-temporal-temporaldurationtostring" aoid="TemporalDurationToString">
       <h1>TemporalDurationToString ( _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _precision_ )</h1>
       <emu-alg>
+        1. Assert: _precision_ is not *"minute"*.
         1. Set _seconds_ to the mathematical value of _seconds_.
         1. Set _milliseconds_ to the mathematical value of _milliseconds_.
         1. Set _microseconds_ to the mathematical value of _microseconds_.


### PR DESCRIPTION
Make it clear that precision is not "minute" in the beginning of TemporalDurationToString

Currently, it is not very clear that the precision cannot be "minute" in this Abstract Operation
So when we look at step 21
In TemporalDurationToString
https://tc39.es/proposal-temporal/#sec-temporal-temporaldurationtostring
21-c. If precision is "auto", then
21-c-i. Set decimalPart to the longest possible substring of decimalPart starting at position 0 and not ending with the code unit 0x0030 (DIGIT ZERO).
21-d. Else if precision ≠ 0, then
21-d-i. Set decimalPart to the substring of decimalPart from 0 to precision.

It has an illusion that , step 21-d and 21-d-i could be troublesome because the precision could be "minute" but  the fact is the precision will never be "minute" from the caller, but that is not clear. 

Noitce the place which the precision could be non "auto" is  while it is called from
 https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tostring

where the precision is passed in by  precision.[[Precision]])
and precision is from 
step 4. Let precision be ? ToSecondsStringPrecision(options).
which could return "minute" as precision.[[Precision]]
but then the only record which return "minute" as precision.[[Precision]]
is the record which also return "minute" as precision.[[Unit]] and in step 5 of Temporal.Duration.prototype.toString it is throw away

But it is not very obvious, unless carefully exam the combination to show that. so I think it is better we add an assertion in the beginning of this abstract operation to make it clear.