### PR TITLE
Editorial: Mark uses of ParseISODateTime as fallible

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1214,7 +1214,7 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalInstantString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
-      1. Let _result_ be ! ParseISODateTime(_isoString_).
+      1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Let _timeZoneResult_ be ? ParseTemporalTimeZoneString(_isoString_).
       1. Let _offsetString_ be _timeZoneResult_.[[OffsetString]].
       1. If _timeZoneResult_.[[Z]] is *true*, then
@@ -1244,7 +1244,7 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalZonedDateTimeString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
-      1. Let _result_ be ! ParseISODateTime(_isoString_).
+      1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Let _timeZoneResult_ be ? ParseTemporalTimeZoneString(_isoString_).
       1. Return the Record {
         [[Year]]: _result_.[[Year]],
@@ -1409,7 +1409,7 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalRelativeToString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
-      1. Let _result_ be ! ParseISODateTime(_isoString_).
+      1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. If _isoString_ satisfies the syntax of a |TemporalZonedDateTimeString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Let _timeZoneResult_ be ! ParseTemporalTimeZoneString(_isoString_).
         1. Let _z_ be _timeZoneResult_.[[Z]].

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1507,7 +1507,6 @@
       1. Assert: Type(_isoString_) is String.
       1. If _isoString_ does not satisfy the syntax of a |TemporalYearMonthString| (see <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>), then
         1. Throw a *RangeError* exception.
-      1. If ! SameValue(_isoString_, *"-000000"*) is *true*, throw a *RangeError* exception.
       1. If _isoString_ contains a |UTCDesignator|, then
         1. Throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).


### PR DESCRIPTION
Discovered while implementing the most recent normative change, h/t @idanHo.

Additionally, one of the -000000 checks is nonsensical and has been removed.