### PR TITLE
Editorial: Remove plural rows and add "timeZone" in Table 13

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1443,7 +1443,7 @@
             1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
               1. Set _value_ to the corresponding Default value of the same row.
         1. Else,
-          1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+          1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
             1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.
             1. Set _value_ to ? _Conversion_(_value_).
         1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
@@ -1527,7 +1527,7 @@
           </tr>
           <tr>
             <td>*"timeZone"*</td>
-            <td>ToString</td>
+            <td></td>
             <td>*undefined*</td>
           </tr>
         </tbody>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1511,56 +1511,6 @@
             <td>0</td>
           </tr>
           <tr>
-            <td>*"years"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <td>*"months"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <td>*"weeks"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <td>*"days"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <td>*"hours"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <td>*"minutes"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <td>*"seconds"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <td>*"milliseconds"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <td>*"microseconds"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <td>*"nanoseconds"*</td>
-            <td>ToIntegerOrInfinity</td>
-            <td>0</td>
-          </tr>
-          <tr>
             <td>*"offset"*</td>
             <td>ToString</td>
             <td>*undefined*</td>
@@ -1573,6 +1523,11 @@
           <tr>
             <td>*"eraYear"*</td>
             <td>ToInteger</td>
+            <td>*undefined*</td>
+          </tr>
+          <tr>
+            <td>*"timeZone"*</td>
+            <td>ToString</td>
             <td>*undefined*</td>
           </tr>
         </tbody>


### PR DESCRIPTION
Table  Table 13: Temporal field requirements is only used by
https://tc39.es/proposal-temporal/#table-temporal-field-requirements
https://tc39.es/proposal-temporal/#sec-temporal-preparetemporalfields
13.46 PrepareTemporalFields ( fields, fieldNames, requiredFields )
and PrepareTemporalFields is NOT used by Temporal.Duration

The fieldNames could only come from one of two places
1. the return of CalendarFields
2. the return of CalendarMergeFields
and according to the spec the iso8601 calendar will not output any token in the plural form from the Temporal.Calendar.prototype.fields and Temporal.Calendar.prototype.mergeFields and I believe there are no reason a custom calendar subclass from that or builtin for i18n has the need or should return a field name in the plural forms.

Notice this is NOT used by the Duration from my reading. (please correct me if I am wrong) and therefore has nothing to do with Duration discussion.

Also, in https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.with
the code will call PrepareTemporalFields with "timeZone" in the fieldsNames but the table 13 does not include the conversion for "timeZone"