### PR TITLE
Meta: bump ecmarkup to 8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^4.3.0",
         "@typescript-eslint/parser": "^4.3.0",
-        "ecmarkup": "^8.0.0",
+        "ecmarkup": "^8.0.1",
         "eslint": "^7.10.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^3.1.4",
@@ -861,9 +861,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-8.0.0.tgz",
-      "integrity": "sha512-qI2zu4VrXqjoHZSYuopOzzzGbb07Hr2Whg5xAWD65YeEfxuyCChH9oO1DnagOINOktLw3pFtKXrOeCTmfL3htA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-8.0.1.tgz",
+      "integrity": "sha512-Vn+W2lQmft0rzMT+1e5dyHtyPyVAUIkN5JaeLSdkP9HhNWrh2P2jQKzLY4bqn7DXijqUoj0IJDQ9Bgf8+Bm0Kg==",
       "dev": true,
       "dependencies": {
         "chalk": "^1.1.3",
@@ -3690,9 +3690,9 @@
       }
     },
     "ecmarkup": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-8.0.0.tgz",
-      "integrity": "sha512-qI2zu4VrXqjoHZSYuopOzzzGbb07Hr2Whg5xAWD65YeEfxuyCChH9oO1DnagOINOktLw3pFtKXrOeCTmfL3htA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-8.0.1.tgz",
+      "integrity": "sha512-Vn+W2lQmft0rzMT+1e5dyHtyPyVAUIkN5JaeLSdkP9HhNWrh2P2jQKzLY4bqn7DXijqUoj0IJDQ9Bgf8+Bm0Kg==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.3.0",
     "@typescript-eslint/parser": "^4.3.0",
-    "ecmarkup": "^8.0.0",
+    "ecmarkup": "^8.0.1",
     "eslint": "^7.10.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.1.4",


### PR DESCRIPTION
This includes a fix for https://github.com/tc39/ecmarkup/issues/333, which should make the table of contents work correctly for sections such as [this one](https://tc39.es/proposal-temporal/#sup-time-zone-names), where the header of the section contains a link.