### PR TITLE
Editorial: Correctly parse relativeTo string

### DIFF
--- a/polyfill/test/Duration/constructor/compare/relativeto-string-invalid.js
+++ b/polyfill/test/Duration/constructor/compare/relativeto-string-invalid.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: RangeError thrown if relativeTo is a string with the wrong format
+features: [Temporal]
+---*/
+
+['bad string', '15:30:45.123456', 'iso8601', 'UTC', 'P1YT1H'].forEach((relativeTo) => {
+  const duration1 = new Temporal.Duration(0, 0, 0, 31);
+  const duration2 = new Temporal.Duration(0, 1);
+  assert.throws(RangeError, () => Temporal.Duration.compare(duration1, duration2, { relativeTo }));
+});

--- a/polyfill/test/Duration/constructor/compare/relativeto-string-plaindatetime.js
+++ b/polyfill/test/Duration/constructor/compare/relativeto-string-plaindatetime.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: The relativeTo option accepts a PlainDateTime-like ISO 8601 string
+features: [Temporal]
+---*/
+
+['2000-01-01', '2000-01-01T00:00', '2000-01-01T00:00[u-ca=iso8601]'].forEach((relativeTo) => {
+  const duration1 = new Temporal.Duration(0, 0, 0, 31);
+  const duration2 = new Temporal.Duration(0, 1);
+  const result = Temporal.Duration.compare(duration1, duration2, { relativeTo });
+  assert.sameValue(result, 0);
+});

--- a/polyfill/test/Duration/constructor/compare/relativeto-string-zoneddatetime-no-z.js
+++ b/polyfill/test/Duration/constructor/compare/relativeto-string-zoneddatetime-no-z.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: RangeError thrown if relativeTo is an ISO 8601 string with a Z as the time zone designator
+features: [Temporal]
+---*/
+
+['2000-01-01T00:00Z', '2000-01-01T00:00Z[UTC]'].forEach((relativeTo) => {
+  const duration1 = new Temporal.Duration(0, 0, 0, 31);
+  const duration2 = new Temporal.Duration(0, 1);
+  assert.throws(RangeError, () => Temporal.Duration.compare(duration1, duration2, { relativeTo }));
+});

--- a/polyfill/test/Duration/constructor/compare/relativeto-string-zoneddatetime.js
+++ b/polyfill/test/Duration/constructor/compare/relativeto-string-zoneddatetime.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.compare
+description: The relativeTo option accepts a ZonedDateTime-like ISO 8601 string
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[
+  '2000-01-01[UTC]',
+  '2000-01-01T00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC][u-ca=iso8601]',
+].forEach((relativeTo) => {
+  const duration1 = new Temporal.Duration(0, 0, 0, 31);
+  const duration2 = new Temporal.Duration(0, 1);
+  const result = Temporal.Duration.compare(duration1, duration2, { relativeTo });
+  assert.sameValue(result, 0);
+});

--- a/polyfill/test/Duration/prototype/add/relativeto-string-invalid.js
+++ b/polyfill/test/Duration/prototype/add/relativeto-string-invalid.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: RangeError thrown if relativeTo is a string with the wrong format
+features: [Temporal]
+---*/
+
+['bad string', '15:30:45.123456', 'iso8601', 'UTC', 'P1YT1H'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(1, 0, 0, 15);
+  assert.throws(RangeError, () => duration.add(new Temporal.Duration(0, 0, 0, 16), { relativeTo }));
+});

--- a/polyfill/test/Duration/prototype/add/relativeto-string-plaindatetime.js
+++ b/polyfill/test/Duration/prototype/add/relativeto-string-plaindatetime.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: The relativeTo option accepts a PlainDateTime-like ISO 8601 string
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+['2000-01-01', '2000-01-01T00:00', '2000-01-01T00:00[u-ca=iso8601]'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(1, 0, 0, 15);
+  const result = duration.add(new Temporal.Duration(0, 0, 0, 16), { relativeTo });
+  TemporalHelpers.assertDuration(result, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+});

--- a/polyfill/test/Duration/prototype/add/relativeto-string-zoneddatetime-no-z.js
+++ b/polyfill/test/Duration/prototype/add/relativeto-string-zoneddatetime-no-z.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: RangeError thrown if relativeTo is an ISO 8601 string with a Z as the time zone designator
+features: [Temporal]
+---*/
+
+['2000-01-01T00:00Z', '2000-01-01T00:00Z[UTC]'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(1, 0, 0, 15);
+  assert.throws(RangeError, () => duration.add(new Temporal.Duration(0, 0, 0, 16), { relativeTo }));
+});

--- a/polyfill/test/Duration/prototype/add/relativeto-string-zoneddatetime.js
+++ b/polyfill/test/Duration/prototype/add/relativeto-string-zoneddatetime.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.add
+description: The relativeTo option accepts a ZonedDateTime-like ISO 8601 string
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[
+  '2000-01-01[UTC]',
+  '2000-01-01T00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC][u-ca=iso8601]',
+].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(1, 0, 0, 15);
+  const result = duration.add(new Temporal.Duration(0, 0, 0, 16), { relativeTo });
+  TemporalHelpers.assertDuration(result, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+});

--- a/polyfill/test/Duration/prototype/round/relativeto-string-invalid.js
+++ b/polyfill/test/Duration/prototype/round/relativeto-string-invalid.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: RangeError thrown if relativeTo is a string with the wrong format
+features: [Temporal]
+---*/
+
+['bad string', '15:30:45.123456', 'iso8601', 'UTC', 'P1YT1H'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(0, 0, 0, 31);
+  assert.throws(RangeError, () => duration.round({ largestUnit: "months", relativeTo }));
+});

--- a/polyfill/test/Duration/prototype/round/relativeto-string-plaindatetime.js
+++ b/polyfill/test/Duration/prototype/round/relativeto-string-plaindatetime.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: The relativeTo option accepts a PlainDateTime-like ISO 8601 string
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+['2000-01-01', '2000-01-01T00:00', '2000-01-01T00:00[u-ca=iso8601]'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(0, 0, 0, 31);
+  const result = duration.round({ largestUnit: "months", relativeTo });
+  TemporalHelpers.assertDuration(result, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+});

--- a/polyfill/test/Duration/prototype/round/relativeto-string-zoneddatetime-no-z.js
+++ b/polyfill/test/Duration/prototype/round/relativeto-string-zoneddatetime-no-z.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: RangeError thrown if relativeTo is an ISO 8601 string with a Z as the time zone designator
+features: [Temporal]
+---*/
+
+['2000-01-01T00:00Z', '2000-01-01T00:00Z[UTC]'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(0, 0, 0, 31);
+  assert.throws(RangeError, () => duration.round({ largestUnit: "months", relativeTo }));
+});

--- a/polyfill/test/Duration/prototype/round/relativeto-string-zoneddatetime.js
+++ b/polyfill/test/Duration/prototype/round/relativeto-string-zoneddatetime.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.round
+description: The relativeTo option accepts a ZonedDateTime-like ISO 8601 string
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[
+  '2000-01-01[UTC]',
+  '2000-01-01T00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC][u-ca=iso8601]',
+].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(0, 0, 0, 31);
+  const result = duration.round({ largestUnit: "months", relativeTo });
+  TemporalHelpers.assertDuration(result, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+});

--- a/polyfill/test/Duration/prototype/subtract/relativeto-string-invalid.js
+++ b/polyfill/test/Duration/prototype/subtract/relativeto-string-invalid.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: RangeError thrown if relativeTo is a string with the wrong format
+features: [Temporal]
+---*/
+
+['bad string', '15:30:45.123456', 'iso8601', 'UTC', 'P1YT1H'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(1, 0, 0, 41);
+  assert.throws(RangeError, () => duration.subtract(new Temporal.Duration(0, 0, 0, 10), { relativeTo }));
+});

--- a/polyfill/test/Duration/prototype/subtract/relativeto-string-plaindatetime.js
+++ b/polyfill/test/Duration/prototype/subtract/relativeto-string-plaindatetime.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: The relativeTo option accepts a PlainDateTime-like ISO 8601 string
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+['2000-01-01', '2000-01-01T00:00', '2000-01-01T00:00[u-ca=iso8601]'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(1, 0, 0, 41);
+  const result = duration.subtract(new Temporal.Duration(0, 0, 0, 10), { relativeTo });
+  TemporalHelpers.assertDuration(result, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+});

--- a/polyfill/test/Duration/prototype/subtract/relativeto-string-zoneddatetime-no-z.js
+++ b/polyfill/test/Duration/prototype/subtract/relativeto-string-zoneddatetime-no-z.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: RangeError thrown if relativeTo is an ISO 8601 string with a Z as the time zone designator
+features: [Temporal]
+---*/
+
+['2000-01-01T00:00Z', '2000-01-01T00:00Z[UTC]'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(1, 0, 0, 41);
+  assert.throws(RangeError, () => duration.subtract(new Temporal.Duration(0, 0, 0, 10), { relativeTo }));
+});

--- a/polyfill/test/Duration/prototype/subtract/relativeto-string-zoneddatetime.js
+++ b/polyfill/test/Duration/prototype/subtract/relativeto-string-zoneddatetime.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.subtract
+description: The relativeTo option accepts a ZonedDateTime-like ISO 8601 string
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[
+  '2000-01-01[UTC]',
+  '2000-01-01T00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC][u-ca=iso8601]',
+].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(1, 0, 0, 41);
+  const result = duration.subtract(new Temporal.Duration(0, 0, 0, 10), { relativeTo });
+  TemporalHelpers.assertDuration(result, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+});

--- a/polyfill/test/Duration/prototype/total/relativeto-string-invalid.js
+++ b/polyfill/test/Duration/prototype/total/relativeto-string-invalid.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: RangeError thrown if relativeTo is a string with the wrong format
+features: [Temporal]
+---*/
+
+['bad string', '15:30:45.123456', 'iso8601', 'UTC', 'P1YT1H'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(0, 0, 0, 31);
+  assert.throws(RangeError, () => duration.total({ unit: "months", relativeTo }));
+});

--- a/polyfill/test/Duration/prototype/total/relativeto-string-plaindatetime.js
+++ b/polyfill/test/Duration/prototype/total/relativeto-string-plaindatetime.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: The relativeTo option accepts a PlainDateTime-like ISO 8601 string
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+['2000-01-01', '2000-01-01T00:00', '2000-01-01T00:00[u-ca=iso8601]'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(0, 0, 0, 31);
+  const result = duration.total({ unit: "months", relativeTo });
+  assert.sameValue(result, 1);
+});

--- a/polyfill/test/Duration/prototype/total/relativeto-string-zoneddatetime-no-z.js
+++ b/polyfill/test/Duration/prototype/total/relativeto-string-zoneddatetime-no-z.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: RangeError thrown if relativeTo is an ISO 8601 string with a Z as the time zone designator
+features: [Temporal]
+---*/
+
+['2000-01-01T00:00Z', '2000-01-01T00:00Z[UTC]'].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(0, 0, 0, 31);
+  assert.throws(RangeError, () => duration.total({ unit: "months", relativeTo }));
+});

--- a/polyfill/test/Duration/prototype/total/relativeto-string-zoneddatetime.js
+++ b/polyfill/test/Duration/prototype/total/relativeto-string-zoneddatetime.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.duration.prototype.total
+description: The relativeTo option accepts a ZonedDateTime-like ISO 8601 string
+features: [Temporal]
+includes: [temporalHelpers.js]
+---*/
+
+[
+  '2000-01-01[UTC]',
+  '2000-01-01T00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC]',
+  '2000-01-01T00:00+00:00[UTC][u-ca=iso8601]',
+].forEach((relativeTo) => {
+  const duration = new Temporal.Duration(0, 0, 0, 31);
+  const result = duration.total({ unit: "months", relativeTo });
+  assert.sameValue(result, 1);
+});

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -3,3 +3,10 @@ Instant/prototype/toLocaleString/options-conflict.js
 PlainDateTime/prototype/toLocaleString/options-conflict.js
 PlainTime/prototype/toLocaleString/options-conflict.js
 ZonedDateTime/prototype/toLocaleString/options-conflict.js
+
+# Blocked on https://github.com/tc39/proposal-temporal/issues/1695
+Duration/constructor/compare/relativeto-string-zoneddatetime-no-z.js
+Duration/prototype/add/relativeto-string-zoneddatetime-no-z.js
+Duration/prototype/round/relativeto-string-zoneddatetime-no-z.js
+Duration/prototype/subtract/relativeto-string-zoneddatetime-no-z.js
+Duration/prototype/total/relativeto-string-zoneddatetime-no-z.js

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -505,7 +505,7 @@
         1. Let _timeZone_ be ? Get(_value_, *"timeZone"*).
       1. Else,
         1. Let _string_ be ? ToString(_value_).
-        1. Let _result_ be ? ParseISODateTime(_string_).
+        1. Let _result_ be ? ParseTemporalRelativeToString(_string_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).
         1. Let _offset_ be _result_.[[TimeZoneOffset]].
         1. Let _timeZone_ be _result_.[[TimeZoneIANAName]].
@@ -1318,6 +1318,42 @@
         [[Year]]: _year_,
         [[Month]]: _month_,
         [[Day]]: _day_
+        }.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-parsetemporalrelativetostring" aoid="ParseTemporalRelativeToString">
+    <h1>ParseTemporalRelativeToString ( _isoString_ )</h1>
+    <p>
+      The ParseTemporalRelativeToString abstract operation parses an ISO 8601 string with or without a time zone, and returns the information needed to construct either a Temporal.ZonedDateTime or a Temporal.PlainDateTime instance, e.g. as the value of a `relativeTo` option.
+    </p>
+    <emu-alg>
+      1. Assert: Type(_isoString_) is String.
+      1. If _isoString_ does not satisfy the syntax of a |TemporalDateTimeString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
+        1. Throw a *RangeError* exception.
+      1. Let _result_ be ! ParseISODateTime(_isoString_).
+      1. If _isoString_ satisfies the syntax of a |TemporalZonedDateTimeString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
+        1. Let _timeZoneResult_ be ! ParseTemporalTimeZoneString(_isoString_).
+        1. If _timeZoneResult_.[[Z]] is not *undefined*, then
+          1. Throw a *RangeError* exception.
+        1. Let _offset_ be _timeZoneResult_.[[Offset]].
+        1. Let _timeZone_ be _timeZoneResult_.[[Name]].
+      1. Else,
+        1. Let _offset_ be *undefined*.
+        1. Let _timeZone_ be *undefined*.
+      1. Return the Record {
+          [[Year]]: _result_.[[Year]],
+          [[Month]]: _result_.[[Month]],
+          [[Day]]: _result_.[[Day]],
+          [[Hour]]: _result_.[[Hour]],
+          [[Minute]]: _result_.[[Minute]],
+          [[Second]]: _result_.[[Second]],
+          [[Millisecond]]: _result_.[[Millisecond]],
+          [[Microsecond]]: _result_.[[Microsecond]],
+          [[Nanosecond]]: _result_.[[Nanosecond]],
+          [[Calendar]]: _result_.[[Calendar]],
+          [[TimeZoneOffset]]: _offset_,
+          [[TimeZoneIANAName]]: _timeZone_
         }.
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
A string given as the value of the relativeTo option must be parsed as a
Temporal.ZonedDateTime if possible, and otherwise as a PlainDateTime.

This is hopefully an editorial change, because the spec text as written
was unimplementable. There were no [[TimeZoneOffset]] or
[[TimeZoneIANAName]] fields on the Record returned from ParseISODateTime.

Closes: #1738