### PR TITLE
Polyfill: Ensure that Temporal prototypes aren't writable

### DIFF
--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -127,6 +127,12 @@ if ('formatRangeToParts' in IntlDateTimeFormat.prototype) {
 
 DateTimeFormat.prototype = Object.create(IntlDateTimeFormat.prototype, properties);
 
+Object.defineProperty(DateTimeFormat, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false
+});
+
 function resolvedOptions() {
   return this[ORIGINAL].resolvedOptions();
 }

--- a/polyfill/lib/shim.mjs
+++ b/polyfill/lib/shim.mjs
@@ -39,4 +39,28 @@ function copy(target, source) {
   }
 }
 
+// Work around https://github.com/babel/babel/issues/2025.
+const types = [
+  globalThis.Temporal.Instant,
+  globalThis.Temporal.Calendar,
+  globalThis.Temporal.PlainDate,
+  globalThis.Temporal.PlainDateTime,
+  globalThis.Temporal.Duration,
+  globalThis.Temporal.PlainMonthDay,
+  // globalThis.Temporal.Now, // plain object (not a constructor), so no `prototype`
+  globalThis.Temporal.PlainTime,
+  globalThis.Temporal.TimeZone,
+  globalThis.Temporal.PlainYearMonth,
+  globalThis.Temporal.ZonedDateTime
+];
+for (const type of types) {
+  const descriptor = Object.getOwnPropertyDescriptor(type, 'prototype');
+  if (descriptor.configurable || descriptor.enumerable || descriptor.writable) {
+    descriptor.configurable = false;
+    descriptor.enumerable = false;
+    descriptor.writable = false;
+    Object.defineProperty(type, 'prototype', descriptor);
+  }
+}
+
 export { Temporal, Intl, toTemporalInstant };


### PR DESCRIPTION
This PR fixes #1965:
1. For Intl.DateTimeFormat, sets `writeable: false` on  `prototype` because it's created using `function` (which has a writeable `prototype`, unlike `class` which is not writeable).
2. For Temporal classes, there's a Babel bug that causes prototypes to be writeable (https://github.com/babel/babel/issues/2025) and this PR works around it.

There are corresponding Test262 tests to check prototype writability here: https://github.com/tc39/test262/pull/3344