### PR TITLE
Normative: Coerce return of CalendarDaysInMonth

### DIFF
--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -105,7 +105,7 @@ export class PlainYearMonth {
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const fields = ES.ToTemporalYearMonthFields(this, fieldNames);
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
-    const day = sign < 0 ? ES.CalendarDaysInMonth(calendar, this) : 1;
+    const day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, this)) : 1;
     const startDate = ES.DateFromFields(calendar, { ...fields, day });
     const addedDate = ES.CalendarDateAdd(calendar, startDate, { ...duration, days }, options);
     const addedDateFields = ES.ToTemporalYearMonthFields(addedDate, fieldNames);
@@ -136,7 +136,7 @@ export class PlainYearMonth {
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const fields = ES.ToTemporalYearMonthFields(this, fieldNames);
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
-    const day = sign < 0 ? ES.CalendarDaysInMonth(calendar, this) : 1;
+    const day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, this)) : 1;
     const startDate = ES.DateFromFields(calendar, { ...fields, day });
     const addedDate = ES.CalendarDateAdd(calendar, startDate, { ...duration, days }, options);
     const addedDateFields = ES.ToTemporalYearMonthFields(addedDate, fieldNames);

--- a/polyfill/test/PlainYearMonth/prototype/add/calendar-daysinmonth-wrong-value.js
+++ b/polyfill/test/PlainYearMonth/prototype/add/calendar-daysinmonth-wrong-value.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: >
+  The appropriate error is thrown if the calendar's daysInMonth method returns a
+  value that cannot be converted to a positive integer
+includes: [compareArray.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const actual = [];
+class CalendarDaysInMonthWrongValue extends Temporal.Calendar {
+  constructor(badValue) {
+    super("iso8601");
+    this._badValue = badValue;
+  }
+  dateFromFields(fields, options) {
+    actual.push("call dateFromFields");
+    return super.dateFromFields(fields, options);
+  }
+  daysInMonth() {
+    return this._badValue;
+  }
+}
+// daysInMonth is only called if we are adding a negative duration
+const duration = new Temporal.Duration(-1, -1);
+
+[Infinity, -Infinity, -42].forEach((badValue) => {
+  const calendar = new CalendarDaysInMonthWrongValue(badValue);
+  const yearMonth = new Temporal.PlainYearMonth(2000, 5, calendar);
+  assert.throws(RangeError, () => yearMonth.add(duration), `daysInMonth ${badValue}`);
+  assert.compareArray(actual, [], "dateFromFields not called");
+});
+
+[Symbol('foo'), 31n].forEach((badValue) => {
+  const calendar = new CalendarDaysInMonthWrongValue(badValue);
+  const yearMonth = new Temporal.PlainYearMonth(2000, 5, calendar);
+  assert.throws(TypeError, () => yearMonth.add(duration), `daysInMonth ${typeof badValue}`);
+  assert.compareArray(actual, [], "dateFromFields not called");
+});

--- a/polyfill/test/PlainYearMonth/prototype/subtract/calendar-daysinmonth-wrong-value.js
+++ b/polyfill/test/PlainYearMonth/prototype/subtract/calendar-daysinmonth-wrong-value.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: >
+  The appropriate error is thrown if the calendar's daysInMonth method returns a
+  value that cannot be converted to a positive integer
+includes: [compareArray.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+const actual = [];
+class CalendarDaysInMonthWrongValue extends Temporal.Calendar {
+  constructor(badValue) {
+    super("iso8601");
+    this._badValue = badValue;
+  }
+  dateFromFields(fields, options) {
+    actual.push("call dateFromFields");
+    return super.dateFromFields(fields, options);
+  }
+  daysInMonth() {
+    return this._badValue;
+  }
+}
+// daysInMonth is only called if we are subtracting a positive duration
+const duration = new Temporal.Duration(1, 1);
+
+[Infinity, -Infinity, -42].forEach((badValue) => {
+  const calendar = new CalendarDaysInMonthWrongValue(badValue);
+  const yearMonth = new Temporal.PlainYearMonth(2000, 5, calendar);
+  assert.throws(RangeError, () => yearMonth.subtract(duration), `daysInMonth ${badValue}`);
+  assert.compareArray(actual, [], "dateFromFields not called");
+});
+
+[Symbol('foo'), 31n].forEach((badValue) => {
+  const calendar = new CalendarDaysInMonthWrongValue(badValue);
+  const yearMonth = new Temporal.PlainYearMonth(2000, 5, calendar);
+  assert.throws(TypeError, () => yearMonth.subtract(duration), `daysInMonth ${typeof badValue}`);
+  assert.compareArray(actual, [], "dateFromFields not called");
+});

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -264,7 +264,8 @@
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. If _sign_ &lt; 0, then
-          1. Let _day_ be ? CalendarDaysInMonth(_calendar_, _yearMonth_).
+          1. Let _dayFromCalendar_ be ? CalendarDaysInMonth(_calendar_, _yearMonth_).
+          1. Let _day_ be ? ToPositiveInteger(_dayFromCalendar_).
         1. Else,
           1. Let _day_ be 1.
         1. Let _date_ be ? CreateTemporalDate(_yearMonth_.[[ISOYear]], _yearMonth_.[[ISOMonth]], _day_, _calendar_).
@@ -291,7 +292,8 @@
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. If _sign_ &lt; 0, then
-          1. Let _day_ be ? CalendarDaysInMonth(_calendar_, _yearMonth_).
+          1. Let _dayFromCalendar_ be ? CalendarDaysInMonth(_calendar_, _yearMonth_).
+          1. Let _day_ be ? ToPositiveInteger(_dayFromCalendar_).
         1. Else,
           1. Let _day_ be 1.
         1. Let _date_ be ? CreateTemporalDate(_yearMonth_.[[ISOYear]], _yearMonth_.[[ISOMonth]], _day_, _calendar_).


### PR DESCRIPTION
Coerce the return value of CalendarDaysInMonth in Temporal.PlainYearMonth.prototype.(add|subtract) method becasue calendar can return any kind of value.
Address https://github.com/tc39/proposal-temporal/issues/1713

I am not sure this should be Editoral or Normative since the current spec text does not hold the Assertion

@sffc @ptomato @Ms2ger @ljharb @justingrant 