### PR TITLE
Normative: Consistently call observable operations with undefined options

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -614,9 +614,11 @@ export const ES = ObjectAssign({}, ES2020, {
     return record;
   },
   ToTemporalOverflow: (options) => {
+    if (options === undefined) return 'constrain';
     return ES.GetOption(options, 'overflow', ['constrain', 'reject'], 'constrain');
   },
   ToTemporalDisambiguation: (options) => {
+    if (options === undefined) return 'compatible';
     return ES.GetOption(options, 'disambiguation', ['compatible', 'earlier', 'later', 'reject'], 'compatible');
   },
   ToTemporalRoundingMode: (options, fallback) => {
@@ -633,6 +635,7 @@ export const ES = ObjectAssign({}, ES2020, {
     }
   },
   ToTemporalOffset: (options, fallback) => {
+    if (options === undefined) return fallback;
     return ES.GetOption(options, 'offset', ['prefer', 'use', 'ignore', 'reject'], fallback);
   },
   ToShowCalendarOption: (options) => {
@@ -994,7 +997,7 @@ export const ES = ObjectAssign({}, ES2020, {
     return ES.PrepareTemporalFields(bag, entries);
   },
 
-  ToTemporalDate: (item, options = ObjectCreate(null)) => {
+  ToTemporalDate: (item, options) => {
     if (ES.Type(item) === 'Object') {
       if (ES.IsTemporalDate(item)) return item;
       if (ES.IsTemporalZonedDateTime(item)) {
@@ -1041,7 +1044,7 @@ export const ES = ObjectAssign({}, ES2020, {
     ));
     return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
   },
-  ToTemporalDateTime: (item, options = ObjectCreate(null)) => {
+  ToTemporalDateTime: (item, options) => {
     let year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar;
     if (ES.Type(item) === 'Object') {
       if (ES.IsTemporalDateTime(item)) return item;
@@ -1134,7 +1137,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
     return new TemporalInstant(ns);
   },
-  ToTemporalMonthDay: (item, options = ObjectCreate(null)) => {
+  ToTemporalMonthDay: (item, options) => {
     if (ES.Type(item) === 'Object') {
       if (ES.IsTemporalMonthDay(item)) return item;
       let calendar, calendarAbsent;
@@ -1168,8 +1171,7 @@ export const ES = ObjectAssign({}, ES2020, {
       return ES.CreateTemporalMonthDay(month, day, calendar);
     }
     const result = ES.CreateTemporalMonthDay(month, day, calendar, referenceISOYear);
-    const canonicalOptions = ObjectCreate(null);
-    return ES.MonthDayFromFields(calendar, result, canonicalOptions);
+    return ES.MonthDayFromFields(calendar, result);
   },
   ToTemporalTime: (item, overflow = 'constrain') => {
     let hour, minute, second, millisecond, microsecond, nanosecond, calendar;
@@ -1219,7 +1221,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const TemporalPlainTime = GetIntrinsic('%Temporal.PlainTime%');
     return new TemporalPlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
   },
-  ToTemporalYearMonth: (item, options = ObjectCreate(null)) => {
+  ToTemporalYearMonth: (item, options) => {
     if (ES.Type(item) === 'Object') {
       if (ES.IsTemporalYearMonth(item)) return item;
       const calendar = ES.GetTemporalCalendarWithISODefault(item);
@@ -1238,8 +1240,7 @@ export const ES = ObjectAssign({}, ES2020, {
       return ES.CreateTemporalYearMonth(year, month, calendar);
     }
     const result = ES.CreateTemporalYearMonth(year, month, calendar, referenceISODay);
-    const canonicalOptions = ObjectCreate(null);
-    return ES.YearMonthFromFields(calendar, result, canonicalOptions);
+    return ES.YearMonthFromFields(calendar, result);
   },
   InterpretISODateTimeOffset: (
     year,
@@ -1314,7 +1315,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const instant = ES.DisambiguatePossibleInstants(possibleInstants, timeZone, dt, disambiguation);
     return GetSlot(instant, EPOCHNANOSECONDS);
   },
-  ToTemporalZonedDateTime: (item, options = ObjectCreate(null)) => {
+  ToTemporalZonedDateTime: (item, options) => {
     let year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, timeZone, offset, calendar;
     let matchMinute = false;
     let offsetBehaviour = 'option';
@@ -2713,8 +2714,7 @@ export const ES = ObjectAssign({}, ES2020, {
           const dateAdd = ES.GetMethod(calendar, 'dateAdd');
           const dateUntil = ES.GetMethod(calendar, 'dateUntil');
           while (MathAbs(years) > 0) {
-            const addOptions = ObjectCreate(null);
-            const newRelativeTo = ES.CalendarDateAdd(calendar, relativeTo, oneYear, addOptions, dateAdd);
+            const newRelativeTo = ES.CalendarDateAdd(calendar, relativeTo, oneYear, undefined, dateAdd);
             const untilOptions = ObjectCreate(null);
             untilOptions.largestUnit = 'month';
             const untilResult = ES.CalendarDateUntil(calendar, relativeTo, newRelativeTo, untilOptions, dateUntil);
@@ -2815,8 +2815,7 @@ export const ES = ObjectAssign({}, ES2020, {
 
         // balance months up to years
         const dateAdd = ES.GetMethod(calendar, 'dateAdd');
-        const addOptions = ObjectCreate(null);
-        newRelativeTo = ES.CalendarDateAdd(calendar, relativeTo, oneYear, addOptions, dateAdd);
+        newRelativeTo = ES.CalendarDateAdd(calendar, relativeTo, oneYear, undefined, dateAdd);
         const dateUntil = ES.GetMethod(calendar, 'dateUntil');
         const untilOptions = ObjectCreate(null);
         untilOptions.largestUnit = 'month';
@@ -2826,8 +2825,7 @@ export const ES = ObjectAssign({}, ES2020, {
           months -= oneYearMonths;
           years += sign;
           relativeTo = newRelativeTo;
-          const addOptions = ObjectCreate(null);
-          newRelativeTo = ES.CalendarDateAdd(calendar, relativeTo, oneYear, addOptions, dateAdd);
+          newRelativeTo = ES.CalendarDateAdd(calendar, relativeTo, oneYear, undefined, dateAdd);
           const untilOptions = ObjectCreate(null);
           untilOptions.largestUnit = 'month';
           untilResult = ES.CalendarDateUntil(calendar, relativeTo, newRelativeTo, untilOptions, dateUntil);
@@ -3152,7 +3150,7 @@ export const ES = ObjectAssign({}, ES2020, {
     ns2,
     calendar,
     largestUnit,
-    options = ObjectCreate(null)
+    options
   ) => {
     let { deltaDays, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.DifferenceTime(
       h1,
@@ -3371,10 +3369,8 @@ export const ES = ObjectAssign({}, ES2020, {
       const dateDuration1 = new TemporalDuration(y1, mon1, w1, d1, 0, 0, 0, 0, 0, 0);
       const dateDuration2 = new TemporalDuration(y2, mon2, w2, d2, 0, 0, 0, 0, 0, 0);
       const dateAdd = ES.GetMethod(calendar, 'dateAdd');
-      const firstAddOptions = ObjectCreate(null);
-      const intermediate = ES.CalendarDateAdd(calendar, relativeTo, dateDuration1, firstAddOptions, dateAdd);
-      const secondAddOptions = ObjectCreate(null);
-      const end = ES.CalendarDateAdd(calendar, intermediate, dateDuration2, secondAddOptions, dateAdd);
+      const intermediate = ES.CalendarDateAdd(calendar, relativeTo, dateDuration1, undefined, dateAdd);
+      const end = ES.CalendarDateAdd(calendar, intermediate, dateDuration2, undefined, dateAdd);
 
       const dateLargestUnit = ES.LargerOfTwoTemporalUnits('day', largestUnit);
       const differenceOptions = ObjectCreate(null);
@@ -3699,8 +3695,7 @@ export const ES = ObjectAssign({}, ES2020, {
     ).days;
   },
   MoveRelativeDate: (calendar, relativeTo, duration) => {
-    const options = ObjectCreate(null);
-    const later = ES.CalendarDateAdd(calendar, relativeTo, duration, options);
+    const later = ES.CalendarDateAdd(calendar, relativeTo, duration);
     const days = ES.DaysUntil(relativeTo, later);
     return { relativeTo: later, days };
   },
@@ -3896,30 +3891,20 @@ export const ES = ObjectAssign({}, ES2020, {
         // relativeTo + years, relativeTo + { years, months, weeks })
         const yearsDuration = new TemporalDuration(years);
         const dateAdd = ES.GetMethod(calendar, 'dateAdd');
-        const firstAddOptions = ObjectCreate(null);
-        const yearsLater = ES.CalendarDateAdd(calendar, relativeTo, yearsDuration, firstAddOptions, dateAdd);
+        const yearsLater = ES.CalendarDateAdd(calendar, relativeTo, yearsDuration, undefined, dateAdd);
         const yearsMonthsWeeks = new TemporalDuration(years, months, weeks);
-        const secondAddOptions = ObjectCreate(null);
-        const yearsMonthsWeeksLater = ES.CalendarDateAdd(
-          calendar,
-          relativeTo,
-          yearsMonthsWeeks,
-          secondAddOptions,
-          dateAdd
-        );
+        const yearsMonthsWeeksLater = ES.CalendarDateAdd(calendar, relativeTo, yearsMonthsWeeks, undefined, dateAdd);
         const monthsWeeksInDays = ES.DaysUntil(yearsLater, yearsMonthsWeeksLater);
         relativeTo = yearsLater;
         days += monthsWeeksInDays;
 
-        const thirdAddOptions = ObjectCreate(null);
-        const daysLater = ES.CalendarDateAdd(calendar, relativeTo, { days }, thirdAddOptions, dateAdd);
+        const daysLater = ES.CalendarDateAdd(calendar, relativeTo, { days }, undefined, dateAdd);
         const untilOptions = ObjectCreate(null);
         untilOptions.largestUnit = 'year';
         const yearsPassed = ES.CalendarDateUntil(calendar, relativeTo, daysLater, untilOptions).years;
         years += yearsPassed;
         const oldRelativeTo = relativeTo;
-        const fourthAddOptions = ObjectCreate(null);
-        relativeTo = ES.CalendarDateAdd(calendar, relativeTo, { years: yearsPassed }, fourthAddOptions, dateAdd);
+        relativeTo = ES.CalendarDateAdd(calendar, relativeTo, { years: yearsPassed }, undefined, dateAdd);
         const daysPassed = ES.DaysUntil(oldRelativeTo, relativeTo);
         days -= daysPassed;
         const oneYear = new TemporalDuration(days < 0 ? -1 : 1);
@@ -3947,17 +3932,9 @@ export const ES = ObjectAssign({}, ES2020, {
         //   { years, months }, relativeTo + { years, months, weeks })
         const yearsMonths = new TemporalDuration(years, months);
         const dateAdd = ES.GetMethod(calendar, 'dateAdd');
-        const firstAddOptions = ObjectCreate(null);
-        const yearsMonthsLater = ES.CalendarDateAdd(calendar, relativeTo, yearsMonths, firstAddOptions, dateAdd);
+        const yearsMonthsLater = ES.CalendarDateAdd(calendar, relativeTo, yearsMonths, undefined, dateAdd);
         const yearsMonthsWeeks = new TemporalDuration(years, months, weeks);
-        const secondAddOptions = ObjectCreate(null);
-        const yearsMonthsWeeksLater = ES.CalendarDateAdd(
-          calendar,
-          relativeTo,
-          yearsMonthsWeeks,
-          secondAddOptions,
-          dateAdd
-        );
+        const yearsMonthsWeeksLater = ES.CalendarDateAdd(calendar, relativeTo, yearsMonthsWeeks, undefined, dateAdd);
         const weeksInDays = ES.DaysUntil(yearsMonthsLater, yearsMonthsWeeksLater);
         relativeTo = yearsMonthsLater;
         days += weeksInDays;

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -95,16 +95,18 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-totemporaloverflow" aoid="ToTemporalOverflow">
-    <h1>ToTemporalOverflow ( _normalizedOptions_ )</h1>
+    <h1>ToTemporalOverflow ( _options_ )</h1>
     <emu-alg>
-      1. Return ? GetOption(_normalizedOptions_, *"overflow"*, « String », « *"constrain"*, *"reject"* », *"constrain"*).
+      1. If _options_ is *undefined*, return *"constrain"*.
+      1. Return ? GetOption(_options_, *"overflow"*, « String », « *"constrain"*, *"reject"* », *"constrain"*).
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-totemporaldisambiguation" aoid="ToTemporalDisambiguation">
-    <h1>ToTemporalDisambiguation ( _normalizedOptions_ )</h1>
+    <h1>ToTemporalDisambiguation ( _options_ )</h1>
     <emu-alg>
-      1. Return ? GetOption(_normalizedOptions_, *"disambiguation"*, « String », « *"compatible"*, *"earlier"*, *"later"*, *"reject"* », *"compatible"*).
+      1. If _options_ is *undefined*, return *"compatible"*.
+      1. Return ? GetOption(_options_, *"disambiguation"*, « String », « *"compatible"*, *"earlier"*, *"later"*, *"reject"* », *"compatible"*).
     </emu-alg>
   </emu-clause>
 
@@ -142,13 +144,14 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-totemporaloffset" aoid="ToTemporalOffset">
-    <h1>ToTemporalOffset ( _normalizedOptions_, _fallback_ )</h1>
+    <h1>ToTemporalOffset ( _options_, _fallback_ )</h1>
     <p>
-      The abstract operation ToTemporalOffset extracts the value of the property named *"offset"* from _normalizedOptions_ and makes sure it is a valid value for the option.
+      The abstract operation ToTemporalOffset extracts the value of the property named *"offset"* from _options_ and makes sure it is a valid value for the option.
       The value _fallback_ is returned if the property is not present.
     </p>
     <emu-alg>
-      1. Return ? GetOption(_normalizedOptions_, *"offset"*, « String », « *"prefer"*, *"use"*, *"ignore"*, *"reject"* », _fallback_).
+      1. If _options_ is *undefined*, return _fallback_.
+      1. Return ? GetOption(_options_, *"offset"*, « String », « *"prefer"*, *"use"*, *"ignore"*, *"reject"* », _fallback_).
     </emu-alg>
   </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -76,9 +76,11 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardateadd" aoid="CalendarDateAdd">
-      <h1>CalendarDateAdd ( _calendar_, _date_, _duration_, _options_ [ , _dateAdd_ ] )</h1>
+      <h1>CalendarDateAdd ( _calendar_, _date_, _duration_ [ , _options_ [ , _dateAdd_ ] ] )</h1>
       <emu-alg>
         1. Assert: Type(_calendar_) is Object.
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. If _dateAdd_ is not present, set _dateAdd_ to ? GetMethod(_calendar_, *"dateAdd"*).
         1. Let _addedDate_ be ? Call(_dateAdd_, _calendar_, « _date_, _duration_, _options_ »).
         1. Perform ? RequireInternalSlot(_addedDate_, [[InitializedTemporalDate]]).
@@ -282,10 +284,12 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-datefromfields" aoid="DateFromFields">
-      <h1>DateFromFields ( _calendar_, _fields_, _options_ )</h1>
+      <h1>DateFromFields ( _calendar_, _fields_ [ , _options_ ] )</h1>
       <emu-alg>
         1. Assert: Type(_calendar_) is Object.
         1. Assert: Type(_fields_) is Object.
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _date_ be ? Invoke(_calendar_, *"dateFromFields"*, « _fields_, _options_ »).
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Return _date_.
@@ -297,10 +301,8 @@
       <emu-alg>
         1. Assert: Type(_calendar_) is Object.
         1. Assert: Type(_fields_) is Object.
-        1. If _options_ is not present, then
-          1. Set _options_ to *undefined*.
-        1. Else,
-          1. Assert: Type(_options_) is Object.
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _yearMonth_ be ? Invoke(_calendar_, *"yearMonthFromFields"*, « _fields_, _options_ »).
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Return _yearMonth_.
@@ -312,10 +314,8 @@
       <emu-alg>
         1. Assert: Type(_calendar_) is Object.
         1. Assert: Type(_fields_) is Object.
-        1. If _options_ is not present, then
-          1. Set _options_ to *undefined*.
-        1. Else,
-          1. Assert: Type(_options_) is Object.
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _monthDay_ be ? Invoke(_calendar_, *"monthDayFromFields"*, « _fields_, _options_ »).
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Return _monthDay_.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1300,8 +1300,7 @@
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
           1. Let _dateUntil_ be ? GetMethod(_calendar_, *"dateUntil"*).
           1. Repeat, while _years_ ≠ 0,
-            1. Let _addOptions_ be OrdinaryObjectCreate(*null*).
-            1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, _addOptions_, _dateAdd_).
+            1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, *undefined*, _dateAdd_).
             1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
             1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
             1. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
@@ -1391,8 +1390,7 @@
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Let _addOptions_ be OrdinaryObjectCreate(*null*).
-          1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, _addOptions_, _dateAdd_).
+          1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, *undefined*, _dateAdd_).
           1. Let _dateUntil_ be ? GetMethod(_calendar_, *"dateUntil"*).
           1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
@@ -1402,8 +1400,7 @@
             1. Set _months_ to _months_ − _oneYearMonths_.
             1. Set _years_ to _years_ + _sign_.
             1. Set _relativeTo_ to _newRelativeTo_.
-            1. Set _addOptions_ to OrdinaryObjectCreate(*null*).
-            1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, _addOptions_, _dateAdd_).
+            1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, *undefined*, _dateAdd_).
             1. Set _untilOptions_ to OrdinaryObjectCreate(*null*).
             1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
             1. Set _untilResult_ to ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
@@ -1477,10 +1474,8 @@
           1. Let _dateDuration1_ be ! CreateTemporalDuration(_y1_, _mon1_, _w1_, _d1_, 0, 0, 0, 0, 0, 0).
           1. Let _dateDuration2_ be ! CreateTemporalDuration(_y2_, _mon2_, _w2_, _d2_, 0, 0, 0, 0, 0, 0).
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Let _firstAddOptions_ be OrdinaryObjectCreate(*null*).
-          1. Let _intermediate_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _dateDuration1_, _firstAddOptions_, _dateAdd_).
-          1. Let _secondAddOptions_ be OrdinaryObjectCreate(*null*).
-          1. Let _end_ be ? CalendarDateAdd(_calendar_, _intermediate_, _dateDuration2_, _secondAddOptions_, _dateAdd_).
+          1. Let _intermediate_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _dateDuration1_, *undefined*, _dateAdd_).
+          1. Let _end_ be ? CalendarDateAdd(_calendar_, _intermediate_, _dateDuration2_, *undefined*, _dateAdd_).
           1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
           1. Let _differenceOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_differenceOptions_, *"largestUnit"*, _dateLargestUnit_).
@@ -1535,8 +1530,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _options_ be OrdinaryObjectCreate(*null*).
-        1. Let _newDate_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _duration_, _options_).
+        1. Let _newDate_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _duration_).
         1. Let _days_ be ! DaysUntil(_relativeTo_, _newDate_).
         1. Return the Record {
             [[RelativeTo]]: _newDate_,
@@ -1616,17 +1610,14 @@
         1. If _unit_ is *"year"*, then
           1. Let _yearsDuration_ be ! CreateTemporalDuration(_years_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Let _firstAddOptions_ be OrdinaryObjectCreate(*null*).
-          1. Let _yearsLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsDuration_, _firstAddOptions_, _dateAdd_).
+          1. Let _yearsLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsDuration_, *undefined*, _dateAdd_).
           1. Let _yearsMonthsWeeks_ be ! CreateTemporalDuration(_years_, _months_, _weeks_, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _secondAddOptions_ be OrdinaryObjectCreate(*null*).
-          1. Let _yearsMonthsWeeksLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsMonthsWeeks_, _secondAddOptions_, _dateAdd_).
+          1. Let _yearsMonthsWeeksLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsMonthsWeeks_, *undefined*, _dateAdd_).
           1. Let _monthsWeeksInDays_ be ! DaysUntil(_yearsLater_, _yearsMonthsWeeksLater_).
           1. Set _relativeTo_ to _yearsLater_.
           1. Let _days_ be _days_ + _monthsWeeksInDays_.
           1. Let _daysDuration_ be ? CreateTemporalDuration(0, 0, 0, _days_, 0, 0, 0, 0, 0, 0).
-          1. Let _thirdAddOptions_ be OrdinaryObjectCreate(*null*).
-          1. Let _daysLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _daysDuration_, _thirdAddOptions_, _dateAdd_).
+          1. Let _daysLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _daysDuration_, *undefined*, _dateAdd_).
           1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"year"*).
           1. Let _timePassed_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _daysLater_, _untilOptions_).
@@ -1634,8 +1625,7 @@
           1. Set _years_ to _years_ + _yearsPassed_.
           1. Let _oldRelativeTo_ be _relativeTo_.
           1. Let _yearsDuration_ be ! CreateTemporalDuration(_yearsPassed_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _fourthAddOptions_ be OrdinaryObjectCreate(*null*).
-          1. Set _relativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsDuration_, _fourthAddOptions_, _dateAdd_).
+          1. Set _relativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsDuration_, *undefined*, _dateAdd_).
           1. Let _daysPassed_ be ! DaysUntil(_oldRelativeTo_, _relativeTo_).
           1. Set _days_ to _days_ - _daysPassed_.
           1. If _days_ &lt; 0, let _sign_ be −1; else, let _sign_ be 1.
@@ -1649,11 +1639,9 @@
         1. Else if _unit_ is *"month"*, then
           1. Let _yearsMonths_ be ! CreateTemporalDuration(_years_, _months_, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Let _firstAddOptions_ be OrdinaryObjectCreate(*null*).
-          1. Let _yearsMonthsLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsMonths_, _firstAddOptions_, _dateAdd_).
+          1. Let _yearsMonthsLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsMonths_, *undefined*, _dateAdd_).
           1. Let _yearsMonthsWeeks_ be ! CreateTemporalDuration(_years_, _months_, _weeks_, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _secondAddOptions_ be OrdinaryObjectCreate(*null*).
-          1. Let _yearsMonthsWeeksLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsMonthsWeeks_, _secondAddOptions_, _dateAdd_).
+          1. Let _yearsMonthsWeeksLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsMonthsWeeks_, *undefined*, _dateAdd_).
           1. Let _weeksInDays_ be ! DaysUntil(_yearsMonthsLater_, _yearsMonthsWeeksLater_).
           1. Set _relativeTo_ to _yearsMonthsLater_.
           1. Let _days_ be _days_ + _weeksInDays_.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -674,8 +674,8 @@
         The abstract operation ToTemporalDate returns its argument _item_ if it is already a Temporal.PlainDate instance, converts _item_ to a new Temporal.PlainDate instance if possible, and throws otherwise.
       </p>
       <emu-alg>
-        1. If _options_ is not present, set _options_ to OrdinaryObjectCreate(*null*).
-        1. Assert: Type(_options_) is Object.
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalDate]] internal slot, then
             1. Return _item_.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -903,7 +903,8 @@
         The abstract operation ToTemporalDateTime returns its argument _item_ if it is already a Temporal.PlainDateTime instance, converts _item_ to a new Temporal.PlainDateTime instance if possible, and throws otherwise.
       </p>
       <emu-alg>
-        1. If _options_ is not present, set _options_ to OrdinaryObjectCreate(*null*).
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
             1. Return _item_.
@@ -1109,7 +1110,8 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _options_ is not present, set _options_ to OrdinaryObjectCreate(*null*).
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _timeDifference_ be ! DifferenceTime(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. Let _timeSign_ be ! DurationSign(0, 0, 0, _timeDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]]).
         1. Let _dateSign_ be ! CompareISODate(_y2_, _mon2_, _d2_, _y1_, _mon1_, _d1_).

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -345,7 +345,8 @@
         The abstract operation ToTemporalMonthDay returns its argument _item_ if it is already a Temporal.PlainMonthDay instance, converts _item_ to a new Temporal.PlainMonthDay instance if possible, and throws otherwise.
       </p>
       <emu-alg>
-        1. If _options_ is not present, set _options_ to OrdinaryObjectCreate(*null*).
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _referenceISOYear_ be 1972 (the first leap year after the Unix epoch).
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalMonthDay]] internal slot, then
@@ -375,8 +376,8 @@
         1. If _result_.[[Year]] is *undefined*, then
           1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _referenceISOYear_).
         1. Set _result_ to ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _referenceISOYear_).
-        1. Let _canonicalMonthDayOptions_ be OrdinaryObjectCreate(*null*).
-        1. Return ? MonthDayFromFields(_calendar_, _result_, _canonicalMonthDayOptions_).
+        1. NOTE: The following operation is called without _options_, in order for the calendar to store a canonical value in the [[ISOYear]] internal slot of the result.
+        1. Return ? MonthDayFromFields(_calendar_, _result_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -567,8 +567,8 @@
         The abstract operation ToTemporalYearMonth returns its argument _item_ if it is already a Temporal.PlainYearMonth instance, converts _item_ to a new Temporal.PlainYearMonth instance if possible, and throws otherwise.
       </p>
       <emu-alg>
-        1. If _options_ is not present, set _options_ to OrdinaryObjectCreate(*null*).
-        1. Assert: Type(_options_) is Object.
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalYearMonth]] internal slot, then
             1. Return _item_.
@@ -581,8 +581,8 @@
         1. Let _result_ be ? ParseTemporalYearMonthString(_string_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).
         1. Set _result_ to ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[Day]]).
-        1. Let _canonicalYearMonthOptions_ be OrdinaryObjectCreate(*null*).
-        1. Return ? YearMonthFromFields(_calendar_, _result_, _canonicalYearMonthOptions_).
+        1. NOTE: The following operation is called without _options_, in order for the calendar to store a canonical value in the [[ISODay]] internal slot of the result.
+        1. Return ? YearMonthFromFields(_calendar_, _result_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1121,7 +1121,8 @@
         The abstract operation ToTemporalZonedDateTime returns its argument _item_ if it is already a Temporal.ZonedDateTime instance, converts _item_ to a new Temporal.PlainDate instance if possible, and throws otherwise.
       </p>
       <emu-alg>
-        1. If _options_ is not present, set _options_ to OrdinaryObjectCreate(*null*).
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _offsetBehaviour_ be ~option~.
         1. Let _matchBehaviour_ be ~match exactly~.
         1. If Type(_item_) is Object, then
@@ -1246,7 +1247,8 @@
       </dl>
       </p>
       <emu-alg>
-        1. If _options_ is not present, set _options_ to OrdinaryObjectCreate(*null*).
+        1. If _options_ is not present, set _options_ to *undefined*.
+        1. Assert: Type(_options_) is Object or Undefined.
         1. If all of _years_, _months_, _weeks_, and _days_ are 0, then
           1. Return ! AddInstant(_epochNanoseconds_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Let _instant_ be ! CreateTemporalInstant(_epochNanoseconds_).


### PR DESCRIPTION
Where possible, observable calls originating from within Temporal, that
require an options argument, should pass `undefined` as that options
argument, rather than `{}` or `Object.create(null)`.

This allows the options parameter to be omitted when calling the abstract
operations CalendarDateAdd, DateFromFields, MonthDayFromFields, and
YearMonthFromFields, and assumes that it is `undefined` if omitted, so
that user code sees `undefined` as well when the options value is passed
along.

Whenever one of these abstract operations is invoked from within Temporal
with the default options, pass `undefined` instead of
! OrdinaryObjectCreate(null).

This also requires changing ToTemporalOverflow, ToTemporalDisambiguation,
and ToTemporalOffset to accept `undefined` in addition to a normalized
options object.

Closes: #1685.