### PR TITLE
Normative: Reject '-000000' as extended year

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -374,6 +374,7 @@ export const ES = ObjectAssign({}, ES2020, {
     if (match) {
       let yearString = match[1];
       if (yearString[0] === '\u2212') yearString = `-${yearString.slice(1)}`;
+      if (yearString === '-000000') throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
       year = ES.ToInteger(yearString);
       month = ES.ToInteger(match[2]);
       calendar = match[3];

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -252,6 +252,7 @@ export const ES = ObjectAssign({}, ES2020, {
     if (!match) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
     let yearString = match[1];
     if (yearString[0] === '\u2212') yearString = `-${yearString.slice(1)}`;
+    if (yearString === '-000000') throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
     const year = ES.ToInteger(yearString);
     const month = ES.ToInteger(match[2] || match[4]);
     const day = ES.ToInteger(match[3] || match[5]);

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1154,7 +1154,7 @@
       1. Let _minute_ be the part of _isoString_ produced by the |TimeMinute|, |TimeMinuteNotValidDay|, |TimeMinuteThirtyOnly|, or |TimeMinuteThirtyOneOnly| productions, or *undefined* if none of those are present.
       1. Let _second_ be the part of _isoString_ produced by the |TimeSecond| or |TimeSecondNotValidMonth| productions, or *undefined* if neither of those are present.
       1. If the first code unit of _year_ is 0x2212 (MINUS SIGN), replace it with the code unit 0x002D (HYPHEN-MINUS).
-      1. If _year_ is "-000000", throw a *RangeError* exception.
+      1. If ! SameValue(_year_, *"-000000"*) is *true*, throw a *RangeError* exception.
       1. Set _year_ to ! ToIntegerOrInfinity(_year_).
       1. If _month_ is *undefined*, then
         1. Set _month_ to 1.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1513,7 +1513,7 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalYearMonthString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
-      1. If _isoString_ is "-000000", throw a *RangeError* exception.
+      1. If ! SameValue(_isoString_, *"-000000"*) is *true*, throw a *RangeError* exception.
       1. If _isoString_ contains a |UTCDesignator|, then
         1. Throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1513,6 +1513,7 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalYearMonthString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
+      1. If _isoString_ is "-000000", throw a *RangeError* exception.
       1. If _isoString_ contains a |UTCDesignator|, then
         1. Throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1154,7 +1154,7 @@
       1. Let _minute_ be the part of _isoString_ produced by the |TimeMinute|, |TimeMinuteNotValidDay|, |TimeMinuteThirtyOnly|, or |TimeMinuteThirtyOneOnly| productions, or *undefined* if none of those are present.
       1. Let _second_ be the part of _isoString_ produced by the |TimeSecond| or |TimeSecondNotValidMonth| productions, or *undefined* if neither of those are present.
       1. If the first code unit of _year_ is 0x2212 (MINUS SIGN), replace it with the code unit 0x002D (HYPHEN-MINUS).
-      1. If year is "-000000", throw a *RangeError* exception.
+      1. If _year_ is "-000000", throw a *RangeError* exception.
       1. Set _year_ to ! ToIntegerOrInfinity(_year_).
       1. If _month_ is *undefined*, then
         1. Set _month_ to 1.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1154,6 +1154,7 @@
       1. Let _minute_ be the part of _isoString_ produced by the |TimeMinute|, |TimeMinuteNotValidDay|, |TimeMinuteThirtyOnly|, or |TimeMinuteThirtyOneOnly| productions, or *undefined* if none of those are present.
       1. Let _second_ be the part of _isoString_ produced by the |TimeSecond| or |TimeSecondNotValidMonth| productions, or *undefined* if neither of those are present.
       1. If the first code unit of _year_ is 0x2212 (MINUS SIGN), replace it with the code unit 0x002D (HYPHEN-MINUS).
+      1. If year is "-000000", throw a *RangeError* exception.
       1. Set _year_ to ! ToIntegerOrInfinity(_year_).
       1. If _month_ is *undefined*, then
         1. Set _month_ to 1.


### PR DESCRIPTION
In #1753 there was some discussion of what to do about dates with an extended year equal to "-000000". It was decided to reject such cases. Here's a simple solution to that.

Alternatives considered:

+ Change the regexp for the year part of dates. This would have the desired effect of rejecting "-000000" as ungrammatical. This alternative wasn't chosen because it seems to me that the invalidity is a domain decision, not a grammar decision. Thus, "-000000" remains grammatically valid and thus *potentially* meaningful; we just reject this one case by a domain convention.

closes #1753 