### PR TITLE
Normative: Emit reference information when calendarName = 'always'

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2093,7 +2093,7 @@ export const ES = ObjectAssign({}, ES2020, {
     let resultString = `${month}-${day}`;
     const calendar = GetSlot(monthDay, CALENDAR);
     const calendarID = ES.ToString(calendar);
-    if (calendarID !== 'iso8601') {
+    if (showCalendar === 'always' || calendarID !== 'iso8601') {
       const year = ES.ISOYearString(GetSlot(monthDay, ISO_YEAR));
       resultString = `${year}-${resultString}`;
     }
@@ -2107,7 +2107,7 @@ export const ES = ObjectAssign({}, ES2020, {
     let resultString = `${year}-${month}`;
     const calendar = GetSlot(yearMonth, CALENDAR);
     const calendarID = ES.ToString(calendar);
-    if (calendarID !== 'iso8601') {
+    if (showCalendar === 'always' || calendarID !== 'iso8601') {
       const day = ES.ISODateTimePartString(GetSlot(yearMonth, ISO_DAY));
       resultString += `-${day}`;
     }

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -405,7 +405,7 @@
         1. Let _day_ be _monthDay_.[[ISODay]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _result_ be the string-concatenation of _month_, the code unit 0x002D (HYPHEN-MINUS), and _day_.
         1. Let _calendarID_ be ? ToString(_monthDay_.[[Calendar]]).
-        1. If _calendarID_ is not *"iso8601"*, then
+        1. If _showCalendar_ is *"always"* or if _calendarID_ is not *"iso8601"*, then
           1. Let _year_ be ! PadISOYear(_monthDay_.[[ISOYear]]).
           1. Set _result_ to the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _result_.
         1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -685,7 +685,7 @@
         1. Let _month_ be _yearMonth_.[[ISOMonth]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
         1. Let _result_ be the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _month_.
         1. Let _calendarID_ be ? ToString(_yearMonth_.[[Calendar]]).
-        1. If _calendarID_ is not *"iso8601"*, then
+        1. If _showCalendar_ is *"always" or if *_calendarID_ is not *"iso8601"*, then
           1. Let _day_ be _yearMonth_.[[ISODay]] formatted as a two-digit decimal number, padded to the left with a zero if necessary.
           1. Set _result_ to the string-concatenation of _result_, the code unit 0x002D (HYPHEN-MINUS), and _day_.
         1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).


### PR DESCRIPTION
closes #1971