### PR TITLE
Fix crash setting `day` outside current era bounds

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1915,6 +1915,8 @@ const nonIsoGeneralImpl = {
   mergeFields(fields, additionalFields) {
     const fieldsCopy = { ...fields };
     const additionalFieldsCopy = { ...additionalFields };
+    // era and eraYear are intentionally unused
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { month, monthCode, year, era, eraYear, ...original } = fieldsCopy;
     const {
       month: newMonth,
@@ -1928,9 +1930,10 @@ const nonIsoGeneralImpl = {
       original.monthCode = monthCode;
     }
     if (newYear === undefined && newEra === undefined && newEraYear === undefined) {
+      // Only `year` is needed. We don't set era and eraYear because it's
+      // possible to create a conflict for eras that start or end mid-year. See
+      // https://github.com/tc39/proposal-temporal/issues/1784.
       original.year = year;
-      original.era = era;
-      original.eraYear = eraYear;
     }
     return { ...original, ...additionalFieldsCopy };
   },

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -1092,6 +1092,13 @@ describe('Intl', () => {
       // equal(date.era, 'bce');
       // equal(date.eraYear, 1);
     });
+    it("`with` doesn't crash when constraining dates out of bounds of the current era", () => {
+      // https://github.com/tc39/proposal-temporal/issues/1784
+      let date = Temporal.PlainDate.from('1989-01-07')
+        .withCalendar(Temporal.Calendar.from('japanese'))
+        .with({ day: 10 });
+      equal(`${date}`, '1989-01-10[u-ca=japanese]');
+    });
   });
 
   describe('Hebrew leap months', () => {


### PR DESCRIPTION
This PR fixes non-ISO calendars' `mergeFields` implementation that was crashing when using `with` for for Japanese calendars to set the day to a day outside the current era.

The root cause was that mergeFields was merging the original `year`,`era`, and `eraYear` with the user-provided `day` field. This fails in calendars like Japanese where eras start and/or end mid-month. So by changing the `day`, suddenly the calculated era won't match the `era` field and we'll throw.  The fix was to omit `era`/`eraYear` from the results in this case because `year` is sufficient.

Fixes #1784