### PR TITLE
Normative: Support 'T' prefix in time-only strings and require it in cases of ambiguity

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -246,7 +246,7 @@ export const ES = ObjectAssign({}, ES2020, {
     if (showCalendar === 'auto' && id === 'iso8601') return '';
     return `[u-ca=${id}]`;
   },
-  ParseISODateTime: (isoString) => {
+  ParseISODateTime: (isoString, { timeRequired = false } = {}) => {
     // ZDT is the superset of fields for every other Temporal type
     const match = PARSE.zoneddatetime.exec(isoString);
     if (!match) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
@@ -255,6 +255,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const year = ES.ToInteger(yearString);
     const month = ES.ToInteger(match[2] || match[4]);
     const day = ES.ToInteger(match[3] || match[5]);
+    if (timeRequired && match[6] === undefined) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
     const hour = ES.ToInteger(match[6]);
     const minute = ES.ToInteger(match[7] || match[10]);
     let second = ES.ToInteger(match[8] || match[11]);
@@ -340,7 +341,9 @@ export const ES = ObjectAssign({}, ES2020, {
       calendar = match[15];
     } else {
       let z;
-      ({ hour, minute, second, millisecond, microsecond, nanosecond, calendar, z } = ES.ParseISODateTime(isoString));
+      ({ hour, minute, second, millisecond, microsecond, nanosecond, calendar, z } = ES.ParseISODateTime(isoString, {
+        timeRequired: true
+      }));
       if (z) throw new RangeError('Z designator not supported for PlainTime');
     }
     return { hour, minute, second, millisecond, microsecond, nanosecond, calendar };

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -28,8 +28,9 @@ export const time = new RegExp(`^T?${timesplit.source}(?:${zonesplit.source})?(?
 // The short forms of YearMonth and MonthDay are only for the ISO calendar.
 // Non-ISO calendar YearMonth and MonthDay have to parse as a Temporal.PlainDate,
 // with the reference fields.
-// YYYYMM forbidden by ISO 8601, but since it is not ambiguous with anything
-// else we could parse in a YearMonth context, we allow it
+// YYYYMM forbidden by ISO 8601 because ambiguous with YYMMDD, but allowed by
+// RFC 3339 and we don't allow 2-digit years, so we allow it.
+// Not ambiguous with HHMMSS because that requires a 'T' prefix
 export const yearmonth = new RegExp(`^(${yearpart.source})-?(${monthpart.source})$`);
 export const monthday = new RegExp(`^(?:--)?(${monthpart.source})-?(${daypart.source})$`);
 

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -23,7 +23,7 @@ export const zoneddatetime = new RegExp(
   'i'
 );
 
-export const time = new RegExp(`^${timesplit.source}(?:${zonesplit.source})?(?:${calendar.source})?$`, 'i');
+export const time = new RegExp(`^T?${timesplit.source}(?:${zonesplit.source})?(?:${calendar.source})?$`, 'i');
 
 // The short forms of YearMonth and MonthDay are only for the ISO calendar.
 // Non-ISO calendar YearMonth and MonthDay have to parse as a Temporal.PlainDate,

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -1014,6 +1014,10 @@ describe('Time', () => {
     it('optional parts', () => {
       equal(`${PlainTime.from('15')}`, '15:00:00');
     });
+    it('time designator prefix', () => {
+      equal(`${PlainTime.from('T15:23:30')}`, '15:23:30');
+      equal(`${PlainTime.from('t152330')}`, '15:23:30');
+    });
     it('no junk at end of string', () => throws(() => PlainTime.from('15:23:30.100junk'), RangeError));
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -1018,6 +1018,9 @@ describe('Time', () => {
       equal(`${PlainTime.from('T15:23:30')}`, '15:23:30');
       equal(`${PlainTime.from('t152330')}`, '15:23:30');
     });
+    it('no implicit midnight from date-only string', () => {
+      throws(() => PlainTime.from('1976-11-18'), RangeError);
+    });
     it('no junk at end of string', () => throws(() => PlainTime.from('15:23:30.100junk'), RangeError));
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -1018,6 +1018,33 @@ describe('Time', () => {
       equal(`${PlainTime.from('T15:23:30')}`, '15:23:30');
       equal(`${PlainTime.from('t152330')}`, '15:23:30');
     });
+    it('time designator required for ambiguous strings', () => {
+      // YYYY-MM or HHMM-UU
+      throws(() => PlainTime.from('2021-12'), RangeError);
+      equal(`${PlainTime.from('T2021-12')}`, '20:21:00');
+      equal(`${PlainTime.from('2021-13')}`, '20:21:00');
+      equal(`${PlainTime.from('0000-00')}`, '00:00:00');
+      // MMDD or HHMM
+      throws(() => PlainTime.from('1214'), RangeError);
+      throws(() => PlainTime.from('0229'), RangeError);
+      throws(() => PlainTime.from('1130'), RangeError);
+      equal(`${PlainTime.from('T1214')}`, '12:14:00');
+      equal(`${PlainTime.from('1314')}`, '13:14:00');
+      equal(`${PlainTime.from('1232')}`, '12:32:00');
+      equal(`${PlainTime.from('0230')}`, '02:30:00');
+      equal(`${PlainTime.from('0631')}`, '06:31:00');
+      equal(`${PlainTime.from('0000')}`, '00:00:00');
+      // MM-DD or HH-UU
+      throws(() => PlainTime.from('12-14'), RangeError);
+      equal(`${PlainTime.from('T12-14')}`, '12:00:00');
+      equal(`${PlainTime.from('13-14')}`, '13:00:00');
+      equal(`${PlainTime.from('00-00')}`, '00:00:00');
+      // YYYYMM or HHMMSS
+      throws(() => PlainTime.from('202112'), RangeError);
+      equal(`${PlainTime.from('T202112')}`, '20:21:12');
+      equal(`${PlainTime.from('202113')}`, '20:21:13');
+      equal(`${PlainTime.from('000000')}`, '00:00:00');
+    });
     it('no implicit midnight from date-only string', () => {
       throws(() => PlainTime.from('1976-11-18'), RangeError);
     });

--- a/polyfill/test/regex.mjs
+++ b/polyfill/test/regex.mjs
@@ -297,9 +297,10 @@ describe('fromString regex', () => {
     test('19761118T152330.1234', [15, 23, 30, 123, 400]);
     // Representations with reduced precision
     test('1976-11-18T15', [15]);
-    test('1976-11-18', []);
     // Time-only forms
-    generateTest('15:23', '');
+    ['T', 't', ''].forEach((prefix) => generateTest(`${prefix}15:23`, ''));
+    test('T1523', [15, 23]);
+    test('T152330', [15, 23, 30]);
     ['+01:00[Europe/Vienna]', '[Europe/Vienna]', '+01:00[Custom/Vienna]', '-04:00', 'Z', ''].forEach((zoneStr) =>
       test(`15${zoneStr}`, [15])
     );

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -185,7 +185,7 @@ const monthsDesignator = character('Mm');
 const durationDesignator = character('Pp');
 const secondsDesignator = character('Ss');
 const dateTimeSeparator = character(' Tt');
-const durationTimeDesignator = character('Tt');
+const timeDesignator = character('Tt');
 const weeksDesignator = character('Ww');
 const yearsDesignator = character('Yy');
 const utcDesignator = withCode(character('Zz'), (data) => {
@@ -293,7 +293,7 @@ const dateSpecYearMonth = seq(dateYear, ['-'], dateMonth);
 const date = choice(seq(dateYear, '-', dateMonth, '-', dateDay), seq(dateYear, dateMonth, dateDay));
 const dateTime = seq(date, [timeSpecSeparator], [timeZone]);
 const calendarDateTime = seq(dateTime, [calendar]);
-const calendarTime = seq(timeSpec, [timeZone], [calendar]);
+const calendarTime = seq([timeDesignator], timeSpec, [timeZone], [calendar]);
 
 const durationFractionalPart = withCode(between(1, 9, digit()), (data, result) => {
   const fraction = result.padEnd(9, '0');
@@ -317,7 +317,7 @@ const durationHours = seq(
   hoursDesignator,
   [choice(durationMinutes, durationSeconds)]
 );
-const durationTime = seq(durationTimeDesignator, choice(durationHours, durationMinutes, durationSeconds));
+const durationTime = seq(timeDesignator, choice(durationHours, durationMinutes, durationSeconds));
 const durationDays = seq(
   withCode(oneOrMore(digit()), (data, result) => (data.days = +result * data.factor)),
   daysDesignator

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -293,6 +293,7 @@ const dateSpecYearMonth = seq(dateYear, ['-'], dateMonth);
 const date = choice(seq(dateYear, '-', dateMonth, '-', dateDay), seq(dateYear, dateMonth, dateDay));
 const dateTime = seq(date, [timeSpecSeparator], [timeZone]);
 const calendarDateTime = seq(dateTime, [calendar]);
+const calendarDateTimeTimeRequired = seq(date, timeSpecSeparator, [timeZone], [calendar]);
 const calendarTime = seq([timeDesignator], timeSpec, [timeZone], [calendar]);
 
 const durationFractionalPart = withCode(between(1, 9, digit()), (data, result) => {
@@ -354,7 +355,7 @@ const goals = {
   DateTime: calendarDateTime,
   Duration: duration,
   MonthDay: choice(dateSpecMonthDay, calendarDateTime),
-  Time: choice(calendarTime, calendarDateTime),
+  Time: choice(calendarTime, calendarDateTimeTimeRequired),
   TimeZone: choice(temporalTimeZoneIdentifier, seq(date, [timeSpecSeparator], timeZone, [calendar])),
   YearMonth: choice(dateSpecYearMonth, calendarDateTime),
   ZonedDateTime: zonedDateTime

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -765,7 +765,7 @@
           `T`
           `t`
 
-      DurationTimeDesignator : one of
+      TimeDesignator : one of
           `T` `t`
 
       WeeksDesignator : one of
@@ -937,7 +937,7 @@
           Date TimeSpecSeparator? TimeZone?
 
       CalendarTime :
-          TimeSpec TimeZone? Calendar?
+          TimeDesignator? TimeSpec TimeZone? Calendar?
 
       CalendarDateTime:
           DateTime Calendar?
@@ -971,9 +971,9 @@
           DurationWholeHours DurationHoursFraction? HoursDesignator DurationSecondsPart?
 
       DurationTime :
-          DurationTimeDesignator DurationHoursPart
-          DurationTimeDesignator DurationMinutesPart
-          DurationTimeDesignator DurationSecondsPart
+          TimeDesignator DurationHoursPart
+          TimeDesignator DurationMinutesPart
+          TimeDesignator DurationSecondsPart
 
       DurationDays :
           DecimalDigits[~Sep]

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -822,6 +822,50 @@
           MinuteSecond
           `60`
 
+      TimeHourNotValidMonth : one of
+          `00` `13` `14` `15` `16` `17` `18` `19` `20` `21` `23`
+
+      TimeHourNotThirtyOneDayMonth : one of
+          `02` `04` `06` `09` `11`
+
+      TimeHourTwoOnly :
+          `02`
+
+      TimeMinuteNotValidDay :
+          `00`
+          `32`
+          `33`
+          `34`
+          `35`
+          `36`
+          `37`
+          `38`
+          `39`
+          `4` DecimalDigit
+          `5` DecimalDigit
+          `60`
+
+      TimeMinuteThirtyOnly :
+          `30`
+
+      TimeMinuteThirtyOneOnly :
+          `31`
+
+      TimeSecondNotValidMonth :
+          `00`
+          `13`
+          `14`
+          `15`
+          `16`
+          `17`
+          `18`
+          `19`
+          `2` DecimalDigit
+          `3` DecimalDigit
+          `4` DecimalDigit
+          `5` DecimalDigit
+          `60`
+
       FractionalPart :
           DecimalDigit DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit?
 
@@ -859,6 +903,18 @@
       TimeZoneUTCOffset :
           TimeZoneNumericUTCOffset
           UTCDesignator
+
+      TimeZoneNumericUTCOffsetNotAmbiguous :
+          `+` TimeZoneUTCOffsetHour
+          U+2212 TimeZoneUTCOffsetHour
+          TimeZoneUTCOffsetSign TimeZoneUTCOffsetHour `:` TimeZoneUTCOffsetMinute
+          TimeZoneUTCOffsetSign TimeZoneUTCOffsetHour TimeZoneUTCOffsetMinute
+          TimeZoneUTCOffsetSign TimeZoneUTCOffsetHour `:` TimeZoneUTCOffsetMinute `:` TimeZoneUTCOffsetSecond TimeZoneUTCOffsetFraction?
+          TimeZoneUTCOffsetSign TimeZoneUTCOffsetHour TimeZoneUTCOffsetMinute TimeZoneUTCOffsetSecond TimeZoneUTCOffsetFraction?
+
+      TimeZoneNumericUTCOffsetNotAmbiguousAllowedNegativeHour :
+          TimeZoneNumericUTCOffsetNotAmbiguous
+          `-` TimeHourNotValidMonth
 
       TimeZoneUTCOffsetName :
           Sign Hour
@@ -930,14 +986,35 @@
           TimeHour `:` TimeMinute `:` TimeSecond TimeFraction?
           TimeHour TimeMinute TimeSecond TimeFraction?
 
+      TimeHourMinuteBasicFormatNotAmbiguous :
+          TimeHourNotValidMonth TimeMinute
+          TimeHour TimeMinuteNotValidDay
+          TimeHourNotThirtyOneDayMonth TimeMinuteThirtyOneOnly
+          TimeHourTwoOnly TimeMinuteThirtyOnly
+
+      TimeSpecWithOptionalTimeZoneNotAmbiguous :
+          TimeHour TimeZoneNumericUTCOffsetNotAmbiguous? TimeZoneBracketedAnnotation?
+          TimeHourNotValidMonth TimeZone
+          TimeHour `:` TimeMinute TimeZone?
+          TimeHourMinuteBasicFormatNotAmbiguous TimeZoneBracketedAnnotation?
+          TimeHour TimeMinute TimeZoneNumericUTCOffsetNotAmbiguousAllowedNegativeHour TimeZoneBracketedAnnotation?
+          TimeHour `:` TimeMinute `:` TimeSecond TimeFraction? TimeZone?
+          TimeHour TimeMinute TimeSecondNotValidMonth TimeZone?
+          TimeHour TimeMinute TimeSecond TimeFraction TimeZone?
+
       TimeSpecSeparator :
           DateTimeSeparator TimeSpec
 
       DateTime :
           Date TimeSpecSeparator? TimeZone?
 
+      CalendarDate :
+          Date Calendar?
+
       CalendarTime :
-          TimeDesignator? TimeSpec TimeZone? Calendar?
+          TimeDesignator TimeSpec TimeZone? Calendar?
+          TimeSpec TimeZone? Calendar
+          TimeSpecWithOptionalTimeZoneNotAmbiguous
 
       CalendarDateTime:
           DateTime Calendar?
@@ -1071,7 +1148,11 @@
     <emu-note>The value of ? ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
     <emu-alg>
       1. Assert: Type(_isoString_) is String.
-      1. Let _year_, _month_, _day_, _hour_, _minute_, _second_, _fraction_, and _calendar_ be the parts of _isoString_ produced respectively by the |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, |TimeFraction|, and |CalendarName| productions, or *undefined* if not present.
+      1. Let _year_, _month_, _day_, _fraction_, and _calendar_ be the parts of _isoString_ produced respectively by the |DateYear|, |DateMonth|, |DateDay|, |TimeFraction|, and |CalendarName| productions, or *undefined* if not present.
+      1. Let _year_ be the part of _isoString_ produced by the |DateYear| production.
+      1. Let _hour_ be the part of _isoString_ produced by the |TimeHour|, |TimeHourNotValidMonth|, |TimeHourNotThirtyOneDayMonth|, or |TimeHourTwoOnly| productions, or *undefined* if none of those are present.
+      1. Let _minute_ be the part of _isoString_ produced by the |TimeMinute|, |TimeMinuteNotValidDay|, |TimeMinuteThirtyOnly|, or |TimeMinuteThirtyOneOnly| productions, or *undefined* if none of those are present.
+      1. Let _second_ be the part of _isoString_ produced by the |TimeSecond| or |TimeSecondNotValidMonth| productions, or *undefined* if neither of those are present.
       1. If the first code unit of _year_ is 0x2212 (MINUS SIGN), replace it with the code unit 0x002D (HYPHEN-MINUS).
       1. Set _year_ to ! ToIntegerOrInfinity(_year_).
       1. If _month_ is *undefined*, then
@@ -1360,6 +1441,9 @@
       1. If _isoString_ contains a |UTCDesignator|, then
         1. Throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
+      1. Assert: ParseText(! StringToCodePoints(_isoString_), |CalendarDate|) is a List of errors.
+      1. Assert: ParseText(! StringToCodePoints(_isoString_), |DateSpecYearMonth|) is a List of errors.
+      1. Assert: ParseText(! StringToCodePoints(_isoString_), |DateSpecMonthDay|) is a List of errors.
       1. Return the Record {
         [[Hour]]: _result_.[[Hour]],
         [[Minute]]: _result_.[[Minute]],

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -942,6 +942,9 @@
       CalendarDateTime:
           DateTime Calendar?
 
+      CalendarDateTimeTimeRequired :
+          Date TimeSpecSeparator TimeZone? Calendar?
+
       DurationWholeSeconds :
           DecimalDigits[~Sep]
 
@@ -1030,7 +1033,7 @@
 
       TemporalTimeString :
           CalendarTime
-          CalendarDateTime
+          CalendarDateTimeTimeRequired
 
       TemporalTimeZoneIdentifier :
           TimeZoneNumericUTCOffset


### PR DESCRIPTION
Includes #1950 to avoid rebase conflicts. I'll make sure that one is merged before this one.

Closes: #1765