### PR TITLE
Normative: Fix [[TimeZoneOffsetString]] value in ParseTemporalInstantString

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1165,7 +1165,7 @@
         [[Millisecond]]: _result_.[[Millisecond]],
         [[Microsecond]]: _result_.[[Microsecond]],
         [[Nanosecond]]: _result_.[[Nanosecond]],
-        [[TimeZoneOffsetString]]: _timeZoneResult_.[[OffsetString]]
+        [[TimeZoneOffsetString]]: _offsetString_
         }.
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
This sets `offsetString` to `timeZoneResult.[[OffsetString]]` and overwrites it in the next step if necessary, but the `[[TimeZoneOffsetString]]` field in the returned record uses `timeZoneResult.[[OffsetString]]` again instead of `offsetString` as intended.

This change is needed to actually make the fix attempted in f6ac475 work.