### PR TITLE
Change unsupported {hebrew} to [u-ca=hebrew]

### DIFF
--- a/docs/iso-string-ext.md
+++ b/docs/iso-string-ext.md
@@ -97,7 +97,7 @@ For example, a `Temporal` object using the Hebrew calendar might store "Iyar 578
 When expressed as an ISO string, we would say:
 
 ```
-2020-04-25{hebrew}
+2020-04-25[u-ca=hebrew]
 ```
 
 Because it is ambiguous whether that string represents a `Temporal.PlainDate`, `Temporal.YearMonth`, or `Temporal.MonthDay`, the appropriate `Temporal` constructor must be chosen in order to get the expected data type back out.


### PR DESCRIPTION
This is a typo of {hebrew} right? I cannot find {} syntax in the ISO8601 grammar