### PR TITLE
initialize whole if unit is "nanosecond" in Duration.total

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -488,6 +488,8 @@
           1. Let _whole_ be _roundResult_.[[Milliseconds]].
         1. If _unit_ is *"microsecond"*, then
           1. Let _whole_ be _roundResult_.[[Microseconds]].
+        1. If _unit_ is *"nanosecond"*, then
+          1. Let _whole_ be _roundResult_.[[Nanoseconds]].
         1. Return _whole_ + _roundResult_.[[Remainder]].
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
In Temporal.Duration.prototype.total
If unit is "nanosecond" currently the variable whole is uninitialized. Need to initialize it to the correct value.

https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.total

@ptomato @ljharb @Ms2ger @ryzokuken @justingrant 