### PR TITLE
Normative: Fix "smallestUnit" property name for options objects created from string argument

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -422,7 +422,7 @@
         1. If Type(_roundTo_) is String, then
           1. Let _paramString_ be _roundTo_.
           1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnitPresent_ be *true*.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -309,7 +309,7 @@
         1. If Type(_roundTo_) is String, then
           1. Let _paramString_ be _roundTo_.
           1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -546,7 +546,7 @@
         1. If Type(_roundTo_) is String, then
           1. Let _paramString_ be _roundTo_.
           1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"* », *undefined*).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -340,7 +340,7 @@
         1. If Type(_roundTo_) is String, then
           1. Let _paramString_ be _roundTo_.
           1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -777,7 +777,7 @@
         1. If Type(_roundTo_) is String, then
           1. Let _paramString_ be _roundTo_.
           1. Set _roundTo_ to ! OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"_smallestUnit_"*, _paramString_).
+          1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"* », *undefined*).


### PR DESCRIPTION
Fixes incorrect property names `"_smallestUnit_"` -> `"smallestUnit"` when creating options objects from a string argument, which was introduced as a new feature in #1875.

![image](https://user-images.githubusercontent.com/19366641/142518171-298a4d7e-3348-46ac-9d7b-5dd203a076f1.png)

Fixes  #1961.