### PR TITLE
Support newer DateTimeFormat output

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2319,14 +2319,11 @@ export const ES = ObjectAssign({}, ES2020, {
   },
   GetFormatterParts: (timeZone, epochMilliseconds) => {
     const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
-    // FIXME: can this use formatToParts instead?
+    // Using `format` instead of `formatToParts` for compatibility with older clients
     const datetime = formatter.format(new Date(epochMilliseconds));
-    const [date, fullYear, time] = datetime.split(/,\s+/);
-    const [month, day] = date.split(' ');
-    const [year, era] = fullYear.split(' ');
-    const [hour, minute, second] = time.split(':');
+    const [month, day, year, era, hour, minute, second] = datetime.split(/[^\w]+/);
     return {
-      year: era === 'BC' ? -year + 1 : +year,
+      year: era.toUpperCase().startsWith('B') ? -year + 1 : +year,
       month: +month,
       day: +day,
       hour: hour === '24' ? 0 : +hour, // bugs.chromium.org/p/chromium/issues/detail?id=1045791


### PR DESCRIPTION
Update GetFormatterParts implementation in polyfill to avoid failed tests on the latest Intl implementations in newer JS engines (e.g. FF nightly).

Port of https://github.com/js-temporal/temporal-polyfill/pull/97