### PR TITLE
Polyfill: Throw RangeError if there's an invalid `offset` string in `ZonedDateTime`-representing property bags

### DIFF
--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -48,8 +48,9 @@ export class TimeZone {
     instant = ES.ToTemporalInstant(instant);
     const id = GetSlot(this, TIMEZONE_ID);
 
-    const offsetNs = ES.ParseOffsetString(id);
-    if (offsetNs !== null) return offsetNs;
+    if (ES.TestTimeZoneOffsetString(id)) {
+      return ES.ParseTimeZoneOffsetString(id);
+    }
 
     return ES.GetIANATimeZoneOffsetNanoseconds(GetSlot(instant, EPOCHNANOSECONDS), id);
   }
@@ -76,8 +77,7 @@ export class TimeZone {
     const Instant = GetIntrinsic('%Temporal.Instant%');
     const id = GetSlot(this, TIMEZONE_ID);
 
-    const offsetNs = ES.ParseOffsetString(id);
-    if (offsetNs !== null) {
+    if (ES.TestTimeZoneOffsetString(id)) {
       const epochNs = ES.GetEpochFromISOParts(
         GetSlot(dateTime, ISO_YEAR),
         GetSlot(dateTime, ISO_MONTH),
@@ -90,6 +90,7 @@ export class TimeZone {
         GetSlot(dateTime, ISO_NANOSECOND)
       );
       if (epochNs === null) throw new RangeError('DateTime outside of supported range');
+      const offsetNs = ES.ParseTimeZoneOffsetString(id);
       return [new Instant(epochNs.minus(offsetNs))];
     }
 
@@ -113,7 +114,7 @@ export class TimeZone {
     const id = GetSlot(this, TIMEZONE_ID);
 
     // Offset time zones or UTC have no transitions
-    if (ES.ParseOffsetString(id) !== null || id === 'UTC') {
+    if (ES.TestTimeZoneOffsetString(id) || id === 'UTC') {
       return null;
     }
 
@@ -128,7 +129,7 @@ export class TimeZone {
     const id = GetSlot(this, TIMEZONE_ID);
 
     // Offset time zones or UTC have no transitions
-    if (ES.ParseOffsetString(id) !== null || id === 'UTC') {
+    if (ES.TestTimeZoneOffsetString(id) || id === 'UTC') {
       return null;
     }
 

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -223,7 +223,7 @@ export class ZonedDateTime {
     fields = ES.PrepareTemporalFields(fields, entries);
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
       ES.InterpretTemporalDateTimeFields(calendar, fields, options);
-    const offsetNs = ES.ParseOffsetString(fields.offset);
+    const offsetNs = ES.ParseTimeZoneOffsetString(fields.offset);
     const epochNanoseconds = ES.InterpretISODateTimeOffset(
       year,
       month,

--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -685,6 +685,15 @@ describe('Duration', () => {
       throws(() => oneDay.add(hours24, { relativeTo: { year: 2019, month: 11 } }), TypeError);
       throws(() => oneDay.add(hours24, { relativeTo: { year: 2019, day: 3 } }), TypeError);
     });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(
+        () =>
+          Temporal.Duration.from('P2D').add('P1M', {
+            relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+          }),
+        RangeError
+      );
+    });
   });
   describe('Duration.subtract()', () => {
     const duration = Duration.from({ days: 3, hours: 1, minutes: 10 });
@@ -927,6 +936,15 @@ describe('Duration', () => {
       equal(zero2.milliseconds, 0);
       equal(zero2.microseconds, 0);
       equal(zero2.nanoseconds, 0);
+    });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(
+        () =>
+          Temporal.Duration.from('P2D').subtract('P1M', {
+            relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+          }),
+        RangeError
+      );
     });
   });
   describe('Duration.abs()', () => {
@@ -1512,6 +1530,16 @@ describe('Duration', () => {
       equal(`${yearAndHalf.round({ relativeTo: '2020-01-01', smallestUnit: 'years' })}`, 'P1Y');
       equal(`${yearAndHalf.round({ relativeTo: '2020-07-01', smallestUnit: 'years' })}`, 'P2Y');
     });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(
+        () =>
+          Temporal.Duration.from('P1M280D').round({
+            smallestUnit: 'month',
+            relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+          }),
+        RangeError
+      );
+    });
   });
   describe('Duration.total()', () => {
     const d = new Duration(5, 5, 5, 5, 5, 5, 5, 5, 5, 5);
@@ -1851,6 +1879,16 @@ describe('Duration', () => {
       equal(d.total({ unit: 'microsecond', relativeTo }), d.total({ unit: 'microseconds', relativeTo }));
       equal(d.total({ unit: 'nanosecond', relativeTo }), d.total({ unit: 'nanoseconds', relativeTo }));
     });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(
+        () =>
+          Temporal.Duration.from('P1M280D').total({
+            unit: 'month',
+            relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+          }),
+        RangeError
+      );
+    });
   });
   describe('Duration.compare', () => {
     describe('time units only', () => {
@@ -1946,6 +1984,15 @@ describe('Duration', () => {
     });
     it('does not lose precision when totaling everything down to nanoseconds', () => {
       notEqual(Duration.compare({ days: 200 }, { days: 200, nanoseconds: 1 }), 0);
+    });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(() => {
+        const d1 = Temporal.Duration.from('P1M280D');
+        const d2 = Temporal.Duration.from('P1M281D');
+        Temporal.Duration.compare(d1, d2, {
+          relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+        });
+      }, RangeError);
     });
   });
 });

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -589,6 +589,23 @@ describe('ZonedDateTime', () => {
       });
       equal(`${zdt}`, '1976-11-18T00:00:00-10:30[-10:30]');
     });
+    it('throws with invalid offset', () => {
+      const offsets = ['use', 'prefer', 'ignore', 'reject'];
+      offsets.forEach((offset) => {
+        throws(() => {
+          Temporal.ZonedDateTime.from(
+            {
+              year: 2021,
+              month: 11,
+              day: 26,
+              offset: '+099:00',
+              timeZone: 'Europe/London'
+            },
+            { offset }
+          );
+        }, RangeError);
+      });
+    });
     describe('Overflow option', () => {
       const bad = { year: 2019, month: 1, day: 32, timeZone: lagos };
       it('reject', () => throws(() => ZonedDateTime.from(bad, { overflow: 'reject' }), RangeError));
@@ -1024,6 +1041,14 @@ describe('ZonedDateTime', () => {
       throws(() => zdt.with('1976-11-18'), TypeError);
       throws(() => zdt.with('12:00'), TypeError);
       throws(() => zdt.with('invalid'), TypeError);
+    });
+    it('throws with invalid offset', () => {
+      const offsets = ['use', 'prefer', 'ignore', 'reject'];
+      offsets.forEach((offset) => {
+        throws(() => {
+          Temporal.ZonedDateTime.from('2022-11-26[Europe/London]').with({ offset: '+088:00' }, { offset });
+        }, RangeError);
+      });
     });
   });
 
@@ -1617,6 +1642,18 @@ describe('ZonedDateTime', () => {
       equal(`${dt1.until(dt2, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P2Y');
       equal(`${dt2.until(dt1, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, '-P1Y');
     });
+    it('throws with invalid offset', () => {
+      throws(() => {
+        const zdt = ZonedDateTime.from('2019-01-01T00:00+00:00[UTC]');
+        zdt.until({
+          year: 2021,
+          month: 11,
+          day: 26,
+          offset: '+099:00',
+          timeZone: 'Europe/London'
+        });
+      }, RangeError);
+    });
   });
   describe('ZonedDateTime.since()', () => {
     const zdt = ZonedDateTime.from('1976-11-18T15:23:30.123456789+01:00[Europe/Vienna]');
@@ -1948,6 +1985,18 @@ describe('ZonedDateTime', () => {
       equal(`${dt2.since(dt1, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P1Y');
       equal(`${dt1.since(dt2, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, '-P2Y');
     });
+    it('throws with invalid offset', () => {
+      throws(() => {
+        const zdt = ZonedDateTime.from('2019-01-01T00:00+00:00[UTC]');
+        zdt.since({
+          year: 2021,
+          month: 11,
+          day: 26,
+          offset: '+099:00',
+          timeZone: 'Europe/London'
+        });
+      }, RangeError);
+    });
   });
 
   describe('ZonedDateTime.round()', () => {
@@ -2187,6 +2236,17 @@ describe('ZonedDateTime', () => {
         () => zdt.equals({ years: 1969, months: 12, days: 31, timeZone: 'America/New_York', calendarName: 'gregory' }),
         TypeError
       );
+    });
+    it('throws with invalid offset', () => {
+      throws(() => {
+        zdt.equals({
+          year: 2021,
+          month: 11,
+          day: 26,
+          offset: '+099:00',
+          timeZone: 'Europe/London'
+        });
+      }, RangeError);
     });
   });
   describe('ZonedDateTime.toString()', () => {
@@ -2893,6 +2953,17 @@ describe('ZonedDateTime', () => {
       const clockAfter = ZonedDateTime.from('2000-01-01T01:30-04:00[America/Halifax]');
       equal(ZonedDateTime.compare(clockBefore, clockAfter), 1);
       equal(Temporal.PlainDateTime.compare(clockBefore.toPlainDateTime(), clockAfter.toPlainDateTime()), -1);
+    });
+    it('throws with invalid offset', () => {
+      throws(() => {
+        Temporal.ZonedDateTime.compare(zdt1, {
+          year: 2021,
+          month: 11,
+          day: 26,
+          offset: '+099:00',
+          timeZone: 'Europe/London'
+        });
+      }, RangeError);
     });
   });
 });


### PR DESCRIPTION
Ensure that the correct RangeError is thrown when an invalid offset is passed to ParseTimeZoneOffsetString. 

Note that validation of the offset in ISO strings is handled separately; this PR only fixes cases where an offset is parsed on its own, e.g. when property bag inputs are used in `ZonedDateTime#(with|from|equals|until|since|compare)` or as `relativeTo` options  passed to `Duration#(add|subtract|compare|round|total)`. The problem was also present in `TimeZone.from` and `ZonedDateTime#withTimeZone` but was caught downstream so didn't fail any previous tests.

Fixes #1972.