### PR TITLE
Normative: Fix undefined variables in HandleDateTimeValue

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -82,19 +82,19 @@ rules:
 overrides:
   - files:
       - polyfill/test/Calendar/**/*.js
+      - polyfill/test/Duration/**/*.js
+      - polyfill/test/helpers/*.js
+      - polyfill/test/Instant/**/*.js
+      - polyfill/test/intl402/**/*.js
+      - polyfill/test/Now/**/*.js
       - polyfill/test/PlainDate/**/*.js
       - polyfill/test/PlainDateTime/**/*.js
-      - polyfill/test/Duration/**/*.js
-      - polyfill/test/Instant/**/*.js
-      - polyfill/test/ISO8601Calendar/**/*.js
       - polyfill/test/PlainMonthDay/**/*.js
-      - polyfill/test/Temporal/**/*.js
       - polyfill/test/PlainTime/**/*.js
-      - polyfill/test/TimeZone/**/*.js
       - polyfill/test/PlainYearMonth/**/*.js
+      - polyfill/test/Temporal/**/*.js
+      - polyfill/test/TimeZone/**/*.js
       - polyfill/test/ZonedDateTime/**/*.js
-      - polyfill/test/helpers/*.js
-      - polyfill/test/Now/**/*.js
     globals:
       Temporal: readonly
       TemporalHelpers: readonly

--- a/polyfill/test/intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
+++ b/polyfill/test/intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-datetime-format-functions
+description: A time zone in resolvedOptions with a large offset still produces the correct string
+locale: [en]
+features: [Temporal]
+---*/
+
+const formatter = new Intl.DateTimeFormat("en", { timeZone: "Pacific/Apia" });
+
+const date = new Temporal.PlainDate(2021, 8, 4);
+const dateResult = formatter.format(date);
+assert.sameValue(dateResult, "8/4/2021", "plain date");
+
+const datetime1 = new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789);
+const datetimeResult1 = formatter.format(datetime1);
+assert.sameValue(datetimeResult1, "8/4/2021, 12:30:45 AM", "plain datetime close to beginning of day");
+const datetime2 = new Temporal.PlainDateTime(2021, 8, 4, 23, 30, 45, 123, 456, 789);
+const datetimeResult2 = formatter.format(datetime2);
+assert.sameValue(datetimeResult2, "8/4/2021, 11:30:45 PM", "plain datetime close to end of day");
+
+const monthDay = new Temporal.PlainMonthDay(8, 4, "gregory");
+const monthDayResult = formatter.format(monthDay);
+assert.sameValue(monthDayResult, "8/4", "plain month-day");
+
+const time1 = new Temporal.PlainTime(0, 30, 45, 123, 456, 789);
+const timeResult1 = formatter.format(time1);
+assert.sameValue(timeResult1, "12:30:45 AM", "plain time close to beginning of day");
+const time2 = new Temporal.PlainTime(23, 30, 45, 123, 456, 789);
+const timeResult2 = formatter.format(time2);
+assert.sameValue(timeResult2, "11:30:45 PM", "plain time close to end of day");
+
+const month = new Temporal.PlainYearMonth(2021, 8, "gregory");
+const monthResult = formatter.format(month);
+assert.sameValue(monthResult, "8/2021", "plain year-month");

--- a/polyfill/test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js
+++ b/polyfill/test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-resolved-time-zone.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-datetime-format-functions
+description: A time zone in resolvedOptions with a large offset still produces the correct string
+locale: [en]
+features: [Temporal, Intl.DateTimeFormat-formatRange]
+---*/
+
+const formatter = new Intl.DateTimeFormat("en", { timeZone: "Pacific/Apia" });
+
+const date1 = new Temporal.PlainDate(2021, 8, 4);
+const date2 = new Temporal.PlainDate(2021, 8, 5);
+const dateResult = formatter.formatRange(date1, date2);
+assert.sameValue(dateResult, "8/4/2021 – 8/5/2021", "plain dates");
+
+const datetime1 = new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789);
+const datetime2 = new Temporal.PlainDateTime(2021, 8, 4, 23, 30, 45, 123, 456, 789);
+const datetimeResult = formatter.formatRange(datetime1, datetime2);
+assert.sameValue(datetimeResult, "8/4/2021, 12:30:45 AM – 11:30:45 PM", "plain datetimes");
+
+const monthDay1 = new Temporal.PlainMonthDay(8, 4, "gregory");
+const monthDay2 = new Temporal.PlainMonthDay(8, 5, "gregory");
+const monthDayResult = formatter.formatRange(monthDay1, monthDay2);
+assert.sameValue(monthDayResult, "8/4 – 8/5", "plain month-days");
+
+const time1 = new Temporal.PlainTime(0, 30, 45, 123, 456, 789);
+const time2 = new Temporal.PlainTime(23, 30, 45, 123, 456, 789);
+const timeResult = formatter.formatRange(time1, time2);
+assert.sameValue(timeResult, "12:30:45 AM – 11:30:45 PM", "plain times");
+
+const month1 = new Temporal.PlainYearMonth(2021, 8, "gregory");
+const month2 = new Temporal.PlainYearMonth(2021, 9, "gregory");
+const monthResult = formatter.formatRange(month1, month2);
+assert.sameValue(monthResult, "8/2021 – 9/2021", "plain year-months");

--- a/polyfill/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-resolved-time-zone.js
+++ b/polyfill/test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-resolved-time-zone.js
@@ -1,0 +1,103 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-datetime-format-functions
+description: A time zone in resolvedOptions with a large offset still produces the correct string
+locale: [en]
+includes: [deepEqual.js]
+features: [Temporal, Intl.DateTimeFormat-formatRange]
+---*/
+
+const formatter = new Intl.DateTimeFormat("en", { timeZone: "Pacific/Apia" });
+
+const date1 = new Temporal.PlainDate(2021, 8, 4);
+const date2 = new Temporal.PlainDate(2021, 8, 5);
+const dateResult = formatter.formatRangeToParts(date1, date2);
+assert.deepEqual(dateResult, [
+  { type: "month", value: "8", source: "startRange" },
+  { type: "literal", value: "/", source: "startRange" },
+  { type: "day", value: "4", source: "startRange" },
+  { type: "literal", value: "/", source: "startRange" },
+  { type: "year", value: "2021", source: "startRange" },
+  { type: "literal", value: " – ", source: "shared" },
+  { type: "month", value: "8", source: "endRange" },
+  { type: "literal", value: "/", source: "endRange" },
+  { type: "day", value: "5", source: "endRange" },
+  { type: "literal", value: "/", source: "endRange" },
+  { type: "year", value: "2021", source: "endRange" },
+], "plain dates");
+
+const datetime1 = new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789);
+const datetime2 = new Temporal.PlainDateTime(2021, 8, 4, 23, 30, 45, 123, 456, 789);
+const datetimeResult = formatter.formatRangeToParts(datetime1, datetime2);
+assert.deepEqual(datetimeResult, [
+  { type: "month", value: "8", source: "shared" },
+  { type: "literal", value: "/", source: "shared" },
+  { type: "day", value: "4", source: "shared" },
+  { type: "literal", value: "/", source: "shared" },
+  { type: "year", value: "2021", source: "shared" },
+  { type: "literal", value: ", ", source: "shared" },
+  { type: "hour", value: "12", source: "startRange" },
+  { type: "literal", value: ":", source: "startRange" },
+  { type: "minute", value: "30", source: "startRange" },
+  { type: "literal", value: ":", source: "startRange" },
+  { type: "second", value: "45", source: "startRange" },
+  { type: "literal", value: " ", source: "startRange" },
+  { type: "dayPeriod", value: "AM", source: "startRange" },
+  { type: "literal", value: " – ", source: "shared" },
+  { type: "hour", value: "11", source: "endRange" },
+  { type: "literal", value: ":", source: "endRange" },
+  { type: "minute", value: "30", source: "endRange" },
+  { type: "literal", value: ":", source: "endRange" },
+  { type: "second", value: "45", source: "endRange" },
+  { type: "literal", value: " ", source: "endRange" },
+  { type: "dayPeriod", value: "PM", source: "endRange" },
+], "plain datetimes");
+
+const monthDay1 = new Temporal.PlainMonthDay(8, 4, "gregory");
+const monthDay2 = new Temporal.PlainMonthDay(8, 5, "gregory");
+const monthDayResult = formatter.formatRangeToParts(monthDay1, monthDay2);
+assert.deepEqual(monthDayResult, [
+  { type: "month", value: "8", source: "startRange" },
+  { type: "literal", value: "/", source: "startRange" },
+  { type: "day", value: "4", source: "startRange" },
+  { type: "literal", value: " – ", source: "shared" },
+  { type: "month", value: "8", source: "endRange" },
+  { type: "literal", value: "/", source: "endRange" },
+  { type: "day", value: "5", source: "endRange" },
+], "plain month-days");
+
+const time1 = new Temporal.PlainTime(0, 30, 45, 123, 456, 789);
+const time2 = new Temporal.PlainTime(23, 30, 45, 123, 456, 789);
+const timeResult = formatter.formatRangeToParts(time1, time2);
+assert.deepEqual(timeResult, [
+  { type: "hour", value: "12", source: "startRange" },
+  { type: "literal", value: ":", source: "startRange" },
+  { type: "minute", value: "30", source: "startRange" },
+  { type: "literal", value: ":", source: "startRange" },
+  { type: "second", value: "45", source: "startRange" },
+  { type: "literal", value: " ", source: "startRange" },
+  { type: "dayPeriod", value: "AM", source: "startRange" },
+  { type: "literal", value: " – ", source: "shared" },
+  { type: "hour", value: "11", source: "endRange" },
+  { type: "literal", value: ":", source: "endRange" },
+  { type: "minute", value: "30", source: "endRange" },
+  { type: "literal", value: ":", source: "endRange" },
+  { type: "second", value: "45", source: "endRange" },
+  { type: "literal", value: " ", source: "endRange" },
+  { type: "dayPeriod", value: "PM", source: "endRange" },
+], "plain times");
+
+const month1 = new Temporal.PlainYearMonth(2021, 8, "gregory");
+const month2 = new Temporal.PlainYearMonth(2021, 9, "gregory");
+const monthResult = formatter.formatRangeToParts(month1, month2);
+assert.deepEqual(monthResult, [
+  { type: "month", value: "8", source: "startRange" },
+  { type: "literal", value: "/", source: "startRange" },
+  { type: "year", value: "2021", source: "startRange" },
+  { type: "literal", value: " – ", source: "shared" },
+  { type: "month", value: "9", source: "endRange" },
+  { type: "literal", value: "/", source: "endRange" },
+  { type: "year", value: "2021", source: "endRange" },
+], "plain year-months");

--- a/polyfill/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-resolved-time-zone.js
+++ b/polyfill/test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-resolved-time-zone.js
@@ -1,0 +1,96 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-Intl.DateTimeFormat.prototype.formatToParts
+description: A time zone in resolvedOptions with a large offset still produces the correct string
+locale: [en]
+includes: [deepEqual.js]
+features: [Temporal]
+---*/
+
+const formatter = new Intl.DateTimeFormat("en", { timeZone: "Pacific/Apia" });
+
+const date = new Temporal.PlainDate(2021, 8, 4);
+const dateResult = formatter.formatToParts(date);
+assert.deepEqual(dateResult, [
+  { type: "month", value: "8" },
+  { type: "literal", value: "/" },
+  { type: "day", value: "4" },
+  { type: "literal", value: "/" },
+  { type: "year", value: "2021" },
+], "plain date");
+
+const datetime1 = new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789);
+const datetimeResult1 = formatter.formatToParts(datetime1);
+assert.deepEqual(datetimeResult1, [
+  { type: "month", value: "8" },
+  { type: "literal", value: "/" },
+  { type: "day", value: "4" },
+  { type: "literal", value: "/" },
+  { type: "year", value: "2021" },
+  { type: "literal", value: ", " },
+  { type: "hour", value: "12" },
+  { type: "literal", value: ":" },
+  { type: "minute", value: "30" },
+  { type: "literal", value: ":" },
+  { type: "second", value: "45" },
+  { type: "literal", value: " " },
+  { type: "dayPeriod", value: "AM" },
+], "plain datetime close to beginning of day");
+const datetime2 = new Temporal.PlainDateTime(2021, 8, 4, 23, 30, 45, 123, 456, 789);
+const datetimeResult2 = formatter.formatToParts(datetime2);
+assert.deepEqual(datetimeResult2, [
+  { type: "month", value: "8" },
+  { type: "literal", value: "/" },
+  { type: "day", value: "4" },
+  { type: "literal", value: "/" },
+  { type: "year", value: "2021" },
+  { type: "literal", value: ", " },
+  { type: "hour", value: "11" },
+  { type: "literal", value: ":" },
+  { type: "minute", value: "30" },
+  { type: "literal", value: ":" },
+  { type: "second", value: "45" },
+  { type: "literal", value: " " },
+  { type: "dayPeriod", value: "PM" },
+], "plain datetime close to end of day");
+
+const monthDay = new Temporal.PlainMonthDay(8, 4, "gregory");
+const monthDayResult = formatter.formatToParts(monthDay);
+assert.deepEqual(monthDayResult, [
+  { type: "month", value: "8" },
+  { type: "literal", value: "/" },
+  { type: "day", value: "4" },
+], "plain month-day");
+
+const time1 = new Temporal.PlainTime(0, 30, 45, 123, 456, 789);
+const timeResult1 = formatter.formatToParts(time1);
+assert.deepEqual(timeResult1, [
+  { type: "hour", value: "12" },
+  { type: "literal", value: ":" },
+  { type: "minute", value: "30" },
+  { type: "literal", value: ":" },
+  { type: "second", value: "45" },
+  { type: "literal", value: " " },
+  { type: "dayPeriod", value: "AM" },
+], "plain time close to beginning of day");
+const time2 = new Temporal.PlainTime(23, 30, 45, 123, 456, 789);
+const timeResult2 = formatter.formatToParts(time2);
+assert.deepEqual(timeResult2, [
+  { type: "hour", value: "11" },
+  { type: "literal", value: ":" },
+  { type: "minute", value: "30" },
+  { type: "literal", value: ":" },
+  { type: "second", value: "45" },
+  { type: "literal", value: " " },
+  { type: "dayPeriod", value: "PM" },
+], "plain time close to end of day");
+
+const month = new Temporal.PlainYearMonth(2021, 8, "gregory");
+const monthResult = formatter.formatToParts(month);
+assert.deepEqual(monthResult, [
+  { type: "month", value: "8" },
+  { type: "literal", value: "/" },
+  { type: "year", value: "2021" },
+], "plain year-month");

--- a/polyfill/test/intl402/Temporal/PlainDate/prototype/toLocaleString/resolved-time-zone.js
+++ b/polyfill/test/intl402/Temporal/PlainDate/prototype/toLocaleString/resolved-time-zone.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tolocalestring
+description: A time zone in resolvedOptions with a large offset still produces the correct string
+locale: [en]
+features: [Temporal]
+---*/
+
+const date = new Temporal.PlainDate(2021, 8, 4);
+const result = date.toLocaleString("en", { timeZone: "Pacific/Apia" });
+assert.sameValue(result, "8/4/2021");

--- a/polyfill/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/resolved-time-zone.js
+++ b/polyfill/test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/resolved-time-zone.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.tolocalestring
+description: A time zone in resolvedOptions with a large offset still produces the correct string
+locale: [en]
+features: [Temporal]
+---*/
+
+const datetime1 = new Temporal.PlainDateTime(2021, 8, 4, 0, 30, 45, 123, 456, 789);
+const result1 = datetime1.toLocaleString("en", { timeZone: "Pacific/Apia" });
+assert.sameValue(result1, "8/4/2021, 12:30:45 AM");
+
+const datetime2 = new Temporal.PlainDateTime(2021, 8, 4, 23, 30, 45, 123, 456, 789);
+const result2 = datetime2.toLocaleString("en", { timeZone: "Pacific/Apia" });
+assert.sameValue(result2, "8/4/2021, 11:30:45 PM");

--- a/polyfill/test/intl402/Temporal/PlainMonthDay/prototype/toLocaleString/resolved-time-zone.js
+++ b/polyfill/test/intl402/Temporal/PlainMonthDay/prototype/toLocaleString/resolved-time-zone.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.tolocalestring
+description: A time zone in resolvedOptions with a large offset still produces the correct string
+locale: [en]
+features: [Temporal]
+---*/
+
+const monthDay = new Temporal.PlainMonthDay(8, 4, "gregory");
+const result = monthDay.toLocaleString("en", { timeZone: "Pacific/Apia" });
+assert.sameValue(result, "8/4");

--- a/polyfill/test/intl402/Temporal/PlainTime/prototype/toLocaleString/resolved-time-zone.js
+++ b/polyfill/test/intl402/Temporal/PlainTime/prototype/toLocaleString/resolved-time-zone.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.tolocalestring
+description: A time zone in resolvedOptions with a large offset still produces the correct string
+locale: [en]
+features: [Temporal]
+---*/
+
+const time1 = new Temporal.PlainTime(0, 30, 45, 123, 456, 789);
+const result1 = time1.toLocaleString("en", { timeZone: "Pacific/Apia" });
+assert.sameValue(result1, "12:30:45 AM");
+
+const time2 = new Temporal.PlainTime(23, 30, 45, 123, 456, 789);
+const result2 = time2.toLocaleString("en", { timeZone: "Pacific/Apia" });
+assert.sameValue(result2, "11:30:45 PM");

--- a/polyfill/test/intl402/Temporal/PlainYearMonth/prototype/toLocaleString/resolved-time-zone.js
+++ b/polyfill/test/intl402/Temporal/PlainYearMonth/prototype/toLocaleString/resolved-time-zone.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.tolocalestring
+description: A time zone in resolvedOptions with a large offset still produces the correct string
+locale: [en]
+features: [Temporal]
+---*/
+
+const month = new Temporal.PlainYearMonth(2021, 8, "gregory");
+const result = month.toLocaleString("en", { timeZone: "Pacific/Apia" });
+assert.sameValue(result, "8/2021");

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -711,6 +711,7 @@
           1. Else,
             1. Throw a *RangeError* exception.
           1. Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _calendarOverride_).
+          1. Let _timeZone_ be ! CreateTemporalTimeZone(_dateTimeFormat_.[[TimeZone]]).
           1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _plainDateTime_, *"compatible"*).
         1. If _x_ has an [[InitializedTemporalYearMonth]] internal slot, then
           1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainYearMonthPattern]].
@@ -718,6 +719,7 @@
           1. If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then
             1. Throw a *RangeError* exception.
           1. Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _x_.[[Calendar]]).
+          1. Let _timeZone_ be ! CreateTemporalTimeZone(_dateTimeFormat_.[[TimeZone]]).
           1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _plainDateTime_, *"compatible"*).
         1. If _x_ has an [[InitializedTemporalMonthDay]] internal slot, then
           1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainMonthDayPattern]].
@@ -725,17 +727,20 @@
           1. If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then
             1. Throw a *RangeError* exception.
           1. Let _plainDateTime_ be ? CreateTemporalDateTime(_x_.[[ISOYear]], _x_.[[ISOMonth]], _x_.[[ISODay]], 12, 0, 0, 0, 0, 0, _x_.[[Calendar]]).
+          1. Let _timeZone_ be ! CreateTemporalTimeZone(_dateTimeFormat_.[[TimeZone]]).
           1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _plainDateTime_, *"compatible"*).
         1. If _x_ has an [[InitializedTemporalTime]] internal slot, then
           1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainTimePattern]].
           1. Let _isoCalendar_ be ! GetISO8601Calendar().
           1. Let _plainDateTime_ be ? CreateTemporalDateTime(1970, 1, 1, _x_.[[ISOHour]], _x_.[[ISOMinute]], _x_.[[ISOSecond]], _x_.[[ISOMillisecond]], _x_.[[ISOMicrosecond]], _x_.[[ISONanosecond]], _isoCalendar_).
+          1. Let _timeZone_ be ! CreateTemporalTimeZone(_dateTimeFormat_.[[TimeZone]]).
           1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _plainDateTime_, *"compatible"*).
         1. If _x_ has an [[InitializedTemporalDateTime]] internal slot, then
           1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainDateTimePattern]].
           1. Let _calendar_ be ? ToString(_x_.[[Calendar]]).
           1. If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then
             1. Throw a *RangeError* exception.
+          1. Let _timeZone_ be ! CreateTemporalTimeZone(_dateTimeFormat_.[[TimeZone]]).
           1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _x_, *"compatible"*).
         1. If _x_ has an [[InitializedTemporalInstant]] internal slot, then
           1. Let _pattern_ be _dateTimeFormat_.[[TemporalInstantPattern]].


### PR DESCRIPTION
In the PlainDate, PlainDateTime, PlainMonthDay, PlainTime, and
PlainYearMonth cases, the _timeZone_ variable was never set before it was
used. This is an error in the spec text. It should be equal to the
time zone in the DateTimeFormat's resolvedOptions.

Add tests proving that this time zone is used when converting the Plain
objects to exact time, so that the wall time in the same time zone is used
when formatting them.