### PR TITLE
Clarify Temporal.Instant docs

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -114,6 +114,10 @@ overrides:
       prettier/prettier: 'off'
       quotes: 'off'
   - files:
+      - docs/cookbook/fromLegacyDateOnly.mjs
+    rules:
+      prettier/prettier: 'off'
+  - files:
       - polyfill/test/helpers/temporalHelpers.js
     rules:
       no-unused-vars: 'off'

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,4 +1,4 @@
-# Temporal Cookbook
+# `Temporal` Cookbook
 
 ## Overview
 
@@ -10,8 +10,8 @@ Running cookbook files: see instructions in [../polyfill/README.md](https://gith
 
 ## Frequently Asked Questions
 
-These are some of the most common tasks that people ask questions about on StackOverflow with legacy Date.
-Here's how they would look using Temporal.
+These are some of the most common tasks that people ask questions about on StackOverflow with legacy `Date`.
+Here's how they would look using `Temporal`.
 
 ### Current date and time
 
@@ -36,11 +36,11 @@ How to get a Unix timestamp?
 ```
 <!-- prettier-ignore-end -->
 
-## Converting between Temporal types and legacy Date
+## Converting between `Temporal` types and legacy `Date`
 
-### Temporal types from legacy Date
+### Legacy `Date` => `Temporal.Instant` and/or `Temporal.ZonedDateTime`
 
-Here's how to convert legacy ECMAScript Date into a Temporal.Instant or Temporal.ZonedDateTime instance corresponding to the same instant in exact time.
+Here's how to convert legacy ECMAScript `Date` into a `Temporal.Instant` or `Temporal.ZonedDateTime` instance corresponding to the same instant in exact time.
 
 <!-- prettier-ignore-start -->
 ```javascript
@@ -48,9 +48,31 @@ Here's how to convert legacy ECMAScript Date into a Temporal.Instant or Temporal
 ```
 <!-- prettier-ignore-end -->
 
-### Legacy Date from Temporal types
+### Date-only values: legacy `Date` => `Temporal.PlainDate`
 
-Legacy Date represents an exact time, so it's straightforward to convert a Temporal.Instant or Temporal.ZonedDateTime instance into a legacy Date instance that corresponds to it.
+A common bug arises from a simple question: what date (year, month, and day) is represented by this `Date`?
+The problem: the answer depends on the time zone.
+The same `Date` can be December 31 in San Francisco but January 1 in London or Tokyo.
+
+Therefore, it's critical to interpret the `Date` in context of the correct time zone _before_ trying to extract the year, month, or day, or before doing calculations like "did this happen yesterday?" involving date units.
+For this reason, `Temporal.Instant` (which is the `Temporal` equivalent of `Date`) does not have `year`, `month`, `day` properties.
+To access date or time units in `Temporal`, a time zone must be provided, as described in the code example above.
+
+Another bug-prone case is when `Date` is (ab)used to store a date-only value, like a user's date of birth.
+With `Date` these values are typically stored with midnight times, but to read back the date correctly you need to know which time zone's midnight was used to create the `Date`.
+For example, `new Date(2000, 0, 1)` uses the caller's time zone, while `new Date('2000-01-01')` uses UTC.
+
+To correctly convert a date-only `Date` to a `Temporal.PlainDate` without being vulnerable to off-by-one-day bugs, you must determine which time zone's midnight was used to construct the `Date`, and then use that same time zone when converting from `Temporal.Instant` to `Temporal.PlainDate`.
+
+<!-- prettier-ignore-start -->
+```javascript
+{{cookbook/fromLegacyDateOnly.mjs}}
+```
+<!-- prettier-ignore-end -->
+
+### `Temporal` types => legacy `Date`
+
+Legacy `Date` represents an exact time, so it's straightforward to convert a `Temporal.Instant` or `Temporal.ZonedDateTime` instance into a legacy `Date` instance that corresponds to it.
 
 <!-- prettier-ignore-start -->
 ```javascript
@@ -72,7 +94,7 @@ Legacy Date represents an exact time, so it's straightforward to convert a Tempo
 
 ### Calendar input element
 
-You can use Temporal objects to set properties on a calendar control.
+You can use `Temporal` objects to set properties on a calendar control.
 Here is an example using an HTML `<input type="date">` element with any day beyond “today” disabled and not selectable.
 
 <input type="date" id="calendar-input">
@@ -115,13 +137,13 @@ An example of combining a day on the calendar (`Temporal.PlainMonthDay`) and a y
 
 ### Zoned instant from instant and time zone
 
-To serialize an exact-time Temporal.Instant into a string, use `toString()`.
+To serialize an exact-time `Temporal.Instant` into a string, use `toString()`.
 Without any arguments, this gives you a string in UTC time.
 
 If you need your string to include a UTC offset, then use the `timeZone` option of `Temporal.Instant.prototype.toString()` which will return a string serialization of the wall-clock time in that time zone corresponding to the exact time.
 
 This loses the information about which time zone the string was in, because it only preserves the UTC offset from the time zone at that particular exact time.
-If you need your string to include the time zone name, use Temporal.ZonedDateTime instead, which retains this information.
+If you need your string to include the time zone name, use `Temporal.ZonedDateTime` instead, which retains this information.
 
 <!-- prettier-ignore-start -->
 ```javascript
@@ -131,12 +153,12 @@ If you need your string to include the time zone name, use Temporal.ZonedDateTim
 
 ## Sorting
 
-Each Temporal type has a `compare()` static method, which can be passed to `Array.prototype.sort()` as the compare function in order to sort an array of Temporal types.
+Each `Temporal` type has a `compare()` static method, which can be passed to `Array.prototype.sort()` as the compare function in order to sort an array of `Temporal` types.
 
-### Sort DateTimes
+### Sort PlainDateTime values
 
 Sort a list of `Temporal.PlainDateTime`s, for example in order to get a conference schedule in the correct order.
-Sorting other Temporal types would work exactly the same way as this.
+Sorting other `Temporal` types would work exactly the same way.
 
 <!-- prettier-ignore-start -->
 ```javascript
@@ -158,7 +180,7 @@ Sort a list of ISO 8601 date/time strings, for example to place log entries in o
 
 ### Round a time down to whole hours
 
-Use the `round()` method of each Temporal type if you want to round the time fields.
+Use the `round()` method of each `Temporal` type if you want to round the time fields.
 Here's an example of rounding a time _down_ to the previously occurring whole hour:
 
 <!-- prettier-ignore-start -->
@@ -187,7 +209,7 @@ See also [Push back a launch date](#push-back-a-launch-date) for an easier way t
 ### Preserving local time
 
 Map a zoneless date and time of day into a `Temporal.Instant` instance at which the local date and time of day in a specified time zone matches it.
-This is easily done with `dateTime.toZonedDateTime(timeZone).toInstant()`, but here is an example of implementing different disambiguation behaviors than the `'compatible'`, `'earlier'`, `'later'`, and `'reject'` ones built in to Temporal.
+This is easily done with `dateTime.toZonedDateTime(timeZone).toInstant()`, but here is an example of implementing different disambiguation behaviors than the `'compatible'`, `'earlier'`, `'later'`, and `'reject'` ones built in to `Temporal`.
 
 <!-- prettier-ignore-start -->
 ```javascript
@@ -262,7 +284,7 @@ Also using `Temporal.TimeZone.getOffsetNanosecondsFor()`, we can map a `Temporal
 
 ### Dealing with dates and times in a fixed location
 
-Here is an example of Temporal used in a graph, showing fictitious activity for a storage tank in a fixed location (Stockholm, Sweden).
+Here is an example of `Temporal` used in a graph, showing fictitious activity for a storage tank in a fixed location (Stockholm, Sweden).
 The graph always starts at midnight in the tank's location, but the graph labels are in the viewer's time zone.
 
 <!-- prettier-ignore-start -->
@@ -397,7 +419,7 @@ An example HTML form inspired by [Days Calculator](https://www.timeanddate.com/d
 
 ### Unit-constrained duration between now and a past/future zoned event
 
-Take the difference between two Temporal.Instant instances as a Temporal.Duration instance (positive or negative), representing the duration between the two instants without using units coarser than specified (e.g., for presenting a meaningful countdown with vs. without using months or days).
+Take the difference between two `Temporal.Instant` instances as a `Temporal.Duration` instance (positive or negative), representing the duration between the two instants without using units coarser than specified (e.g., for presenting a meaningful countdown with vs. without using months or days).
 
 <!-- prettier-ignore-start -->
 ```javascript
@@ -407,7 +429,7 @@ Take the difference between two Temporal.Instant instances as a Temporal.Duratio
 
 ### Nearest offset transition in a time zone
 
-Map a Temporal.Instant instance and a Temporal.TimeZone object into a Temporal.Instant instance representing the nearest following exact time at which there is an offset transition in the time zone (e.g., for setting reminders).
+Map a `Temporal.Instant` instance and a `Temporal.TimeZone` object into a `Temporal.Instant` instance representing the nearest following exact time at which there is an offset transition in the time zone (e.g., for setting reminders).
 
 <!-- prettier-ignore-start -->
 ```javascript
@@ -539,12 +561,12 @@ The following example calculates this.
 
 ## Advanced use cases
 
-These are not expected to be part of the normal usage of Temporal, but show some unusual things that can be done with Temporal.
+These are not expected to be part of the normal usage of `Temporal`, but show some unusual things that can be done with `Temporal`.
 Since they are generally larger than these cookbook recipes, they're on their own pages.
 
 ### Extra-expanded years
 
-Extend Temporal to support arbitrarily-large years (e.g., **+635427810-02-02**) for astronomical purposes.
+Extend `Temporal` to support arbitrarily-large years (e.g., **+635427810-02-02**) for astronomical purposes.
 
 → [Extra-expanded years](cookbook-expandedyears.md)
 

--- a/docs/cookbook/all.mjs
+++ b/docs/cookbook/all.mjs
@@ -5,6 +5,7 @@ import './bridgePublicHolidays.mjs';
 import './calculateDailyOccurrence.mjs';
 import './countPrecedingWeeklyDaysInMonth.mjs';
 import './fromLegacyDate.mjs';
+import './fromLegacyDateOnly.mjs';
 import './getBusinessOpenStateText.mjs';
 import './getCurrentDate.mjs';
 import './getElapsedDurationSinceInstant.mjs';

--- a/docs/cookbook/fromLegacyDate.mjs
+++ b/docs/cookbook/fromLegacyDate.mjs
@@ -13,7 +13,7 @@ assert.equal(instant.toString(), '1970-01-01T00:00:01Z');
 // whether you want that exact time interpreted as a UTC value
 // (using methods containing "UTC" in their names) or in the
 // current system time zone (using other methods). This is
-// confusing, so Temporal has a more explict way to do this.
+// confusing, so Temporal has a more explicit way to do this.
 
 // To use the system's local time zone, which corresponds to using
 // legacy Date's getFullYear(), getMonth(), etc. methods, pass

--- a/docs/cookbook/fromLegacyDateOnly.mjs
+++ b/docs/cookbook/fromLegacyDateOnly.mjs
@@ -1,0 +1,18 @@
+// Convert a year/month/day `Date` to a `Temporal.PlainDate`. Uses the caller's time zone.
+let date = new Date(2000, 0, 1); // => Sat Jan 01 2000 00:00:00 GMT-0800 (Pacific Standard Time)
+let plainDate = date
+  .toTemporalInstant()                         // => 2000-01-01T08:00:00Z
+  .toZonedDateTimeISO(Temporal.Now.timeZone()) // => 2000-01-01T00:00:00-08:00[America/Los_Angeles]
+  .toPlainDate();                              // => 2000-01-01
+
+assert.equal(plainDate.toString(), '2000-01-01');
+
+// Convert a year/month/day `Date` to a `Temporal.PlainDate`. Uses UTC.
+date = new Date(Date.UTC(2000, 0, 1)); // => Fri Dec 31 1999 16:00:00 GMT-0800 (Pacific Standard Time)
+date = new Date('2000-01-01T00:00Z');  // => Fri Dec 31 1999 16:00:00 GMT-0800 (Pacific Standard Time)
+plainDate = date
+  .toTemporalInstant()       // => 2000-01-01T00:00:00Z
+  .toZonedDateTimeISO('UTC') // => 2000-01-01T00:00:00+00:00[UTC]
+  .toPlainDate();            // => 2000-01-01
+
+assert.equal(plainDate.toString(), '2000-01-01');

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -81,6 +81,8 @@ plainDate = date
 ```
 <!-- prettier-ignore-end -->
 
+For detailed how-to information about interoperating with `Date`, see [Converting between `Temporal` types and legacy `Date`](cookbook.md#converting-between-temporal-types-and-legacy-date).
+
 ## Constructor
 
 ### **new Temporal.Instant**(_epochNanoseconds_ : bigint) : Temporal.Instant

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -47,41 +47,31 @@ instant = Temporal.Instant.from('2020-01-01T00:00:00.123456789+05:30');
 date = new Date(instant.epochMilliseconds);
 date.toISOString();                                        // => 2019-12-31T18:30:00.123Z
 
-// `Date`, like `Temporal.Instant`, only stores an integer count of time since epoch.
-// It does not store a time zone nor an offset. The time zone & offset shown below
-// are fetched (from the caller's time zone) at runtime by `Date.prototype.toString`.
-date.toString(); // => Tue Dec 31 2019 10:30:00 GMT-0800 (Pacific Standard Time)
-
-// All three lines below convert `Date` to `Temporal.Instant`, but `toTemporalInstant` is recommended.
-instant2 = date.toTemporalInstant();                       // => 2019-12-31T18:30:00.123Z
-instant3 = Temporal.Instant.fromEpochMilliseconds(date);   // => 2019-12-31T18:30:00.123Z
-instant4 = Temporal.Instant.from(date.toISOString());      // => 2019-12-31T18:30:00.123Z
+// Convert from `Date` to `Temporal.Instant`
+sameInstant = date.toTemporalInstant();                    // => 2019-12-31T18:30:00.123Z
 ```
 <!-- prettier-ignore-end -->
 
-After a `Date` has been converted to a `Temporal.Instant`, it's easy to convert to other `Temporal` types.
-Just make sure to use the correct time zone when converting between `Temporal.Instant` and other `Temporal` types.
+A `Date` that's been converted to a `Temporal.Instant` can be easily converted to a `Temporal.ZonedDateTime` object by providing a time zone.
+From there, calendar and clock properties like `day` or `hour` are available.
+Conversions to narrower types like `Temporal.PlainDate` or `Temporal.PlainTime` are also provided.
 
 <!-- prettier-ignore-start -->
 ```javascript
-// Convert a year/month/day `Date` to a `Temporal.PlainDate`. Uses the caller's time zone.
-date = new Date(2000, 0, 1); // => Sat Jan 01 2000 00:00:00 GMT-0800 (Pacific Standard Time)
-plainDate = date
-  .toTemporalInstant()                         // => 2000-01-01T08:00:00Z
-  .toZonedDateTimeISO(Temporal.Now.timeZone()) // => 2000-01-01T00:00:00-08:00[America/Los_Angeles]
-  .toPlainDate();                              // => 2000-01-01
-
-// Convert a year/month/day `Date` to a `Temporal.PlainDate`. Uses UTC.
-date = new Date(Date.UTC(2000, 0, 1)); // => Fri Dec 31 1999 16:00:00 GMT-0800 (Pacific Standard Time)
-date = new Date('2000-01-01T00:00Z');  // => Fri Dec 31 1999 16:00:00 GMT-0800 (Pacific Standard Time)
-plainDate = date
-  .toTemporalInstant()       // => 2000-01-01T00:00:00Z
-  .toZonedDateTimeISO('UTC') // => 2000-01-01T00:00:00+00:00[UTC]
-  .toPlainDate();            // => 2000-01-01
+date = new Date(2019, 11, 31, 18, 30);  // => Tue Dec 31 2019 18:30:00 GMT-0800 (Pacific Standard Time)
+instant = date.toTemporalInstant();     // => 2020-01-01T02:30:00Z
+zonedDateTime = instant.toZonedDateTimeISO(Temporal.Now.timeZone());
+                                        // => 2019-12-31T18:30:00-08:00[America/Los_Angeles]
+zonedDateTime.day;                      // => 31
+dateOnly = zonedDateTime.toPlainDate(); // => 2019-12-31
 ```
 <!-- prettier-ignore-end -->
 
-For detailed how-to information about interoperating with `Date`, see [Converting between `Temporal` types and legacy `Date`](cookbook.md#converting-between-temporal-types-and-legacy-date).
+Bugs in `Date`=>`Temporal` conversions can be caused by picking the wrong time zone when converting from `Temporal.Instant` to `Temporal.ZonedDateTime`.
+For example, the example above constructs the `Date` using local-timezone parameters, so it uses the system time zone: `Temporal.Now.timeZone()`.
+But if the `Date` had been initialized with a string like `'2019-12-31'`, then getting the same date back in a `Temporal.PlainDate` would require using the `'UTC'` time zone instead.
+
+For discussion and code examples about picking the correct time zone, and also about `Date`<=>`Temporal` interoperability in general, see [Converting between `Temporal` types and legacy `Date`](cookbook.md#converting-between-temporal-types-and-legacy-date) in the documentation cookbook.
 
 ## Constructor
 

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -7,14 +7,46 @@
 
 A `Temporal.Instant` is a single point in time (called **"exact time"**), with a precision in nanoseconds.
 No time zone or calendar information is present.
-As such `Temporal.Instant` has no concept of days, months or even hours.
+To obtain local date/time units like year, month, day, or hour, a `Temporal.Instant` must be combined with a `Temporal.TimeZone` instance or a time zone string.
 
-For convenience of interoperability, it internally uses nanoseconds since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time) (midnight UTC on January 1, 1970).
-However, a `Temporal.Instant` can be created from any of several expressions that refer to an exact time, including an ISO 8601 string with a time zone such as `'2020-01-23T17:04:36.491865121-08:00'`.
+<!-- prettier-ignore-start -->
+```javascript
+instant = Temporal.Instant.from('2020-01-01T00:00+05:30'); // => 2019-12-31T18:30:00Z
+instant.epochNanoseconds; // => 1577817000000000000n
 
-If you have a legacy `Date` instance, you can use its `toTemporalInstant()` method to convert to a `Temporal.Instant`.
+// `Temporal.Instant` lacks properties that depend on time zone or calendar
+instant.year; // => undefined
 
-Since `Temporal.Instant` doesn't contain any information about time zones, a `Temporal.TimeZone` is needed in order to convert it into a `Temporal.ZonedDateTime` or `Temporal.PlainDateTime` (and from there into any of the other `Temporal` objects.)
+zdtTokyo = instant.toZonedDateTimeISO('Asia/Tokyo'); // => 2020-01-01T03:30:00+09:00[Asia/Tokyo]
+zdtTokyo.year; // => 2020
+zdtTokyo.toPlainDate(); // => 2020-01-01
+
+tzLA = Temporal.TimeZone.from('America/Los_Angeles');
+zdtLA = instant.toZonedDateTimeISO(tzLA); // => 2019-12-31T10:30:00-08:00[America/Los_Angeles]
+zdtLA.year; // => 2019
+zdtLA.toPlainDate(); // => 2019-12-31
+```
+<!-- prettier-ignore-end -->
+
+`Temporal.Instant` stores a count of integer nanoseconds since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time): midnight UTC on January 1, 1970.
+For interoperability with `Date` (which uses millisecond precision) or other APIs, `Temporal.Instant` also offers conversion properties and methods for seconds, milliseconds, or microseconds since epoch.
+A `Temporal.Instant` can also be created from an ISO 8601 / RFC 3339 string like `'2020-01-24T01:04Z'` or `'2020-01-23T17:04:36.491865121-08:00'`.
+
+<!-- prettier-ignore-start -->
+```javascript
+// New Year's in India
+instant = Temporal.Instant.from('2020-01-01T00:00+05:30'); // => 2019-12-31T18:30:00Z
+date = new Date(instant.epochMilliseconds); 
+  // => Tue Dec 31 2019 10:30:00 GMT-0800 (Pacific Standard Time)
+  // The time zone shown above is the time zone of the caller, not the `Date` object.
+  // `Date`, like `Temporal.Instant`, only stores a count of time since epoch.
+
+// All three lines below convert `Date` to `Temporal.Instant`
+instant2 = date.toTemporalInstant();                       // => 2019-12-31T18:30:00Z
+instant3 = Temporal.Instant.fromEpochMilliseconds(date);   // => 2019-12-31T18:30:00Z
+instant4 = Temporal.Instant.from(date.toISOString());      // => 2019-12-31T18:30:00Z
+```
+<!-- prettier-ignore-end -->
 
 Like Unix time, `Temporal.Instant` ignores leap seconds.
 
@@ -116,13 +148,12 @@ The number of milliseconds since the Unix epoch is also returned from the `getTi
 However, for conversion from legacy `Date` to `Temporal.Instant`, use `Date.prototype.toTemporalInstant`:
 
 ```js
-legacyDate = new Date('December 17, 1995 03:24:00 GMT');
+legacyDate = new Date('1995-12-17T03:24Z');
 instant = Temporal.Instant.fromEpochMilliseconds(legacyDate.getTime()); // => 1995-12-17T03:24:00Z
-instant = Temporal.Instant.fromEpochMilliseconds(+legacyDate); // valueOf() called implicitly
+instant = Temporal.Instant.fromEpochMilliseconds(legacyDate); // valueOf() called implicitly
 instant = legacyDate.toTemporalInstant(); // recommended
 
-// Use fromEpochMilliseconds, for example, if you have epoch millisecond
-// data stored in a file:
+// Use fromEpochMilliseconds, for example, if you have epoch millisecond data stored in a file
 todayMs = Temporal.Instant.fromEpochMilliseconds(msReadFromFile);
 ```
 


### PR DESCRIPTION
Following up from #2131, this PR makes a few minor clarifying changes to the `Instant` docs:
* Adds code samples to intro section to clarify the concepts discussed in the intro, and side-stepping some of the contentious questions raised in #2130.
* Wordsmiths the intro section
* Adds reference to RFC 3339
* Removes unnecessary (and, IMHO, confusing) unary `+` in a code sample

Fixes #2130.