### PR TITLE
Normative: Duration operations should be the same in PlainDate.add and Calendar.dateAdd

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -2,7 +2,26 @@
 
 import { ES } from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass.mjs';
-import { CALENDAR_ID, ISO_YEAR, ISO_MONTH, ISO_DAY, CreateSlots, GetSlot, HasSlot, SetSlot } from './slots.mjs';
+import {
+  CALENDAR_ID,
+  ISO_YEAR,
+  ISO_MONTH,
+  ISO_DAY,
+  YEARS,
+  MONTHS,
+  WEEKS,
+  DAYS,
+  HOURS,
+  MINUTES,
+  SECONDS,
+  MILLISECONDS,
+  MICROSECONDS,
+  NANOSECONDS,
+  CreateSlots,
+  GetSlot,
+  HasSlot,
+  SetSlot
+} from './slots.mjs';
 
 const ArrayIncludes = Array.prototype.includes;
 const ArrayPrototypePush = Array.prototype.push;
@@ -77,7 +96,25 @@ export class Calendar {
     duration = ES.ToTemporalDuration(duration);
     options = ES.GetOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
-    return impl[GetSlot(this, CALENDAR_ID)].dateAdd(date, duration, overflow, this);
+    const { days } = ES.BalanceDuration(
+      GetSlot(duration, DAYS),
+      GetSlot(duration, HOURS),
+      GetSlot(duration, MINUTES),
+      GetSlot(duration, SECONDS),
+      GetSlot(duration, MILLISECONDS),
+      GetSlot(duration, MICROSECONDS),
+      GetSlot(duration, NANOSECONDS),
+      'day'
+    );
+    return impl[GetSlot(this, CALENDAR_ID)].dateAdd(
+      date,
+      GetSlot(duration, YEARS),
+      GetSlot(duration, MONTHS),
+      GetSlot(duration, WEEKS),
+      days,
+      overflow,
+      this
+    );
   }
   dateUntil(one, two, options = undefined) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
@@ -235,8 +272,7 @@ impl['iso8601'] = {
     }
     return merged;
   },
-  dateAdd(date, duration, overflow, calendar) {
-    const { years, months, weeks, days } = duration;
+  dateAdd(date, years, months, weeks, days, overflow, calendar) {
     let year = GetSlot(date, ISO_YEAR);
     let month = GetSlot(date, ISO_MONTH);
     let day = GetSlot(date, ISO_DAY);
@@ -1884,8 +1920,7 @@ const nonIsoGeneralImpl = {
     }
     return { ...original, ...additionalFieldsCopy };
   },
-  dateAdd(date, duration, overflow, calendar) {
-    const { years, months, weeks, days } = duration;
+  dateAdd(date, years, months, weeks, days, overflow, calendar) {
     const cache = OneObjectCache.getCacheForObject(date);
     const calendarDate = this.helper.temporalToCalendarDate(date, cache);
     const added = this.helper.addCalendar(calendarDate, { years, months, weeks, days }, overflow, cache);

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -186,18 +186,7 @@ export class Duration {
   }
   negated() {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    return new Duration(
-      -GetSlot(this, YEARS),
-      -GetSlot(this, MONTHS),
-      -GetSlot(this, WEEKS),
-      -GetSlot(this, DAYS),
-      -GetSlot(this, HOURS),
-      -GetSlot(this, MINUTES),
-      -GetSlot(this, SECONDS),
-      -GetSlot(this, MILLISECONDS),
-      -GetSlot(this, MICROSECONDS),
-      -GetSlot(this, NANOSECONDS)
-    );
+    return ES.CreateNegatedTemporalDuration(this);
   }
   abs() {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2863,6 +2863,21 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     return 0;
   },
+  CreateNegatedTemporalDuration: (duration) => {
+    const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+    return new TemporalDuration(
+      -GetSlot(duration, YEARS),
+      -GetSlot(duration, MONTHS),
+      -GetSlot(duration, WEEKS),
+      -GetSlot(duration, DAYS),
+      -GetSlot(duration, HOURS),
+      -GetSlot(duration, MINUTES),
+      -GetSlot(duration, SECONDS),
+      -GetSlot(duration, MILLISECONDS),
+      -GetSlot(duration, MICROSECONDS),
+      -GetSlot(duration, NANOSECONDS)
+    );
+  },
 
   ConstrainToRange: (value, min, max) => MathMin(max, MathMax(min, value)),
   ConstrainISODate: (year, month, day) => {

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -134,23 +134,17 @@ export class PlainDate {
   add(temporalDurationLike, options = undefined) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
 
-    let duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
+    const duration = ES.ToTemporalDuration(temporalDurationLike);
     options = ES.GetOptionsObject(options);
 
-    let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
-    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'day'));
-    duration = { years, months, weeks, days };
     return ES.CalendarDateAdd(GetSlot(this, CALENDAR), this, duration, options);
   }
   subtract(temporalDurationLike, options = undefined) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
 
-    let duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
+    const duration = ES.CreateNegatedTemporalDuration(ES.ToTemporalDuration(temporalDurationLike));
     options = ES.GetOptionsObject(options);
 
-    let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
-    ({ days } = ES.BalanceDuration(days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, 'day'));
-    duration = { years: -years, months: -months, weeks: -weeks, days: -days };
     return ES.CalendarDateAdd(GetSlot(this, CALENDAR), this, duration, options);
   }
   until(other, options = undefined) {

--- a/polyfill/test/Calendar/prototype/dateAdd/balance-smaller-units.js
+++ b/polyfill/test/Calendar/prototype/dateAdd/balance-smaller-units.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: Durations with units smaller than days are balanced before adding
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+const date = new Temporal.PlainDate(2000, 5, 2, calendar);
+const duration = new Temporal.Duration(0, 0, 0, 1, 24, 1440, 86400, 86400_000, 86400_000_000, 86400_000_000_000);
+
+const result = calendar.dateAdd(date, duration);
+TemporalHelpers.assertPlainDate(result, 2000, 5, "M05", 9, "units smaller than days are balanced");
+
+const resultString = calendar.dateAdd(date, "P1DT24H1440M86400S");
+TemporalHelpers.assertPlainDate(resultString, 2000, 5, "M05", 6, "units smaller than days are balanced");
+
+const resultPropBag = calendar.dateAdd(date, { days: 1, hours: 24, minutes: 1440, seconds: 86400, milliseconds: 86400_000, microseconds: 86400_000_000, nanoseconds: 86400_000_000_000 });
+TemporalHelpers.assertPlainDate(resultPropBag, 2000, 5, "M05", 9, "units smaller than days are balanced");

--- a/polyfill/test/Calendar/prototype/dateAdd/duration-argument-string-negative-fractional-units.js
+++ b/polyfill/test/Calendar/prototype/dateAdd/duration-argument-string-negative-fractional-units.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: Strings with fractional duration units are treated with the correct sign
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+
+const resultHours = calendar.dateAdd(instance, "-PT24.567890123H");
+TemporalHelpers.assertPlainDate(resultHours, 2000, 5, "M05", 1, "negative fractional hours");
+
+const resultMinutes = calendar.dateAdd(instance, "-PT1440.567890123M");
+TemporalHelpers.assertPlainDate(resultMinutes, 2000, 5, "M05", 1, "negative fractional minutes");

--- a/polyfill/test/PlainDate/prototype/add/balance-smaller-units.js
+++ b/polyfill/test/PlainDate/prototype/add/balance-smaller-units.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: Durations with units smaller than days are balanced before adding, in the calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const actual = [];
+
+class DateAddCalendar extends Temporal.Calendar {
+  constructor() {
+    super("iso8601");
+  }
+
+  dateAdd(date, duration, options) {
+    actual.push(duration);
+    return super.dateAdd(date, duration, options);
+  }
+}
+
+const calendar = new DateAddCalendar();
+const date = new Temporal.PlainDate(2000, 5, 2, calendar);
+const duration = new Temporal.Duration(0, 0, 0, 1, 24, 1440, 86400, 86400_000, 86400_000_000, 86400_000_000_000);
+
+const result = date.add(duration);
+TemporalHelpers.assertPlainDate(result, 2000, 5, "M05", 9, "units smaller than days are balanced");
+
+assert.sameValue(actual.length, 1, "calendar.dateAdd called exactly once");
+assert.sameValue(actual[0], duration, "the duration is passed directly to the calendar");
+
+const resultString = date.add("P1DT24H1440M86400S");
+TemporalHelpers.assertPlainDate(resultString, 2000, 5, "M05", 6, "units smaller than days are balanced");
+
+assert.sameValue(actual.length, 2, "calendar.dateAdd called exactly once");
+TemporalHelpers.assertDuration(actual[1], 0, 0, 0, 1, 24, 1440, 86400, 0, 0, 0, "the duration is not balanced before passing to the calendar");
+
+const resultPropBag = date.add({ days: 1, hours: 24, minutes: 1440, seconds: 86400, milliseconds: 86400_000, microseconds: 86400_000_000, nanoseconds: 86400_000_000_000 });
+TemporalHelpers.assertPlainDate(resultPropBag, 2000, 5, "M05", 9, "units smaller than days are balanced");
+
+assert.sameValue(actual.length, 3, "calendar.dateAdd called exactly once");
+TemporalHelpers.assertDuration(actual[2], 0, 0, 0, 1, 24, 1440, 86400, 86400_000, 86400_000_000, 86400_000_000_000, "the duration is not balanced before passing to the calendar");
+
+const negativeDuration = new Temporal.Duration(0, 0, 0, -1, -24, -1440, -86400, -86400_000, -86400_000_000, -86400_000_000_000);
+const resultNegative = date.add(negativeDuration);
+TemporalHelpers.assertPlainDate(resultNegative, 2000, 4, "M04", 25, "units smaller than days are balanced");
+
+assert.sameValue(actual.length, 4, "calendar.dateAdd called exactly once");
+assert.sameValue(actual[3], negativeDuration, "the duration is passed directly to the calendar");

--- a/polyfill/test/PlainDate/prototype/subtract/balance-smaller-units.js
+++ b/polyfill/test/PlainDate/prototype/subtract/balance-smaller-units.js
@@ -1,0 +1,53 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.dateadd
+description: Durations with units smaller than days are balanced before adding, in the calendar
+includes: [temporalHelpers.js]
+features: [Temporal]
+---*/
+
+const actual = [];
+
+class DateAddCalendar extends Temporal.Calendar {
+  constructor() {
+    super("iso8601");
+  }
+
+  dateAdd(date, duration, options) {
+    actual.push(duration);
+    return super.dateAdd(date, duration, options);
+  }
+}
+
+const calendar = new DateAddCalendar();
+const date = new Temporal.PlainDate(2000, 5, 2, calendar);
+const duration = new Temporal.Duration(0, 0, 0, 1, 24, 1440, 86400, 86400_000, 86400_000_000, 86400_000_000_000);
+
+const result = date.subtract(duration);
+TemporalHelpers.assertPlainDate(result, 2000, 4, "M04", 25, "units smaller than days are balanced");
+
+assert.sameValue(actual.length, 1, "calendar.dateAdd called exactly once");
+TemporalHelpers.assertDuration(actual[0], 0, 0, 0, -1, -24, -1440, -86400, -86400_000, -86400_000_000, -86400_000_000_000, "the duration is negated but not balanced before passing to the calendar");
+assert.notSameValue(actual[0], duration, "the duration is not passed directly to the calendar");
+
+const resultString = date.subtract("P1DT24H1440M86400S");
+TemporalHelpers.assertPlainDate(resultString, 2000, 4, "M04", 28, "units smaller than days are balanced");
+
+assert.sameValue(actual.length, 2, "calendar.dateAdd called exactly once");
+TemporalHelpers.assertDuration(actual[1], 0, 0, 0, -1, -24, -1440, -86400, 0, 0, 0, "the duration is negated but not balanced before passing to the calendar");
+
+const resultPropBag = date.subtract({ days: 1, hours: 24, minutes: 1440, seconds: 86400, milliseconds: 86400_000, microseconds: 86400_000_000, nanoseconds: 86400_000_000_000 });
+TemporalHelpers.assertPlainDate(resultPropBag, 2000, 4, "M04", 25, "units smaller than days are balanced");
+
+assert.sameValue(actual.length, 3, "calendar.dateAdd called exactly once");
+TemporalHelpers.assertDuration(actual[2], 0, 0, 0, -1, -24, -1440, -86400, -86400_000, -86400_000_000, -86400_000_000_000, "the duration is not balanced before passing to the calendar");
+
+const negativeDuration = new Temporal.Duration(0, 0, 0, -1, -24, -1440, -86400, -86400_000, -86400_000_000, -86400_000_000_000);
+const resultNegative = date.subtract(negativeDuration);
+TemporalHelpers.assertPlainDate(resultNegative, 2000, 5, "M05", 9, "units smaller than days are balanced");
+
+assert.sameValue(actual.length, 4, "calendar.dateAdd called exactly once");
+TemporalHelpers.assertDuration(actual[3], 0, 0, 0, 1, 24, 1440, 86400, 86400_000, 86400_000_000, 86400_000_000_000, "the duration is negated but not balanced before passing to the calendar");
+assert.notSameValue(actual[3], negativeDuration, "the duration is not passed directly to the calendar");

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -795,7 +795,8 @@
         1. Set _duration_ to ? ToTemporalDuration(_duration_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _overflow_).
+        1. Let _balanceResult_ be ! BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
+        1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_).
         1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -358,7 +358,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return ! CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_duration_.[[Days]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]]).
+        1. Return ! CreateNegatedTemporalDuration(_duration_).
       </emu-alg>
     </emu-clause>
 
@@ -812,6 +812,18 @@
         1. Set _object_.[[Microseconds]] to _microseconds_.
         1. Set _object_.[[Nanoseconds]] to _nanoseconds_.
         1. Return _object_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-createnegatedtemporalduration" aoid="CreateNegatedTemporalDuration">
+      <h1>CreateNegatedTemporalDuration ( _duration_ )</h1>
+      <p>
+        The abstract operation CreateNegatedTemporalDuration returns a new Temporal.Duration instance that is the negation of _duration_.
+      </p>
+      <emu-alg>
+        1. Assert: Type(_duration_) is Object.
+        1. Assert: _duration_ has an [[InitializedTemporalDuration]] internal slot.
+        1. Return ! CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_duration_.[[Days]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1206,7 +1206,7 @@
             1. Else,
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
-              1. Let _result_ be a Record with [[Year]], [[Month]], and [[Day]] fields, that is the result of implementation-defined processing of _fields_, _overflow_, and the value of _calendar_.[[Identifier]].
+              1. Let _result_ be a Record with [[Year]], [[Month]], and [[Day]] fields, that is the result of implementation-defined processing of _fields_, _overflow_, and _calendar_.[[Identifier]].
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
           </emu-alg>
         </emu-clause>
@@ -1227,7 +1227,7 @@
             1. Else,
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « »).
-              1. Let _result_ be a Record with [[Year]], [[Month]], and [[ReferenceISODay]] integer fields, that is the result of implementation-defined processing of _fields_, _overflow_, and the value of _calendar_.[[Identifier]].
+              1. Let _result_ be a Record with [[Year]], [[Month]], and [[ReferenceISODay]] integer fields, that is the result of implementation-defined processing of _fields_, _overflow_, and _calendar_.[[Identifier]].
             1. Return ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[ReferenceISODay]]).
           </emu-alg>
         </emu-clause>
@@ -1248,7 +1248,7 @@
             1. Else,
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-              1. Let _result_ be a Record with [[Month]], [[Day]], and [[ReferenceISOYear]] fields, that is the result of implementation-defined processing of _fields_, _overflow_, and the value of _calendar_.[[Identifier]].
+              1. Let _result_ be a Record with [[Month]], [[Day]], and [[ReferenceISOYear]] fields, that is the result of implementation-defined processing of _fields_, _overflow_, and _calendar_.[[Identifier]].
             1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _result_.[[ReferenceISOYear]]).
           </emu-alg>
         </emu-clause>
@@ -1292,7 +1292,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ! DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
             1. Else,
-              1. Let _result_ be a Record with [[Years]], [[Months]], [[Weeks]], and [[Days]] fields, that is the result of implementation-defined processing of _one_, _two_, _largestUnit_, and the value of _calendar_.[[Identifier]].
+              1. Let _result_ be a Record with [[Years]], [[Months]], [[Weeks]], and [[Days]] fields, that is the result of implementation-defined processing of _one_, _two_, _largestUnit_, and _calendar_.[[Identifier]].
             1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
           </emu-alg>
         </emu-clause>
@@ -1310,7 +1310,7 @@
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return *undefined*.
-            1. Let _era_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+            1. Let _era_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return _era_.
           </emu-alg>
         </emu-clause>
@@ -1328,7 +1328,7 @@
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return *undefined*.
-            1. Let _eraYear_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+            1. Let _eraYear_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_eraYear_).
           </emu-alg>
         </emu-clause>
@@ -1348,7 +1348,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _year_ be ! ISOYear(_temporalDateLike_).
             1. Else,
-              1. Let _year_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+              1. Let _year_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_year_).
           </emu-alg>
         </emu-clause>
@@ -1370,7 +1370,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _month_ be ! ISOMonth(_temporalDateLike_).
             1. Else,
-              1. Let _month_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+              1. Let _month_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_month_).
           </emu-alg>
         </emu-clause>
@@ -1390,7 +1390,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _monthCode_ be ! ISOMonthCode(_temporalDateLike_).
             1. Else,
-              1. Let _monthCode_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+              1. Let _monthCode_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return _monthCode_.
           </emu-alg>
         </emu-clause>
@@ -1410,7 +1410,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _day_ be ! ISODay(_temporalDateLike_).
             1. Else,
-              1. Let _day_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+              1. Let _day_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_day_).
           </emu-alg>
         </emu-clause>
@@ -1429,7 +1429,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _dayOfWeek_ be ! ToISODayOfWeek(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
             1. Else,
-              1. Let _dayOfWeek_ be the result of implementation-defined processing of _temporalDate_ and the value of _calendar_.[[Identifier]].
+              1. Let _dayOfWeek_ be the result of implementation-defined processing of _temporalDate_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_dayOfWeek_).
           </emu-alg>
         </emu-clause>
@@ -1448,7 +1448,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _dayOfYear_ be ! ToISODayOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
             1. Else,
-              1. Let _dayOfYear_ be the result of implementation-defined processing of _temporalDate_ and the value of _calendar_.[[Identifier]].
+              1. Let _dayOfYear_ be the result of implementation-defined processing of _temporalDate_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_dayOfYear_).
           </emu-alg>
         </emu-clause>
@@ -1467,7 +1467,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _weekOfYear_ be ! ToISOWeekOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
             1. Else,
-              1. Let _weekOfYear_ be the result of implementation-defined processing of _temporalDate_ and the value of _calendar_.[[Identifier]].
+              1. Let _weekOfYear_ be the result of implementation-defined processing of _temporalDate_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_weekOfYear_).
           </emu-alg>
         </emu-clause>
@@ -1486,7 +1486,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _daysInWeek_ be 7.
             1. Else,
-              1. Let _daysInWeek_ be the result of implementation-defined processing of _temporalDate_ and the value of _calendar_.[[Identifier]].
+              1. Let _daysInWeek_ be the result of implementation-defined processing of _temporalDate_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_daysInWeek_).
           </emu-alg>
         </emu-clause>
@@ -1506,7 +1506,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _daysInMonth_ be ! ISODaysInMonth(_temporalDateLike_.[[ISOYear]], _temporalDateLike_.[[ISOMonth]]).
             1. Else,
-              1. Let _daysInMonth_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+              1. Let _daysInMonth_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_daysInMonth_).
           </emu-alg>
         </emu-clause>
@@ -1526,7 +1526,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _daysInYear_ be ! ISODaysInYear(_temporalDateLike_.[[ISOYear]]).
             1. Else,
-              1. Let _daysInYear_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+              1. Let _daysInYear_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_daysInYear_).
           </emu-alg>
         </emu-clause>
@@ -1546,7 +1546,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _monthsInYear_ be 12.
             1. Else,
-              1. Let _monthsInYear_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+              1. Let _monthsInYear_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return 𝔽(_monthsInYear_).
           </emu-alg>
         </emu-clause>
@@ -1566,7 +1566,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _inLeapYear_ be ! IsISOLeapYear(_temporalDateLike_.[[ISOYear]]).
             1. Else,
-              1. Let _inLeapYear_ be the result of implementation-defined processing of _temporalDateLike_ and the value of _calendar_.[[Identifier]].
+              1. Let _inLeapYear_ be the result of implementation-defined processing of _temporalDateLike_ and _calendar_.[[Identifier]].
             1. Return _inLeapYear_.
           </emu-alg>
         </emu-clause>
@@ -1585,7 +1585,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be _fieldNames_.
             1. Else,
-              1. Let _result_ be the result of implementation-defined processing of _fieldNames_ and the value of _calendar_.[[Identifier]].
+              1. Let _result_ be the result of implementation-defined processing of _fieldNames_ and _calendar_.[[Identifier]].
             1. Return ! CreateArrayFromList(_result_).
           </emu-alg>
         </emu-clause>
@@ -1616,7 +1616,7 @@
               1. Let _propValue_ be ? Get(_additionalFields_, _key_).
               1. If _propValue_ is not *undefined*, then
                 1. Perform ! CreateDataPropertyOrThrow(_additionalFieldsCopied_, _key_, _propValue_).
-            1. Return the result of implementation-defined processing of _fieldsCopied_, _additionalFieldsCopied_, and the value of _calendar_.[[Identifier]].
+            1. Return the result of implementation-defined processing of _fieldsCopied_, _additionalFieldsCopied_, and _calendar_.[[Identifier]].
           </emu-alg>
         </emu-clause>
       </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1266,10 +1266,11 @@
             1. Set _duration_ to ? ToTemporalDuration(_duration_).
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+            1. Let _balanceResult_ be ! BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _overflow_).
+              1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_).
             1. Else,
-              1. Let _result_ be a Record with [[Year]], [[Month]], and [[Day]] fields, that is the result of implementation-defined processing of _date_, _duration_, _overflow_, and the value of _calendar_.[[Identifier]].
+              1. Let _result_ be a Record with [[Year]], [[Month]], and [[Day]] fields, that is the result of implementation-defined processing of _date_, _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_, and _calendar_.[[Identifier]].
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
           </emu-alg>
         </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -347,11 +347,9 @@
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
+        1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
-        1. Let _balancedDuration_ be ? CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
-        1. Return ? CalendarDateAdd(_temporalDate_.[[Calendar]], _temporalDate_, _balancedDuration_, _options_).
+        1. Return ? CalendarDateAdd(_temporalDate_.[[Calendar]], _temporalDate_, _duration_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -364,10 +362,9 @@
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « »).
+        1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
-        1. Let _negatedDuration_ be ? CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _negatedDuration_ be ! CreateNegatedTemporalDuration(_duration_).
         1. Return ? CalendarDateAdd(_temporalDate_.[[Calendar]], _temporalDate_, _negatedDuration_, _options_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Fixes a discrepancy between how durations are treated depending on whether
they are passed to PlainDate.prototype.add() or
Calendar.prototype.dateAdd(). The treatment should be the same in both
cases.

In the case of PlainDate.prototype.subtract(), the duration should be
negated before being passed to Calendar.prototype.dateAdd().

Closes: #1708