### PR TITLE
Editorial: Mark RoundTemporalInstant as infallible

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1427,7 +1427,7 @@
             [[Microseconds]]: _microseconds_,
             [[Nanoseconds]]: _nanoseconds_
             }.
-        1. Set _timeRemainderNs_ to ? RoundTemporalInstant(ℤ(_timeRemainderNs_ − _dayLengthNs_), _increment_, _unit_, _roundingMode_).
+        1. Set _timeRemainderNs_ to ! RoundTemporalInstant(ℤ(_timeRemainderNs_ − _dayLengthNs_), _increment_, _unit_, _roundingMode_).
         1. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, _relativeTo_).
         1. Let _adjustedTimeDuration_ be ? BalanceDuration(0, 0, 0, 0, 0, 0, _timeRemainderNs_, *"hour"*).
         1. Return the Record {

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -324,7 +324,7 @@
           1. Assert: _smallestUnit_ is *"nanosecond"*.
           1. Let _maximum_ be 8.64 × 10<sup>13</sup>.
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *true*).
-        1. Let _roundedNs_ be ? RoundTemporalInstant(_instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalInstant(_roundedNs_).
       </emu-alg>
     </emu-clause>
@@ -359,7 +359,7 @@
           1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
         1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _roundedNs_ be ? RoundTemporalInstant(_instant_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Let _roundedInstant_ be ! CreateTemporalInstant(_roundedNs_).
         1. Return ? TemporalInstantToString(_roundedInstant_, _timeZone_, _precision_.[[Precision]]).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1185,7 +1185,7 @@
         1. If _increment_ is not present, set it to 1.
         1. If _unit_ is not present, set it to *"nanosecond"*.
         1. If _roundingMode_ is not present, set it to *"trunc"*.
-        1. Let _ns_ be ? RoundTemporalInstant(_zonedDateTime_.[[Nanoseconds]], _increment_, _unit_, _roundingMode_).
+        1. Let _ns_ be ! RoundTemporalInstant(_zonedDateTime_.[[Nanoseconds]], _increment_, _unit_, _roundingMode_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_ns_).
         1. Let _isoCalendar_ be ! GetISO8601Calendar().


### PR DESCRIPTION
Current `RoundTemporalInstant` definition:
```
1. Assert: Type(ns) is BigInt.
2. If unit is "hour", then
    a. Let incrementNs be increment × 3.6 × 1012.
3. Else if unit is "minute", then
    a. Let incrementNs be increment × 6 × 1010.
4. Else if unit is "second", then
    a. Let incrementNs be increment × 109.
5. Else if unit is "millisecond", then
    a. Let incrementNs be increment × 106.
6. Else if unit is "microsecond", then
    a. Let incrementNs be increment × 103.
7. Else,
    a. Assert: unit is "nanosecond".
    b. Let incrementNs be increment.
8. Return ! RoundNumberToIncrement(ℝ(ns), incrementNs, roundingMode).
```

Current `RoundNumberToIncrement` definition:
```
1. Assert: x and increment are mathematical values.
2. Assert: roundingMode is "ceil", "floor", "trunc", or "halfExpand".
3. Let quotient be x / increment.
4. If roundingMode is "ceil", then
    a. Let rounded be −floor(−quotient).
5. Else if roundingMode is "floor", then
    a. Let rounded be floor(quotient).
6. Else if roundingMode is "trunc", then
    a. Let rounded be the integral part of quotient, removing any fractional digits.
7. Else,
    a. Let rounded be ! RoundHalfAwayFromZero(quotient).
8. Return rounded × increment.
```

Current `RoundHalfAwayFromZero` definition:
```
1. Assert: x is a mathematical value.
2. Return the mathematical value that is closest to x and is an integer. If two integers are equally close to x, then the result is the integer that is farther away from 0. If x is already an integer, then the result is x.
```