### PR TITLE
Simplify ISOMonthDayFromFields

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -524,19 +524,11 @@
         1. Assert: Type(_fields_) is Object.
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », «»).
-        1. Let _month_ be ? Get(_fields_, *"month"*).
-        1. Let _monthCode_ be ? Get(_fields_, *"monthCode"*).
-        1. Let _year_ be ? Get(_fields_, *"year"*).
-        1. If _month_ is not *undefined*, and _monthCode_ and _year_ are both *undefined*, then
-          1. Throw a *TypeError* exception.
         1. Set _month_ to ? ResolveISOMonth(_fields_).
         1. Let _day_ be ? Get(_fields_, *"day"*).
         1. If _day_ is *undefined*, throw a *TypeError* exception.
         1. Let _referenceISOYear_ be 1972 (the first leap year after the Unix epoch).
-        1. If _monthCode_ is *undefined*, then
-          1. Let _result_ be ? RegulateISODate(_year_, _month_, _day_, _overflow_).
-        1. Else,
-          1. Let _result_ be ? RegulateISODate(_referenceISOYear_, _month_, _day_, _overflow_).
+        1. Let _result_ be ? RegulateISODate(_referenceISOYear_, _month_, _day_, _overflow_).
         1. Return the new Record {
             [[Month]]: _result_.[[Month]],
             [[Day]]: _result_.[[Day]],


### PR DESCRIPTION
Notice this AO is for ISO8601 and ISO8601 ONLY. It is NOT called by calendars other than ISO8601 in the spec. And all the places which call ISOMonthDayFromFields is guarded with either assert or IF to ensure it is only called when the calendar is guarantee to be ISO8601. Under that condition, there are no reason we should throw if both year and monthCode are undefined 

Any reason why this AO is not as simple as what I proposed here?

@justingrant @ptomato @sffc @Ms2ger @ryzokuken 
See discussion in https://github.com/tc39/proposal-temporal/issues/1614 also
Notice I just try to use this PR to show my question about why the spec is in the current shape and would like to understand why it is NOT what I propose here. I understand if the AO is written for all other calender than we may need to consider a lot of other factor, but the AO is clearly only wirtten for ISO8601 and ISO8601 only. So in that condition, I see no reason it need to be this complicated. 