### PR TITLE
Docs: `compare` methods now ignore calendar/TZ

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -129,14 +129,14 @@ date = Temporal.PlainDate.from({ year: 2001, month: 1, day: 32 }, { overflow: 'r
 Compares two `Temporal.PlainDate` objects.
 Returns an integer indicating whether `one` comes before or after or is equal to `two`.
 
-- &minus;1 if `one` comes before `two`;
-- 0 if `one` and `two` are the same date and their `calendar` properties are also the same;
-- 1 if `one` comes after `two`.
+- &minus;1 if `one` comes before `two`
+- 0 if `one` and `two` are the same date when projected into the ISO 8601 calendar
+- 1 if `one` comes after `two`
 
 If `one` or `two` are not `Temporal.PlainDate` objects, then they will be converted to one as if they were passed to `Temporal.PlainDate.from()`.
 
-Note that this function will not return 0 if the two objects have different `calendar` properties, even if the actual dates are equal.
-If the dates are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
+Calendars are ignored in the comparison.
+For example, this method returns `0` for instances that fall on the same day in the ISO 8601 calendar, even if their calendars describe it with a different `month`, `year`, and/or `day`.
 
 This function can be used to sort arrays of `Temporal.PlainDate` objects.
 For example:

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -184,14 +184,14 @@ dt = Temporal.PlainDateTime.from({ year: 2001, month: 1, day: 1, minute: 60 }, {
 Compares two `Temporal.PlainDateTime` objects.
 Returns an integer indicating whether `one` comes before or after or is equal to `two`.
 
-- &minus;1 if `one` comes before `two`;
-- 0 if `one` and `two` are the same date and their `calendar` properties are also the same;
-- 1 if `one` comes after `two`.
+- &minus;1 if `one` comes before `two`
+- 0 if `one` and `two` are the same date and time when projected into the ISO 8601 calendar
+- 1 if `one` comes after `two`
 
 If `one` and `two` are not `Temporal.PlainDateTime` objects, then they will be converted to one as if they were passed to `Temporal.PlainDateTime.from()`.
 
-Note that this function will not return 0 if the two objects have different `calendar` properties, even if the actual dates and times are equal.
-If the dates and times are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
+Calendars are ignored in the comparison.
+For example, this method returns `0` for instances that fall on the same day and time in the ISO 8601 calendar, even if their calendars describe it with a different `year`, `month`, and/or `day`.
 
 This function can be used to sort arrays of `Temporal.PlainDateTime` objects.
 For example:

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -124,14 +124,14 @@ ym = Temporal.PlainYearMonth.from({ year: 2001, month: 13 }, { overflow: 'reject
 Compares two `Temporal.PlainYearMonth` objects.
 Returns an integer indicating whether `one` comes before or after or is equal to `two`.
 
-- &minus;1 if `one` comes before `two`;
-- 0 if `one` and `two` are the same month and their `calendar` properties are also the same;
-- 1 if `one` comes after `two`.
+- &minus;1 if `one` comes before `two`
+- 0 if `one` and `two` start on the same date when projected into the ISO 8601 calendar
+- 1 if `one` comes after `two`
 
 If `one` and `two` are not `Temporal.PlainYearMonth` objects, then they will be converted to one as if they were passed to `Temporal.PlainYearMonth.from()`.
 
-Note that this function will not return 0 if the two objects have different `calendar` properties, even if the actual years and months are equal.
-If the months are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
+Comparison is based on the first day of the month in the real world, regardless of the `calendar`.
+For example, this method returns `0` for months that start on the same day in the ISO 8601 calendar, even if their calendars describe that day with a different `year` and/or `month`.
 
 This function can be used to sort arrays of `Temporal.PlainYearMonth` objects.
 For example:

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -220,18 +220,16 @@ zdt = Temporal.ZonedDateTime.from({ timeZone: 'Europe/Paris', year: 2001, month:
 
 **Returns:** an integer indicating whether `one` comes before or after or is equal to `two`.
 
-- Zero if all fields are equal, including the calendar ID and the time zone ID.
 - &minus;1 if `one` is less than `two`
-- 1 if `one` is greater than `two`.
+- Zero if the two instances describe the same exact instant, ignoring the time zone and calendar
+- 1 if `one` is greater than `two`
 
 This function can be used to sort arrays of `Temporal.ZonedDateTime` objects.
 
 Comparison will use exact time, not clock time, because sorting is almost always based on when events happened in the real world.
 Note that during the hour before and after DST ends, sorting of clock time may not match the order the events actually occurred.
 
-Note that this function will not return 0 if the two objects have different `calendar` or `timeZone` properties, even if the exact timestamps are equal.
-If exact timestamps are equal, then `.calendar.id` will be compared lexicographically, in order to ensure a deterministic sort order.
-If those are equal too, then `.timeZone.id` will be compared lexicographically.
+Note that this function will return `0` if the two objects have different `calendar` or `timeZone` properties, as long as their exact timestamps are equal.
 
 For example:
 


### PR DESCRIPTION
This commit fixes #1706 by updating docs to clarify that calendars and time zones are ignored by `compare` methods in PlainDate, PlainDateTime, PlainYearMonth, and ZonedDateTime types.

It also fixes #1846 by clarifying that the first day of the month is used to compare PlainYearMonth instances.

This reflects a change in behavior made shortly before this proposal reached Stage 3.