### PR TITLE
Editoral: use Set to instead of Let be for old var

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1041,9 +1041,9 @@
             1. Set _months_ to _months_ − _oneYearMonths_.
             1. Set _years_ to _years_ + _sign_.
             1. Set _relativeTo_ to _newRelativeTo_.
-            1. Let _addOptions_ be ! OrdinaryObjectCreate(*null*).
+            1. Set _addOptions_ to ! OrdinaryObjectCreate(*null*).
             1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, _addOptions_, _dateAdd_).
-            1. Let _untilOptions_ be ! OrdinaryObjectCreate(*null*).
+            1. Set _untilOptions_ to ! OrdinaryObjectCreate(*null*).
             1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
             1. Set _untilResult_ to ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
             1. Set _oneYearMonths_ to ? Get(_untilResult_, *"months"*).


### PR DESCRIPTION
In 7.5.12 BalanceDurationRelative ( years, months, weeks, days, largestUnit, relativeTo )
https://tc39.es/proposal-temporal/#sec-temporal-balancedurationrelative

Chagne to use "Set ... to" instead of "Let .. be" 
for 
1. addOptions in step 9-q-iv because it is already use in step 9-j
2. untilOptions in step 9-q-vi because it is already use in step 9-m

@ptomato @ljharb @ryzokuken @Ms2ger 