### PR TITLE
Editorial: Remove "or *undefined*" from  InterpretISODateTimeOffset assert

### DIFF
--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1087,7 +1087,7 @@
         In the case of more than one possible exact time, or no possible exact time, an answer is determined using _offsetBehaviour_ (one of ~option~, ~exact~, or ~wall~), _disambiguation_ (one of *"earlier"*, *"later"*, *"compatible"*, or *"reject"*) and _offsetOption_ (one of *"ignore"*, *"use"*, *"prefer"*, or *"reject"*).
       </p>
       <emu-alg>
-        1. Assert: _offsetNanoseconds_ is an integer or *undefined*.
+        1. Assert: _offsetNanoseconds_ is an integer.
         1. Let _calendar_ be ! GetISO8601Calendar().
         1. Let _dateTime_ be ? CreateTemporalDateTime(_year_, _month_, _day_, _hour_, _minute_. _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_).
         1. If _offsetBehaviour_ is ~wall~, or _offsetOption_ is *"ignore"*, then


### PR DESCRIPTION
Remove "or *undefined*" from the assert of offsetNanoseconds in InterpretISODateTimeOffset
This is no longer needed. offsetNanoseconds now will not be undefined after the merge of 
https://github.com/tc39/proposal-temporal/commit/f6ac475e6131ab0f11dc641ae55dcf72e6ab1118

It used to accept undefined but the above commit set that value to 0 so all the possible cases are now all integer

@ptomato @justingrant @ljharb @ryzokuken @Ms2ger 

There are 4 Callers of InterpretISODateTimeOffset

6.3.30 Temporal.ZonedDateTime.prototype.with ( temporalZonedDateTimeLike [ , options ] )
https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.with
```
25. Let offsetNanoseconds be ? ParseTimeZoneOffsetString(offsetString).
26. Let epochNanoseconds be ? InterpretISODateTimeOffset(...
```
ParseTimeZoneOffsetString alsways return integer. 

6.3.39 Temporal.ZonedDateTime.prototype.round ( options )
https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.round

```
21. Let offsetNanoseconds be ? GetOffsetNanosecondsFor(timeZone, instant).
22. Let epochNanoseconds be ? InterpretISODateTimeOffset(
```
GetOffsetNanosecondsFor alsways return integer. 

6.5.2 ToTemporalZonedDateTime ( item [ , options ] )
https://tc39.es/proposal-temporal/#sec-temporal-totemporalzoneddatetime
```
5. Let offsetNanoseconds be 0.
6. If offsetBehaviour is option, then
a. Set offsetNanoseconds to ? ParseTimeZoneOffsetString(offsetString).
...
9. Let epochNanoseconds be ? InterpretISODateTimeOffset(
```

13.21 ToRelativeTemporalObject ( options )
https://tc39.es/proposal-temporal/#sec-temporal-torelativetemporalobject

```
b. If offsetBehaviour is option, then
...
ii. Let offsetNs be ? ParseTimeZoneOffsetString(offsetString).
c. Else,
i. Let offsetNs be 0.
d. Let epochNanoseconds be ? InterpretISODateTimeOffset(
```

@ptomato @justingrant @Ms2ger @ryzokuken @ljharb 