### PR TITLE
Improve "missing time in string" error message

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -246,7 +246,7 @@ export const ES = ObjectAssign({}, ES2020, {
     if (showCalendar === 'auto' && id === 'iso8601') return '';
     return `[u-ca=${id}]`;
   },
-  ParseISODateTime: (isoString, { timeRequired = false } = {}) => {
+  ParseISODateTime: (isoString) => {
     // ZDT is the superset of fields for every other Temporal type
     const match = PARSE.zoneddatetime.exec(isoString);
     if (!match) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
@@ -255,7 +255,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const year = ES.ToInteger(yearString);
     const month = ES.ToInteger(match[2] || match[4]);
     const day = ES.ToInteger(match[3] || match[5]);
-    if (timeRequired && match[6] === undefined) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
+    const hasTime = match[6] !== undefined;
     const hour = ES.ToInteger(match[6]);
     const minute = ES.ToInteger(match[7] || match[10]);
     let second = ES.ToInteger(match[8] || match[11]);
@@ -298,6 +298,7 @@ export const ES = ObjectAssign({}, ES2020, {
       year,
       month,
       day,
+      hasTime,
       hour,
       minute,
       second,
@@ -340,10 +341,10 @@ export const ES = ObjectAssign({}, ES2020, {
       nanosecond = ES.ToInteger(fraction.slice(6, 9));
       calendar = match[15];
     } else {
-      let z;
-      ({ hour, minute, second, millisecond, microsecond, nanosecond, calendar, z } = ES.ParseISODateTime(isoString, {
-        timeRequired: true
-      }));
+      let z, hasTime;
+      ({ hasTime, hour, minute, second, millisecond, microsecond, nanosecond, calendar, z } =
+        ES.ParseISODateTime(isoString));
+      if (!hasTime) throw new RangeError(`time is missing in string: ${isoString}`);
       if (z) throw new RangeError('Z designator not supported for PlainTime');
     }
     // if it's a date-time string, OK

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -1014,9 +1014,16 @@ describe('Time', () => {
     it('optional parts', () => {
       equal(`${PlainTime.from('15')}`, '15:00:00');
     });
+    it('date-only formats not allowed', () => {
+      throws(() => PlainTime.from('2020-12-01'), RangeError);
+      throws(() => PlainTime.from('20201201'), RangeError);
+    });
     it('time designator prefix', () => {
       equal(`${PlainTime.from('T15:23:30')}`, '15:23:30');
       equal(`${PlainTime.from('t152330')}`, '15:23:30');
+    });
+    it('space not accepted as time designator prefix', () => {
+      throws(() => PlainTime.from(' 15:23:30'), RangeError);
     });
     it('time designator required for ambiguous strings', () => {
       // YYYY-MM or HHMM-UU


### PR DESCRIPTION
Slightly refector the implementation of #1952 to enable a clearer error message when the user tries to parse a date-only string with `PlainTime.from`.

This is the same pattern that's used for other polyfill parsing: `ParseISODateTime` is used for generic, regex-only parsing
while type-specific validation happens in the calling method, e.g. `ParseTemporalTimeString` or `ParseTemporalZonedDateTimeString`.

Also add tests to verify that date strings are not allowed, and that space is not accepted as a time designator prefix even though space is accepted as a date/time separator.