### PR TITLE
Editorial: Consistently use dateTime instead

### DIFF
--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -411,12 +411,12 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _temporalDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_temporalDateTime_, [[InitializedTemporalDateTime]]).
+        1. Let _dateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. If _plainTimeLike_ is *undefined*, then
-          1. Return ? CreateTemporalDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], 0, 0, 0, 0, 0, 0, _temporalDateTime_.[[Calendar]]).
+          1. Return ? CreateTemporalDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], 0, 0, 0, 0, 0, 0, _dateTime_.[[Calendar]]).
         1. Let _plainTime_ be ? ToTemporalTime(_plainTimeLike_).
-        1. Return ? CreateTemporalDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _plainTime_.[[ISOHour]], _plainTime_.[[ISOMinute]], _plainTime_.[[ISOSecond]], _plainTime_.[[ISOMillisecond]], _plainTime_.[[ISOMicrosecond]], _plainTime_.[[ISONanosecond]], _temporalDateTime_.[[Calendar]]).
+        1. Return ? CreateTemporalDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _plainTime_.[[ISOHour]], _plainTime_.[[ISOMinute]], _plainTime_.[[ISOSecond]], _plainTime_.[[ISOMillisecond]], _plainTime_.[[ISOMicrosecond]], _plainTime_.[[ISONanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -427,11 +427,11 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _temporalDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_temporalDateTime_, [[InitializedTemporalDateTime]]).
+        1. Let _dateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _plainDate_ be ? ToTemporalDate(_plainDateLike_).
-        1. Let _calendar_ be ? ConsolidateCalendars(_temporalDateTime_.[[Calendar]], _plainDate_.[[Calendar]]).
-        1. Return ? CreateTemporalDateTime(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _calendar_).
+        1. Let _calendar_ be ? ConsolidateCalendars(_dateTime_.[[Calendar]], _plainDate_.[[Calendar]]).
+        1. Return ? CreateTemporalDateTime(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -442,10 +442,10 @@
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _temporalDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_temporalDateTime_, [[InitializedTemporalDateTime]]).
+        1. Let _dateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _calendar_ be ? ToTemporalCalendar(_calendar_).
-        1. Return ? CreateTemporalDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _calendar_).
+        1. Return ? CreateTemporalDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Most places use dateTime but some places use temporalDateTime referring to "this". Make it consistent.

@ptomato @Ms2ger 