### PR TITLE
Normative: Consistent order of operations in PMD.toPD and PYM.toPD

### DIFF
--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -93,6 +93,7 @@ export class PlainMonthDay {
   }
   toPlainDate(item) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (ES.Type(item) !== 'Object') throw new TypeError('argument should be an object');
     const calendar = GetSlot(this, CALENDAR);
 
     const receiverFieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -296,6 +296,7 @@ export class PlainYearMonth {
   }
   toPlainDate(item) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (ES.Type(item) !== 'Object') throw new TypeError('argument should be an object');
     const calendar = GetSlot(this, CALENDAR);
 
     const receiverFieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);

--- a/polyfill/test/PlainMonthDay/prototype/toPlainDate/argument-not-object.js
+++ b/polyfill/test/PlainMonthDay/prototype/toPlainDate/argument-not-object.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainmonthday.prototype.toplaindate
+description: Throws a TypeError if the argument is not an Object, before any other observable actions
+includes: [compareArray.js, temporalHelpers.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+[null, undefined, true, 3.1416, "a string", Symbol("symbol"), 7n].forEach((primitive) => {
+  const calendar = TemporalHelpers.calendarThrowEverything();
+  const plainMonthDay = new Temporal.PlainMonthDay(5, 2, calendar);
+  assert.throws(TypeError, () => plainMonthDay.toPlainDate(primitive));
+});

--- a/polyfill/test/PlainYearMonth/prototype/toPlainDate/argument-not-object.js
+++ b/polyfill/test/PlainYearMonth/prototype/toPlainDate/argument-not-object.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.toplaindate
+description: Throws a TypeError if the argument is not an Object, before any other observable actions
+includes: [compareArray.js, temporalHelpers.js]
+features: [BigInt, Symbol, Temporal]
+---*/
+
+[null, undefined, true, 3.1416, "a string", Symbol("symbol"), 7n].forEach((primitive) => {
+  const calendar = TemporalHelpers.calendarThrowEverything();
+  const plainYearMonth = new Temporal.PlainYearMonth(2000, 5, calendar);
+  assert.throws(TypeError, () => plainYearMonth.toPlainDate(primitive));
+});

--- a/polyfill/test/helpers/temporalHelpers.js
+++ b/polyfill/test/helpers/temporalHelpers.js
@@ -118,6 +118,20 @@ var TemporalHelpers = {
   },
 
   /*
+   * assertUnreachable(description):
+   *
+   * Helper for asserting that code is not executed. This is useful for
+   * assertions that methods of user calendars and time zones are not called.
+   */
+  assertUnreachable(description) {
+    let message = "This code should not be executed";
+    if (description) {
+      message = `${message}: ${description}`;
+    }
+    throw new Test262Error(message);
+  },
+
+  /*
    * checkCalendarDateUntilLargestUnitSingular(func, expectedLargestUnitCalls):
    *
    * When an options object with a largestUnit property is synthesized inside
@@ -1057,6 +1071,63 @@ var TemporalHelpers = {
         calls.push(`set ${propertyName}`);
       }
     });
+  },
+
+  /*
+   * A custom calendar that does not allow any of its methods to be called, for
+   * the purpose of asserting that a particular operation does not call into
+   * user code.
+   */
+  calendarThrowEverything() {
+    class CalendarThrowEverything extends Temporal.Calendar {
+      constructor() {
+        super("iso8601");
+      }
+      toString() {
+        TemporalHelpers.assertUnreachable("toString should not be called");
+      }
+      dateFromFields() {
+        TemporalHelpers.assertUnreachable("dateFromFields should not be called");
+      }
+      yearMonthFromFields() {
+        TemporalHelpers.assertUnreachable("yearMonthFromFields should not be called");
+      }
+      monthDayFromFields() {
+        TemporalHelpers.assertUnreachable("monthDayFromFields should not be called");
+      }
+      dateAdd() {
+        TemporalHelpers.assertUnreachable("dateAdd should not be called");
+      }
+      dateUntil() {
+        TemporalHelpers.assertUnreachable("dateUntil should not be called");
+      }
+      era() {
+        TemporalHelpers.assertUnreachable("era should not be called");
+      }
+      eraYear() {
+        TemporalHelpers.assertUnreachable("eraYear should not be called");
+      }
+      year() {
+        TemporalHelpers.assertUnreachable("year should not be called");
+      }
+      month() {
+        TemporalHelpers.assertUnreachable("month should not be called");
+      }
+      monthCode() {
+        TemporalHelpers.assertUnreachable("monthCode should not be called");
+      }
+      day() {
+        TemporalHelpers.assertUnreachable("day should not be called");
+      }
+      fields() {
+        TemporalHelpers.assertUnreachable("fields should not be called");
+      }
+      mergeFields() {
+        TemporalHelpers.assertUnreachable("mergeFields should not be called");
+      }
+    }
+
+    return new CalendarThrowEverything();
   },
 
   /*

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -245,11 +245,11 @@
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
+        1. If Type(_item_) is not Object, then
+          1. Throw a *TypeError* exception.
         1. Let _calendar_ be _monthDay_.[[Calendar]].
         1. Let _receiverFieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"monthCode"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_monthDay_, _receiverFieldNames_, «»).
-        1. If Type(_item_) is not Object, then
-          1. Throw a *TypeError* exception.
         1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"year"* »).
         1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
         1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).


### PR DESCRIPTION
The spec text was inconsistent about whether the type check on the
argument or the calendar.fields checks should occur first. In
Temporal.PlainMonthDay.prototype.toPlainDate, the fields checks were
first. In Temporal.PlainYearMonth.prototype.toPlainDate, the type check
was first. This changes the PlainMonthDay algorithm to match the
PlainYearMonth one, and adds tests to both.

Closes: #1702 