### PR TITLE
Normative: Remove extra  NegateTemporalRoundingMode which revert the effect of the first one.

### DIFF
--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -370,7 +370,6 @@
         1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
           1. Return ? CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _relativeTo_ be ? CreateTemporalDateTime(_thisDate_.[[ISOYear]], _thisDate_.[[ISOMonth]], _thisDate_.[[ISODay]], 0, 0, 0, 0, 0, 0, _calendar_).
-        1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _result_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
         1. Return ? CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>


### PR DESCRIPTION
Notice currently the NegateTemporalRoundingMode got called twice in 
https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.since

```
12. Set roundingMode to ! NegateTemporalRoundingMode(roundingMode).
...
25. Set roundingMode to ! NegateTemporalRoundingMode(roundingMode).
```
and there are no code to use roundingMode between step 12 and step 25. I believe the one in step 25 is extra, which  "revert" the negation of the rounding mode in step 12.


@ptomato @justingrant @ljharb @ryzokuken @Ms2ger 