### PR TITLE
Normative: fix accepted types of `calendar` & `timeZone` options of `toLocaleString` & `Intl.DateTimeFormat`

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -525,8 +525,9 @@
             1. Return _temporalCalendarLike_.[[Calendar]].
           1. If ? ObjectImplementsTemporalCalendarProtocol(_temporalCalendarLike_) is *false*, throw a *TypeError* exception.
           1. Return _temporalCalendarLike_.
-        1. Let _identifier_ be ? ToString(_temporalCalendarLike_).
-        1. Set _identifier_ to ? ParseTemporalCalendarString(_identifier_).
+        1. Assert: No non-String, non-Object value, when coerced to a String, is a built-in calendar identifier.
+        1. If Type(_temporalCalendarLike_) is not String, throw a *TypeError* exception.
+        1. Let _identifier_ be ? ParseTemporalCalendarString(_temporalCalendarLike_).
         1. If IsBuiltinCalendar(_identifier_) is *false*, throw a *RangeError* exception.
         1. Return the ASCII-lowercase of _identifier_.
       </emu-alg>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -208,9 +208,8 @@
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, *"string"*, « *"lookup"*, *"best fit"* », *"best fit"*).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _calendar_ be ? GetOption(_options_, *"calendar"*, *"string"*, *undefined*, *undefined*).
-        1. If _calendar_ is not *undefined*, then
-          1. If _calendar_ does not match the Unicode Locale Identifier `type` nonterminal, throw a *RangeError* exception.
+        1. Let _calendar_ be ? Get(_options_, *"calendar"*).
+        1. Set _calendar_ to ? InterpretCalendarOption(_calendar_).
         1. Set _opt_.[[ca]] to _calendar_.
         1. Let _numberingSystem_ be ? GetOption(_options_, *"numberingSystem"*, *"string"*, *undefined*, *undefined*).
         1. If _numberingSystem_ is not *undefined*, then
@@ -240,17 +239,15 @@
           1. If _hc_ is *null*, set _hc_ to _hcDefault_.
         1. <del>Set _dateTimeFormat_.[[HourCycle]] to _hc_.</del>
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
-        1. If _timeZone_ is *undefined*, then
-          1. <ins>If _toLocaleStringTimeZone_ is present, then</ins>
-            1. <ins>Set _timeZone_ to _toLocaleStringTimeZone_.</ins>
-          1. <ins>Else,</ins>
-            1. Set _timeZone_ to DefaultTimeZone().
-        1. Else,
-          1. <ins>If _toLocaleStringTimeZone_ is present, throw a *TypeError* exception.</ins>
-          1. Set _timeZone_ to ? ToString(_timeZone_).
-          1. If <del>the result of IsValidTimeZoneName(_timeZone_)</del><ins>IsAvailableTimeZoneName(_timeZone_)</ins> is *false*, then
-            1. Throw a *RangeError* exception.
-          1. Set _timeZone_ to CanonicalizeTimeZoneName(_timeZone_).
+        1. Set _timeZone_ to ? InterpretTimeZoneOption(_timeZone_).
+        1. <del>Let _timeZone_ be ? Get(_options_, *"timeZone"*).</del>
+        1. <del>If _timeZone_ is *undefined*, then</del>
+          1. <del>Set _timeZone_ to DefaultTimeZone().</del>
+        1. <del>Else,</del>
+          1. <del>Set _timeZone_ to ? ToString(_timeZone_).</del>
+          1. <del>If the result of IsValidTimeZoneName(_timeZone_) is *false*, then</del>
+            1. <del>Throw a *RangeError* exception.</del>
+          1. <del>Set _timeZone_ to CanonicalizeTimeZoneName(_timeZone_).</del>
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
         1. Let _formatOptions_ be a new Record.
         1. Set _formatOptions_.[[hourCycle]] to _hc_.
@@ -376,6 +373,79 @@
       </emu-table>
       </ins>
     </emu-clause>
+
+    <ins class="block">
+    <emu-clause id="sec-interprettimezoneoption" type="abstract operation">
+      <h1>InterpretTimeZoneOption (
+          _timeZone_: an ECMAScript value,
+          optional _toLocaleStringTimeZone_: a String
+        ): either a normal completion containing a String, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It determines the time zone identifier to use when creating a %DateTimeFormat% instance.
+          If _toLocaleStringTimeZone_ is provided, it must be a canonical time zone identifier and it will be used to implement the behaviour of `Temporal.ZonedDateTime.prototype.toLocaleString`.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. If _timeZone_ is *undefined*, then
+          1. If _toLocaleStringTimeZone_ is present, return _toLocaleStringTimeZone_.
+          1. Return DefaultTimeZone().
+        1. Assert: _toLocaleStringTimeZone_ is not present.
+        1. Assert: No non-String, non-Object value, when coerced to a String, is an available time zone identifier.
+        1. If Type(_timeZone_) is String, then
+          1. If IsAvailableTimeZoneName(_timeZone_) is *true*, return CanonicalizeTimeZoneName(_timeZone_).
+          1. Set _timeZone_ to ? ExtractTimeZoneIdentifierFromString (_timeZone_).
+        1. Else,
+          1. If Type(_timeZone_) is not Object, throw a *TypeError* exception.
+          1. If _timeZone_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+            1. Set _timeZone_ to ? ToTemporalTimeZoneIdentifier(_timeZone_.[[TimeZone]]).
+          1. Else if ? ObjectImplementsTemporalTimeZoneProtocol (_timeZone_) is *true*, then
+            1. Set _timeZone_ to ? ToTemporalTimeZoneIdentifier(_timeZone_).
+          1. Else,
+            1. Set _timeZone_ to ? ToString(_timeZone_).
+            1. NOTE: To maintain %DateTimeFormat% backwards compatibility, this abstract operation (unlike ToTemporalTimeZoneSlotValue) accepts an object that can be coerced to an available time zone identifier even if ObjectImplementsTemporalTimeZoneProtocol returns *false*, and in that case ToString is used instead of reading the *id* property of the object.
+        1. If IsTimeZoneOffsetString(_timeZone_) is *true*, throw a *RangeError* exception.
+        1. If IsAvailableTimeZoneName(_timeZone_) is *false*, throw a *RangeError* exception.
+        1. Set _timeZone_ to CanonicalizeTimeZoneName(_timeZone_).
+        1. Return _timeZone_.
+      </emu-alg>
+    </emu-clause>
+    </ins>
+
+    <ins class="block">
+    <emu-clause id="sec-interpretcalendaroption" type="abstract operation">
+      <h1>
+        InterpretCalendarOption (
+          _calendar_: an ECMAScript value
+        ): either a normal completion containing a String, or a throw completion</h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines the calendar identifier to use when creating a %DateTimeFormat% instance.</dd>
+      </dl>
+
+      <emu-alg>
+        1. If _calendar_ is *undefined*, return _calendar_.
+        1. Assert: No non-String, non-Object value, when coerced to a String, is a built-in calendar identifier.
+        1. If Type(_calendar_) is String, then
+          1. If IsBuiltinCalendar is *true*, return _calendar_.
+          1. Set _calendar_ to ? ParseTemporalCalendarString(_calendar_).
+        1. Else,
+          1. If Type(_calendar_) is not Object, throw a *TypeError* exception.
+          1. If _calendar_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
+            1. Set _calendar_ to _calendar_.[[Calendar]].
+            1. If Type(_calendar_) is String, return _calendar_.
+            1. Set _calendar_ to ? ToTemporalCalendarIdentifier(_calendar_).
+          1. Else if _calendar_ has an [[InitializedTemporalCalendar]] internal slot, then
+            1. Set _calendar_ to ? ToTemporalCalendarIdentifier(_calendar_).
+          1. Else, set _calendar_ to ? ToString(_calendar_).
+          1. NOTE: To maintain %DateTimeFormat% backwards compatibility, this abstract operation (unlike ToTemporalCalendarSlotValue) accepts an object that can be coerced to a built-in calendar identifier even if it would return *false* from ObjectImplementsTemporalCalendarProtocol, and in that case ToString is used instead of reading the *id* property of the object.
+        1. If IsBuiltinCalendar(_calendar_) is *false*, throw a *RangeError* exception.
+        1. Return _calendar_.
+      </emu-alg>
+    </emu-clause>
+    </ins>
 
     <emu-clause id="sec-datetime-format-functions">
       <h1>DateTime Format Functions</h1>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -601,8 +601,9 @@
             1. Return _temporalTimeZoneLike_.[[TimeZone]].
           1. If ? ObjectImplementsTemporalTimeZoneProtocol(_temporalTimeZoneLike_) is *false*, throw a *TypeError* exception.
           1. Return _temporalTimeZoneLike_.
-        1. Let _identifier_ be ? ToString(_temporalTimeZoneLike_).
-        1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_identifier_).
+        1. Assert: No non-String, non-Object value, when coerced to a String, is an available time zone identifier.
+        1. If Type(_temporalTimeZoneLike_) is not String, throw a *TypeError* exception.
+        1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_temporalTimeZoneLike_).
         1. If _parseResult_.[[Name]] is not *undefined*, then
           1. Let _name_ be _parseResult_.[[Name]].
           1. If IsTimeZoneOffsetString(_name_) is *true*, return CanonicalizeTimeZoneOffsetString(_name_).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -568,6 +568,23 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-canonicalizetimezoneoffsetstring" type="abstract operation">
+      <h1>
+        CanonicalizeTimeZoneOffsetString (
+          _offsetString_: a String
+        ): a String
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _offsetString_, which must be a valid time zone offset string, into its canonical form.</dd>
+      </dl>
+      <emu-alg>
+        1. Assert: IsTimeZoneOffsetString(_offsetString_) is *true*.
+        1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_offsetString_).
+        1. Return ! FormatTimeZoneOffsetString(_offsetNanoseconds_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-totemporaltimezoneslotvalue" type="abstract operation">
       <h1>
         ToTemporalTimeZoneSlotValue (
@@ -588,14 +605,11 @@
         1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_identifier_).
         1. If _parseResult_.[[Name]] is not *undefined*, then
           1. Let _name_ be _parseResult_.[[Name]].
-          1. If IsTimeZoneOffsetString(_name_) is *true*, then
-            1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_name_).
-            1. Return ! FormatTimeZoneOffsetString(_offsetNanoseconds_).
+          1. If IsTimeZoneOffsetString(_name_) is *true*, return CanonicalizeTimeZoneOffsetString(_name_).
           1. If IsAvailableTimeZoneName(_name_) is *false*, throw a *RangeError* exception.
           1. Return ! CanonicalizeTimeZoneName(_name_).
         1. If _parseResult_.[[Z]] is *true*, return *"UTC"*.
-        1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_parseResult_.[[OffsetString]]).
-        1. Return ! FormatTimeZoneOffsetString(_offsetNanoseconds_).
+        1. Return CanonicalizeTimeZoneOffsetString(_parseResult_.[[OffsetString]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -585,6 +585,33 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-extracttimezoneidentifierfromstring" type="abstract operation">
+      <h1>
+        ExtractTimeZoneIdentifierFromString (
+          _temporalTimeZoneLike_: a String,
+        ): either a normal completion containing a String, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It extracts a time zone identifier from a string.
+          If _temporalTimeZoneLike_ is not a time zone identifier, then it must be a string with a time zone annotation that is accepted by ParseTemporalZonedDateTimeString or a string with a UTC offset that is accepted by ParseTemporalInstant.
+          If the result is an offset time zone identifier, then its canonical form is returned.
+          If the result is a named time zone identifier, then it will be resolved to its canonical name.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_temporalTimeZoneLike_).
+        1. If _parseResult_.[[Name]] is not *undefined*, then
+          1. Let _name_ be _parseResult_.[[Name]].
+          1. If IsTimeZoneOffsetString(_name_) is *true*, return CanonicalizeTimeZoneOffsetString(_name_).
+          1. If IsAvailableTimeZoneName(_name_) is *false*, throw a *RangeError* exception.
+          1. Return ! CanonicalizeTimeZoneName(_name_).
+        1. If _parseResult_.[[Z]] is *true*, return *"UTC"*.
+        1. Return CanonicalizeTimeZoneOffsetString(_parseResult_.[[OffsetString]]).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-totemporaltimezoneslotvalue" type="abstract operation">
       <h1>
         ToTemporalTimeZoneSlotValue (
@@ -596,21 +623,17 @@
         <dd>It attempts to derive a value from _temporalTimeZoneLike_ that is suitable for storing in a Temporal.ZonedDateTime's [[TimeZone]] internal slot, and returns that value if found or throws an exception if not.</dd>
       </dl>
       <emu-alg>
-        1. If Type(_temporalTimeZoneLike_) is Object, then
-          1. If _temporalTimeZoneLike_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
-            1. Return _temporalTimeZoneLike_.[[TimeZone]].
-          1. If ? ObjectImplementsTemporalTimeZoneProtocol(_temporalTimeZoneLike_) is *false*, throw a *TypeError* exception.
-          1. Return _temporalTimeZoneLike_.
         1. Assert: No non-String, non-Object value, when coerced to a String, is an available time zone identifier.
-        1. If Type(_temporalTimeZoneLike_) is not String, throw a *TypeError* exception.
-        1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_temporalTimeZoneLike_).
-        1. If _parseResult_.[[Name]] is not *undefined*, then
-          1. Let _name_ be _parseResult_.[[Name]].
-          1. If IsTimeZoneOffsetString(_name_) is *true*, return CanonicalizeTimeZoneOffsetString(_name_).
-          1. If IsAvailableTimeZoneName(_name_) is *false*, throw a *RangeError* exception.
-          1. Return ! CanonicalizeTimeZoneName(_name_).
-        1. If _parseResult_.[[Z]] is *true*, return *"UTC"*.
-        1. Return CanonicalizeTimeZoneOffsetString(_parseResult_.[[OffsetString]]).
+        1. If Type(_temporalTimeZoneLike_) is String, then
+          1. If IsAvailableTimeZoneName(_temporalTimeZoneLike_) is *true*, return CanonicalizeTimeZoneName(_temporalTimeZoneLike_).
+          1. Set _temporalTimeZoneLike_ to ? ExtractTimeZoneIdentifierFromString (_temporalTimeZoneLike_).
+        1. Else,
+          1. If Type(_temporalTimeZoneLike_) is not Object, throw a *TypeError* exception.
+          1. If _temporalTimeZoneLike_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+            1. Set _temporalTimeZoneLike_ to _temporalTimeZoneLike_.[[TimeZone]].
+          1. Else if ? ObjectImplementsTemporalTimeZoneProtocol(_temporalTimeZoneLike_) is *false*, then
+            1. Throw a *TypeError* exception.
+        1. Return _temporalTimeZoneLike_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
This PR makes the `calendar` and `timeZone` options in Temporal types' `toLocaleString` methods accept the same types as other Temporal methods that accept a calendar or time zone parameter.  This PR also makes the same change to `Intl.DateTimeFormat`  constructor, which is implemented using a common abstract operation as `toLocaleString`. Fixes #2005.

Before this PR, the only types accepted by these localization methods were:
* string IDs of the calendar or time zone
* Temporal.TimeZone or Temporal.Calendar instances, because they can be coerced to string IDs.

This PR adds support for the following types in order to match the behavior of other Temporal methods which also accept the following in place of a calendar or time zone parameter:
* ISO strings, e.g. `"2020-01-01T00:00-05:00[Asia/Tokyo][u-ca=japanese]"`
* other Temporal types that have a `calendar` or `timeZone` property, e.g. `Temporal.PlainDate` or `Temporal.ZonedDateTime`

Note that `InitializeDateTimeFormat` currently: 
* Accepts objects that can be coerced into built-in identifiers, while `ToTemporal(Calendar|TimeZone)SlotValue` rejects objects unless they implement the time zone or calendar protocols, respectively.
* Uses `ToString` to get the identifier from an object, while `ToTemporal(Calendar|TimeZone)SlotValue` uses the `id` getter.

I assume that we want to continue using the existing behavior for `InitializeDateTimeFormat` options, even if it means a slight deviation from how objects are treated in Temporal methods.