### PR TITLE
Normative: Handle precision for blank Durations as intended

### DIFF
--- a/polyfill/test/Duration/prototype/toString/blank-duration-precision.js
+++ b/polyfill/test/Duration/prototype/toString/blank-duration-precision.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.tostring
+description: >
+    Precision is handled correctly for blank durations, whether specified by
+    fractionalSecondDigits or smallestUnit
+features: [Temporal]
+---*/
+
+const blank = new Temporal.Duration();
+
+assert.sameValue(blank.toString({ fractionalSecondDigits: "auto" }), "PT0S");
+assert.sameValue(blank.toString({ fractionalSecondDigits: 0 }), "PT0S");
+assert.sameValue(blank.toString({ fractionalSecondDigits: 2 }), "PT0.00S");
+assert.sameValue(blank.toString({ fractionalSecondDigits: 9 }), "PT0.000000000S");
+
+assert.sameValue(blank.toString({ smallestUnit: "seconds" }), "PT0S");
+assert.sameValue(blank.toString({ smallestUnit: "milliseconds" }), "PT0.000S");
+assert.sameValue(blank.toString({ smallestUnit: "microseconds" }), "PT0.000000S");
+assert.sameValue(blank.toString({ smallestUnit: "nanoseconds" }), "PT0.000000000S");

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1463,8 +1463,6 @@
         1. Set _microseconds_ to _microseconds_ modulo 1000.
         1. Set _seconds_ to _seconds_ + the integral part of _milliseconds_ / 1000.
         1. Set _milliseconds_ to _milliseconds_ modulo 1000.
-        1. If _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are all 0, then
-          1. Return the string *"PT0S"*.
         1. Let _datePart_ be *""*.
         1. If _years_ is not 0, then
           1. Set _datePart_ to the string concatenation of abs(_years_) formatted as a decimal number and the code unit 0x0059 (LATIN CAPITAL LETTER Y).
@@ -1479,7 +1477,7 @@
           1. Set _timePart_ to the string concatenation of abs(_hours_) formatted as a decimal number and the code unit 0x0048 (LATIN CAPITAL LETTER H).
         1. If _minutes_ is not 0, then
           1. Set _timePart_ to the string concatenation of _timePart_, abs(_minutes_) formatted as a decimal number, and the code unit 0x004D (LATIN CAPITAL LETTER M).
-        1. If any of _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are not 0, then
+        1. If any of _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are not 0; or _years_, _months_, _weeks_, _days_, _hours_, and _minutes_ are all 0, then
           1. Let _fraction_ be abs(_milliseconds_) × 10<sup>6</sup> + abs(_microseconds_) × 10<sup>3</sup> + abs(_nanoseconds_).
           1. Let _decimalPart_ be _fraction_ formatted as a nine-digit decimal number, padded to the left with zeroes if necessary.
           1. If _precision_ is *"auto"*, then


### PR DESCRIPTION
The shortcut of returning PT0S became incorrect after we added options to
control the precision of the toString output.

Closes: #1697