### PR TITLE
Editorial: Call FormatTimeZoneOffsetString with identifier parse result

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -418,7 +418,7 @@
           1. Set _object_.[[Identifier]] to _identifier_.
           1. Set _object_.[[OffsetNanoseconds]] to *undefined*.
         1. Else,
-          1. Set _object_.[[Identifier]] to ! FormatTimeZoneOffsetString(_identifier_).
+          1. Set _object_.[[Identifier]] to ! FormatTimeZoneOffsetString(_offsetNanosecondsResult_.[[Value]]).
           1. Set _object_.[[OffsetNanoseconds]] to _offsetNanosecondsResult_.[[Value]].
         1. Return _object_.
       </emu-alg>


### PR DESCRIPTION
...and not the identifier itself, which would fail the assertion in the first step of the AO:

    1. Assert: offsetNanoseconds is an integer.

---

I even LGTM'd this in the PR, but only noticed this while implementing the change :upside_down_face: 