### PR TITLE
Normative: Optimize calls into user code in InterpretISODateTimeOffset

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1307,7 +1307,7 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     // fall through: offsetOpt === 'prefer', but the offset doesn't match
     // so fall back to use the time zone instead.
-    const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dt, disambiguation);
+    const instant = ES.DisambiguatePossibleInstants(possibleInstants, timeZone, dt, disambiguation);
     return GetSlot(instant, EPOCHNANOSECONDS);
   },
   ToTemporalZonedDateTime: (item, options = ObjectCreate(null)) => {
@@ -1783,8 +1783,11 @@ export const ES = ObjectAssign({}, ES2020, {
     );
   },
   BuiltinTimeZoneGetInstantFor: (timeZone, dateTime, disambiguation) => {
-    const Instant = GetIntrinsic('%Temporal.Instant%');
     const possibleInstants = ES.GetPossibleInstantsFor(timeZone, dateTime);
+    return ES.DisambiguatePossibleInstants(possibleInstants, timeZone, dateTime, disambiguation);
+  },
+  DisambiguatePossibleInstants: (possibleInstants, timeZone, dateTime, disambiguation) => {
+    const Instant = GetIntrinsic('%Temporal.Instant%');
     const numInstants = possibleInstants.length;
 
     if (numInstants === 1) return possibleInstants[0];

--- a/polyfill/test/ZonedDateTime/constructor/from/balance-negative-time-units.js
+++ b/polyfill/test/ZonedDateTime/constructor/from/balance-negative-time-units.js
@@ -30,9 +30,10 @@ info: |
         ...
       ...
       6. Assert: _offset_ is *"prefer"* or *"reject"*.
+      7. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
       ...
       9. If _offset_ is *"reject"*, throw a *RangeError* exception.
-      10. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _dateTime_, _disambiguation_).
+      10. Let _instant_ be ? DisambiguatePossibleInstants(_possibleInstants_, _timeZone_, _dateTime_, _disambiguation_).
     sec-temporal-totemporalzoneddatetime step 7:
       7. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).
     sec-temporal.zoneddatetime.from step 3:

--- a/polyfill/test/ZonedDateTime/prototype/with/balance-negative-time-units.js
+++ b/polyfill/test/ZonedDateTime/prototype/with/balance-negative-time-units.js
@@ -30,9 +30,10 @@ info: |
         ...
       ...
       6. Assert: _offset_ is *"prefer"* or *"reject"*.
+      7. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
       ...
       9. If _offset_ is *"reject"*, throw a *RangeError* exception.
-      10. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _dateTime_, _disambiguation_).
+      10. Let _instant_ be ? DisambiguatePossibleInstants(_possibleInstants_, _timeZone_, _dateTime_, _disambiguation_).
     sec-temporal.zoneddatetime.prototype.with step 26:
       26. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).
 includes: [compareArray.js, temporalHelpers.js]
@@ -47,21 +48,15 @@ const datetime1 = new Temporal.ZonedDateTime(3661_001_001_000n, tz1);
 // disambiguation is `earlier` and the shift is a spring-forward change
 datetime1.with({ nanosecond: 1 }, { offset: "ignore", disambiguation: "earlier" });
 
-const expected1 = [
+const expected = [
   "1970-01-01T01:01:01.001001001",
   "1970-01-01T01:01:01.001000999",
 ];
-assert.compareArray(tz1.getPossibleInstantsForCalledWith, expected1);
+assert.compareArray(tz1.getPossibleInstantsForCalledWith, expected);
 
 const tz2 = TemporalHelpers.oneShiftTimeZone(shiftInstant, 2);
 const datetime2 = new Temporal.ZonedDateTime(3661_001_001_000n, tz2);
 
 datetime2.with({ nanosecond: 1 }, { offset: "prefer", disambiguation: "earlier" });
 
-const expected2 = [
-  "1970-01-01T01:01:01.001001001",
-  "1970-01-01T01:01:01.001001001",
-  "1970-01-01T01:01:01.001000999",
-];
-assert.compareArray(tz2.getPossibleInstantsForCalledWith, expected2);
-
+assert.compareArray(tz2.getPossibleInstantsForCalledWith, expected);

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -607,6 +607,20 @@
       <emu-alg>
         1. Assert: _dateTime_ has an [[InitializedTemporalDateTime]] internal slot.
         1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
+        1. Return ? DisambiguatePossibleInstants(_possibleInstants_, _timeZone_, _dateTime_, _disambiguation_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-disambiguatepossibleinstants" aoid="DisambiguatePossibleInstants">
+      <h1>DisambiguatePossibleInstants ( _possibleInstants_, _timeZone_, _dateTime_, _disambiguation_ )</h1>
+      <p>
+        The abstract operation DisambiguatePossibleInstants chooses from a List of possible `Temporal.Instant` instances the one indicated by the _disambiguation_ parameter.
+      </p>
+      <p>
+        The _possibleInstants_ List may be empty, in which case it observably calls the time zone's `getOffsetNanosecondsFor` method twice, and `getPossibleInstantsFor` once, if _disambiguation_ is not *"reject"*.
+      </p>
+      <emu-alg>
+        1. Assert: _dateTime_ has an [[InitializedTemporalDateTime]] internal slot.
         1. Let _n_ be _possibleInstants_'s length.
         1. If _n_ = 1, then
           1. Return _possibleInstants_[0].

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1101,7 +1101,7 @@
           1. If ? GetOffsetNanosecondsFor(_timeZone_, _candidate_) = _offsetNanoseconds_, then
             1. Return _candidate_.[[Nanoseconds]].
         1. If _offsetOption_ is *"reject"*, throw a *RangeError* exception.
-        1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _dateTime_, _disambiguation_).
+        1. Let _instant_ be ? DisambiguatePossibleInstants(_possibleInstants_, _timeZone_, _dateTime_, _disambiguation_).
         1. Return _instant_.[[Nanoseconds]].
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
In the current spec text algorithm, there was an unnecessary call to
timeZone.getPossibleInstantsFor(), which potentially calls observably into
user code. Fix the algorithm so it doesn't make any more calls than
necessary.