### PR TITLE
Editorial: Remove "designed to be subclassable"

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -623,9 +623,18 @@
     <h1>The Temporal.Calendar Constructor</h1>
     <p>The Temporal.Calendar constructor:</p>
     <ul>
-      <li>creates and initializes a new Temporal.Calendar object when called as a constructor.</li>
-      <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Temporal.Calendar behaviour must include a super call to the %Temporal.Calendar% constructor to create and initialize subclass instances with the necessary internal slots.</li>
-      <li>has a *"length"* property whose value is 1.</li>
+      <li>
+        creates and initializes a new Temporal.Calendar object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.Calendar behaviour must
+        include a super call to the %Temporal.Calendar% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
     </ul>
 
     <emu-clause id="sec-temporal.calendar">

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -14,17 +14,22 @@
 
   <emu-clause id="sec-temporal-duration-constructor">
     <h1>The Temporal.Duration Constructor</h1>
-    <p>
-      The Temporal.Duration constructor creates and initializes a new
-      Temporal.Duration object when called as a constructor.
-    </p>
-    <p>
-      The Temporal.Duration constructor is designed to be subclassable. It may
-      be used as the value of an extends clause of a class definition. Subclass
-      constructors that intend to inherit the specified Duration behaviour must
-      include a super call to the %Temporal.Duration% constructor to create and
-      initialize subclass instances with the necessary internal slots.
-    </p>
+    <p>The Temporal.Duration constructor:</p>
+    <ul>
+      <li>
+        creates and initializes a new Temporal.Duration object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.Duration behaviour must
+        include a super call to the %Temporal.Duration% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
+    </ul>
+
     <emu-clause id="sec-temporal.duration">
       <h1>Temporal.Duration ( [ _years_ [ , _months_ [ , _weeks_ [ , _days_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _milliseconds_ [ , _microseconds_ [ , _nanoseconds_ ] ] ] ] ] ] ] ] ] ] )</h1>
       <p>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -7,14 +7,21 @@
 
   <emu-clause id="sec-temporal-instant-constructor">
     <h1>The Temporal.Instant Constructor</h1>
-    <p>
-      The Temporal.Instant constructor creates and initializes a new Temporal.Instant object when called as a constructor.
-    </p>
-    <p>
-      The Temporal.Instant constructor is designed to be subclassable.
-      It may be used as the value of an extends clause of a class definition.
-      Subclass constructors that intend to inherit the specified Instant behaviour must include a super call to the %Temporal.Instant% constructor to create and initialize subclass instances with the necessary internal slots.
-    </p>
+    <p>The Temporal.Instant constructor:</p>
+    <ul>
+      <li>
+        creates and initializes a new Temporal.Instant object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.Instant behaviour must
+        include a super call to the %Temporal.Instant% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
+    </ul>
 
     <emu-clause id="sec-temporal.instant">
       <h1>Temporal.Instant ( _epochNanoseconds_ )</h1>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -11,8 +11,18 @@
     <h1>The Temporal.PlainDate Constructor</h1>
     <p>The Temporal.PlainDate constructor:</p>
     <ul>
-      <li>creates and initializes a new Temporal.PlainDate object when called as a constructor.</li>
-      <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified Temporal.PlainDate behaviour must include a super call to the %Temporal.PlainDate% constructor to create and initialize subclass instances with the necessary internal slots.</li>
+      <li>
+        creates and initializes a new Temporal.PlainDate object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.PlainDate behaviour must
+        include a super call to the %Temporal.PlainDate% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
     </ul>
 
     <emu-clause id="sec-temporal.plaindate">

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -7,14 +7,21 @@
 
   <emu-clause id="sec-temporal-plaindatetime-constructor">
     <h1>The Temporal.PlainDateTime Constructor</h1>
-    <p>
-      The Temporal.PlainDateTime constructor creates and initializes a new Temporal.PlainDateTime object when called as a constructor.
-    </p>
-    <p>
-      The Temporal.PlainDateTime constructor is designed to be subclassable.
-      It may be used as the value of an extends clause of a class definition.
-      Subclass constructors that intend to inherit the specified DateTime behaviour must include a super call to the %Temporal.PlainDateTime% constructor to create and initialize subclass instances with the necessary internal slots.
-    </p>
+    <p>The Temporal.PlainDateTime constructor:</p>
+    <ul>
+      <li>
+        creates and initializes a new Temporal.PlainDateTime object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.PlainDateTime behaviour must
+        include a super call to the %Temporal.PlainDateTime% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
+    </ul>
 
     <emu-clause id="sec-temporal.plaindatetime">
       <h1>Temporal.PlainDateTime ( _isoYear_, _isoMonth_, _isoDay_ [ , _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ [ , _microsecond_ [ , _nanosecond_ [ , _calendarLike_ ] ] ] ] ] ] ] )</h1>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -7,14 +7,21 @@
 
   <emu-clause id="sec-temporal-plainmonthday-constructor">
     <h1>The Temporal.PlainMonthDay Constructor</h1>
-    <p>
-      The Temporal.PlainMonthDay constructor creates and initializes a new Temporal.PlainMonthDay object when called as a constructor.
-    </p>
-    <p>
-      The Temporal.PlainMonthDay constructor is designed to be subclassable.
-      It may be used as the value of an extends clause of a class definition.
-      Subclass constructors that intend to inherit the specified MonthDay behaviour must include a super call to the %Temporal.PlainMonthDay% constructor to create and initialize subclass instances with the necessary internal slots.
-    </p>
+    <p>The Temporal.PlainMonthDay constructor:</p>
+    <ul>
+      <li>
+        creates and initializes a new Temporal.PlainMonthDay object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.PlainMonthDay behaviour must
+        include a super call to the %Temporal.PlainMonthDay% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
+    </ul>
 
     <emu-clause id="sec-temporal.plainmonthday">
       <h1>Temporal.PlainMonthDay ( _isoMonth_, _isoDay_ [ , _calendarLike_ [ , _referenceISOYear_ ] ] )</h1>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -8,14 +8,21 @@
 
   <emu-clause id="sec-temporal-plaintime-constructor">
     <h1>The Temporal.PlainTime Constructor</h1>
-    <p>
-      The Temporal.PlainTime constructor creates and initializes a new Temporal.PlainTime object when called as a constructor.
-    </p>
-    <p>
-      The Temporal.PlainTime constructor is designed to be subclassable.
-      It may be used as the value of an extends clause of a class definition.
-      Subclass constructors that intend to inherit the specified Time behaviour must include a super call to the %Temporal.PlainTime% constructor to create and initialize subclass instances with the necessary internal slots.
-    </p>
+    <p>The Temporal.PlainTime constructor:</p>
+    <ul>
+      <li>
+        creates and initializes a new Temporal.PlainTime object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.PlainTime behaviour must
+        include a super call to the %Temporal.PlainTime% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
+    </ul>
 
     <emu-clause id="sec-temporal.plaintime">
       <h1>Temporal.PlainTime ( [ _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ [ , _microsecond_ [ , _nanosecond_ ] ] ] ] ] ] )</h1>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -7,14 +7,21 @@
 
   <emu-clause id="sec-temporal-plainyearmonth-constructor">
     <h1>The Temporal.PlainYearMonth Constructor</h1>
-    <p>
-      The Temporal.PlainYearMonth constructor creates and initializes a new Temporal.PlainYearMonth object when called as a constructor.
-    </p>
-    <p>
-      The Temporal.PlainYearMonth constructor is designed to be subclassable.
-      It may be used as the value of an extends clause of a class definition.
-      Subclass constructors that intend to inherit the specified YearMonth behaviour must include a super call to the %Temporal.PlainYearMonth% constructor to create and initialize subclass instances with the necessary internal slots.
-    </p>
+    <p>The Temporal.PlainYearMonth constructor:</p>
+    <ul>
+      <li>
+        creates and initializes a new Temporal.PlainYearMonth object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.PlainYearMonth behaviour must
+        include a super call to the %Temporal.PlainYearMonth% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
+    </ul>
 
     <emu-clause id="sec-temporal.plainyearmonth">
       <h1>Temporal.PlainYearMonth ( _isoYear_, _isoMonth_ [ , _calendarLike_ [ , _referenceISODay_ ] ] )</h1>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -109,14 +109,21 @@
 
   <emu-clause id="sec-temporal-timezone-constructor">
     <h1>The Temporal.TimeZone Constructor</h1>
-    <p>
-      The Temporal.TimeZone constructor creates and initializes a new Temporal.TimeZone object when called as a constructor.
-    </p>
-    <p>
-      The Temporal.TimeZone constructor is designed to be subclassable.
-      It may be used as the value of an extends clause of a class definition.
-      Subclass constructors that intend to inherit the specified TimeZone behaviour must include a super call to the %Temporal.TimeZone% constructor to create and initialize subclass instances with the necessary internal slots.
-    </p>
+    <p>The Temporal.TimeZone constructor:</p>
+    <ul>
+      <li>
+        creates and initializes a new Temporal.TimeZone object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.TimeZone behaviour must
+        include a super call to the %Temporal.TimeZone% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
+    </ul>
 
     <emu-clause id="sec-temporal.timezone">
       <h1>Temporal.TimeZone ( _identifier_ )</h1>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -9,14 +9,21 @@
 
   <emu-clause id="sec-temporal-zoneddatetime-constructor">
     <h1>The Temporal.ZonedDateTime Constructor</h1>
-    <p>
-      The Temporal.ZonedDateTime constructor creates and initializes a new Temporal.ZonedDateTime object when called as a constructor.
-    </p>
-    <p>
-      The Temporal.ZonedDateTime constructor is designed to be subclassable.
-      It may be used as the value of an extends clause of a class definition.
-      Subclass constructors that intend to inherit the specified ZonedDateTime behaviour must include a super call to the %Temporal.ZonedDateTime% constructor to create and initialize subclass instances with the necessary internal slots.
-    </p>
+    <p>The Temporal.ZonedDateTime constructor:</p>
+    <ul>
+      <li>
+        creates and initializes a new Temporal.ZonedDateTime object when called as a constructor.
+      </li>
+      <li>
+        is not intended to be called as a function and will throw an exception when called in that manner.
+      </li>
+      <li>
+        may be used as the value of an `extends` clause of a class definition.
+        Subclass constructors that intend to inherit the specified Temporal.ZonedDateTime behaviour must
+        include a super call to the %Temporal.ZonedDateTime% constructor to create and initialize subclass
+        instances with the necessary internal slots.
+      </li>
+    </ul>
 
     <emu-clause id="sec-temporal.zoneddatetime">
       <h1>Temporal.ZonedDateTime ( _epochNanoseconds_, _timeZoneLike_ [ , _calendarLike_ ] )</h1>


### PR DESCRIPTION
See https://github.com/tc39/ecma262/pull/2360

Bring the language around this in line with the main ECMA-262 text, using
the same unordered list form and the same bullet points everywhere.