### PR TITLE
Editorial: Rename DateFromFields to CalendarDateFromFields, etc.

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1018,7 +1018,7 @@ export const ES = ObjectAssign({}, ES2020, {
       const calendar = ES.GetTemporalCalendarWithISODefault(item);
       const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);
       const fields = ES.ToTemporalDateFields(item, fieldNames);
-      return ES.DateFromFields(calendar, fields, options);
+      return ES.CalendarDateFromFields(calendar, fields, options);
     }
     ES.ToTemporalOverflow(options); // validate and ignore
     let { year, month, day, calendar, z } = ES.ParseTemporalDateString(ES.ToString(item));
@@ -1029,7 +1029,7 @@ export const ES = ObjectAssign({}, ES2020, {
   InterpretTemporalDateTimeFields: (calendar, fields, options) => {
     let { hour, minute, second, millisecond, microsecond, nanosecond } = ES.ToTemporalTimeRecord(fields);
     const overflow = ES.ToTemporalOverflow(options);
-    const date = ES.DateFromFields(calendar, fields, options);
+    const date = ES.CalendarDateFromFields(calendar, fields, options);
     const year = GetSlot(date, ISO_YEAR);
     const month = GetSlot(date, ISO_MONTH);
     const day = GetSlot(date, ISO_DAY);
@@ -1158,7 +1158,7 @@ export const ES = ObjectAssign({}, ES2020, {
       if (calendarAbsent && fields.month !== undefined && fields.monthCode === undefined && fields.year === undefined) {
         fields.year = 1972;
       }
-      return ES.MonthDayFromFields(calendar, fields, options);
+      return ES.CalendarMonthDayFromFields(calendar, fields, options);
     }
 
     ES.ToTemporalOverflow(options); // validate and ignore
@@ -1171,7 +1171,7 @@ export const ES = ObjectAssign({}, ES2020, {
       return ES.CreateTemporalMonthDay(month, day, calendar);
     }
     const result = ES.CreateTemporalMonthDay(month, day, calendar, referenceISOYear);
-    return ES.MonthDayFromFields(calendar, result);
+    return ES.CalendarMonthDayFromFields(calendar, result);
   },
   ToTemporalTime: (item, overflow = 'constrain') => {
     let hour, minute, second, millisecond, microsecond, nanosecond, calendar;
@@ -1227,7 +1227,7 @@ export const ES = ObjectAssign({}, ES2020, {
       const calendar = ES.GetTemporalCalendarWithISODefault(item);
       const fieldNames = ES.CalendarFields(calendar, ['month', 'monthCode', 'year']);
       const fields = ES.ToTemporalYearMonthFields(item, fieldNames);
-      return ES.YearMonthFromFields(calendar, fields, options);
+      return ES.CalendarYearMonthFromFields(calendar, fields, options);
     }
 
     ES.ToTemporalOverflow(options); // validate and ignore
@@ -1240,7 +1240,7 @@ export const ES = ObjectAssign({}, ES2020, {
       return ES.CreateTemporalYearMonth(year, month, calendar);
     }
     const result = ES.CreateTemporalYearMonth(year, month, calendar, referenceISODay);
-    return ES.YearMonthFromFields(calendar, result);
+    return ES.CalendarYearMonthFromFields(calendar, result);
   },
   InterpretISODateTimeOffset: (
     year,
@@ -1682,19 +1682,19 @@ export const ES = ObjectAssign({}, ES2020, {
       throw new RangeError('irreconcilable calendars');
     }
   },
-  DateFromFields: (calendar, fields, options) => {
+  CalendarDateFromFields: (calendar, fields, options) => {
     const dateFromFields = ES.GetMethod(calendar, 'dateFromFields');
     const result = ES.Call(dateFromFields, calendar, [fields, options]);
     if (!ES.IsTemporalDate(result)) throw new TypeError('invalid result');
     return result;
   },
-  YearMonthFromFields: (calendar, fields, options) => {
+  CalendarYearMonthFromFields: (calendar, fields, options) => {
     const yearMonthFromFields = ES.GetMethod(calendar, 'yearMonthFromFields');
     const result = ES.Call(yearMonthFromFields, calendar, [fields, options]);
     if (!ES.IsTemporalYearMonth(result)) throw new TypeError('invalid result');
     return result;
   },
-  MonthDayFromFields: (calendar, fields, options) => {
+  CalendarMonthDayFromFields: (calendar, fields, options) => {
     const monthDayFromFields = ES.GetMethod(calendar, 'monthDayFromFields');
     const result = ES.Call(monthDayFromFields, calendar, [fields, options]);
     if (!ES.IsTemporalMonthDay(result)) throw new TypeError('invalid result');

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -114,7 +114,7 @@ export class PlainDate {
 
     options = ES.GetOptionsObject(options);
 
-    return ES.DateFromFields(calendar, fields, options);
+    return ES.CalendarDateFromFields(calendar, fields, options);
   }
   withCalendar(calendar) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
@@ -339,14 +339,14 @@ export class PlainDate {
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const fields = ES.ToTemporalYearMonthFields(this, fieldNames);
-    return ES.YearMonthFromFields(calendar, fields);
+    return ES.CalendarYearMonthFromFields(calendar, fields);
   }
   toPlainMonthDay() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);
     const fields = ES.ToTemporalMonthDayFields(this, fieldNames);
-    return ES.MonthDayFromFields(calendar, fields);
+    return ES.CalendarMonthDayFromFields(calendar, fields);
   }
   getISOFields() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -632,14 +632,14 @@ export class PlainDateTime {
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const fields = ES.ToTemporalYearMonthFields(this, fieldNames);
-    return ES.YearMonthFromFields(calendar, fields);
+    return ES.CalendarYearMonthFromFields(calendar, fields);
   }
   toPlainMonthDay() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);
     const fields = ES.ToTemporalMonthDayFields(this, fieldNames);
-    return ES.MonthDayFromFields(calendar, fields);
+    return ES.CalendarMonthDayFromFields(calendar, fields);
   }
   toPlainTime() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -54,7 +54,7 @@ export class PlainMonthDay {
     fields = ES.ToTemporalMonthDayFields(fields, fieldNames);
 
     options = ES.GetOptionsObject(options);
-    return ES.MonthDayFromFields(calendar, fields, options);
+    return ES.CalendarMonthDayFromFields(calendar, fields, options);
   }
   equals(other) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
@@ -112,7 +112,7 @@ export class PlainMonthDay {
     mergedFields = ES.PrepareTemporalFields(mergedFields, mergedEntries);
     const options = ObjectCreate(null);
     options.overflow = 'reject';
-    return ES.DateFromFields(calendar, mergedFields, options);
+    return ES.CalendarDateFromFields(calendar, mergedFields, options);
   }
   getISOFields() {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -83,7 +83,7 @@ export class PlainYearMonth {
 
     options = ES.GetOptionsObject(options);
 
-    return ES.YearMonthFromFields(calendar, fields, options);
+    return ES.CalendarYearMonthFromFields(calendar, fields, options);
   }
   add(temporalDurationLike, options = undefined) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
@@ -98,12 +98,12 @@ export class PlainYearMonth {
     const fields = ES.ToTemporalYearMonthFields(this, fieldNames);
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
     const day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, this)) : 1;
-    const startDate = ES.DateFromFields(calendar, { ...fields, day });
+    const startDate = ES.CalendarDateFromFields(calendar, { ...fields, day });
     const optionsCopy = { ...options };
     const addedDate = ES.CalendarDateAdd(calendar, startDate, { ...duration, days }, options);
     const addedDateFields = ES.ToTemporalYearMonthFields(addedDate, fieldNames);
 
-    return ES.YearMonthFromFields(calendar, addedDateFields, optionsCopy);
+    return ES.CalendarYearMonthFromFields(calendar, addedDateFields, optionsCopy);
   }
   subtract(temporalDurationLike, options = undefined) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
@@ -130,12 +130,12 @@ export class PlainYearMonth {
     const fields = ES.ToTemporalYearMonthFields(this, fieldNames);
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
     const day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, this)) : 1;
-    const startDate = ES.DateFromFields(calendar, { ...fields, day });
+    const startDate = ES.CalendarDateFromFields(calendar, { ...fields, day });
     const optionsCopy = { ...options };
     const addedDate = ES.CalendarDateAdd(calendar, startDate, { ...duration, days }, options);
     const addedDateFields = ES.ToTemporalYearMonthFields(addedDate, fieldNames);
 
-    return ES.YearMonthFromFields(calendar, addedDateFields, optionsCopy);
+    return ES.CalendarYearMonthFromFields(calendar, addedDateFields, optionsCopy);
   }
   until(other, options = undefined) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
@@ -159,8 +159,8 @@ export class PlainYearMonth {
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const otherFields = ES.ToTemporalYearMonthFields(other, fieldNames);
     const thisFields = ES.ToTemporalYearMonthFields(this, fieldNames);
-    const otherDate = ES.DateFromFields(calendar, { ...otherFields, day: 1 });
-    const thisDate = ES.DateFromFields(calendar, { ...thisFields, day: 1 });
+    const otherDate = ES.CalendarDateFromFields(calendar, { ...otherFields, day: 1 });
+    const thisDate = ES.CalendarDateFromFields(calendar, { ...thisFields, day: 1 });
 
     const untilOptions = { ...options, largestUnit };
     const result = ES.CalendarDateUntil(calendar, thisDate, otherDate, untilOptions);
@@ -209,8 +209,8 @@ export class PlainYearMonth {
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const otherFields = ES.ToTemporalYearMonthFields(other, fieldNames);
     const thisFields = ES.ToTemporalYearMonthFields(this, fieldNames);
-    const otherDate = ES.DateFromFields(calendar, { ...otherFields, day: 1 });
-    const thisDate = ES.DateFromFields(calendar, { ...thisFields, day: 1 });
+    const otherDate = ES.CalendarDateFromFields(calendar, { ...otherFields, day: 1 });
+    const thisDate = ES.CalendarDateFromFields(calendar, { ...thisFields, day: 1 });
 
     const untilOptions = { ...options, largestUnit };
     let { years, months } = ES.CalendarDateUntil(calendar, thisDate, otherDate, untilOptions);
@@ -293,7 +293,7 @@ export class PlainYearMonth {
     mergedFields = ES.PrepareTemporalFields(mergedFields, mergedEntries);
     const options = ObjectCreate(null);
     options.overflow = 'reject';
-    return ES.DateFromFields(calendar, mergedFields, options);
+    return ES.CalendarDateFromFields(calendar, mergedFields, options);
   }
   getISOFields() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -739,14 +739,14 @@ export class ZonedDateTime {
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const fields = ES.ToTemporalYearMonthFields(this, fieldNames);
-    return ES.YearMonthFromFields(calendar, fields);
+    return ES.CalendarYearMonthFromFields(calendar, fields);
   }
   toPlainMonthDay() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);
     const fields = ES.ToTemporalMonthDayFields(this, fieldNames);
-    return ES.MonthDayFromFields(calendar, fields);
+    return ES.CalendarMonthDayFromFields(calendar, fields);
   }
   getISOFields() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -283,39 +283,60 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-datefromfields" aoid="DateFromFields">
-      <h1>DateFromFields ( _calendar_, _fields_ [ , _options_ ] )</h1>
+    <emu-clause id="sec-temporal-calendardatefromfields" type="abstract operation">
+      <h1>
+        CalendarDateFromFields (
+          _calendar_: an Object,
+          _fields_: an Object,
+          optional _options_: an Object or *undefined*,
+        ): either a normal completion containing a `Temporal.PlainDate` or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It calls the given _calendar_'s `dateFromFields()` method and validates the result.</dd>
+      </dl>
       <emu-alg>
-        1. Assert: Type(_calendar_) is Object.
-        1. Assert: Type(_fields_) is Object.
         1. If _options_ is not present, set _options_ to *undefined*.
-        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _date_ be ? Invoke(_calendar_, *"dateFromFields"*, « _fields_, _options_ »).
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Return _date_.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-yearmonthfromfields" aoid="YearMonthFromFields">
-      <h1>YearMonthFromFields ( _calendar_, _fields_ [ , _options_ ] )</h1>
+    <emu-clause id="sec-temporal-calendaryearmonthfromfields" type="abstract operation">
+      <h1>
+        CalendarYearMonthFromFields (
+          _calendar_: an Object,
+          _fields_: an Object,
+          optional _options_: an Object or *undefined*,
+        ): either a normal completion containing a `Temporal.PlainYearMonth` or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It calls the given _calendar_'s `yearMonthFromFields()` method and validates the result.</dd>
+      </dl>
       <emu-alg>
-        1. Assert: Type(_calendar_) is Object.
-        1. Assert: Type(_fields_) is Object.
         1. If _options_ is not present, set _options_ to *undefined*.
-        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _yearMonth_ be ? Invoke(_calendar_, *"yearMonthFromFields"*, « _fields_, _options_ »).
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Return _yearMonth_.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-monthdayfromfields" aoid="MonthDayFromFields">
-      <h1>MonthDayFromFields ( _calendar_, _fields_ [ , _options_ ] )</h1>
+    <emu-clause id="sec-temporal-calendarmonthdayfromfields" type="abstract operation">
+      <h1>
+        CalendarMonthDayFromFields (
+          _calendar_: an Object,
+          _fields_: an Object,
+          optional _options_: an Object or *undefined*,
+        ): either a normal completion containing a `Temporal.PlainMonthDay` or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It calls the given _calendar_'s `monthDayFromFields()` method and validates the result.</dd>
+      </dl>
       <emu-alg>
-        1. Assert: Type(_calendar_) is Object.
-        1. Assert: Type(_fields_) is Object.
         1. If _options_ is not present, set _options_ to *undefined*.
-        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _monthDay_ be ? Invoke(_calendar_, *"monthDayFromFields"*, « _fields_, _options_ »).
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Return _monthDay_.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -302,7 +302,7 @@
         1. Let _calendar_ be _temporalDate_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDate_, _fieldNames_, «»).
-        1. Return ? YearMonthFromFields(_calendar_, _fields_).
+        1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_).
       </emu-alg>
     </emu-clause>
 
@@ -317,7 +317,7 @@
         1. Let _calendar_ be _temporalDate_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"monthCode"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDate_, _fieldNames_, «»).
-        1. Return ? MonthDayFromFields(_calendar_, _fields_).
+        1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_).
       </emu-alg>
     </emu-clause>
 
@@ -388,7 +388,7 @@
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDate_, _fieldNames_, «»).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialDate_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, «»).
-        1. Return ? DateFromFields(_calendar_, _fields_, _options_).
+        1. Return ? CalendarDateFromFields(_calendar_, _fields_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -688,7 +688,7 @@
           1. Let _calendar_ be ? GetTemporalCalendarWithISODefault(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
-          1. Return ? DateFromFields(_calendar_, _fields_, _options_).
+          1. Return ? CalendarDateFromFields(_calendar_, _fields_, _options_).
         1. Perform ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalDateString(_string_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -672,7 +672,7 @@
         1. Let _calendar_ be _dateTime_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_dateTime_, _fieldNames_, «»).
-        1. Return ? YearMonthFromFields(_calendar_, _fields_).
+        1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_).
       </emu-alg>
     </emu-clause>
 
@@ -687,7 +687,7 @@
         1. Let _calendar_ be _dateTime_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"monthCode"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_dateTime_, _fieldNames_, «»).
-        1. Return ? MonthDayFromFields(_calendar_, _fields_).
+        1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_).
       </emu-alg>
     </emu-clause>
 
@@ -881,7 +881,7 @@
       <emu-alg>
         1. Let _timeResult_ be ? ToTemporalTimeRecord(_fields_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Let _temporalDate_ be ? DateFromFields(_calendar_, _fields_, _options_).
+        1. Let _temporalDate_ be ? CalendarDateFromFields(_calendar_, _fields_, _options_).
         1. Let _timeResult_ be ? RegulateTime(_timeResult_.[[Hour]], _timeResult_.[[Minute]], _timeResult_.[[Second]], _timeResult_.[[Millisecond]], _timeResult_.[[Microsecond]], _timeResult_.[[Nanosecond]], _overflow_).
         1. Return the Record {
           [[Year]]: _temporalDate_.[[ISOYear]],

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -156,7 +156,7 @@
         1. Let _fields_ be ? PrepareTemporalFields(_monthDay_, _fieldNames_, «»).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialMonthDay_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, «»).
-        1. Return ? MonthDayFromFields(_calendar_, _fields_, _options_).
+        1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -251,7 +251,7 @@
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _mergedFieldNames_, «»).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).
-        1. Return ? DateFromFields(_calendar_, _mergedFields_, _options_).
+        1. Return ? CalendarDateFromFields(_calendar_, _mergedFields_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -368,7 +368,7 @@
           1. Let _year_ be ? Get(_fields_, *"year"*).
           1. If _calendarAbsent_ is *true*, and _month_ is not *undefined*, and _monthCode_ is *undefined* and _year_ is *undefined*, then
             1. Perform ! CreateDataPropertyOrThrow(_fields_, *"year"*, 𝔽(_referenceISOYear_)).
-          1. Return ? MonthDayFromFields(_calendar_, _fields_, _options_).
+          1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_, _options_).
         1. Perform ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalMonthDayString(_string_).
@@ -377,7 +377,7 @@
           1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _referenceISOYear_).
         1. Set _result_ to ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _referenceISOYear_).
         1. NOTE: The following operation is called without _options_, in order for the calendar to store a canonical value in the [[ISOYear]] internal slot of the result.
-        1. Return ? MonthDayFromFields(_calendar_, _result_).
+        1. Return ? CalendarMonthDayFromFields(_calendar_, _result_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -238,7 +238,7 @@
         1. Let _fields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialYearMonth_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, «»).
-        1. Return ? YearMonthFromFields(_calendar_, _fields_, _options_).
+        1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -264,7 +264,7 @@
         1. Else,
           1. Let _day_ be 1.
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, _day_).
-        1. Let _date_ be ? DateFromFields(_calendar_, _fields_, *undefined*).
+        1. Let _date_ be ? CalendarDateFromFields(_calendar_, _fields_, *undefined*).
         1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _optionsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _entries_ be ? EnumerableOwnPropertyNames(_options_, ~key+value~).
@@ -272,7 +272,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_optionsCopy_, _nextEntry_[0], _nextEntry_[1]).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _options_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).
-        1. Return ? YearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).
+        1. Return ? CalendarYearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).
       </emu-alg>
     </emu-clause>
 
@@ -299,7 +299,7 @@
         1. Else,
           1. Let _day_ be 1.
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, _day_).
-        1. Let _date_ be ? DateFromFields(_calendar_, _fields_, *undefined*).
+        1. Let _date_ be ? CalendarDateFromFields(_calendar_, _fields_, *undefined*).
         1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _optionsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _entries_ be ? EnumerableOwnPropertyNames(_options_, ~key+value~).
@@ -307,7 +307,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_optionsCopy_, _nextEntry_[0], _nextEntry_[1]).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _options_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).
-        1. Return ? YearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).
+        1. Return ? CalendarYearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).
       </emu-alg>
     </emu-clause>
 
@@ -333,10 +333,10 @@
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _otherFields_ be ? PrepareTemporalFields(_other_, _fieldNames_, «»).
         1. Perform ! CreateDataPropertyOrThrow(_otherFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _otherDate_ be ? DateFromFields(_calendar_, _otherFields_).
+        1. Let _otherDate_ be ? CalendarDateFromFields(_calendar_, _otherFields_).
         1. Let _thisFields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
         1. Perform ! CreateDataPropertyOrThrow(_thisFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _thisDate_ be ? DateFromFields(_calendar_, _thisFields_).
+        1. Let _thisDate_ be ? CalendarDateFromFields(_calendar_, _thisFields_).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
         1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
@@ -369,10 +369,10 @@
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _otherFields_ be ? PrepareTemporalFields(_other_, _fieldNames_, «»).
         1. Perform ! CreateDataPropertyOrThrow(_otherFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _otherDate_ be ? DateFromFields(_calendar_, _otherFields_).
+        1. Let _otherDate_ be ? CalendarDateFromFields(_calendar_, _otherFields_).
         1. Let _thisFields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
         1. Perform ! CreateDataPropertyOrThrow(_thisFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _thisDate_ be ? DateFromFields(_calendar_, _thisFields_).
+        1. Let _thisDate_ be ? CalendarDateFromFields(_calendar_, _thisFields_).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
         1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
@@ -473,7 +473,7 @@
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _mergedFieldNames_, «»).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).
-        1. Return ? DateFromFields(_calendar_, _mergedFields_, _options_).
+        1. Return ? CalendarDateFromFields(_calendar_, _mergedFields_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -575,14 +575,14 @@
           1. Let _calendar_ be ? GetTemporalCalendarWithISODefault(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
-          1. Return ? YearMonthFromFields(_calendar_, _fields_, _options_).
+          1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_, _options_).
         1. Perform ? ToTemporalOverflow(_options_).
         1. Let _string_ be ? ToString(_item_).
         1. Let _result_ be ? ParseTemporalYearMonthString(_string_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).
         1. Set _result_ to ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[Day]]).
         1. NOTE: The following operation is called without _options_, in order for the calendar to store a canonical value in the [[ISODay]] internal slot of the result.
-        1. Return ? YearMonthFromFields(_calendar_, _result_).
+        1. Return ? CalendarYearMonthFromFields(_calendar_, _result_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -968,7 +968,7 @@
         1. Let _temporalDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDateTime_, _fieldNames_, «»).
-        1. Return ? YearMonthFromFields(_calendar_, _fields_).
+        1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_).
       </emu-alg>
     </emu-clause>
 
@@ -986,7 +986,7 @@
         1. Let _temporalDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"monthCode"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDateTime_, _fieldNames_, «»).
-        1. Return ? MonthDayFromFields(_calendar_, _fields_).
+        1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Naming these in line with all the other CalendarFoo operations that call
the 'foo' method of the given calendar, makes them easier to understand
when reading the spec text.

Closes: #1670