### PR TITLE
Editorial: Drop "integral part of" language

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -636,10 +636,17 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-roundtowardszero" aoid="RoundTowardsZero">
-    <h1>RoundTowardsZero ( _x_ )</h1>
+  <emu-clause id="sec-temporal-roundtowardszero" type="abstract operation">
+    <h1>
+      RoundTowardsZero (
+        _x_: a mathematical value,
+      ): an integer
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>The returned integer is the integral part of _x_, with any fractional part removed.</dd>
+    </dl>
     <emu-alg>
-      1. Assert: _x_ is a mathematical value.
       1. Return the mathematical value that is the same sign as _x_ and whose magnitude is floor(abs(_x_)).
     </emu-alg>
   </emu-clause>
@@ -673,7 +680,7 @@
       1. Else if _roundingMode_ is *"floor"*, then
         1. Let _rounded_ be floor(_quotient_).
       1. Else if _roundingMode_ is *"trunc"*, then
-        1. Let _rounded_ be the integral part of _quotient_, removing any fractional digits.
+        1. Let _rounded_ be RoundTowardsZero(_quotient_).
       1. Else,
         1. Let _rounded_ be ! RoundHalfAwayFromZero(_quotient_).
       1. Return _rounded_ × _increment_.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1807,11 +1807,11 @@
       </dl>
       <emu-alg>
         1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Set _microseconds_ to _microseconds_ + the integral part of _nanoseconds_ / 1000.
+        1. Set _microseconds_ to _microseconds_ + RoundTowardsZero(_nanoseconds_ / 1000).
         1. Set _nanoseconds_ to remainder(_nanoseconds_, 1000).
-        1. Set _milliseconds_ to _milliseconds_ + the integral part of _microseconds_ / 1000.
+        1. Set _milliseconds_ to _milliseconds_ + RoundTowardsZero(_microseconds_ / 1000).
         1. Set _microseconds_ to remainder(_microseconds_, 1000).
-        1. Set _seconds_ to _seconds_ + the integral part of _milliseconds_ / 1000.
+        1. Set _seconds_ to _seconds_ + RoundTowardsZero(_milliseconds_ / 1000).
         1. Set _milliseconds_ to remainder(_milliseconds_, 1000).
         1. Let _datePart_ be *""*.
         1. If _years_ is not 0, then

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1364,7 +1364,7 @@
         1. If _nanoseconds_ &lt; 0, let _sign_ be −1; else, let _sign_ be 1.
         1. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Return the Record {
-            [[Days]]: the integral part of _nanoseconds_ / _dayLengthNs_,
+            [[Days]]: RoundTowardsZero(_nanoseconds_ / _dayLengthNs_),
             [[Nanoseconds]]: (abs(_nanoseconds_) modulo _dayLengthNs_) × _sign_,
             [[DayLength]]: _dayLengthNs_
             }.


### PR DESCRIPTION
The term "integral part of" isn't defined anywhere. Instead, we have an
abstract operation for this already.

Closes: #1890