### PR TITLE
Normative: Pass user difference options into calendar.dateUntil() from ZDT

### DIFF
--- a/polyfill/test/PlainDateTime/prototype/since/calendar-dateuntil-called-with-copy-of-options.js
+++ b/polyfill/test/PlainDateTime/prototype/since/calendar-dateuntil-called-with-copy-of-options.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.since
+description: The dateUntil() method on the calendar is called with a copy of the options bag
+features: [Temporal]
+---*/
+
+const originalOptions = {
+  largestUnit: "year",
+  shouldBeCopied: {},
+};
+let called = false;
+
+class Calendar extends Temporal.Calendar {
+  constructor() {
+    super("iso8601");
+  }
+
+  dateUntil(d1, d2, options) {
+    called = true;
+    assert.notSameValue(options, originalOptions, "options bag should be a copy");
+    assert.sameValue(options.shouldBeCopied, originalOptions.shouldBeCopied, "options bag should be a shallow copy");
+    return new Temporal.Duration();
+  }
+}
+const calendar = new Calendar();
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 988, 655, 322, calendar);
+earlier.since(later, originalOptions);
+assert(called, "calendar.dateUntil must be called");

--- a/polyfill/test/PlainDateTime/prototype/until/calendar-dateuntil-called-with-copy-of-options.js
+++ b/polyfill/test/PlainDateTime/prototype/until/calendar-dateuntil-called-with-copy-of-options.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.plaindatetime.prototype.until
+description: The dateUntil() method on the calendar is called with a copy of the options bag
+features: [Temporal]
+---*/
+
+const originalOptions = {
+  largestUnit: "year",
+  shouldBeCopied: {},
+};
+let called = false;
+
+class Calendar extends Temporal.Calendar {
+  constructor() {
+    super("iso8601");
+  }
+
+  dateUntil(d1, d2, options) {
+    called = true;
+    assert.notSameValue(options, originalOptions, "options bag should be a copy");
+    assert.sameValue(options.shouldBeCopied, originalOptions.shouldBeCopied, "options bag should be a shallow copy");
+    return new Temporal.Duration();
+  }
+}
+const calendar = new Calendar();
+const earlier = new Temporal.PlainDateTime(2000, 5, 2, 12, 34, 56, 987, 654, 321, calendar);
+const later = new Temporal.PlainDateTime(2001, 6, 3, 13, 35, 57, 988, 655, 322, calendar);
+earlier.until(later, originalOptions);
+assert(called, "calendar.dateUntil must be called");

--- a/polyfill/test/ZonedDateTime/prototype/since/calendar-dateuntil-called-with-copy-of-options.js
+++ b/polyfill/test/ZonedDateTime/prototype/since/calendar-dateuntil-called-with-copy-of-options.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.since
+description: The dateUntil() method on the calendar is called with a copy of the options bag
+features: [Temporal]
+---*/
+
+const originalOptions = {
+  largestUnit: "year",
+  shouldBeCopied: {},
+};
+let called = false;
+
+class Calendar extends Temporal.Calendar {
+  constructor() {
+    super("iso8601");
+  }
+
+  dateUntil(d1, d2, options) {
+    called = true;
+    assert.notSameValue(options, originalOptions, "options bag should be a copy");
+    assert.sameValue(options.shouldBeCopied, originalOptions.shouldBeCopied, "options bag should be a shallow copy");
+    return new Temporal.Duration(-1);
+  }
+}
+const calendar = new Calendar();
+const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", calendar);
+// exactly one year later; avoids NanosecondsToDays path
+const later = new Temporal.ZonedDateTime(1_031_536_000_000_000_000n, "UTC", calendar);
+later.since(earlier, originalOptions);
+assert(called, "calendar.dateUntil must be called");

--- a/polyfill/test/ZonedDateTime/prototype/until/calendar-dateuntil-called-with-copy-of-options.js
+++ b/polyfill/test/ZonedDateTime/prototype/until/calendar-dateuntil-called-with-copy-of-options.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.zoneddatetime.prototype.until
+description: The dateUntil() method on the calendar is called with a copy of the options bag
+features: [Temporal]
+---*/
+
+const originalOptions = {
+  largestUnit: "year",
+  shouldBeCopied: {},
+};
+let called = false;
+
+class Calendar extends Temporal.Calendar {
+  constructor() {
+    super("iso8601");
+  }
+
+  dateUntil(d1, d2, options) {
+    called = true;
+    assert.notSameValue(options, originalOptions, "options bag should be a copy");
+    assert.sameValue(options.shouldBeCopied, originalOptions.shouldBeCopied, "options bag should be a shallow copy");
+    return new Temporal.Duration(1);
+  }
+}
+const calendar = new Calendar();
+const earlier = new Temporal.ZonedDateTime(1_000_000_000_000_000_000n, "UTC", calendar);
+// exactly one year later; avoids NanosecondsToDays path
+const later = new Temporal.ZonedDateTime(1_031_536_000_000_000_000n, "UTC", calendar);
+earlier.until(later, originalOptions);
+assert(called, "calendar.dateUntil must be called");

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -729,7 +729,8 @@
           1. Return ? CreateTemporalDuration(0, 0, 0, 0, _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
-        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_).
+        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_, _untilOptions_).
         1. Let _roundResult_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
         1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
         1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
@@ -763,7 +764,8 @@
           1. Return ? CreateTemporalDuration(0, 0, 0, 0, −_balanceResult_.[[Hours]], −_balanceResult_.[[Minutes]], −_balanceResult_.[[Seconds]], −_balanceResult_.[[Milliseconds]], −_balanceResult_.[[Microseconds]], −_balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
-        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_).
+        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_, _untilOptions_).
         1. Let _roundResult_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
         1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
         1. Return ? CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], −_result_.[[Weeks]], −_result_.[[Days]], −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]]).


### PR DESCRIPTION
In ZonedDateTime.prototype.until() and ZonedDateTime.prototype.since(),
the main invocation of calendar.dateUntil() should get a copy of the
user-originated options object (with largestUnit adjusted), just like
the same methods on PlainDateTime do.

(This doesn't hold for the NanosecondsToDays step in
DifferenceZonedDateTime, which must be called with blank options. So, for
the ZonedDateTime tests we choose values that don't go through that path.)

Closes: #1721