### PR TITLE
Editorial: Move common code into RejectTemporalCalendarType

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -219,6 +219,18 @@ export const ES = ObjectAssign({}, ES2020, {
   IsTemporalYearMonth: (item) => HasSlot(item, YEAR_MONTH_BRAND),
   IsTemporalMonthDay: (item) => HasSlot(item, MONTH_DAY_BRAND),
   IsTemporalZonedDateTime: (item) => HasSlot(item, EPOCHNANOSECONDS, TIME_ZONE, CALENDAR),
+  RejectObjectWithCalendarOrTimeZone: (item) => {
+    if (HasSlot(item, CALENDAR) || HasSlot(item, TIME_ZONE)) {
+      throw new TypeError('with() does not support a calendar or timeZone property');
+    }
+    if (item.calendar !== undefined) {
+      throw new TypeError('with() does not support a calendar property');
+    }
+    if (item.timeZone !== undefined) {
+      throw new TypeError('with() does not support a timeZone property');
+    }
+  },
+
   TemporalTimeZoneFromString: (stringIdent) => {
     let { ianaName, offset, z } = ES.ParseTemporalTimeZoneString(stringIdent);
     let identifier = ianaName;

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -12,10 +12,8 @@ import {
   ISO_MICROSECOND,
   ISO_NANOSECOND,
   CALENDAR,
-  TIME_ZONE,
   EPOCHNANOSECONDS,
-  GetSlot,
-  HasSlot
+  GetSlot
 } from './slots.mjs';
 
 const DISALLOWED_UNITS = ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'];
@@ -102,15 +100,7 @@ export class PlainDate {
     if (ES.Type(temporalDateLike) !== 'Object') {
       throw new TypeError('invalid argument');
     }
-    if (HasSlot(temporalDateLike, CALENDAR) || HasSlot(temporalDateLike, TIME_ZONE)) {
-      throw new TypeError('with() does not support a calendar or timeZone property');
-    }
-    if (temporalDateLike.calendar !== undefined) {
-      throw new TypeError('with() does not support a calendar property');
-    }
-    if (temporalDateLike.timeZone !== undefined) {
-      throw new TypeError('with() does not support a timeZone property');
-    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalDateLike);
 
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -13,10 +13,8 @@ import {
   ISO_MICROSECOND,
   ISO_NANOSECOND,
   CALENDAR,
-  TIME_ZONE,
   EPOCHNANOSECONDS,
-  GetSlot,
-  HasSlot
+  GetSlot
 } from './slots.mjs';
 
 export class PlainDateTime {
@@ -154,15 +152,7 @@ export class PlainDateTime {
     if (ES.Type(temporalDateTimeLike) !== 'Object') {
       throw new TypeError('invalid argument');
     }
-    if (HasSlot(temporalDateTimeLike, CALENDAR) || HasSlot(temporalDateTimeLike, TIME_ZONE)) {
-      throw new TypeError('with() does not support a calendar or timeZone property');
-    }
-    if (temporalDateTimeLike.calendar !== undefined) {
-      throw new TypeError('with() does not support a calendar property');
-    }
-    if (temporalDateTimeLike.timeZone !== undefined) {
-      throw new TypeError('with() does not support a timeZone property');
-    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalDateTimeLike);
 
     options = ES.GetOptionsObject(options);
     const calendar = GetSlot(this, CALENDAR);

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -1,7 +1,7 @@
 import { ES } from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
-import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, TIME_ZONE, GetSlot, HasSlot } from './slots.mjs';
+import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, GetSlot } from './slots.mjs';
 
 const ObjectCreate = Object.create;
 
@@ -41,15 +41,7 @@ export class PlainMonthDay {
     if (ES.Type(temporalMonthDayLike) !== 'Object') {
       throw new TypeError('invalid argument');
     }
-    if (HasSlot(temporalMonthDayLike, CALENDAR) || HasSlot(temporalMonthDayLike, TIME_ZONE)) {
-      throw new TypeError('with() does not support a calendar or timeZone property');
-    }
-    if (temporalMonthDayLike.calendar !== undefined) {
-      throw new TypeError('with() does not support a calendar property');
-    }
-    if (temporalMonthDayLike.timeZone !== undefined) {
-      throw new TypeError('with() does not support a timeZone property');
-    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalMonthDayLike);
 
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -15,11 +15,9 @@ import {
   ISO_MICROSECOND,
   ISO_NANOSECOND,
   CALENDAR,
-  TIME_ZONE,
   EPOCHNANOSECONDS,
   CreateSlots,
   GetSlot,
-  HasSlot,
   SetSlot
 } from './slots.mjs';
 
@@ -127,15 +125,7 @@ export class PlainTime {
     if (ES.Type(temporalTimeLike) !== 'Object') {
       throw new TypeError('invalid argument');
     }
-    if (HasSlot(temporalTimeLike, CALENDAR) || HasSlot(temporalTimeLike, TIME_ZONE)) {
-      throw new TypeError('with() does not support a calendar or timeZone property');
-    }
-    if (temporalTimeLike.calendar !== undefined) {
-      throw new TypeError('with() does not support a calendar property');
-    }
-    if (temporalTimeLike.timeZone !== undefined) {
-      throw new TypeError('with() does not support a timeZone property');
-    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalTimeLike);
 
     options = ES.GetOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -1,7 +1,7 @@
 import { ES } from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
-import { ISO_YEAR, ISO_MONTH, ISO_DAY, CALENDAR, TIME_ZONE, GetSlot, HasSlot } from './slots.mjs';
+import { ISO_YEAR, ISO_MONTH, ISO_DAY, CALENDAR, GetSlot } from './slots.mjs';
 
 const ObjectCreate = Object.create;
 
@@ -69,15 +69,7 @@ export class PlainYearMonth {
     if (ES.Type(temporalYearMonthLike) !== 'Object') {
       throw new TypeError('invalid argument');
     }
-    if (HasSlot(temporalYearMonthLike, CALENDAR) || HasSlot(temporalYearMonthLike, TIME_ZONE)) {
-      throw new TypeError('with() does not support a calendar or timeZone property');
-    }
-    if (temporalYearMonthLike.calendar !== undefined) {
-      throw new TypeError('with() does not support a calendar property');
-    }
-    if (temporalYearMonthLike.timeZone !== undefined) {
-      throw new TypeError('with() does not support a timeZone property');
-    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalYearMonthLike);
 
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['month', 'monthCode', 'year']);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -15,8 +15,7 @@ import {
   ISO_NANOSECOND,
   ISO_SECOND,
   TIME_ZONE,
-  GetSlot,
-  HasSlot
+  GetSlot
 } from './slots.mjs';
 
 import bigInt from 'big-integer';
@@ -173,15 +172,7 @@ export class ZonedDateTime {
     if (ES.Type(temporalZonedDateTimeLike) !== 'Object') {
       throw new TypeError('invalid zoned-date-time-like');
     }
-    if (HasSlot(temporalZonedDateTimeLike, CALENDAR) || HasSlot(temporalZonedDateTimeLike, TIME_ZONE)) {
-      throw new TypeError('with() does not support a calendar or timeZone property');
-    }
-    if (temporalZonedDateTimeLike.calendar !== undefined) {
-      throw new TypeError('calendar invalid for with(). use withCalendar()');
-    }
-    if (temporalZonedDateTimeLike.timeZone !== undefined) {
-      throw new TypeError('timeZone invalid for with(). use withTimeZone()');
-    }
+    ES.RejectObjectWithCalendarOrTimeZone(temporalZonedDateTimeLike);
 
     options = ES.GetOptionsObject(options);
     const disambiguation = ES.ToTemporalDisambiguation(options);

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -599,15 +599,21 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-rejecttemporalcalendartype" aoid="RejectTemporalCalendarType">
-    <h1>RejectTemporalCalendarType ( _object_ )</h1>
+  <emu-clause id="sec-temporal-rejectobjectwithcalendarortimezone" aoid="RejectObjectWithCalendarOrTimeZone">
+    <h1>RejectObjectWithCalendarOrTimeZone ( _object_ )</h1>
     <p>
-      The abstract operation RejectTemporalCalendarType throws an exception if its argument _object_ is an instance of one of the Temporal types that carries a calendar.
+      The abstract operation RejectObjectWithCalendarOrTimeZone throws an exception if its argument _object_ is an instance of one of the Temporal types that carries a calendar or time zone, or is an object that has a "calendar" or "timeZone" property.
     </p>
     <emu-alg>
       1. Assert: Type(_object_) is Object.
       1. If _object_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalTime]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
-          1. Throw a *TypeError* exception.
+        1. Throw a *TypeError* exception.
+      1. Let _calendarProperty_ be ? Get(_object_, *"calendar"*).
+      1. If _calendarProperty_ is not *undefined*, then
+        1. Throw a *TypeError* exception.
+      1. Let _timeZoneProperty_ be ? Get(_object_, *"timeZone"*).
+      1. If _timeZoneProperty_ is not *undefined*, then
+        1. Throw a *TypeError* exception.
     </emu-alg>
   </emu-clause>
 

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -380,13 +380,7 @@
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. If Type(_temporalDateLike_) is not Object, then
           1. Throw a *TypeError* exception.
-        1. Perform ? RejectTemporalCalendarType(_temporalDateLike_).
-        1. Let _calendarProperty_ be ? Get(_temporalDateLike_, *"calendar"*).
-        1. If _calendarProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _timeZoneProperty_ be ? Get(_temporalDateLike_, *"timeZone"*).
-        1. If _timeZoneProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalDateLike_).
         1. Let _calendar_ be _temporalDate_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
         1. Let _partialDate_ be ? PreparePartialTemporalFields(_temporalDateLike_, _fieldNames_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -383,13 +383,7 @@
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. If Type(_temporalDateTimeLike_) is not Object, then
           1. Throw a *TypeError* exception.
-        1. Perform ? RejectTemporalCalendarType(_temporalDateTimeLike_).
-        1. Let _calendarProperty_ be ? Get(_temporalDateTimeLike_, *"calendar"*).
-        1. If _calendarProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _timeZoneProperty_ be ? Get(_temporalDateTimeLike_, *"timeZone"*).
-        1. If _timeZoneProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalDateTimeLike_).
         1. Let _calendar_ be _dateTime_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
         1. Let _partialDateTime_ be ? PreparePartialTemporalFields(_temporalDateTimeLike_, _fieldNames_).

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -148,13 +148,7 @@
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. If Type(_temporalMonthDayLike_) is not Object, then
           1. Throw a *TypeError* exception.
-        1. Perform ? RejectTemporalCalendarType(_temporalMonthDayLike_).
-        1. Let _calendarProperty_ be ? Get(_temporalMonthDayLike_, *"calendar"*).
-        1. If _calendarProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _timeZoneProperty_ be ? Get(_temporalMonthDayLike_, *"timeZone"*).
-        1. If _timeZoneProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalMonthDayLike_).
         1. Let _calendar_ be _monthDay_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
         1. Let _partialMonthDay_ be ? PreparePartialTemporalFields(_temporalMonthDayLike_, _fieldNames_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -244,13 +244,7 @@
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. If Type(_temporalTimeLike_) is not Object, then
           1. Throw a *TypeError* exception.
-        1. Perform ? RejectTemporalCalendarType(_temporalTimeLike_).
-        1. Let _calendarProperty_ be ? Get(_temporalTimeLike_, *"calendar"*).
-        1. If _calendarProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _timeZoneProperty_ be ? Get(_temporalTimeLike_, *"timeZone"*).
-        1. If _timeZoneProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalTimeLike_).
         1. Let _partialTime_ be ? ToPartialTime(_temporalTimeLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -230,13 +230,7 @@
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. If Type(_temporalYearMonthLike_) is not Object, then
           1. Throw a *TypeError* exception.
-        1. Perform ? RejectTemporalCalendarType(_temporalYearMonthLike_).
-        1. Let _calendarProperty_ be ? Get(_temporalYearMonthLike_, *"calendar"*).
-        1. If _calendarProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _timeZoneProperty_ be ? Get(_temporalYearMonthLike_, *"timeZone"*).
-        1. If _timeZoneProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalYearMonthLike_).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"monthCode"*, *"year"* »).
         1. Let _partialYearMonth_ be ? PreparePartialTemporalFields(_temporalYearMonthLike_, _fieldNames_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -565,13 +565,7 @@
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. If Type(_temporalZonedDateTimeLike_) is not Object, then
           1. Throw a *TypeError* exception.
-        1. Perform ? RejectTemporalCalendarType(_temporalZonedDateTimeLike_).
-        1. Let _calendarProperty_ be ? Get(_temporalZonedDateTimeLike_, *"calendar"*).
-        1. If _calendarProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _timeZoneProperty_ be ? Get(_temporalZonedDateTimeLike_, *"timeZone"*).
-        1. If _timeZoneProperty_ is not *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalZonedDateTimeLike_).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
         1. Append *"offset"* to _fieldNames_.


### PR DESCRIPTION
Move the following code into RejectTemporalCalendarType
```
        1. Let _calendarProperty_ be ? Get(_temporalDateLike_, *"calendar"*).
        1. If _calendarProperty_ is not *undefined*, then
          1. Throw a *TypeError* exception.
        1. Let _timeZoneProperty_ be ? Get(_temporalDateLike_, *"timeZone"*).
        1. If _timeZoneProperty_ is not *undefined*, then
          1. Throw a *TypeError* exception.
```