### PR TITLE
Normative: Reject non-integer Duration fields in Duration.with()

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -94,6 +94,13 @@ const ToPositiveInteger = (value, property) => {
   }
   return value;
 };
+const ToIntegerNoFraction = (value) => {
+  value = ES.ToNumber(value);
+  if (!ES.IsInteger(value)) {
+    throw new RangeError(`unsupported fractional value ${value}`);
+  }
+  return value;
+};
 
 const BUILTIN_CASTS = new Map([
   ['year', ToIntegerThrowOnInfinity],
@@ -106,16 +113,16 @@ const BUILTIN_CASTS = new Map([
   ['millisecond', ToIntegerThrowOnInfinity],
   ['microsecond', ToIntegerThrowOnInfinity],
   ['nanosecond', ToIntegerThrowOnInfinity],
-  ['years', ToInteger],
-  ['months', ToInteger],
-  ['weeks', ToInteger],
-  ['days', ToInteger],
-  ['hours', ToInteger],
-  ['minutes', ToInteger],
-  ['seconds', ToInteger],
-  ['milliseconds', ToInteger],
-  ['microseconds', ToInteger],
-  ['nanoseconds', ToInteger],
+  ['years', ToIntegerNoFraction],
+  ['months', ToIntegerNoFraction],
+  ['weeks', ToIntegerNoFraction],
+  ['days', ToIntegerNoFraction],
+  ['hours', ToIntegerNoFraction],
+  ['minutes', ToIntegerNoFraction],
+  ['seconds', ToIntegerNoFraction],
+  ['milliseconds', ToIntegerNoFraction],
+  ['microseconds', ToIntegerNoFraction],
+  ['nanoseconds', ToIntegerNoFraction],
   ['era', ToString],
   ['eraYear', ToInteger],
   ['offset', ToString]
@@ -185,6 +192,7 @@ function getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier) {
 export const ES = ObjectAssign({}, ES2020, {
   ToPositiveInteger: ToPositiveInteger,
   ToIntegerThrowOnInfinity,
+  ToIntegerNoFraction,
   IsTemporalInstant: (item) => HasSlot(item, EPOCHNANOSECONDS) && !HasSlot(item, TIME_ZONE, CALENDAR),
   IsTemporalTimeZone: (item) => HasSlot(item, TIMEZONE_ID),
   IsTemporalCalendar: (item) => HasSlot(item, CALENDAR_ID),
@@ -535,28 +543,18 @@ export const ES = ObjectAssign({}, ES2020, {
         nanoseconds: GetSlot(item, NANOSECONDS)
       };
     }
-    const props = ES.ToPartialRecord(
-      item,
-      [
-        'days',
-        'hours',
-        'microseconds',
-        'milliseconds',
-        'minutes',
-        'months',
-        'nanoseconds',
-        'seconds',
-        'weeks',
-        'years'
-      ],
-      (v) => {
-        v = ES.ToNumber(v);
-        if (MathFloor(v) !== v) {
-          throw new RangeError(`unsupported fractional value ${v}`);
-        }
-        return v;
-      }
-    );
+    const props = ES.ToPartialRecord(item, [
+      'days',
+      'hours',
+      'microseconds',
+      'milliseconds',
+      'minutes',
+      'months',
+      'nanoseconds',
+      'seconds',
+      'weeks',
+      'years'
+    ]);
     if (!props) throw new TypeError('invalid duration-like');
     let {
       years = 0,

--- a/polyfill/test/Duration/constructor/from/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Duration/constructor/from/non-integer-throws-rangeerror.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.with
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => Temporal.Duration.from({ [field]: 1.5 }));
+});

--- a/polyfill/test/Duration/constructor/from/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Duration/constructor/from/non-integer-throws-rangeerror.js
@@ -21,4 +21,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => Temporal.Duration.from({ [field]: 1.5 }));
+  assert.throws(RangeError, () => Temporal.Duration.from({ [field]: -1.5 }));
 });

--- a/polyfill/test/Duration/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/add/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.add({ [field]: -1.5 }));
 });

--- a/polyfill/test/Duration/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/add/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+});

--- a/polyfill/test/Duration/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/subtract/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+});

--- a/polyfill/test/Duration/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/subtract/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: -1.5 }));
 });

--- a/polyfill/test/Duration/prototype/with/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/with/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.with({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.with({ [field]: -1.5 }));
 });

--- a/polyfill/test/Duration/prototype/with/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Duration/prototype/with/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.with
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 987, 654, 321);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.with({ [field]: 1.5 }));
+});

--- a/polyfill/test/Duration/prototype/with/order-of-operations.js
+++ b/polyfill/test/Duration/prototype/with/order-of-operations.js
@@ -32,16 +32,16 @@ const expected = [
 ];
 const actual = [];
 const fields = {
-  years: 1.7,
-  months: 1.7,
-  weeks: 1.7,
-  days: 1.7,
-  hours: 1.7,
-  minutes: 1.7,
-  seconds: 1.7,
-  milliseconds: 1.7,
-  microseconds: 1.7,
-  nanoseconds: 1.7,
+  years: 1,
+  months: 1,
+  weeks: 1,
+  days: 1,
+  hours: 1,
+  minutes: 1,
+  seconds: 1,
+  milliseconds: 1,
+  microseconds: 1,
+  nanoseconds: 1,
 };
 const argument = new Proxy(fields, {
   get(target, key) {

--- a/polyfill/test/Instant/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Instant/prototype/add/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.add
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+});

--- a/polyfill/test/Instant/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Instant/prototype/add/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.add({ [field]: -1.5 }));
 });

--- a/polyfill/test/Instant/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Instant/prototype/subtract/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.instant.prototype.subtract
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.Instant(1_000_000_000_000_000_000n);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+});

--- a/polyfill/test/Instant/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/Instant/prototype/subtract/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: -1.5 }));
 });

--- a/polyfill/test/PlainDate/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainDate/prototype/add/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.add({ [field]: -1.5 }));
 });

--- a/polyfill/test/PlainDate/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainDate/prototype/add/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.add
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+});

--- a/polyfill/test/PlainDate/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainDate/prototype/subtract/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindate.prototype.subtract
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDate(2000, 5, 2);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+});

--- a/polyfill/test/PlainDate/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainDate/prototype/subtract/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: -1.5 }));
 });

--- a/polyfill/test/PlainDateTime/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainDateTime/prototype/add/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.add
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 15, 30, 45, 987, 654, 321);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+});

--- a/polyfill/test/PlainDateTime/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainDateTime/prototype/add/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.add({ [field]: -1.5 }));
 });

--- a/polyfill/test/PlainDateTime/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainDateTime/prototype/subtract/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.subtract
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainDateTime(2000, 5, 2, 15, 30, 45, 987, 654, 321);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+});

--- a/polyfill/test/PlainDateTime/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainDateTime/prototype/subtract/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: -1.5 }));
 });

--- a/polyfill/test/PlainTime/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainTime/prototype/add/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.add
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(15, 30, 45, 987, 654, 321);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+});

--- a/polyfill/test/PlainTime/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainTime/prototype/add/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.add({ [field]: -1.5 }));
 });

--- a/polyfill/test/PlainTime/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainTime/prototype/subtract/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaintime.prototype.subtract
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainTime(15, 30, 45, 987, 654, 321);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+});

--- a/polyfill/test/PlainTime/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainTime/prototype/subtract/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: -1.5 }));
 });

--- a/polyfill/test/PlainYearMonth/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainYearMonth/prototype/add/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.add({ [field]: -1.5 }));
 });

--- a/polyfill/test/PlainYearMonth/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainYearMonth/prototype/add/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.add
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2000, 5);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+});

--- a/polyfill/test/PlainYearMonth/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainYearMonth/prototype/subtract/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plainyearmonth.prototype.subtract
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.PlainYearMonth(2000, 5);
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+});

--- a/polyfill/test/PlainYearMonth/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/PlainYearMonth/prototype/subtract/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: -1.5 }));
 });

--- a/polyfill/test/ZonedDateTime/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/ZonedDateTime/prototype/add/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.add
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+});

--- a/polyfill/test/ZonedDateTime/prototype/add/non-integer-throws-rangeerror.js
+++ b/polyfill/test/ZonedDateTime/prototype/add/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.add({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.add({ [field]: -1.5 }));
 });

--- a/polyfill/test/ZonedDateTime/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/ZonedDateTime/prototype/subtract/non-integer-throws-rangeerror.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.subtract
+description: A non-integer value for any recognized property in the property bag, throws a RangeError
+features: [Temporal]
+---*/
+
+const instance = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC");
+const fields = [
+  "years",
+  "months",
+  "weeks",
+  "days",
+  "hours",
+  "minutes",
+  "seconds",
+  "milliseconds",
+  "microseconds",
+  "nanoseconds",
+];
+fields.forEach((field) => {
+  assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+});

--- a/polyfill/test/ZonedDateTime/prototype/subtract/non-integer-throws-rangeerror.js
+++ b/polyfill/test/ZonedDateTime/prototype/subtract/non-integer-throws-rangeerror.js
@@ -22,4 +22,5 @@ const fields = [
 ];
 fields.forEach((field) => {
   assert.throws(RangeError, () => instance.subtract({ [field]: 1.5 }));
+  assert.throws(RangeError, () => instance.subtract({ [field]: -1.5 }));
 });

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -683,7 +683,6 @@
 
     <emu-clause id="sec-temporal-totemporaldurationrecord" aoid="ToTemporalDurationRecord">
       <h1>ToTemporalDurationRecord ( _temporalDurationLike_ )</h1>
-      <emu-note>The value of ? ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. Assert: Type(_temporalDurationLike_) is Object.
         1. If _temporalDurationLike_ has an [[InitializedTemporalDuration]] internal slot, then
@@ -787,7 +786,9 @@
           1. Let _value_ be ? Get(_temporalDurationLike_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
-            1. Set _value_ to ? ToIntegerOrInfinity(_value_).
+            1. Set _value_ to ? ToNumber(_value_).
+            1. If ! IsIntegralNumber(_value_) is *false*, then
+              1. Throw a *RangeError* exception.
             1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
         1. If _any_ is *false*, then
           1. Throw a *TypeError* exception.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -708,9 +708,7 @@
           1. Else,
             1. Set _any_ to *true*.
             1. Let _val_ be ? ToNumber(_val_).
-            1. If _val_ is *NaN*, +∞ or -∞, then
-              1. Throw a *RangeError* exception.
-            1. If floor(_val_) ≠ _val_, then
+            1. If ! IsIntegralNumber(_val_) is *false*, then
               1. Throw a *RangeError* exception.
             1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _val_.
         1. If _any_ is *false*, then


### PR DESCRIPTION
Unintentionally forgot with() when rejecting non-integer Duration fields
in issue #938.

Adds tests for anywhere Duration property bags are accepted, fixes a test
that would fail under the new spec text, and brings the testing polyfill
code in alignment with the new spec text.

Closes: #1704