### PR TITLE
Editorial: document infallibility of abstract op.

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -42,7 +42,7 @@
     <emu-clause id="sec-temporal-getiso8601calendar" aoid="GetISO8601Calendar">
       <h1>GetISO8601Calendar ( )</h1>
       <emu-alg>
-        1. Return ? GetBuiltinCalendar(*"iso8601"*).
+        1. Return ! GetBuiltinCalendar(*"iso8601"*).
       </emu-alg>
     </emu-clause>
 
@@ -259,7 +259,7 @@
       </p>
       <emu-alg>
         1. If _temporalCalendarLike_ is *undefined*, then
-          1. Return ? GetISO8601Calendar().
+          1. Return ! GetISO8601Calendar().
         1. Return ? ToTemporalCalendar(_temporalCalendarLike_).
       </emu-alg>
     </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -431,7 +431,7 @@
           1. If _timeZoneProperty_ is not *undefined*, then
             1. Set _item_ to _timeZoneProperty_.
         1. Let _timeZone_ be ? ToTemporalTimeZone(_item_).
-        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Let _calendar_ be ! GetISO8601Calendar().
         1. Return ? CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -607,7 +607,7 @@
         1. Let _outputTimeZone_ be _timeZone_.
         1. If _outputTimeZone_ is *undefined*, then
           1. Set _outputTimeZone_ to ? CreateTemporalTimeZone(*"UTC"*).
-        1. Let _isoCalendar_ be ? GetISO8601Calendar().
+        1. Let _isoCalendar_ be ! GetISO8601Calendar().
         1. Let _dateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_outputTimeZone_, _instant_, _isoCalendar_).
         1. Let _dateTimeString_ be ? TemporalDateTimeToString(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], *undefined*, _precision_, *"never"*).
         1. If _timeZone_ is *undefined*, then

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -728,7 +728,7 @@
           1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _plainDateTime_, *"compatible"*).
         1. If _x_ has an [[InitializedTemporalTime]] internal slot, then
           1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainTimePattern]].
-          1. Let _isoCalendar_ be ? GetISO8601Calendar().
+          1. Let _isoCalendar_ be ! GetISO8601Calendar().
           1. Let _plainDateTime_ be ? CreateTemporalDateTime(1970, 1, 1, _x_.[[ISOHour]], _x_.[[ISOMinute]], _x_.[[ISOSecond]], _x_.[[ISOMillisecond]], _x_.[[ISOMicrosecond]], _x_.[[ISONanosecond]], _isoCalendar_).
           1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _plainDateTime_, *"compatible"*).
         1. If _x_ has an [[InitializedTemporalDateTime]] internal slot, then

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -816,7 +816,7 @@
         1. Set _object_.[[ISOMillisecond]] to _millisecond_.
         1. Set _object_.[[ISOMicrosecond]] to _microsecond_.
         1. Set _object_.[[ISONanosecond]] to _nanosecond_.
-        1. Set _object_.[[Calendar]] to ? GetISO8601Calendar().
+        1. Set _object_.[[Calendar]] to ! GetISO8601Calendar().
         1. Return _object_.
       </emu-alg>
     </emu-clause>

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -111,7 +111,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Let _calendar_ be ! GetISO8601Calendar().
         1. Return ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -134,7 +134,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Let _calendar_ be ! GetISO8601Calendar().
         1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -158,7 +158,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Let _calendar_ be ! GetISO8601Calendar().
         1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
         1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
       </emu-alg>
@@ -171,7 +171,7 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Let _calendar_ be ! GetISO8601Calendar().
         1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
         1. Return ? CreateTemporalTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -418,7 +418,7 @@
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _isoCalendar_ be ? GetISO8601Calendar().
+        1. Let _isoCalendar_ be ! GetISO8601Calendar().
         1. Let _temporalDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _instant_, _isoCalendar_).
         1. Let _year_ be _temporalDateTime_.[[ISOYear]].
         1. Let _month_ be _temporalDateTime_.[[ISOMonth]].
@@ -783,7 +783,7 @@
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _temporalDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
-        1. Let _isoCalendar_ be ? GetISO8601Calendar().
+        1. Let _isoCalendar_ be ! GetISO8601Calendar().
         1. Let _dtStart_ be ? CreateTemporalDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], 0, 0, 0, 0, 0, 0, _isoCalendar_).
         1. Let _instantStart_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _dtStart_, *"compatible"*).
         1. Let _startNs_ be _instantStart_.[[Nanoseconds]].
@@ -1078,7 +1078,7 @@
       </p>
       <emu-alg>
         1. Assert: _offsetNanoseconds_ is an integer or *null*.
-        1. Let _calendar_ be ? GetISO8601Calendar().
+        1. Let _calendar_ be ! GetISO8601Calendar().
         1. Let _dateTime_ be ? CreateTemporalDateTime(_year_, _month_, _day_, _hour_, _minute_. _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_).
         1. If _offsetNanoseconds_ is *null*, or _offset_ is *"ignore"*, then
           1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _dateTime_, _disambiguation_).
@@ -1164,7 +1164,7 @@
         1. Let _ns_ be ? RoundTemporalInstant(_zonedDateTime_.[[Nanoseconds]], _increment_, _unit_, _roundingMode_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_ns_).
-        1. Let _isoCalendar_ be ? GetISO8601Calendar().
+        1. Let _isoCalendar_ be ! GetISO8601Calendar().
         1. Let _temporalDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _instant_, _isoCalendar_).
         1. Let _dateTimeString_ be ? TemporalDateTimeToString(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _isoCalendar_, _precision_, *"never"*).
         1. If _showOffset_ is *"never"*, then


### PR DESCRIPTION
Whether an ECMAScript implementation uses the "default" version of
IsBuiltinCalendar proposed for ECMA262 or a version which satisfies the
constraints proposed for ECMA402, the GetISO8601Calendar abstract
operation never returns an abrupt completion.