### PR TITLE
Update TS types, docs w/ temporal-polyfill changes

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -17,14 +17,14 @@ It can also be combined with a `Temporal.PlainTime` to yield a "zoneless" `Tempo
 
 ## Constructor
 
-### **new Temporal.PlainDate**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _calendar_?: object) : Temporal.PlainDate
+### **new Temporal.PlainDate**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _calendar_?: string | object) : Temporal.PlainDate
 
 **Parameters:**
 
 - `isoYear` (number): A year.
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
 - `isoDay` (number): A day of the month, ranging between 1 and 31 inclusive.
-- `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the date into.
+- `calendar` (optional `Temporal.Calendar`, plain object, or string): A calendar to project the date into.
 
 **Returns:** a new `Temporal.PlainDate` object.
 

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -36,7 +36,7 @@ To learn more about time zones and DST best practices, visit [Time Zones and Res
 
 ## Constructor
 
-### **new Temporal.PlainDateTime**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _isoHour_: number = 0, _isoMinute_: number = 0, _isoSecond_: number = 0, _isoMillisecond_: number = 0, _isoMicrosecond_: number = 0, _isoNanosecond_: number = 0, _calendar_?: object) : Temporal.PlainDateTime
+### **new Temporal.PlainDateTime**(_isoYear_: number, _isoMonth_: number, _isoDay_: number, _isoHour_: number = 0, _isoMinute_: number = 0, _isoSecond_: number = 0, _isoMillisecond_: number = 0, _isoMicrosecond_: number = 0, _isoNanosecond_: number = 0, _calendar_?: string | object) : Temporal.PlainDateTime
 
 **Parameters:**
 
@@ -49,7 +49,7 @@ To learn more about time zones and DST best practices, visit [Time Zones and Res
 - `isoMillisecond` (optional number): A number of milliseconds, ranging between 0 and 999 inclusive.
 - `isoMicrosecond` (optional number): A number of microseconds, ranging between 0 and 999 inclusive.
 - `isoNanosecond` (optional number): A number of nanoseconds, ranging between 0 and 999 inclusive.
-- `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the datetime into.
+- `calendar` (optional `Temporal.Calendar`, plain object, or string): A calendar to project the datetime into.
 
 **Returns:** a new `Temporal.PlainDateTime` object.
 

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -13,13 +13,13 @@ A `Temporal.PlainMonthDay` can be converted into a `Temporal.PlainDate` by combi
 
 ## Constructor
 
-### **new Temporal.PlainMonthDay**(_isoMonth_: number, _isoDay_: number, _calendar_?: object, _referenceISOYear_?: number) : Temporal.PlainMonthDay
+### **new Temporal.PlainMonthDay**(_isoMonth_: number, _isoDay_: number, _calendar_?: string | object, _referenceISOYear_?: number) : Temporal.PlainMonthDay
 
 **Parameters:**
 
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
 - `isoDay` (number): A day of the month, ranging between 1 and 31 inclusive.
-- `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the date into.
+- `calendar` (optional `Temporal.Calendar`, plain object, or string): A calendar to project the date into.
 - `referenceISOYear` (optional for ISO 8601 calendar; required for other calendars):
   A reference year in the ISO 8601 calendar for disambiguation when implementing calendar systems.
   The default for the ISO 8601 calendar is the first leap year after the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -13,13 +13,13 @@ A `Temporal.PlainYearMonth` can be converted into a `Temporal.PlainDate` by comb
 
 ## Constructor
 
-### **new Temporal.PlainYearMonth**(_isoYear_: number, _isoMonth_: number, _calendar_?: object, _referenceISODay_: number = 1) : Temporal.PlainYearMonth
+### **new Temporal.PlainYearMonth**(_isoYear_: number, _isoMonth_: number, _calendar_?: string | object, _referenceISODay_: number = 1) : Temporal.PlainYearMonth
 
 **Parameters:**
 
 - `isoYear` (number): A year.
 - `isoMonth` (number): A month, ranging between 1 and 12 inclusive.
-- `calendar` (optional `Temporal.Calendar` or plain object): A calendar to project the month into.
+- `calendar` (optional `Temporal.Calendar`, plain object, or string): A calendar to project the month into.
 - `referenceISODay` (optional for ISO 8601 calendar; required for other calendars): A reference day, used for disambiguation when implementing calendar systems.
   For the ISO 8601 calendar, this parameter will default to 1 if omitted.
   For other calendars, the must set this parameter to the ISO-calendar day corresponding to the first day of the desired calendar year and month.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -31,7 +31,7 @@ The `Temporal.ZonedDateTime` API is a superset of `Temporal.PlainDateTime`, whic
 
 - `epochNanoseconds` (bigint): A number of nanoseconds.
 - `timeZone` (`Temporal.TimeZone` or plain object): The time zone in which the event takes place.
-- `calendar` (optional `Temporal.Calendar` or plain object): Calendar used to interpret dates and times. Usually set to `'iso8601'`.
+- `calendar` (optional `Temporal.Calendar`, plain object, or string): Calendar used to interpret dates and times. Usually set to `'iso8601'`.
 
 **Returns:** a new `Temporal.ZonedDateTime` object.
 

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -663,25 +663,25 @@ export namespace Temporal {
     ): boolean;
     dateFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined; day: number },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainDate;
     yearMonthFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainYearMonth;
     monthDayFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined; day: number },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainMonthDay;
     dateAdd?(
       date: Temporal.PlainDate | PlainDateLike | string,
       duration: Temporal.Duration | DurationLike | string,
-      options: ArithmeticOptions
+      options?: ArithmeticOptions
     ): Temporal.PlainDate;
     dateUntil?(
       one: Temporal.PlainDate | PlainDateLike | string,
       two: Temporal.PlainDate | PlainDateLike | string,
-      options: DifferenceOptions<
+      options?: DifferenceOptions<
         | 'year'
         | 'month'
         | 'week'
@@ -749,20 +749,20 @@ export namespace Temporal {
     ): boolean;
     dateFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined; day: number },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainDate;
     yearMonthFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainYearMonth;
     monthDayFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined; day: number },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainMonthDay;
     dateAdd(
       date: Temporal.PlainDate | PlainDateLike | string,
       duration: Temporal.Duration | DurationLike | string,
-      options: ArithmeticOptions
+      options?: ArithmeticOptions
     ): Temporal.PlainDate;
     dateUntil(
       one: Temporal.PlainDate | PlainDateLike | string,
@@ -814,7 +814,7 @@ export namespace Temporal {
       one: Temporal.PlainDate | PlainDateLike | string,
       two: Temporal.PlainDate | PlainDateLike | string
     ): ComparisonResult;
-    constructor(isoYear: number, isoMonth: number, isoDay: number, calendar?: CalendarProtocol);
+    constructor(isoYear: number, isoMonth: number, isoDay: number, calendar?: CalendarProtocol | string);
     readonly era: string | undefined;
     readonly eraYear: number | undefined;
     readonly year: number;
@@ -937,7 +937,7 @@ export namespace Temporal {
       millisecond?: number,
       microsecond?: number,
       nanosecond?: number,
-      calendar?: CalendarProtocol
+      calendar?: CalendarProtocol | string
     );
     readonly era: string | undefined;
     readonly eraYear: number | undefined;
@@ -1071,7 +1071,7 @@ export namespace Temporal {
       item: Temporal.PlainMonthDay | PlainMonthDayLike | string,
       options?: AssignmentOptions
     ): Temporal.PlainMonthDay;
-    constructor(isoMonth: number, isoDay: number, calendar?: CalendarProtocol, referenceISOYear?: number);
+    constructor(isoMonth: number, isoDay: number, calendar?: CalendarProtocol | string, referenceISOYear?: number);
     readonly monthCode: string;
     readonly day: number;
     readonly calendar: CalendarProtocol;
@@ -1305,7 +1305,7 @@ export namespace Temporal {
       one: Temporal.PlainYearMonth | PlainYearMonthLike | string,
       two: Temporal.PlainYearMonth | PlainYearMonthLike | string
     ): ComparisonResult;
-    constructor(isoYear: number, isoMonth: number, calendar?: CalendarProtocol, referenceISODay?: number);
+    constructor(isoYear: number, isoMonth: number, calendar?: CalendarProtocol | string, referenceISODay?: number);
     readonly era: string | undefined;
     readonly eraYear: number | undefined;
     readonly year: number;


### PR DESCRIPTION
Updates TS types to port changes from temporal-polyfill:
* Calendar/CalendarProtocol types' options parameters should be optional
* `calendar` parameters in constructors accept string IDs too

The latter change also affects docs, so docs changes are included too.