### PR TITLE
Speed up TimeZone and ZonedDateTime code and tests

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -148,6 +148,27 @@ const ES2020 = {
   Type
 };
 
+const IntlDateTimeFormatEnUsCache = new Map();
+
+function getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier) {
+  let instance = IntlDateTimeFormatEnUsCache.get(timeZoneIdentifier);
+  if (instance === undefined) {
+    instance = new IntlDateTimeFormat('en-us', {
+      timeZone: String(timeZoneIdentifier),
+      hour12: false,
+      era: 'short',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric'
+    });
+    IntlDateTimeFormatEnUsCache.set(timeZoneIdentifier, instance);
+  }
+  return instance;
+}
+
 export const ES = ObjectAssign({}, ES2020, {
   ToPositiveInteger: ToPositiveInteger,
   ToFiniteInteger: (value) => {
@@ -2081,16 +2102,7 @@ export const ES = ObjectAssign({}, ES2020, {
   GetCanonicalTimeZoneIdentifier: (timeZoneIdentifier) => {
     const offsetNs = ES.ParseOffsetString(timeZoneIdentifier);
     if (offsetNs !== null) return ES.FormatTimeZoneOffsetString(offsetNs);
-    const formatter = new IntlDateTimeFormat('en-us', {
-      timeZone: String(timeZoneIdentifier),
-      hour12: false,
-      year: 'numeric',
-      month: 'numeric',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      second: 'numeric'
-    });
+    const formatter = getIntlDateTimeFormatEnUsForTimeZone(String(timeZoneIdentifier));
     return formatter.resolvedOptions().timeZone;
   },
   GetIANATimeZoneOffsetNanoseconds: (epochNanoseconds, id) => {
@@ -2209,17 +2221,7 @@ export const ES = ObjectAssign({}, ES2020, {
     return result;
   },
   GetFormatterParts: (timeZone, epochMilliseconds) => {
-    const formatter = new IntlDateTimeFormat('en-us', {
-      timeZone,
-      hour12: false,
-      era: 'short',
-      year: 'numeric',
-      month: 'numeric',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      second: 'numeric'
-    });
+    const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
     // FIXME: can this use formatToParts instead?
     const datetime = formatter.format(new Date(epochMilliseconds));
     const [date, fullYear, time] = datetime.split(/,\s+/);


### PR DESCRIPTION
Creating `Intl.DateTimeFormat` instances in V8 is slow and memory heavy. `ES.GetFormatterParts` and `ES.GetCanonicalTimeZoneIdentifier` are functions that are called many times when using Temporal, and they used to create new instances of Intl.DateTimeFormat for each call. In this commit, we cache them using the time zone identifier as the key.

It should be noted that doing the same to SystemTimeZone was avoided. This is due to the fact that user's time zone may change during the execution of a program. An example: `Temporal.now.zonedDateTimeISO()` should always output the correct time zone. This shouldn't be a problem for server-side code that usually doesn't (or rather, shouldn't) use the time zone from the environment for calculations.

This PR was ported from https://github.com/js-temporal/temporal-polyfill/pull/10.