### PR TITLE
Fix TS types bug in ZonedDateTimeISOFields

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1357,7 +1357,7 @@ export namespace Temporal {
     isoMillisecond: number;
     isoMicrosecond: number;
     isoNanosecond: number;
-    offsetNanoseconds: number;
+    offset: string;
     timeZone: TimeZoneProtocol;
     calendar: CalendarProtocol;
   };


### PR DESCRIPTION
Fixes a bug found in https://github.com/js-temporal/temporal-polyfill/pull/37 where the TS types didn't match the implementation.