### PR TITLE
Normative: Use modulo instead of remainder in GetISOPartsFromEpoch

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -435,7 +435,7 @@
       </p>
       <emu-alg>
         1. Assert: _epochNanoseconds_ is an integer.
-        1. Let _remainderNs_ be remainder(_epochNanoseconds_, 10<sup>6</sup>).
+        1. Let _remainderNs_ be _epochNanoseconds_ modulo 10<sup>6</sup>.
         1. Let _epochMilliseconds_ be (_epochNanoseconds_ − _remainderNs_) / 10<sup>6</sup>.
         1. Let _year_ be ! YearFromTime(_epochMilliseconds_).
         1. Let _month_ be ! MonthFromTime(_epochMilliseconds_) + 1.


### PR DESCRIPTION
I had previously changed this from modulo to remainder in [baaa8fd], but
that was incorrect. I was probably confused by the fact that the
reference code used BigInteger.divmod() here, which performs remainder,
but I missed that we add some extra code after that which ensures the
operation performed on the BigInteger is equivalent to modulo.

Closes: #1927