### PR TITLE
Normative: Fix typo in UnbalanceDurationRelative.

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -965,7 +965,7 @@
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
             1. Set _months_ to _months_ − _sign_.
         1. Else,
-          1. If any of _years_, _months_, and _days_ are not zero, then
+          1. If any of _years_, _months_, and _weeks_ are not zero, then
             1. If _calendar_ is *undefined*, then
               1. Throw a *RangeError* exception.
             1. Repeat, while _years_ ≠ 0,


### PR DESCRIPTION
UnbalanceDurationRelative has this guard:
```
12. Else,
    a. If any of years, months, and days are not zero, then
```
However, it takes action based on `years`, `months`, and _`weeks`_, not `days`.

Swapping the variable seems to match what the [polyfill](https://github.com/rkirsling/proposal-temporal/blob/patch-1/polyfill/lib/ecmascript.mjs#L2633) actually does, but it's not the only possible solution—note that the handling of `days` in this AO is currently pretty weird:

-  If `days` is the only non-zero unit and `relativeTo` is undefined, then (as of this proposed change), we throw just when the unit is `"month"` or `"week"`.
- But nothing in this AO performs a calculation based on `days`—in particular, the `"month"` and `"week"` paths do not differ from the Else path in this respect, so they should probably exhibit the same throwing behavior.
- If throwing on non-zero `days` is intentional, then 12a should simply be removed. If not, then the `"month"` and `"week"` paths should have similar guards.