### PR TITLE
Correct argument to TemporalTimeToString

### DIFF
--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -469,7 +469,7 @@
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. Return ? TemporalTimeToString(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], *"auto"*, *"auto"*).
+        1. Return ? TemporalTimeToString(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], *"auto"*).
       </emu-alg>
     </emu-clause>
 
@@ -481,7 +481,7 @@
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. Return ? TemporalTimeToString(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _temporalTime_.[[Calendar]], *"auto"*, *"auto"*).
+        1. Return ? TemporalTimeToString(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], *"auto"*).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Current spec text pass one extra "auto" as the second precision to TemporalTimeToString in 
4.3.21 Temporal.PlainTime.prototype.toLocaleString ( [ locales [ , options ] ] )
https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tolocalestring

and pass the calendar and one extra "auto" as another precision to TemporalTimeToString in
4.3.22 Temporal.PlainTime.prototype.toJSON ( )
https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson

This make the three different calls to TemporalTimeToString all pass different number of arguments. 
We should make it only passing one precision and no calendar in all cases.

@sffc @justingrant @ptomato @Ms2ger  @ryzokuken 