### PR TITLE
Normative: shift substring index by 1 to count "."

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1433,7 +1433,7 @@
         1. Set _seconds_ to ! ToIntegerOrInfinity(_seconds_).
         1. If _fraction_ is not *undefined*, then
           1. Set _fraction_ to the string-concatenation of the previous value of _fraction_ and the string *"000000000"*.
-          1. Let _nanoseconds_ be the String value equal to the substring of _fraction_ from 0 to 9.
+          1. Let _nanoseconds_ be the String value equal to the substring of _fraction_ from 1 to 10.
           1. Set _nanoseconds_ to ! ToIntegerOrInfinity(_nanoseconds_).
         1. Else,
           1. Let _nanoseconds_ be 0.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1433,7 +1433,7 @@
         1. Set _seconds_ to ! ToIntegerOrInfinity(_seconds_).
         1. If _fraction_ is not *undefined*, then
           1. Set _fraction_ to the string-concatenation of the previous value of _fraction_ and the string *"000000000"*.
-          1. Let _nanoseconds_ be the String value equal to the substring of _fraction_ consisting of the code units with indices 1 (inclusive) through 10 (exclusive).
+          1. Let _nanoseconds_ be the String value equal to the substring of _fraction_ from 1 to 10.
           1. Set _nanoseconds_ to ! ToIntegerOrInfinity(_nanoseconds_).
         1. Else,
           1. Let _nanoseconds_ be 0.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1433,7 +1433,7 @@
         1. Set _seconds_ to ! ToIntegerOrInfinity(_seconds_).
         1. If _fraction_ is not *undefined*, then
           1. Set _fraction_ to the string-concatenation of the previous value of _fraction_ and the string *"000000000"*.
-          1. Let _nanoseconds_ be the String value equal to the substring of _fraction_ from 1 to 10.
+          1. Let _nanoseconds_ be the String value equal to the substring of _fraction_ consisting of the code units with indices 1 (inclusive) through 10 (exclusive).
           1. Set _nanoseconds_ to ! ToIntegerOrInfinity(_nanoseconds_).
         1. Else,
           1. Let _nanoseconds_ be 0.


### PR DESCRIPTION
fraction in ParseTemporalTimeZoneString is referring to TimeZoneUTCOffsetFraction which include the "." in the first char.
Therefore the substring of fraction from 0 to 9 is ".12345678" but not "123456789' .
change it from 0 to 9 to 1 to 10 will make it to be "123456789'

Fix https://github.com/tc39/proposal-temporal/issues/1795

Also an editoral change based on the text in ParseTimeZoneOffsetString which  state 

"... consisting of the code units with indices **start** (inclusive) through **end** (exclusive)."

@ptomato @justingrant @Ms2ger @ljharb @gibson042 