### PR TITLE
Normative: Simplify Duration parsing

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1243,10 +1243,6 @@
       1. Let _duration_ be ParseText(! StringToCodePoints(_isoString_), |TemporalDurationString|).
       1. If _duration_ is a List of errors, throw a *RangeError* exception.
       1. Let each of _sign_, _years_, _months_, _weeks_, _days_, _hours_, _fHours_, _minutes_, _fMinutes_, _seconds_, and _fSeconds_ be the source text matched by the respective |Sign|, |DurationYears|, |DurationMonths|, |DurationWeeks|, |DurationDays|, |DurationWholeHours|, |DurationHoursFraction|, |DurationWholeMinutes|, |DurationMinutesFraction|, |DurationWholeSeconds|, and |DurationSecondsFraction| Parse Node enclosed by _duration_, or an empty sequence of code points if not present.
-      1. If _sign_ contains the code point 0x002D (HYPHEN-MINUS) or 0x2212 (MINUS SIGN), then
-        1. Let _factor_ be −1.
-      1. Else,
-        1. Let _factor_ be 1.
       1. Let _yearsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_years_)).
       1. Let _monthsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_months_)).
       1. Let _weeksMV_ be ! ToIntegerOrInfinity(CodePointsToString(_weeks_)).
@@ -1276,6 +1272,10 @@
         1. Let _millisecondsMV_ be remainder(_secondsMV_, 1) × 1000.
       1. Let _microsecondsMV_ be remainder(_millisecondsMV_, 1) × 1000.
       1. Let _nanosecondsMV_ be remainder(_microsecondsMV_, 1) × 1000.
+      1. If _sign_ contains the code point 0x002D (HYPHEN-MINUS) or 0x2212 (MINUS SIGN), then
+        1. Let _factor_ be −1.
+      1. Else,
+        1. Let _factor_ be 1.
       1. Return the Record {
         [[Years]]: _yearsMV_ × _factor_,
         [[Months]]: _monthsMV_ × _factor_,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -94,41 +94,6 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-durationhandlefractions" aoid="DurationHandleFractions">
-    <h1>DurationHandleFractions ( _fHours_, _minutes_, _fMinutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ )</h1>
-    <emu-alg>
-      1. Assert: _fHours_, _minutes_, _fMinutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are integers.
-      1. If _fHours_ is not equal to 0, then
-        1. If any of _minutes_, _fMinutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ is not 0, throw a *RangeError* exception.
-        1. Let _mins_ be _fHours_ × 60.
-        1. Set _minutes_ to floor(_mins_).
-        1. Set _fMinutes_ to remainder(_mins_, 1).
-      1. If _fMinutes_ is not equal to 0, then
-        1. If any of _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ is not 0, throw a *RangeError* exception.
-        1. Let _secs_ be _fMinutes_ × 60.
-        1. Set _seconds_ to floor(_secs_).
-        1. Let _fSeconds_ be remainder(_secs_, 1).
-        1. If _fSeconds_ is not equal to 0, then
-          1. Let _mils_ be _fSeconds_ × 1000.
-          1. Set _milliseconds_ to floor(_mils_).
-          1. Let _fMilliseconds_ be remainder(_mils_, 1).
-          1. If _fMilliseconds_ is not equal to 0, then
-            1. Let _mics_ be _fMilliseconds_ × 1000.
-            1. Set _microseconds_ to floor(_mics_).
-            1. Let _fMicroseconds_ be remainder(_mics_, 1).
-            1. If _fMicroseconds_ is not equal to 0, then
-              1. Let _nans_ be _fMicroseconds_ × 1000.
-              1. Set _nanoseconds_ to floor(_nans_).
-      1. Return {
-        [[Minutes]]: _minutes_,
-        [[Seconds]]: _seconds_,
-        [[Milliseconds]]: _milliseconds_,
-        [[Microseconds]]: _microseconds_,
-        [[Nanoseconds]]: _nanoseconds_
-      }.
-    </emu-alg>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-totemporaloverflow" aoid="ToTemporalOverflow">
     <h1>ToTemporalOverflow ( _normalizedOptions_ )</h1>
     <emu-alg>
@@ -1282,50 +1247,46 @@
         1. Let _factor_ be −1.
       1. Else,
         1. Let _factor_ be 1.
-      1. Let _yearsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_years_)) × _factor_.
-      1. Let _monthsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_months_)) × _factor_.
-      1. Let _weeksMV_ be ! ToIntegerOrInfinity(CodePointsToString(_weeks_)) × _factor_.
-      1. Let _daysMV_ be ! ToIntegerOrInfinity(CodePointsToString(_days_)) × _factor_.
-      1. Let _hoursMV_ be ! ToIntegerOrInfinity(CodePointsToString(_hours_)) × _factor_.
-      1. Let _minutesMV_ be ! ToIntegerOrInfinity(CodePointsToString(_minutes_)) × _factor_.
-      1. Let _secondsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_seconds_)) × _factor_.
-      1. If _fSeconds_ is not empty, then
-        1. Let _fSecondsDigits_ be the substring of ! CodePointsToString(_fSeconds_) from 1.
-        1. Let _fSecondsDigitsExtended_ be the string-concatenation of _fSecondsDigits_ and *"000000000"*.
-        1. Let _milliseconds_ be the substring of _fSecondsDigitsExtended_ from 0 to 3.
-        1. Let _millisecondsMV_ be ! ToIntegerOrInfinity(_milliseconds_) × _factor_.
-        1. Let _microseconds_ be the substring of _fSecondsDigitsExtended_ from 3 to 6.
-        1. Let _microsecondsMV_ be ! ToIntegerOrInfinity(_microseconds_) × _factor_.
-        1. Let _nanoseconds_ be the substring of _fSecondsDigitsExtended_ from 6 to 9.
-        1. Let _nanosecondsMV_ be ! ToIntegerOrInfinity(_nanoseconds_) × _factor_.
-      1. Else,
-        1. Let _millisecondsMV_ be 0.
-        1. Let _microsecondsMV_ be 0.
-        1. Let _nanosecondsMV_ be 0.
+      1. Let _yearsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_years_)).
+      1. Let _monthsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_months_)).
+      1. Let _weeksMV_ be ! ToIntegerOrInfinity(CodePointsToString(_weeks_)).
+      1. Let _daysMV_ be ! ToIntegerOrInfinity(CodePointsToString(_days_)).
+      1. Let _hoursMV_ be ! ToIntegerOrInfinity(CodePointsToString(_hours_)).
       1. If _fHours_ is not empty, then
+        1. If any of _minutes_, _fMinutes_, _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fHoursDigits_ be the substring of ! CodePointsToString(_fHours_) from 1.
         1. Let _fHoursScale_ be the length of _fHoursDigits_.
-        1. Let _fHoursMV_ be ! ToIntegerOrInfinity(_fHoursDigits_) × _factor_ / 10<sup>_fHoursScale_</sup>.
+        1. Let _minutesMV_ be ! ToIntegerOrInfinity(_fHoursDigits_) / 10<sup>_fHoursScale_</sup> × 60.
       1. Else,
-        1. Let _fHoursMV_ be 0.
+        1. Let _minutesMV_ be ! ToIntegerOrInfinity(CodePointsToString(_minutes_)).
       1. If _fMinutes_ is not empty, then
+        1. If any of _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fMinutesDigits_ be the substring of ! CodePointsToString(_fMinutes_) from 1.
         1. Let _fMinutesScale_ be the length of _fMinutesDigits_.
-        1. Let _fMinutesMV_ be ! ToIntegerOrInfinity(_fMinutesDigits_) × _factor_ / 10<sup>_fMinutesScale_</sup>.
+        1. Let _secondsMV_ be ! ToIntegerOrInfinity(_fMinutesDigits_) / 10<sup>_fMinutesScale_</sup> × 60.
+      1. Else if _seconds_ is not empty, then
+        1. Let _secondsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_seconds_)).
       1. Else,
-        1. Let _fMinutesMV_ be 0.
-      1. Let _result_ be ? DurationHandleFractions(_fHoursMV_, _minutesMV_, _fMinutesMV_, _secondsMV_, _millisecondsMV_, _microsecondsMV_, _nanosecondsMV_).
+        1. Let _secondsMV_ be remainder(_minutesMV_, 1) × 60.
+      1. If _fSeconds_ is not empty, then
+        1. Let _fSecondsDigits_ be the substring of ! CodePointsToString(_fSeconds_) from 1.
+        1. Let _fSecondsScale_ be the length of _fSecondsDigits_.
+        1. Let _millisecondsMV_ be ! ToIntegerOrInfinity(_fSecondsDigits_) / 10<sup>_fSecondsScale_</sup> × 1000.
+      1. Else,
+        1. Let _millisecondsMV_ be remainder(_secondsMV_, 1) × 1000.
+      1. Let _microsecondsMV_ be remainder(_millisecondsMV_, 1) × 1000.
+      1. Let _nanosecondsMV_ be remainder(_microsecondsMV_, 1) × 1000.
       1. Return the Record {
-        [[Years]]: _yearsMV_,
-        [[Months]]: _monthsMV_,
-        [[Weeks]]: _weeksMV_,
-        [[Days]]: _daysMV_,
-        [[Hours]]: _hoursMV_,
-        [[Minutes]]: _result_.[[Minutes]],
-        [[Seconds]]: _result_.[[Seconds]],
-        [[Milliseconds]]: _result_.[[Milliseconds]],
-        [[Microseconds]]: _result_.[[Microseconds]],
-        [[Nanoseconds]]: _result_.[[Nanoseconds]]
+        [[Years]]: _yearsMV_ × _factor_,
+        [[Months]]: _monthsMV_ × _factor_,
+        [[Weeks]]: _weeksMV_ × _factor_,
+        [[Days]]: _daysMV_ × _factor_,
+        [[Hours]]: _hoursMV_ × _factor_,
+        [[Minutes]]: floor(_minutesMV_) × _factor_,
+        [[Seconds]]: floor(_secondsMV_) × _factor_,
+        [[Milliseconds]]: floor(_millisecondsMV_) × _factor_,
+        [[Microseconds]]: floor(_microsecondsMV_) × _factor_,
+        [[Nanoseconds]]: floor(_nanosecondsMV_) × _factor_
         }.
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
...as mentioned in #1759. This also fixes some spec bugs from use of `floor` with negative values.

This also requires care with respect to using mathematical values rather than approximations, and I'd like to see a test for input like ±PT46H66M71.50040904S (which produced an off-by-one error at the nanoseconds level when I was evaluating a JS-based implementation of the new algorithm that took too many liberties in that respect).

Fixes #1754