### PR TITLE
Remove tests that were ported to test262

### DIFF
--- a/polyfill/test/duration.mjs
+++ b/polyfill/test/duration.mjs
@@ -295,35 +295,6 @@ describe('Duration', () => {
       equal(d2.toString(options), 'PT15H23M30.0000000S');
       equal(d3.toString(options), 'PT15H23M30.5432000S');
     });
-    it('pads correctly in edge cases', () => {
-      const d4 = Duration.from({ years: 3 });
-      equal(d4.toString(), 'P3Y');
-      equal(d4.toString({ fractionalSecondDigits: 0 }), 'P3YT0S');
-      equal(d4.toString({ smallestUnit: 'seconds' }), 'P3YT0S');
-      equal(d4.toString({ smallestUnit: 'milliseconds' }), 'P3YT0.000S');
-      equal(d4.toString({ fractionalSecondDigits: 5 }), 'P3YT0.00000S');
-
-      const d5 = Duration.from({ minutes: 30 });
-      equal(d5.toString(), 'PT30M');
-      equal(d5.toString({ fractionalSecondDigits: 0 }), 'PT30M0S');
-      equal(d5.toString({ smallestUnit: 'seconds' }), 'PT30M0S');
-      equal(d5.toString({ smallestUnit: 'milliseconds' }), 'PT30M0.000S');
-      equal(d5.toString({ fractionalSecondDigits: 5 }), 'PT30M0.00000S');
-
-      const d6 = Duration.from({ milliseconds: 100 });
-      equal(d6.toString(), 'PT0.1S');
-      equal(d6.toString({ fractionalSecondDigits: 0 }), 'PT0S');
-      equal(d6.toString({ smallestUnit: 'seconds' }), 'PT0S');
-      equal(d6.toString({ smallestUnit: 'milliseconds' }), 'PT0.100S');
-      equal(d6.toString({ fractionalSecondDigits: 5 }), 'PT0.10000S');
-
-      const zero = new Duration();
-      equal(zero.toString(), 'PT0S');
-      equal(zero.toString({ fractionalSecondDigits: 0 }), 'PT0S');
-      equal(zero.toString({ smallestUnit: 'seconds' }), 'PT0S');
-      equal(zero.toString({ smallestUnit: 'milliseconds' }), 'PT0.000S');
-      equal(zero.toString({ fractionalSecondDigits: 5 }), 'PT0.00000S');
-    });
     it('auto is the default', () => {
       [d1, d2, d3].forEach((d) => equal(d.toString({ fractionalSecondDigits: 'auto' }), d.toString()));
     });

--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -351,34 +351,11 @@ describe('Instant', () => {
       equal(nsDiff.microseconds, 0);
       equal(nsDiff.nanoseconds, 86400250250250);
     });
-    it('cannot return days, weeks, months, and years', () => {
-      throws(() => feb21.since(feb20, { largestUnit: 'days' }), RangeError);
-      throws(() => feb21.since(feb20, { largestUnit: 'weeks' }), RangeError);
-      throws(() => feb21.since(feb20, { largestUnit: 'months' }), RangeError);
-      throws(() => feb21.since(feb20, { largestUnit: 'years' }), RangeError);
-    });
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
         throws(() => feb21.since(feb20, badOptions), TypeError)
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${feb21.since(feb20, options)}`, 'PT31622400S'));
-    });
-    it('throws on disallowed or invalid smallestUnit', () => {
-      ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
-        (smallestUnit) => {
-          throws(() => later.since(earlier, { smallestUnit }), RangeError);
-        }
-      );
-    });
-    it('throws if smallestUnit is larger than largestUnit', () => {
-      const units = ['hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
-      for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
-        for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
-          const largestUnit = units[largestIdx];
-          const smallestUnit = units[smallestIdx];
-          throws(() => later.since(earlier, { largestUnit, smallestUnit }), RangeError);
-        }
-      }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than seconds', () => {
       equal(`${later.since(earlier, { smallestUnit: 'hours', roundingMode: 'halfExpand' })}`, 'PT376435H');
@@ -606,34 +583,11 @@ describe('Instant', () => {
       equal(nsDiff.microseconds, 0);
       equal(nsDiff.nanoseconds, 86400250250250);
     });
-    it('cannot return days, weeks, months, and years', () => {
-      throws(() => feb20.until(feb21, { largestUnit: 'days' }), RangeError);
-      throws(() => feb20.until(feb21, { largestUnit: 'weeks' }), RangeError);
-      throws(() => feb20.until(feb21, { largestUnit: 'months' }), RangeError);
-      throws(() => feb20.until(feb21, { largestUnit: 'years' }), RangeError);
-    });
     it('options may only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) =>
         throws(() => feb20.until(feb21, badOptions), TypeError)
       );
       [{}, () => {}, undefined].forEach((options) => equal(`${feb20.until(feb21, options)}`, 'PT31622400S'));
-    });
-    it('throws on disallowed or invalid smallestUnit', () => {
-      ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
-        (smallestUnit) => {
-          throws(() => earlier.until(later, { smallestUnit }), RangeError);
-        }
-      );
-    });
-    it('throws if smallestUnit is larger than largestUnit', () => {
-      const units = ['hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
-      for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
-        for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
-          const largestUnit = units[largestIdx];
-          const smallestUnit = units[smallestIdx];
-          throws(() => earlier.until(later, { largestUnit, smallestUnit }), RangeError);
-        }
-      }
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than seconds', () => {
       equal(`${earlier.until(later, { smallestUnit: 'hours', roundingMode: 'halfExpand' })}`, 'PT440610H');

--- a/polyfill/test/intl.mjs
+++ b/polyfill/test/intl.mjs
@@ -389,7 +389,7 @@ describe('Intl', () => {
           'islamicc: 5/18/-640 AH\n' +
           'japanese: 1/3/-643 Taika (645–650)\n' +
           'persian: 10/11/-621 AP\n' +
-          'roc: 1/3/1911 Before R.O.C.',
+          'roc: 1/3/1911 B.R.O.C.',
         node16:
           'iso8601: 1/1/1\n' +
           'buddhist: 1/3/544 BE\n' +

--- a/polyfill/test/plaindatetime.mjs
+++ b/polyfill/test/plaindatetime.mjs
@@ -526,32 +526,6 @@ describe('DateTime', () => {
     });
     const earlier = PlainDateTime.from('2019-01-08T08:22:36.123456789');
     const later = PlainDateTime.from('2021-09-07T12:39:40.987654321');
-    it('throws on disallowed or invalid smallestUnit', () => {
-      ['era', 'nonsense'].forEach((smallestUnit) => {
-        throws(() => earlier.until(later, { smallestUnit }), RangeError);
-      });
-    });
-    it('throws if smallestUnit is larger than largestUnit', () => {
-      const units = [
-        'years',
-        'months',
-        'weeks',
-        'days',
-        'hours',
-        'minutes',
-        'seconds',
-        'milliseconds',
-        'microseconds',
-        'nanoseconds'
-      ];
-      for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
-        for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
-          const largestUnit = units[largestIdx];
-          const smallestUnit = units[smallestIdx];
-          throws(() => earlier.until(later, { largestUnit, smallestUnit }), RangeError);
-        }
-      }
-    });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
       equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
       equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');
@@ -847,32 +821,6 @@ describe('DateTime', () => {
     });
     const earlier = PlainDateTime.from('2019-01-08T08:22:36.123456789');
     const later = PlainDateTime.from('2021-09-07T12:39:40.987654321');
-    it('throws on disallowed or invalid smallestUnit', () => {
-      ['era', 'nonsense'].forEach((smallestUnit) => {
-        throws(() => later.since(earlier, { smallestUnit }), RangeError);
-      });
-    });
-    it('throws if smallestUnit is larger than largestUnit', () => {
-      const units = [
-        'years',
-        'months',
-        'weeks',
-        'days',
-        'hours',
-        'minutes',
-        'seconds',
-        'milliseconds',
-        'microseconds',
-        'nanoseconds'
-      ];
-      for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
-        for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
-          const largestUnit = units[largestIdx];
-          const smallestUnit = units[smallestIdx];
-          throws(() => later.since(earlier, { largestUnit, smallestUnit }), RangeError);
-        }
-      }
-    });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
       equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
       equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');

--- a/polyfill/test/plaintime.mjs
+++ b/polyfill/test/plaintime.mjs
@@ -47,12 +47,6 @@ describe('Time', () => {
       equal(`${time1.until(time2, { largestUnit: 'auto' })}`, 'PT6H52M42S');
       equal(`${time1.until(time2, { largestUnit: 'hours' })}`, 'PT6H52M42S');
     });
-    it('higher units are not allowed', () => {
-      throws(() => time1.until(time2, { largestUnit: 'days' }), RangeError);
-      throws(() => time1.until(time2, { largestUnit: 'weeks' }), RangeError);
-      throws(() => time1.until(time2, { largestUnit: 'months' }), RangeError);
-      throws(() => time1.until(time2, { largestUnit: 'years' }), RangeError);
-    });
     it('can return lower units', () => {
       equal(`${time1.until(time2, { largestUnit: 'minutes' })}`, 'PT412M42S');
       equal(`${time1.until(time2, { largestUnit: 'seconds' })}`, 'PT24762S');
@@ -83,23 +77,6 @@ describe('Time', () => {
     });
     const earlier = PlainTime.from('08:22:36.123456789');
     const later = PlainTime.from('12:39:40.987654321');
-    it('throws on disallowed or invalid smallestUnit', () => {
-      ['era', 'years', 'months', 'weeks', 'days', 'year', 'month', 'week', 'day', 'nonsense'].forEach(
-        (smallestUnit) => {
-          throws(() => earlier.until(later, { smallestUnit }), RangeError);
-        }
-      );
-    });
-    it('throws if smallestUnit is larger than largestUnit', () => {
-      const units = ['hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
-      for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
-        for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
-          const largestUnit = units[largestIdx];
-          const smallestUnit = units[smallestIdx];
-          throws(() => earlier.until(later, { largestUnit, smallestUnit }), RangeError);
-        }
-      }
-    });
     it('throws on invalid roundingMode', () => {
       throws(() => earlier.until(later, { roundingMode: 'cile' }), RangeError);
     });
@@ -351,23 +328,6 @@ describe('Time', () => {
     });
     const earlier = PlainTime.from('08:22:36.123456789');
     const later = PlainTime.from('12:39:40.987654321');
-    it('throws on disallowed or invalid smallestUnit', () => {
-      ['era', 'years', 'months', 'weeks', 'days', 'year', 'month', 'week', 'day', 'nonsense'].forEach(
-        (smallestUnit) => {
-          throws(() => later.since(earlier, { smallestUnit }), RangeError);
-        }
-      );
-    });
-    it('throws if smallestUnit is larger than largestUnit', () => {
-      const units = ['hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds'];
-      for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
-        for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
-          const largestUnit = units[largestIdx];
-          const smallestUnit = units[smallestIdx];
-          throws(() => later.since(earlier, { largestUnit, smallestUnit }), RangeError);
-        }
-      }
-    });
     it('throws on invalid roundingMode', () => {
       throws(() => later.since(earlier, { roundingMode: 'cile' }), RangeError);
     });

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -1394,32 +1394,6 @@ describe('ZonedDateTime', () => {
     });
     const earlier = ZonedDateTime.from('2019-01-08T09:22:36.123456789+01:00[Europe/Vienna]');
     const later = ZonedDateTime.from('2021-09-07T14:39:40.987654321+02:00[Europe/Vienna]');
-    it('throws on disallowed or invalid smallestUnit', () => {
-      ['era', 'nonsense'].forEach((smallestUnit) => {
-        throws(() => earlier.until(later, { smallestUnit }), RangeError);
-      });
-    });
-    it('throws if smallestUnit is larger than largestUnit', () => {
-      const units = [
-        'years',
-        'months',
-        'weeks',
-        'days',
-        'hours',
-        'minutes',
-        'seconds',
-        'milliseconds',
-        'microseconds',
-        'nanoseconds'
-      ];
-      for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
-        for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
-          const largestUnit = units[largestIdx];
-          const smallestUnit = units[smallestIdx];
-          throws(() => earlier.until(later, { largestUnit, smallestUnit }), RangeError);
-        }
-      }
-    });
     it('assumes a different default for largestUnit if smallestUnit is larger than hours', () => {
       equal(`${earlier.until(later, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
       equal(`${earlier.until(later, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');
@@ -1738,32 +1712,6 @@ describe('ZonedDateTime', () => {
     });
     const earlier = ZonedDateTime.from('2019-01-08T09:22:36.123456789+01:00[Europe/Vienna]');
     const later = ZonedDateTime.from('2021-09-07T14:39:40.987654321+02:00[Europe/Vienna]');
-    it('throws on disallowed or invalid smallestUnit', () => {
-      ['era', 'nonsense'].forEach((smallestUnit) => {
-        throws(() => later.since(earlier, { smallestUnit }), RangeError);
-      });
-    });
-    it('throws if smallestUnit is larger than largestUnit', () => {
-      const units = [
-        'years',
-        'months',
-        'weeks',
-        'days',
-        'hours',
-        'minutes',
-        'seconds',
-        'milliseconds',
-        'microseconds',
-        'nanoseconds'
-      ];
-      for (let largestIdx = 1; largestIdx < units.length; largestIdx++) {
-        for (let smallestIdx = 0; smallestIdx < largestIdx; smallestIdx++) {
-          const largestUnit = units[largestIdx];
-          const smallestUnit = units[smallestIdx];
-          throws(() => later.since(earlier, { largestUnit, smallestUnit }), RangeError);
-        }
-      }
-    });
     it('assumes a different default for largestUnit if smallestUnit is larger than days', () => {
       equal(`${later.since(earlier, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P3Y');
       equal(`${later.since(earlier, { smallestUnit: 'months', roundingMode: 'halfExpand' })}`, 'P32M');


### PR DESCRIPTION
test262 gained these tests as part of the recent batches of tests that
represented normative changes from the October and December TC39 plenary
meetings. We can now remove them from the Demitasse test suite.