### PR TITLE
Normative: Fix typo of days -> weeks

### DIFF
--- a/polyfill/test/Duration/constructor/compare/relativeto-undefined-throw-on-calendar-units.js
+++ b/polyfill/test/Duration/constructor/compare/relativeto-undefined-throw-on-calendar-units.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: >
+    The relativeTo option is required when either Duration contains years,
+    months, or weeks
+features: [Temporal]
+---*/
+
+const oneYear = new Temporal.Duration(1);
+const oneMonth = new Temporal.Duration(0, 1);
+const oneWeek = new Temporal.Duration(0, 0, 1);
+const oneDay = new Temporal.Duration(0, 0, 0, 1);
+
+assert.sameValue(Temporal.Duration.compare(oneDay, oneDay), 0, "days do not require relativeTo");
+
+assert.throws(RangeError, () => Temporal.Duration.compare(oneWeek, oneDay), "weeks in left operand require relativeTo");
+assert.throws(RangeError, () => Temporal.Duration.compare(oneDay, oneWeek), "weeks in right operand require relativeTo");
+
+assert.throws(RangeError, () => Temporal.Duration.compare(oneMonth, oneDay), "months in left operand require relativeTo");
+assert.throws(RangeError, () => Temporal.Duration.compare(oneDay, oneMonth), "months in right operand require relativeTo");
+
+assert.throws(RangeError, () => Temporal.Duration.compare(oneYear, oneDay), "years in left operand require relativeTo");
+assert.throws(RangeError, () => Temporal.Duration.compare(oneDay, oneYear), "years in right operand require relativeTo");

--- a/polyfill/test/Duration/prototype/round/relativeto-undefined-throw-on-calendar-units.js
+++ b/polyfill/test/Duration/prototype/round/relativeto-undefined-throw-on-calendar-units.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: >
+    The relativeTo option is required when the Duration contains years, months,
+    or weeks, and largestUnit is days; or largestUnit is weeks or months
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const oneYear = new Temporal.Duration(1);
+const oneMonth = new Temporal.Duration(0, 1);
+const oneWeek = new Temporal.Duration(0, 0, 1);
+const oneDay = new Temporal.Duration(0, 0, 0, 1);
+
+const options = { largestUnit: "days" };
+TemporalHelpers.assertDuration(oneDay.round(options), 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, "days do not require relativeTo");
+assert.throws(RangeError, () => oneWeek.round(options), "balancing weeks to days requires relativeTo");
+assert.throws(RangeError, () => oneMonth.round(options), "balancing months to days requires relativeTo");
+assert.throws(RangeError, () => oneYear.round(options), "balancing years to days requires relativeTo");
+
+["months", "weeks"].forEach((largestUnit) => {
+  [oneDay, oneWeek, oneMonth, oneYear].forEach((duration) => {
+    assert.throws(RangeError, () => duration.round({ largestUnit }), `balancing ${duration} to ${largestUnit} requires relativeTo`);
+  });
+});

--- a/polyfill/test/Duration/prototype/total/relativeto-undefined-throw-on-calendar-units.js
+++ b/polyfill/test/Duration/prototype/total/relativeto-undefined-throw-on-calendar-units.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: >
+    The relativeTo option is required when the Duration contains years, months,
+    or weeks, and largestUnit is days; or largestUnit is weeks or months
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+const oneYear = new Temporal.Duration(1);
+const oneMonth = new Temporal.Duration(0, 1);
+const oneWeek = new Temporal.Duration(0, 0, 1);
+const oneDay = new Temporal.Duration(0, 0, 0, 1);
+
+const options = { unit: "days" };
+assert.sameValue(oneDay.total(options), 1, "days do not require relativeTo");
+assert.throws(RangeError, () => oneWeek.total(options), "total days of weeks requires relativeTo");
+assert.throws(RangeError, () => oneMonth.total(options), "total days of months requires relativeTo");
+assert.throws(RangeError, () => oneYear.total(options), "total days of years requires relativeTo");
+
+["months", "weeks"].forEach((unit) => {
+  [oneDay, oneWeek, oneMonth, oneYear].forEach((duration) => {
+    assert.throws(RangeError, () => duration.total({ unit }), `${duration} total ${unit} requires relativeTo`);
+  });
+});

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -965,7 +965,7 @@
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
             1. Set _months_ to _months_ − _sign_.
         1. Else,
-          1. If any of _years_, _months_, and _days_ are not zero, then
+          1. If any of _years_, _months_, and _weeks_ are not zero, then
             1. If _calendar_ is *undefined*, then
               1. Throw a *RangeError* exception.
             1. Repeat, while _years_ ≠ 0,


### PR DESCRIPTION
I believe the IF check is on weeks not days based on the logic below.

I am not 100% sure this is right but the later 3 while looks on checking on 
years, months and weeks != 0 but the if check is on years, months and days, which does not make sense to me.

@ljharb @Ms2ger @ryzokuken @ptomato @jugglinmike @justingrant 