### PR TITLE
Use correct filed from return

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -401,7 +401,7 @@
         1. Assert: Type(_string_) is String.
         1. Let _result_ be ? ParseTemporalTimeZoneString(_string_).
         1. If _result_.[[Z]] is not *undefined*, return *"UTC"*.
-        1. Return _result_.[[TimeZoneName]].
+        1. Return _result_.[[Name]].
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
11.6.1 ParseTemporalTimeZone ( string )
in step 4 currently Return result.[[TimeZoneName]].
where in step 2. Let result be ? ParseTemporalTimeZoneString(string).

But ParseTemporalTimeZoneString in
https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezonestring
only 
Return the new Record: { [[Z]]: "Z", [[OffsetString]]: "+00:00", [[Name]]: undefined }. in step 4a 
OR
Return the new Record: { [[Z]]: undefined, [[OffsetString]]: offsetString, [[Name]]: name }.

in either case, there are no [[TimeZoneName]] in the return record.
I believe this is a typo and should change from result.[[TimeZoneName]]  to result.[[Name]] 
in ParseTemporalTimeZone

Otherwise, ParseTemporalTimeZone will always only return either "UTC" or undefined