### PR TITLE
Bring polyfill in line with ParseTemporalTimeZone operation in specification

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -235,20 +235,11 @@ export const ES = ObjectAssign({}, ES2020, {
     }
   },
 
-  TemporalTimeZoneFromString: (stringIdent) => {
+  ParseTemporalTimeZone: (stringIdent) => {
     let { ianaName, offset, z } = ES.ParseTemporalTimeZoneString(stringIdent);
-    let identifier = ianaName;
-    if (!identifier && z) identifier = 'UTC';
-    if (!identifier) identifier = offset;
-    const result = ES.GetCanonicalTimeZoneIdentifier(identifier);
-    if (offset && identifier !== offset) {
-      const ns = ES.ParseTemporalInstant(stringIdent);
-      const offsetNs = ES.GetIANATimeZoneOffsetNanoseconds(ns, result);
-      if (ES.FormatTimeZoneOffsetString(offsetNs) !== offset) {
-        throw new RangeError(`invalid offset ${offset}[${ianaName}]`);
-      }
-    }
-    return result;
+    if (ianaName) return ianaName;
+    if (z) return 'UTC';
+    return offset;
   },
   FormatCalendarAnnotation: (id, showCalendar) => {
     if (showCalendar === 'never') return '';
@@ -1751,7 +1742,7 @@ export const ES = ObjectAssign({}, ES2020, {
       }
     }
     const identifier = ES.ToString(temporalTimeZoneLike);
-    const timeZone = ES.TemporalTimeZoneFromString(identifier);
+    const timeZone = ES.ParseTemporalTimeZone(identifier);
     const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
     return new TemporalTimeZone(timeZone);
   },
@@ -4232,7 +4223,7 @@ export const ES = ObjectAssign({}, ES2020, {
   SystemTimeZone: () => {
     const fmt = new IntlDateTimeFormat('en-us');
     const TemporalTimeZone = GetIntrinsic('%Temporal.TimeZone%');
-    return new TemporalTimeZone(ES.TemporalTimeZoneFromString(fmt.resolvedOptions().timeZone));
+    return new TemporalTimeZone(ES.ParseTemporalTimeZone(fmt.resolvedOptions().timeZone));
   },
   ComparisonResult: (value) => (value < 0 ? -1 : value > 0 ? 1 : value),
   GetOptionsObject: (options) => {

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -112,3 +112,6 @@ intl402/Temporal/PlainTime/prototype/toLocaleString/timezone-getoffsetnanosecond
 intl402/Temporal/PlainYearMonth/prototype/toLocaleString/timezone-getoffsetnanosecondsfor-not-callable.js
 intl402/Temporal/ZonedDateTime/prototype/era/timezone-getoffsetnanosecondsfor-not-callable.js
 intl402/Temporal/ZonedDateTime/prototype/eraYear/timezone-getoffsetnanosecondsfor-not-callable.js
+
+# https://github.com/tc39/test262/pull/3316
+intl402/Temporal/TimeZone/from/argument-invalid.js

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -483,9 +483,10 @@ describe('fromString regex', () => {
       generateTest('1976-11-18T15:23', zoneString, '-04:00')
     );
     // Various numbers of decimal places
-    ['1', '12', '123', '1234', '12345', '123456', '1234567', '12345678'].forEach((decimals) =>
-      test(`1976-11-18T15:23:30.${decimals}Z`, 'UTC')
-    );
+    ['1', '12', '123', '1234', '12345', '123456', '1234567', '12345678'].forEach((decimals) => {
+      test(`1976-11-18T15:23:30.${decimals}Z`, 'UTC');
+      test(`1976-11-18T15:23+01:00[+01:00:00.${decimals}]`, `+01:00:00.${decimals}`);
+    });
     // Lowercase UTC designator
     generateTest('1976-11-18T15:23', 'z', 'UTC');
     // Comma decimal separator


### PR DESCRIPTION
This fixes some polyfill code that no longer applies. Ever since the change to allow UTC offsets to be rounded to minutes in ISO strings (#1871), the `identifier !== offset` line has been incorrect, but there are no tests for this case in our test suite. No change to the specification is needed, since this algorithm didn't exist in this form in the spec text, which is also why I originally overlooked it.

Rename the abstract operation TemporalTimeZoneFromString to ParseTemporalTimeZone so that it matches [the spec](https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezone), and simplify its logic to match what is written in the spec as well.

I'm in the process of adding test262 tests that cover this, but this PR includes a quick test in the old test suite just so that it's covered in the meantime, and to illustrate which case would previously have failed.