### PR TITLE
Normative: Fix abstract operations that assume the wrong definition of modulo

### DIFF
--- a/polyfill/test/Duration/constructor/compare/argument-string-negative-fractional-units.js
+++ b/polyfill/test/Duration/constructor/compare/argument-string-negative-fractional-units.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const expectedHours = new Temporal.Duration(0, 0, 0, 0, -24, -34, -4, -404, -442, -799);
+const resultHours1 = Temporal.Duration.compare("-PT24.567890123H", expectedHours);
+assert.sameValue(resultHours1, 0, "negative fractional hours (first argument)");
+const resultHours2 = Temporal.Duration.compare(expectedHours, "-PT24.567890123H");
+assert.sameValue(resultHours2, 0, "negative fractional hours (second argument)");
+
+const expectedMinutes = new Temporal.Duration(0, 0, 0, 0, 0, -1440, -34, -73, -407, -379);
+const resultMinutes1 = Temporal.Duration.compare("-PT1440.567890123M", expectedMinutes);
+assert.sameValue(resultMinutes1, 0, "negative fractional minutes (first argument)");
+const resultMinutes2 = Temporal.Duration.compare("-PT1440.567890123M", expectedMinutes);
+assert.sameValue(resultMinutes2, 0, "negative fractional minutes (second argument)");

--- a/polyfill/test/Duration/constructor/compare/relativeto-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/Duration/constructor/compare/relativeto-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const relativeTo = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+const duration = new Temporal.Duration(0, 0, 0, 1);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time; in this
+// case via relativeTo.
+
+const result = Temporal.Duration.compare(duration, duration, { relativeTo });
+assert.sameValue(result, 0);

--- a/polyfill/test/Duration/constructor/from/argument-string-negative-fractional-units.js
+++ b/polyfill/test/Duration/constructor/from/argument-string-negative-fractional-units.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const resultHours = Temporal.Duration.from("-PT24.567890123H");
+TemporalHelpers.assertDuration(resultHours, 0, 0, 0, 0, -24, -34, -4, -404, -442, -799, "negative fractional hours");
+
+const resultMinutes = Temporal.Duration.from("-PT1440.567890123M");
+TemporalHelpers.assertDuration(resultMinutes, 0, 0, 0, 0, 0, -1440, -34, -73, -407, -379, "negative fractional minutes");

--- a/polyfill/test/Duration/prototype/add/argument-string-negative-fractional-units.js
+++ b/polyfill/test/Duration/prototype/add/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration();
+
+const resultHours = instance.add("-PT24.567890123H");
+TemporalHelpers.assertDuration(resultHours, 0, 0, 0, 0, -24, -34, -4, -404, -442, -799, "negative fractional hours");
+
+const resultMinutes = instance.add("-PT1440.567890123M");
+TemporalHelpers.assertDuration(resultMinutes, 0, 0, 0, 0, 0, -1440, -34, -73, -407, -379, "negative fractional minutes");

--- a/polyfill/test/Duration/prototype/add/balance-negative-result.js
+++ b/polyfill/test/Duration/prototype/add/balance-negative-result.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: A negative duration result is balanced correctly by the modulo operation in NanosecondsToDays
+info: |
+    sec-temporal-nanosecondstodays step 6:
+      6. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
+        a. Return the new Record { ..., [[Nanoseconds]]: abs(_nanoseconds_) modulo _dayLengthNs_ × _sign_, ... }.
+    sec-temporal-balanceduration step 4:
+      4. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        a. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
+    sec-temporal-addduration steps 5–6:
+      5. If _relativeTo_ is *undefined*, then
+        ...
+        b. Let _result_ be ! BalanceDuration(_d1_ + _d2_, _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
+        ...
+      6. Else if _relativeTo_ has an [[InitializedTemporalPlainDateTime]] internal slot, then
+        ...
+        n. Let _result_ be ! BalanceDuration(_dateDifference_.[[Days]], _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
+    sec-temporal.duration.prototype.add step 6:
+      6. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _other_.[[Years]], _other_.[[Months]], _other_.[[Weeks]], _other_.[[Days]], _other_.[[Hours]], _other_.[[Minutes]], _other_.[[Seconds]], _other_.[[Milliseconds]], _other_.[[Microseconds]], _other_.[[Nanoseconds]], _relativeTo_).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const duration1 = new Temporal.Duration(0, 0, 0, 0, -60);
+const duration2 = new Temporal.Duration(0, 0, 0, -1);
+
+const resultNotRelative = duration1.add(duration2);
+TemporalHelpers.assertDuration(resultNotRelative, 0, 0, 0, -3, -12, 0, 0, 0, 0, 0);
+
+const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
+const resultRelative = duration1.add(duration2, { relativeTo });
+TemporalHelpers.assertDuration(resultRelative, 0, 0, 0, -3, -12, 0, 0, 0, 0, 0);

--- a/polyfill/test/Duration/prototype/add/relativeto-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/Duration/prototype/add/relativeto-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const relativeTo = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+const duration = new Temporal.Duration(0, 0, 0, 1);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time; in this
+// case via relativeTo.
+
+const result = duration.add(duration, { relativeTo });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0);

--- a/polyfill/test/Duration/prototype/round/balance-negative-result.js
+++ b/polyfill/test/Duration/prototype/round/balance-negative-result.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: A negative duration result is balanced correctly by the modulo operation in NanosecondsToDays
+info: |
+    sec-temporal-nanosecondstodays step 6:
+      6. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
+        a. Return the new Record { ..., [[Nanoseconds]]: abs(_nanoseconds_) modulo _dayLengthNs_ × _sign_, ... }.
+    sec-temporal-balanceduration step 4:
+      4. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        a. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
+    sec-temporal.duration.prototype.round step 25:
+      25. Let _result_ be ? BalanceDuration(_balanceResult_.[[Days]], _adjustResult_.[[Hours]], _adjustResult_.[[Minutes]], _adjustResult_.[[Seconds]], _adjustResult_.[[Milliseconds]], _adjustResult_.[[Microseconds]], _adjustResult_.[[Nanoseconds]], _largestUnit_, _relativeTo_).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const duration = new Temporal.Duration(0, 0, 0, 0, -60);
+const result = duration.round({ largestUnit: "days" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, -2, -12, 0, 0, 0, 0, 0);

--- a/polyfill/test/Duration/prototype/round/relativeto-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/Duration/prototype/round/relativeto-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const relativeTo = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+const duration = new Temporal.Duration(0, 0, 0, 1);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time; in this
+// case via relativeTo.
+
+const result = duration.round({ relativeTo, largestUnit: "days" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0);

--- a/polyfill/test/Duration/prototype/round/round-negative-result.js
+++ b/polyfill/test/Duration/prototype/round/round-negative-result.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: A negative duration result is balanced correctly by the modulo operation in NanosecondsToDays
+info: |
+    sec-temporal-nanosecondstodays step 6:
+      6. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
+        a. Return the new Record { ..., [[Nanoseconds]]\: abs(_nanoseconds_) modulo _dayLengthNs_ × _sign_, ... }.
+    sec-temporal-roundduration step 6:
+      6. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+        d. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_).
+    sec-temporal.duration.prototype.round step 21:
+      21. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_[[Seconds]], _duration_[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const duration = new Temporal.Duration(0, 0, 0, 0, -60);
+const result = duration.round({ smallestUnit: "days" });
+TemporalHelpers.assertDuration(result, 0, 0, 0, -3, 0, 0, 0, 0, 0, 0);

--- a/polyfill/test/Duration/prototype/subtract/argument-string-negative-fractional-units.js
+++ b/polyfill/test/Duration/prototype/subtract/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration();
+
+const resultHours = instance.subtract("-PT24.567890123H");
+TemporalHelpers.assertDuration(resultHours, 0, 0, 0, 0, 24, 34, 4, 404, 442, 799, "negative fractional hours");
+
+const resultMinutes = instance.subtract("-PT1440.567890123M");
+TemporalHelpers.assertDuration(resultMinutes, 0, 0, 0, 0, 0, 1440, 34, 73, 407, 379, "negative fractional minutes");

--- a/polyfill/test/Duration/prototype/subtract/balance-negative-result.js
+++ b/polyfill/test/Duration/prototype/subtract/balance-negative-result.js
@@ -1,0 +1,36 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: A negative duration result is balanced correctly by the modulo operation in NanosecondsToDays
+info: |
+    sec-temporal-nanosecondstodays step 6:
+      6. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
+        a. Return the new Record { ..., [[Nanoseconds]]: abs(_nanoseconds_) modulo _dayLengthNs_ × _sign_, ... }.
+    sec-temporal-balanceduration step 4:
+      4. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        a. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
+    sec-temporal-addduration steps 5–6:
+      5. If _relativeTo_ is *undefined*, then
+        ...
+        b. Let _result_ be ! BalanceDuration(_d1_ + _d2_, _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
+        ...
+      6. Else if _relativeTo_ has an [[InitializedTemporalPlainDateTime]] internal slot, then
+        ...
+        n. Let _result_ be ! BalanceDuration(_dateDifference_.[[Days]], _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
+    sec-temporal.duration.prototype.subtract step 6:
+      6. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], −_other_.[[Years]], −_other_.[[Months]], −_other_.[[Weeks]], −_other_.[[Days]], −_other_.[[Hours]], −_other_.[[Minutes]], −_other_.[[Seconds]], −_other_.[[Milliseconds]], −_other_.[[Microseconds]], −_other_.[[Nanoseconds]], _relativeTo_).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const duration1 = new Temporal.Duration(0, 0, 0, 0, -60);
+const duration2 = new Temporal.Duration(0, 0, 0, -1);
+
+const resultNotRelative = duration1.subtract(duration2);
+TemporalHelpers.assertDuration(resultNotRelative, 0, 0, 0, -1, -12, 0, 0, 0, 0, 0);
+
+const relativeTo = new Temporal.PlainDateTime(2000, 1, 1);
+const resultRelative = duration1.subtract(duration2, { relativeTo });
+TemporalHelpers.assertDuration(resultRelative, 0, 0, 0, -1, -12, 0, 0, 0, 0, 0);

--- a/polyfill/test/Duration/prototype/subtract/relativeto-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/Duration/prototype/subtract/relativeto-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const relativeTo = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+const duration = new Temporal.Duration(0, 0, 0, 1);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time; in this
+// case via relativeTo.
+
+const result = duration.subtract(duration, { relativeTo });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);

--- a/polyfill/test/Duration/prototype/total/balance-negative-result.js
+++ b/polyfill/test/Duration/prototype/total/balance-negative-result.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: A negative duration result is balanced correctly by the modulo operation in NanosecondsToDays
+info: |
+    sec-temporal-nanosecondstodays step 6:
+      6. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
+        a. Return the new Record { ..., [[Nanoseconds]]: abs(_nanoseconds_) modulo _dayLengthNs_ × _sign_, ... }.
+    sec-temporal-balanceduration step 4:
+      4. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        a. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
+    sec-temporal.duration.prototype.round step 9:
+      9. Let _balanceResult_ be ? BalanceDuration(_unbalanceResult_.[[Days]], _unbalanceResult_.[[Hours]], _unbalanceResult_.[[Minutes]], _unbalanceResult_.[[Seconds]], _unbalanceResult_.[[Milliseconds]], _unbalanceResult_.[[Microseconds]], _unbalanceResult_.[[Nanoseconds]], _unit_, _intermediate_).
+features: [Temporal]
+---*/
+
+const duration = new Temporal.Duration(0, 0, 0, 0, -60);
+const result = duration.total({ unit: "days" });
+assert.sameValue(result, -2.5);

--- a/polyfill/test/Duration/prototype/total/relativeto-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/Duration/prototype/total/relativeto-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const relativeTo = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+const duration = new Temporal.Duration(0, 0, 0, 1);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time; in this
+// case via relativeTo.
+
+const result = duration.total({ relativeTo, unit: "days" });
+assert.sameValue(result, 1);

--- a/polyfill/test/Instant/prototype/add/argument-string-negative-fractional-units.js
+++ b/polyfill/test/Instant/prototype/add/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.add
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
+
+const resultHours = instance.add("-PT24.567890123H");
+assert.sameValue(resultHours.epochNanoseconds, 999_911_555_595_557_201n, "negative fractional hours");
+
+const resultMinutes = instance.add("-PT1440.567890123M");
+assert.sameValue(resultMinutes.epochNanoseconds, 999_913_565_926_592_621n, "negative fractional minutes");

--- a/polyfill/test/Instant/prototype/subtract/argument-string-negative-fractional-units.js
+++ b/polyfill/test/Instant/prototype/subtract/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.subtract
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
+
+const resultHours = instance.subtract("-PT24.567890123H");
+assert.sameValue(resultHours.epochNanoseconds, 1_000_088_444_404_442_799n, "negative fractional hours");
+
+const resultMinutes = instance.subtract("-PT1440.567890123M");
+assert.sameValue(resultMinutes.epochNanoseconds, 1_000_086_434_073_407_379n, "negative fractional minutes");

--- a/polyfill/test/Instant/prototype/toJSON/negative-epochnanoseconds.js
+++ b/polyfill/test/Instant/prototype/toJSON/negative-epochnanoseconds.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tojson
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.Instant(-13849764_999_999_999n);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.toJSON();
+assert.sameValue(result, "1969-07-24T16:50:35.000000001Z");

--- a/polyfill/test/Instant/prototype/toString/negative-epochnanoseconds.js
+++ b/polyfill/test/Instant/prototype/toString/negative-epochnanoseconds.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.tostring
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.Instant(-13849764_999_999_999n);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.toString();
+assert.sameValue(result, "1969-07-24T16:50:35.000000001Z");

--- a/polyfill/test/PlainDate/prototype/add/argument-string-negative-fractional-units.js
+++ b/polyfill/test/PlainDate/prototype/add/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const resultHours = instance.add("-PT24.567890123H");
+TemporalHelpers.assertPlainDate(resultHours, 2000, 5, "M05", 1, "negative fractional hours");
+
+const resultMinutes = instance.add("-PT1440.567890123M");
+TemporalHelpers.assertPlainDate(resultMinutes, 2000, 5, "M05", 1, "negative fractional minutes");

--- a/polyfill/test/PlainDate/prototype/subtract/argument-string-negative-fractional-units.js
+++ b/polyfill/test/PlainDate/prototype/subtract/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+
+const resultHours = instance.subtract("-PT24.567890123H");
+TemporalHelpers.assertPlainDate(resultHours, 2000, 5, "M05", 3, "negative fractional hours");
+
+const resultMinutes = instance.subtract("-PT1440.567890123M");
+TemporalHelpers.assertPlainDate(resultMinutes, 2000, 5, "M05", 3, "negative fractional minutes");

--- a/polyfill/test/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainDate/prototype/toPlainDateTime/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.toplaindatetime
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+const result = instance.toPlainDateTime(datetime);
+TemporalHelpers.assertPlainDateTime(result, 2000, 5, "M05", 2, 16, 50, 35, 0, 0, 1);

--- a/polyfill/test/PlainDate/prototype/toZonedDateTime/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainDate/prototype/toZonedDateTime/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.tozoneddatetime
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+const result = instance.toZonedDateTime({ plainTime: datetime, timeZone: "UTC" });
+assert.sameValue(result.epochNanoseconds, 957286235_000_000_001n);

--- a/polyfill/test/PlainDateTime/constructor/compare/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainDateTime/constructor/compare/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.compare
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const zoned = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+const plain = new Temporal.PlainDateTime(1969, 7, 24, 16, 50, 35, 0, 0, 1);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result1 = Temporal.PlainDateTime.compare(plain, zoned);
+assert.sameValue(result1, 0);
+
+const result2 = Temporal.PlainDateTime.compare(zoned, plain);
+assert.sameValue(result2, 0);

--- a/polyfill/test/PlainDateTime/constructor/from/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainDateTime/constructor/from/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.from
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = Temporal.PlainDateTime.from(datetime);
+TemporalHelpers.assertPlainDateTime(result, 1969, 7, "M07", 24, 16, 50, 35, 0, 0, 1);

--- a/polyfill/test/PlainDateTime/prototype/add/argument-string-negative-fractional-units.js
+++ b/polyfill/test/PlainDateTime/prototype/add/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
+
+const resultHours = instance.add("-PT24.567890123H");
+TemporalHelpers.assertPlainDateTime(resultHours, 2000, 4, "M04", 30, 23, 25, 55, 595, 557, 201, "negative fractional hours");
+
+const resultMinutes = instance.add("-PT1440.567890123M");
+TemporalHelpers.assertPlainDateTime(resultMinutes, 2000, 4, "M04", 30, 23, 59, 25, 926, 592, 621, "negative fractional minutes");

--- a/polyfill/test/PlainDateTime/prototype/equals/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainDateTime/prototype/equals/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.equals
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.PlainDateTime(1969, 7, 24, 16, 50, 35, 0, 0, 1);
+const result = instance.equals(datetime);
+assert.sameValue(result, true);

--- a/polyfill/test/PlainDateTime/prototype/since/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainDateTime/prototype/since/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 15, 30, 45, 987, 654, 321);
+const result = instance.since(datetime);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 11239, 22, 40, 10, 987, 654, 320);

--- a/polyfill/test/PlainDateTime/prototype/since/balance-negative-duration.js
+++ b/polyfill/test/PlainDateTime/prototype/since/balance-negative-duration.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Negative durations are balanced correctly by the modulo operation in NanosecondsToDays
+info: |
+    sec-temporal-nanosecondstodays step 6:
+      6. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
+        a. Return the new Record { ..., [[Nanoseconds]]: abs(_nanoseconds_) modulo _dayLengthNs_ × _sign_, ... }.
+    sec-temporal-balanceduration step 4:
+      4. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        a. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
+    sec-temporal-differenceisodatetime steps 7 and 13:
+      7. If _timeSign_ is -_dateSign_, then
+        ...
+        b. Set _timeDifference_ to ? BalanceDuration(-_timeSign_, _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
+      ...
+      16. Return ? BalanceDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
+    sec-temporal.plaindatetime.prototype.since step 14:
+      14. Let _diff_ be ? DifferenceISODateTime(_other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier1 = new Temporal.PlainDateTime(2000, 5, 2, 9);
+const later1 = new Temporal.PlainDateTime(2000, 5, 5, 10);
+const result1 = later1.since(earlier1, { largestUnit: 'day' });
+TemporalHelpers.assertDuration(result1, 0, 0, 0, 3, 1, 0, 0, 0, 0, 0, "date sign == time sign");
+
+const earlier2 = new Temporal.PlainDateTime(2000, 5, 2, 10);
+const later2 = new Temporal.PlainDateTime(2000, 5, 5, 9);
+const result2 = later2.since(earlier2, { largestUnit: 'day' });
+TemporalHelpers.assertDuration(result2, 0, 0, 0, 2, 23, 0, 0, 0, 0, 0, "date sign != time sign");

--- a/polyfill/test/PlainDateTime/prototype/since/round-negative-duration.js
+++ b/polyfill/test/PlainDateTime/prototype/since/round-negative-duration.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: Negative durations are rounded correctly by the modulo operation in NanosecondsToDays
+info: |
+    sec-temporal-nanosecondstodays step 6:
+      6. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
+        a. Return the new Record { ..., [[Nanoseconds]]: abs(_nanoseconds_) modulo _dayLengthNs_ × _sign_, ... }.
+    sec-temporal-roundduration step 6:
+      6. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+        d. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_).
+    sec-temporal.plaindatetime.prototype.since step 15:
+      15. Let _roundResult_ be ? RoundDuration(−_diff_.[[Years]], −_diff_.[[Months]], −_diff_.[[Weeks]], −_diff_.[[Days]], −_diff_.[[Hours]], −_diff_.[[Minutes]], −_diff_.[[Seconds]], −_diff_.[[Milliseconds]], −_diff_.[[Microseconds]], −_diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dateTime_).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12);
+const later = new Temporal.PlainDateTime(2000, 5, 5);
+const result = later.since(earlier, { smallestUnit: "day", roundingIncrement: 2 });
+TemporalHelpers.assertDuration(result, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0);

--- a/polyfill/test/PlainDateTime/prototype/subtract/argument-string-negative-fractional-units.js
+++ b/polyfill/test/PlainDateTime/prototype/subtract/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2);
+
+const resultHours = instance.subtract("-PT24.567890123H");
+TemporalHelpers.assertPlainDateTime(resultHours, 2000, 5, "M05", 3, 0, 34, 4, 404, 442, 799, "negative fractional hours");
+
+const resultMinutes = instance.subtract("-PT1440.567890123M");
+TemporalHelpers.assertPlainDateTime(resultMinutes, 2000, 5, "M05", 3, 0, 0, 34, 73, 407, 379, "negative fractional minutes");

--- a/polyfill/test/PlainDateTime/prototype/until/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainDateTime/prototype/until/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 15, 30, 45, 987, 654, 321);
+const result = instance.until(datetime);
+TemporalHelpers.assertDuration(result, 0, 0, 0, -11239, -22, -40, -10, -987, -654, -320);

--- a/polyfill/test/PlainDateTime/prototype/until/balance-negative-duration.js
+++ b/polyfill/test/PlainDateTime/prototype/until/balance-negative-duration.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Negative durations are balanced correctly by the modulo operation in NanosecondsToDays
+info: |
+    sec-temporal-nanosecondstodays step 6:
+      6. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
+        a. Return the new Record { ..., [[Nanoseconds]]: abs(_nanoseconds_) modulo _dayLengthNs_ × _sign_, ... }.
+    sec-temporal-balanceduration step 4:
+      4. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        a. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _relativeTo_).
+    sec-temporal-differenceisodatetime steps 7 and 13:
+      7. If _timeSign_ is -_dateSign_, then
+        ...
+        b. Set _timeDifference_ to ? BalanceDuration(-_timeSign_, _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
+      ...
+      13. Return ? BalanceDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
+    sec-temporal.plaindatetime.prototype.until step 13:
+      13. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier1 = new Temporal.PlainDateTime(2000, 5, 2, 9);
+const later1 = new Temporal.PlainDateTime(2000, 5, 5, 10);
+const result1 = later1.until(earlier1, { largestUnit: 'day' });
+TemporalHelpers.assertDuration(result1, 0, 0, 0, -3, -1, 0, 0, 0, 0, 0, "date sign == time sign");
+
+const earlier2 = new Temporal.PlainDateTime(2000, 5, 2, 10);
+const later2 = new Temporal.PlainDateTime(2000, 5, 5, 9);
+const result2 = later2.until(earlier2, { largestUnit: 'day' });
+TemporalHelpers.assertDuration(result2, 0, 0, 0, -2, -23, 0, 0, 0, 0, 0, "date sign != time sign");

--- a/polyfill/test/PlainDateTime/prototype/until/round-negative-duration.js
+++ b/polyfill/test/PlainDateTime/prototype/until/round-negative-duration.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: Negative durations are rounded correctly by the modulo operation in NanosecondsToDays
+info: |
+    sec-temporal-nanosecondstodays step 6:
+      6. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
+        a. Return the new Record { ..., [[Nanoseconds]]: abs(_nanoseconds_) modulo _dayLengthNs_ × _sign_, ... }.
+    sec-temporal-roundduration step 6:
+      6. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+        ...
+        d. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_).
+    sec-temporal.plaindatetime.prototype.until step 14:
+      14. Let _roundResult_ be ? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dateTime_).
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12);
+const later = new Temporal.PlainDateTime(2000, 5, 5);
+const result = later.until(earlier, { smallestUnit: "day", roundingIncrement: 2 });
+TemporalHelpers.assertDuration(result, 0, 0, 0, -2, 0, 0, 0, 0, 0, 0);

--- a/polyfill/test/PlainDateTime/prototype/withPlainTime/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainDateTime/prototype/withPlainTime/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.withplaintime
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 15, 30, 45, 987, 654, 321);
+const result = instance.withPlainTime(datetime);
+TemporalHelpers.assertPlainDateTime(result, 2000, 5, "M05", 2, 16, 50, 35, 0, 0, 1);

--- a/polyfill/test/PlainTime/constructor/compare/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainTime/constructor/compare/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.compare
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+const time = new Temporal.PlainTime(16, 50, 35, 0, 0, 1);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result1 = Temporal.PlainTime.compare(time, datetime);
+assert.sameValue(result1, 0);
+
+const result2 = Temporal.PlainTime.compare(datetime, time);
+assert.sameValue(result2, 0);

--- a/polyfill/test/PlainTime/constructor/from/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainTime/constructor/from/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.from
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = Temporal.PlainTime.from(datetime);
+TemporalHelpers.assertPlainTime(result, 16, 50, 35, 0, 0, 1);

--- a/polyfill/test/PlainTime/prototype/add/argument-string-negative-fractional-units.js
+++ b/polyfill/test/PlainTime/prototype/add/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.add
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime();
+
+const resultHours = instance.add("-PT24.567890123H");
+TemporalHelpers.assertPlainTime(resultHours, 23, 25, 55, 595, 557, 201, "negative fractional hours");
+
+const resultMinutes = instance.add("-PT1440.567890123M");
+TemporalHelpers.assertPlainTime(resultMinutes, 23, 59, 25, 926, 592, 621, "negative fractional minutes");

--- a/polyfill/test/PlainTime/prototype/equals/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainTime/prototype/equals/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.equals
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.PlainTime(16, 50, 35, 0, 0, 1);
+const result = instance.equals(datetime);
+assert.sameValue(result, true);

--- a/polyfill/test/PlainTime/prototype/since/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainTime/prototype/since/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.since
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.PlainTime(15);
+const result = instance.since(datetime);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, -1, -50, -35, 0, 0, -1);

--- a/polyfill/test/PlainTime/prototype/subtract/argument-string-negative-fractional-units.js
+++ b/polyfill/test/PlainTime/prototype/subtract/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.subtract
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime();
+
+const resultHours = instance.subtract("-PT24.567890123H");
+TemporalHelpers.assertPlainTime(resultHours, 0, 34, 4, 404, 442, 799, "negative fractional hours");
+
+const resultMinutes = instance.subtract("-PT1440.567890123M");
+TemporalHelpers.assertPlainTime(resultMinutes, 0, 0, 34, 73, 407, 379, "negative fractional minutes");

--- a/polyfill/test/PlainTime/prototype/until/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/PlainTime/prototype/until/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.until
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.PlainTime(15);
+const result = instance.until(datetime);
+TemporalHelpers.assertDuration(result, 0, 0, 0, 0, 1, 50, 35, 0, 0, 1);

--- a/polyfill/test/PlainYearMonth/prototype/add/argument-string-negative-fractional-units.js
+++ b/polyfill/test/PlainYearMonth/prototype/add/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2000, 5);
+
+const resultHours = instance.add("-PT24.567890123H");
+TemporalHelpers.assertPlainYearMonth(resultHours, 2000, 5, "M05", "negative fractional hours");
+
+const resultMinutes = instance.add("-PT1440.567890123M");
+TemporalHelpers.assertPlainYearMonth(resultMinutes, 2000, 5, "M05", "negative fractional minutes");

--- a/polyfill/test/PlainYearMonth/prototype/subtract/argument-string-negative-fractional-units.js
+++ b/polyfill/test/PlainYearMonth/prototype/subtract/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2000, 5);
+
+const resultHours = instance.subtract("-PT24.567890123H");
+TemporalHelpers.assertPlainYearMonth(resultHours, 2000, 5, "M05", "negative fractional hours");
+
+const resultMinutes = instance.subtract("-PT1440.567890123M");
+TemporalHelpers.assertPlainYearMonth(resultMinutes, 2000, 5, "M05", "negative fractional minutes");

--- a/polyfill/test/TimeZone/prototype/getInstantFor/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/TimeZone/prototype/getInstantFor/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getinstantfor
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.TimeZone("UTC");
+const result = instance.getInstantFor(datetime);
+assert.sameValue(result.epochNanoseconds, -13849764_999_999_999n);

--- a/polyfill/test/TimeZone/prototype/getPlainDateTimeFor/argument-negative-epochnanoseconds.js
+++ b/polyfill/test/TimeZone/prototype/getPlainDateTimeFor/argument-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getplaindatetimefor
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const instant = new Temporal.Instant(-13849764_999_999_999n);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.TimeZone("UTC");
+const result = instance.getPlainDateTimeFor(instant);
+TemporalHelpers.assertPlainDateTime(result, 1969, 7, "M07", 24, 16, 50, 35, 0, 0, 1);

--- a/polyfill/test/TimeZone/prototype/getPossibleInstantsFor/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/TimeZone/prototype/getPossibleInstantsFor/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.timezone.prototype.getpossibleinstantsfor
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [compareArray.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.TimeZone("UTC");
+const result = instance.getPossibleInstantsFor(datetime);
+assert.compareArray(result.map((i) => i.epochNanoseconds), [-13849764_999_999_999n]);

--- a/polyfill/test/ZonedDateTime/prototype/add/argument-string-negative-fractional-units.js
+++ b/polyfill/test/ZonedDateTime/prototype/add/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+const resultHours = instance.add("-PT24.567890123H");
+assert.sameValue(resultHours.epochNanoseconds, 999_911_555_595_557_201n, "negative fractional hours");
+
+const resultMinutes = instance.add("-PT1440.567890123M");
+assert.sameValue(resultMinutes.epochNanoseconds, 999_913_565_926_592_621n, "negative fractional minutes");

--- a/polyfill/test/ZonedDateTime/prototype/add/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/add/negative-epochnanoseconds.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.add(new Temporal.Duration(0, 0, 0, 1));
+assert.sameValue(result.epochNanoseconds, -13763364_999_999_999n);

--- a/polyfill/test/ZonedDateTime/prototype/getISOFields/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/getISOFields/negative-epochnanoseconds.js
@@ -1,0 +1,37 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.getisofields
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [deepEqual.js]
+---*/
+
+const timeZone = new Temporal.TimeZone("UTC");
+const calendar = new Temporal.Calendar("iso8601");
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, timeZone, calendar);
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.getISOFields();
+assert.deepEqual(result, {
+  calendar,
+  isoDay: 24,
+  isoHour: 16,
+  isoMicrosecond: 0,
+  isoMillisecond: 0,
+  isoMinute: 50,
+  isoMonth: 7,
+  isoNanosecond: 1,
+  isoSecond: 35,
+  isoYear: 1969,
+  offset: "+00:00",
+  timeZone,
+});

--- a/polyfill/test/ZonedDateTime/prototype/microsecond/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/microsecond/negative-epochnanoseconds.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.microsecond
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+assert.sameValue(datetime.microsecond, 0);

--- a/polyfill/test/ZonedDateTime/prototype/millisecond/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/millisecond/negative-epochnanoseconds.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.millisecond
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+assert.sameValue(datetime.millisecond, 0);

--- a/polyfill/test/ZonedDateTime/prototype/nanosecond/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/nanosecond/negative-epochnanoseconds.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.nanosecond
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+assert.sameValue(datetime.nanosecond, 1);

--- a/polyfill/test/ZonedDateTime/prototype/round/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/round/negative-epochnanoseconds.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.round
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.round({ smallestUnit: "millisecond" });
+assert.sameValue(result.epochNanoseconds, -13849765_000_000_000n);

--- a/polyfill/test/ZonedDateTime/prototype/since/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/since/negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.since(new Temporal.ZonedDateTime(0n, "UTC"), { largestUnit: "month" });
+TemporalHelpers.assertDuration(result, 0, -5, 0, -7, -7, -9, -24, -999, -999, -999);

--- a/polyfill/test/ZonedDateTime/prototype/subtract/argument-string-negative-fractional-units.js
+++ b/polyfill/test/ZonedDateTime/prototype/subtract/argument-string-negative-fractional-units.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+
+const resultHours = instance.subtract("-PT24.567890123H");
+assert.sameValue(resultHours.epochNanoseconds, 1_000_088_444_404_442_799n, "negative fractional hours");
+
+const resultMinutes = instance.subtract("-PT1440.567890123M");
+assert.sameValue(resultMinutes.epochNanoseconds, 1_000_086_434_073_407_379n, "negative fractional minutes");

--- a/polyfill/test/ZonedDateTime/prototype/subtract/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/subtract/negative-epochnanoseconds.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.subtract(new Temporal.Duration(0, 0, 0, 1));
+assert.sameValue(result.epochNanoseconds, -13936164_999_999_999n);

--- a/polyfill/test/ZonedDateTime/prototype/toJSON/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/toJSON/negative-epochnanoseconds.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tojson
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.toJSON();
+assert.sameValue(result, "1969-07-24T16:50:35.000000001+00:00[UTC]");

--- a/polyfill/test/ZonedDateTime/prototype/toPlainDateTime/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/toPlainDateTime/negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.toplaindatetime
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.toPlainDateTime();
+TemporalHelpers.assertPlainDateTime(result, 1969, 7, "M07", 24, 16, 50, 35, 0, 0, 1);

--- a/polyfill/test/ZonedDateTime/prototype/toPlainTime/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/toPlainTime/negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.toplaintime
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.toPlainTime();
+TemporalHelpers.assertPlainTime(result, 16, 50, 35, 0, 0, 1);

--- a/polyfill/test/ZonedDateTime/prototype/toString/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/toString/negative-epochnanoseconds.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.tostring
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.toString();
+assert.sameValue(result, "1969-07-24T16:50:35.000000001+00:00[UTC]");

--- a/polyfill/test/ZonedDateTime/prototype/until/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/until/negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.until(new Temporal.ZonedDateTime(0n, "UTC"), { largestUnit: "month" });
+TemporalHelpers.assertDuration(result, 0, 5, 0, 7, 7, 9, 24, 999, 999, 999);

--- a/polyfill/test/ZonedDateTime/prototype/withPlainDate/negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/withPlainDate/negative-epochnanoseconds.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaindate
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const result = datetime.withPlainDate(new Temporal.PlainDate(2000, 5, 2));
+assert.sameValue(result.epochNanoseconds, 957286235_000_000_001n);

--- a/polyfill/test/ZonedDateTime/prototype/withPlainTime/argument-zoneddatetime-negative-epochnanoseconds.js
+++ b/polyfill/test/ZonedDateTime/prototype/withPlainTime/argument-zoneddatetime-negative-epochnanoseconds.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.withplaintime
+description: A pre-epoch value is handled correctly by the modulo operation in GetISOPartsFromEpoch
+info: |
+    sec-temporal-getisopartsfromepoch step 1:
+      1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+    sec-temporal-builtintimezonegetplaindatetimefor step 2:
+      2. Let _result_ be ! GetISOPartsFromEpoch(_instant_.[[Nanoseconds]]).
+features: [Temporal]
+---*/
+
+const datetime = new Temporal.ZonedDateTime(-13849764_999_999_999n, "UTC");
+
+// This code path shows up anywhere we convert an exact time, before the Unix
+// epoch, with nonzero microseconds or nanoseconds, into a wall time.
+
+const instance = new Temporal.ZonedDateTime(0n, "UTC");
+const result = instance.withPlainTime(datetime);
+assert.sameValue(result.epochNanoseconds, 60635_000_000_001n);

--- a/spec.html
+++ b/spec.html
@@ -46,5 +46,5 @@ contributors: Maggie Pint, Matt Johnson, Brian Terlson, Daniel Ehrenberg, Philip
 <emu-import href="spec/timezone.html"></emu-import>
 <emu-import href="spec/calendar.html"></emu-import>
 <emu-import href="spec/abstractops.html"></emu-import>
-<emu-import href="spec/legacydate.html"></emu-import>
+<emu-import href="spec/mainadditions.html"></emu-import>
 <emu-import href="spec/intl.html"></emu-import>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -101,20 +101,20 @@
         1. If any of _minutes_, _fMinutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ is not 0, throw a *RangeError* exception.
         1. Let _mins_ be _fHours_ × 60.
         1. Set _minutes_ to floor(_mins_).
-        1. Set _fMinutes_ to _mins_ modulo 1.
+        1. Set _fMinutes_ to the mathematical value whose sign is the sign of _mins_ and whose magnitude is abs(_mins_) modulo 1.
       1. If _fMinutes_ is not equal to 0, then
         1. If any of _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ is not 0, throw a *RangeError* exception.
         1. Let _secs_ be _fMinutes_ × 60.
         1. Set _seconds_ to floor(_secs_).
-        1. Let _fSeconds_ be _secs_ modulo 1.
+        1. Let _fSeconds_ be the mathematical value whose sign is the sign of _secs_ and whose magnitude is abs(_secs_) modulo 1.
         1. If _fSeconds_ is not equal to 0, then
           1. Let _mils_ be _fSeconds_ × 1000.
           1. Set _milliseconds_ to floor(_mils_).
-          1. Let _fMilliseconds_ be _mils_ modulo 1.
+          1. Let _fMilliseconds_ be the mathematical value whose sign is the sign of _mils_ and whose magnitude is abs(_mils_) modulo 1.
           1. If _fMilliseconds_ is not equal to 0, then
             1. Let _mics_ be _fMilliseconds_ × 1000.
             1. Set _microseconds_ to floor(_mics_).
-            1. Let _fMicroseconds_ be _mics_ modulo 1.
+            1. Let _fMicroseconds_ be the mathematical value whose sign is the sign of _mics_ and whose magnitude is abs(_mics_) modulo 1.
             1. If _fMicroseconds_ is not equal to 0, then
               1. Let _nans_ be _fMicroseconds_ × 1000.
               1. Set _nanoseconds_ to floor(_nans_).

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -101,20 +101,20 @@
         1. If any of _minutes_, _fMinutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ is not 0, throw a *RangeError* exception.
         1. Let _mins_ be _fHours_ × 60.
         1. Set _minutes_ to floor(_mins_).
-        1. Set _fMinutes_ to the mathematical value whose sign is the sign of _mins_ and whose magnitude is abs(_mins_) modulo 1.
+        1. Set _fMinutes_ to remainder(_mins_, 1).
       1. If _fMinutes_ is not equal to 0, then
         1. If any of _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ is not 0, throw a *RangeError* exception.
         1. Let _secs_ be _fMinutes_ × 60.
         1. Set _seconds_ to floor(_secs_).
-        1. Let _fSeconds_ be the mathematical value whose sign is the sign of _secs_ and whose magnitude is abs(_secs_) modulo 1.
+        1. Let _fSeconds_ be remainder(_secs_, 1).
         1. If _fSeconds_ is not equal to 0, then
           1. Let _mils_ be _fSeconds_ × 1000.
           1. Set _milliseconds_ to floor(_mils_).
-          1. Let _fMilliseconds_ be the mathematical value whose sign is the sign of _mils_ and whose magnitude is abs(_mils_) modulo 1.
+          1. Let _fMilliseconds_ be remainder(_mils_, 1).
           1. If _fMilliseconds_ is not equal to 0, then
             1. Let _mics_ be _fMilliseconds_ × 1000.
             1. Set _microseconds_ to floor(_mics_).
-            1. Let _fMicroseconds_ be the mathematical value whose sign is the sign of _mics_ and whose magnitude is abs(_mics_) modulo 1.
+            1. Let _fMicroseconds_ be remainder(_mics_, 1).
             1. If _fMicroseconds_ is not equal to 0, then
               1. Let _nans_ be _fMicroseconds_ × 1000.
               1. Set _nanoseconds_ to floor(_nans_).

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -11,6 +11,16 @@
     </p>
   </emu-note>
 
+  <emu-clause id="sec-mathematical-operations">
+    <h1>Mathematical Operations</h1>
+    <p>[...]</p>
+    <p>The notation &ldquo;<emu-eqn id="eqn-modulo" aoid="modulo">_x_ modulo _y_</emu-eqn>&rdquo; (_y_ must be finite and non-zero) computes a value _k_ of the same sign as _y_ (or zero) such that <emu-eqn>abs(_k_) &lt; abs(_y_) and _x_ - _k_ = _q_ &times; _y_</emu-eqn> for some integer _q_.</p>
+    <p><ins>The mathematical function <emu-eqn id="eqn-remainder" aoid="remainder">remainder(_x_, _y_)</emu-eqn> produces the mathematical value whose sign is the sign of _x_ and whose magnitude is <emu-eqn>abs(_x_) modulo _y_</emu-eqn>.</ins></p>
+    <p>[...]</p>
+    <p>Mathematical functions min, max, abs, <ins>remainder,</ins> and floor are not defined for Numbers and BigInts, and any usage of those methods that have non-mathematical value arguments would be an editorial error in this specification.</p>
+    <p>[...]</p>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-properties-of-the-legacy-date-prototype-object">
     <h1><a href="https://tc39.es/ecma262/#sec-properties-of-the-date-prototype-object">Properties of the Date Prototype Object</a></h1>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -434,7 +434,7 @@
         The abstract operation GetISOPartsFromEpoch returns the components of a date corresponding to the given number of nanoseconds since the Unix epoch in UTC.
       </p>
       <emu-alg>
-        1. Let _remainderNs_ be _epochNanoseconds_ modulo 10<sup>6</sup>.
+        1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
         1. Let _epochMilliseconds_ be (_epochNanoseconds_ − _remainderNs_) / 10<sup>6</sup>.
         1. Let _year_ be ! YearFromTime(_epochMilliseconds_).
         1. Let _month_ be ! MonthFromTime(_epochMilliseconds_) + 1.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -434,7 +434,7 @@
         The abstract operation GetISOPartsFromEpoch returns the components of a date corresponding to the given number of nanoseconds since the Unix epoch in UTC.
       </p>
       <emu-alg>
-        1. Let _remainderNs_ be the mathematical value whose sign is the sign of _epochNanoseconds_ and whose magnitude is abs(_epochNanoseconds_) modulo 10<sup>6</sup>.
+        1. Let _remainderNs_ be remainder(_epochNanoseconds_, 10<sup>6</sup>).
         1. Let _epochMilliseconds_ be (_epochNanoseconds_ − _remainderNs_) / 10<sup>6</sup>.
         1. Let _year_ be ! YearFromTime(_epochMilliseconds_).
         1. Let _month_ be ! MonthFromTime(_epochMilliseconds_) + 1.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1264,7 +1264,7 @@
         1. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Return the Record {
             [[Days]]: the integral part of _nanoseconds_ / _dayLengthNs_,
-            [[Nanoseconds]]: _nanoseconds_ modulo _dayLengthNs_,
+            [[Nanoseconds]]: (abs(_nanoseconds_) modulo _dayLengthNs_) × _sign_,
             [[DayLength]]: _dayLengthNs_
             }.
         1. Let _startNs_ be ℝ(_relativeTo_.[[Nanoseconds]]).


### PR DESCRIPTION
In Ecma-262, the modulo operation is defined differently than the way the `%` operator works in JS. This has led to some confusion: there are a few abstract operations in the Temporal spec text that assume that modulo works the same way as `%`. This is a normative change that should correct these, and adds tests that will fail if the implementation follows the old spec text literally.