### PR TITLE
Editorial: Fix internal slot name in Temporal.PlainDateTime.prototype.getISOFields

### DIFF
--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -721,7 +721,7 @@
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMinute"*, 𝔽(_dateTime_.[[ISOMinute]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoMonth"*, 𝔽(_dateTime_.[[ISOMonth]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoNanosecond"*, 𝔽(_dateTime_.[[ISONanosecond]])).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoSecond"*, 𝔽(_dateTime_.[[Second]])).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoSecond"*, 𝔽(_dateTime_.[[ISOSecond]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoYear"*, 𝔽(_dateTime_.[[ISOYear]])).
         1. Return _fields_.
       </emu-alg>


### PR DESCRIPTION
Temporal.PlainDateTime objects don't have a [[Second]] internal slot, the correct name is [[ISOSecond]] for the "isoSecond" property.