### PR TITLE
Normative: Fix fractionalSecondDigits behaviour in Duration.toString()

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2053,7 +2053,7 @@ export const ES = ObjectAssign({}, ES2020, {
       decimalPart = `${fraction}`.padStart(9, '0').slice(0, precision);
     }
     if (decimalPart) secondParts.unshift('.', decimalPart);
-    if (!seconds.isZero() || secondParts.length) secondParts.unshift(seconds.abs().toString());
+    if (!seconds.isZero() || secondParts.length || precision !== 'auto') secondParts.unshift(seconds.abs().toString());
     if (secondParts.length) timeParts.push(`${secondParts.join('')}S`);
     if (timeParts.length) timeParts.unshift('T');
     if (!dateParts.length && !timeParts.length) return 'PT0S';

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -295,6 +295,35 @@ describe('Duration', () => {
       equal(d2.toString(options), 'PT15H23M30.0000000S');
       equal(d3.toString(options), 'PT15H23M30.5432000S');
     });
+    it('pads correctly in edge cases', () => {
+      const d4 = Duration.from({ years: 3 });
+      equal(d4.toString(), 'P3Y');
+      equal(d4.toString({ fractionalSecondDigits: 0 }), 'P3YT0S');
+      equal(d4.toString({ smallestUnit: 'seconds' }), 'P3YT0S');
+      equal(d4.toString({ smallestUnit: 'milliseconds' }), 'P3YT0.000S');
+      equal(d4.toString({ fractionalSecondDigits: 5 }), 'P3YT0.00000S');
+
+      const d5 = Duration.from({ minutes: 30 });
+      equal(d5.toString(), 'PT30M');
+      equal(d5.toString({ fractionalSecondDigits: 0 }), 'PT30M0S');
+      equal(d5.toString({ smallestUnit: 'seconds' }), 'PT30M0S');
+      equal(d5.toString({ smallestUnit: 'milliseconds' }), 'PT30M0.000S');
+      equal(d5.toString({ fractionalSecondDigits: 5 }), 'PT30M0.00000S');
+
+      const d6 = Duration.from({ milliseconds: 100 });
+      equal(d6.toString(), 'PT0.1S');
+      equal(d6.toString({ fractionalSecondDigits: 0 }), 'PT0S');
+      equal(d6.toString({ smallestUnit: 'seconds' }), 'PT0S');
+      equal(d6.toString({ smallestUnit: 'milliseconds' }), 'PT0.100S');
+      equal(d6.toString({ fractionalSecondDigits: 5 }), 'PT0.10000S');
+
+      const zero = new Duration();
+      equal(zero.toString(), 'PT0S');
+      equal(zero.toString({ fractionalSecondDigits: 0 }), 'PT0S');
+      equal(zero.toString({ smallestUnit: 'seconds' }), 'PT0S');
+      equal(zero.toString({ smallestUnit: 'milliseconds' }), 'PT0.000S');
+      equal(zero.toString({ fractionalSecondDigits: 5 }), 'PT0.00000S');
+    });
     it('auto is the default', () => {
       [d1, d2, d3].forEach((d) => equal(d.toString({ fractionalSecondDigits: 'auto' }), d.toString()));
     });

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1496,7 +1496,7 @@
           1. Set _timePart_ to the string concatenation of abs(_hours_) formatted as a decimal number and the code unit 0x0048 (LATIN CAPITAL LETTER H).
         1. If _minutes_ is not 0, then
           1. Set _timePart_ to the string concatenation of _timePart_, abs(_minutes_) formatted as a decimal number, and the code unit 0x004D (LATIN CAPITAL LETTER M).
-        1. If any of _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are not 0; or _years_, _months_, _weeks_, _days_, _hours_, and _minutes_ are all 0, then
+        1. If any of _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are not 0; or _years_, _months_, _weeks_, _days_, _hours_, and _minutes_ are all 0; or _precision_ is not *"auto"*; then
           1. Let _fraction_ be abs(_milliseconds_) × 10<sup>6</sup> + abs(_microseconds_) × 10<sup>3</sup> + abs(_nanoseconds_).
           1. Let _decimalPart_ be _fraction_ formatted as a nine-digit decimal number, padded to the left with zeroes if necessary.
           1. If _precision_ is *"auto"*, then


### PR DESCRIPTION
Previously, code that combined zero subsecond units with a specified
precision, such as the following:

Temporal.Duration.from({ years: 3 }).toString({ fractionalSecondDigits: 5 })

would not render the seconds with the correct precision. The above example
would return 'P3Y' and not 'P3YT0.00000S'.

Closes: #1763