### PR TITLE
Editorial: Mark CreateTemporalTimeZone("UTC") as infallible

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -620,7 +620,7 @@
         1. Assert: _instant_ has an [[InitializedTemporalInstant]] internal slot.
         1. Let _outputTimeZone_ be _timeZone_.
         1. If _outputTimeZone_ is *undefined*, then
-          1. Set _outputTimeZone_ to ? CreateTemporalTimeZone(*"UTC"*).
+          1. Set _outputTimeZone_ to ! CreateTemporalTimeZone(*"UTC"*).
         1. Let _isoCalendar_ be ! GetISO8601Calendar().
         1. Let _dateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_outputTimeZone_, _instant_, _isoCalendar_).
         1. Let _dateTimeString_ be ? TemporalDateTimeToString(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], *undefined*, _precision_, *"never"*).


### PR DESCRIPTION
When `newTarget` is not provided, it falls back to `%Temporal.TimeZone%` & the only fallible operation in `CreateTemporalTimeZone`,  the call of `OrdinaryCreateFromConstructor`, becomes infallible.

See also:

https://github.com/tc39/proposal-temporal/blob/2a81fbca981eb684f1dc10ec479b5a8e872d8c37/spec/timezone.html#L584