### PR TITLE
Editorial: Fix rendering of table reference in ResolveISOMonth

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -459,7 +459,7 @@
         It returns the integer month.
       </p>
       <emu-alg>
-        1. Assert: _fields_ is an ordinary object with no more and no less than the own data properties listed in [Table 13](https://tc39.es/proposal-temporal/#table-temporal-field-requirements).
+        1. Assert: _fields_ is an ordinary object with no more and no less than the own data properties listed in <emu-xref href="#table-temporal-field-requirements"></emu-xref>.
         1. Let _month_ be ! Get(_fields_, *"month"*).
         1. Let _monthCode_ be ! Get(_fields_, *"monthCode"*).
         1. If _monthCode_ is *undefined*, then


### PR DESCRIPTION
The markdown link is not understood by ecmarkup, and the table number might change in the future.

![image](https://user-images.githubusercontent.com/19366641/158664414-90ce7c82-fbc9-442b-8f8c-61b26bd14532.png)
