### PR TITLE
TS types for missing overloads of `PlainDate.p.toZonedDateTime()`

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -857,10 +857,15 @@ export namespace Temporal {
       >
     ): Temporal.Duration;
     toPlainDateTime(temporalTime?: Temporal.PlainTime | TimeLike | string): Temporal.PlainDateTime;
-    toZonedDateTime(timeZoneAndTime: {
-      timeZone: TimeZoneProtocol | string;
-      plainTime?: Temporal.PlainTime | TimeLike | string;
-    }): Temporal.ZonedDateTime;
+    toZonedDateTime(
+      timeZoneAndTime:
+        | TimeZoneProtocol
+        | string
+        | {
+            timeZone: TimeZoneProtocol | string;
+            plainTime?: Temporal.PlainTime | TimeLike | string;
+          }
+    ): Temporal.ZonedDateTime;
     toPlainYearMonth(): Temporal.PlainYearMonth;
     toPlainMonthDay(): Temporal.PlainMonthDay;
     getISOFields(): DateISOFields;


### PR DESCRIPTION
_(ported from https://github.com/js-temporal/temporal-polyfill/pull/25)_ 

The TS types file is missing overloads for `PlainDate.prototype.toZonedDateTime()` when the argument is a timezone string or a TimeZoneProtocol object.

The current TS types support only object-bag arguments like these:
```ts
Temporal.Now.plainDateISO().toZonedDateTime({ timeZone: 'Asia/Tokyo' })
Temporal.Now.plainDateISO().toZonedDateTime({ timeZone: 'Asia/Tokyo', plainTime: '10:00' });
```

This PR adds TS types for the following overloads which work fine in the polyfill and spec but cause errors in TS: 
```ts
Temporal.Now.plainDateISO().toZonedDateTime(Temporal.Now.timeZone());
Temporal.Now.plainDateISO().toZonedDateTime('Asia/Tokyo');
```