### PR TITLE
Unbreak validStrings.mjs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,3 +103,16 @@ jobs:
           node-version: 12.x
       - run: npm ci
       - run: npm run test-cookbook
+  test-validstrings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: use node.js v16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - run: npm ci
+      - run: |
+          cd polyfill
+          npm install
+          node --experimental-modules --no-warnings --icu-data-dir ./node_modules/full-icu/ test/validStrings.mjs

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -190,7 +190,6 @@ const weeksDesignator = character('Ww');
 const yearsDesignator = character('Yy');
 const utcDesignator = withCode(character('Zz'), (data) => {
   data.z = 'Z';
-  data.offset = '+00:00';
 });
 const timeFractionalPart = between(1, 9, digit());
 const fraction = seq(decimalSeparator, timeFractionalPart);


### PR DESCRIPTION
It looks like the `validStrings.mjs` test tool had bitrotted somewhat. The commit that broke it (causes it to die very early, usually in the very first example string that it generates) is f6ac475e6131ab0f11dc641ae55dcf72e6ab1118. I can confirm that this simple change is enough to restore it to life.

In addition, I've added a run of `validStrings.mjs` to the pipeline. Had we had this check in place, we would have detected the breakage earlier.