### PR TITLE
Editorial: Replace use of ToInteger with ToIntegerOrInfinity in PrepareTemporalFields

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1523,7 +1523,7 @@
           </tr>
           <tr>
             <td>*"eraYear"*</td>
-            <td>ToInteger</td>
+            <td>ToIntegerOrInfinity</td>
             <td>*undefined*</td>
           </tr>
           <tr>


### PR DESCRIPTION
`ToInteger` got renamed to `ToIntegerOrInfinity` a while ago. The link in the generated HTML links to the right abstract operation already.

Found by @IdanHo while implementing it in SerenityOS's LibJS.