### PR TITLE
Editorial: document infallible AO invocations

### DIFF
--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -147,7 +147,7 @@
       </p>
       <emu-alg>
         1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
-        1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
+        1. Return ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -160,7 +160,7 @@
       <emu-alg>
         1. Let _calendar_ be ? GetISO8601Calendar().
         1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
-        1. Return ? CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
+        1. Return ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -173,7 +173,7 @@
       <emu-alg>
         1. Let _calendar_ be ? GetISO8601Calendar().
         1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
-        1. Return ? CreateTemporalTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
+        1. Return ! CreateTemporalTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
In Temporal.now.plainDate and Temporal.now.plainDateISO, the
CreateTemporalDate abstract operation predictably returns a normal
completion record. The arguments are derived from a PlainDateTime object
which is known to be valid because it was produced from a successful
invocation of the SystemDateTime abstract operation.

The invocation of CreateTemporalTime in Temporal.now.plainTimeISO will
always return a normal completion record by the same logic.