### PR TITLE
Remove incorrect text from `withCalendar` docs

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -385,8 +385,6 @@ nextMonthDate.with({ day: nextMonthDate.daysInMonth }); // => 2006-02-28
 
 **Returns:** a new `Temporal.PlainDate` object which is the date indicated by `date`, projected into `calendar`.
 
-This method is the same as `date.with({ calendar })`, but may be more efficient.
-
 Usage example:
 
 ```javascript

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -548,8 +548,6 @@ dt.withPlainDate('2017-09-06[u-ca=japanese]'); // => 2017-09-06T03:24:30[u-ca=ja
 
 **Returns:** a new `Temporal.PlainDateTime` object which is the date indicated by `datetime`, projected into `calendar`.
 
-This method is the same as `datetime.with({ calendar })`, but may be more efficient.
-
 Usage example:
 
 ```javascript


### PR DESCRIPTION
This PR removes leftover text in the docs for `withCalendar` in PlainDate and PlainDateTime that is no longer true after we disallowed `.with({calendar})`.