### PR TITLE
Include the valueOf function in Temporal.Duration.

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -542,6 +542,7 @@ export namespace Temporal {
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(options?: ToStringPrecisionOptions): string;
+    valueOf(): never;
     readonly [Symbol.toStringTag]: 'Temporal.Duration';
   }
 


### PR DESCRIPTION
This was missed in https://github.com/tc39/proposal-temporal/commit/bc0b188c0e07657319f03489d7b8caa89c420a5d, and is a port of https://github.com/js-temporal/temporal-polyfill/pull/121