### PR TITLE
Missing the first "-" in TemporalMonthDayToString

### DIFF
--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -404,11 +404,11 @@
         1. Assert: _monthDay_ has an [[InitializedTemporalMonthDay]] internal slot.
         1. Let _month_ be _monthDay_.[[ISOMonth]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _day_ be _monthDay_.[[ISODay]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
-        1. Let _result_ be the string-concatenation of _month_, the code unit 0x002D (HYPHEN-MINUS), and _day_.
+        1. Let _result_ be the string-concatenation of the code unit 0x002D (HYPHEN-MINUS), _month_, the code unit 0x002D (HYPHEN-MINUS), and _day_.
         1. Let _calendarID_ be ? ToString(_monthDay_.[[Calendar]]).
         1. If _calendarID_ is not *"iso8601"*, then
           1. Let _year_ be ! PadISOYear(_monthDay_.[[ISOYear]]).
-          1. Set _result_ to the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _result_.
+          1. Set _result_ to the string-concatenation of _year_ and _result_.
         1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
         1. If _calendarString_ is not the empty String, then
           1. Set _result_ to the string-concatenation of _result_ and _calendarString_.


### PR DESCRIPTION
When the calendar is "iso8601", PlainMonthDay of 
July 4, 2021 should be format as "-07-04" not  "07-04".