### PR TITLE
Editorial: name = TimeZoneBracketedName <= TimeZoneIANAName

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1421,7 +1421,7 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalTimeZoneString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
-      1. Let _z_, _sign_, _hours_, _minutes_, _seconds_, _fraction_ and _name_ be the parts of _isoString_ produced respectively by the |UTCDesignator|, |TimeZoneUTCOffsetSign|, |TimeZoneUTCOffsetHour|, |TimeZoneUTCOffsetMinute|, |TimeZoneUTCOffsetSecond|, |TimeZoneUTCOffsetFractionalPart|, and |TimeZoneIANAName| productions, or *undefined* if not present.
+      1. Let _z_, _sign_, _hours_, _minutes_, _seconds_, _fraction_ and _name_ be the parts of _isoString_ produced respectively by the |UTCDesignator|, |TimeZoneUTCOffsetSign|, |TimeZoneUTCOffsetHour|, |TimeZoneUTCOffsetMinute|, |TimeZoneUTCOffsetSecond|, |TimeZoneUTCOffsetFractionalPart|, and |TimeZoneBracketedName| productions, or *undefined* if not present.
       1. If _z_ is not *undefined*, then
         1. Return the Record {
           [[Z]]: *true*,


### PR DESCRIPTION
Change the definition of name in ParseTemporalTimeZoneString
from TimeZoneIANAName to TimeZoneBracketedName

Without this change, the assertion mententioned in https://github.com/tc39/proposal-temporal/issues/1924 will fail and therefore is not implementable and the tests mentioned in https://github.com/tc39/test262/issues/3319 will also fail

Fix https://github.com/tc39/proposal-temporal/issues/1924

@ptomato @pdunkel @ljharb @justingrant @ryzokuken 