### PR TITLE
EDITORAIL: Rename to calendarLike

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -276,8 +276,8 @@
       <emu-alg>
         1. If _item_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalTime]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Return _item_.[[Calendar]].
-        1. Let _calendar_ be ? Get(_item_, *"calendar"*).
-        1. Return ? ToTemporalCalendarWithISODefault(_calendar_).
+        1. Let _calendarLike_ be ? Get(_item_, *"calendar"*).
+        1. Return ? ToTemporalCalendarWithISODefault(_calendarLike_).
       </emu-alg>
     </emu-clause>
 
@@ -671,13 +671,13 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.calendar.from">
-      <h1>Temporal.Calendar.from ( _item_ )</h1>
+      <h1>Temporal.Calendar.from ( _calendarLike_ )</h1>
       <p>
-        The `from` method takes one argument _item_.
+        The `from` method takes one argument _calendarLike_.
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Return ? ToTemporalCalendar(_item_).
+        1. Return ? ToTemporalCalendar(_calendarLike_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -393,15 +393,15 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.plaindate.prototype.withcalendar">
-      <h1>Temporal.PlainDate.prototype.withCalendar ( _calendar_ )</h1>
+      <h1>Temporal.PlainDate.prototype.withCalendar ( _calendarLike_ )</h1>
       <p>
-        The `withCalendar` method takes one argument _calendar_.
+        The `withCalendar` method takes one argument _calendarLike_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Let _calendar_ be ? ToTemporalCalendar(_calendar_).
+        1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
         1. Return ? CreateTemporalDate(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _calendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -430,15 +430,15 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.plaindatetime.prototype.withcalendar">
-      <h1>Temporal.PlainDateTime.prototype.withCalendar ( _calendar_ )</h1>
+      <h1>Temporal.PlainDateTime.prototype.withCalendar ( _calendarLike_ )</h1>
       <p>
-        The `withCalendar` method takes one argument _calendar_.
+        The `withCalendar` method takes one argument _calendarLike_.
         The following steps are taken:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Let _calendar_ be ? ToTemporalCalendar(_calendar_).
+        1. Let _calendar_ be ? ToTemporalCalendar(_calendarLike_).
         1. Return ? CreateTemporalDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -359,7 +359,7 @@
               1. Let _calendarAbsent_ be *true*.
             1. Else,
               1. Let _calendarAbsent_ be *false*.
-            1. Let _calendar_ to ? ToTemporalCalendarWithISODefault(_calendarLike_).
+            1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
           1. Let _month_ be ? Get(_fields_, *"month"*).

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -354,12 +354,12 @@
             1. Let _calendar_ be _item_.[[Calendar]].
             1. Let _calendarAbsent_ be *false*.
           1. Else,
-            1. Let _calendar_ be ? Get(_item_, *"calendar"*).
-            1. If _calendar_ is *undefined*, then
+            1. Let _calendarLike_ be ? Get(_item_, *"calendar"*).
+            1. If _calendarLike_ is *undefined*, then
               1. Let _calendarAbsent_ be *true*.
             1. Else,
               1. Let _calendarAbsent_ be *false*.
-            1. Set _calendar_ to ? ToTemporalCalendarWithISODefault(_calendar_).
+            1. Let _calendar_ to ? ToTemporalCalendarWithISODefault(_calendarLike_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
           1. Let _month_ be ? Get(_fields_, *"month"*).

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -112,13 +112,13 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.now.plaindatetime">
-      <h1>Temporal.Now.plainDateTime ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
+      <h1>Temporal.Now.plainDateTime ( _calendarLike_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `plainDateTime` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
+        The `plainDateTime` method takes two arguments, _calendarLike_ and _temporalTimeZoneLike_.
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Return ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
+        1. Return ? SystemDateTime(_temporalTimeZoneLike_, _calendarLike_).
       </emu-alg>
     </emu-clause>
 
@@ -135,13 +135,13 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.now.zoneddatetime">
-      <h1>Temporal.Now.zonedDateTime ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
+      <h1>Temporal.Now.zonedDateTime ( _calendarLike_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `zonedDateTime` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
+        The `zonedDateTime` method takes two arguments, _calendarLike_ and _temporalTimeZoneLike_.
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_, _calendar_).
+        1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_, _calendarLike_).
       </emu-alg>
     </emu-clause>
 
@@ -158,13 +158,13 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.now.plaindate">
-      <h1>Temporal.Now.plainDate ( _calendar_ [ , _temporalTimeZoneLike_ ] )</h1>
+      <h1>Temporal.Now.plainDate ( _calendarLike_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `plainDate` method takes two arguments, _calendar_ and _temporalTimeZoneLike_.
+        The `plainDate` method takes two arguments, _calendarLike_ and _temporalTimeZoneLike_.
         The following steps are taken:
       </p>
       <emu-alg>
-        1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendar_).
+        1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendarLike_).
         1. Return ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Rename variable which need to pass through ToTemporalCalendar*()
from calendar to calendarLike.

motivation: https://chromium-review.googlesource.com/c/v8/v8/+/3380305/6/src/objects/js-temporal-objects.h#120
@syg 