### PR TITLE
Fix build for zh_CN  docs

### DIFF
--- a/docs/buildDocs.js
+++ b/docs/buildDocs.js
@@ -122,9 +122,10 @@ async function go() {
     const tail = await fs.readFile('tail.html.part', { encoding });
     // copy or render /docs/* to /out/docs/
     await Promise.all(
-      [...(await fs.readdir('.')), 
-       ...(await fs.readdir('ja')).map((x) => 'ja/' + x), 
-       ...(await fs.readdir('zh_CN')).map((x) => 'zh_CN/' + x)
+      [
+        ...(await fs.readdir('.')),
+        ...(await fs.readdir('ja')).map((x) => 'ja/' + x),
+        ...(await fs.readdir('zh_CN')).map((x) => 'zh_CN/' + x)
       ].map((file) => {
         switch (path.extname(file)) {
           // copy files *.css, *.html, *.svg to /out/docs

--- a/docs/buildDocs.js
+++ b/docs/buildDocs.js
@@ -122,7 +122,10 @@ async function go() {
     const tail = await fs.readFile('tail.html.part', { encoding });
     // copy or render /docs/* to /out/docs/
     await Promise.all(
-      [...(await fs.readdir('.')), ...(await fs.readdir('ja')).map((x) => 'ja/' + x)].map((file) => {
+      [...(await fs.readdir('.')), 
+       ...(await fs.readdir('ja')).map((x) => 'ja/' + x), 
+       ...(await fs.readdir('zh_CN')).map((x) => 'zh_CN/' + x)
+      ].map((file) => {
         switch (path.extname(file)) {
           // copy files *.css, *.html, *.svg to /out/docs
           case '.css':
@@ -151,6 +154,7 @@ async function go() {
       [
         ['../out/docs/README.html', '../out/docs/index.html'],
         ['../out/docs/ja/README.html', '../out/docs/ja/index.html'],
+        ['../out/docs/zh_CN/README.html', '../out/docs/zh_CN/index.html'],
         ['node_modules/prismjs/themes/prism.css', '../out/docs/prism.css']
       ].map(([file1, file2]) => {
         return fs.copyFile(path.resolve(file1), path.resolve(file2));


### PR DESCRIPTION
Currently, in
https://github.com/tc39/proposal-temporal/README.md
Temporal 文档(zh_CN) (translated a part of the English document into Chinese)
is pointing to https://tc39.es/proposal-temporal/docs/zh_CN/
but got a 404, try to fix the build rule to push it to https://tc39.es/proposal-temporal/docs/zh_CN/

I hope I did the right thing here....

@ryzokuken @sititou70 @ptomato @sxyazi