### PR TITLE
fix typo in TemporalTimeToString

### DIFF
--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -849,7 +849,7 @@
       <emu-alg>
         1. Assert: _hour_, _minute_, _second_, _millisecond_, _microsecond_ and _nanosecond_ are integers.
         1. Let _hour_ be _hour_ formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-        1. Let _hour_ be _minute_ formatted as a two-digit decimal number, padded to the left with a zero if necessary.
+        1. Let _minute_ be _minute_ formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _seconds_ be ! FormatSecondsStringPart(_second_, _millisecond_, _microsecond_, _nanosecond_, _precision_).
         1. Return the string-concatenation of _hour_, the code unit 0x003A (COLON), _minute_, and _seconds_.
       </emu-alg>


### PR DESCRIPTION
Step 3 should be 
3. Let minute be minute formatted as a two-digit decimal number, padded to the left with a zero if necessary.
not
3. Let hour be minute formatted as a two-digit decimal number, padded to the left with a zero if necessary.

@sffc @ptomato @justingrant @Ms2ger @ryzokuken 