### PR TITLE
Editorial: Fix broken return from DifferenceISODateTime

### DIFF
--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1079,7 +1079,7 @@
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
         1. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
         1. Let _balanceResult_ be ? BalanceDuration(_dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
-        1. Return the new Record: {
+        1. Return the Record {
             [[Years]]: _dateDifference_.[[Years]],
             [[Months]]: _dateDifference_.[[Months]],
             [[Weeks]]: _dateDifference_.[[Weeks]],
@@ -1089,7 +1089,7 @@
             [[Seconds]]: _balanceResult_.[[Seconds]],
             [[Milliseconds]]: _balanceResult_.[[Milliseconds]],
             [[Microseconds]]: _balanceResult_.[[Microseconds]],
-            [[Nanoseconds]]: _balanceResult_.[[Nanoseconds]],
+            [[Nanoseconds]]: _balanceResult_.[[Nanoseconds]]
           }.
       </emu-alg>
     </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1078,7 +1078,19 @@
         1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
         1. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
-        1. Return ? BalanceDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
+        1. Let _balanceResult_ be ? BalanceDuration(_dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
+        1. Return the new Record: {
+            [[Years]]: _dateDifference_.[[Years]],
+            [[Months]]: _dateDifference_.[[Months]],
+            [[Weeks]]: _dateDifference_.[[Weeks]],
+            [[Days]]: _balanceResult_.[[Days]],
+            [[Hours]]: _balanceResult_.[[Hours]],
+            [[Minutes]]: _balanceResult_.[[Minutes]],
+            [[Seconds]]: _balanceResult_.[[Seconds]],
+            [[Milliseconds]]: _balanceResult_.[[Milliseconds]],
+            [[Microseconds]]: _balanceResult_.[[Microseconds]],
+            [[Nanoseconds]]: _balanceResult_.[[Nanoseconds]],
+          }.
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
The spec text described accesses to the wrong Record slots from the return
value of BalanceDuration, so this was unimplementable as is.

Closes: #1722