### PR TITLE
Normative: Adjust grammar of Duration ISO 8601 strings

### DIFF
--- a/polyfill/test/Duration/constructor/from/string-with-skipped-units.js
+++ b/polyfill/test/Duration/constructor/from/string-with-skipped-units.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.from
+description: |
+  Creating a Duration from an ISO 8601 string with an absent designator between
+  two other designators
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+// Date designators: years-weeks (months missing)
+
+const d1 = Temporal.Duration.from("P3Y4W");
+TemporalHelpers.assertDuration(d1, 3, 0, 4, 0, 0, 0, 0, 0, 0, 0, "years-weeks string");
+
+// Date designators: years-days (months and weeks missing)
+
+const d2 = Temporal.Duration.from("P3Y4D");
+TemporalHelpers.assertDuration(d2, 3, 0, 0, 4, 0, 0, 0, 0, 0, 0, "years-days string");
+
+// Date designators: months-days (weeks missing)
+
+const d3 = Temporal.Duration.from("P3M4D");
+TemporalHelpers.assertDuration(d3, 0, 3, 0, 4, 0, 0, 0, 0, 0, 0, "months-days string");
+
+// Time designators: hours-seconds (minutes missing)
+
+const d4 = Temporal.Duration.from("PT3H4.123456789S");
+TemporalHelpers.assertDuration(d4, 0, 0, 0, 0, 3, 0, 4, 123, 456, 789, "hours-seconds string");

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -319,7 +319,7 @@ const durationMinutes = seq(
 const durationHours = seq(
   withCode(oneOrMore(digit()), (data, result) => (data.hours = +result * data.factor)),
   hoursDesignator,
-  [durationMinutes]
+  [choice(durationMinutes, durationSeconds)]
 );
 const durationTime = seq(durationTimeDesignator, choice(durationHours, durationMinutes, durationSeconds));
 const durationDays = seq(
@@ -334,12 +334,12 @@ const durationWeeks = seq(
 const durationMonths = seq(
   withCode(oneOrMore(digit()), (data, result) => (data.months = +result * data.factor)),
   monthsDesignator,
-  [durationWeeks]
+  [choice(durationWeeks, durationDays)]
 );
 const durationYears = seq(
   withCode(oneOrMore(digit()), (data, result) => (data.years = +result * data.factor)),
   yearsDesignator,
-  [durationMonths]
+  [choice(durationMonths, durationWeeks, durationDays)]
 );
 const durationDate = seq(choice(durationYears, durationMonths, durationWeeks, durationDays), [durationTime]);
 const duration = seq(

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -985,7 +985,8 @@
           TimeFraction
 
       DurationHoursPart :
-          DurationWholeHours DurationHoursFraction? HoursDesignator DurationMinutesPart?
+          DurationWholeHours DurationHoursFraction? HoursDesignator DurationMinutesPart
+          DurationWholeHours DurationHoursFraction? HoursDesignator DurationSecondsPart?
 
       DurationTime :
           DurationTimeDesignator DurationHoursPart
@@ -1008,13 +1009,16 @@
           Digits
 
       DurationMonthsPart :
-          DurationMonths MonthsDesignator DurationWeeksPart?
+          DurationMonths MonthsDesignator DurationWeeksPart
+          DurationMonths MonthsDesignator DurationDaysPart?
 
       DurationYears :
           Digits
 
       DurationYearsPart :
-          DurationYears YearsDesignator DurationMonthsPart?
+          DurationYears YearsDesignator DurationMonthsPart
+          DurationYears YearsDesignator DurationWeeksPart
+          DurationYears YearsDesignator DurationDaysPart?
 
       DurationDate :
           DurationYearsPart DurationTime?


### PR DESCRIPTION
Previously, the grammar in the spec text would reject strings like
"PT1H1S", with a missing time unit in between two other time units, or
"P1Y1D", with missing calendar units in between two other calendar units.
This was never intended, but is now a normative change.

Closes: #1682