### PR TITLE
Editorial: pass relativeTo as PlainDateTime MoveRelativeDate

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1210,7 +1210,7 @@
       </p>
       <emu-alg>
         1. Assert: Type(_relativeTo_) is Object.
-        1. Assert: _relativeTo_ has an [[InitializedTemporalDateTime]] internal slot.        
+        1. Assert: _relativeTo_ has an [[InitializedTemporalDateTime]] internal slot.
         1. Let _options_ be ! OrdinaryObjectCreate(*null*).
         1. Let _later_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _duration_, _options_).
         1. Let _days_ be ? DaysUntil(_relativeTo_, _later_).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1209,6 +1209,8 @@
         This is used when balancing or rounding durations relative to a particular date.
       </p>
       <emu-alg>
+        1. Assert: Type(_relativeTo_) is Object.
+        1. Assert: _relativeTo_ has an [[InitializedTemporalDateTime]] internal slot.        
         1. Let _options_ be ! OrdinaryObjectCreate(*null*).
         1. Let _later_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _duration_, _options_).
         1. Let _days_ be ? DaysUntil(_relativeTo_, _later_).
@@ -1286,6 +1288,7 @@
           1. Let _sign_ be ! Sign(_days_).
           1. If _sign_ is 0, set _sign_ to 1.
           1. Let _oneYear_ be ? CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Set _relativeTo_ to ! CreateTemporalDateTime(_relativeTo_.[[ISOYear]], _relativeTo_.[[ISOMonth]], _relativeTo_.[[ISODay]], 0, 0, 0, 0, 0, 0, _relativeTo_.[[Calendar]]).
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
           1. Let _fractionalYears_ be _years_ + _days_ / abs(_oneYearDays_).
@@ -1306,6 +1309,7 @@
           1. Let _sign_ be ! Sign(_days_).
           1. If _sign_ is 0, set _sign_ to 1.
           1. Let _oneMonth_ be ? CreateTemporalDuration(0, _sign_, 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Set _relativeTo_ to ! CreateTemporalDateTime(_relativeTo_.[[ISOYear]], _relativeTo_.[[ISOMonth]], _relativeTo_.[[ISODay]], 0, 0, 0, 0, 0, 0, _relativeTo_.[[Calendar]]).
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].


### PR DESCRIPTION
Always pass relativeTo as PlainDateTime to MoveRelativeDate
Assert the relativeTo
Convert to PlainDateTime inside 
RoundDuration
https://tc39.es/proposal-temporal/#sec-temporal-roundduration

Address https://github.com/tc39/proposal-temporal/issues/1782

@ptomato @justingrant @ryzokuken @Ms2ger 