### PR TITLE
Update return type of `Calendar.p.fields` in docs and TS types to match the spec

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -368,13 +368,13 @@ Temporal.Calendar.from('chinese').dateUntil(
 ); // => P1M2D
 ```
 
-### calendar.**fields**(_fields_: Iterable&lt;string>) : Iterable&lt;string>
+### calendar.**fields**(_fields_: Iterable&lt;string>) : string[]
 
 **Parameters:**
 
 - `fields` (array of strings, or other iterable yielding strings): A list of field names.
 
-**Returns:** a new list of field names.
+**Returns:** a new array of field names.
 
 This method does not need to be called directly except in specialized code.
 It is called indirectly when using the `from()` static methods and `with()` methods of `Temporal.PlainDateTime`, `Temporal.PlainDate`, `Temporal.PlainMonthDay`, `Temporal.PlainYearMonth`, and `Temporal.ZonedDateTime`, and a number of other methods.

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -746,7 +746,7 @@ export namespace Temporal {
       two: Temporal.PlainDate | PlainDateLike | string,
       options?: DifferenceOptions<'year' | 'month' | 'week' | 'day'>
     ): Temporal.Duration;
-    fields(fields: Iterable<string>): Iterable<string>;
+    fields(fields: Iterable<string>): string[];
     mergeFields(fields: Record<string, unknown>, additionalFields: Record<string, unknown>): Record<string, unknown>;
     toString(): string;
     toJSON(): string;
@@ -1340,7 +1340,7 @@ export namespace Temporal {
      * a more ergonomic alternative to this method is
      * `Temporal.Now.zonedDateTimeISO()`.
      *
-     * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
+     * @param {CalendarLike} [calendar] - calendar identifier, or
      * a `Temporal.Calendar` instance, or an object implementing the calendar
      * protocol.
      * @param {TimeZoneLike} [tzLike] -
@@ -1377,7 +1377,7 @@ export namespace Temporal {
      * `Temporal.Now.zonedDateTimeISO` or `Temporal.Now.zonedDateTime` instead
      * of this function.
      *
-     * @param {Temporal.Calendar | string} [calendar] - calendar identifier, or
+     * @param {CalendarLike} [calendar] - calendar identifier, or
      * a `Temporal.Calendar` instance, or an object implementing the calendar
      * protocol.
      * @param {TimeZoneLike} [tzLike] -


### PR DESCRIPTION
The [spec](https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.fields) defines the return type of `Calendar.fields` as an Array. This commit aligns the docs and the TS types to what the spec says.

Fixes #2052