### PR TITLE
Normative: Convert ret of T.Calendar.p.mergeFields ToObject

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -69,7 +69,9 @@
         1. Let _mergeFields_ be ? GetMethod(_calendar_, *"mergeFields"*).
         1. If _mergeFields_ is *undefined*, then
           1. Return ? DefaultMergeFields(_fields_, _additionalFields_).
-        1. Return ? Call(_mergeFields_, _calendar_, « _fields_, _additionalFields_ »).
+        1. Let _result_ be ? Call(_mergeFields_, _calendar_, « _fields_, _additionalFields_ »).
+        1. Set _result_ to ? ToObject(_result_).
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -69,9 +69,7 @@
         1. Let _mergeFields_ be ? GetMethod(_calendar_, *"mergeFields"*).
         1. If _mergeFields_ is *undefined*, then
           1. Return ? DefaultMergeFields(_fields_, _additionalFields_).
-        1. Let _result_ be ? Call(_mergeFields_, _calendar_, « _fields_, _additionalFields_ »).
-        1. Set _result_ to ? ToObject(_result_).
-        1. Return _result_.
+        1. Return ? ToObject(? Call(_mergeFields_, _calendar_, « _fields_, _additionalFields_ »)).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Convert the return resutl from Temporal.Calendar.prototype.mergeFields to Obejct by callint ToObject before return in CalendarMergeFields.
The calendar.mergeFields may not always return Object. but the caller of  CalendarMergeFields


next to PrepareTemporalFields
https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.with
```
3.3.21 Temporal.PlainDate.prototype.with ( temporalDateLike [ , options ] )
14. Set fields to ? CalendarMergeFields(calendar, fields, partialDate).
15. Set fields to ? PrepareTemporalFields(fields, fieldNames, «»).
```

https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with
```
5.3.22 Temporal.PlainDateTime.prototype.with ( temporalDateTimeLike [ , options ] )
14. Set fields to ? CalendarMergeFields(calendar, fields, partialDateTime).
15. Set fields to ? PrepareTemporalFields(fields, fieldNames, «»).
```

https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.with
```
6.3.30 Temporal.ZonedDateTime.prototype.with ( temporalZonedDateTimeLike [ , options ] )
19. Set fields to ? CalendarMergeFields(calendar, fields, partialZonedDateTime).
20. Set fields to ? PrepareTemporalFields(fields, fieldNames, « "timeZone" »).
```

https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.with
```
9.3.11 Temporal.PlainYearMonth.prototype.with ( temporalYearMonthLike [ , options ] )
14. Set fields to ? CalendarMergeFields(calendar, fields, partialYearMonth).
15. Set fields to ? PrepareTemporalFields(fields, fieldNames, «»).
```

https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.toplaindate
```
9.3.21 Temporal.PlainYearMonth.prototype.toPlainDate ( item )
9. Let mergedFields be ? CalendarMergeFields(calendar, fields, inputFields).
11. Set mergedFields to ? PrepareTemporalFields(mergedFields, mergedFieldNames, «»).
```

https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with
```
10.3.6 Temporal.PlainMonthDay.prototype.with ( temporalMonthDayLike [ , options ] )
14. Set fields to ? CalendarMergeFields(calendar, fields, partialMonthDay).
15. Set fields to ? PrepareTemporalFields(fields, fieldNames, «»).
```

https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate
```
10.3.12 Temporal.PlainMonthDay.prototype.toPlainDate ( item )
9. Let mergedFields be ? CalendarMergeFields(calendar, fields, inputFields).
11. Set mergedFields to ? PrepareTemporalFields(mergedFields, mergedFieldNames, «»).
```

But then inside PrepareTemporalFields
https://tc39.es/proposal-temporal/#sec-temporal-preparetemporalfields
```
13.46 PrepareTemporalFields ( fields, fieldNames, requiredFields )
1. Assert: Type(fields) is Object.
```

Which won't be true if the calendar's mergeFields return non Object types, right?
I think the easiest fix is to call the ToObejct before CalendarMergeFields return the result from the value it received from Call()