### PR TITLE
Normative: Ensure an Object is returned from calendar.mergeFields()

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1510,7 +1510,9 @@ export const ES = ObjectAssign({}, ES2020, {
   CalendarMergeFields: (calendar, fields, additionalFields) => {
     const mergeFields = ES.GetMethod(calendar, 'mergeFields');
     if (mergeFields === undefined) return { ...fields, ...additionalFields };
-    return ES.Call(mergeFields, calendar, [fields, additionalFields]);
+    const result = ES.Call(mergeFields, calendar, [fields, additionalFields]);
+    if (ES.Type(result) !== 'Object') throw new TypeError('bad return from calendar.mergeFields()');
+    return result;
   },
   CalendarDateAdd: (calendar, date, duration, options, dateAdd) => {
     if (dateAdd === undefined) {

--- a/polyfill/test/PlainDate/prototype/with/calendar-merge-fields-returns-primitive.js
+++ b/polyfill/test/PlainDate/prototype/with/calendar-merge-fields-returns-primitive.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.with
+description: >
+    with() should throw a TypeError if mergeFields() returns a primitive,
+    without passing the value on to any other calendar methods
+includes: [compareArray.js, temporalHelpers.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+[undefined, null, true, 3.14159, "bad value", Symbol("no"), 7n].forEach((primitive) => {
+  const calendar = TemporalHelpers.calendarMergeFieldsReturnsPrimitive(primitive);
+  const instance = new Temporal.PlainDate(2000, 5, 2, calendar);
+  assert.throws(TypeError, () => instance.with({ year: 2005 }), "bad return from mergeFields() throws");
+  assert.sameValue(calendar.dateFromFieldsCallCount, 0, "dateFromFields() never called");
+});

--- a/polyfill/test/PlainDateTime/prototype/with/calendar-merge-fields-returns-primitive.js
+++ b/polyfill/test/PlainDateTime/prototype/with/calendar-merge-fields-returns-primitive.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.with
+description: >
+    with() should throw a TypeError if mergeFields() returns a primitive,
+    without passing the value on to any other calendar methods
+includes: [compareArray.js, temporalHelpers.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+[undefined, null, true, 3.14159, "bad value", Symbol("no"), 7n].forEach((primitive) => {
+  const calendar = TemporalHelpers.calendarMergeFieldsReturnsPrimitive(primitive);
+  const instance = new Temporal.PlainDateTime(2000, 5, 2, 15, 30, 45, 987, 654, 321, calendar);
+  assert.throws(TypeError, () => instance.with({ year: 2005 }), "bad return from mergeFields() throws");
+  assert.sameValue(calendar.dateFromFieldsCallCount, 0, "dateFromFields() never called");
+});

--- a/polyfill/test/PlainMonthDay/prototype/toPlainDate/calendar-merge-fields-returns-primitive.js
+++ b/polyfill/test/PlainMonthDay/prototype/toPlainDate/calendar-merge-fields-returns-primitive.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.toplaindate
+description: >
+    with() should throw a TypeError if mergeFields() returns a primitive,
+    without passing the value on to any other calendar methods
+includes: [compareArray.js, temporalHelpers.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+[undefined, null, true, 3.14159, "bad value", Symbol("no"), 7n].forEach((primitive) => {
+  const calendar = TemporalHelpers.calendarMergeFieldsReturnsPrimitive(primitive);
+  const instance = new Temporal.PlainMonthDay(5, 2, calendar);
+  assert.throws(TypeError, () => instance.toPlainDate({ year: 2005 }), "bad return from mergeFields() throws");
+  assert.sameValue(calendar.dateFromFieldsCallCount, 0, "dateFromFields() never called");
+});

--- a/polyfill/test/PlainMonthDay/prototype/with/calendar-merge-fields-returns-primitive.js
+++ b/polyfill/test/PlainMonthDay/prototype/with/calendar-merge-fields-returns-primitive.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.with
+description: >
+    with() should throw a TypeError if mergeFields() returns a primitive,
+    without passing the value on to any other calendar methods
+includes: [compareArray.js, temporalHelpers.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+[undefined, null, true, 3.14159, "bad value", Symbol("no"), 7n].forEach((primitive) => {
+  const calendar = TemporalHelpers.calendarMergeFieldsReturnsPrimitive(primitive);
+  const instance = new Temporal.PlainMonthDay(5, 2, calendar);
+  assert.throws(TypeError, () => instance.with({ year: 2005 }), "bad return from mergeFields() throws");
+  assert.sameValue(calendar.monthDayFromFieldsCallCount, 0, "monthDayFromFields() never called");
+});

--- a/polyfill/test/PlainYearMonth/prototype/toPlainDate/calendar-merge-fields-returns-primitive.js
+++ b/polyfill/test/PlainYearMonth/prototype/toPlainDate/calendar-merge-fields-returns-primitive.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.toplaindate
+description: >
+    with() should throw a TypeError if mergeFields() returns a primitive,
+    without passing the value on to any other calendar methods
+includes: [compareArray.js, temporalHelpers.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+[undefined, null, true, 3.14159, "bad value", Symbol("no"), 7n].forEach((primitive) => {
+  const calendar = TemporalHelpers.calendarMergeFieldsReturnsPrimitive(primitive);
+  const instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+  assert.throws(TypeError, () => instance.toPlainDate({ day: 2 }), "bad return from mergeFields() throws");
+  assert.sameValue(calendar.dateFromFieldsCallCount, 0, "dateFromFields() never called");
+});

--- a/polyfill/test/PlainYearMonth/prototype/with/calendar-merge-fields-returns-primitive.js
+++ b/polyfill/test/PlainYearMonth/prototype/with/calendar-merge-fields-returns-primitive.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.with
+description: >
+    with() should throw a TypeError if mergeFields() returns a primitive,
+    without passing the value on to any other calendar methods
+includes: [compareArray.js, temporalHelpers.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+[undefined, null, true, 3.14159, "bad value", Symbol("no"), 7n].forEach((primitive) => {
+  const calendar = TemporalHelpers.calendarMergeFieldsReturnsPrimitive(primitive);
+  const instance = new Temporal.PlainYearMonth(2000, 5, calendar);
+  assert.throws(TypeError, () => instance.with({ year: 2005 }), "bad return from mergeFields() throws");
+  assert.sameValue(calendar.yearMonthFromFieldsCallCount, 0, "yearMonthFromFields() never called");
+});

--- a/polyfill/test/ZonedDateTime/prototype/with/calendar-merge-fields-returns-primitive.js
+++ b/polyfill/test/ZonedDateTime/prototype/with/calendar-merge-fields-returns-primitive.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.with
+description: >
+    with() should throw a TypeError if mergeFields() returns a primitive,
+    without passing the value on to any other calendar methods
+includes: [compareArray.js, temporalHelpers.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+[undefined, null, true, 3.14159, "bad value", Symbol("no"), 7n].forEach((primitive) => {
+  const calendar = TemporalHelpers.calendarMergeFieldsReturnsPrimitive(primitive);
+  const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", calendar);
+  assert.throws(TypeError, () => instance.with({ year: 2005 }), "bad return from mergeFields() throws");
+  assert.sameValue(calendar.dateFromFieldsCallCount, 0, "dateFromFields() never called");
+});

--- a/polyfill/test/helpers/temporalHelpers.js
+++ b/polyfill/test/helpers/temporalHelpers.js
@@ -1018,6 +1018,47 @@ var TemporalHelpers = {
   },
 
   /*
+   * A custom calendar whose mergeFields() method returns a primitive value,
+   * given by @primitive, and which records the number of calls made to its
+   * dateFromFields(), yearMonthFromFields(), and monthDayFromFields() methods.
+   */
+  calendarMergeFieldsReturnsPrimitive(primitive) {
+    class CalendarMergeFieldsPrimitive extends Temporal.Calendar {
+      constructor(mergeFieldsReturnValue) {
+        super("iso8601");
+        this._mergeFieldsReturnValue = mergeFieldsReturnValue;
+        this.dateFromFieldsCallCount = 0;
+        this.monthDayFromFieldsCallCount = 0;
+        this.yearMonthFromFieldsCallCount = 0;
+      }
+
+      toString() {
+        return "merge-fields-primitive";
+      }
+
+      dateFromFields(fields, options) {
+        this.dateFromFieldsCallCount++;
+        return super.dateFromFields(fields, options);
+      }
+
+      yearMonthFromFields(fields, options) {
+        this.yearMonthFromFieldsCallCount++;
+        return super.yearMonthFromFields(fields, options);
+      }
+
+      monthDayFromFields(fields, options) {
+        this.monthDayFromFieldsCallCount++;
+        return super.monthDayFromFields(fields, options);
+      }
+
+      mergeFields() {
+        return this._mergeFieldsReturnValue;
+      }
+    }
+    return new CalendarMergeFieldsPrimitive(primitive);
+  },
+
+  /*
    * observeProperty(calls, object, propertyName, value):
    *
    * Defines an own property @object.@propertyName with value @value, that

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -69,7 +69,9 @@
         1. Let _mergeFields_ be ? GetMethod(_calendar_, *"mergeFields"*).
         1. If _mergeFields_ is *undefined*, then
           1. Return ? DefaultMergeFields(_fields_, _additionalFields_).
-        1. Return ? Call(_mergeFields_, _calendar_, « _fields_, _additionalFields_ »).
+        1. Let _result_ be ? Call(_mergeFields_, _calendar_, « _fields_, _additionalFields_ »).
+        1. If Type(_result_) is not Object, throw a *TypeError* exception.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
In each case where CalendarMergeFields is called, it is later asserted in
PrepareTemporalFields that Type(_fields_) is Object. Previously the spec
text failed this assertion.

The tests check that a TypeError is thrown in this case, as well as that
the TypeError is thrown before the value is passed to any dateFromFields()
or similar method.