### PR TITLE
Editoral: Simplify TemporalRelativeToString

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1099,7 +1099,6 @@
 
       TemporalRelativeToString :
           TemporalDateTimeString
-          TemporalZonedDateTimeString
     </emu-grammar>
   </emu-clause>
 


### PR DESCRIPTION
TemporalZonedDateTimeString is a subset of TemporalDateTimeString
no need to list both under TemporalRelativeToString

Fix https://github.com/tc39/proposal-temporal/issues/1939
@ptomato @pdunkel @ljharb @gibson042 @ryzokuken @justingrant 