### PR TITLE
Editorial: Add missing check in ParseTemporalInstant.

### DIFF
--- a/polyfill/test/instant.mjs
+++ b/polyfill/test/instant.mjs
@@ -912,6 +912,8 @@ describe('Instant', () => {
       throws(() => Instant.from('+275760-09-13T00:00:00.000000001Z'), RangeError);
       equal(`${Instant.from('-271821-04-20T00:00Z')}`, '-271821-04-20T00:00:00Z');
       equal(`${Instant.from('+275760-09-13T00:00Z')}`, '+275760-09-13T00:00:00Z');
+      throws(() => Instant.from('-271821-04-20T00:00:00+00:01'), RangeError);
+      throws(() => Instant.from('+275760-09-13T00:00:00-00:01'), RangeError);
     });
     it('converting from DateTime', () => {
       const min = Temporal.PlainDateTime.from('-271821-04-19T00:00:00.000000001');

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -546,7 +546,10 @@
         1. If _utc_ &lt; −8.64 × 10<sup>21</sup> or _utc_ &gt; 8.64 × 10<sup>21</sup>, then
           1. Throw a *RangeError* exception.
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
-        1. Return _utc_ − _offsetNanoseconds_.
+        1. Let _result_ be _utc_ − _offsetNanoseconds_.
+        1. If ! IsValidEpochNanoseconds(ℤ(_result_)) is *false*, then
+          1. Throw a *RangeError* exception.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Without this check, we hit an assertion failure in CreateTemporalInstant, so I'm considering the change to be editorial.