### PR TITLE
Normative: sameTemporalType checks for InitializedTemporalMonthDay

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -649,6 +649,7 @@
         1. If _x_ has an [[InitializedTemporalDateTime]] internal slot and _y_ does not, return *false*.
         1. If _x_ has an [[InitializedTemporalZonedDateTime]] internal slot and _y_ does not, return *false*.
         1. If _x_ has an [[InitializedTemporalYearMonth]] internal slot and _y_ does not, return *false*.
+        1. If _x_ has an [[InitializedTemporalMonthDay]] internal slot and _y_ does not, return *false*.
         1. If _x_ has an [[InitializedTemporalInstant]] internal slot and _y_ does not, return *false*.
         1. Return *true*.
       </emu-alg>


### PR DESCRIPTION
`sameTemporalType` checks for all Temporal types, but randomly omits `MonthDay`. It should be added. This probably is a normative change.

See discussion in https://github.com/tc39/proposal-temporal/issues/2037