### PR TITLE
Editorial: Consistenly use yearMonth

### DIFF
--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -115,9 +115,9 @@
         Its get accessor function performs the following steps:
       </p>
       <emu-alg>
-        1. Let _plainYearMonth_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_plainYearMonth_, [[InitializedTemporalYearMonth]]).
-        1. Return _plainYearMonth_.[[Calendar]].
+        1. Let _yearMonth_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
+        1. Return _yearMonth_.[[Calendar]].
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
only one plcae use plainYearMonth to refer to this, change it to alos use yearMonth

@ptomato @Ms2ger 