### PR TITLE
Normative: Call GetOptionsObject in T.Calendar.p.mergeFields

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1082,9 +1082,11 @@
       <emu-alg>
         1. Let _calendar_ be the *this* value.
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-        1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Set _fields_ to ? ToObject(_fields_).
+        1. Set _fields_ to ? GetOptionsObject(_fields_). 
         1. Set _additionalFields_ to ? ToObject(_additionalFields_).
+        1. Set _additionalFields_ to ? GetOptionsObject(_additionalFields_).
+        1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Return ? DefaultMergeFields(_fields_, _additionalFields_).
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1595,7 +1595,9 @@
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. Set _fields_ to ? ToObject(_fields_).
+            1. Set _fields_ to ? GetOptionsObject(_fields_).
             1. Set _additionalFields_ to ? ToObject(_additionalFields_).
+            1. Set _additionalFields_ to ? GetOptionsObject(_additionalFields_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return ? DefaultMergeFields(_fields_, _additionalFields_).
             1. Let _fieldsKeys_ be ? EnumerableOwnPropertyNames(_fields_, ~key~).


### PR DESCRIPTION
To fix the assertion issue in https://github.com/tc39/proposal-temporal/issues/1647
This is a Normative change which will cause T.Calendar.p.mergeFields to throw if any of the two arguments Type(O) is not Object in additional to Null or Undefined. (which mean Bollean, number, BigInt, String or BigInt as argument will also throw TypeError with the change. Without this fix, the Assertion inside EnumerableOwnPropertyNames which is called in step 2 and 4 of DefaultMergeFields is invalid.
Related part of the spec
https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.mergefields
https://tc39.es/proposal-temporal/#sup-temporal.calendar.prototype.mergefields

https://tc39.es/ecma262/#sec-toobject (notice it only throw on Undefined and Null but not other types and the return are not always make "Type(O) is Object" true

https://tc39.es/proposal-temporal/#sec-temporal-defaultmergefields
https://tc39.es/ecma262/#sec-enumerableownpropertynames
Notice it Assert: Type(O) is Object.
