### PR TITLE
README changes to prepare for polyfill deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This proposal is currently [Stage 3](https://github.com/tc39/proposals#stage-3) 
 
 This proposal is now in the hands of ECMAScript engine implementers, so the bar for making API changes is extremely high.
 Nonetheless, changes may occur as the result of feedback from implementation in JS engines.
-Editorial changes to the spec and bug fixes to the spec, polyfill, tests, and docs are also ongoing, as is customary for Stage 3 proposals.
+Editorial changes to the spec and bug fixes to the spec, tests, and docs are also ongoing, as is customary for Stage 3 proposals.
 Additional tests and documentation content are also being added during Stage 3.
 
 ## Champions
@@ -43,19 +43,22 @@ For a detailed breakdown of motivations, see:
 
 The specification text can be found [here](https://tc39.es/proposal-temporal/).
 
-## Polyfill
-
-A [non-production polyfill](./polyfill) was built to validate this proposal.
-The champions of this proposal will soon start work on a production-ready polyfill, and once it's started it will be linked here.
-If you're working on a different production-quality polyfill, let us know and we can link it here too!
-
-When viewing the [reference documentation](https://tc39.es/proposal-temporal/docs/index.html), the polyfill is automatically loaded in your browser, so you can try it out by opening your browser's developer tools console.
-
-**NOTE: We encourage you to experiment with the polyfill, but don't use it in production!**
-**The API may change based on feedback from implementers, and the current non-production polyfill is very slow for some operations.**
-
 ## Documentation
 
 Reference documentation and examples can be found [here](https://tc39.es/proposal-temporal/docs/index.html).
 
 A cookbook to help you get started and learn the ins and outs of Temporal is available [here](https://tc39.es/proposal-temporal/docs/cookbook.html)
+
+## Polyfills
+
+| Polyfill                                                                         | Repo                                                                              | Status                            |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------- |
+| **[@js-temporal/polyfill](https://www.npmjs.com/package/@js-temporal/polyfill)** | [js-temporal/temporal-polyfill](https://github.com/js-temporal/temporal-polyfill) | Preparing for first alpha release |
+
+If you're working on a production polyfill, please file an issue or PR so we can add yours to the table above.
+
+A [non-production polyfill](./polyfill) was built to validate this proposal, and continues in this repo for the sole purpose of running tests.
+DO NOT use this polyfill in your own projects!
+Instead, please use one of the polyfills in the table above.
+
+When viewing the [reference documentation](https://tc39.es/proposal-temporal/docs/index.html), the non-production polyfill is automatically loaded in your browser, so you can try out Temporal by opening your browser's developer tools console.

--- a/README.md
+++ b/README.md
@@ -55,10 +55,14 @@ A cookbook to help you get started and learn the ins and outs of Temporal is ava
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------- |
 | **[@js-temporal/polyfill](https://www.npmjs.com/package/@js-temporal/polyfill)** | [js-temporal/temporal-polyfill](https://github.com/js-temporal/temporal-polyfill) | Preparing for first alpha release |
 
-If you're working on a production polyfill, please file an issue or PR so we can add yours to the table above.
+If you're working on a polyfill, please file an issue or PR so we can add yours here.
 
-A [non-production polyfill](./polyfill) was built to validate this proposal, and continues in this repo for the sole purpose of running tests.
-DO NOT use this polyfill in your own projects!
-Instead, please use one of the polyfills in the table above.
+A [non-production polyfill](./polyfill) was built to validate this proposal.
+This polyfill continues to live in this repo, but only for the purposes of running tests and powering the documentation "playground" as described below.
+
+**DO NOT use this polyfill in your own projects!
+Instead, please use a polyfill from the table above.**
+
+## Documentation Playground
 
 When viewing the [reference documentation](https://tc39.es/proposal-temporal/docs/index.html), the non-production polyfill is automatically loaded in your browser, so you can try out Temporal by opening your browser's developer tools console.

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -1,15 +1,8 @@
 # Non-Production, Test-Only Temporal Polyfill
 
-A non-production polyfill was built to validate this proposal, and continues in this repo for the sole purpose of running tests.
-
-**DO NOT use this polyfill in your own projects! Instead, please use one of the polyfills listed in the table [here](../#polyfills).**
-
-When viewing the reference documentation, this non-production polyfill is automatically loaded in your browser.
-You can experiment with Temporal by opening your browser's developer tools console.
-
-Please report polyfill bugs in the [issue tracker](https://github.com/tc39/proposal-temporal/issues).
-
-The polyfill requires Node.js 12 or later.
+A non-production polyfill was built to validate this proposal.
+This polyfill continues to live in this repo, but only for the purposes of running tests and powering the documentation "playground" as described below.
+**DO NOT use this polyfill in your own projects! Instead, please use a polyfill listed in the table [here](../#polyfills).**
 
 ## Documentation
 
@@ -17,16 +10,10 @@ Reference documentation and examples can be found [here](https://tc39.es/proposa
 
 A [cookbook](https://tc39.es/proposal-temporal/docs/index.html) of common use cases can help you get started with Temporal.
 
-## Node REPL with Temporal
+## Documentation Playground
 
-There are two easy ways to interactively run and test Temporal code using this polyfill.
-The first, as noted above, is to open the browser devtools console from any page in the [Temporal documentation](https://tc39.es/proposal-temporal/docs/index.html).
-The other is to use the built-in Node REPL.
-
-```bash
-# run from the /polyfill folder
-$ npm run playground
-```
+When viewing the [reference documentation](https://tc39.es/proposal-temporal/docs/index.html), this non-production polyfill is automatically loaded in your browser.
+You can experiment with Temporal by opening your browser's developer tools console.
 
 ## Running Documentation Cookbook as Tests
 

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -1,55 +1,41 @@
-# Temporal Polyfill
+# Non-Production, Test-Only Temporal Polyfill
 
-**Polyfill for [Proposal: Temporal](https://github.com/tc39/proposal-temporal)**
+A non-production polyfill was built to validate this proposal, and continues in this repo for the sole purpose of running tests.
 
-**NOTE: We encourage you to experiment with the polyfill, but don't use it in production!**
-**The API may change based on feedback from implementers, and the current non-production polyfill is very slow for some operations.**
-Please report bugs in the [issue tracker](https://github.com/tc39/proposal-temporal/issues).
+**DO NOT use this polyfill in your own projects! Instead, please use one of the polyfills listed in the table [here](../#polyfills).**
 
-Please run the polyfill with Node.js 12 or later.
+When viewing the reference documentation, this non-production polyfill is automatically loaded in your browser.
+You can experiment with Temporal by opening your browser's developer tools console.
+
+Please report polyfill bugs in the [issue tracker](https://github.com/tc39/proposal-temporal/issues).
+
+The polyfill requires Node.js 12 or later.
 
 ## Documentation
 
 Reference documentation and examples can be found [here](https://tc39.es/proposal-temporal/docs/index.html).
 
-A cookbook to help you get started and learn the ins and outs of Temporal is available [here](https://tc39.es/proposal-temporal/docs/index.html)
-
-## Import as a Module
-
-You can depend on the unstable Temporal polyfill in your personal projects:
-
-```bash
-$ npm install --save proposal-temporal
-```
-
-In code:
-
-```javascript
-const { Temporal } = require('proposal-temporal');
-```
-
-Or, import the polyfill as an ES6 module:
-
-```javascript
-import { Temporal } from 'proposal-temporal/lib/index.mjs';
-```
+A [cookbook](https://tc39.es/proposal-temporal/docs/index.html) of common use cases can help you get started with Temporal.
 
 ## Node REPL with Temporal
 
-From this directory:
+There are two easy ways to interactively run and test Temporal code using this polyfill.
+The first, as noted above, is to open the browser devtools console from any page in the [Temporal documentation](https://tc39.es/proposal-temporal/docs/index.html).
+The other is to use the built-in Node REPL.
 
 ```bash
+# run from the /polyfill folder
 $ npm run playground
 ```
 
-## Running Cookbook Files
+## Running Documentation Cookbook as Tests
 
-From this directory:
+Documentation cookbook code samples are also runnable as tests.
 
 ```bash
-# Run all cookbook files:
+# Run all cookbook tests (run from /polyfill folder)
 $ npm run test-cookbook
 
-# Run a single cookbook file:
+# Test one cookbook file (run from /polyfill folder)
 $ env TEST=dateTimeFromLegacyDate npm run test-cookbook-one
 ```


### PR DESCRIPTION
This PR makes a few changes to main and ./polyfill README content to prepare for deprecation of the old polyfill. 

There's a new "Polyfills" table in the README that will point readers to any available polyfills. Initially there's only one entry in the table for @js-temporal/polyfill but developers of polyfills are encouraged to add theirs to the table too.  The champions of this proposal have no opinion about which polyfill developers should use; we just want polyfills to be easily discoverable. 

While I was in the neighborhood, I made some minor edits to other content on these pages.