### PR TITLE
Editorial: Move calendar validation out of ParseTemporalCalendarString

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1222,8 +1222,6 @@
       1. Let _id_ be the part of _isoString_ produced by the |CalendarName| production, or *undefined* if not present.
       1. If _id_ is *undefined*, then
         1. Return *"iso8601"*.
-      1. If ! IsBuiltinCalendar(_id_) is *false*, then
-        1. Throw a *RangeError* exception.
       1. Return _id_.
     </emu-alg>
   </emu-clause>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1260,8 +1260,7 @@
         1. Throw a *RangeError* exception.
       1. If _isoString_ contains a |UTCDesignator|, then
         1. Throw a *RangeError* exception.
-      1. Let _result_ be ? ParseISODateTime(_isoString_).
-      1. Return _result_.
+      1. Return ? ParseISODateTime(_isoString_).
     </emu-alg>
   </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -248,7 +248,8 @@
           1. If Type(_temporalCalendarLike_) is Object and ? HasProperty(_temporalCalendarLike_, *"calendar"*) is *false*, return _temporalCalendarLike_.
         1. Let _identifier_ be ? ToString(_temporalCalendarLike_).
         1. If ! IsBuiltinCalendar(_identifier_) is *false*, then
-          1. Let _identifier_ be ? ParseTemporalCalendarString(_identifier_).
+          1. Set _identifier_ to ? ParseTemporalCalendarString(_identifier_).
+          1. If ! IsBuiltinCalendar(_identifier_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalCalendar(_identifier_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Similar to #1897, we want to move any validation that is not purely syntactic out of ParseTemporal___String abstract operations. This accomplishes that for Calendar. However, it affects nothing observable, just reorganizes code.

Closes: #1901