### PR TITLE
Normative: Adjust ISO8601 representation for years between 1 BCE and 999 CE

### DIFF
--- a/docs/cookbook/makeExpandedTemporal.mjs
+++ b/docs/cookbook/makeExpandedTemporal.mjs
@@ -8,12 +8,12 @@ function bigIntAbs(n) {
 // number of digits.
 function formatExpandedYear(year) {
   let yearString;
-  if (year < 1000 || year > 9999) {
+  if (year < 0 || year > 9999) {
     let sign = year < 0 ? '-' : '+';
     let yearNumber = bigIntAbs(year);
     yearString = sign + `${yearNumber}`.padStart(10, '0');
   } else {
-    yearString = `${year}`;
+    yearString = `${year}`.padStart(4, '0');
   }
   return yearString;
 }

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1956,12 +1956,12 @@ export const ES = ObjectAssign({}, ES2020, {
   },
   ISOYearString: (year) => {
     let yearString;
-    if (year < 1000 || year > 9999) {
+    if (year < 0 || year > 9999) {
       let sign = year < 0 ? '-' : '+';
       let yearNumber = MathAbs(year);
       yearString = sign + `000000${yearNumber}`.slice(-6);
     } else {
-      yearString = `${year}`;
+      yearString = `0000${year}`.slice(-4);
     }
     return yearString;
   },

--- a/polyfill/test/timezone.mjs
+++ b/polyfill/test/timezone.mjs
@@ -113,21 +113,27 @@ describe('TimeZone', () => {
       equal(`${tz.getInstantFor(dt)}`, '2019-10-29T09:46:38.271986102Z');
     });
     it('year ≤ 99', () => {
-      const dt = Temporal.PlainDateTime.from('+000098-10-29T10:46:38.271986102');
+      let dt = Temporal.PlainDateTime.from('0098-10-29T10:46:38.271986102');
       const tz = Temporal.TimeZone.from('+06:00');
-      equal(`${tz.getInstantFor(dt)}`, '+000098-10-29T04:46:38.271986102Z');
+      equal(`${tz.getInstantFor(dt)}`, '0098-10-29T04:46:38.271986102Z');
+      dt = Temporal.PlainDateTime.from('+000098-10-29T10:46:38.271986102');
+      equal(`${tz.getInstantFor(dt)}`, '0098-10-29T04:46:38.271986102Z');
     });
     it('year < 1', () => {
-      let dt = Temporal.PlainDateTime.from('+000000-10-29T10:46:38.271986102');
+      let dt = Temporal.PlainDateTime.from('0000-10-29T10:46:38.271986102');
       const tz = Temporal.TimeZone.from('+06:00');
-      equal(`${tz.getInstantFor(dt)}`, '+000000-10-29T04:46:38.271986102Z');
+      equal(`${tz.getInstantFor(dt)}`, '0000-10-29T04:46:38.271986102Z');
+      dt = Temporal.PlainDateTime.from('+000000-10-29T10:46:38.271986102');
+      equal(`${tz.getInstantFor(dt)}`, '0000-10-29T04:46:38.271986102Z');
       dt = Temporal.PlainDateTime.from('-001000-10-29T10:46:38.271986102');
       equal(`${tz.getInstantFor(dt)}`, '-001000-10-29T04:46:38.271986102Z');
     });
     it('year 0 leap day', () => {
-      const dt = Temporal.PlainDateTime.from('+000000-02-29T00:00');
+      let dt = Temporal.PlainDateTime.from('0000-02-29T00:00');
       const tz = Temporal.TimeZone.from('Europe/London');
-      equal(`${tz.getInstantFor(dt)}`, '+000000-02-29T00:01:15Z');
+      equal(`${tz.getInstantFor(dt)}`, '0000-02-29T00:01:15Z');
+      dt = Temporal.PlainDateTime.from('+000000-02-29T00:00');
+      equal(`${tz.getInstantFor(dt)}`, '0000-02-29T00:01:15Z');
     });
     it('outside of Instant range', () => {
       const max = Temporal.PlainDateTime.from('+275760-09-13T23:59:59.999999999');

--- a/polyfill/test/zoneddatetime.mjs
+++ b/polyfill/test/zoneddatetime.mjs
@@ -2386,18 +2386,24 @@ describe('ZonedDateTime', () => {
       equal(`${zdt.toInstant()}`, '2019-10-29T09:46:38.271986102Z');
     });
     it('year ≤ 99', () => {
-      const zdt = ZonedDateTime.from('+000098-10-29T10:46:38.271986102+00:00[UTC]');
-      equal(`${zdt.toInstant()}`, '+000098-10-29T10:46:38.271986102Z');
+      let zdt = ZonedDateTime.from('0098-10-29T10:46:38.271986102+00:00[UTC]');
+      equal(`${zdt.toInstant()}`, '0098-10-29T10:46:38.271986102Z');
+      zdt = ZonedDateTime.from('+000098-10-29T10:46:38.271986102+00:00[UTC]');
+      equal(`${zdt.toInstant()}`, '0098-10-29T10:46:38.271986102Z');
     });
     it('year < 1', () => {
-      let zdt = ZonedDateTime.from('+000000-10-29T10:46:38.271986102+00:00[UTC]');
-      equal(`${zdt.toInstant()}`, '+000000-10-29T10:46:38.271986102Z');
+      let zdt = ZonedDateTime.from('0000-10-29T10:46:38.271986102+00:00[UTC]');
+      equal(`${zdt.toInstant()}`, '0000-10-29T10:46:38.271986102Z');
+      zdt = ZonedDateTime.from('+000000-10-29T10:46:38.271986102+00:00[UTC]');
+      equal(`${zdt.toInstant()}`, '0000-10-29T10:46:38.271986102Z');
       zdt = ZonedDateTime.from('-001000-10-29T10:46:38.271986102+00:00[UTC]');
       equal(`${zdt.toInstant()}`, '-001000-10-29T10:46:38.271986102Z');
     });
     it('year 0 leap day', () => {
-      const zdt = ZonedDateTime.from('+000000-02-29T00:00-00:01:15[Europe/London]');
-      equal(`${zdt.toInstant()}`, '+000000-02-29T00:01:15Z');
+      let zdt = ZonedDateTime.from('0000-02-29T00:00-00:01:15[Europe/London]');
+      equal(`${zdt.toInstant()}`, '0000-02-29T00:01:15Z');
+      zdt = ZonedDateTime.from('+000000-02-29T00:00-00:01:15[Europe/London]');
+      equal(`${zdt.toInstant()}`, '0000-02-29T00:01:15Z');
     });
   });
   describe('ZonedDateTime.toPlainDate()', () => {

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -864,9 +864,9 @@
       <h1>PadISOYear ( _y_ )</h1>
       <emu-alg>
         1. Assert: _y_ is an integer.
-        1. If _y_ &gt; 999 and _y_ ≤ 9999, then
-          1. Return _y_ formatted as a four-digit decimal number.
-        1. If _y_ ≥ 0, let _yearSign_ be *"+"*; otherwise, let _yearSign_ be *"-"*.
+        1. If _y_ ≥ 0 and _y_ ≤ 9999, then
+          1. Return _y_ formatted as a four-digit decimal number, padded to the left with zeroes as necessary.
+        1. If _y_ &gt; 0, let _yearSign_ be *"+"*; otherwise, let _yearSign_ be *"-"*.
         1. Let _year_ be abs(_y_), formatted as a six-digit decimal number, padded to the left with zeroes as necessary.
         1. Return the string-concatenation of _yearSign_ and _year_.
       </emu-alg>


### PR DESCRIPTION
Fixes: https://github.com/tc39/proposal-temporal/issues/2082

Old format: `+000YYY`, e.g. `+000098-10-29T10:46:38`
New format: `0YYY`, e.g. `0098-10-29T10:46:38`