### PR TITLE
Normative: Remove unneeded ToTemporalOverflow

### DIFF
--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -57,7 +57,6 @@
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. If Type(_item_) is Object and _item_ has an [[InitializedTemporalDate]] internal slot, then
-          1. Perform ? ToTemporalOverflow(_options_).
           1. Return ? CreateTemporalDate(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[Calendar]]).
         1. Return ? ToTemporalDate(_item_, _options_).
       </emu-alg>
@@ -691,7 +690,6 @@
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
           1. Return ? DateFromFields(_calendar_, _fields_, _options_).
-        1. Perform ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalDateString(_string_).
         1. Assert: ! IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -69,7 +69,6 @@
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. If Type(_item_) is Object and _item_ has an [[InitializedTemporalDateTime]] internal slot, then
-          1. Perform ? ToTemporalOverflow(_options_).
           1. Return ? CreateTemporalDateTime(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]], _item_.[[Calendar]]).
         1. Return ? ToTemporalDateTime(_item_, _options_).
       </emu-alg>
@@ -918,7 +917,6 @@
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
           1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Else,
-          1. Perform ? ToTemporalOverflow(_options_).
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalDateTimeString(_string_).
           1. Assert: ! IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -59,7 +59,6 @@
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. If Type(_item_) is Object and _item_ has an [[InitializedTemporalMonthDay]] internal slot, then
-          1. Perform ? ToTemporalOverflow(_options_).
           1. Return ? CreateTemporalMonthDay(_item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[Calendar]], _item_.[[ISOYear]]).
         1. Return ? ToTemporalMonthDay(_item_, _options_).
       </emu-alg>
@@ -369,7 +368,6 @@
           1. If _calendarAbsent_ is *true*, and _month_ is not *undefined*, and _monthCode_ is *undefined* and _year_ is *undefined*, then
             1. Perform ! CreateDataPropertyOrThrow(_fields_, *"year"*, 𝔽(_referenceISOYear_)).
           1. Return ? MonthDayFromFields(_calendar_, _fields_, _options_).
-        1. Perform ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalMonthDayString(_string_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -58,7 +58,6 @@
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. If Type(_item_) is Object and _item_ has an [[InitializedTemporalYearMonth]] internal slot, then
-          1. Perform ? ToTemporalOverflow(_options_).
           1. Return ? CreateTemporalYearMonth(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[Calendar]], _item_.[[ISODay]]).
         1. Return ? ToTemporalYearMonth(_item_, _options_).
       </emu-alg>
@@ -565,7 +564,6 @@
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
           1. Return ? YearMonthFromFields(_calendar_, _fields_, _options_).
-        1. Perform ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalYearMonthString(_string_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -55,9 +55,6 @@
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. If Type(_item_) is Object and _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
-          1. Perform ? ToTemporalOverflow(_options_).
-          1. Perform ? ToTemporalDisambiguation(_options_).
-          1. Perform ? ToTemporalOffset(_options_, *"reject"*).
           1. Return ? CreateTemporalZonedDateTime(_item_.[[Nanoseconds]], _item_.[[TimeZone]], _item_.[[Calendar]]).
         1. Return ? ToTemporalZonedDateTime(_item_, _options_).
       </emu-alg>
@@ -1117,7 +1114,6 @@
           1. If _offsetString_ is not *undefined*, set it to ? ToString(_offsetString_).
           1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Else,
-          1. Perform ? ToTemporalOverflow(_options_).
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalZonedDateTimeString(_string_).
           1. If _result_.[[TimeZoneName]] is *undefined*, throw a *RangeError* exception.


### PR DESCRIPTION
We should remove some calls to ToTemporalOverflow / ToTemporalDisambiguation / ToTemporalOffset because in these places it read the overview/disambiguation/offset option but did nothing with return value beside possible throwing exception as side effect during the get option.

https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from
3.2.2 Temporal.PlainDate.from ( item [ , options ] )
step 2-a. Perform ? ToTemporalOverflow(options).

https://tc39.es/proposal-temporal/#sec-temporal-totemporaldate
3.5.2 ToTemporalDate ( item [ , options ] )
step 4. Perform ? ToTemporalOverflow(options).

https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from
5.2.2 Temporal.PlainDateTime.from ( item [ , options ] )
step 2-a. Perform ? ToTemporalOverflow(options).

https://tc39.es/proposal-temporal/#sec-temporal-totemporaldatetime
5.5.4 ToTemporalDateTime ( item [ , options ] )
step 3-a. Perform ? ToTemporalOverflow(options).

https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from
6.2.2 Temporal.ZonedDateTime.from ( item [ , options ] )
stpe 2-a. Perform ? ToTemporalOverflow(options).
stpe 2-b. Perform ? ToTemporalDisambiguation(options).
stpe 2-c. Perform ? ToTemporalOffset(options, "reject").

https://tc39.es/proposal-temporal/#sec-temporal-totemporalzoneddatetime
6.5.2 ToTemporalZonedDateTime ( item [ , options ] )
step 3-a. Perform ? ToTemporalOverflow(options).

https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.from
9.2.2 Temporal.PlainYearMonth.from ( item [ , options ] )
step 2-a. Perform ? ToTemporalOverflow(options).

https://tc39.es/proposal-temporal/#sec-temporal-totemporalyearmonth
9.5.1 ToTemporalYearMonth ( item [ , options ] )
step 4. Perform ? ToTemporalOverflow(options).

https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from
10.2.2 Temporal.PlainMonthDay.from ( item [ , options ] )
step 2-a. Perform ? ToTemporalOverflow(options).

https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday
10.5.1 ToTemporalMonthDay ( item [ , options ] )
step 4. Perform ? ToTemporalOverflow(options).

The calling may throw if the options contains value which is out of the defined set, but why should we read these option in these places if we are not going to use the value. 
