### PR TITLE
Validate input to Calendar.prototype.fields

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -61,8 +61,22 @@ export class Calendar {
   fields(fields) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const fieldsArray = [];
+    const allowed = new Set([
+      'year',
+      'month',
+      'monthCode',
+      'day',
+      'hour',
+      'minute',
+      'second',
+      'millisecond',
+      'microsecond',
+      'nanosecond'
+    ]);
     for (const name of fields) {
-      if (ES.Type(name) !== 'String') throw new TypeError('invalid fields');
+      if (fieldsArray.length > 10) throw new RangeError('too many fields');
+      if (!allowed.has(name)) throw new RangeError('invalid field name');
+      allowed.delete(name);
       ArrayPrototypePush.call(fieldsArray, name);
     }
     return impl[GetSlot(this, CALENDAR_ID)].fields(fieldsArray);

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -74,8 +74,8 @@ export class Calendar {
       'nanosecond'
     ]);
     for (const name of fields) {
-      if (fieldsArray.length > 10) throw new RangeError('too many fields');
-      if (!allowed.has(name)) throw new RangeError('invalid field name');
+      if (ES.Type(name) !== 'String') throw new TypeError('invalid fields');
+      if (!allowed.has(name)) throw new RangeError(`invalid field name ${name}`);
       allowed.delete(name);
       ArrayPrototypePush.call(fieldsArray, name);
     }

--- a/polyfill/test/Calendar/prototype/fields/argument-throws-duplicate-keys.js
+++ b/polyfill/test/Calendar/prototype/fields/argument-throws-duplicate-keys.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.fields
+description: Duplicate fields are not allowed in the argument to Calendar.prototype.fields
+info: |
+    sec-temporal.calendar.prototype.fields step 7.b.iii:
+      iii. If _fieldNames_ contains _nextValue_, then
+        1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
+        2. Return ? IteratorClose(_iteratorRecord_, _completion_).
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+assert.throws(RangeError, () => calendar.fields(["day", "month", "day"]));
+assert.throws(RangeError, () => calendar.fields(["year", "month", "monthCode", "day", "hour", "minute", "second", "millisecond", "microsecond", "nanosecond", "year"]));
+
+const manyFields = {
+  count: 0
+};
+
+manyFields[Symbol.iterator] = function*() {
+  while (this.count++ < 100) yield "year";
+};
+
+assert.throws(RangeError, () => calendar.fields(manyFields), "Rejected duplicate values");
+assert.sameValue(manyFields.count, 2, "Rejected first duplicate value");

--- a/polyfill/test/Calendar/prototype/fields/argument-throws-invalid-keys.js
+++ b/polyfill/test/Calendar/prototype/fields/argument-throws-invalid-keys.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2021 Igalia, S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-temporal.calendar.prototype.fields
+description: Calendar.prototype.fields rejects input field names that are not singular names of temporal units
+info: |
+    sec-temporal.calendar.prototype.fields step 7.b.ii:
+      7. Repeat, while next is not false,
+        a. Set next to ? IteratorStep(iteratorRecord).
+        b. If next is not false, then
+          i. Let nextValue be ? IteratorValue(next).
+          ii. If Type(nextValue) is not String, then
+            1. Let completion be ThrowCompletion(a newly created TypeError object).
+            2. Return ? IteratorClose(iteratorRecord, completion).
+    sec-temporal.calendar.prototype.fields step 7.b.iv:
+          iv. If _nextValue_ is not one of *"year"*, *"month"*, *"monthCode"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"*, then
+            1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
+            2. Return ? IteratorClose(_iteratorRecord_, _completion_).
+
+features: [Temporal]
+---*/
+
+const calendar = new Temporal.Calendar("iso8601");
+assert.throws(TypeError, () => calendar.fields([1]));
+assert.throws(TypeError, () => calendar.fields([1n]));
+assert.throws(TypeError, () => calendar.fields([Symbol('foo')]));
+assert.throws(TypeError, () => calendar.fields([true]));
+assert.throws(TypeError, () => calendar.fields([null]));
+assert.throws(TypeError, () => calendar.fields([{}]));
+assert.throws(TypeError, () => calendar.fields([undefined]));
+assert.throws(TypeError, () => calendar.fields(["day", 1]));
+assert.throws(RangeError, () => calendar.fields(["month", "days"]));
+assert.throws(RangeError, () => calendar.fields(["days"]));
+assert.throws(RangeError, () => calendar.fields(["people"]));

--- a/polyfill/test/Calendar/prototype/fields/non-string-element-throws.js
+++ b/polyfill/test/Calendar/prototype/fields/non-string-element-throws.js
@@ -12,5 +12,5 @@ features: [Temporal]
 
 const calendar = new Temporal.Calendar("iso8601");
 [true, 3, 3n, {}, () => {}, Symbol(), undefined, null].forEach((element) => {
-  assert.throws(RangeError, () => calendar.fields([element]), "bad input to calendar.fields()");
+  assert.throws(TypeError, () => calendar.fields([element]), "bad input to calendar.fields()");
 });

--- a/polyfill/test/Calendar/prototype/fields/non-string-element-throws.js
+++ b/polyfill/test/Calendar/prototype/fields/non-string-element-throws.js
@@ -12,5 +12,5 @@ features: [Temporal]
 
 const calendar = new Temporal.Calendar("iso8601");
 [true, 3, 3n, {}, () => {}, Symbol(), undefined, null].forEach((element) => {
-  assert.throws(TypeError, () => calendar.fields([element]), "bad input to calendar.fields()");
+  assert.throws(RangeError, () => calendar.fields([element]), "bad input to calendar.fields()");
 });

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1077,13 +1077,12 @@
         1. Let _fieldNames_ be a new empty List.
         1. Let _next_ be *true*.
         1. Repeat, while _next_ is not *false*,
-          1. Let _length_ be the number of elements in _fieldNames_.
-          1. If _length_ &gt; 10, then
-            1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
-            1. Return ? IteratorClose(_iteratorRecord_, _completion_).
           1. Set _next_ to ? IteratorStep(_iteratorRecord_).
           1. If _next_ is not *false*, then
             1. Let _nextValue_ be ? IteratorValue(_next_).
+            1. If Type(_nextValue_) is not String, then
+              1. Let _completion_ be ThrowCompletion(a newly created *TypeError* object).
+              1. Return ? IteratorClose(_iteratorRecord_, _completion_).
             1. If _fieldNames_ contains _nextValue_, then
               1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
               1. Return ? IteratorClose(_iteratorRecord_, _completion_).

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1073,7 +1073,24 @@
         1. Let _calendar_ be the *this* value.
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
-        1. Let _fieldNames_ be ? IterableToListOfType(_fields_, « String »).
+        1. Let _iteratorRecord_ be ? Getiterator(_fields_, ~sync~).
+        1. Let _fieldNames_ be a new empty List.
+        1. Let _next_ be *true*.
+        1. Repeat, while _next_ is not *false*,
+          1. Let _length_ be the number of elements in _fieldNames_.
+          1. If _length_ &gt; 10, then
+            1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
+            1. Return ? IteratorClose(_iteratorRecord_, _completion_).
+          1. Set _next_ to ? IteratorStep(_iteratorRecord_).
+          1. If _next_ is not *false*, then
+            1. Let _nextValue_ be ? IteratorValue(_next_).
+            1. If _fieldNames_ contains _nextValue_, then
+              1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
+              1. Return ? IteratorClose(_iteratorRecord_, _completion_).
+            1. If _nextValue_ is not one of *"year"*, *"month"*, *"monthCode"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"*, then
+                1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
+                1. Return ? IteratorClose(_iteratorRecord_, _completion_).
+            1. Append _nextValue_ to the end of the List _fieldNames_.
         1. Return ! CreateArrayFromList(_fieldNames_).
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1579,13 +1579,12 @@
             1. Let _fieldNames_ be a new empty List.
             1. Let _next_ be *true*.
             1. Repeat, while _next_ is not *false*,
-              1. Let _length_ be the number of elements in _fieldNames_.
-              1. If _length_ &gt; 10, then
-                1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
-                1. Return ? IteratorClose(_iteratorRecord_, _completion_).
               1. Set _next_ to ? IteratorStep(_iteratorRecord_).
               1. If _next_ is not *false*, then
                 1. Let _nextValue_ be ? IteratorValue(_next_).
+                1. If Type(_nextValue_) is not String, then
+                  1. Let _completion_ be ThrowCompletion(a newly created *TypeError* object).
+                  1. Return ? IteratorClose(_iteratorRecord_, _completion_).
                 1. If _fieldNames_ contains _nextValue_, then
                   1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
                   1. Return ? IteratorClose(_iteratorRecord_, _completion_).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1575,7 +1575,24 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-            1. Let _fieldNames_ be ? IterableToListOfType(_fields_, « String »).
+            1. Let _iteratorRecord_ be ? Getiterator(_fields_, ~sync~).
+            1. Let _fieldNames_ be a new empty List.
+            1. Let _next_ be *true*.
+            1. Repeat, while _next_ is not *false*,
+              1. Let _length_ be the number of elements in _fieldNames_.
+              1. If _length_ &gt; 10, then
+                1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
+                1. Return ? IteratorClose(_iteratorRecord_, _completion_).
+              1. Set _next_ to ? IteratorStep(_iteratorRecord_).
+              1. If _next_ is not *false*, then
+                1. Let _nextValue_ be ? IteratorValue(_next_).
+                1. If _fieldNames_ contains _nextValue_, then
+                  1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
+                  1. Return ? IteratorClose(_iteratorRecord_, _completion_).
+                1. If _nextValue_ is not one of *"year"*, *"month"*, *"monthCode"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"*, then
+                    1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
+                    1. Return ? IteratorClose(_iteratorRecord_, _completion_).
+                1. Append _nextValue_ to the end of the List _fieldNames_.
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be _fieldNames_.
             1. Else,


### PR DESCRIPTION
As discussed in #1610, we restrict values returned by the iterator to be no more than the ten known values, prohibiting duplicates. The check for String values has been removed as all of those values are Strings, so the value restriction is plenty.

This does not address the question of return value validation.