### PR TITLE
Normative: Temporal.Duration constructor throws if given a non-integer

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -31,16 +31,16 @@ export class Duration {
     microseconds = 0,
     nanoseconds = 0
   ) {
-    years = ES.ToIntegerThrowOnInfinity(years);
-    months = ES.ToIntegerThrowOnInfinity(months);
-    weeks = ES.ToIntegerThrowOnInfinity(weeks);
-    days = ES.ToIntegerThrowOnInfinity(days);
-    hours = ES.ToIntegerThrowOnInfinity(hours);
-    minutes = ES.ToIntegerThrowOnInfinity(minutes);
-    seconds = ES.ToIntegerThrowOnInfinity(seconds);
-    milliseconds = ES.ToIntegerThrowOnInfinity(milliseconds);
-    microseconds = ES.ToIntegerThrowOnInfinity(microseconds);
-    nanoseconds = ES.ToIntegerThrowOnInfinity(nanoseconds);
+    years = ES.ToIntegerWithoutRounding(years);
+    months = ES.ToIntegerWithoutRounding(months);
+    weeks = ES.ToIntegerWithoutRounding(weeks);
+    days = ES.ToIntegerWithoutRounding(days);
+    hours = ES.ToIntegerWithoutRounding(hours);
+    minutes = ES.ToIntegerWithoutRounding(minutes);
+    seconds = ES.ToIntegerWithoutRounding(seconds);
+    milliseconds = ES.ToIntegerWithoutRounding(milliseconds);
+    microseconds = ES.ToIntegerWithoutRounding(microseconds);
+    nanoseconds = ES.ToIntegerWithoutRounding(nanoseconds);
 
     const sign = ES.DurationSign(
       years,

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -95,12 +95,16 @@ const ToPositiveInteger = (value, property) => {
   }
   return value;
 };
-const ToIntegerNoFraction = (value) => {
+const ToIntegerWithoutRounding = (value) => {
   value = ES.ToNumber(value);
+  if (NumberIsNaN(value)) return 0;
+  if (!NumberIsFinite(value)) {
+    throw new RangeError('infinity is out of range');
+  }
   if (!ES.IsInteger(value)) {
     throw new RangeError(`unsupported fractional value ${value}`);
   }
-  return value;
+  return ES.ToInteger(value); // ℝ(value) in spec text; converts -0 to 0
 };
 
 const BUILTIN_CASTS = new Map([
@@ -114,16 +118,16 @@ const BUILTIN_CASTS = new Map([
   ['millisecond', ToIntegerThrowOnInfinity],
   ['microsecond', ToIntegerThrowOnInfinity],
   ['nanosecond', ToIntegerThrowOnInfinity],
-  ['years', ToIntegerNoFraction],
-  ['months', ToIntegerNoFraction],
-  ['weeks', ToIntegerNoFraction],
-  ['days', ToIntegerNoFraction],
-  ['hours', ToIntegerNoFraction],
-  ['minutes', ToIntegerNoFraction],
-  ['seconds', ToIntegerNoFraction],
-  ['milliseconds', ToIntegerNoFraction],
-  ['microseconds', ToIntegerNoFraction],
-  ['nanoseconds', ToIntegerNoFraction],
+  ['years', ToIntegerWithoutRounding],
+  ['months', ToIntegerWithoutRounding],
+  ['weeks', ToIntegerWithoutRounding],
+  ['days', ToIntegerWithoutRounding],
+  ['hours', ToIntegerWithoutRounding],
+  ['minutes', ToIntegerWithoutRounding],
+  ['seconds', ToIntegerWithoutRounding],
+  ['milliseconds', ToIntegerWithoutRounding],
+  ['microseconds', ToIntegerWithoutRounding],
+  ['nanoseconds', ToIntegerWithoutRounding],
   ['era', ToString],
   ['eraYear', ToInteger],
   ['offset', ToString]
@@ -193,7 +197,7 @@ function getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier) {
 export const ES = ObjectAssign({}, ES2020, {
   ToPositiveInteger: ToPositiveInteger,
   ToIntegerThrowOnInfinity,
-  ToIntegerNoFraction,
+  ToIntegerWithoutRounding,
   IsTemporalInstant: (item) => HasSlot(item, EPOCHNANOSECONDS) && !HasSlot(item, TIME_ZONE, CALENDAR),
   IsTemporalTimeZone: (item) => HasSlot(item, TIMEZONE_ID),
   IsTemporalCalendar: (item) => HasSlot(item, CALENDAR_ID),

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -118,6 +118,18 @@ describe('Duration', () => {
       throws(() => new Duration(1, 1, 1, 1, 1, 1, 1, 1, -1, 1), RangeError);
       throws(() => new Duration(1, 1, 1, 1, 1, 1, 1, 1, 1, -1), RangeError);
     });
+    it('fractional values throw', () => {
+      throws(() => new Duration(1.1), RangeError);
+      throws(() => new Duration(0, 1.1), RangeError);
+      throws(() => new Duration(0, 0, 1.1), RangeError);
+      throws(() => new Duration(0, 0, 0, 1.1), RangeError);
+      throws(() => new Duration(0, 0, 0, 0, 1.1), RangeError);
+      throws(() => new Duration(0, 0, 0, 0, 0, 1.1), RangeError);
+      throws(() => new Duration(0, 0, 0, 0, 0, 0, 1.1), RangeError);
+      throws(() => new Duration(0, 0, 0, 0, 0, 0, 0, 1.1), RangeError);
+      throws(() => new Duration(0, 0, 0, 0, 0, 0, 0, 0, 1.1), RangeError);
+      throws(() => new Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 1.1), RangeError);
+    });
   });
   describe('from()', () => {
     it('Duration.from(P5Y) is not the same object', () => {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1513,6 +1513,21 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-tointegerwithoutrounding" aoid="ToIntegerWithoutRounding">
+    <h1>ToIntegerWithoutRounding ( _argument_ )</h1>
+    <p>
+      The abstract operation ToIntegerWithoutRounding takes argument _argument_.
+      It converts _argument_ to an integer, throwing if doing so would require rounding.
+      It performs the following steps:
+    </p>
+    <emu-alg>
+      1. Let _number_ be ? ToNumber(_argument_).
+      1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, or *−0*<sub>𝔽</sub> return 0.
+      1. If ! IsIntegralNumber(_number_) is *false*, throw a *RangeError* exception.
+      1. Return ℝ(_number_).
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-preparetemporalfields" aoid="PrepareTemporalFields">
     <h1>PrepareTemporalFields ( _fields_, _fieldNames_, _requiredFields_ )</h1>
     <p>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -39,16 +39,16 @@
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _y_ be ? ToIntegerThrowOnInfinity(_years_).
-        1. Let _mo_ be ? ToIntegerThrowOnInfinity(_months_).
-        1. Let _w_ be ? ToIntegerThrowOnInfinity(_weeks_).
-        1. Let _d_ be ? ToIntegerThrowOnInfinity(_days_).
-        1. Let _h_ be ? ToIntegerThrowOnInfinity(_hours_).
-        1. Let _m_ be ? ToIntegerThrowOnInfinity(_minutes_).
-        1. Let _s_ be ? ToIntegerThrowOnInfinity(_seconds_).
-        1. Let _ms_ be ? ToIntegerThrowOnInfinity(_milliseconds_).
-        1. Let _mis_ be ? ToIntegerThrowOnInfinity(_microseconds_).
-        1. Let _ns_ be ? ToIntegerThrowOnInfinity(_nanoseconds_).
+        1. Let _y_ be ? ToIntegerWithoutRounding(_years_).
+        1. Let _mo_ be ? ToIntegerWithoutRounding(_months_).
+        1. Let _w_ be ? ToIntegerWithoutRounding(_weeks_).
+        1. Let _d_ be ? ToIntegerWithoutRounding(_days_).
+        1. Let _h_ be ? ToIntegerWithoutRounding(_hours_).
+        1. Let _m_ be ? ToIntegerWithoutRounding(_minutes_).
+        1. Let _s_ be ? ToIntegerWithoutRounding(_seconds_).
+        1. Let _ms_ be ? ToIntegerWithoutRounding(_milliseconds_).
+        1. Let _mis_ be ? ToIntegerWithoutRounding(_microseconds_).
+        1. Let _ns_ be ? ToIntegerWithoutRounding(_nanoseconds_).
         1. Return ? CreateTemporalDuration(_y_, _mo_, _w_, _d_, _h_, _m_, _s_, _ms_, _mis_, _ns_, NewTarget).
       </emu-alg>
     </emu-clause>
@@ -708,9 +708,7 @@
             1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to 0.
           1. Else,
             1. Set _any_ to *true*.
-            1. Let _val_ be ? ToNumber(_val_).
-            1. If ! IsIntegralNumber(_val_) is *false*, then
-              1. Throw a *RangeError* exception.
+            1. Let _val_ be 𝔽(? ToIntegerWithoutRounding(_val_)).
             1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _val_.
         1. If _any_ is *false*, then
           1. Throw a *TypeError* exception.
@@ -785,9 +783,7 @@
           1. Let _value_ be ? Get(_temporalDurationLike_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
-            1. Set _value_ to ? ToNumber(_value_).
-            1. If ! IsIntegralNumber(_value_) is *false*, then
-              1. Throw a *RangeError* exception.
+            1. Set _value_ to 𝔽(? ToIntegerWithoutRounding(_value_)).
             1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
         1. If _any_ is *false*, then
           1. Throw a *TypeError* exception.


### PR DESCRIPTION
The Temporal.Duration constructor, unlike Temporal.Duration.from(), would
previously drop the fractional part of numbers given to it. from() throws
if given a non-integer number, because Temporal.Duration.from('PT1.1H')
results in 1 hour, 6 minutes, but Temporal.Duration.from({ hours: 1.1 })
cannot be exact, yet should not silently drop the .1, as discussed in
issue #938.

Temporal.Duration(0, 0, 0, 0, 1.1) should now throw the same exception as
Temporal.Duration.from({ hours: 1.1 }) in order to be consistent and avoid
the surprise to users of silently dropping the .1.

Closes: #1832