### PR TITLE
Normative: Remove step 2 of GetOffsetNanosecondsFor

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -565,7 +565,6 @@
       <h1>GetOffsetNanosecondsFor ( _timeZone_, _instant_ )</h1>
       <emu-alg>
         1. Let _getOffsetNanosecondsFor_ be ? GetMethod(_timeZone_, *"getOffsetNanosecondsFor"*).
-        1. If _getOffsetNanosecondsFor_ is *undefined*, set _getOffsetNanosecondsFor_ to %Temporal.TimeZone.prototype.getOffsetNanosecondsFor%.
         1. Let _offsetNanoseconds_ be ? Call(_getOffsetNanosecondsFor_, _timeZone_, « _instant_ »).
         1. If Type(_offsetNanoseconds_) is not Number, throw a *TypeError* exception.
         1. If ! IsIntegralNumber(_offsetNanoseconds_) is *false*, throw a *RangeError* exception.


### PR DESCRIPTION
Discussed this in bi-weekly meeting 2021-09-16

1. If the timeZone is not a Custom time zones and the caller does not modify timeZone then "If getOffsetNanosecondsFor is undefined" will be false and this step is no-op
2. If the timeZone is a Custom time zones which is  from an object of " a class inheriting from Temporal.TimeZone" , then "If getOffsetNanosecondsFor is undefined" will be false and this step is no-op
3. If the timeZone is a Custom time zones which is "a plain object implementing the Temporal.TimeZone protocol, without subclassing." then it will not have a [[InitializedTemporalTimeZone]] internal slot, and the 
step 2. Perform ? RequireInternalSlot(timeZone, [[InitializedTemporalTimeZone]]).
in 11.4.4 Temporal.TimeZone.prototype.getOffsetNanosecondsFor ( instant ) will throw when GetOffsetNanosecondsFor proceed and run step 3. Let offsetNanoseconds be ? Call(getOffsetNanosecondsFor, timeZone, « instant »). anyway
4. The only case getOffsetNanosecondsFor is undefined and may be impacted is when we have a builtin TimeZone or  " a class inheriting from Temporal.TimeZone" and the developer set the getOffsetNanosecondsFor to undefined, then it will not throw. But there are no reason we should force it not throw if the developer want to remove getOffsetNanosecondsFor. 

Based on the discussion in that meeting, I put the PR here to receive feedback and see is there any reason we should not remove that step. 

@ptomato @sffc @ljharb @justingrant @ryzokuken @Ms2ger @anba 