### PR TITLE
Editorial: Simplify text with new ToIntegerThrowOnInfinity abstract op

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -73,6 +73,14 @@ const YEAR_MIN = -271821;
 const YEAR_MAX = 275760;
 const BEFORE_FIRST_DST = bigInt(-388152).multiply(1e13); // 1847-01-01T00:00:00Z
 
+const ToIntegerThrowOnInfinity = (value) => {
+  const integer = ES.ToInteger(value);
+  if (!NumberIsFinite(integer)) {
+    throw new RangeError('infinity is out of range');
+  }
+  return integer;
+};
+
 const ToPositiveInteger = (value, property) => {
   value = ToInteger(value);
   if (value < 1) {
@@ -173,13 +181,7 @@ function getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier) {
 
 export const ES = ObjectAssign({}, ES2020, {
   ToPositiveInteger: ToPositiveInteger,
-  ToFiniteInteger: (value) => {
-    const integer = ES.ToInteger(value);
-    if (!NumberIsFinite(integer)) {
-      throw new RangeError('infinity is out of range');
-    }
-    return integer;
-  },
+  ToIntegerThrowOnInfinity,
   IsTemporalInstant: (item) => HasSlot(item, EPOCHNANOSECONDS) && !HasSlot(item, TIME_ZONE, CALENDAR),
   IsTemporalTimeZone: (item) => HasSlot(item, TIMEZONE_ID),
   IsTemporalCalendar: (item) => HasSlot(item, CALENDAR_ID),

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -22,12 +22,13 @@ const DISALLOWED_UNITS = ['hour', 'minute', 'second', 'millisecond', 'microsecon
 
 export class PlainDate {
   constructor(isoYear, isoMonth, isoDay, calendar = ES.GetISO8601Calendar()) {
-    isoYear = ES.ToFiniteInteger(isoYear);
-    isoMonth = ES.ToFiniteInteger(isoMonth);
-    isoDay = ES.ToFiniteInteger(isoDay);
+    isoYear = ES.ToIntegerThrowOnInfinity(isoYear);
+    isoMonth = ES.ToIntegerThrowOnInfinity(isoMonth);
+    isoDay = ES.ToIntegerThrowOnInfinity(isoDay);
     calendar = ES.ToTemporalCalendar(calendar);
 
-    // Note: if the arguments are not passed, ToInteger(undefined) will have returned 0, which will
+    // Note: if the arguments are not passed,
+    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
     //       be rejected by RejectISODate in CreateTemporalDateSlots. This check
     //       exists only to improve the error message.
     if (arguments.length < 3) {

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -32,18 +32,19 @@ export class PlainDateTime {
     nanosecond = 0,
     calendar = ES.GetISO8601Calendar()
   ) {
-    isoYear = ES.ToFiniteInteger(isoYear);
-    isoMonth = ES.ToFiniteInteger(isoMonth);
-    isoDay = ES.ToFiniteInteger(isoDay);
-    hour = ES.ToFiniteInteger(hour);
-    minute = ES.ToFiniteInteger(minute);
-    second = ES.ToFiniteInteger(second);
-    millisecond = ES.ToFiniteInteger(millisecond);
-    microsecond = ES.ToFiniteInteger(microsecond);
-    nanosecond = ES.ToFiniteInteger(nanosecond);
+    isoYear = ES.ToIntegerThrowOnInfinity(isoYear);
+    isoMonth = ES.ToIntegerThrowOnInfinity(isoMonth);
+    isoDay = ES.ToIntegerThrowOnInfinity(isoDay);
+    hour = ES.ToIntegerThrowOnInfinity(hour);
+    minute = ES.ToIntegerThrowOnInfinity(minute);
+    second = ES.ToIntegerThrowOnInfinity(second);
+    millisecond = ES.ToIntegerThrowOnInfinity(millisecond);
+    microsecond = ES.ToIntegerThrowOnInfinity(microsecond);
+    nanosecond = ES.ToIntegerThrowOnInfinity(nanosecond);
     calendar = ES.ToTemporalCalendar(calendar);
 
-    // Note: if the arguments are not passed, ToInteger(undefined) will have returned 0, which will
+    // Note: if the arguments are not passed,
+    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
     //       be rejected by RejectDateTime in CreateTemporalDateTimeSlots. This
     //       check exists only to improve the error message.
     if (arguments.length < 3) {

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -7,12 +7,13 @@ const ObjectCreate = Object.create;
 
 export class PlainMonthDay {
   constructor(isoMonth, isoDay, calendar = ES.GetISO8601Calendar(), referenceISOYear = 1972) {
-    isoMonth = ES.ToFiniteInteger(isoMonth);
-    isoDay = ES.ToFiniteInteger(isoDay);
+    isoMonth = ES.ToIntegerThrowOnInfinity(isoMonth);
+    isoDay = ES.ToIntegerThrowOnInfinity(isoDay);
     calendar = ES.ToTemporalCalendar(calendar);
-    referenceISOYear = ES.ToFiniteInteger(referenceISOYear);
+    referenceISOYear = ES.ToIntegerThrowOnInfinity(referenceISOYear);
 
-    // Note: if the arguments are not passed, ToInteger(undefined) will have returned 0, which will
+    // Note: if the arguments are not passed,
+    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
     //       be rejected by RejectISODate in CreateTemporalMonthDaySlots. This
     //       check exists only to improve the error message.
     if (arguments.length < 2) {

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -66,12 +66,12 @@ function TemporalTimeToString(time, precision, options = undefined) {
 
 export class PlainTime {
   constructor(isoHour = 0, isoMinute = 0, isoSecond = 0, isoMillisecond = 0, isoMicrosecond = 0, isoNanosecond = 0) {
-    isoHour = ES.ToFiniteInteger(isoHour);
-    isoMinute = ES.ToFiniteInteger(isoMinute);
-    isoSecond = ES.ToFiniteInteger(isoSecond);
-    isoMillisecond = ES.ToFiniteInteger(isoMillisecond);
-    isoMicrosecond = ES.ToFiniteInteger(isoMicrosecond);
-    isoNanosecond = ES.ToFiniteInteger(isoNanosecond);
+    isoHour = ES.ToIntegerThrowOnInfinity(isoHour);
+    isoMinute = ES.ToIntegerThrowOnInfinity(isoMinute);
+    isoSecond = ES.ToIntegerThrowOnInfinity(isoSecond);
+    isoMillisecond = ES.ToIntegerThrowOnInfinity(isoMillisecond);
+    isoMicrosecond = ES.ToIntegerThrowOnInfinity(isoMicrosecond);
+    isoNanosecond = ES.ToIntegerThrowOnInfinity(isoNanosecond);
 
     ES.RejectTime(isoHour, isoMinute, isoSecond, isoMillisecond, isoMicrosecond, isoNanosecond);
     CreateSlots(this);

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -9,12 +9,13 @@ const DISALLOWED_UNITS = ['week', 'day', 'hour', 'minute', 'second', 'millisecon
 
 export class PlainYearMonth {
   constructor(isoYear, isoMonth, calendar = ES.GetISO8601Calendar(), referenceISODay = 1) {
-    isoYear = ES.ToFiniteInteger(isoYear);
-    isoMonth = ES.ToFiniteInteger(isoMonth);
+    isoYear = ES.ToIntegerThrowOnInfinity(isoYear);
+    isoMonth = ES.ToIntegerThrowOnInfinity(isoMonth);
     calendar = ES.ToTemporalCalendar(calendar);
-    referenceISODay = ES.ToFiniteInteger(referenceISODay);
+    referenceISODay = ES.ToIntegerThrowOnInfinity(referenceISODay);
 
-    // Note: if the arguments are not passed, ToInteger(undefined) will have returned 0, which will
+    // Note: if the arguments are not passed,
+    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
     //       be rejected by RejectISODate in CreateTemporalYearMonthSlots. This
     //       check exists only to improve the error message.
     if (arguments.length < 2) {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1425,6 +1425,19 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-tointegerthrowoninfinity" aoid="ToIntegerThrowOnInfinity">
+    <h1>ToIntegerThrowOnInfinity ( _argument_ )</h1>
+    <p>
+      The abstract operation ToIntegerThrowOnInfinity takes argument _argument_. It converts _argument_ to an integer. It performs the following steps:
+    </p>
+    <emu-alg>
+      1. Let _integer_ be ? ToIntegerOrInfinity(_argument_).
+      1. If _integer_ is −∞ or +∞ , then
+        1. Throw a *RangeError* exception.
+      1. Return _integer_.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-preparetemporalfields" aoid="PrepareTemporalFields">
     <h1>PrepareTemporalFields ( _fields_, _fieldNames_, _requiredFields_ )</h1>
     <p>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -30,14 +30,12 @@
       <p>
         When the `Temporal.PlainDate` function is called, the following steps are taken:
       </p>
+      <emu-note>The value of ? ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _y_ be ? ToIntegerOrInfinity(_isoYear_).
-        1. If _y_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _m_ be ? ToIntegerOrInfinity(_isoMonth_).
-        1. If _m_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _d_ be ? ToIntegerOrInfinity(_isoDay_).
-        1. If _d_ is +∞ or -∞, throw a *RangeError* exception.
+        1. Let _y_ be ? ToIntegerThrowOnInfinity(_isoYear_).
+        1. Let _m_ be ? ToIntegerThrowOnInfinity(_isoMonth_).
+        1. Let _d_ be ? ToIntegerThrowOnInfinity(_isoDay_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
         1. Return ? CreateTemporalDate(_y_, _m_, _d_, _calendar_, NewTarget).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -28,28 +28,19 @@
       <p>
         When the `Temporal.PlainDateTime` function is called, the following steps are taken:
       </p>
-      <emu-note>The value of ? ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ? ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _isoYear_ be ? ToIntegerOrInfinity(_isoYear_).
-        1. If _isoYear_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _isoMonth_ be ? ToIntegerOrInfinity(_isoMonth_).
-        1. If _isoMonth_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _isoDay_ be ? ToIntegerOrInfinity(_isoDay_).
-        1. If _isoDay_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _hour_ be ? ToIntegerOrInfinity(_hour_).
-        1. If _hour_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _minute_ be ? ToIntegerOrInfinity(_minute_).
-        1. If _minute_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _second_ be ? ToIntegerOrInfinity(_second_).
-        1. If _second_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _millisecond_ be ? ToIntegerOrInfinity(_millisecond_).
-        1. If _millisecond_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _microsecond_ be ? ToIntegerOrInfinity(_microsecond_).
-        1. If _microsecond_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _nanosecond_ be ? ToIntegerOrInfinity(_nanosecond_).
-        1. If _nanosecond_ is +∞ or -∞, throw a *RangeError* exception.
+        1. Let _isoYear_ be ? ToIntegerThrowOnInfinity(_isoYear_).
+        1. Let _isoMonth_ be ? ToIntegerThrowOnInfinity(_isoMonth_).
+        1. Let _isoDay_ be ? ToIntegerThrowOnInfinity(_isoDay_).
+        1. Let _hour_ be ? ToIntegerThrowOnInfinity(_hour_).
+        1. Let _minute_ be ? ToIntegerThrowOnInfinity(_minute_).
+        1. Let _second_ be ? ToIntegerThrowOnInfinity(_second_).
+        1. Let _millisecond_ be ? ToIntegerThrowOnInfinity(_millisecond_).
+        1. Let _microsecond_ be ? ToIntegerThrowOnInfinity(_microsecond_).
+        1. Let _nanosecond_ be ? ToIntegerThrowOnInfinity(_nanosecond_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
         1. Return ? CreateTemporalDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_, NewTarget).
       </emu-alg>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -28,18 +28,16 @@
       <p>
         When the `Temporal.PlainMonthDay` function is called, the following steps are taken:
       </p>
+      <emu-note>The value of ? ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. If _referenceISOYear_ is *undefined*, then
           1. Set _referenceISOYear_ to *1972*<sub>𝔽</sub>.
-        1. Let _m_ be ? ToIntegerOrInfinity(_isoMonth_).
-        1. If _m_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _d_ be ? ToIntegerOrInfinity(_isoDay_).
-        1. If _d_ is +∞ or -∞, throw a *RangeError* exception.
+        1. Let _m_ be ? ToIntegerThrowOnInfinity(_isoMonth_).
+        1. Let _d_ be ? ToIntegerThrowOnInfinity(_isoDay_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-        1. Let _ref_ be ? ToIntegerOrInfinity(_referenceISOYear_).
-        1. If _ref_ is +∞ or -∞, throw a *RangeError* exception.
+        1. Let _ref_ be ? ToIntegerThrowOnInfinity(_referenceISOYear_).
         1. Return ? CreateTemporalMonthDay(_m_, _d_, _calendar_, _ref_, NewTarget).
       </emu-alg>
       <emu-note>1972 is the first leap year after the Unix epoch.</emu-note>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -29,22 +29,16 @@
       <p>
         When the `Temporal.PlainTime` function is called, the following steps are taken:
       </p>
-      <emu-note>The value of ? ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ? ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _hour_ be ? ToIntegerOrInfinity(_hour_).
-        1. If _hour_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _minute_ be ? ToIntegerOrInfinity(_minute_).
-        1. If _minute_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _second_ be ? ToIntegerOrInfinity(_second_).
-        1. If _second_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _millisecond_ be ? ToIntegerOrInfinity(_millisecond_).
-        1. If _millisecond_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _microsecond_ be ? ToIntegerOrInfinity(_microsecond_).
-        1. If _microsecond_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _nanosecond_ be ? ToIntegerOrInfinity(_nanosecond_).
-        1. If _nanosecond_ is +∞ or -∞, throw a *RangeError* exception.
+        1. Let _hour_ be ? ToIntegerThrowOnInfinity(_hour_).
+        1. Let _minute_ be ? ToIntegerThrowOnInfinity(_minute_).
+        1. Let _second_ be ? ToIntegerThrowOnInfinity(_second_).
+        1. Let _millisecond_ be ? ToIntegerThrowOnInfinity(_millisecond_).
+        1. Let _microsecond_ be ? ToIntegerThrowOnInfinity(_microsecond_).
+        1. Let _nanosecond_ be ? ToIntegerThrowOnInfinity(_nanosecond_).
         1. Return ? CreateTemporalTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, NewTarget).
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -28,18 +28,16 @@
       <p>
         When the `Temporal.PlainYearMonth` function is called, the following steps are taken:
       </p>
+      <emu-note>The value of ? ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. If _referenceISODay_ is *undefined*, then
           1. Set _referenceISODay_ to *1*<sub>𝔽</sub>.
-        1. Let _y_ be ? ToIntegerOrInfinity(_isoYear_).
-        1. If _y_ is +∞ or -∞, throw a *RangeError* exception.
-        1. Let _m_ be ? ToIntegerOrInfinity(_isoMonth_).
-        1. If _m_ is +∞ or -∞, throw a *RangeError* exception.
+        1. Let _y_ be ? ToIntegerThrowOnInfinity(_isoYear_).
+        1. Let _m_ be ? ToIntegerThrowOnInfinity(_isoMonth_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-        1. Let _ref_ be ? ToIntegerOrInfinity(_referenceISODay_).
-        1. If _ref_ is +∞ or -∞, throw a *RangeError* exception.
+        1. Let _ref_ be ? ToIntegerThrowOnInfinity(_referenceISODay_).
         1. Return ? CreateTemporalYearMonth(_y_, _m_, _calendar_, _ref_, NewTarget).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
This adds a new ToIntegerThrowOnInfinity abstract operation which allows
simplifying several long checks for infinity into something more
readable.

See, for original discussion: #1638