### PR TITLE
Editorial: Remove dead code in tautological comparison

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2950,7 +2950,7 @@ export const ES = ObjectAssign({}, ES2020, {
         // 1) same month: use simple subtraction
         // 2) end is previous month from intermediate (negative duration)
         // 3) end is next month from intermediate (positive duration)
-        if (mid.month === end.month && mid.year === end.year) {
+        if (mid.month === end.month) {
           // 1) same month: use simple subtraction
           days = end.day - mid.day;
         } else if (sign < 0) {

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -742,7 +742,9 @@
             1. Set _mid_ be ! AddISODate(_y1_, _m1_, _d1_, _years_, _months_, 0, 0, *"constrain"*).
             1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. Let _days_ be 0.
-          1. If _mid_.[[Month]] is equal to _end_.[[Month]] and _mid_.[[Year]] is equal to _mid_.[[Year]], set _days_ to _end_.[[Day]] - _mid_.[[Day]].
+          1. If _mid_.[[Month]] = _end_.[[Month]], then
+            1. Assert: _mid_.[[Year]] = _end_.[[Year]].
+            1. Set _days_ to _end_.[[Day]] - _mid_.[[Day]].
           1. Else if _sign_ &lt; 0, set _days_ to -_mid_.[[Day]] - (! ISODaysInMonth(_end_.[[Year]], _end_.[[Month]]) - _end_.[[Day]]).
           1. Else, set _days_ to _end_.[[Day]] + (! ISODaysInMonth(_mid_.[[Year]], _mid_.[[Month]]) - _mid_.[[Day]]).
           1. If _largestUnit_ is *"month"*, then


### PR DESCRIPTION
In every case where _mid_.[[Month]] = _end_.[[Month]], it also holds that
_mid_.[[Year]] = _end_.[[Year]]. In other words, due to the preceding
algorithm steps, _mid_ is always in the previous month, the same month, or
the following month compared to _end_. There is never a case where _mid_
and _end_ are 12 months apart.

Therefore, the second part of this comparison was unnecessary and would
never be compared due to short-circuiting. Replace it with an assertion.

Closes: #1649