### PR TITLE
Normative: allow strings as required param in `round` and `total` methods

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -386,25 +386,28 @@ d = Temporal.Duration.from('-PT8H30M');
 d.abs(); // PT8H30M
 ```
 
-### duration.**round**(_options_: object) : Temporal.Duration
+### duration.**round**(_roundTo_: string | object) : Temporal.Duration
 
 **Parameters:**
 
-- `options` (object): An object with properties representing options for the operation.
-  The following options are recognized:
-  - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
-    Valid values are `'auto'`, `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
-    The default is `'auto'`.
-  - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
-    Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
-    The default is `'nanosecond'`, i.e. no rounding.
-  - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
-    The default is 1.
-  - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'halfExpand'`.
-  - `relativeTo` (`Temporal.PlainDateTime`): The starting point to use when converting between years, months, weeks, and days.
-    It must be a `Temporal.PlainDateTime`, or a value that can be passed to `Temporal.PlainDateTime.from()`.
+- `roundTo` (string | object): A required string or object to control the operation.
+  - If a string is provided, the resulting `Temporal.Duration` object will be rounded to that unit.
+    Valid values are `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    A string parameter is treated the same as an object whose `smallestUnit` property value is that string.
+  - If an object is passed, the following properties are recognized:
+    - `largestUnit` (string): The largest unit of time to allow in the resulting `Temporal.Duration` object.
+      Valid values are `'auto'`, `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+      The default is `'auto'`.
+    - `smallestUnit` (string): The smallest unit of time to round to in the resulting `Temporal.Duration` object.
+      Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+      The default is `'nanosecond'`, i.e. no rounding.
+    - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
+      The default is 1.
+    - `roundingMode` (string): How to handle the remainder, if rounding.
+      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      The default is `'halfExpand'`.
+    - `relativeTo` (`Temporal.PlainDateTime`): The starting point to use when converting between years, months, weeks, and days.
+      It must be a `Temporal.PlainDateTime`, or a value that can be passed to `Temporal.PlainDateTime.from()`.
 
 **Returns:** a new `Temporal.Duration` object which is `duration`, rounded and/or balanced.
 
@@ -418,15 +421,15 @@ This operation is called "balancing."
 
 For usage examples and a more complete explanation of how balancing works, see [Duration balancing](./balancing.md).
 
-A `largestUnit` value of `'auto'`, which is the default if only `smallestUnit` is given, means that `largestUnit` should be the largest nonzero unit in the duration that is larger than `smallestUnit`.
+A `largestUnit` value of `'auto'`, which is the default if only `smallestUnit` is given (or if `roundTo` is a string), means that `largestUnit` should be the largest nonzero unit in the duration that is larger than `smallestUnit`.
 For example, in a duration of 3 days and 12 hours, `largestUnit: 'auto'` would mean the same as `largestUnit: 'day'`.
 This behavior implies that the default balancing behavior of this method to not "grow" the duration beyond its current largest unit unless needed for rounding.
 
-The `smallestUnit` option determines the unit to round to.
+The `smallestUnit` option (or the value of `roundTo` if a string parameter is used) determines the unit to round to.
 For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
-The default, if only `largestUnit` is given, is to do no rounding.
+The default, if only `largestUnit` is given, is to do no rounding of smaller units.
 
-At least one of `largestUnit` or `smallestUnit` is required.
+If an object parameter is used, at least one of `largestUnit` or `smallestUnit` is required.
 
 Converting between years, months, weeks, and other units requires a reference point.
 If `largestUnit` or `smallestUnit` is years, months, or weeks, or the duration has nonzero years, months, or weeks, then the `relativeTo` option is required.
@@ -516,17 +519,20 @@ quarters = d.months / 3;
 quarters; // => 3
 ```
 
-### duration.**total**(_options_: object) : number
+### duration.**total**(_totalOf_: string | object) : number
 
 **Parameters:**
 
-- `options` (object): An object with properties representing options for the operation.
-  The following options are recognized:
-  - `unit` (string): The unit of time that will be returned.
-    Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
-    There is no default; `unit` is required.
-  - `relativeTo` (`Temporal.PlainDateTime`): The starting point to use when converting between years, months, weeks, and days.
-    It must be a `Temporal.PlainDateTime`, or a value that can be passed to `Temporal.PlainDateTime.from()`.
+- `totalOf` (string | object): A required string or object to control the operation.
+  - If a string is passed, it represents the unit of time that will be returned.
+    Valid values are `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    A string parameter is treated the same as an object whose `unit` property value is that string.
+  - If an object is passed, the following properties are recognized:
+    - `unit` (string): The unit of time that will be returned.
+      Valid values are `'year'`, `'month'`, `'week'`, `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+      There is no default; `unit` is required.
+    - `relativeTo` (`Temporal.PlainDateTime` ): The starting point to use when converting between years, months, weeks, and days.
+      It must be a `Temporal.PlainDateTime`, or a value that can be passed to `Temporal.PlainDateTime.from()`.
 
 **Returns:** a floating-point number representing the number of desired units in the `Temporal.Duration`.
 
@@ -535,10 +541,11 @@ If the duration IS NOT evenly divisible by the desired unit, then a fractional r
 If the duration IS evenly divisible by the desired unit, then the integer result will be identical to `duration.round({ smallestUnit: unit, largestUnit: unit, relativeTo })[unit]`.
 
 Interpreting years, months, or weeks requires a reference point.
-Therefore, `unit` is `'year'`, `'month'`, or `'week'`, or the duration has nonzero 'year', 'month', or 'week', then the `relativeTo` option is required.
+Therefore, if `unit` is `'year'`, `'month'`, or `'week'`, or the duration has nonzero 'year', 'month', or 'week', then the `relativeTo` option is required.
+For this reason, it's required to use the object (not string) form of `totalOf` in these cases.
 
 The `relativeTo` option gives the starting point used when converting between or rounding to years, months, weeks, or days.
-It is a `Temporal.PlainDateTime` instance.
+It is a `Temporal.PlainDateTime` or `Temporal.ZonedDateTime` instance.
 If any other type is provided, then it will be converted to a `Temporal.PlainDateTime` as if it were passed to `Temporal.PlainDateTime.from(..., { overflow: 'reject' })`.
 A `Temporal.PlainDate` or a date string like `2020-01-01` is also accepted because time is optional when creating a `Temporal.PlainDateTime`.
 

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -474,25 +474,28 @@ billion = Temporal.Instant.fromEpochSeconds(1e9);
 billion.since(epoch); // => PT1000000000S
 ```
 
-### instant.**round**(_options_: object) : Temporal.Instant
+### instant.**round**(_roundTo_: string | object) : Temporal.Instant
 
 **Parameters:**
 
-- `options` (object): An object with properties representing options for the operation.
-  The following options are recognized:
-  - `smallestUnit` (required string): The unit to round to.
+- `roundTo` (string | object): A required string or object to control the operation.
+  - If a string is provided, the resulting `Temporal.Instant` object will be rounded to that unit.
     Valid values are `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
-  - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
-    The default is 1.
-  - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'halfExpand'`.
+    A string parameter is treated the same as an object whose `smallestUnit` property value is that string.
+  - If an object is passed, the following properties are recognized:
+    - `smallestUnit` (required string): The unit to round to.
+      Valid values are `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
+      The default is 1.
+    - `roundingMode` (string): How to handle the remainder.
+      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      The default is `'halfExpand'`.
 
-**Returns:** a new `Temporal.Instant` object which is `instant` rounded to `roundingIncrement` of `smallestUnit`.
+**Returns:** a new `Temporal.Instant` object which is `instant` rounded to `roundTo` (if a string parameter is used) or `roundingIncrement` of `smallestUnit` (if an object parameter is used).
 
 Rounds `instant` to the given unit and increment, and returns the result as a new `Temporal.Instant` object.
 
-The `smallestUnit` option determines the unit to round to.
+The `smallestUnit` option (or the value of `roundTo` if a string parameter is used) determines the unit to round to.
 For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
 This option is required.
 
@@ -510,6 +513,10 @@ The `roundingMode` option controls how the rounding is performed.
   (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
 - `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `ceil`.
+
+As expected for a method named "round", the default rounding mode is `'halfExpand'` to match the behavior of `Math.round`.
+Note that this is different than the `'trunc'` default used by `until` and `since` options because rounding up would be an unexpected default for those operations.
+Other properties behave identically between these methods.
 
 Example usage:
 

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -750,25 +750,28 @@ dt2 = Temporal.PlainDateTime.from('2019-01-31T15:30');
 dt2.since(dt1); // => P8456DT12H5M29.9999965S
 ```
 
-### datetime.**round**(_options_: object) : Temporal.PlainDateTime
+### datetime.**round**(_roundTo_: string | object) : Temporal.PlainDateTime
 
 **Parameters:**
 
-- `options` (object): An object with properties representing options for the operation.
-  The following options are recognized:
-  - `smallestUnit` (required string): The unit to round to.
+- `roundTo` (string | object): A required string or object to control the operation.
+  - If a string is provided, the resulting `Temporal.PlainDateTime` object will be rounded to that unit.
     Valid values are `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
-  - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
-    The default is 1.
-  - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'halfExpand'`.
+    A string parameter is treated the same as an object whose `smallestUnit` property value is that string.
+  - If an object is passed, the following properties are recognized:
+    - `smallestUnit` (required string): The unit to round to.
+      Valid values are `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
+      The default is 1.
+    - `roundingMode` (string): How to handle the remainder.
+      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      The default is `'halfExpand'`.
 
-**Returns:** a new `Temporal.PlainDateTime` object which is `datetime` rounded to `roundingIncrement` of `smallestUnit`.
+**Returns:** a new `Temporal.PlainDateTime` object which is `datetime` rounded to `roundTo` (if a string parameter is used) or `roundingIncrement` of `smallestUnit` (if an object parameter is used).
 
 Rounds `datetime` to the given unit and increment, and returns the result as a new `Temporal.PlainDateTime` object.
 
-The `smallestUnit` option determines the unit to round to.
+The `smallestUnit` option (or the value of `roundTo` if a string parameter is used) determines the unit to round to.
 For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
 This option is required.
 
@@ -789,6 +792,10 @@ The `roundingMode` option controls how the rounding is performed.
   (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
 - `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `ceil`.
+
+As expected for a method named "round", the default rounding mode is `'halfExpand'` to match the behavior of `Math.round`.
+Note that this is different than the `'trunc'` default used by `until` and `since` options because rounding up would be an unexpected default for those operations.
+Other properties behave identically between these methods.
 
 Example usage:
 

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -374,25 +374,28 @@ time.since(Temporal.PlainTime.from('19:39:09.068346205')); // => PT34M11.9030518
 time.since(Temporal.PlainTime.from('22:39:09.068346205')); // => -PT2H25M48.096948106S
 ```
 
-### time.**round**(_options_: object) : Temporal.PlainTime
+### time.**round**(_roundTo_: string | object) : Temporal.PlainTime
 
 **Parameters:**
 
-- `options` (object): An object with properties representing options for the operation.
-  The following options are recognized:
-  - `smallestUnit` (required string): The unit to round to.
+- `roundTo` (string | object): A required string or object to control the operation.
+  - If a string is provided, the resulting `Temporal.PlainTime` object will be rounded to that unit.
     Valid values are `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
-  - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
-    The default is 1.
-  - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'halfExpand'`.
+    A string parameter is treated the same as an object whose `smallestUnit` property value is that string.
+  - If an object is passed, the following properties are recognized:
+    - `smallestUnit` (required string): The unit to round to.
+      Valid values are `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
+      The default is 1.
+    - `roundingMode` (string): How to handle the remainder.
+      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      The default is `'halfExpand'`.
 
-**Returns:** a new `Temporal.PlainTime` object which is `time` rounded to `roundingIncrement` of `smallestUnit`.
+**Returns:** a new `Temporal.PlainTime` object which is `time` rounded to `roundTo` (if a string parameter is used) or `roundingIncrement` of `smallestUnit` (if an object parameter is used).
 
 Rounds `time` to the given unit and increment, and returns the result as a new `Temporal.PlainTime` object.
 
-The `smallestUnit` option determines the unit to round to.
+The `smallestUnit` option (or the value of `roundTo` if a string parameter is used) determines the unit to round to.
 For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
 This option is required.
 
@@ -411,6 +414,10 @@ The `roundingMode` option controls how the rounding is performed.
   (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
 - `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `ceil`.
+
+As expected for a method named "round", the default rounding mode is `'halfExpand'` to match the behavior of `Math.round`.
+Note that this is different than the `'trunc'` default used by `until` and `since` options because rounding up would be an unexpected default for those operations.
+Other properties behave identically between these methods.
 
 Example usage:
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1132,24 +1132,28 @@ zdt2 = Temporal.ZonedDateTime.from('2019-01-31T15:30+05:30[Asia/Kolkata]');
 zdt2.since(zdt1); // => PT202956H5M29.9999965S
 ```
 
-### zonedDateTime.**round**(_options_: object) : Temporal.ZonedDateTime
+### zonedDateTime.**round**(_roundTo_: string | object) : Temporal.ZonedDateTime
 
 **Parameters:**
 
-- `options` (object): An object which may have some or all of the following properties:
-  - `smallestUnit` (required string): The unit to round to.
+- `roundTo` (string | object): A required string or object to control the operation.
+  - If a string is provided, the resulting `Temporal.ZonedDateTime` object will be rounded to that unit.
     Valid values are `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
-  - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
-    The default is 1.
-  - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
-    The default is `'halfExpand'`.
+    A string parameter is treated the same as an object whose `smallestUnit` property value is that string.
+  - If an object is passed, the following properties are recognized:
+    - `smallestUnit` (required string): The unit to round to.
+      Valid values are `'day'`, `'hour'`, `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
+    - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
+      The default is 1.
+    - `roundingMode` (string): How to handle the remainder.
+      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      The default is `'halfExpand'`.
 
-**Returns:** a new `Temporal.ZonedDateTime` object which is `zonedDateTime` rounded to `roundingIncrement` of `smallestUnit`.
+**Returns:** a new `Temporal.ZonedDateTime` object which is `zonedDateTime` rounded to `roundTo` (if a string parameter is used) or `roundingIncrement` of `smallestUnit` (if an object parameter is used).
 
 Rounds `zonedDateTime` to the given unit and increment, and returns the result as a new `Temporal.ZonedDateTime` object.
 
-The `smallestUnit` option determines the unit to round to.
+The `smallestUnit` option (or the value of `roundTo` if a string parameter is used) determines the unit to round to.
 For example, to round to the nearest minute, use `smallestUnit: 'minute'`.
 This option is required.
 
@@ -1170,6 +1174,10 @@ The `roundingMode` option controls how the rounding is performed.
   (These two modes behave the same, but are both included for consistency with `Temporal.Duration.prototype.round()`, where they are not the same.)
 - `'halfExpand'`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `'ceil'`.
+
+As expected for a method named "round", the default rounding mode is `'halfExpand'` to match the behavior of `Math.round`.
+Note that this is different than the `'trunc'` default used by `until` and `since` options because rounding up would be an unexpected default for those operations.
+Other properties behave identically between these methods.
 
 Example usage:
 

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -17,6 +17,8 @@ import {
   GetSlot
 } from './slots.mjs';
 
+const ObjectCreate = Object.create;
+
 export class PlainDateTime {
   constructor(
     isoYear,
@@ -510,13 +512,19 @@ export class PlainDateTime {
       -nanoseconds
     );
   }
-  round(options) {
+  round(roundTo) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    if (options === undefined) throw new TypeError('options parameter is required');
-    options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week']);
+    if (roundTo === undefined) throw new TypeError('options parameter is required');
+    if (ES.Type(roundTo) === 'String') {
+      const stringParam = roundTo;
+      roundTo = ObjectCreate(null);
+      roundTo.smallestUnit = stringParam;
+    } else {
+      roundTo = ES.GetOptionsObject(roundTo);
+    }
+    const smallestUnit = ES.ToSmallestTemporalUnit(roundTo, undefined, ['year', 'month', 'week']);
     if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
+    const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
     const maximumIncrements = {
       day: 1,
       hour: 24,
@@ -526,7 +534,7 @@ export class PlainDateTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo, maximumIncrements[smallestUnit], false);
 
     let year = GetSlot(this, ISO_YEAR);
     let month = GetSlot(this, ISO_MONTH);

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -22,6 +22,7 @@ import {
 } from './slots.mjs';
 
 const ObjectAssign = Object.assign;
+const ObjectCreate = Object.create;
 
 const DISALLOWED_UNITS = ['year', 'month', 'week', 'day'];
 const MAX_INCREMENTS = {
@@ -332,14 +333,20 @@ export class PlainTime {
     const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
-  round(options) {
+  round(roundTo) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
-    if (options === undefined) throw new TypeError('options parameter is required');
-    options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, DISALLOWED_UNITS);
+    if (roundTo === undefined) throw new TypeError('options parameter is required');
+    if (ES.Type(roundTo) === 'String') {
+      const stringParam = roundTo;
+      roundTo = ObjectCreate(null);
+      roundTo.smallestUnit = stringParam;
+    } else {
+      roundTo = ES.GetOptionsObject(roundTo);
+    }
+    const smallestUnit = ES.ToSmallestTemporalUnit(roundTo, undefined, DISALLOWED_UNITS);
     if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(options, MAX_INCREMENTS[smallestUnit], false);
+    const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo, MAX_INCREMENTS[smallestUnit], false);
 
     let hour = GetSlot(this, ISO_HOUR);
     let minute = GetSlot(this, ISO_MINUTE);

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -829,10 +829,17 @@ describe('Instant', () => {
       throws(() => inst.round({}), RangeError);
       throws(() => inst.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('throws on disallowed or invalid smallestUnit (object param)', () => {
       ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
         (smallestUnit) => {
           throws(() => inst.round({ smallestUnit }), RangeError);
+        }
+      );
+    });
+    it('throws on disallowed or invalid smallestUnit (string param)', () => {
+      ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
+        (smallestUnit) => {
+          throws(() => inst.round(smallestUnit), RangeError);
         }
       );
     });
@@ -919,6 +926,16 @@ describe('Instant', () => {
       throws(() => inst.round({ smallestUnit: 'millisecond', roundingIncrement: 29 }), RangeError);
       throws(() => inst.round({ smallestUnit: 'microsecond', roundingIncrement: 29 }), RangeError);
       throws(() => inst.round({ smallestUnit: 'nanosecond', roundingIncrement: 29 }), RangeError);
+    });
+    it('accepts plural units', () => {
+      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(inst.round({ smallestUnit }).equals(inst.round({ smallestUnit: `${smallestUnit}s` })));
+      });
+    });
+    it('accepts string parameter as shortcut for {smallestUnit}', () => {
+      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(inst.round(smallestUnit).equals(inst.round({ smallestUnit })));
+      });
     });
   });
   describe('Min/max range', () => {

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -1104,9 +1104,14 @@ describe('DateTime', () => {
       throws(() => dt.round({}), RangeError);
       throws(() => dt.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('throws on disallowed or invalid smallestUnit (object param)', () => {
       ['era', 'year', 'month', 'week', 'years', 'months', 'weeks', 'nonsense'].forEach((smallestUnit) => {
         throws(() => dt.round({ smallestUnit }), RangeError);
+      });
+    });
+    it('throws on disallowed or invalid smallestUnit (string param)', () => {
+      ['era', 'year', 'month', 'week', 'years', 'months', 'weeks', 'nonsense'].forEach((smallestUnit) => {
+        throws(() => dt.round(smallestUnit), RangeError);
       });
     });
     it('throws on invalid roundingMode', () => {
@@ -1228,13 +1233,14 @@ describe('DateTime', () => {
       });
     });
     it('accepts plural units', () => {
-      assert(dt.round({ smallestUnit: 'days' }).equals(dt.round({ smallestUnit: 'day' })));
-      assert(dt.round({ smallestUnit: 'hours' }).equals(dt.round({ smallestUnit: 'hour' })));
-      assert(dt.round({ smallestUnit: 'minutes' }).equals(dt.round({ smallestUnit: 'minute' })));
-      assert(dt.round({ smallestUnit: 'seconds' }).equals(dt.round({ smallestUnit: 'second' })));
-      assert(dt.round({ smallestUnit: 'milliseconds' }).equals(dt.round({ smallestUnit: 'millisecond' })));
-      assert(dt.round({ smallestUnit: 'microseconds' }).equals(dt.round({ smallestUnit: 'microsecond' })));
-      assert(dt.round({ smallestUnit: 'nanoseconds' }).equals(dt.round({ smallestUnit: 'nanosecond' })));
+      ['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(dt.round({ smallestUnit }).equals(dt.round({ smallestUnit: `${smallestUnit}s` })));
+      });
+    });
+    it('accepts string parameter as shortcut for {smallestUnit}', () => {
+      ['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(dt.round(smallestUnit).equals(dt.round({ smallestUnit })));
+      });
     });
   });
   describe('DateTime.from() works', () => {

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -563,10 +563,17 @@ describe('Time', () => {
       throws(() => time.round({}), RangeError);
       throws(() => time.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('throws on disallowed or invalid smallestUnit (object param)', () => {
       ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
         (smallestUnit) => {
           throws(() => time.round({ smallestUnit }), RangeError);
+        }
+      );
+    });
+    it('throws on disallowed or invalid smallestUnit (string param)', () => {
+      ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
+        (smallestUnit) => {
+          throws(() => time.round(smallestUnit), RangeError);
         }
       );
     });
@@ -676,12 +683,14 @@ describe('Time', () => {
       });
     });
     it('accepts plural units', () => {
-      assert(time.round({ smallestUnit: 'hours' }).equals(time.round({ smallestUnit: 'hour' })));
-      assert(time.round({ smallestUnit: 'minutes' }).equals(time.round({ smallestUnit: 'minute' })));
-      assert(time.round({ smallestUnit: 'seconds' }).equals(time.round({ smallestUnit: 'second' })));
-      assert(time.round({ smallestUnit: 'milliseconds' }).equals(time.round({ smallestUnit: 'millisecond' })));
-      assert(time.round({ smallestUnit: 'microseconds' }).equals(time.round({ smallestUnit: 'microsecond' })));
-      assert(time.round({ smallestUnit: 'nanoseconds' }).equals(time.round({ smallestUnit: 'nanosecond' })));
+      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(time.round({ smallestUnit }).equals(time.round({ smallestUnit: `${smallestUnit}s` })));
+      });
+    });
+    it('accepts string parameter as shortcut for {smallestUnit}', () => {
+      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(time.round(smallestUnit).equals(time.round({ smallestUnit })));
+      });
     });
   });
   describe('Time.compare() works', () => {

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -1959,9 +1959,14 @@ describe('ZonedDateTime', () => {
       throws(() => zdt.round({}), RangeError);
       throws(() => zdt.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('throws on disallowed or invalid smallestUnit (object param)', () => {
       ['era', 'year', 'month', 'week', 'years', 'months', 'weeks', 'nonsense'].forEach((smallestUnit) => {
         throws(() => zdt.round({ smallestUnit }), RangeError);
+      });
+    });
+    it('throws on disallowed or invalid smallestUnit (string param)', () => {
+      ['era', 'year', 'month', 'week', 'years', 'months', 'weeks', 'nonsense'].forEach((smallestUnit) => {
+        throws(() => zdt.round(smallestUnit), RangeError);
       });
     });
     it('throws on invalid roundingMode', () => {
@@ -2107,26 +2112,28 @@ describe('ZonedDateTime', () => {
       });
     });
     it('accepts plural units', () => {
-      assert(zdt.round({ smallestUnit: 'hours' }).equals(zdt.round({ smallestUnit: 'hour' })));
-      assert(zdt.round({ smallestUnit: 'minutes' }).equals(zdt.round({ smallestUnit: 'minute' })));
-      assert(zdt.round({ smallestUnit: 'seconds' }).equals(zdt.round({ smallestUnit: 'second' })));
-      assert(zdt.round({ smallestUnit: 'milliseconds' }).equals(zdt.round({ smallestUnit: 'millisecond' })));
-      assert(zdt.round({ smallestUnit: 'microseconds' }).equals(zdt.round({ smallestUnit: 'microsecond' })));
-      assert(zdt.round({ smallestUnit: 'nanoseconds' }).equals(zdt.round({ smallestUnit: 'nanosecond' })));
+      ['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(zdt.round({ smallestUnit }).equals(zdt.round({ smallestUnit: `${smallestUnit}s` })));
+      });
+    });
+    it('accepts string parameter as shortcut for {smallestUnit}', () => {
+      ['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(zdt.round(smallestUnit).equals(zdt.round({ smallestUnit })));
+      });
     });
     it('rounds correctly to a 25-hour day', () => {
-      const options = { smallestUnit: 'day' };
+      const roundTo = { smallestUnit: 'day' };
       const roundMeDown = ZonedDateTime.from('2020-11-01T12:29:59-08:00[America/Vancouver]');
-      equal(`${roundMeDown.round(options)}`, '2020-11-01T00:00:00-07:00[America/Vancouver]');
+      equal(`${roundMeDown.round(roundTo)}`, '2020-11-01T00:00:00-07:00[America/Vancouver]');
       const roundMeUp = ZonedDateTime.from('2020-11-01T12:30:01-08:00[America/Vancouver]');
-      equal(`${roundMeUp.round(options)}`, '2020-11-02T00:00:00-08:00[America/Vancouver]');
+      equal(`${roundMeUp.round(roundTo)}`, '2020-11-02T00:00:00-08:00[America/Vancouver]');
     });
     it('rounds correctly to a 23-hour day', () => {
-      const options = { smallestUnit: 'day' };
+      const roundTo = { smallestUnit: 'day' };
       const roundMeDown = ZonedDateTime.from('2020-03-08T11:29:59-07:00[America/Vancouver]');
-      equal(`${roundMeDown.round(options)}`, '2020-03-08T00:00:00-08:00[America/Vancouver]');
+      equal(`${roundMeDown.round(roundTo)}`, '2020-03-08T00:00:00-08:00[America/Vancouver]');
       const roundMeUp = ZonedDateTime.from('2020-03-08T11:30:01-07:00[America/Vancouver]');
-      equal(`${roundMeUp.round(options)}`, '2020-03-09T00:00:00-07:00[America/Vancouver]');
+      equal(`${roundMeUp.round(roundTo)}`, '2020-03-09T00:00:00-07:00[America/Vancouver]');
     });
     it('rounding up to a nonexistent wall-clock time', () => {
       const almostSkipped = ZonedDateTime.from('2018-11-03T23:59:59.999999999-03:00[America/Sao_Paulo]');

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -409,26 +409,31 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.duration.prototype.round">
-      <h1>Temporal.Duration.prototype.round ( _options_ )</h1>
+      <h1>Temporal.Duration.prototype.round ( _roundTo_ )</h1>
       <p>
-        The `round` method takes one argument _options_.
+        The `round` method takes one argument _roundTo_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. If _options_ is *undefined*, then
+        1. If _roundTo_ is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
+        1. If Type(_roundTo_) is String, then
+          1. Let _paramString_ be _roundTo_.
+          1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+        1. Else,
+          1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnitPresent_ be *true*.
         1. Let _largestUnitPresent_ be *true*.
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *undefined*).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « », *undefined*).
         1. If _smallestUnit_ is *undefined*, then
           1. Set _smallestUnitPresent_ to *false*.
           1. Set _smallestUnit_ to *"nanosecond"*.
         1. Let _defaultLargestUnit_ be ! DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
         1. Set _defaultLargestUnit_ to ! LargerOfTwoTemporalUnits(_defaultLargestUnit_, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *undefined*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_roundTo_, « », *undefined*).
         1. If _largestUnit_ is *undefined*, then
           1. Set _largestUnitPresent_ to *false*.
           1. Set _largestUnit_ to _defaultLargestUnit_.
@@ -437,10 +442,10 @@
         1. If _smallestUnitPresent_ is *false* and _largestUnitPresent_ is *false*, then
           1. Throw a *RangeError* exception.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_options_).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_, _maximum_, *false*).
+        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_roundTo_).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _relativeTo_).
         1. Let _roundResult_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_[[Seconds]], _duration_[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
         1. Let _adjustResult_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
@@ -453,18 +458,23 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.duration.prototype.total">
-      <h1>Temporal.Duration.prototype.total ( _options_ )</h1>
+      <h1>Temporal.Duration.prototype.total ( _totalOf_ )</h1>
       <p>
-        The `total` method takes one argument _options_.
+        The `total` method takes one argument _totalOf_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. If _options_ is *undefined*, throw a *TypeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_options_).
-        1. Let _unit_ be ? ToTemporalDurationTotalUnit(_options_).
+        1. If _totalOf_ is *undefined*, throw a *TypeError* exception.
+        1. If Type(_totalOf_) is String, then
+          1. Let _paramString_ be _totalOf_.
+          1. Set _totalOf_ to ! OrdinaryObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_totalOf_, *"unit"*, _paramString_).
+        1. Else,
+          1. Set _totalOf_ to ? GetOptionsObject(_totalOf_).
+        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_totalOf_).
+        1. Let _unit_ be ? ToTemporalDurationTotalUnit(_totalOf_).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _relativeTo_).
         1. Let _intermediate_ be *undefined*.
         1. If _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -296,20 +296,25 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.instant.prototype.round">
-      <h1>Temporal.Instant.prototype.round ( _options_ )</h1>
+      <h1>Temporal.Instant.prototype.round ( _roundTo_ )</h1>
       <p>
-        The `round` method takes one argument _options_.
+        The `round` method takes one argument _roundTo_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. If _options_ is *undefined*, then
+        1. If _roundTo_ is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
+        1. If Type(_roundTo_) is String, then
+          1. Let _paramString_ be _roundTo_.
+          1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+        1. Else,
+          1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
           1. Let _maximum_ be 24.
         1. Else if _smallestUnit_ is *"minute"*, then
@@ -323,7 +328,7 @@
         1. Else,
           1. Assert: _smallestUnit_ is *"nanosecond"*.
           1. Let _maximum_ be 8.64 × 10<sup>13</sup>.
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *true*).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_, _maximum_, *true*).
         1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalInstant(_roundedNs_).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -533,21 +533,26 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.plaindatetime.prototype.round">
-      <h1>Temporal.PlainDateTime.prototype.round ( _options_ )</h1>
+      <h1>Temporal.PlainDateTime.prototype.round ( _roundTo_ )</h1>
       <p>
-        The `round` method takes one argument _options_.
+        The `round` method takes one argument _roundTo_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. If _options_ is *undefined*, then
+        1. If _roundTo_ is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"* », *undefined*).
+        1. If Type(_roundTo_) is String, then
+          1. Let _paramString_ be _roundTo_.
+          1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+        1. Else,
+          1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"* », *undefined*).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
-        1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_options_, _smallestUnit_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
+        1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -327,27 +327,32 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.plaintime.prototype.round">
-      <h1>Temporal.PlainTime.prototype.round ( _options_ )</h1>
+      <h1>Temporal.PlainTime.prototype.round ( _roundTo_ )</h1>
       <p>
-        The `round` method takes one argument _options_.
+        The `round` method takes one argument _roundTo_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. If _options_ is *undefined*, then
+        1. If _roundTo_ is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
+        1. If Type(_roundTo_) is String, then
+          1. Let _paramString_ be _roundTo_.
+          1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+        1. Else,
+          1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
           1. Let _maximum_ be 24.
         1. Else if _smallestUnit_ is *"minute"* or *"second"*, then
           1. Let _maximum_ be 60.
         1. Else,
           1. Let _maximum_ be 1000.
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_, _maximum_, *false*).
         1. Let _result_ be ! RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -764,21 +764,26 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.zoneddatetime.prototype.round">
-      <h1>Temporal.ZonedDateTime.prototype.round ( _options_ )</h1>
+      <h1>Temporal.ZonedDateTime.prototype.round ( _roundTo_ )</h1>
       <p>
-        The `round` method takes one argument _options_.
+        The `round` method takes one argument _roundTo_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. If _options_ is *undefined*, then
+        1. If _roundTo_ is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"* », *undefined*).
+        1. If Type(_roundTo_) is String, then
+          1. Let _paramString_ be _roundTo_.
+          1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+        1. Else,
+          1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"* », *undefined*).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"halfExpand"*).
-        1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_options_, _smallestUnit_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
+        1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].


### PR DESCRIPTION
This PR addresses reviewer feedback from @ljharb that required parameters should not only be an options bag if some of those "options" are actually required properties. With this PR, all affected methods (`round` on multiple types, and `total` on Duration) now also accept a string as their single required parameter. 

For advanced use cases, the string can be substituted with a property bag containing the string parameter as a property, plus additional optional properties.

The champions met this morning and came to consensus that we support this change because it makes the API more ergonomic without breaking any existing use cases. 

This is a normative change but not a breaking change. Fixes #1756.

Examples:
* `duration.total('hours')` is equivalent to `duration.total({ unit: 'hours' })`
* `time.round('hours')` is equivalent to  `time.round({ smallestUnit: 'hours' })`