### PR TITLE
Remove bad examples

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -94,7 +94,6 @@ Example usage:
 ```javascript
 date = Temporal.PlainDate.from('2006-08-24'); // => 2006-08-24
 date = Temporal.PlainDate.from('2006-08-24T15:43:27'); // => 2006-08-24
-date = Temporal.PlainDate.from('2006-08-24T15:43:27Z'); // => 2006-08-24
 date = Temporal.PlainDate.from('2006-08-24T15:43:27+01:00[Europe/Brussels]');
   // => 2006-08-24
 date === Temporal.PlainDate.from(date); // => false

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -126,7 +126,6 @@ Example usage:
 <!-- prettier-ignore-start -->
 ```javascript
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30');
-dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30Z'); // => 1995-12-07T03:24:30
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30+01:00[Europe/Brussels]');
   // => 1995-12-07T03:24:30
   // same as above; time zone is ignored

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -94,7 +94,6 @@ Example usage:
 md = Temporal.PlainMonthDay.from('08-24'); // => 08-24
 md = Temporal.PlainMonthDay.from('2006-08-24'); // => 08-24
 md = Temporal.PlainMonthDay.from('2006-08-24T15:43:27'); // => 08-24
-md = Temporal.PlainMonthDay.from('2006-08-24T15:43:27Z'); // => 08-24
 md = Temporal.PlainMonthDay.from('2006-08-24T15:43:27+01:00[Europe/Brussels]');
 // => 08-24
 md === Temporal.PlainMonthDay.from(md); // => false

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -86,7 +86,6 @@ Example usage:
 ```javascript
 time = Temporal.PlainTime.from('03:24:30'); // => 03:24:30
 time = Temporal.PlainTime.from('1995-12-07T03:24:30'); // => 03:24:30
-time = Temporal.PlainTime.from('1995-12-07T03:24:30Z'); // => 03:24:30
 time = Temporal.PlainTime.from('1995-12-07T03:24:30+01:00[Europe/Brussels]');
   // => 03:24:30
   // (same as above; time zone is ignored)

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -96,7 +96,6 @@ Example usage:
 ym = Temporal.PlainYearMonth.from('2019-06'); // => 2019-06
 ym = Temporal.PlainYearMonth.from('2019-06-24'); // => 2019-06
 ym = Temporal.PlainYearMonth.from('2019-06-24T15:43:27'); // => 2019-06
-ym = Temporal.PlainYearMonth.from('2019-06-24T15:43:27Z'); // => 2019-06
 ym = Temporal.PlainYearMonth.from('2019-06-24T15:43:27+01:00[Europe/Brussels]');
   // => 2019-06
 ym === Temporal.PlainYearMonth.from(ym); // => false


### PR DESCRIPTION
Using a `Z` designator when creating an instance of the these `PlainX` types is incorrect.