### PR TITLE
Normative: Fix AddDateTime arguments

### DIFF
--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -461,7 +461,18 @@ export class PlainTime {
     const nanosecond = GetSlot(this, ISO_NANOSECOND);
 
     const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
-    const dt = new PlainDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    const dt = new PlainDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
     const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dt, 'compatible');
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -250,7 +250,18 @@ export class ZonedDateTime {
     calendar = ES.ConsolidateCalendars(GetSlot(this, CALENDAR), calendar);
     const timeZone = GetSlot(this, TIME_ZONE);
     const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
-    const dt = new PlainDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    const dt = new PlainDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
     const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dt, 'compatible');
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
@@ -274,7 +285,18 @@ export class ZonedDateTime {
 
     const timeZone = GetSlot(this, TIME_ZONE);
     const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
-    const dt = new PlainDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    const dt = new PlainDateTime(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      calendar
+    );
     const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dt, 'compatible');
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
@@ -656,10 +678,22 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const dt = dateTime(this);
     const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
-    const dtStart = new DateTime(GetSlot(dt, ISO_YEAR), GetSlot(dt, ISO_MONTH), GetSlot(dt, ISO_DAY), 0, 0, 0, 0, 0, 0);
+    const calendar = GetSlot(this, CALENDAR);
+    const dtStart = new DateTime(
+      GetSlot(dt, ISO_YEAR),
+      GetSlot(dt, ISO_MONTH),
+      GetSlot(dt, ISO_DAY),
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      calendar
+    );
     const timeZone = GetSlot(this, TIME_ZONE);
     const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dtStart, 'compatible');
-    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, GetSlot(this, CALENDAR));
+    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
   toInstant() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/test/Duration/constructor/compare/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/Duration/constructor/compare/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const relativeTo = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+const duration1 = new Temporal.Duration(0, 0, 1);
+const duration2 = new Temporal.Duration(0, 0, 1);
+Temporal.Duration.compare(duration1, duration2, { relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 4);
+// one call in CalculateOffsetShift for each duration argument, plus one in
+// UnbalanceDurationRelative for each duration argument

--- a/polyfill/test/Duration/prototype/add/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/Duration/prototype/add/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const instance = new Temporal.Duration(1, 1, 1, 1);
+instance.add(instance, { relativeTo: new Temporal.ZonedDateTime(0n, timeZone, calendar) });
+assert.sameValue(calendar.dateAddCallCount, 5);

--- a/polyfill/test/Duration/prototype/round/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/Duration/prototype/round/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const relativeTo = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+// Rounding with smallestUnit a calendar unit.
+// The calls come from these paths:
+// Duration.round() ->
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   BalanceDurationRelative ->
+//     MoveRelativeDate -> calendar.dateAdd() (2x)
+//     calendar.dateAdd()
+//   MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   BalanceDuration ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+const instance1 = new Temporal.Duration(1, 1, 1, 1, 1);
+instance1.round({ smallestUnit: "days", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 9, "rounding with calendar smallestUnit");
+
+// Rounding with a non-default largestUnit to cover the path in
+// UnbalanceDurationRelative where larger units are converted into smaller
+// units; and with a smallestUnit larger than days to cover the path in
+// RoundDuration where days are converted into larger units.
+// The calls come from these paths:
+// Duration.round() ->
+//   UnbalanceDurationRelative -> MoveRelativeDate -> calendar.dateAdd()
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     MoveRelativeDate -> calendar.dateAdd() (5x)
+//   BalanceDurationRelative
+//     MoveRelativeDate -> calendar.dateAdd()
+//   MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+
+calendar.dateAddCallCount = 0;
+
+const instance2 = new Temporal.Duration(0, 1, 1, 1);
+instance2.round({ largestUnit: "weeks", smallestUnit: "weeks", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 9, "rounding with non-default largestUnit and calendar smallestUnit");
+
+// Rounding with smallestUnit a non-calendar unit, and having the resulting time
+// difference be longer than a calendar day, covering the paths that go through
+// AdjustRoundedDurationDays.
+// The calls come from these paths:
+// Duration.round() ->
+//   AdjustRoundedDurationDays ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     AddDuration ->
+//       AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//       NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+//   BalanceDuration ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+calendar.dateAddCallCount = 0;
+
+const instance3 = new Temporal.Duration(0, 0, 0, 0, 23, 59, 59, 999, 999, 999);
+instance3.round({ largestUnit: "days", smallestUnit: "hours", roundingMode: "ceil", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 7, "rounding with time difference exceeding calendar day");

--- a/polyfill/test/Duration/prototype/subtract/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/Duration/prototype/subtract/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const instance = new Temporal.Duration(1, 1, 1, 1);
+instance.subtract(new Temporal.Duration(-1, -1, -1, -1), { relativeTo: new Temporal.ZonedDateTime(0n, timeZone, calendar) });
+assert.sameValue(calendar.dateAddCallCount, 5);

--- a/polyfill/test/Duration/prototype/total/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/Duration/prototype/total/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const relativeTo = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+// Total of a calendar unit where larger calendar units have to be converted
+// down, to cover the path that goes through UnbalanceDurationRelative
+// The calls come from these paths:
+// Duration.total() ->
+//   UnbalanceDurationRelative -> MoveRelativeDate -> calendar.dateAdd() (3x)
+//   BalanceDuration ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+
+const instance1 = new Temporal.Duration(1, 1, 1, 1, 1);
+instance1.total({ unit: "days", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 8, "converting larger calendar units down");
+
+// Total of a calendar unit where smaller calendar units have to be converted
+// up, to cover the path that goes through MoveRelativeZonedDateTime
+// The calls come from these paths:
+// Duration.total() ->
+//   MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   BalanceDuration ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     MoveRelativeDate -> calendar.dateAdd()
+
+calendar.dateAddCallCount = 0;
+
+const instance2 = new Temporal.Duration(0, 0, 1, 1);
+instance2.total({ unit: "weeks", relativeTo });
+assert.sameValue(calendar.dateAddCallCount, 6, "converting smaller calendar units up");

--- a/polyfill/test/PlainDate/prototype/toZonedDateTime/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/PlainDate/prototype/toZonedDateTime/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const instance = new Temporal.PlainDate(1970, 1, 1, calendar);
+instance.toZonedDateTime({ timeZone });
+assert.sameValue(calendar.dateAddCallCount, 1);

--- a/polyfill/test/PlainDateTime/prototype/toZonedDateTime/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/PlainDateTime/prototype/toZonedDateTime/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tozoneddatetime
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const instance = new Temporal.PlainDateTime(1970, 1, 1, 0, 0, 0, 0, 0, 0, calendar);
+
+["earlier", "compatible", "later"].forEach((disambiguation) => {
+  calendar.dateAddCallCount = 0;
+
+  instance.toZonedDateTime(timeZone, { disambiguation });
+  assert.sameValue(calendar.dateAddCallCount, 1, `calling with disambiguation ${disambiguation}`);
+});

--- a/polyfill/test/PlainTime/prototype/toZonedDateTime/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/PlainTime/prototype/toZonedDateTime/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tozoneddatetime
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const instance = new Temporal.PlainTime();
+instance.toZonedDateTime({ plainDate: new Temporal.PlainDate(1970, 1, 1, calendar), timeZone });
+assert.sameValue(calendar.dateAddCallCount, 1);

--- a/polyfill/test/TimeZone/prototype/getInstantFor/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/TimeZone/prototype/getInstantFor/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const pdt = new Temporal.PlainDateTime(1970, 1, 1, 0, 0, 0, 0, 0, 0, calendar);
+
+["earlier", "compatible", "later"].forEach((disambiguation) => {
+  calendar.dateAddCallCount = 0;
+
+  timeZone.getInstantFor(pdt, { disambiguation });
+  assert.sameValue(calendar.dateAddCallCount, 1, `calling with disambiguation ${disambiguation}`);
+});

--- a/polyfill/test/ZonedDateTime/prototype/round/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/ZonedDateTime/prototype/round/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.round
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const instance = new Temporal.ZonedDateTime(7200_000_000_000n, timeZone, calendar);
+instance.round({ smallestUnit: "day" });
+assert.sameValue(calendar.dateAddCallCount, 1);

--- a/polyfill/test/ZonedDateTime/prototype/round/dateadd-options.js
+++ b/polyfill/test/ZonedDateTime/prototype/round/dateadd-options.js
@@ -27,6 +27,4 @@ assert.sameValue(actual.length, 4, "three arguments");
 assert.sameValue(actual[0], calendar, "this value");
 TemporalHelpers.assertPlainDate(actual[1], 1970, 1, "M01", 1, "date argument");
 TemporalHelpers.assertDuration(actual[2], 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, "duration argument");
-assert.sameValue(typeof actual[3], "object", "options type");
-assert.notSameValue(actual[3], null, "options not null");
-assert.sameValue(Object.getPrototypeOf(actual[3]), null, "options prototype");
+assert.sameValue(actual[3], undefined, "options should be undefined");

--- a/polyfill/test/ZonedDateTime/prototype/since/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/ZonedDateTime/prototype/since/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const earlier = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+// Basic difference with largestUnit larger than days.
+// The calls come from these paths:
+// ZonedDateTime.since() -> DifferenceZonedDateTime ->
+//   AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+
+const later1 = new Temporal.ZonedDateTime(1_213_200_000_000_000n, timeZone, calendar);
+later1.since(earlier, { largestUnit: "weeks" });
+assert.sameValue(calendar.dateAddCallCount, 2, "basic difference with largestUnit >days");
+
+// Basic difference with largestUnit equal to days, to cover the second path in
+// AddZonedDateTime.
+// The calls come from these paths:
+// ZonedDateTime.since() -> DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+calendar.dateAddCallCount = 0;
+
+later1.since(earlier, { largestUnit: "days" });
+assert.sameValue(calendar.dateAddCallCount, 2, "basic difference with largestUnit days");
+
+// Difference with rounding, with smallestUnit a calendar unit.
+// The calls come from these paths:
+// ZonedDateTime.since() ->
+//   DifferenceZonedDateTime ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     MoveRelativeDate -> calendar.dateAdd()
+
+calendar.dateAddCallCount = 0;
+
+later1.since(earlier, { smallestUnit: "weeks" });
+assert.sameValue(calendar.dateAddCallCount, 5, "rounding difference with calendar smallestUnit");
+
+// Difference with rounding, with smallestUnit a non-calendar unit, and having
+// the resulting time difference be longer than a calendar day, covering the
+// paths that go through AdjustRoundedDurationDays. (The path through
+// AdjustRoundedDurationDays -> AddDuration that's covered in the corresponding
+// test in until() only happens in one direction.)
+// The calls come from these paths:
+// ZonedDateTime.since() ->
+//   DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (3x)
+//   AdjustRoundedDurationDays ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (3x)
+
+calendar.dateAddCallCount = 0;
+
+const later2 = new Temporal.ZonedDateTime(86_399_999_999_999n, timeZone, calendar);
+later2.since(earlier, { largestUnit: "days", smallestUnit: "hours", roundingMode: "ceil" });
+assert.sameValue(calendar.dateAddCallCount, 6, "rounding difference with non-calendar smallestUnit and time difference longer than a calendar day");

--- a/polyfill/test/ZonedDateTime/prototype/startOfDay/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/ZonedDateTime/prototype/startOfDay/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.startofday
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const instance = new Temporal.ZonedDateTime(7200_000_000_000n, timeZone, calendar);
+instance.startOfDay();
+assert.sameValue(calendar.dateAddCallCount, 1);

--- a/polyfill/test/ZonedDateTime/prototype/until/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/ZonedDateTime/prototype/until/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const earlier = new Temporal.ZonedDateTime(0n, timeZone, calendar);
+
+// Basic difference with largestUnit larger than days.
+// The calls come from these paths:
+// ZonedDateTime.until() -> DifferenceZonedDateTime ->
+//   AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+
+const later1 = new Temporal.ZonedDateTime(1_213_200_000_000_000n, timeZone, calendar);
+earlier.until(later1, { largestUnit: "weeks" });
+assert.sameValue(calendar.dateAddCallCount, 2, "basic difference with largestUnit >days");
+
+// Basic difference with largestUnit equal to days, to cover the second path in
+// AddZonedDateTime.
+// The calls come from these paths:
+// ZonedDateTime.until() -> DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+calendar.dateAddCallCount = 0;
+
+earlier.until(later1, { largestUnit: "days" });
+assert.sameValue(calendar.dateAddCallCount, 2, "basic difference with largestUnit days");
+
+// Difference with rounding, with smallestUnit a calendar unit.
+// The calls come from these paths:
+// ZonedDateTime.until() ->
+//   DifferenceZonedDateTime ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   RoundDuration ->
+//     MoveRelativeZonedDateTime -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     MoveRelativeDate -> calendar.dateAdd()
+
+calendar.dateAddCallCount = 0;
+
+earlier.until(later1, { smallestUnit: "weeks" });
+assert.sameValue(calendar.dateAddCallCount, 5, "rounding difference with calendar smallestUnit");
+
+// Difference with rounding, with smallestUnit a non-calendar unit, and having
+// the resulting time difference be longer than a calendar day, covering the
+// paths that go through AdjustRoundedDurationDays.
+// The calls come from these paths:
+// ZonedDateTime.until() ->
+//   DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//   AdjustRoundedDurationDays ->
+//     AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//     AddDuration ->
+//       AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd()
+//       DifferenceZonedDateTime -> NanosecondsToDays -> AddZonedDateTime -> BuiltinTimeZoneGetInstantFor -> calendar.dateAdd() (2x)
+
+calendar.dateAddCallCount = 0;
+
+const later2 = new Temporal.ZonedDateTime(86_399_999_999_999n, timeZone, calendar);
+earlier.until(later2, { largestUnit: "days", smallestUnit: "hours", roundingMode: "ceil" });
+assert.sameValue(calendar.dateAddCallCount, 5, "rounding difference with non-calendar smallestUnit and time difference longer than a calendar day");

--- a/polyfill/test/ZonedDateTime/prototype/withPlainDate/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/ZonedDateTime/prototype/withPlainDate/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const instance = new Temporal.ZonedDateTime(82800_000_000_000n, timeZone, calendar);
+instance.withPlainDate(new Temporal.PlainDate(1970, 1, 1, calendar));
+assert.sameValue(calendar.dateAddCallCount, 1);

--- a/polyfill/test/ZonedDateTime/prototype/withPlainTime/calendar-dateadd-called-with-options-undefined.js
+++ b/polyfill/test/ZonedDateTime/prototype/withPlainTime/calendar-dateadd-called-with-options-undefined.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
+description: >
+    BuiltinTimeZoneGetInstantFor calls Calendar.dateAdd with undefined as the
+    options value
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = TemporalHelpers.calendarDateAddUndefinedOptions();
+const timeZone = TemporalHelpers.oneShiftTimeZone(new Temporal.Instant(0n), 3600e9);
+const instance = new Temporal.ZonedDateTime(7200_000_000_000n, timeZone, calendar);
+instance.withPlainTime();
+assert.sameValue(calendar.dateAddCallCount, 1);

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -10,3 +10,11 @@ Duration/prototype/add/relativeto-string-zoneddatetime-no-z.js
 Duration/prototype/round/relativeto-string-zoneddatetime-no-z.js
 Duration/prototype/subtract/relativeto-string-zoneddatetime-no-z.js
 Duration/prototype/total/relativeto-string-zoneddatetime-no-z.js
+
+# Blocked on https://github.com/tc39/proposal-temporal/issues/1685
+# (MoveRelativeDate should pass undefined as options)
+Duration/constructor/compare/calendar-dateadd-called-with-options-undefined.js
+Duration/prototype/round/calendar-dateadd-called-with-options-undefined.js
+Duration/prototype/total/calendar-dateadd-called-with-options-undefined.js
+ZonedDateTime/prototype/since/calendar-dateadd-called-with-options-undefined.js
+ZonedDateTime/prototype/until/calendar-dateadd-called-with-options-undefined.js

--- a/polyfill/test/helpers/temporalHelpers.js
+++ b/polyfill/test/helpers/temporalHelpers.js
@@ -856,6 +856,30 @@ var TemporalHelpers = {
   },
 
   /*
+   * A custom calendar that asserts its dateAdd() method is called with the
+   * options parameter having the value undefined.
+   */
+  calendarDateAddUndefinedOptions() {
+    class CalendarDateAddUndefinedOptions extends Temporal.Calendar {
+      constructor() {
+        super("iso8601");
+        this.dateAddCallCount = 0;
+      }
+
+      toString() {
+        return "dateadd-undef-options";
+      }
+
+      dateAdd(one, two, options) {
+        this.dateAddCallCount++;
+        assert.sameValue(options, undefined, "dateAdd shouldn't be called with options");
+        return super.dateAdd(one, two, options);
+      }
+    }
+    return new CalendarDateAddUndefinedOptions();
+  },
+
+  /*
    * A custom calendar that returns @returnValue from its dateUntil() method,
    * recording the call in @calls.
    */

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -626,12 +626,12 @@
         1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayAfter_).
         1. Let _nanoseconds_ be _offsetAfter_ − _offsetBefore_.
         1. If _disambiguation_ is *"earlier"*, then
-          1. Let _earlier_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], 0, 0, 0, 0, 0, 0, 0, 0, 0, −_nanoseconds_, *"constrain"*).
+          1. Let _earlier_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, −_nanoseconds_, *undefined*).
           1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlier_).
           1. If _possibleInstants_ is empty, throw a *RangeError* exception.
           1. Return _possibleInstants_[0].
         1. Assert: _disambiguation_ is *"compatible"* or *"later"*.
-        1. Let _later_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], 0, 0, 0, 0, 0, 0, 0, 0, 0, _nanoseconds_, *"constrain"*).
+        1. Let _later_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, _nanoseconds_, *undefined*).
         1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _later_).
         1. Set _n_ to _possibleInstants_'s length.
         1. If _n_ = 0, throw a *RangeError* exception.


### PR DESCRIPTION
Fix https://github.com/tc39/proposal-temporal/issues/1664
1. Pass (insert) in dateTime.[[Calendar]] as the missing 10th argument of calendar
2. change string "constain" to *undefined* so Temporal.Calendar.prototype.dateAdd won't throw when call GetOptionsObject and allow the default overflow 'constrain' to perform the 'constrain'.

@ptomato @ljharb @justingrant @Ms2ger @ryzokuken 