### PR TITLE
Editorial: Simplify parsing UTC offset strings

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -476,7 +476,7 @@
         1. Let _string_ be ? ToString(_value_).
         1. Let _result_ be ? ParseTemporalRelativeToString(_string_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).
-        1. Let _offsetString_ be _result_.[[TimeZoneOffset]].
+        1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
         1. Let _timeZoneName_ be _result_.[[TimeZoneIANAName]].
         1. If _timeZoneName_ is not *undefined*, then
           1. If ParseText(! StringToCodePoints(_timeZoneName_), |TimeZoneNumericUTCOffset|) is not a List of errors, then
@@ -1412,11 +1412,11 @@
       1. If _isoString_ satisfies the syntax of a |TemporalZonedDateTimeString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Let _timeZoneResult_ be ! ParseTemporalTimeZoneString(_isoString_).
         1. Let _z_ be _timeZoneResult_.[[Z]].
-        1. Let _offset_ be _timeZoneResult_.[[Offset]].
+        1. Let _offsetString_ be _timeZoneResult_.[[OffsetString]].
         1. Let _timeZone_ be _timeZoneResult_.[[Name]].
       1. Else,
         1. Let _z_ be *false*.
-        1. Let _offset_ be *undefined*.
+        1. Let _offsetString_ be *undefined*.
         1. Let _timeZone_ be *undefined*.
       1. Return the Record {
           [[Year]]: _result_.[[Year]],
@@ -1430,7 +1430,7 @@
           [[Nanosecond]]: _result_.[[Nanosecond]],
           [[Calendar]]: _result_.[[Calendar]],
           [[TimeZoneZ]]: _z_,
-          [[TimeZoneOffset]]: _offset_,
+          [[TimeZoneOffsetString]]: _offsetString_,
           [[TimeZoneIANAName]]: _timeZone_
         }.
     </emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1470,34 +1470,24 @@
     </p>
     <emu-alg>
       1. Assert: Type(_isoString_) is String.
-      1. If _isoString_ does not satisfy the syntax of a |TemporalTimeZoneString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
+      1. Let _parseResult_ be ParseText(! StringToCodePoints(_isoString_), |TemporalTimeZoneString|).
+      1. If _parseResult_ is a List of errors, then
         1. Throw a *RangeError* exception.
-      1. Let _z_, _sign_, _hours_, _minutes_, _seconds_, _fraction_ and _name_ be the parts of _isoString_ produced respectively by the |UTCDesignator|, |TimeZoneUTCOffsetSign|, |TimeZoneUTCOffsetHour|, |TimeZoneUTCOffsetMinute|, |TimeZoneUTCOffsetSecond|, |TimeZoneUTCOffsetFractionalPart|, and |TimeZoneIANAName| productions, or *undefined* if not present.
-      1. If _z_ is not *undefined*, then
+      1. Let each of _z_, _offsetString_, and _name_ be the source text matched by the respective |UTCDesignator|, |TimeZoneNumericUTCOffset|, and |TimeZoneIANAName| Parse Node enclosed by _parseResult_, or an empty sequence of code points if not present.
+      1. If _name_ is empty, then
+        1. Set _name_ to *undefined*.
+      1. Else,
+        1. Set _name_ to ! CodePointsToString(_name_).
+      1. If _z_ is not empty, then
         1. Return the Record {
           [[Z]]: *true*,
           [[OffsetString]]: *undefined*,
           [[Name]]: _name_
           }.
-      1. If _hours_ is *undefined*, then
-        1. Let _offsetString_ be *undefined*.
+      1. If _offsetString_ is empty, then
+        1. Set _offsetString_ to *undefined*.
       1. Else,
-        1. Assert: _sign_ is not *undefined*.
-        1. Set _hours_ to ! ToIntegerOrInfinity(_hours_).
-        1. If _sign_ is the code unit 0x002D (HYPHEN-MINUS) or the code unit 0x2212 (MINUS SIGN), then
-          1. Set _sign_ to −1.
-        1. Else,
-          1. Set _sign_ to 1.
-        1. Set _minutes_ to ! ToIntegerOrInfinity(_minutes_).
-        1. Set _seconds_ to ! ToIntegerOrInfinity(_seconds_).
-        1. If _fraction_ is not *undefined*, then
-          1. Set _fraction_ to the string-concatenation of the previous value of _fraction_ and the string *"000000000"*.
-          1. Let _nanoseconds_ be the String value equal to the substring of _fraction_ from 1 to 10.
-          1. Set _nanoseconds_ to ! ToIntegerOrInfinity(_nanoseconds_).
-        1. Else,
-          1. Let _nanoseconds_ be 0.
-        1. Let _offsetNanoseconds_ be _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).
-        1. Let _offsetString_ be ! FormatTimeZoneOffsetString(_offsetNanoseconds_).
+        1. Set _offsetString_ to ! CodePointsToString(_offsetString_).
       1. Return the Record {
         [[Z]]: *false*,
         [[OffsetString]]: _offsetString_,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -967,8 +967,8 @@
           TimeZoneUTCOffset? TimeZoneBracketedAnnotation
 
       TimeZone :
-          TimeZoneOffsetRequired
-          TimeZoneNameRequired
+          TimeZoneUTCOffset TimeZoneBracketedAnnotation?
+          TimeZoneBracketedAnnotation
 
       CalChar :
           Alpha

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -263,7 +263,7 @@
         1. Else,
           1. Let _day_ be 1.
         1. Let _date_ be ? CreateTemporalDate(_yearMonth_.[[ISOYear]], _yearMonth_.[[ISOMonth]], _day_, _calendar_).
-        1. Let _durationToAdd_ be ? CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _optionsCopy_ be ! OrdinaryObjectCreate(%Object.prototype%).
         1. Let _entries_ be ? EnumerableOwnPropertyNames(_options_, ~key+value~).
         1. For each element _nextEntry_ of _entries_, do
@@ -295,7 +295,7 @@
         1. Else,
           1. Let _day_ be 1.
         1. Let _date_ be ? CreateTemporalDate(_yearMonth_.[[ISOYear]], _yearMonth_.[[ISOMonth]], _day_, _calendar_).
-        1. Let _durationToAdd_ be ? CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _durationToAdd_ be ! CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _optionsCopy_ be ! OrdinaryObjectCreate(%Object.prototype%).
         1. Let _entries_ be ? EnumerableOwnPropertyNames(_options_, ~key+value~).
         1. For each element _nextEntry_ of _entries_, do
@@ -335,9 +335,9 @@
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
         1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
-          1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _result_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_).
-        1. Return ? CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
 
@@ -371,9 +371,9 @@
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
         1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
-          1. Return ? CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Return ! CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _result_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_).
-        1. Return ? CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Return ! CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -138,14 +138,12 @@
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. Set _identifier_ to ? ToString(_identifier_).
-        1. If _identifier_ satisfies the syntax of a |TimeZoneNumericUTCOffset| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
-          1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_identifier_).
-          1. Let _canonical_ be ! FormatTimeZoneOffsetString(_offsetNanoseconds_).
-        1. Else,
+        1. Let _parseResult_ be ParseText(! StringToCodePoints(_identifier_), |TimeZoneNumericUTCOffset|).
+        1. If _parseResult_ is a List of errors, then
           1. If ! IsValidTimeZoneName(_identifier_) is *false*, then
             1. Throw a *RangeError* exception.
-          1. Let _canonical_ be ! CanonicalizeTimeZoneName(_identifier_).
-        1. Return ? CreateTemporalTimeZone(_canonical_, NewTarget).
+          1. Set _identifier_ to ! CanonicalizeTimeZoneName(_identifier_).
+        1. Return ? CreateTemporalTimeZone(_identifier_, NewTarget).
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
I noticed that in a few places we parse a UTC offset string into a nanosecond offset, only to turn it back into an offset string later. This can be simplified with an editorial change.

While I was working on this, I changed the UTC offset parsing algorithms to use ParseText like @gibson042 did in #1907.