### PR TITLE
Allow other repositories to re-use the Test262 setup.

### DIFF
--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TESTS=${@:-"./*/**/*.js"}
+PRELUDE=${PRELUDE:-script.js}
 
 export NODE_PATH=$PWD/node_modules
 npm run build262
@@ -13,9 +14,8 @@ else
   cd ..
 fi
 
-PRELUDE=script.js
 if [ "x$COVERAGE" = xyes ]; then
-  nyc instrument script.js > script-instrumented.js
+  nyc instrument "$PRELUDE" > script-instrumented.js
   PRELUDE=script-instrumented.js
   TRANSFORMER_ARG="--transformer ./transform.test262.js"
 fi


### PR DESCRIPTION
Allow the prelude used with the Test262 harness to be specified via an
environment variable so other Temporal polyfills can re-use the test
harness.

This is in preparation for fixing https://github.com/js-temporal/temporal-polyfill/issues/4.