### PR TITLE
Fix typo in error message

### DIFF
--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -645,7 +645,7 @@ export class ZonedDateTime {
     const endNs = ES.AddZonedDateTime(instantStart, timeZone, calendar, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0);
     const dayLengthNs = endNs.subtract(GetSlot(instantStart, EPOCHNANOSECONDS));
     if (dayLengthNs.isZero()) {
-      throw new RangeError('can not round a ZonedDateTime in a calendar with zero-length days');
+      throw new RangeError('cannot round a ZonedDateTime in a calendar with zero-length days');
     }
     ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundISODateTime(
       year,


### PR DESCRIPTION
"can not" => "cannot"