### PR TITLE
Normative: Don't accept Z designators in strings for Plain types

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -335,9 +335,11 @@ export const ES = ObjectAssign({}, ES2020, {
       nanosecond = ES.ToInteger(fraction.slice(6, 9));
       calendar = match[15];
     } else {
-      ({ hour, minute, second, millisecond, microsecond, nanosecond, calendar } = ES.ParseISODateTime(isoString, {
+      let z;
+      ({ hour, minute, second, millisecond, microsecond, nanosecond, calendar, z } = ES.ParseISODateTime(isoString, {
         zoneRequired: false
       }));
+      if (z) throw new RangeError('Z designator not supported for PlainTime');
     }
     return { hour, minute, second, millisecond, microsecond, nanosecond, calendar };
   },
@@ -351,7 +353,9 @@ export const ES = ObjectAssign({}, ES2020, {
       month = ES.ToInteger(match[2]);
       calendar = match[3];
     } else {
-      ({ year, month, calendar, day: referenceISODay } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
+      let z;
+      ({ year, month, calendar, day: referenceISODay, z } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
+      if (z) throw new RangeError('Z designator not supported for PlainYearMonth');
     }
     return { year, month, calendar, referenceISODay };
   },
@@ -362,7 +366,9 @@ export const ES = ObjectAssign({}, ES2020, {
       month = ES.ToInteger(match[1]);
       day = ES.ToInteger(match[2]);
     } else {
-      ({ month, day, calendar, year: referenceISOYear } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
+      let z;
+      ({ month, day, calendar, year: referenceISOYear, z } = ES.ParseISODateTime(isoString, { zoneRequired: false }));
+      if (z) throw new RangeError('Z designator not supported for PlainMonthDay');
     }
     return { month, day, calendar, referenceISOYear };
   },
@@ -1017,7 +1023,8 @@ export const ES = ObjectAssign({}, ES2020, {
       return ES.DateFromFields(calendar, fields, options);
     }
     ES.ToTemporalOverflow(options); // validate and ignore
-    let { year, month, day, calendar } = ES.ParseTemporalDateString(ES.ToString(item));
+    let { year, month, day, calendar, z } = ES.ParseTemporalDateString(ES.ToString(item));
+    if (z) throw new RangeError('Z designator not supported for PlainDate');
     const TemporalPlainDate = GetIntrinsic('%Temporal.PlainDate%');
     return new TemporalPlainDate(year, month, day, calendar); // include validation
   },
@@ -1083,8 +1090,10 @@ export const ES = ObjectAssign({}, ES2020, {
         ES.InterpretTemporalDateTimeFields(calendar, fields, options));
     } else {
       ES.ToTemporalOverflow(options); // validate and ignore
-      ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar } =
+      let z;
+      ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar, z } =
         ES.ParseTemporalDateTimeString(ES.ToString(item)));
+      if (z) throw new RangeError('Z designator not supported for PlainDateTime');
       ES.RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
       if (calendar === undefined) calendar = ES.GetISO8601Calendar();
       calendar = ES.ToTemporalCalendar(calendar);

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -115,3 +115,6 @@ intl402/Temporal/ZonedDateTime/prototype/eraYear/timezone-getoffsetnanosecondsfo
 
 # https://github.com/tc39/test262/pull/3316
 intl402/Temporal/TimeZone/from/argument-invalid.js
+
+# Waiting on submitting tests for https://github.com/tc39/proposal-temporal/pull/1874
+built-ins/Temporal/PlainMonthDay/from/fields-string.js

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -1161,7 +1161,7 @@ describe('DateTime', () => {
       equal(`${dt.round({ smallestUnit: 'second' })}`, '1976-11-18T14:23:30');
     });
     it('rounding down is towards the Big Bang, not towards 1 BCE', () => {
-      const dt2 = PlainDateTime.from('-000099-12-15T12:00:00.5Z');
+      const dt2 = PlainDateTime.from('-000099-12-15T12:00:00.5');
       const smallestUnit = 'second';
       equal(`${dt2.round({ smallestUnit, roundingMode: 'ceil' })}`, '-000099-12-15T12:00:01');
       equal(`${dt2.round({ smallestUnit, roundingMode: 'floor' })}`, '-000099-12-15T12:00:00');
@@ -1303,23 +1303,27 @@ describe('DateTime', () => {
         throws(() => PlainDateTime.from('2020-13-34T24:60', { overflow: 'constrain' }), RangeError);
       });
     });
+    it('Z not supported', () => {
+      throws(() => PlainDateTime.from('2019-10-01T09:00:00Z'), RangeError);
+      throws(() => PlainDateTime.from('2019-10-01T09:00:00Z[Europe/Berlin]'), RangeError);
+    });
     it('variant time separators', () => {
-      equal(`${PlainDateTime.from('1976-11-18t15:23Z')}`, '1976-11-18T15:23:00');
-      equal(`${PlainDateTime.from('1976-11-18 15:23Z')}`, '1976-11-18T15:23:00');
+      equal(`${PlainDateTime.from('1976-11-18t15:23')}`, '1976-11-18T15:23:00');
+      equal(`${PlainDateTime.from('1976-11-18 15:23')}`, '1976-11-18T15:23:00');
     });
     it('any number of decimal places', () => {
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30.1Z')}`, '1976-11-18T15:23:30.1');
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30.12Z')}`, '1976-11-18T15:23:30.12');
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30.123Z')}`, '1976-11-18T15:23:30.123');
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30.1234Z')}`, '1976-11-18T15:23:30.1234');
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30.12345Z')}`, '1976-11-18T15:23:30.12345');
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30.123456Z')}`, '1976-11-18T15:23:30.123456');
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30.1234567Z')}`, '1976-11-18T15:23:30.1234567');
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30.12345678Z')}`, '1976-11-18T15:23:30.12345678');
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30.123456789Z')}`, '1976-11-18T15:23:30.123456789');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30.1')}`, '1976-11-18T15:23:30.1');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30.12')}`, '1976-11-18T15:23:30.12');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30.123')}`, '1976-11-18T15:23:30.123');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30.1234')}`, '1976-11-18T15:23:30.1234');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30.12345')}`, '1976-11-18T15:23:30.12345');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30.123456')}`, '1976-11-18T15:23:30.123456');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30.1234567')}`, '1976-11-18T15:23:30.1234567');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30.12345678')}`, '1976-11-18T15:23:30.12345678');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30.123456789')}`, '1976-11-18T15:23:30.123456789');
     });
     it('variant decimal separator', () => {
-      equal(`${PlainDateTime.from('1976-11-18T15:23:30,12Z')}`, '1976-11-18T15:23:30.12');
+      equal(`${PlainDateTime.from('1976-11-18T15:23:30,12')}`, '1976-11-18T15:23:30.12');
     });
     it('variant minus sign', () => {
       equal(`${PlainDateTime.from('1976-11-18T15:23:30.12\u221202:00')}`, '1976-11-18T15:23:30.12');

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -966,19 +966,23 @@ describe('Time', () => {
       const t = PlainTime.from('2020-02-12T11:42:00+01:00[Europe/Amsterdam]');
       notEqual(PlainTime.from(t), t);
     });
+    it('Z not supported', () => {
+      throws(() => PlainTime.from('2019-10-01T09:00:00Z'), RangeError);
+      throws(() => PlainTime.from('2019-10-01T09:00:00Z[Europe/Berlin]'), RangeError);
+    });
     it('any number of decimal places', () => {
-      equal(`${PlainTime.from('1976-11-18T15:23:30.1Z')}`, '15:23:30.1');
-      equal(`${PlainTime.from('1976-11-18T15:23:30.12Z')}`, '15:23:30.12');
-      equal(`${PlainTime.from('1976-11-18T15:23:30.123Z')}`, '15:23:30.123');
-      equal(`${PlainTime.from('1976-11-18T15:23:30.1234Z')}`, '15:23:30.1234');
-      equal(`${PlainTime.from('1976-11-18T15:23:30.12345Z')}`, '15:23:30.12345');
-      equal(`${PlainTime.from('1976-11-18T15:23:30.123456Z')}`, '15:23:30.123456');
-      equal(`${PlainTime.from('1976-11-18T15:23:30.1234567Z')}`, '15:23:30.1234567');
-      equal(`${PlainTime.from('1976-11-18T15:23:30.12345678Z')}`, '15:23:30.12345678');
-      equal(`${PlainTime.from('1976-11-18T15:23:30.123456789Z')}`, '15:23:30.123456789');
+      equal(`${PlainTime.from('1976-11-18T15:23:30.1')}`, '15:23:30.1');
+      equal(`${PlainTime.from('1976-11-18T15:23:30.12')}`, '15:23:30.12');
+      equal(`${PlainTime.from('1976-11-18T15:23:30.123')}`, '15:23:30.123');
+      equal(`${PlainTime.from('1976-11-18T15:23:30.1234')}`, '15:23:30.1234');
+      equal(`${PlainTime.from('1976-11-18T15:23:30.12345')}`, '15:23:30.12345');
+      equal(`${PlainTime.from('1976-11-18T15:23:30.123456')}`, '15:23:30.123456');
+      equal(`${PlainTime.from('1976-11-18T15:23:30.1234567')}`, '15:23:30.1234567');
+      equal(`${PlainTime.from('1976-11-18T15:23:30.12345678')}`, '15:23:30.12345678');
+      equal(`${PlainTime.from('1976-11-18T15:23:30.123456789')}`, '15:23:30.123456789');
     });
     it('variant decimal separator', () => {
-      equal(`${PlainTime.from('1976-11-18T15:23:30,12Z')}`, '15:23:30.12');
+      equal(`${PlainTime.from('1976-11-18T15:23:30,12')}`, '15:23:30.12');
     });
     it('variant minus sign', () => {
       equal(`${PlainTime.from('1976-11-18T15:23:30.12\u221202:00')}`, '15:23:30.12');

--- a/polyfill/test/plainyearmonth.mjs
+++ b/polyfill/test/plainyearmonth.mjs
@@ -26,8 +26,12 @@ describe('YearMonth', () => {
     it('ym.monthsInYear is 12', () => equal(ym.monthsInYear, 12));
     describe('.from()', () => {
       it('YearMonth.from(2019-10) == 2019-10', () => equal(`${PlainYearMonth.from('2019-10')}`, '2019-10'));
-      it('YearMonth.from(2019-10-01T09:00:00Z) == 2019-10', () =>
-        equal(`${PlainYearMonth.from('2019-10-01T09:00:00Z')}`, '2019-10'));
+      it('YearMonth.from(2019-10-01T09:00:00+00:00) == 2019-10', () =>
+        equal(`${PlainYearMonth.from('2019-10-01T09:00:00+00:00')}`, '2019-10'));
+      it('Z not supported', () => {
+        throws(() => PlainYearMonth.from('2019-10-01T09:00:00Z'), RangeError);
+        throws(() => PlainYearMonth.from('2019-10-01T09:00:00Z[Europe/Berlin]'), RangeError);
+      });
       it("YearMonth.from('1976-11') == (1976-11)", () => equal(`${PlainYearMonth.from('1976-11')}`, '1976-11'));
       it("YearMonth.from('1976-11-18') == (1976-11)", () => equal(`${PlainYearMonth.from('1976-11-18')}`, '1976-11'));
       it('can be constructed with monthCode and without month', () =>

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -160,7 +160,7 @@ describe('fromString regex', () => {
       test('1976-11-18T15', [1976, 11, 18, 15]);
       test('1976-11-18', [1976, 11, 18]);
       // Representations with calendar
-      ['', 'Z', '+01:00[Europe/Vienna]', '+01:00[Custom/Vienna]', '[Europe/Vienna]'].forEach((zoneString) =>
+      ['', '+01:00[Europe/Vienna]', '+01:00[Custom/Vienna]', '[Europe/Vienna]'].forEach((zoneString) =>
         test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [1976, 11, 18, 15, 23, 30, 123, 456, 789])
       );
     });
@@ -240,7 +240,7 @@ describe('fromString regex', () => {
     test('1512-11-18', [1512, 11, 18]);
     test('15121118', [1512, 11, 18]);
     // Representations with calendar
-    ['', 'Z', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
+    ['', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
       test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [1976, 11, 18])
     );
     test('1976-11-18[u-ca=iso8601]', [1976, 11, 18]);
@@ -304,7 +304,7 @@ describe('fromString regex', () => {
       test(`15${zoneStr}`, [15])
     );
     // Representations with calendar
-    ['', 'Z', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
+    ['', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
       test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [15, 23, 30, 123, 456, 789])
     );
     test('15:23:30.123456789[u-ca=iso8601]', [15, 23, 30, 123, 456, 789]);
@@ -357,7 +357,7 @@ describe('fromString regex', () => {
       '1976-11-18T15'
     ].forEach((str) => test(str, [1976, 11]));
     // Unicode minus sign
-    test('\u2212009999-11-18T15:23:30.1234Z', [-9999, 11]);
+    test('\u2212009999-11-18T15:23:30.1234', [-9999, 11]);
     // Date-only forms
     test('1976-11-18', [1976, 11]);
     test('19761118', [1976, 11]);
@@ -377,7 +377,7 @@ describe('fromString regex', () => {
     test('1512-11', [1512, 11]);
     test('151211', [1512, 11]);
     // Representations with calendar
-    ['', 'Z', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
+    ['', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
       test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [1976, 11])
     );
     test('1976-11-01[u-ca=iso8601]', [1976, 11]);
@@ -453,7 +453,7 @@ describe('fromString regex', () => {
     test('--11-18', [11, 18]);
     test('--1118', [11, 18]);
     // Representations with calendar
-    ['', 'Z', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
+    ['', '+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]'].forEach((zoneString) =>
       test(`1976-11-18T15:23:30.123456789${zoneString}[u-ca=iso8601]`, [11, 18])
     );
     test('1972-11-18[u-ca=iso8601]', [11, 18]);

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1243,6 +1243,8 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalDateString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
+      1. If _isoString_ contains a |UTCDesignator|, then
+        1. Throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Return the Record {
         [[Year]]: _result_.[[Year]],
@@ -1261,6 +1263,8 @@
     <emu-alg>
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalDateTimeString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
+        1. Throw a *RangeError* exception.
+      1. If _isoString_ contains a |UTCDesignator|, then
         1. Throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Return _result_.
@@ -1340,6 +1344,8 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalMonthDayString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
+      1. If _isoString_ contains a |UTCDesignator|, then
+        1. Throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Let _year_ be _result_.[[Year]].
       1. If no part of _isoString_ is produced by the |DateYear| production, then
@@ -1398,6 +1404,8 @@
     <emu-alg>
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalTimeString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
+        1. Throw a *RangeError* exception.
+      1. If _isoString_ contains a |UTCDesignator|, then
         1. Throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Return the Record {
@@ -1467,6 +1475,8 @@
     <emu-alg>
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalYearMonthString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
+        1. Throw a *RangeError* exception.
+      1. If _isoString_ contains a |UTCDesignator|, then
         1. Throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Return the Record {


### PR DESCRIPTION
Accepting this kind of string in Plain types poses a risk when
deserializing from databases, as some attach local-time-zone semantics to
this kind of string. This could cause user-facing off-by-one-day bugs.

(Note: this could probably be refactored to have these strings actually be invalid according to the ISO 8601 grammar, but this PR is set up so that could be done separately as an editorial change.)

Closes: #1751