### PR TITLE
Document workarounds for parsing Z strings

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -70,7 +70,11 @@ If the value is any other object, it:
 - May have a `calendar` property. If omitted, the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates) will be used by default.
 
 Any non-object value is converted to a string, which is expected to be in ISO 8601 format.
-Any time or time zone part is optional and will be ignored.
+Any time part is optional and will be ignored.
+Time zone or UTC offset information will also be ignored, with one exception: if a string contains a `Z` in place of a numeric UTC offset, then a `RangeError` will be thrown because interpreting these strings as a local date and time is usually a bug. `Temporal.Instant.from` should be used instead to parse these strings, and the result's `toZonedDateTimeISO` method can be used to obtain a timezone-local date and time.
+
+In unusual cases of needing date or time components of `Z`-terminated timestamp strings (e.g. daily rollover of a UTC-timestamped log file), use the time zone `'UTC'`. For example, the following code returns a "UTC date": `Temporal.Instant.from(thing).toZonedDateTimeISO('UTC').toPlainDate()`.
+
 If the string isn't valid according to ISO 8601, then a `RangeError` will be thrown regardless of the value of `overflow`.
 
 The `overflow` option works as follows, if `thing` is an object:

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -96,11 +96,14 @@ If the value is any other object, a `Temporal.PlainDateTime` will be constructed
 At least the `year` (or `era` and `eraYear`), `month` (or `monthCode`), and `day` properties must be present.
 Default values for other missing fields are determined by the calendar.
 
-If the `calendar` property is not present, it will be assumed to be `Temporal.Calendar.from('iso8601')`, the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
+If the `calendar` property is not present, it's assumed to be `Temporal.Calendar.from('iso8601')`, the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 Any other missing properties will be assumed to be 0 (for time fields).
 
 Any non-object value is converted to a string, which is expected to be in ISO 8601 format.
-Any time zone part is optional and will be ignored.
+Time zone or UTC offset information will be ignored, with one exception: if a string contains a `Z` in place of a numeric UTC offset, then a `RangeError` will be thrown because interpreting these strings as a local date and time is usually a bug. `Temporal.Instant.from` should be used instead to parse these strings, and the result's `toZonedDateTimeISO` method can be used to obtain a timezone-local date and time.
+
+In unusual cases of needing date or time components of `Z`-terminated timestamp strings (e.g. daily rollover of a UTC-timestamped log file), use the time zone `'UTC'`. For example, the following code returns a "UTC date": `Temporal.Instant.from(thing).toZonedDateTimeISO('UTC').toPlainDate()`.
+
 If the string isn't valid according to ISO 8601, then a `RangeError` will be thrown regardless of the value of `overflow`.
 
 The `overflow` option works as follows, if `thing` is an object:

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -76,7 +76,7 @@ For other calendars, the year and calendar are also parsed in addition to month 
 Any other parts of the string are optional and will be ignored.
 
 If the string isn't valid according to ISO 8601, then a `RangeError` will be thrown regardless of the value of `overflow`.
-A `RangeError` will also be thrown for strings that contains a `Z` in place of a numeric UTC offset, because interpreting these strings as a local date is usually a bug.
+A `RangeError` will also be thrown for strings that contain a `Z` in place of a numeric UTC offset, because interpreting these strings as a local date is usually a bug.
 
 The `overflow` option works as follows, if `thing` is an object:
 

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -74,7 +74,9 @@ Any non-object value will be converted to a string, which is expected to be in I
 For the ISO 8601 calendar, only the month and day will be parsed from the string.
 For other calendars, the year and calendar are also parsed in addition to month and day.
 Any other parts of the string are optional and will be ignored.
+
 If the string isn't valid according to ISO 8601, then a `RangeError` will be thrown regardless of the value of `overflow`.
+A `RangeError` will also be thrown for strings that contains a `Z` in place of a numeric UTC offset, because interpreting these strings as a local date is usually a bug.
 
 The `overflow` option works as follows, if `thing` is an object:
 

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -63,7 +63,10 @@ Any missing ones will be assumed to be 0.
 If the `calendar` property is present, it must be the string `'iso8601'` or the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates), for future compatibility.
 
 Any non-object value will be converted to a string, which is expected to be in ISO 8601 format.
-If the string designates a date or a time zone, they will be ignored.
+If the string designates a date, it will be ignored.
+Time zone or UTC offset information will also be ignored, with one exception: if a string contains a `Z` in place of a numeric UTC offset, then a `RangeError` will be thrown because interpreting these strings as a local time is usually a bug. `Temporal.Instant.from` should be used instead to parse these strings, and the result's `toZonedDateTimeISO` method can be used to obtain a timezone-local date and time.
+
+In unusual cases of needing date or time components of `Z`-terminated timestamp strings (e.g. daily rollover of a UTC-timestamped log file), use the time zone `'UTC'`. For example, the following code returns a "UTC time": `Temporal.Instant.from(thing).toZonedDateTimeISO('UTC').toPlainTime()`.
 
 The `overflow` option works as follows, if `thing` is an object:
 

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -76,7 +76,7 @@ Any non-object value is converted to a string, which is expected to be in ISO 86
 Any parts of the string other than the year and the month are optional and will be ignored.
 
 If the string isn't valid according to ISO 8601, then a `RangeError` will be thrown regardless of the value of `overflow`.
-A `RangeError` will also be thrown for strings that contains a `Z` in place of a numeric UTC offset, because interpreting these strings as a local date is usually a bug.
+A `RangeError` will also be thrown for strings that contain a `Z` in place of a numeric UTC offset, because interpreting these strings as a local date is usually a bug.
 
 The `overflow` option works as follows, if `thing` is an object:
 

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -69,12 +69,14 @@ If the value is another `Temporal.PlainYearMonth` object, a new object represent
 If the value is any other object, it must have `year` (or `era` and `eraYear`), `month` (or `monthCode`) properties, and optionally a `calendar` property.
 A `Temporal.PlainYearMonth` will be constructed from these properties.
 
-If the `calendar` property is not present, it will be assumed to be `Temporal.Calendar.from('iso8601')`, the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
+If the `calendar` property is not present, it's assumed to be `Temporal.Calendar.from('iso8601')`, the [ISO 8601 calendar](https://en.wikipedia.org/wiki/ISO_8601#Dates).
 In this calendar, `era` is ignored.
 
 Any non-object value is converted to a string, which is expected to be in ISO 8601 format.
 Any parts of the string other than the year and the month are optional and will be ignored.
+
 If the string isn't valid according to ISO 8601, then a `RangeError` will be thrown regardless of the value of `overflow`.
+A `RangeError` will also be thrown for strings that contains a `Z` in place of a numeric UTC offset, because interpreting these strings as a local date is usually a bug.
 
 The `overflow` option works as follows, if `thing` is an object:
 


### PR DESCRIPTION
In #1874, we removed the ability to parse Z strings with Plain types' `from` methods. This PR explains this change and documents workarounds.

The docs for PlainYearMonth and PlainMonthDay (where Z strings are rare) get only minimal text. PlainDate, PlainDateTime, and PlainTime (where Z-string use cases are most likely) get a little more explanation and a short code sample.