### PR TITLE
Editorial: Mark GetEpochFromISOParts as infallible

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -537,7 +537,7 @@
         1. Let _result_ be ? ParseTemporalInstantString(_isoString_).
         1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
         1. Assert: _offsetString_ is not *undefined*.
-        1. Let _utc_ be ? GetEpochFromISOParts(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
+        1. Let _utc_ be ! GetEpochFromISOParts(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
         1. If _utc_ &lt; −8.64 × 10<sup>21</sup> or _utc_ &gt; 8.64 × 10<sup>21</sup>, then
           1. Throw a *RangeError* exception.
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1094,7 +1094,7 @@
           1. Let _instant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _dateTime_, _disambiguation_).
           1. Return _instant_.[[Nanoseconds]].
         1. If _offsetBehaviour_ is ~exact~, or _offsetOption_ is *"use"*, then
-          1. Let _epochNanoseconds_ be ? GetEpochFromISOParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+          1. Let _epochNanoseconds_ be ! GetEpochFromISOParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
           1. Return _epochNanoseconds_ − _offsetNanoseconds_.
         1. Assert: _offsetBehaviour_ is ~option~.
         1. Assert: _offsetOption_ is *"prefer"* or *"reject"*.


### PR DESCRIPTION
Lots of `!`, no `?`.

```
5.5.1 GetEpochFromISOParts ( year, month, day, hour, minute, second, millisecond, microsecond, nanosecond )

    1. Assert: year, month, day, hour, minute, second, millisecond, microsecond, and nanosecond are integers.
    2. Assert: ! IsValidISODate(year, month, day) is true.
    3. Assert: ! IsValidTime(hour, minute, second, millisecond, microsecond, nanosecond) is true.
    4. Let date be ! MakeDay(𝔽(year), 𝔽(month − 1), 𝔽(day)).
    5. Let time be ! MakeTime(𝔽(hour), 𝔽(minute), 𝔽(second), 𝔽(millisecond)).
    6. Let ms be ! MakeDate(date, time).
    7. Assert: ms is finite.
    8. Return ℝ(ms) × 10^6 + microsecond × 10^3 + nanosecond.
```

`ISODateTimeWithinLimits`, `Temporal.TimeZone.prototype.getPossibleInstantsFor`, and `DisambiguatePossibleInstants` already have it correctly.