### PR TITLE
Editoral: Call ToString before ParseTimeZoneOffsetString

### DIFF
--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -588,7 +588,7 @@
         1. If _offsetString_ is not *undefined*, then
           1. Perform ? Set(_fields_, *"offset"*, _offsetString_).
         1. Else,
-          1. Set _offsetString_ to ? Get(_fields_, *"offset"*).
+          1. Set _offsetString_ to ? ToString(? Get(_fields_, *"offset"*)).
         1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -584,11 +584,11 @@
         1. Let _fields_ be ? PrepareTemporalFields(_zonedDateTime_, _fieldNames_, « *"timeZone"* »).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialZonedDateTime_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « *"timeZone"* »).
-        1. Let _offsetString_ be ? Get(_partialZonedDateTime_, *"offset"*).
+        1. Let _offsetString_ be ! Get(_partialZonedDateTime_, *"offset"*).
         1. If _offsetString_ is not *undefined*, then
           1. Perform ? Set(_fields_, *"offset"*, _offsetString_).
         1. Else,
-          1. Set _offsetString_ to ? ToString(? Get(_fields_, *"offset"*)).
+          1. Set _offsetString_ to ? ToString(! Get(_fields_, *"offset"*)).
         1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).


### PR DESCRIPTION
in Temporal.ZonedDateTime.prototype.with we need to call ToString before passing that string to ParseTimeZoneOffsetString

https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.with
offsetString could be anything after the Get but ParseTimeZoneOffsetString assert on the argument to be String
@ptomato @Ms2ger @ljharb 