### PR TITLE
Editorial: Adjust grammar for years to exclude -000000

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1145,6 +1145,11 @@
       TemporalRelativeToString :
           TemporalDateTimeString
     </emu-grammar>
+    <ul>
+      <li>
+        It is a Syntax Error if |DateExtendedYear| is *"-000000"* or *"−000000"* (U+2212 MINUS SIGN followed by `000000`).
+      </li>
+    </ul>
   </emu-clause>
 
   <emu-clause id="sec-temporal-parseisodatetime" aoid="ParseISODateTime">
@@ -1160,7 +1165,6 @@
       1. Let _minute_ be the part of _isoString_ produced by the |TimeMinute|, |TimeMinuteNotValidDay|, |TimeMinuteThirtyOnly|, or |TimeMinuteThirtyOneOnly| productions, or *undefined* if none of those are present.
       1. Let _second_ be the part of _isoString_ produced by the |TimeSecond| or |TimeSecondNotValidMonth| productions, or *undefined* if neither of those are present.
       1. If the first code unit of _year_ is 0x2212 (MINUS SIGN), replace it with the code unit 0x002D (HYPHEN-MINUS).
-      1. If SameValue(_year_, *"-000000"*) is *true*, throw a *RangeError* exception.
       1. Set _year_ to ! ToIntegerOrInfinity(_year_).
       1. If _month_ is *undefined*, then
         1. Set _month_ to 1.


### PR DESCRIPTION
~~Also, remove redundant check in `ParseISODateTime`.~~