### PR TITLE
Normative: require parameter in Instant#round

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -297,6 +297,8 @@
       <emu-alg>
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
+        1. If _options_ is *undefined*, then
+          1. Throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.


### PR DESCRIPTION
Similar to the four other methods named `round`, the description of
`Temporal.Instant.prototype.round` does not describe its sole parameter
as being optional. Unlike the other methods, its algorithm does not
include a step to reject invocations where a value is not provided.
Update the algorithm to produce a TypeError when the value is
`undefined`.