### PR TITLE
Editoral: Mark use of TotalDurationNanoseconds inside AdjustRoundedDurationDays as infallible

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1413,7 +1413,7 @@
             [[Microseconds]]: _microseconds_,
             [[Nanoseconds]]: _nanoseconds_
             }.
-        1. Let _timeRemainderNs_ be ? TotalDurationNanoseconds(0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, 0).
+        1. Let _timeRemainderNs_ be ! TotalDurationNanoseconds(0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, 0).
         1. Let _direction_ be ! ℝ(Sign(𝔽(_timeRemainderNs_))).
         1. Let _dayStart_ be ? AddZonedDateTime(_relativeTo_.[[Nanoseconds]], _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
         1. Let _dayEnd_ be ? AddZonedDateTime(_dayStart_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0).


### PR DESCRIPTION
Current definition (https://tc39.es/proposal-temporal/#sec-temporal-totaldurationnanoseconds):
```
1. Assert: offsetShift is an integer.
2. Set nanoseconds to ℝ(nanoseconds).
3. If days ≠ 0, then
    a. Set nanoseconds to nanoseconds − offsetShift.
4. Set hours to ℝ(hours) + ℝ(days) × 24.
5. Set minutes to ℝ(minutes) + hours × 60.
6. Set seconds to ℝ(seconds) + minutes × 60.
7. Set milliseconds to ℝ(milliseconds) + seconds × 1000.
8. Set microseconds to ℝ(microseconds) + milliseconds × 1000.
9. Return nanoseconds + microseconds × 1000.
```