### PR TITLE
Fix TS types for required CalendarProtocol methods

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -631,20 +631,20 @@ export namespace Temporal {
     day(date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainMonthDay | PlainDateLike | string): number;
     era(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): string | undefined;
     eraYear(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): number | undefined;
-    dayOfWeek?(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): number;
-    dayOfYear?(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): number;
-    weekOfYear?(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): number;
-    daysInWeek?(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): number;
-    daysInMonth?(
+    dayOfWeek(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): number;
+    dayOfYear(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): number;
+    weekOfYear(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): number;
+    daysInWeek(date: Temporal.PlainDate | Temporal.PlainDateTime | PlainDateLike | string): number;
+    daysInMonth(
       date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainYearMonth | PlainDateLike | string
     ): number;
-    daysInYear?(
+    daysInYear(
       date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainYearMonth | PlainDateLike | string
     ): number;
-    monthsInYear?(
+    monthsInYear(
       date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainYearMonth | PlainDateLike | string
     ): number;
-    inLeapYear?(
+    inLeapYear(
       date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainYearMonth | PlainDateLike | string
     ): boolean;
     dateFromFields(
@@ -659,12 +659,12 @@ export namespace Temporal {
       fields: EitherMonthCodeOrMonthAndYear & { day: number },
       options?: AssignmentOptions
     ): Temporal.PlainMonthDay;
-    dateAdd?(
+    dateAdd(
       date: Temporal.PlainDate | PlainDateLike | string,
       duration: Temporal.Duration | DurationLike | string,
       options?: ArithmeticOptions
     ): Temporal.PlainDate;
-    dateUntil?(
+    dateUntil(
       one: Temporal.PlainDate | PlainDateLike | string,
       two: Temporal.PlainDate | PlainDateLike | string,
       options?: DifferenceOptions<'year' | 'month' | 'week' | 'day'>


### PR DESCRIPTION
The [docs](https://tc39.es/proposal-temporal/docs/calendar.html#custom-calendars) say: 

> The other, more difficult, way to create a custom calendar is to create a plain object implementing the `Temporal.Calendar` protocol, without subclassing. The object must implement all of the `Temporal.Calendar` properties and methods except for `id`, `fields()`, `mergeFields()`, and `toJSON()`.

The TS types currently allow many CalendarProtocol methods to be undefined other than the 4 above. This PR aligns the TS types to the docs.

@sffc @ptomato holler if the docs are wrong.