### PR TITLE
Normative: Throw earlier in ZonedDateTime.with if offset field is missing

### DIFF
--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -206,9 +206,29 @@ export class ZonedDateTime {
     if (!props) {
       throw new TypeError('invalid zoned-date-time-like');
     }
-    let fields = ES.ToTemporalZonedDateTimeFields(this, fieldNames);
+    const entries = [
+      ['day', undefined],
+      ['hour', 0],
+      ['microsecond', 0],
+      ['millisecond', 0],
+      ['minute', 0],
+      ['month', undefined],
+      ['monthCode', undefined],
+      ['nanosecond', 0],
+      ['second', 0],
+      ['year', undefined],
+      ['offset'],
+      ['timeZone']
+    ];
+    // Add extra fields from the calendar at the end
+    fieldNames.forEach((fieldName) => {
+      if (!entries.some(([name]) => name === fieldName)) {
+        entries.push([fieldName, undefined]);
+      }
+    });
+    let fields = ES.PrepareTemporalFields(this, entries);
     fields = ES.CalendarMergeFields(calendar, fields, props);
-    fields = ES.ToTemporalZonedDateTimeFields(fields, fieldNames);
+    fields = ES.PrepareTemporalFields(fields, entries);
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
       ES.InterpretTemporalDateTimeFields(calendar, fields, options);
     const offsetNs = ES.ParseOffsetString(fields.offset);

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -581,14 +581,11 @@
         1. Let _offset_ be ? ToTemporalOffset(_options_, *"prefer"*).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Append *"timeZone"* to _fieldNames_.
-        1. Let _fields_ be ? PrepareTemporalFields(_zonedDateTime_, _fieldNames_, « *"timeZone"* »).
+        1. Let _fields_ be ? PrepareTemporalFields(_zonedDateTime_, _fieldNames_, « *"timeZone"*, *"offset"* »).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialZonedDateTime_).
-        1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « *"timeZone"* »).
-        1. Let _offsetString_ be ! Get(_partialZonedDateTime_, *"offset"*).
-        1. If _offsetString_ is not *undefined*, then
-          1. Perform ? Set(_fields_, *"offset"*, _offsetString_).
-        1. Else,
-          1. Set _offsetString_ to ? ToString(! Get(_fields_, *"offset"*)).
+        1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « *"timeZone"*, *"offset"* »).
+        1. Let _offsetString_ be ! Get(_fields_, *"offset"*).
+        1. Assert: Type(_offsetString_) is String.
         1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_).


### PR DESCRIPTION
As discussed in https://github.com/tc39/proposal-temporal/pull/1762#discussion_r695948180

This changes ZonedDateTime.prototype.with() to throw slightly earlier
(before calling calendar methods in user code) in the unlikely case that
the offset field is messed up or missing.