### PR TITLE
Editorial: Fix CanonicalizeTimeZoneName formatting

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -49,10 +49,11 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sup-canonicalizetimezonename" aoid="CanonicalizeTimeZoneName402">
-      <h1><a href="https://tc39.es/ecma402/#sec-canonicalizetimezonename">CanonicalizeTimeZoneName</a> ( _timeZone_ )</h1>
+    <!-- Remove the zero-width space when merging into ecma402; this is in order
+         to prevent ecmarkup from complaining about duplicate-named AOs -->
+    <emu-clause id="sup-canonicalizetimezonename" type="abstract operation">
       <h1>
-        CanonicalizeTimeZoneName (
+        CanonicalizeTimeZoneName&ZeroWidthSpace; (
           _timeZone_: a String value that is a valid time zone name as verified by IsValidTimeZoneName,
         )
       </h1>
@@ -61,16 +62,16 @@
         <dd>It returns the canonical and case-regularized form of _timeZone_.</dd>
       </dl>
 
-      <ins class="block">
-        <p>This definition supersedes the definition provided in <emu-xref href="#sec-canonicalizetimezonename"></emu-xref>.</p>
-      </ins>
-
       <emu-alg>
         1. Let _ianaTimeZone_ be the String value of the Zone or Link name of the IANA Time Zone Database that is an ASCII-case-insensitive match of _timeZone_ as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"></emu-xref>.
         1. If _ianaTimeZone_ is a Link name, let _ianaTimeZone_ be the String value of the corresponding Zone name as specified in the file <code>backward</code> of the IANA Time Zone Database.
         1. If _ianaTimeZone_ is *"Etc/UTC"* or *"Etc/GMT"*, return *"UTC"*.
         1. Return _ianaTimeZone_.
       </emu-alg>
+
+      <ins class="block">
+        <p>This definition supersedes the definition provided in <emu-xref href="#sec-canonicalizetimezonename"></emu-xref>.</p>
+      </ins>
     </emu-clause>
 
     <emu-clause id="sup-defaulttimezone">


### PR DESCRIPTION
CanonicalizeTimeZoneName ended up with two headers, probably due to a
rebase error.

Adds a zero-width space to the operation name, otherwise ecmarkup will not
allow a 262 and 402 version to be defined in the same document.

Finally, moves the note about superseding the previous definition to the
end of the clause. Otherwise ecmarkup will not render the "It performs the
following steps" text.