### PR TITLE
Normative: Throw TypeError in Instant.round if options is undefined

### DIFF
--- a/polyfill/test/Instant/prototype/round/options-wrong-type.js
+++ b/polyfill/test/Instant/prototype/round/options-wrong-type.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.round
+features: [Symbol, Temporal]
+---*/
+
+const values = [
+  undefined,
+  null,
+  true,
+  "string",
+  Symbol(),
+  1,
+  2n,
+];
+
+const instance = new Temporal.Instant(0n);
+assert.throws(TypeError, () => instance.round(), "missing argument");
+for (const value of values) {
+  assert.throws(TypeError, () => instance.round(value), `argument ${String(value)}`);
+}

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -297,6 +297,8 @@
       <emu-alg>
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
+        1. If _options_ is *undefined*, then
+          1. Throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.


### PR DESCRIPTION
Make the Instant.prototype.round() throw also TypeError instead of RangeError if options is undefined.
See https://github.com/tc39/proposal-temporal/issues/1639#issuecomment-880355197

@justingrant @ptomato @Ms2ger @ryzokuken 