### PR TITLE
Bump ecmarkup and enable "user code" annotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "@tc39/ecma262-biblio": "=1.0.2251",
+        "@tc39/ecma262-biblio": "=2.0.2285",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
         "@typescript-eslint/parser": "^5.12.1",
-        "ecmarkup": "^10.0.2",
+        "ecmarkup": "^12.0.2",
         "eslint": "^8.9.0",
         "eslint-config-prettier": "^8.4.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@tc39/ecma262-biblio": {
-      "version": "1.0.2251",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-1.0.2251.tgz",
-      "integrity": "sha512-ZeJAQRaAdPHtxchEBv5jb7SOvlXVansgfTcQxCeWkWy7ERi2l73qkNUbFoWBkges3E9YDfUnWnIkrV3r7j+9sQ==",
+      "version": "2.0.2285",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.0.2285.tgz",
+      "integrity": "sha512-nPPoDa9X4oRpjT1rkEPYsqqRpEWN3ZjDbuUvKOg09rCLTt3VsMBldcr7j1w5sBFlriU9dUaIuuZr4lzj8iCOxg==",
       "dev": true
     },
     "node_modules/@tootallnate/once": {
@@ -573,23 +573,38 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=7.0.0"
       }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -668,19 +683,19 @@
       }
     },
     "node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -953,12 +968,12 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-10.0.2.tgz",
-      "integrity": "sha512-n7+7oHHA/vKZr/J4KNAFNLfaqOuNohAytwBmY55t+iUcZzoCZod7I3HIG0gSwnOGnET4sWQwv1HF41nbR3MqjA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.0.2.tgz",
+      "integrity": "sha512-83vIhURcVOr+5VyCzPXXESeDD7l0RkY0YSdEvYPMaq5vth+Iy7zN8sEG8E6LbVaKaIoALLQLnvCM3Ic6Zy1Vkg==",
       "dev": true,
       "dependencies": {
-        "chalk": "^1.1.3",
+        "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
@@ -1156,76 +1171,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/eslint-formatter-codeframe/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/eslint-formatter-codeframe/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/eslint-formatter-codeframe/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-formatter-codeframe/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/eslint-formatter-codeframe/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint-formatter-codeframe/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
@@ -1305,59 +1250,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/eslint/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/eslint/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
@@ -1394,15 +1290,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/eslint/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/eslint/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1422,18 +1309,6 @@
       "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -1746,18 +1621,6 @@
       },
       "bin": {
         "grammarkdown": "bin/grammarkdown"
-      }
-    },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/has-flag": {
@@ -2450,18 +2313,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2475,12 +2326,24 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=8"
       }
     },
     "node_modules/symbol-tree": {
@@ -3050,9 +2913,9 @@
       }
     },
     "@tc39/ecma262-biblio": {
-      "version": "1.0.2251",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-1.0.2251.tgz",
-      "integrity": "sha512-ZeJAQRaAdPHtxchEBv5jb7SOvlXVansgfTcQxCeWkWy7ERi2l73qkNUbFoWBkges3E9YDfUnWnIkrV3r7j+9sQ==",
+      "version": "2.0.2285",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.0.2285.tgz",
+      "integrity": "sha512-nPPoDa9X4oRpjT1rkEPYsqqRpEWN3ZjDbuUvKOg09rCLTt3VsMBldcr7j1w5sBFlriU9dUaIuuZr4lzj8iCOxg==",
       "dev": true
     },
     "@tootallnate/once": {
@@ -3226,17 +3089,31 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -3303,16 +3180,13 @@
       "dev": true
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       }
     },
     "color-convert": {
@@ -3533,12 +3407,12 @@
       }
     },
     "ecmarkup": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-10.0.2.tgz",
-      "integrity": "sha512-n7+7oHHA/vKZr/J4KNAFNLfaqOuNohAytwBmY55t+iUcZzoCZod7I3HIG0gSwnOGnET4sWQwv1HF41nbR3MqjA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-12.0.2.tgz",
+      "integrity": "sha512-83vIhURcVOr+5VyCzPXXESeDD7l0RkY0YSdEvYPMaq5vth+Iy7zN8sEG8E6LbVaKaIoALLQLnvCM3Ic6Zy1Vkg==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
+        "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
@@ -3676,44 +3550,10 @@
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "escape-string-regexp": {
@@ -3738,12 +3578,6 @@
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3760,15 +3594,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }
@@ -3788,57 +3613,6 @@
       "requires": {
         "@babel/code-frame": "7.12.11",
         "chalk": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "eslint-plugin-prettier": {
@@ -4123,15 +3897,6 @@
       "requires": {
         "@esfx/async-canceltoken": "^1.0.0-pre.13",
         "@esfx/cancelable": "^1.0.0-pre.13"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -4637,15 +4402,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4653,10 +4409,21 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        }
+      }
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "main": "polyfill/lib/index.mjs",
   "devDependencies": {
-    "@tc39/ecma262-biblio": "=1.0.2251",
+    "@tc39/ecma262-biblio": "=2.0.2285",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
-    "ecmarkup": "^10.0.2",
+    "ecmarkup": "^12.0.2",
     "eslint": "^8.9.0",
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/spec.html
+++ b/spec.html
@@ -4,6 +4,7 @@
 title: Temporal proposal
 stage: 3
 contributors: Maggie Pint, Matt Johnson, Brian Terlson, Daniel Ehrenberg, Philipp Dunkel, Sasha Pierson, Ujjwal Sharma, Philip Chimento, Justin Grant
+markEffects: true
 </pre>
 <emu-biblio href="spec/biblio.json"></emu-biblio>
 

--- a/spec.html
+++ b/spec.html
@@ -13,7 +13,7 @@ contributors: Maggie Pint, Matt Johnson, Brian Terlson, Daniel Ehrenberg, Philip
   <p>The Temporal set of types addresses these challenges with a built-in date and time API for ECMAScript that includes:</p>
   <ul>
     <li>First-class support for all time zones, including DST-safe arithmetic</li>
-    <li>Strongly-typed objects for dates, times, date/time values, year/month values, month/year values, "zoned" date/time values, and durations</li>
+    <li>Strongly-typed objects for dates, times, date/<emu-not-ref>time values</emu-not-ref>, year/month values, month/year values, "zoned" date/<emu-not-ref>time values</emu-not-ref>, and durations</li>
     <li>Immutability for all Temporal objects</li>
     <li>String serialization and interoperability via standardized formats</li>
     <li>Compliance with industry standards like ISO 8601, RFC 3339, and RFC5545 (iCalendar)</li>

--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -1,119 +1,116 @@
-{
-  "https://tc39.es/ecma262/": [
-    {
-      "type": "term",
-      "term": "%Date.now%",
-      "id": "sec-date.now"
-    },
-    {
-      "type": "term",
-      "term": "clamping",
-      "id": "clamping"
-    }
-  ],
-  "https://tc39.es/ecma402/": [
-    {
-      "type": "note",
-      "id": "legacy-constructor"
-    },
-    {
-      "type": "op",
-      "aoid": "BasicFormatMatcher",
-      "id": "sec-basicformatmatcher"
-    },
-    {
-      "type": "op",
-      "aoid": "BestFitFormatMatcher",
-      "id": "sec-bestfitformatmatcher"
-    },
-    {
-      "type": "op",
-      "aoid": "CanonicalizeLocaleList",
-      "id": "sec-canonicalizelocalelist"
-    },
-    {
-      "type": "op",
-      "aoid": "FormatNumeric",
-      "id": "sec-formatnumber"
-    },
-    {
-      "type": "op",
-      "aoid": "GetNumberOption",
-      "id": "sec-getnumberoption"
-    },
-    {
-      "type": "op",
-      "aoid": "ToDateTimeOptions",
-      "id": "sec-todatetimeoptions"
-    },
-    {
-      "type": "op",
-      "aoid": "ToLocalTime",
-      "id": "sec-tolocaltime"
-    },
-    {
-      "type": "op",
-      "aoid": "UnwrapDateTimeFormat",
-      "id": "sec-unwrapdatetimeformat"
-    },
-    {
-      "type": "clause",
-      "number": "Internal slots",
-      "id": "sec-intl.datetimeformat-internal-slots"
-    },
-    {
-      "type": "clause",
-      "number": "get Intl.DateTimeFormat.prototype.format",
-      "id": "sec-intl.datetimeformat.prototype.format"
-    },
-    {
-      "type": "clause",
-      "number": "6.1",
-      "id": "sec-case-sensitivity-and-case-mapping"
-    },
-    {
-      "type": "term",
-      "term": "%DateTimeFormat%",
-      "id": "sec-intl-datetimeformat-constructor"
-    },
-    {
-      "type": "term",
-      "term": "%NumberFormat%",
-      "id": "sec-intl-numberformat-constructor"
-    },
-    {
-      "type": "clause",
-      "number": "Table 6",
-      "id": "table-datetimeformat-components"
-    },
-    {
-      "type": "clause",
-      "number": "Table 7",
-      "id": "table-datetimeformat-tolocaltime-record"
-    },
-    {
-      "type": "op",
-      "aoid": "DateTimeStyleFormat",
-      "id": "sec-date-time-style-format"
-    },
-    {
-      "type": "op",
-      "aoid": "PartitionPattern",
-      "id": "sec-partitionpattern"
-    }
-  ],
-  "https://tc39.es/proposal-intl-duration-format/": [
-    {
-      "type": "op",
-      "aoid": "PartitionDurationFormatPattern",
-      "id": "sec-partitiondurationformatpattern"
-    }
-  ],
-  "https://tc39.es/proposal-intl-DateTimeFormat-formatRange/": [
-    {
-      "type": "clause",
-      "number": 3,
-      "id": "table-datetimeformat-rangepatternfields"
-    }
-  ]
-}
+[
+  {
+    "location": "https://tc39.es/ecma402/",
+    "entries": [
+      {
+        "type": "note",
+        "id": "legacy-constructor"
+      },
+      {
+        "type": "op",
+        "aoid": "BasicFormatMatcher",
+        "id": "sec-basicformatmatcher"
+      },
+      {
+        "type": "op",
+        "aoid": "BestFitFormatMatcher",
+        "id": "sec-bestfitformatmatcher"
+      },
+      {
+        "type": "op",
+        "aoid": "CanonicalizeLocaleList",
+        "id": "sec-canonicalizelocalelist"
+      },
+      {
+        "type": "op",
+        "aoid": "FormatNumeric",
+        "id": "sec-formatnumber"
+      },
+      {
+        "type": "op",
+        "aoid": "GetNumberOption",
+        "id": "sec-getnumberoption"
+      },
+      {
+        "type": "op",
+        "aoid": "ToDateTimeOptions",
+        "id": "sec-todatetimeoptions"
+      },
+      {
+        "type": "op",
+        "aoid": "ToLocalTime",
+        "id": "sec-tolocaltime"
+      },
+      {
+        "type": "op",
+        "aoid": "UnwrapDateTimeFormat",
+        "id": "sec-unwrapdatetimeformat"
+      },
+      {
+        "type": "clause",
+        "number": "Internal slots",
+        "id": "sec-intl.datetimeformat-internal-slots"
+      },
+      {
+        "type": "clause",
+        "number": "get Intl.DateTimeFormat.prototype.format",
+        "id": "sec-intl.datetimeformat.prototype.format"
+      },
+      {
+        "type": "clause",
+        "number": "6.1",
+        "id": "sec-case-sensitivity-and-case-mapping"
+      },
+      {
+        "type": "term",
+        "term": "%DateTimeFormat%",
+        "id": "sec-intl-datetimeformat-constructor"
+      },
+      {
+        "type": "term",
+        "term": "%NumberFormat%",
+        "id": "sec-intl-numberformat-constructor"
+      },
+      {
+        "type": "clause",
+        "number": "Table 6",
+        "id": "table-datetimeformat-components"
+      },
+      {
+        "type": "clause",
+        "number": "Table 7",
+        "id": "table-datetimeformat-tolocaltime-record"
+      },
+      {
+        "type": "op",
+        "aoid": "DateTimeStyleFormat",
+        "id": "sec-date-time-style-format"
+      },
+      {
+        "type": "op",
+        "aoid": "PartitionPattern",
+        "id": "sec-partitionpattern"
+      }
+    ]
+  },
+  {
+    "location": "https://tc39.es/proposal-intl-duration-format/",
+    "entries": [
+      {
+        "type": "op",
+        "aoid": "PartitionDurationFormatPattern",
+        "id": "sec-partitiondurationformatpattern"
+      }
+    ]
+  },
+  {
+    "location": "https://tc39.es/proposal-intl-DateTimeFormat-formatRange/",
+    "entries": [
+      {
+        "type": "clause",
+        "number": 3,
+        "id": "table-datetimeformat-rangepatternfields"
+      }
+    ]
+  }
+]

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -49,17 +49,17 @@
       </emu-alg>
     </emu-clause>
 
-    <!-- Remove the zero-width space when merging into ecma402; this is in order
-         to prevent ecmarkup from complaining about duplicate-named AOs -->
     <emu-clause id="sup-canonicalizetimezonename" type="abstract operation">
       <h1>
-        CanonicalizeTimeZoneName&ZeroWidthSpace; (
+        CanonicalizeTimeZoneName (
           _timeZone_: a String value that is a valid time zone name as verified by IsValidTimeZoneName,
         )
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It returns the canonical and case-regularized form of _timeZone_.</dd>
+        <dt>redefinition</dt>
+        <dd>true</dd>
       </dl>
 
       <emu-alg>


### PR DESCRIPTION
cc @gibson042 

See https://github.com/tc39/ecma262/pull/2548 for a description of the annotation. The relevant information is now propagated in the biblio, so it can be used in proposals. In ecmarkup the annotation off by default because it may require manual annotation to be correct, but I've enabled it in this PR: I don't think any sites in this PR need annotation - there's no use of `[[Get]]` and friends directly, no weird stuff with generators, etc. (I didn't review extremely carefully, though.)

Also
- makes use of https://github.com/tc39/ecmarkup/pull/428 to get rid of the `&ZeroWidthSpace;` hack.
- marks a couple of uses of the phrase "time value" as not being [in the more precise ecma262 sense of the term](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-time-values-and-time-range).