### PR TITLE
Editoral: rm test _calendarString_ is empty before concat

### DIFF
--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -410,8 +410,7 @@
           1. Let _year_ be ! PadISOYear(_monthDay_.[[ISOYear]]).
           1. Set _result_ to the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _result_.
         1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
-        1. If _calendarString_ is not the empty String, then
-          1. Set _result_ to the string-concatenation of _result_ and _calendarString_.
+        1. Set _result_ to the string-concatenation of _result_ and _calendarString_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -682,8 +682,7 @@
           1. Let _day_ be _yearMonth_.[[ISODay]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
           1. Set _result_ to the string-concatenation of _result_, the code unit 0x002D (HYPHEN-MINUS), and _day_.
         1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
-        1. If _calendarString_ is not the empty String, then
-          1. Set _result_ to the string-concatenation of _result_ and _calendarString_.
+        1. Set _result_ to the string-concatenation of _result_ and _calendarString_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
No need to check the if, the concat of empty string is the same.