### PR TITLE
Normative: add "offset" to fieldNames in ToTemporalZonedDateTime

### DIFF
--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1122,6 +1122,7 @@
           1. Let _calendar_ be ? GetTemporalCalendarWithISODefault(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
           1. Append *"timeZone"* to _fieldNames_.
+          1. Append *"offset"* to _fieldNames_.
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, « *"timeZone"* »).
           1. Let _timeZone_ be ? Get(_fields_, *"timeZone"*).
           1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).


### PR DESCRIPTION
Fix https://github.com/tc39/proposal-temporal/issues/1892 to avoid deadcode
Needed to fulfil 
https://github.com/tc39/test262/blob/main/test/built-ins/Temporal/ZonedDateTime/from/offset-undefined.js
https://github.com/tc39/test262/blob/main/test/built-ins/Temporal/ZonedDateTime/from/options-undefined.js

@pdunkel @ptomato @jugglinmike @Ms2ger @ljharb @justingrant