### PR TITLE
Editorial: Remove unncessary Else

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -586,7 +586,7 @@
         1. Return *undefined*.
       1. If _unit_ is *"hour"*, then
         1. Return 24.
-      1. Else if _unit_ is *"minute"* or *"second"*, then
+      1. If _unit_ is *"minute"* or *"second"*, then
         1. Return 60.
       1. Assert: _unit_ is one of *"millisecond"*, *"microsecond"*, or *"nanosecond"*.
       1. Return 1000.
@@ -1439,9 +1439,8 @@
         1. If _value_ is *undefined*, then
           1. If _requiredFields_ contains _property_, then
             1. Throw a *TypeError* exception.
-          1. Else,
-            1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
-              1. Set _value_ to the corresponding Default value of the same row.
+          1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+            1. Set _value_ to the corresponding Default value of the same row.
         1. Else,
           1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
             1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -714,7 +714,7 @@
           1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
             1. If _largestUnit_ is *"year"*, return the new Record { [[Years]]: _years_, [[Months]]: 0, [[Weeks]]: 0, [[Days]]: 0 }.
-            1. Else, return the new Record { [[Years]]: 0, [[Months]]: _years_ × 12, [[Weeks]]: 0, [[Days]]: 0 }.
+            1. Return the new Record { [[Years]]: 0, [[Months]]: _years_ × 12, [[Weeks]]: 0, [[Days]]: 0 }.
           1. Let _months_ be _end_.[[Month]] − _start_.[[Month]].
           1. If _midSign_ is not equal to _sign_, then
             1. Set _years_ to _years_ - _sign_.
@@ -723,7 +723,7 @@
           1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
             1. If _largestUnit_ is *"year"*, return the new Record { [[Years]]: _years_, [[Months]]: _months_, [[Weeks]]: 0, [[Days]]: 0 }.
-            1. Else, return the new Record { [[Years]]: 0, [[Months]]: _months_ + _years_ × 12, [[Weeks]]: 0, [[Days]]: 0 }.
+            1. Return the new Record { [[Years]]: 0, [[Months]]: _months_ + _years_ × 12, [[Weeks]]: 0, [[Days]]: 0 }.
           1. If _midSign_ is not equal to _sign_, then
             1. Set _months_ to _months_ - _sign_.
             1. If _months_ is equal to -_sign_, then


### PR DESCRIPTION
Remove the else if the end of the IF block is return or throw to simplify the logic.