### PR TITLE
Easier debugging and troubleshooting of Test262 tests

### DIFF
--- a/polyfill/ci_test.sh
+++ b/polyfill/ci_test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TESTS=${@:-"./*/**/*.js"}
+TIMEOUT=${TIMEOUT:-10000}
 PRELUDE=${PRELUDE:-script.js}
 
 export NODE_PATH=$PWD/node_modules
@@ -37,6 +38,7 @@ test262-harness \
   --reporter-keys file,rawResult,result,scenario \
   --test262Dir ../test262 \
   --prelude "../$PRELUDE" \
+  --timeout "$TIMEOUT" \
   --preprocessor ./preprocessor.test262.js \
   $TRANSFORMER_ARG \
   "$TESTS" \

--- a/polyfill/test/parseResults.js
+++ b/polyfill/test/parseResults.js
@@ -52,6 +52,11 @@ stdin.on('end', function () {
   const unexpectedPasses = [];
   for (const test of tests) {
     const { result, scenario, file } = test;
+    if (result.message === 'Debugger attached.\nWaiting for the debugger to disconnect...\n') {
+      // work around https://github.com/nodejs/node/issues/34799 when running tests in the debugger
+      result.message = '';
+      result.pass = true;
+    }
     const expectedFailure = expectedFailures.has(file);
     const message = `${PREFIXES[+expectedFailure][+result.pass]} ${file} (${scenario})\n`;
     stdout.write(message);


### PR DESCRIPTION
This PR enables running Test262 in debuggers like VSCode:
* Adds a `TIMEOUT` environment variable (in msecs) to prevent the harness from killing the process while you're debugging it. Default is 10,000ms === 10 seconds. (same as existing default)
* Works around a problem where passing tests were mistakenly labelled as failures when run in the debugger because of Node's debug-related console output.

js-temporal/temporal-polyfill#46 depends on this PR to work properly.