### PR TITLE
Editorial: Read [[TimeZoneZ]]  instead of [[Z]]

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -509,7 +509,7 @@
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).
         1. Let _offsetString_ be _result_.[[TimeZoneOffset]].
         1. Let _timeZone_ be _result_.[[TimeZoneIANAName]].
-        1. If _result_.[[Z]] is *true*, then
+        1. If _result_.[[TimeZoneZ]] is *true*, then
           1. Set _offsetBehaviour_ to ~exact~.
         1. Else if _offsetString_ is *undefined*, then
           1. Set _offsetBehaviour_ to ~wall~.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1137,7 +1137,7 @@
           1. Let _result_ be ? ParseTemporalZonedDateTimeString(_string_).
           1. Assert: _result_.[[TimeZoneName]] is not *undefined*.
           1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
-          1. If _result_.[[Z]] is *true*, then
+          1. If _result_.[[TimeZoneZ]] is *true*, then
             1. Set _offsetBehaviour_ to ~exact~.
           1. Else if _offsetString_ is *undefined*, then
             1. Set _offsetBehaviour_ to ~wall~.


### PR DESCRIPTION
Rename the reading of [[Z]] to [[TimeZoneZ]]  

ParseTemporalZonedDateTimeString is called inside
ToTemporalZonedDateTime https://tc39.es/proposal-temporal/#sec-temporal-totemporalzoneddatetime
```
step 4
c. Let result be ? ParseTemporalZonedDateTimeString(string).
...
f. If result.[[Z]] is true, then
```
But
ParseTemporalZonedDateTimeString 
https://tc39.es/proposal-temporal/#sec-temporal-parsetemporalzoneddatetimestring
return that field as [[TimeZoneZ]]
```
5. Return the Record { [[Year]]: result.[[Year]], [[Month]]: result.[[Month]], [[Day]]: result.[[Day]], 
[[Hour]]: result.[[Hour]], [[Minute]]: result.[[Minute]], [[Second]]: result.[[Second]], 
[[Millisecond]]: result.[[Millisecond]], [[Microsecond]]: result.[[Microsecond]], 
[[Nanosecond]]: result.[[Nanosecond]], [[TimeZoneZ]]: timeZoneResult.[[Z]], 
[[TimeZoneOffsetString]]: timeZoneResult.[[OffsetString]], [[TimeZoneName]]: timeZoneResult.[[Name]] }.
```
not [[Z]]

ParseTemporalRelativeToString is called inside 
ToRelativeTemporalObject
https://tc39.es/proposal-temporal/#sec-temporal-torelativetemporalobject

```
in step 6
b. Let result be ? ParseTemporalRelativeToString(string).
...
f. If result.[[Z]] is true, then
```

but ParseTemporalRelativeToString  
https://tc39.es/proposal-temporal/#sec-temporal-parsetemporalrelativetostring
return that field as [[TimeZoneZ]]
```
6. Return the Record { [[Year]]: result.[[Year]], [[Month]]: result.[[Month]], [[Day]]: result.[[Day]], 
[[Hour]]: result.[[Hour]], [[Minute]]: result.[[Minute]], [[Second]]: result.[[Second]], [[Millisecond]]: result.[[Millisecond]],
[[Microsecond]]: result.[[Microsecond]], [[Nanosecond]]: result.[[Nanosecond]], [[Calendar]]: result.[[Calendar]],
[[TimeZoneZ]]: z, [[TimeZoneOffset]]: offset, [[TimeZoneIANAName]]: timeZone }.
```

I mark this PR Editorial because w/o this PR the spec is not implementable. 

@ptomato @ljharb @Ms2ger @justingrant @ryzokuken 