### PR TITLE
Copy options object for PlainYearMonth.{add,subtract} and InterpretTemporalDateTimeFields

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1025,11 +1025,11 @@ export const ES = ObjectAssign({}, ES2020, {
   },
   InterpretTemporalDateTimeFields: (calendar, fields, options) => {
     let { hour, minute, second, millisecond, microsecond, nanosecond } = ES.ToTemporalTimeRecord(fields);
+    const overflow = ES.ToTemporalOverflow(options);
     const date = ES.DateFromFields(calendar, fields, options);
     const year = GetSlot(date, ISO_YEAR);
     const month = GetSlot(date, ISO_MONTH);
     const day = GetSlot(date, ISO_DAY);
-    const overflow = ES.ToTemporalOverflow(options);
     ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateTime(
       hour,
       minute,

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -107,10 +107,11 @@ export class PlainYearMonth {
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
     const day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, this)) : 1;
     const startDate = ES.DateFromFields(calendar, { ...fields, day });
+    const optionsCopy = { ...options };
     const addedDate = ES.CalendarDateAdd(calendar, startDate, { ...duration, days }, options);
     const addedDateFields = ES.ToTemporalYearMonthFields(addedDate, fieldNames);
 
-    return ES.YearMonthFromFields(calendar, addedDateFields, options);
+    return ES.YearMonthFromFields(calendar, addedDateFields, optionsCopy);
   }
   subtract(temporalDurationLike, options = undefined) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
@@ -138,10 +139,11 @@ export class PlainYearMonth {
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
     const day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, this)) : 1;
     const startDate = ES.DateFromFields(calendar, { ...fields, day });
+    const optionsCopy = { ...options };
     const addedDate = ES.CalendarDateAdd(calendar, startDate, { ...duration, days }, options);
     const addedDateFields = ES.ToTemporalYearMonthFields(addedDate, fieldNames);
 
-    return ES.YearMonthFromFields(calendar, addedDateFields, options);
+    return ES.YearMonthFromFields(calendar, addedDateFields, optionsCopy);
   }
   until(other, options = undefined) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');

--- a/polyfill/test/PlainYearMonth/prototype/add/calendar-arguments-extra-options.js
+++ b/polyfill/test/PlainYearMonth/prototype/add/calendar-arguments-extra-options.js
@@ -2,8 +2,8 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-temporal.plainyearmonth.prototype.subtract
-description: plainyearmonth.prototype.subtract should respect calendar arguments and pass copied options objects.
+esid: sec-temporal.plainyearmonth.prototype.add
+description: PlainYearMonth.prototype.add should pass extra fields in copied options objects.
 info: |
     YearMonthFromFields ( calendar, fields [ , options ] )
 
@@ -14,14 +14,10 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
+  "get extra",
   "get overflow",
-  "get overflow",
-  "get overflow.toString",
-  "call overflow.toString",
-  "get overflow.toString",
-  "call overflow.toString",
 ];
-const options = new Proxy({ overflow: "constrain" }, {
+const options = new Proxy({ extra: 5 }, {
   get(target, key) {
     actual.push(`get ${key}`);
     const result = target[key];
@@ -52,7 +48,7 @@ class CustomCalendar extends Temporal.Calendar {
     return super.yearMonthFromFields(...args);
   }
 }
-const plainYearMonth = new Temporal.PlainYearMonth(2000, 7, new CustomCalendar());
-const result = plainYearMonth.subtract({ months: 9 }, options);
-TemporalHelpers.assertPlainYearMonth(result, 1999, 10, "M10");
-assert.compareArray(actual, expected, "copied options object order of operations");
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 3, new CustomCalendar());
+const result = plainYearMonth.add({ months: 5 }, options);
+TemporalHelpers.assertPlainYearMonth(result, 2000, 8, "M08");
+assert.compareArray(actual, expected, "extra field options object order of operations");

--- a/polyfill/test/PlainYearMonth/prototype/add/calendar-arguments.js
+++ b/polyfill/test/PlainYearMonth/prototype/add/calendar-arguments.js
@@ -3,26 +3,57 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.prototype.add
+description: PlainYearMonth.prototype.add should respect calendar arguments and pass copied options objects.
 info: |
     YearMonthFromFields ( calendar, fields [ , options ] )
 
     5. Let yearMonth be ? Invoke(calendar, "yearMonthFromFields", « fields, options »).
-includes: [temporalHelpers.js]
+includes: [compareArray.js, temporalHelpers.js]
 features: [Temporal]
 ---*/
 
-const options = {};
+const actual = [];
+const expected = [
+  "get overflow",
+  "get overflow",
+  "get overflow.toString",
+  "call overflow.toString",
+  "get overflow.toString",
+  "call overflow.toString",
+];
+const options = new Proxy({ overflow: "constrain" }, {
+  get(target, key) {
+    actual.push(`get ${key}`);
+    const result = target[key];
+    if (result === undefined) {
+      return undefined;
+    }
+    return TemporalHelpers.toPrimitiveObserver(actual, result, key);
+  },
+  has(target, key) {
+    actual.push(`has ${key}`);
+    return key in target;
+  },
+});
+
 class CustomCalendar extends Temporal.Calendar {
   constructor() {
     super("iso8601");
   }
+  dateAdd(date, duration, options) {
+    const result = super.dateAdd(date, duration, options);
+    options.overflow = 'meatloaf';
+    return result;
+  }
   yearMonthFromFields(...args) {
     assert.sameValue(args.length, 2, "args.length");
     assert.sameValue(typeof args[0], "object", "args[0]");
-    assert.sameValue(args[1], options, "args[1]");
+    assert.notSameValue(args[1], options, "args[1]");
     return super.yearMonthFromFields(...args);
   }
 }
+
 const plainYearMonth = new Temporal.PlainYearMonth(2000, 3, new CustomCalendar());
-const result = plainYearMonth.add({ months: 2 }, options);
-TemporalHelpers.assertPlainYearMonth(result, 2000, 5, "M05");
+const result = plainYearMonth.add({ months: 10 }, options);
+TemporalHelpers.assertPlainYearMonth(result, 2001, 1, "M01");
+assert.compareArray(actual, expected, "copied options object order of operations");

--- a/polyfill/test/PlainYearMonth/prototype/subtract/calendar-arguments-extra-options.js
+++ b/polyfill/test/PlainYearMonth/prototype/subtract/calendar-arguments-extra-options.js
@@ -3,7 +3,7 @@
 
 /*---
 esid: sec-temporal.plainyearmonth.prototype.subtract
-description: plainyearmonth.prototype.subtract should respect calendar arguments and pass copied options objects.
+description: plainyearmonth.prototype.subtract should pass extra fields in copied options objects.
 info: |
     YearMonthFromFields ( calendar, fields [ , options ] )
 
@@ -14,14 +14,10 @@ features: [Temporal]
 
 const actual = [];
 const expected = [
+  "get extra",
   "get overflow",
-  "get overflow",
-  "get overflow.toString",
-  "call overflow.toString",
-  "get overflow.toString",
-  "call overflow.toString",
 ];
-const options = new Proxy({ overflow: "constrain" }, {
+const options = new Proxy({ extra: 5 }, {
   get(target, key) {
     actual.push(`get ${key}`);
     const result = target[key];
@@ -52,7 +48,7 @@ class CustomCalendar extends Temporal.Calendar {
     return super.yearMonthFromFields(...args);
   }
 }
-const plainYearMonth = new Temporal.PlainYearMonth(2000, 7, new CustomCalendar());
-const result = plainYearMonth.subtract({ months: 9 }, options);
+const plainYearMonth = new Temporal.PlainYearMonth(2000, 3, new CustomCalendar());
+const result = plainYearMonth.subtract({ months: 5 }, options);
 TemporalHelpers.assertPlainYearMonth(result, 1999, 10, "M10");
-assert.compareArray(actual, expected, "copied options object order of operations");
+assert.compareArray(actual, expected, "extra field options object order of operations");

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -879,8 +879,8 @@
       </p>
       <emu-alg>
         1. Let _timeResult_ be ? ToTemporalTimeRecord(_fields_).
-        1. Let _temporalDate_ be ? DateFromFields(_calendar_, _fields_, _options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Let _temporalDate_ be ? DateFromFields(_calendar_, _fields_, _options_).
         1. Let _timeResult_ be ? RegulateTime(_timeResult_.[[Hour]], _timeResult_.[[Minute]], _timeResult_.[[Second]], _timeResult_.[[Millisecond]], _timeResult_.[[Microsecond]], _timeResult_.[[Nanosecond]], _overflow_).
         1. Return the Record {
           [[Year]]: _temporalDate_.[[ISOYear]],

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -270,9 +270,13 @@
           1. Let _day_ be 1.
         1. Let _date_ be ? CreateTemporalDate(_yearMonth_.[[ISOYear]], _yearMonth_.[[ISOMonth]], _day_, _calendar_).
         1. Let _durationToAdd_ be ? CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _optionsCopy_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _entries_ be ? EnumerableOwnPropertyNames(_options_, ~key+value~).
+        1. For each element _nextEntry_ of _entries_, do
+          1. Perform ! CreateDataPropertyOrThrow(_optionsCopy_, _nextEntry_[0], _nextEntry_[1]).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _options_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).
-        1. Return ? YearMonthFromFields(_calendar_, _addedDateFields_, _options_).
+        1. Return ? YearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).
       </emu-alg>
     </emu-clause>
 
@@ -298,9 +302,13 @@
           1. Let _day_ be 1.
         1. Let _date_ be ? CreateTemporalDate(_yearMonth_.[[ISOYear]], _yearMonth_.[[ISOMonth]], _day_, _calendar_).
         1. Let _durationToAdd_ be ? CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _optionsCopy_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _entries_ be ? EnumerableOwnPropertyNames(_options_, ~key+value~).
+        1. For each element _nextEntry_ of _entries_, do
+          1. Perform ! CreateDataPropertyOrThrow(_optionsCopy_, _nextEntry_[0], _nextEntry_[1]).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _options_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).
-        1. Return ? YearMonthFromFields(_calendar_, _addedDateFields_, _options_).
+        1. Return ? YearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
… to prevent user-modified objects from interfering with later operations.

Fixes #1686