### PR TITLE
Editorial: Simplify ParseTemporalMonthDayString

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1329,21 +1329,15 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalMonthDayString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
-      1. Let _year_, _month_ and _day_ be the parts of _isoString_ produced respectively by the |DateYear|, |DateMonth| and |DateDay| productions, or *undefined* if not present.
-      1. If _year_ is not *undefined*, then
-        1. Set _year_ to ! ToIntegerOrInfinity(_year_).
-      1. If _month_ is *undefined*, then
-        1. Set _month_ to 1.
-      1. Else,
-        1. Set _month_ to ! ToIntegerOrInfinity(_month_).
-      1. If _day_ is *undefined*, then
-        1. Set _day_ to 1.
-      1. Else,
-        1. Set _day_ to ! ToIntegerOrInfinity(_day_).
+      1. Let _result_ be ? ParseISODateTime(_isoString_).
+      1. Let _year_ be _result_.[[Year]].
+      1. If no part of _isoString_ is produced by the |DateYear| production, then
+        1. Set _year_ to *undefined*.
       1. Return the Record {
         [[Year]]: _year_,
-        [[Month]]: _month_,
-        [[Day]]: _day_
+        [[Month]]: _result_.[[Month]],
+        [[Day]]: _result_.[[Day]],
+        [[Calendar]]: _result_.[[Calendar]]
         }.
     </emu-alg>
   </emu-clause>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1097,7 +1097,7 @@
   <emu-clause id="sec-temporal-parseisodatetime" aoid="ParseISODateTime">
     <h1>ParseISODateTime ( _isoString_ )</h1>
     <p>
-      The ParseISODateTime abstract operation examines any |Time|, |DateTime| or |CalendarDateTime| string accepted by the grammar in <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref> and returns a record with all the date and time components found.
+      The ParseISODateTime abstract operation examines any ISO 8601 string that adheres to the syntax of the |TemporalDateString|, |TemporalDateTimeString|, |TemporalInstantString|, |TemporalMonthDayString|, |TemporalRelativeToString|, |TemporalTimeString|, |TemporalYearMonthString|, or |TemporalZonedDateTimeString| productions of the grammar in <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref> and returns a record with all the date and time components found.
     </p>
     <emu-note>The value of ? ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
     <emu-alg>


### PR DESCRIPTION
ParseTemporalMonthDayString could be simplfy for not dealing impossible condiction
https://tc39.es/proposal-temporal/#sec-temporal-parsetemporalmonthdaystring

Since we throw in step 2. If isoString does not satisfy the syntax of a TemporalMonthDayString (see 13.33), then
we know we have a TemporalMonthDayString which is either DateSpecMonthDay or DateTime
DateSpecMonthDay =  --opt DateMonth -opt DateDay
and
DateTime = Date TimeSpecSeparatoropt TimeZoneopt

and we know Date is either of the following two
DateYear - DateMonth - DateDay   
DateYear DateMonth DateDay

so in all three cases we have both DateMonth and DateDay
and if either DateMonth or DateDay is not presented then step 2 will throw.
Therefore, both 5. If month is undefined, and 7. If day is undefined,  can never happen

@pdunkel @ptomato @justingrant @sffc @Ms2ger @ryzokuken 