### PR TITLE
Normative: Don't validate numeric timezone in ToRelativeTemporalObject

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -493,7 +493,7 @@
         1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
         1. Let _timeZoneName_ be _result_.[[TimeZoneIANAName]].
         1. If _timeZoneName_ is not *undefined*, then
-          1. If ParseText(StringToCodePoints(_timeZoneName_), |TimeZoneNumericUTCOffset|) is not a List of errors, then
+          1. If ParseText(StringToCodePoints(_timeZoneName_), |TimeZoneNumericUTCOffset|) is a List of errors, then
             1. If ! IsValidTimeZoneName(_timeZoneName_) is *false*, throw a *RangeError* exception.
             1. Set _timeZoneName_ to ! CanonicalizeTimeZoneName(_timeZoneName_).
           1. Let _timeZone_ be ! CreateTemporalTimeZone(_timeZoneName_).


### PR DESCRIPTION
See commit message for details.