### PR TITLE
Normative: Change internal slots of Duration to store mathematical values

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -798,7 +798,7 @@
         1. Set _duration_ to ? ToTemporalDuration(_duration_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Let _balanceResult_ be ! BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
+        1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
         1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_).
         1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -147,7 +147,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Years]].
+        1. Return 𝔽(_duration_.[[Years]]).
       </emu-alg>
     </emu-clause>
 
@@ -160,7 +160,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Months]].
+        1. Return 𝔽(_duration_.[[Months]]).
       </emu-alg>
     </emu-clause>
 
@@ -173,7 +173,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Weeks]].
+        1. Return 𝔽(_duration_.[[Weeks]]).
       </emu-alg>
     </emu-clause>
 
@@ -186,7 +186,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Days]].
+        1. Return 𝔽(_duration_.[[Days]]).
       </emu-alg>
     </emu-clause>
 
@@ -199,7 +199,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Hours]].
+        1. Return 𝔽(_duration_.[[Hours]]).
       </emu-alg>
     </emu-clause>
 
@@ -212,7 +212,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Minutes]].
+        1. Return 𝔽(_duration_.[[Minutes]]).
       </emu-alg>
     </emu-clause>
 
@@ -225,7 +225,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Seconds]].
+        1. Return 𝔽(_duration_.[[Seconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -238,7 +238,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Milliseconds]].
+        1. Return 𝔽(_duration_.[[Milliseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -251,7 +251,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Microseconds]].
+        1. Return 𝔽(_duration_.[[Microseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -264,7 +264,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return _duration_.[[Nanoseconds]].
+        1. Return 𝔽(_duration_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -570,6 +570,13 @@
       Temporal.Duration instances are ordinary objects that inherit properties from the %Temporal.Duration.prototype% intrinsic object.
       Temporal.Duration instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-temporalduration-instances"></emu-xref>.
     </p>
+    <p>
+      A <dfn variants="float64-representable integers">float64-representable integer</dfn> is an integer that is exactly representable as a Number value.
+      That is, for a float64-representable integer _x_, it must hold that ℝ(𝔽(_x_)) = _x_.
+    </p>
+    <emu-note>
+      The use of float64-representable integers here is intended so that implementations can store and do arithmetic on Duration fields using 64-bit floating-point values.
+    </emu-note>
     <emu-table id="table-internal-slots-of-temporalduration-instances" caption="Internal Slots of Temporal.Duration Instances">
       <table>
         <tbody>
@@ -594,7 +601,7 @@
               [[Years]]
             </td>
             <td>
-              An integer Number value representing the number of years in the duration.
+              A float64-representable integer representing the number of years in the duration.
             </td>
           </tr>
           <tr>
@@ -602,7 +609,7 @@
               [[Months]]
             </td>
             <td>
-              An integer Number value representing the number of months in the duration.
+              A float64-representable integer representing the number of months in the duration.
             </td>
           </tr>
           <tr>
@@ -610,7 +617,7 @@
               [[Weeks]]
             </td>
             <td>
-              An integer Number value representing the number of weeks in the duration.
+              A float64-representable integer representing the number of weeks in the duration.
             </td>
           </tr>
           <tr>
@@ -618,7 +625,7 @@
               [[Days]]
             </td>
             <td>
-              An integer Number value representing the number of days in the duration.
+              A float64-representable integer representing the number of days in the duration.
             </td>
           </tr>
           <tr>
@@ -626,7 +633,7 @@
               [[Hours]]
             </td>
             <td>
-              An integer Number value representing the number of hours in the duration.
+              A float64-representable integer representing the number of hours in the duration.
             </td>
           </tr>
           <tr>
@@ -634,7 +641,7 @@
               [[Minutes]]
             </td>
             <td>
-              An integer Number value representing the number of minutes in the duration.
+              A float64-representable integer representing the number of minutes in the duration.
             </td>
           </tr>
           <tr>
@@ -642,7 +649,7 @@
               [[Seconds]]
             </td>
             <td>
-              An integer Number value representing the number of seconds in the duration.
+              A float64-representable integer representing the number of seconds in the duration.
             </td>
           </tr>
           <tr>
@@ -650,7 +657,7 @@
               [[Milliseconds]]
             </td>
             <td>
-              An integer Number value representing the number of milliseconds in the duration.
+              A float64-representable integer representing the number of milliseconds in the duration.
             </td>
           </tr>
           <tr>
@@ -658,7 +665,7 @@
               [[Microseconds]]
             </td>
             <td>
-              An integer Number value representing the number of microseconds in the duration.
+              A float64-representable integer representing the number of microseconds in the duration.
             </td>
           </tr>
           <tr>
@@ -666,7 +673,7 @@
               [[Nanoseconds]]
             </td>
             <td>
-              An integer Number value representing the number of nanoseconds in the duration.
+              A float64-representable integer representing the number of nanoseconds in the duration.
             </td>
           </tr>
         </tbody>
@@ -697,7 +704,7 @@
           <tr>
             <td>[[Days]]</td>
             <td>*"days"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of days in the duration.
             </td>
@@ -705,7 +712,7 @@
           <tr>
             <td>[[Hours]]</td>
             <td>*"hours"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of hours in the duration.
             </td>
@@ -713,7 +720,7 @@
           <tr>
             <td>[[Microseconds]]</td>
             <td>*"microseconds"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of microseconds in the duration.
             </td>
@@ -721,7 +728,7 @@
           <tr>
             <td>[[Milliseconds]]</td>
             <td>*"milliseconds"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of milliseconds in the duration.
             </td>
@@ -729,7 +736,7 @@
           <tr>
             <td>[[Minutes]]</td>
             <td>*"minutes"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of minutes in the duration.
             </td>
@@ -737,7 +744,7 @@
           <tr>
             <td>[[Months]]</td>
             <td>*"months"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of months in the duration.
             </td>
@@ -745,7 +752,7 @@
           <tr>
             <td>[[Nanoseconds]]</td>
             <td>*"nanoseconds"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of nanoseconds in the duration.
             </td>
@@ -753,7 +760,7 @@
           <tr>
             <td>[[Seconds]]</td>
             <td>*"seconds"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of seconds in the duration.
             </td>
@@ -761,7 +768,7 @@
           <tr>
             <td>[[Weeks]]</td>
             <td>*"weeks"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of weeks in the duration.
             </td>
@@ -769,7 +776,7 @@
           <tr>
             <td>[[Years]]</td>
             <td>*"years"*</td>
-            <td>an integer</td>
+            <td>a float64-representable integer</td>
             <td>
               The number of years in the duration.
             </td>
@@ -834,16 +841,16 @@
       <emu-alg>
         1. If ! IsValidDuration(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return the Record {
-            [[Years]]: _years_,
-            [[Months]]: _months_,
-            [[Weeks]]: _weeks_,
-            [[Days]]: _days_,
-            [[Hours]]: _hours_,
-            [[Minutes]]: _minutes_,
-            [[Seconds]]: _seconds_,
-            [[Milliseconds]]: _milliseconds_,
-            [[Microseconds]]: _microseconds_,
-            [[Nanoseconds]]: _nanoseconds_
+            [[Years]]: ℝ(𝔽(_years_)),
+            [[Months]]: ℝ(𝔽(_months_)),
+            [[Weeks]]: ℝ(𝔽(_weeks_)),
+            [[Days]]: ℝ(𝔽(_days_)),
+            [[Hours]]: ℝ(𝔽(_hours_)),
+            [[Minutes]]: ℝ(𝔽(_minutes_)),
+            [[Seconds]]: ℝ(𝔽(_seconds_)),
+            [[Milliseconds]]: ℝ(𝔽(_milliseconds_)),
+            [[Microseconds]]: ℝ(𝔽(_microseconds_)),
+            [[Nanoseconds]]: ℝ(𝔽(_nanoseconds_))
           }.
       </emu-alg>
     </emu-clause>
@@ -864,10 +871,10 @@
       <emu-alg>
         1. If ! IsValidDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0) is *false*, throw a *RangeError* exception.
         1. Return the Record {
-            [[Years]]: _years_,
-            [[Months]]: _months_,
-            [[Weeks]]: _weeks_,
-            [[Days]]: _days_,
+            [[Years]]: ℝ(𝔽(_years_)),
+            [[Months]]: ℝ(𝔽(_months_)),
+            [[Weeks]]: ℝ(𝔽(_weeks_)),
+            [[Days]]: ℝ(𝔽(_days_))
           }.
       </emu-alg>
     </emu-clause>
@@ -891,13 +898,13 @@
       <emu-alg>
         1. If ! IsValidDuration(0, 0, 0, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return the Record {
-            [[Days]]: _days_,
-            [[Hours]]: _hours_,
-            [[Minutes]]: _minutes_,
-            [[Seconds]]: _seconds_,
-            [[Milliseconds]]: _milliseconds_,
-            [[Microseconds]]: _microseconds_,
-            [[Nanoseconds]]: _nanoseconds_
+            [[Days]]: ℝ(𝔽(_days_)),
+            [[Hours]]: ℝ(𝔽(_hours_)),
+            [[Minutes]]: ℝ(𝔽(_minutes_)),
+            [[Seconds]]: ℝ(𝔽(_seconds_)),
+            [[Milliseconds]]: ℝ(𝔽(_milliseconds_)),
+            [[Microseconds]]: ℝ(𝔽(_microseconds_)),
+            [[Nanoseconds]]: ℝ(𝔽(_nanoseconds_))
           }.
       </emu-alg>
     </emu-clause>
@@ -945,7 +952,7 @@
             1. Set _result_'s field whose name is the Field Name value of the current row to 0.
           1. Else,
             1. Set _any_ to *true*.
-            1. Let _val_ be 𝔽(? ToIntegerWithoutRounding(_val_)).
+            1. Let _val_ be ? ToIntegerWithoutRounding(_val_).
             1. Set _result_'s field whose name is the Field Name value of the current row to _val_.
         1. If _any_ is *false*, then
           1. Throw a *TypeError* exception.
@@ -1004,7 +1011,7 @@
       <emu-alg>
         1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. For each value _v_ of « _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ », do
-          1. If _v_ is not finite, return *false*.
+          1. If 𝔽(_v_) is not finite, return *false*.
           1. If _v_ &lt; 0 and _sign_ &gt; 0, return *false*.
           1. If _v_ &gt; 0 and _sign_ &lt; 0, return *false*.
         1. Return *true*.
@@ -1063,7 +1070,7 @@
           1. Let _value_ be ? Get(_temporalDurationLike_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
-            1. Set _value_ to 𝔽(? ToIntegerWithoutRounding(_value_)).
+            1. Set _value_ to ? ToIntegerWithoutRounding(_value_).
             1. Set _result_'s field whose name is the Field Name value of the current row to _value_.
         1. If _any_ is *false*, then
           1. Throw a *TypeError* exception.
@@ -1095,16 +1102,16 @@
         1. If ! IsValidDuration(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_) is *false*, throw a *RangeError* exception.
         1. If _newTarget_ is not present, set _newTarget_ to %Temporal.Duration%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.Duration.prototype%"*, « [[InitializedTemporalDuration]], [[Years]], [[Months]], [[Weeks]], [[Days]], [[Hours]], [[Minutes]], [[Seconds]], [[Milliseconds]], [[Microseconds]], [[Nanoseconds]] »).
-        1. Set _object_.[[Years]] to _years_.
-        1. Set _object_.[[Months]] to _months_.
-        1. Set _object_.[[Weeks]] to _weeks_.
-        1. Set _object_.[[Days]] to _days_.
-        1. Set _object_.[[Hours]] to _hours_.
-        1. Set _object_.[[Minutes]] to _minutes_.
-        1. Set _object_.[[Seconds]] to _seconds_.
-        1. Set _object_.[[Milliseconds]] to _milliseconds_.
-        1. Set _object_.[[Microseconds]] to _microseconds_.
-        1. Set _object_.[[Nanoseconds]] to _nanoseconds_.
+        1. Set _object_.[[Years]] to ℝ(𝔽(_years_)).
+        1. Set _object_.[[Months]] to ℝ(𝔽(_months_)).
+        1. Set _object_.[[Weeks]] to ℝ(𝔽(_weeks_)).
+        1. Set _object_.[[Days]] to ℝ(𝔽(_days_)).
+        1. Set _object_.[[Hours]] to ℝ(𝔽(_hours_)).
+        1. Set _object_.[[Minutes]] to ℝ(𝔽(_minutes_)).
+        1. Set _object_.[[Seconds]] to ℝ(𝔽(_seconds_)).
+        1. Set _object_.[[Milliseconds]] to ℝ(𝔽(_milliseconds_)).
+        1. Set _object_.[[Microseconds]] to ℝ(𝔽(_microseconds_)).
+        1. Set _object_.[[Nanoseconds]] to ℝ(𝔽(_nanoseconds_)).
         1. Return _object_.
       </emu-alg>
     </emu-clause>
@@ -1158,13 +1165,13 @@
     <emu-clause id="sec-temporal-totaldurationnanoseconds" type="abstract operation">
       <h1>
         TotalDurationNanoseconds (
-          _days_: an integer Number value,
-          _hours_: an integer Number value,
-          _minutes_: an integer Number value,
-          _seconds_: an integer Number value,
-          _milliseconds_: an integer Number value,
-          _microseconds_: an integer Number value,
-          _nanoseconds_: an integer Number value,
+          _days_: an integer,
+          _hours_: an integer,
+          _minutes_: an integer,
+          _seconds_: an integer,
+          _milliseconds_: an integer,
+          _microseconds_: an integer,
+          _nanoseconds_: an integer,
           _offsetShift_: an integer,
         )
       </h1>
@@ -1173,14 +1180,13 @@
         <dd>It computes an integer number of nanoseconds from the given units, applying a given time zone offset shift in nanoseconds when converting from days to hours.</dd>
       </dl>
       <emu-alg>
-        1. Set _nanoseconds_ to ℝ(_nanoseconds_).
         1. If _days_ ≠ 0, then
           1. Set _nanoseconds_ to _nanoseconds_ − _offsetShift_.
-        1. Set _hours_ to ℝ(_hours_) + ℝ(_days_) × 24.
-        1. Set _minutes_ to ℝ(_minutes_) + _hours_ × 60.
-        1. Set _seconds_ to ℝ(_seconds_) + _minutes_ × 60.
-        1. Set _milliseconds_ to ℝ(_milliseconds_) + _seconds_ × 1000.
-        1. Set _microseconds_ to ℝ(_microseconds_) + _milliseconds_ × 1000.
+        1. Set _hours_ to _hours_ + _days_ × 24.
+        1. Set _minutes_ to _minutes_ + _hours_ × 60.
+        1. Set _seconds_ to _seconds_ + _minutes_ × 60.
+        1. Set _milliseconds_ to _milliseconds_ + _seconds_ × 1000.
+        1. Set _microseconds_ to _microseconds_ + _milliseconds_ × 1000.
         1. Return _nanoseconds_ + _microseconds_ × 1000.
       </emu-alg>
     </emu-clause>
@@ -1257,7 +1263,7 @@
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
         1. Else,
           1. Assert: _largestUnit_ is *"nanosecond"*.
-        1. Return ! CreateTimeDurationRecord(_days_, _hours_ × _sign_, _minutes_ × _sign_, _seconds_ × _sign_, _milliseconds_ × _sign_, _microseconds_ × _sign_, _nanoseconds_ × _sign_).
+        1. Return ? CreateTimeDurationRecord(_days_, _hours_ × _sign_, _minutes_ × _sign_, _seconds_ × _sign_, _milliseconds_ × _sign_, _microseconds_ × _sign_, _nanoseconds_ × _sign_).
       </emu-alg>
     </emu-clause>
 
@@ -1431,26 +1437,26 @@
     <emu-clause id="sec-temporal-addduration" type="abstract operation">
       <h1>
         AddDuration (
-          _y1_: an integer Number value,
-          _mon1_: an integer Number value,
-          _w1_: an integer Number value,
-          _d1_: an integer Number value,
-          _h1_: an integer Number value,
-          _min1_: an integer Number value,
-          _s1_: an integer Number value,
-          _ms1_: an integer Number value,
-          _mus1_: an integer Number value,
-          _ns1_: an integer Number value,
-          _y2_: an integer Number value,
-          _mon2_: an integer Number value,
-          _w2_: an integer Number value,
-          _d2_: an integer Number value,
-          _h2_: an integer Number value,
-          _min2_: an integer Number value,
-          _s2_: an integer Number value,
-          _ms2_: an integer Number value,
-          _mus2_: an integer Number value,
-          _ns2_: an integer Number value,
+          _y1_: an integer,
+          _mon1_: an integer,
+          _w1_: an integer,
+          _d1_: an integer,
+          _h1_: an integer,
+          _min1_: an integer,
+          _s1_: an integer,
+          _ms1_: an integer,
+          _mus1_: an integer,
+          _ns1_: an integer,
+          _y2_: an integer,
+          _mon2_: an integer,
+          _w2_: an integer,
+          _d2_: an integer,
+          _h2_: an integer,
+          _min2_: an integer,
+          _s2_: an integer,
+          _ms2_: an integer,
+          _mus2_: an integer,
+          _ns2_: an integer,
           _relativeTo_: *undefined*, a Temporal.PlainDate, or a Temporal.ZonedDateTime,
         )
       </h1>
@@ -1465,8 +1471,8 @@
         1. If _relativeTo_ is *undefined*, then
           1. If _largestUnit_ is one of *"year"*, *"month"*, or *"week"*, then
             1. Throw a *RangeError* exception.
-          1. Let _result_ be ! BalanceDuration(_d1_ + _d2_, _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
-          1. Return ? CreateDurationRecord(0, 0, 0, _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+          1. Let _result_ be ? BalanceDuration(_d1_ + _d2_, _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
+          1. Return ! CreateDurationRecord(0, 0, 0, _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. If _relativeTo_ has an [[InitializedTemporalDate]] internal slot, then
           1. Let _calendar_ be _relativeTo_.[[Calendar]].
           1. Let _dateDuration1_ be ! CreateTemporalDuration(_y1_, _mon1_, _w1_, _d1_, 0, 0, 0, 0, 0, 0).
@@ -1480,8 +1486,8 @@
           1. Let _differenceOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_differenceOptions_, *"largestUnit"*, _dateLargestUnit_).
           1. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _end_, _differenceOptions_).
-          1. Let _result_ be ! BalanceDuration(_dateDifference_.[[Days]], _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
-          1. Return ? CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+          1. Let _result_ be ? BalanceDuration(_dateDifference_.[[Days]], _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
+          1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Assert: _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot.
         1. Let _timeZone_ be _relativeTo_.[[TimeZone]].
         1. Let _calendar_ be _relativeTo_.[[Calendar]].
@@ -1562,16 +1568,16 @@
     <emu-clause id="sec-temporal-roundduration" type="abstract operation">
       <h1>
         RoundDuration (
-          _years_: an integer Number value,
-          _months_: an integer Number value,
-          _weeks_: an integer Number value,
-          _days_: an integer Number value,
-          _hours_: an integer Number value,
-          _minutes_: an integer Number value,
-          _seconds_: an integer Number value,
-          _milliseconds_: an integer Number value,
-          _microseconds_: an integer Number value,
-          _nanoseconds_: an integer Number value,
+          _years_: an integer,
+          _months_: an integer,
+          _weeks_: an integer,
+          _days_: an integer,
+          _hours_: an integer,
+          _minutes_: an integer,
+          _seconds_: an integer,
+          _milliseconds_: an integer,
+          _microseconds_: an integer,
+          _nanoseconds_: an integer,
           _increment_: an integer,
           _unit_: a String,
           _roundingMode_: a String,
@@ -1584,7 +1590,6 @@
       </dl>
       <emu-alg>
         1. If _relativeTo_ is not present, set _relativeTo_ to *undefined*.
-        1. Let _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, and _increment_ each be the mathematical values of themselves.
         1. If _unit_ is *"year"*, *"month"*, or *"week"*, and _relativeTo_ is *undefined*, then
           1. Throw a *RangeError* exception.
         1. Let _zonedRelativeTo_ be *undefined*.
@@ -1801,10 +1806,10 @@
           _days_: an integer,
           _hours_: an integer,
           _minutes_: an integer,
-          _seconds_: an integer Number value,
-          _milliseconds_: an integer Number value,
-          _microseconds_: an integer Number value,
-          _nanoseconds_: an integer Number value,
+          _seconds_: an integer,
+          _milliseconds_: an integer,
+          _microseconds_: an integer,
+          _nanoseconds_: an integer,
           _precision_: an integer between 0 and 9 inclusive, or *"auto"*,
         )
       </h1>
@@ -1813,10 +1818,6 @@
         <dd>It returns a String which is the ISO 8601 representation of the duration denoted by _years_ through _nanoseconds_, with the number of decimal places in the seconds value controlled by _precision_.</dd>
       </dl>
       <emu-alg>
-        1. Set _seconds_ to the mathematical value of _seconds_.
-        1. Set _milliseconds_ to the mathematical value of _milliseconds_.
-        1. Set _microseconds_ to the mathematical value of _microseconds_.
-        1. Set _nanoseconds_ to the mathematical value of _nanoseconds_.
         1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Set _microseconds_ to _microseconds_ + the integral part of _nanoseconds_ / 1000.
         1. Set _nanoseconds_ to remainder(_nanoseconds_, 1000).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -566,12 +566,12 @@
       <h1>
         AddInstant (
           _epochNanoseconds_: a BigInt value,
-          _hours_: an integer Number value,
-          _minutes_: an integer Number value,
-          _seconds_: an integer Number value,
-          _milliseconds_: an integer Number value,
-          _microseconds_: an integer Number value,
-          _nanoseconds_: an integer Number value,
+          _hours_: an integer,
+          _minutes_: an integer,
+          _seconds_: an integer,
+          _milliseconds_: an integer,
+          _microseconds_: an integer,
+          _nanoseconds_: an integer,
         )
       </h1>
       <dl class="header">

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1421,7 +1421,7 @@
             1. Set _duration_ to ? ToTemporalDuration(_duration_).
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-            1. Let _balanceResult_ be ! BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
+            1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_).
             1. Else,

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -501,8 +501,8 @@
         1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
         1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
         1. Let _roundResult_ be (? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].
-        1. Let _result_ be ! BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
-        1. Return ? CreateTemporalDuration(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Let _result_ be ? BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
+        1. Return ! CreateTemporalDuration(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -529,8 +529,8 @@
         1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
         1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
         1. Let _roundResult_ be (? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].
-        1. Let _result_ be ! BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
-        1. Return ? CreateTemporalDuration(−_roundResult_.[[Years]], −_roundResult_.[[Months]], −_roundResult_.[[Weeks]], −_result_.[[Days]], −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]]).
+        1. Let _result_ be ? BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
+        1. Return ! CreateTemporalDuration(−_roundResult_.[[Years]], −_roundResult_.[[Months]], −_roundResult_.[[Weeks]], −_result_.[[Days]], −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -1012,16 +1012,16 @@
           _microsecond_: an integer,
           _nanosecond_: an integer,
           _calendar_: an Object,
-          _years_: an integer Number value,
-          _months_: an integer Number value,
-          _weeks_: an integer Number value,
-          _days_: an integer Number value,
-          _hours_: an integer Number value,
-          _minutes_: an integer Number value,
-          _seconds_: an integer Number value,
-          _milliseconds_: an integer Number value,
-          _microseconds_: an integer Number value,
-          _nanoseconds_: an integer Number value,
+          _years_: an integer,
+          _months_: an integer,
+          _weeks_: an integer,
+          _days_: an integer,
+          _hours_: an integer,
+          _minutes_: an integer,
+          _seconds_: an integer,
+          _milliseconds_: an integer,
+          _microseconds_: an integer,
+          _nanoseconds_: an integer,
           _options_: an Object or *undefined*,
         )
       </h1>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -296,8 +296,8 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _result_ be ! DifferenceTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]]).
         1. Set _result_ to (? RoundDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
-        1. Set _result_ to ! BalanceDuration(0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _largestUnit_).
-        1. Return ? CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Set _result_ to ? BalanceDuration(0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _largestUnit_).
+        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -321,8 +321,8 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _result_ be ! DifferenceTime(_other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]]).
         1. Set _result_ to (? RoundDuration(0, 0, 0, 0, −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
-        1. Set _result_ to ! BalanceDuration(0, −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]], _largestUnit_).
-        1. Return ? CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Set _result_ to ? BalanceDuration(0, −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]], _largestUnit_).
+        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
This changes the internal slots of Duration to store mathematical values
instead of Number values. However, only mathematical values that are (1)
integers, and (2) representable by Number values, are allowed. This is
achieved by storing ℝ(𝔽(_value_)) in the internal slots of Durations and
in the fields of Duration Records.

This should solve the problem of type confusion between Number values and
mathematical values, and eliminate places where operations only defined on
mathematical values (such as abs() and floor()) were applied to the Number
domain.

This is a normative change because it means that it is now impossible for
the Number values NaN, +Infinity, -Infinity, and -0, as well as any
non-integer Number values, and not-exactly-representable Number values >MAX_SAFE_INTEGER, to be
exposed to JS via the property getters of Temporal.Duration. I suspect
this was not possible previously with NaN and non-integer Numbers, I
suspect it may have been possible with infinities and >MAX_SAFE_INTEGER,
and it was definitely possible with -0.

Closes: #1604
Closes: #1715