### PR TITLE
Normative: Fix PlainTime and relativeTo property bags

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -749,7 +749,18 @@ export const ES = ObjectAssign({}, ES2020, {
         );
       }
       calendar = ES.GetTemporalCalendarWithISODefault(relativeTo);
-      const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);
+      const fieldNames = ES.CalendarFields(calendar, [
+        'day',
+        'hour',
+        'microsecond',
+        'millisecond',
+        'minute',
+        'month',
+        'monthCode',
+        'nanosecond',
+        'second',
+        'year'
+      ]);
       const fields = ES.ToTemporalDateTimeFields(relativeTo, fieldNames);
       const dateOptions = ObjectCreate(null);
       dateOptions.overflow = 'constrain';

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -495,7 +495,7 @@
         1. If _value_ has an [[InitializedTemporalDate]] internal slot, then
           1. Return ? CreateTemporalDateTime(_value_.[[ISOYear]], _value_.[[ISOMonth]], _value_.[[ISODay]], 0, 0, 0, 0, 0, 0, _value_.[[Calendar]]).
         1. Let _calendar_ be ? GetTemporalCalendarWithISODefault(_value_).
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_value_, _fieldNames_, «»).
         1. Let _dateOptions_ be ! OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_dateOptions_, *"overflow"*, *"constrain"*).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -824,6 +824,7 @@
 
     <emu-clause id="sec-temporal-totemporaltimerecord" aoid="ToTemporalTimeRecord">
       <h1>ToTemporalTimeRecord ( _temporalTimeLike_ )</h1>
+      <emu-note>The value of ? ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. Assert: Type(_temporalTimeLike_) is Object.
         1. Let _result_ be the Record {
@@ -834,13 +835,16 @@
           [[Microsecond]]: *undefined*,
           [[Nanosecond]]: *undefined*
           }.
+        1. Let _any_ be *false*.
         1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
           1. Let _property_ be the Property value of the current row.
           1. Let _value_ be ? Get(_temporalTimeLike_, _property_).
-          1. If _value_ is *undefined*, then
-            1. Throw a *TypeError* exception.
+          1. If _value_ is not *undefined*, then
+            1. Set _any_ to *true*.
           1. Set _value_ to ? ToIntegerThrowOnInfinity(_value_).
           1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+        1. If _any_ is *false*, then
+          1. Throw a *TypeError* exception.
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Previously, ToTemporalTimeRecord (called for PlainTime, PlainDateTime,
ZonedDateTime, and relativeTo property bags) would throw a TypeError
unless all six time properties were present: hour, minute, second,
millisecond, microsecond, and nanoseconds. This was not intended. Instead,
if any of these are missing then they should default to 0, and a TypeError
should only be thrown if all of them are missing.

This only affected PlainTime and relativeTo property bags, since all code
paths involving PlainDateTime and ZonedDateTime property bags ensured via
other means that the properties were present.

No polyfill or documentation changes needed, as the intention was already
correctly reflected there.

Closes: #1803