### PR TITLE
Normative: Do not validate time zone names when parsing Instant string

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -468,6 +468,8 @@
         1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _dateOptions_).
         1. Let _offsetString_ be ? Get(_value_, *"offset"*).
         1. Let _timeZone_ be ? Get(_value_, *"timeZone"*).
+        1. If _timeZone_ is not *undefined*, then
+          1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
         1. If _offsetString_ is *undefined*, then
           1. Set _offsetBehaviour_ to ~wall~.
       1. Else,
@@ -475,14 +477,20 @@
         1. Let _result_ be ? ParseTemporalRelativeToString(_string_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).
         1. Let _offsetString_ be _result_.[[TimeZoneOffset]].
-        1. Let _timeZone_ be _result_.[[TimeZoneIANAName]].
+        1. Let _timeZoneName_ be _result_.[[TimeZoneIANAName]].
+        1. If _timeZoneName_ is not *undefined*, then
+          1. If ParseText(! StringToCodePoints(_timeZoneName_), |TimeZoneNumericUTCOffset|) is not a List of errors, then
+            1. If ! IsValidTimeZoneName(_timeZoneName_) is *false*, throw a *RangeError* exception.
+            1. Set _timeZoneName_ to ! CanonicalizeTimeZoneName(_timeZoneName_).
+          1. Let _timeZone_ be ! CreateTemporalTimeZone(_timeZoneName_).
+        1. Else,
+          1. Let _timeZone_ be *undefined*.
         1. If _result_.[[TimeZoneZ]] is *true*, then
           1. Set _offsetBehaviour_ to ~exact~.
         1. Else if _offsetString_ is *undefined*, then
           1. Set _offsetBehaviour_ to ~wall~.
         1. Set _matchBehaviour_ to ~match minutes~.
       1. If _timeZone_ is not *undefined*, then
-        1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
         1. If _offsetBehaviour_ is ~option~, then
           1. Set _offsetString_ to ? ToString(_offsetString_).
           1. Let _offsetNs_ be ? ParseTimeZoneOffsetString(_offsetString_).
@@ -1490,9 +1498,6 @@
           1. Let _nanoseconds_ be 0.
         1. Let _offsetNanoseconds_ be _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).
         1. Let _offsetString_ be ! FormatTimeZoneOffsetString(_offsetNanoseconds_).
-      1. If _name_ is not *undefined*, then
-        1. If ! IsValidTimeZoneName(_name_) is *false*, throw a *RangeError* exception.
-        1. Set _name_ to ! CanonicalizeTimeZoneName(_name_).
       1. Return the Record {
         [[Z]]: *false*,
         [[OffsetString]]: _offsetString_,

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -409,17 +409,6 @@
   <emu-clause id="sec-temporal-timezone-abstract-ops">
     <h1>Abstract operations</h1>
 
-    <emu-clause id="sec-temporal-parsetemporaltimezone" aoid="ParseTemporalTimeZone">
-      <h1>ParseTemporalTimeZone ( _string_ )</h1>
-      <emu-alg>
-        1. Assert: Type(_string_) is String.
-        1. Let _result_ be ? ParseTemporalTimeZoneString(_string_).
-        1. If _result_.[[Name]] is not *undefined*, return _result_.[[Name]].
-        1. If _result_.[[Z]] is *true*, return *"UTC"*.
-        1. Return _result_.[[OffsetString]].
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-createtemporaltimezone" aoid="CreateTemporalTimeZone">
       <h1>CreateTemporalTimeZone ( _identifier_ [ , _newTarget_ ] )</h1>
       <emu-alg>
@@ -585,8 +574,15 @@
           1. Set _temporalTimeZoneLike_ to ? Get(_temporalTimeZoneLike_, *"timeZone"*).
           1. If Type(_temporalTimeZoneLike_) is Object and ? HasProperty(_temporalTimeZoneLike_, *"timeZone"*) is *false*, return _temporalTimeZoneLike_.
         1. Let _identifier_ be ? ToString(_temporalTimeZoneLike_).
-        1. Let _result_ be ? ParseTemporalTimeZone(_identifier_).
-        1. Return ? CreateTemporalTimeZone(_result_).
+        1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_identifier_).
+        1. If _parseResult_.[[Name]] is not *undefined*, then
+          1. If ParseText(! StringToCodePoints(_parseResult_.[[Name]], |TimeZoneNumericUTCOffset|)) is not a List of errors, then
+            1. If _parseResult_.[[OffsetString]] is not *undefined*, and ! ParseTimeZoneOffsetString(_parseResult_.[[OffsetString]]) ≠ ! ParseTimeZoneOffsetString(_parseResult_.[[Name]]), throw a *RangeError* exception.
+          1. Else,
+            1. If ! IsValidTimeZoneName(_parseResult_.[[Name]]) is *false*, throw a *RangeError* exception.
+          1. Return ! CreateTemporalTimeZone(! CanonicalizeTimeZoneName(_parseResult_.[[Name]])).
+        1. If _parseResult_.[[Z]] is *true*, return ! CreateTemporalTimeZone(*"UTC"*).
+        1. Return ! CreateTemporalTimeZone(_parseResult_.[[OffsetString]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1142,13 +1142,17 @@
           1. Perform ? ToTemporalOverflow(_options_).
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalZonedDateTimeString(_string_).
-          1. Assert: _result_.[[TimeZoneName]] is not *undefined*.
+          1. Let _timeZoneName_ be _result_.[[TimeZoneName]].
+          1. Assert: _timeZoneName_ is not *undefined*.
+          1. If ParseText(! StringToCodePoints(_timeZoneName_), |TimeZoneNumericUTCOffset|) is a List of errors, then
+            1. If ! IsValidTimeZoneName(_timeZoneName_) is *false*, throw a *RangeError* exception.
+            1. Set _timeZoneName_ to ! CanonicalizeTimeZoneName(_timeZoneName_).
           1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
           1. If _result_.[[TimeZoneZ]] is *true*, then
             1. Set _offsetBehaviour_ to ~exact~.
           1. Else if _offsetString_ is *undefined*, then
             1. Set _offsetBehaviour_ to ~wall~.
-          1. Let _timeZone_ be ? CreateTemporalTimeZone(_result_.[[TimeZoneName]]).
+          1. Let _timeZone_ be ! CreateTemporalTimeZone(_timeZoneName_).
           1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).
           1. Set _matchBehaviour_ to ~match minutes~.
         1. Let _offsetNanoseconds_ be 0.


### PR DESCRIPTION
This commit looks like it just moves a few things around, moving the
validation of time zone names from ParseTemporalTimeZoneString to its
callers. But the important part to note is that the validation no longer
takes place in ParseTemporalInstantString, one of the callers of
ParseTemporalTimeZoneString.

This is already covered by test262 tests.

Closes: #1897