### PR TITLE
Editorial: Fixup "Don't parse and re-format offset string in ParseTemporalTimeZoneString"

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -412,12 +412,14 @@
       <emu-alg>
         1. If _newTarget_ is not present, set it to %Temporal.TimeZone%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.TimeZone.prototype%"*, « [[InitializedTemporalTimeZone]], [[Identifier]], [[OffsetNanoseconds]] »).
-        1. Set _object_.[[Identifier]] to _identifier_.
-        1. If _identifier_ satisfies the syntax of a |TimeZoneNumericUTCOffset| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
-          1. Set _object_.[[OffsetNanoseconds]] to ! ParseTimeZoneOffsetString(_identifier_).
-        1. Else,
+        1. Let _offsetNanosecondsResult_ be ParseTimeZoneOffsetString(_identifier_).
+        1. If _offsetNanosecondsResult_ is an abrupt completion, then
           1. Assert: ! CanonicalizeTimeZoneName(_identifier_) is _identifier_.
+          1. Set _object_.[[Identifier]] to _identifier_.
           1. Set _object_.[[OffsetNanoseconds]] to *undefined*.
+        1. Else,
+          1. Set _object_.[[Identifier]] to ! FormatTimeZoneOffsetString(_identifier_).
+          1. Set _object_.[[OffsetNanoseconds]] to _offsetNanosecondsResult_.[[Value]].
         1. Return _object_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
75490b98 inadvertently made an observable change: a non-canonical offset
string would be stored in the time zone's [[Identifier]] internal slot,
and would be visible to user code via toString(). This change restores the
previous behaviour so that the editorial change is actually editorial.

Closes: #2007