### PR TITLE
Use US spelling in docs (behaviour => behavior)

### DIFF
--- a/docs/calendar-draft.md
+++ b/docs/calendar-draft.md
@@ -673,7 +673,7 @@ All of the following APIs would gain an internal slot for the calendar.
 - Temporal.PlainYearMonth
 - Temporal.PlainMonthDay
 
-### New behaviour of Temporal.PlainMonthDay.withYear
+### New behavior of Temporal.PlainMonthDay.withYear
 
 In some calendars (such as the Japanese imperial calendar) a year is not enough information to be able to convert Temporal.PlainMonthDay to Temporal.PlainDate.
 Temporal.PlainMonthDay.withYear, which previously took a number argument (the year), can now be passed an object which must have properties that provide the needed information.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -17,9 +17,11 @@ Here's how they would look using Temporal.
 
 How to get the current date and time in the local time zone?
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getCurrentDate.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 Note that if you just want the date and not the time, you should use `Temporal.PlainDate`.
 If you want both, use `Temporal.PlainDateTime`.
@@ -28,9 +30,11 @@ If you want both, use `Temporal.PlainDateTime`.
 
 How to get a Unix timestamp?
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getTimeStamp.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ## Converting between Temporal types and legacy Date
 
@@ -38,9 +42,11 @@ How to get a Unix timestamp?
 
 Map a legacy ECMAScript Date instance into a Temporal.Instant instance corresponding to the same instant in exact time.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/instantFromLegacyDate.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ## Construction
 
@@ -48,9 +54,11 @@ Map a legacy ECMAScript Date instance into a Temporal.Instant instance correspon
 
 `Temporal.TimeZone.from()` can convert an IANA time zone name into a `Temporal.TimeZone` object.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getTimeZoneObjectFromIanaName.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Calendar input element
 
@@ -59,6 +67,7 @@ Here is an example using an HTML `<input type="date">` element with any day beyo
 
 <input type="date" id="calendar-input">
 
+<!-- prettier-ignore-start -->
 <script type="text/javascript">
 {
 {{cookbook/calendarInput.js}}
@@ -68,6 +77,7 @@ Here is an example using an HTML `<input type="date">` element with any day beyo
 ```javascript
 {{cookbook/calendarInput.js}}
 ```
+<!-- prettier-ignore-end -->
 
 ## Converting between types
 
@@ -75,17 +85,21 @@ Here is an example using an HTML `<input type="date">` element with any day beyo
 
 An example of combining a calendar date (`Temporal.PlainDate`) and a wall-clock time (`Temporal.PlainTime`) into a `Temporal.PlainDateTime`.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/noonOnDate.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Birthday in 2030
 
 An example of combining a day on the calendar (`Temporal.PlainMonthDay`) and a year into a `Temporal.PlainDate`.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/birthdayIn2030.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ## Serialization
 
@@ -99,9 +113,11 @@ If you need your string to include a UTC offset, then use the `timeZone` option 
 This loses the information about which time zone the string was in, because it only preserves the UTC offset from the time zone at that particular exact time.
 If you need your string to include the time zone name, use Temporal.ZonedDateTime instead, which retains this information.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getParseableZonedStringAtInstant.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ## Sorting
 
@@ -112,17 +128,21 @@ Each Temporal type has a `compare()` static method, which can be passed to `Arra
 Sort a list of `Temporal.PlainDateTime`s, for example in order to get a conference schedule in the correct order.
 Sorting other Temporal types would work exactly the same way as this.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getSortedLocalDateTimes.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Sort ISO date/time strings
 
 Sort a list of ISO 8601 date/time strings, for example to place log entries in order.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/sortExactTimeStrings.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ## Rounding
 
@@ -131,9 +151,11 @@ Sort a list of ISO 8601 date/time strings, for example to place log entries in o
 Use the `round()` method of each Temporal type if you want to round the time fields.
 Here's an example of rounding a time _down_ to the previously occurring whole hour:
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/roundDownToWholeHours.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Round a date to the nearest start of the month
 
@@ -142,9 +164,11 @@ Rounding a date field can be ambiguous, so date-only types such as `Temporal.Pla
 If you need to round a date to the nearest month, for example, then you must explicitly pick what kind of rounding you want.
 Here is an example of rounding to the nearest start of a month, rounding up in case of a tie:
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/roundToNearestMonth.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 See also [Push back a launch date](#push-back-a-launch-date) for an easier way to round up unconditionally to the _next_ start of a month.
 
@@ -155,18 +179,22 @@ See also [Push back a launch date](#push-back-a-launch-date) for an easier way t
 Map a zoneless date and time of day into a `Temporal.Instant` instance at which the local date and time of day in a specified time zone matches it.
 This is easily done with `dateTime.toZonedDateTime(timeZone).toInstant()`, but here is an example of implementing different disambiguation behaviors than the `'compatible'`, `'earlier'`, `'later'`, and `'reject'` ones built in to Temporal.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getInstantWithLocalTimeInZone.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Preserving exact time
 
 Map a zoned date and time of day into another zoned date and time of day in a target time zone at the corresponding exact time.
 This could be used when converting user-input date-time values between time zones.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/zonedDateTimeInOtherZone.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 Here is another example similar to the previous one, using the time zone for future events.
 The times and locations of a series of future meetings are stored as a pair of strings: one for the calendar date and wall-clock time, and one for the time zone.
@@ -175,48 +203,59 @@ So if the time zone rules changed, the event's exact time would change.
 
 This example calculates the starting times of all the Ecma TC39 meetings in 2019, in local time in Tokyo.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/localTimeForFutureEvents.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Daily occurrence in local time
 
 Similar to the previous recipe, calculate the exact times of a daily occurrence that happens at a particular local time in a particular time zone.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/calculateDailyOccurrence.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### UTC offset for a zoned event, as a string
 
 Use `Temporal.TimeZone.getOffsetStringFor()` or `Temporal.ZonedDateTime.offset` to map a `Temporal.Instant` instance and a time zone into the UTC offset at that exact time in that time zone, as a string.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getUtcOffsetStringAtInstant.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### UTC offset for a zoned event, as a number of seconds
 
 Similarly, use `Temporal.TimeZone.getOffsetNanosecondsFor()` to do the same thing for the offset as a number of seconds.
 (Remember to divide by 10<sup>9</sup> to convert nanoseconds to seconds.)
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getUtcOffsetSecondsAtInstant.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Offset between two time zones at an exact time
 
 Also using `Temporal.TimeZone.getOffsetNanosecondsFor()`, we can map a `Temporal.Instant` instance and two time zones into the signed difference of UTC offsets between those time zones at that exact time, as a number of seconds.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getUtcOffsetDifferenceSecondsAtInstant.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Dealing with dates and times in a fixed location
 
 Here is an example of Temporal used in a graph, showing fictitious activity for a storage tank in a fixed location (Stockholm, Sweden).
 The graph always starts at midnight in the tank's location, but the graph labels are in the viewer's time zone.
 
+<!-- prettier-ignore-start -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"></script>
 
 <canvas id="storage-tank" width="600" height="400"></canvas>
@@ -240,6 +279,7 @@ for (let ix = 1; ix < tankDataY.length; ix++) {
 ```javascript
 {{cookbook/storageTank.js}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Book a meeting across time zones
 
@@ -297,6 +337,7 @@ Across the web there are several tools for finding meeting times that are approp
 <table id="meeting-planner">
 </table>
 
+<!-- prettier-ignore-start -->
 <script type="text/javascript" id="meeting-planner-source">
 {
 {{cookbook/meetingPlanner.js}}
@@ -306,6 +347,7 @@ Across the web there are several tools for finding meeting times that are approp
 ```javascript
 {{cookbook/meetingPlanner.js}}
 ```
+<!-- prettier-ignore-end -->
 
 ## Arithmetic
 
@@ -337,56 +379,70 @@ An example HTML form inspired by [Days Calculator](https://www.timeanddate.com/d
 }
 </script>
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/futureDateForm.js}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Unit-constrained duration between now and a past/future zoned event
 
 Take the difference between two Temporal.Instant instances as a Temporal.Duration instance (positive or negative), representing the duration between the two instants without using units coarser than specified (e.g., for presenting a meaningful countdown with vs. without using months or days).
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getElapsedDurationSinceInstant.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Nearest offset transition in a time zone
 
 Map a Temporal.Instant instance and a Temporal.TimeZone object into a Temporal.Instant instance representing the nearest following exact time at which there is an offset transition in the time zone (e.g., for setting reminders).
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getInstantOfNearestOffsetTransitionToInstant.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Comparison of an exact time to business hours
 
 This example takes a roster of wall-clock opening and closing times for a business, and maps an exact time into a time-sensitive state indicator ("opening soon" vs. "open" vs. "closing soon" vs. "closed").
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getBusinessOpenStateText.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Flight arrival/departure/duration
 
 Map localized trip departure and arrival times into trip duration in units no larger than hours.
 (By default, differences between ZonedDateTime instances are exact differences in time units.)
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getTripDurationInHrMinSec.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 Given a departure time with time zone and a flight duration, get an arrival time in the destination time zone, using time zone-aware math.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getLocalizedArrival.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Push back a launch date
 
 Add the number of days it took to get an approval, and advance to the start of the following month.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/plusAndRoundToMonthStart.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Schedule a reminder ahead of matching a record-setting duration
 
@@ -396,64 +452,80 @@ It returns the exact time at which a notification could be sent, for example "Ke
 
 This could be used for workout tracking, racing (including _long_ and potentially time-zone-crossing races like the Bullrun Rally, Iditarod, Self-Transcendence 3100, and Clipper Round The World), or even open-ended analogs like event-every-day "streaks".
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getInstantBeforeOldRecord.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Nth weekday of the month
 
 Example of getting a `Temporal.PlainDate` representing the first Tuesday of the given `Temporal.PlainYearMonth`, adaptable to other weekdays.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getFirstTuesdayOfMonth.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 Given a `Temporal.PlainYearMonth` instance and an ISO 8601 ordinal calendar day of the week ranging from 1 (Monday) to 7 (Sunday), return a chronologically ordered array of `Temporal.PlainDate` instances corresponding with every day in the month that is the specified day of the week (of which there will always be either four or five).
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/getWeeklyDaysInMonth.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 Given a `Temporal.PlainDate` instance, return the count of preceding days in its month that share its day of the week.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/countPrecedingWeeklyDaysInMonth.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Manipulating the day of the month
 
 Here are some examples of taking an existing date, and adjusting the day of the month.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/adjustDayOfMonth.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Same date in another month
 
 Likewise, here are some examples of taking an existing date and adjusting the month, but keeping the day and year the same.
 
-Depending on the behaviour you want, you will need to pick the right `overflow` option, but the default of `"constrain"` should be correct for most cases.
+Depending on the behavior you want, you will need to pick the right `overflow` option, but the default of `"constrain"` should be correct for most cases.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/adjustMonth.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Next weekly occurrence
 
 From a `Temporal.ZonedDateTime` instance, get a `Temporal.ZonedDateTime` representing the next occurrence of a weekly event that is scheduled on a particular weekday and time in a particular time zone. (For example, "weekly on Thursdays at 08:45 California time").
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/nextWeeklyOccurrence.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ### Weekday of yearly occurrence
 
 In some countries, when a public holiday falls on a Tuesday or Thursday, an extra "bridge" public holiday is observed on Monday or Friday in order to give workers a long weekend off.
 The following example calculates this.
 
+<!-- prettier-ignore-start -->
 ```javascript
 {{cookbook/bridgePublicHolidays.mjs}}
 ```
+<!-- prettier-ignore-end -->
 
 ## Advanced use cases
 

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -58,7 +58,7 @@ Any missing or `undefined` numerical arguments are taken to be zero, and all non
 Any non-zero arguments must all have the same sign.
 
 Use this constructor directly if you have the correct parameters already as numerical values.
-Otherwise `Temporal.Duration.from()` is probably more convenient because it accepts more kinds of input and allows controlling the overflow behaviour.
+Otherwise `Temporal.Duration.from()` is probably more convenient because it accepts more kinds of input and allows controlling the overflow behavior.
 
 Usage examples:
 
@@ -420,7 +420,7 @@ For usage examples and a more complete explanation of how balancing works, see [
 
 A `largestUnit` value of `'auto'`, which is the default if only `smallestUnit` is given, means that `largestUnit` should be the largest nonzero unit in the duration that is larger than `smallestUnit`.
 For example, in a duration of 3 days and 12 hours, `largestUnit: 'auto'` would mean the same as `largestUnit: 'day'`.
-This behavior implies that the default balancing behaviour of this method to not 'grow' the duration beyond its current largest unit unless needed for rounding.
+This behavior implies that the default balancing behavior of this method to not "grow" the duration beyond its current largest unit unless needed for rounding.
 
 The `smallestUnit` option determines the unit to round to.
 For example, to round to the nearest minute, use `smallestUnit: 'minute'`.

--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -29,7 +29,7 @@ It can also be combined with a `Temporal.PlainTime` to yield a "zoneless" `Tempo
 **Returns:** a new `Temporal.PlainDate` object.
 
 Use this constructor if you have the correct parameters for the date already as individual number values in the ISO 8601 calendar.
-Otherwise, `Temporal.PlainDate.from()`, which accepts more kinds of input, allows inputting dates in different calendar reckonings, and allows controlling the overflow behaviour, is probably more convenient.
+Otherwise, `Temporal.PlainDate.from()`, which accepts more kinds of input, allows inputting dates in different calendar reckonings, and allows controlling the overflow behavior, is probably more convenient.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in that calendar, even if you are passing a different calendar as the `calendar` parameter.

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -54,7 +54,7 @@ To learn more about time zones and DST best practices, visit [Time Zones and Res
 **Returns:** a new `Temporal.PlainDateTime` object.
 
 Use this constructor if you have the correct parameters for the datetime already as individual number values in the ISO 8601 calendar.
-Otherwise, `Temporal.PlainDateTime.from()`, which accepts more kinds of input, allows inputting dates and times in different calendar reckonings, and allows controlling the overflow behaviour, is probably more convenient.
+Otherwise, `Temporal.PlainDateTime.from()`, which accepts more kinds of input, allows inputting dates and times in different calendar reckonings, and allows controlling the overflow behavior, is probably more convenient.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in that calendar, even if you are passing a different calendar as the `calendar` parameter, and the time parameters must represent a valid time of day.

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -29,7 +29,7 @@ It can also be combined with a `Temporal.PlainDate` to yield a "zoneless" `Tempo
 **Returns:** a new `Temporal.PlainTime` object.
 
 Use this constructor if you have the correct parameters for the time already as individual number values in the ISO 8601 calendar.
-Otherwise, `Temporal.PlainTime.from()`, which accepts more kinds of input and allows controlling the overflow behaviour, is probably more convenient.
+Otherwise, `Temporal.PlainTime.from()`, which accepts more kinds of input and allows controlling the overflow behavior, is probably more convenient.
 
 All values are given as reckoned in the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -285,7 +285,7 @@ If `dateTime` is not a `Temporal.PlainDateTime` object, then it will be converte
 Normally there is only one possible exact time corresponding to a wall-clock time, but around a daylight saving change, a wall-clock time may not exist, or the same wall-clock time may exist twice in a row.
 See [Resolving ambiguity](./ambiguity.md) for usage examples and a more complete explanation.
 
-Although this method is useful for implementing a custom time zone or custom disambiguation behaviour, usually you won't have to use this method; `Temporal.TimeZone.prototype.getInstantFor()` will be more convenient for most use cases.
+Although this method is useful for implementing a custom time zone or custom disambiguation behavior, usually you won't have to use this method; `Temporal.TimeZone.prototype.getInstantFor()` will be more convenient for most use cases.
 During "skipped" clock time like the hour after DST starts in the Spring, `Temporal.TimeZone.prototype.getInstantFor()` returns a `Temporal.Instant` (by default interpreting the `Temporal.PlainDateTime` using the pre-transition time zone offset), while this method returns zero results during those skipped periods.
 
 ### timeZone.**getNextTransition**(_startingPoint_: Temporal.Instant | string) : Temporal.Instant


### PR DESCRIPTION
I split this out of #1875 so that this part is not blocked on anything.