### PR TITLE
Editorial: Pass in T*PlainDateTime to GetPossibleInstantsFor

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -642,12 +642,14 @@
         1. Let _nanoseconds_ be _offsetAfter_ − _offsetBefore_.
         1. If _disambiguation_ is *"earlier"*, then
           1. Let _earlier_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, −_nanoseconds_, *undefined*).
-          1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlier_).
+          1. Let _earlier_date_time_ be ? CreateTemporalDateTime(_earlier_.[[Year]], _earlier_.[[Month]], _earlier_.[[Day]], _earlier_.[[Hour]], _earlier_.[[Minute]], _earlier_.[[Second]], _earlier_.[[Millisecond]], _earlier_.[[Microsecond]], _earlier_.[[Nanosecond]], _dateTime_.[[Calendar]]).
+          1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlier_date_time_).
           1. If _possibleInstants_ is empty, throw a *RangeError* exception.
           1. Return _possibleInstants_[0].
         1. Assert: _disambiguation_ is *"compatible"* or *"later"*.
         1. Let _later_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, _nanoseconds_, *undefined*).
-        1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _later_).
+        1. Let _later_date_time_ be ? CreateTemporalDateTime(_later_.[[Year]], _later_.[[Month]], _later_.[[Day]], _later_.[[Hour]], _later_.[[Minute]], _later_.[[Second]], _later_.[[Millisecond]], _later_.[[Microsecond]], _later_.[[Nanosecond]], _dateTime_.[[Calendar]]).
+        1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _later_date_time_).
         1. Set _n_ to _possibleInstants_'s length.
         1. If _n_ = 0, throw a *RangeError* exception.
         1. Return _possibleInstants_[_n_ − 1].
@@ -657,6 +659,7 @@
     <emu-clause id="sec-temporal-getpossibleinstantsfor" aoid="GetPossibleInstantsFor">
       <h1>GetPossibleInstantsFor ( _timeZone_, _dateTime_ )</h1>
       <emu-alg>
+        1. Assert: _dateTime_ has an [[InitializedTemporalDateTime]] internal slot.
         1. Let _possibleInstants_ be ? Invoke(_timeZone_, *"getPossibleInstantsFor"*, « _dateTime_ »).
         1. Let _iteratorRecord_ be ? GetIterator(_possibleInstants_, ~sync~).
         1. Let _list_ be a new empty List.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -642,14 +642,14 @@
         1. Let _nanoseconds_ be _offsetAfter_ − _offsetBefore_.
         1. If _disambiguation_ is *"earlier"*, then
           1. Let _earlier_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, −_nanoseconds_, *undefined*).
-          1. Let _earlier_date_time_ be ? CreateTemporalDateTime(_earlier_.[[Year]], _earlier_.[[Month]], _earlier_.[[Day]], _earlier_.[[Hour]], _earlier_.[[Minute]], _earlier_.[[Second]], _earlier_.[[Millisecond]], _earlier_.[[Microsecond]], _earlier_.[[Nanosecond]], _dateTime_.[[Calendar]]).
-          1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlier_date_time_).
+          1. Let _earlierDateTime_ be ? CreateTemporalDateTime(_earlier_.[[Year]], _earlier_.[[Month]], _earlier_.[[Day]], _earlier_.[[Hour]], _earlier_.[[Minute]], _earlier_.[[Second]], _earlier_.[[Millisecond]], _earlier_.[[Microsecond]], _earlier_.[[Nanosecond]], _dateTime_.[[Calendar]]).
+          1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
           1. If _possibleInstants_ is empty, throw a *RangeError* exception.
           1. Return _possibleInstants_[0].
         1. Assert: _disambiguation_ is *"compatible"* or *"later"*.
         1. Let _later_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, _nanoseconds_, *undefined*).
-        1. Let _later_date_time_ be ? CreateTemporalDateTime(_later_.[[Year]], _later_.[[Month]], _later_.[[Day]], _later_.[[Hour]], _later_.[[Minute]], _later_.[[Second]], _later_.[[Millisecond]], _later_.[[Microsecond]], _later_.[[Nanosecond]], _dateTime_.[[Calendar]]).
-        1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _later_date_time_).
+        1. Let _laterDateTime_ be ? CreateTemporalDateTime(_later_.[[Year]], _later_.[[Month]], _later_.[[Day]], _later_.[[Hour]], _later_.[[Minute]], _later_.[[Second]], _later_.[[Millisecond]], _later_.[[Microsecond]], _later_.[[Nanosecond]], _dateTime_.[[Calendar]]).
+        1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
         1. Set _n_ to _possibleInstants_'s length.
         1. If _n_ = 0, throw a *RangeError* exception.
         1. Return _possibleInstants_[_n_ − 1].

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -648,7 +648,7 @@
           1. Return _possibleInstants_[0].
         1. Assert: _disambiguation_ is *"compatible"* or *"later"*.
         1. Let _later_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, _nanoseconds_, *undefined*).
-        1. Let _laterDateTime_ be ? CreateTemporalDateTime(_later_.[[Year]], _later_.[[Month]], _later_.[[Day]], _later_.[[Hour]], _later_.[[Minute]], _later_.[[Second]], _later_.[[Millisecond]], _later_.[[Microsecond]], _later_.[[Nanosecond]], _dateTime_.[[Calendar]]).
+        1. Let _laterDateTime_ be ! CreateTemporalDateTime(_later_.[[Year]], _later_.[[Month]], _later_.[[Day]], _later_.[[Hour]], _later_.[[Minute]], _later_.[[Second]], _later_.[[Millisecond]], _later_.[[Microsecond]], _later_.[[Nanosecond]], _dateTime_.[[Calendar]]).
         1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
         1. Set _n_ to _possibleInstants_'s length.
         1. If _n_ = 0, throw a *RangeError* exception.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -642,7 +642,7 @@
         1. Let _nanoseconds_ be _offsetAfter_ − _offsetBefore_.
         1. If _disambiguation_ is *"earlier"*, then
           1. Let _earlier_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, −_nanoseconds_, *undefined*).
-          1. Let _earlierDateTime_ be ? CreateTemporalDateTime(_earlier_.[[Year]], _earlier_.[[Month]], _earlier_.[[Day]], _earlier_.[[Hour]], _earlier_.[[Minute]], _earlier_.[[Second]], _earlier_.[[Millisecond]], _earlier_.[[Microsecond]], _earlier_.[[Nanosecond]], _dateTime_.[[Calendar]]).
+          1. Let _earlierDateTime_ be ! CreateTemporalDateTime(_earlier_.[[Year]], _earlier_.[[Month]], _earlier_.[[Day]], _earlier_.[[Hour]], _earlier_.[[Minute]], _earlier_.[[Second]], _earlier_.[[Millisecond]], _earlier_.[[Microsecond]], _earlier_.[[Nanosecond]], _dateTime_.[[Calendar]]).
           1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
           1. If _possibleInstants_ is empty, throw a *RangeError* exception.
           1. Return _possibleInstants_[0].


### PR DESCRIPTION
Pass in TemporalPlainDateTime to GetPossibleInstantsFor

Fix the issue that DisambiguatePossibleInstants pass Record return from AddDateTime into Invoke inside GetPossibleInstantsFor reported in https://github.com/tc39/proposal-temporal/issues/1816

I mark this as Editorial because the current spec text is unimplementable w/o this fix.

@ptomato @justingrant @Ms2ger @ljharb @ryzokuken 



