### PR TITLE
Normative: Make PlainDate difference methods units handling consistent

### DIFF
--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -420,7 +420,8 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _disallowedUnits_ be « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"day"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"day"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
@@ -446,7 +447,8 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _disallowedUnits_ be « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"day"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"day"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).


### PR DESCRIPTION
To bring the default for largestUnit in PlainDate's since() and until()
methods in line with other types' since() and until() methods, we have to
add an algorithm step for LargerOfTwoTemporalUnits.

Without this, code such as
date1.until(date2, { smallestUnit: 'months' })
would throw because the default largestUnit is days. As per
https://github.com/tc39/proposal-temporal/issues/827#issuecomment-685248205
this was not intended.

PlainDate seems to be the only place where this was not working as
intended. ZonedDateTime, Instant, PlainTime, PlainYearMonth, and
PlainDateTime either already have this step or their default largestUnit
is already the largest one so they wouldn't have this problem.

The reference polyfill code is already correct in this regard.

Closes: #1864