### PR TITLE
Remove `zoneRequired` option in ParseTemporalTimeZoneString & better align parsing to spec

### DIFF
--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -18,12 +18,8 @@ export const offset = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5
 const zonesplit = new RegExp(`(?:([zZ])|(?:${offset.source})?)(?:\\[(${timeZoneID.source})\\])?`);
 const calendar = new RegExp(`\\[u-ca=(${calendarID.source})\\]`);
 
-export const instant = new RegExp(
+export const zoneddatetime = new RegExp(
   `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?${zonesplit.source}(?:${calendar.source})?$`,
-  'i'
-);
-export const datetime = new RegExp(
-  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?(?:${zonesplit.source})?(?:${calendar.source})?$`,
   'i'
 );
 


### PR DESCRIPTION
The `zoneRequired` option in `ES.ParseTemporalTimeZoneString` doesn't work, because the `zonesplit` regex in regex.mjs matches any string. (It does correctly match each component, it just doesn't fail if none match.) Furthermore, callers of this option don't really follow the spec that requires throwing as soon as we know that it's not the right regex for the type.

This PR fixes #1973 by:
* Removing the `zoneRequired` option
* Removing the now-unused `datetime` regex, and renaming the `instant` regex to `zoneddatetime` to better reflect what it's doing.
* Refactoring a few of the parsing methods to better match the spec, which expects that strings that don't satisfy the production will throw before doing non-parsing work. After this PR, every `Parse*` AO will throw if the string doesn't match the production for that type.