### PR TITLE
Normative: Add optional calendar to PlainTime, PlainYearMonth, and PlainMonthDay productions

### DIFF
--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -291,9 +291,9 @@ const timeSpecSeparator = seq(dateTimeSeparator, timeSpec);
 const dateSpecMonthDay = seq(['--'], dateMonth, ['-'], dateDay);
 const dateSpecYearMonth = seq(dateYear, ['-'], dateMonth);
 const date = choice(seq(dateYear, '-', dateMonth, '-', dateDay), seq(dateYear, dateMonth, dateDay));
-const time = seq(timeSpec, [timeZone]);
 const dateTime = seq(date, [timeSpecSeparator], [timeZone]);
 const calendarDateTime = seq(dateTime, [calendar]);
+const calendarTime = seq(timeSpec, [timeZone], [calendar]);
 
 const durationFractionalPart = withCode(between(1, 9, digit()), (data, result) => {
   const fraction = result.padEnd(9, '0');
@@ -353,10 +353,10 @@ const goals = {
   Date: calendarDateTime,
   DateTime: calendarDateTime,
   Duration: duration,
-  MonthDay: choice(dateSpecMonthDay, dateTime),
-  Time: choice(time, dateTime),
+  MonthDay: choice(dateSpecMonthDay, calendarDateTime),
+  Time: choice(calendarTime, calendarDateTime),
   TimeZone: choice(temporalTimeZoneIdentifier, seq(date, [timeSpecSeparator], timeZone, [calendar])),
-  YearMonth: choice(dateSpecYearMonth, dateTime),
+  YearMonth: choice(dateSpecYearMonth, calendarDateTime),
   ZonedDateTime: zonedDateTime
 };
 
@@ -378,10 +378,10 @@ const comparisonItems = {
     'microseconds',
     'nanoseconds'
   ],
-  MonthDay: ['month', 'day'],
-  Time: timeItems,
+  MonthDay: ['month', 'day', 'calendar'],
+  Time: [...timeItems, 'calendar'],
   TimeZone: ['offset', 'ianaName'],
-  YearMonth: ['year', 'month'],
+  YearMonth: ['year', 'month', 'calendar'],
   ZonedDateTime: [...dateItems, ...timeItems, 'offset', 'ianaName', 'calendar']
 };
 const plainModes = ['Date', 'DateTime', 'MonthDay', 'Time', 'YearMonth'];

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -933,14 +933,14 @@
           TimeHour `:` TimeMinute `:` TimeSecond TimeFraction?
           TimeHour TimeMinute TimeSecond TimeFraction?
 
-      Time :
-          TimeSpec TimeZone?
-
       TimeSpecSeparator :
           DateTimeSeparator TimeSpec
 
       DateTime :
           Date TimeSpecSeparator? TimeZone?
+
+      CalendarTime :
+          TimeSpec TimeZone? Calendar?
 
       CalendarDateTime:
           DateTime Calendar?
@@ -1029,11 +1029,11 @@
 
       TemporalMonthDayString :
           DateSpecMonthDay
-          DateTime
+          CalendarDateTime
 
       TemporalTimeString :
-          Time
-          DateTime
+          CalendarTime
+          CalendarDateTime
 
       TemporalTimeZoneIdentifier :
           TimeZoneNumericUTCOffset
@@ -1045,7 +1045,7 @@
 
       TemporalYearMonthString :
           DateSpecYearMonth
-          DateTime
+          CalendarDateTime
 
       TemporalZonedDateTimeString :
           Date TimeSpecSeparator? TimeZoneNameRequired Calendar?
@@ -1054,7 +1054,7 @@
           CalendarName
           TemporalInstantString
           CalendarDateTime
-          Time
+          CalendarTime
           DateSpecYearMonth
           DateSpecMonthDay
 


### PR DESCRIPTION
This was mistakenly left out when we added calendar annotations to
Temporal.

Note that PlainTime currently only supports the iso8601 calendar and
Temporal.PlainTime.from() will throw if any other calendar is specified in
the calendar annotation. This keeps open the possibility to support more
calendars in PlainTime in a future proposal.

Note also that only the YYYY-MM-DD forms of PlainMonthDay and
PlainYearMonth support calendar annotations. The YYYY-MM and MM-DD forms
always require the iso8601 calendar, because otherwise there is no
reference ISO year or reference ISO day, respectively.

Closes: #1896
Closes: #1912