### PR TITLE
Normative: Fix the scale adjustment of fractional duration string components

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1267,13 +1267,15 @@
         1. Let _microseconds_ be 0.
         1. Let _nanoseconds_ be 0.
       1. If _fHours_ is not *undefined*, then
-        1. Let _fraction_ be the part of _isoString_ produced by the |TimeFractionalPart| production.
-        1. Set _fHours_ to ! ToIntegerOrInfinity(_fraction_) × _factor_ / 10 raised to the power of the length of _fHours_.
+        1. Let _fHoursDigits_ be the substring of _fHours_ from 1.
+        1. Let _fHoursScale_ be the length of _fHoursDigits_.
+        1. Set _fHours_ to ! ToIntegerOrInfinity(_fHoursDigits_) × _factor_ / 10<sup>_fHoursScale_</sup>.
       1. Else,
         1. Set _fHours_ to 0.
       1. If _fMinutes_ is not *undefined*, then
-        1. Let _fraction_ be the part of _isoString_ produced by the |TimeFractionalPart| production.
-        1. Set _fMinutes_ to ! ToIntegerOrInfinity(_fraction_) × _factor_ / 10 raised to the power of the length of _fMinutes_.
+        1. Let _fMinutesDigits_ be the substring of _fMinutes_ from 1.
+        1. Let _fMinutesScale_ be the length of _fMinutesDigits_.
+        1. Set _fMinutes_ to ! ToIntegerOrInfinity(_fMinutesDigits_) × _factor_ / 10<sup>_fMinutesScale_</sup>.
       1. Else,
         1. Set _fMinutes_ to 0.
       1. Let _result_ be ? DurationHandleFractions(_fHours_, _minutes_, _fMinutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1254,13 +1254,13 @@
       1. Set _minutes_ to ? ToIntegerOrInfinity(_minutes_) × _factor_.
       1. Set _seconds_ to ? ToIntegerOrInfinity(_seconds_) × _factor_.
       1. If _fSeconds_ is not *undefined*, then
-        1. Let _fraction_ be the part of _isoString_ produced by the |TimeFractionalPart| production.
-        1. Set _fraction_ to the string-concatenation of the previous value of _fraction_ and the string *"000000000"*.
-        1. Let _milliseconds_ be the String value equal to the substring of _fraction_ from 0 to 3.
+        1. Let _fSecondsDigits_ be the substring of _fSeconds_ from 1.
+        1. Let _fSecondsDigitsExtended_ be the string-concatenation of _fSecondsDigits_ and *"000000000"*.
+        1. Let _milliseconds_ be the substring of _fSecondsDigitsExtended_ from 0 to 3.
         1. Set _milliseconds_ to ! ToIntegerOrInfinity(_milliseconds_) × _factor_.
-        1. Let _microseconds_ be the String value equal to the substring of _fraction_ from 3 to 6.
+        1. Let _microseconds_ be the substring of _fSecondsDigitsExtended_ from 3 to 6.
         1. Set _microseconds_ to ! ToIntegerOrInfinity(_microseconds_) × _factor_.
-        1. Let _nanoseconds_ be the String value equal to the substring of _fraction_ from 6 to 9.
+        1. Let _nanoseconds_ be the substring of _fSecondsDigitsExtended_ from 6 to 9.
         1. Set _nanoseconds_ to ! ToIntegerOrInfinity(_nanoseconds_) × _factor_.
       1. Else,
         1. Let _milliseconds_ be 0.


### PR DESCRIPTION
Fixes #1758, which is clearly a spec bug, and also reduces nearby ambiguity by eliminating context-free references to |TimeFractionalPart|. I'd further like to bring _fSeconds_ into alignment as well, but left that out here to avoid cluttering up the diff.