### PR TITLE
Work around Firefox bug with `'gregory'` calendar era names

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1617,8 +1617,12 @@ const helperGregory = ObjectAssign(
   {
     reviseIntlEra(calendarDate /*, isoDate*/) {
       let { era, eraYear } = calendarDate;
-      if (era === 'bc') era = 'bce';
-      if (era === 'ad') era = 'ce';
+      // Firefox 96 introduced a bug where the `'short'` format of the era
+      // option mistakenly returns the one-letter (narrow) format instead. The
+      // code below handles either the correct or Firefox-buggy format. See
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1752253
+      if (era === 'bc' || era === 'b') era = 'bce';
+      if (era === 'ad' || era === 'a') era = 'ce';
       return { era, eraYear };
     }
   }


### PR DESCRIPTION
Works around https://bugzilla.mozilla.org/show_bug.cgi?id=1752253 by allowing either `'a'` or `'ad'` for the CE era and `'b'` or `'bc'` for the BCE era.

This bug only occurs with Firefox and our tests don't use FF, so there wasn't any way to add a test for it. But I did verify it on the docs playground and it works great in FF 97.

Fixes #2020.