### PR TITLE
Editorial: Improve consistency of mathematical conventions

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -623,7 +623,7 @@
       1. Assert: _second_, _millisecond_, _microsecond_ and _nanosecond_ are integers.
       1. If _precision_ is *"minute"*, return *""*.
       1. Let _secondsString_ be the string-concatenation of the code unit 0x003A (COLON) and ToZeroPaddedDecimalString(_second_, 2).
-      1. Let _fraction_ be _millisecond_ × 10<sup>6</sup> + _microsecond_ × 10<sup>3</sup> + _nanosecond_.
+      1. Let _fraction_ be _millisecond_ &times; 10<sup>6</sup> + _microsecond_ &times; 10<sup>3</sup> + _nanosecond_.
       1. If _precision_ is *"auto"*, then
         1. If _fraction_ is 0, return _secondsString_.
         1. Set _fraction_ to ToZeroPaddedDecimalString(_fraction_, 9).
@@ -683,7 +683,7 @@
         1. Let _rounded_ be RoundTowardsZero(_quotient_).
       1. Else,
         1. Let _rounded_ be ! RoundHalfAwayFromZero(_quotient_).
-      1. Return _rounded_ × _increment_.
+      1. Return _rounded_ &times; _increment_.
     </emu-alg>
   </emu-clause>
 
@@ -1360,31 +1360,31 @@
         1. If any of _minutes_, _fMinutes_, _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fHoursDigits_ be the substring of CodePointsToString(_fHours_) from 1.
         1. Let _fHoursScale_ be the length of _fHoursDigits_.
-        1. Let _minutesMV_ be ! ToIntegerOrInfinity(_fHoursDigits_) / 10<sup>_fHoursScale_</sup> × 60.
+        1. Let _minutesMV_ be ! ToIntegerOrInfinity(_fHoursDigits_) / 10<sup>_fHoursScale_</sup> &times; 60.
       1. Else,
         1. Let _minutesMV_ be ! ToIntegerOrInfinity(CodePointsToString(_minutes_)).
       1. If _fMinutes_ is not empty, then
         1. If any of _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fMinutesDigits_ be the substring of CodePointsToString(_fMinutes_) from 1.
         1. Let _fMinutesScale_ be the length of _fMinutesDigits_.
-        1. Let _secondsMV_ be ! ToIntegerOrInfinity(_fMinutesDigits_) / 10<sup>_fMinutesScale_</sup> × 60.
+        1. Let _secondsMV_ be ! ToIntegerOrInfinity(_fMinutesDigits_) / 10<sup>_fMinutesScale_</sup> &times; 60.
       1. Else if _seconds_ is not empty, then
         1. Let _secondsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_seconds_)).
       1. Else,
-        1. Let _secondsMV_ be remainder(_minutesMV_, 1) × 60.
+        1. Let _secondsMV_ be remainder(_minutesMV_, 1) &times; 60.
       1. If _fSeconds_ is not empty, then
         1. Let _fSecondsDigits_ be the substring of CodePointsToString(_fSeconds_) from 1.
         1. Let _fSecondsScale_ be the length of _fSecondsDigits_.
-        1. Let _millisecondsMV_ be ! ToIntegerOrInfinity(_fSecondsDigits_) / 10<sup>_fSecondsScale_</sup> × 1000.
+        1. Let _millisecondsMV_ be ! ToIntegerOrInfinity(_fSecondsDigits_) / 10<sup>_fSecondsScale_</sup> &times; 1000.
       1. Else,
-        1. Let _millisecondsMV_ be remainder(_secondsMV_, 1) × 1000.
-      1. Let _microsecondsMV_ be remainder(_millisecondsMV_, 1) × 1000.
-      1. Let _nanosecondsMV_ be remainder(_microsecondsMV_, 1) × 1000.
+        1. Let _millisecondsMV_ be remainder(_secondsMV_, 1) &times; 1000.
+      1. Let _microsecondsMV_ be remainder(_millisecondsMV_, 1) &times; 1000.
+      1. Let _nanosecondsMV_ be remainder(_microsecondsMV_, 1) &times; 1000.
       1. If _sign_ contains the code point 0x002D (HYPHEN-MINUS) or 0x2212 (MINUS SIGN), then
         1. Let _factor_ be -1.
       1. Else,
         1. Let _factor_ be 1.
-      1. Return ? CreateDurationRecord(_yearsMV_ × _factor_, _monthsMV_ × _factor_, _weeksMV_ × _factor_, _daysMV_ × _factor_, _hoursMV_ × _factor_, floor(_minutesMV_) × _factor_, floor(_secondsMV_) × _factor_, floor(_millisecondsMV_) × _factor_, floor(_microsecondsMV_) × _factor_, floor(_nanosecondsMV_) × _factor_).
+      1. Return ? CreateDurationRecord(_yearsMV_ &times; _factor_, _monthsMV_ &times; _factor_, _weeksMV_ &times; _factor_, _daysMV_ &times; _factor_, _hoursMV_ &times; _factor_, floor(_minutesMV_) &times; _factor_, floor(_secondsMV_) &times; _factor_, floor(_millisecondsMV_) &times; _factor_, floor(_microsecondsMV_) &times; _factor_, floor(_nanosecondsMV_) &times; _factor_).
     </emu-alg>
   </emu-clause>
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -214,7 +214,7 @@
     </dl>
     <emu-alg>
       1. If _dividend_ is *undefined*, then
-        1. Let _maximum_ be *+∞*<sub>𝔽</sub>.
+        1. Let _maximum_ be *+&infin;*<sub>𝔽</sub>.
       1. Else if _inclusive_ is *true*, then
         1. Let _maximum_ be 𝔽(_dividend_).
       1. Else if _dividend_ is more than 1, then
@@ -1552,7 +1552,7 @@
     </p>
     <emu-alg>
       1. Let _integer_ be ? ToIntegerOrInfinity(_argument_).
-      1. If _integer_ is -∞ or +∞ , then
+      1. If _integer_ is -&infin; or +&infin;, then
         1. Throw a *RangeError* exception.
       1. Return _integer_.
     </emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -218,7 +218,7 @@
       1. Else if _inclusive_ is *true*, then
         1. Let _maximum_ be 𝔽(_dividend_).
       1. Else if _dividend_ is more than 1, then
-        1. Let _maximum_ be 𝔽(_dividend_ − 1).
+        1. Let _maximum_ be 𝔽(_dividend_ - 1).
       1. Else,
         1. Let _maximum_ be *1*<sub>𝔽</sub>.
       1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, « Number », ~empty~, *1*<sub>𝔽</sub>).
@@ -305,19 +305,19 @@
         1. Return the Record {
             [[Precision]]: _digits_,
             [[Unit]]: *"millisecond"*,
-            [[Increment]]: 10<sup>3 − _digits_</sup>
+            [[Increment]]: 10<sup>3 - _digits_</sup>
           }.
       1. If _digits_ is 4, 5, or 6, then
         1. Return the Record {
             [[Precision]]: _digits_,
             [[Unit]]: *"microsecond"*,
-            [[Increment]]: 10<sup>6 − _digits_</sup>
+            [[Increment]]: 10<sup>6 - _digits_</sup>
           }.
       1. Assert: _digits_ is 7, 8, or 9.
       1. Return the Record {
           [[Precision]]: _digits_,
           [[Unit]]: *"nanosecond"*,
-          [[Increment]]: 10<sup>9 − _digits_</sup>
+          [[Increment]]: 10<sup>9 - _digits_</sup>
         }.
     </emu-alg>
   </emu-clause>
@@ -676,7 +676,7 @@
       1. Assert: _roundingMode_ is *"ceil"*, *"floor"*, *"trunc"*, or *"halfExpand"*.
       1. Let _quotient_ be _x_ / _increment_.
       1. If _roundingMode_ is *"ceil"*, then
-        1. Let _rounded_ be −floor(−_quotient_).
+        1. Let _rounded_ be -floor(-_quotient_).
       1. Else if _roundingMode_ is *"floor"*, then
         1. Let _rounded_ be floor(_quotient_).
       1. Else if _roundingMode_ is *"trunc"*, then
@@ -1381,7 +1381,7 @@
       1. Let _microsecondsMV_ be remainder(_millisecondsMV_, 1) × 1000.
       1. Let _nanosecondsMV_ be remainder(_microsecondsMV_, 1) × 1000.
       1. If _sign_ contains the code point 0x002D (HYPHEN-MINUS) or 0x2212 (MINUS SIGN), then
-        1. Let _factor_ be −1.
+        1. Let _factor_ be -1.
       1. Else,
         1. Let _factor_ be 1.
       1. Return ? CreateDurationRecord(_yearsMV_ × _factor_, _monthsMV_ × _factor_, _weeksMV_ × _factor_, _daysMV_ × _factor_, _hoursMV_ × _factor_, floor(_minutesMV_) × _factor_, floor(_secondsMV_) × _factor_, floor(_millisecondsMV_) × _factor_, floor(_microsecondsMV_) × _factor_, floor(_nanosecondsMV_) × _factor_).
@@ -1552,7 +1552,7 @@
     </p>
     <emu-alg>
       1. Let _integer_ be ? ToIntegerOrInfinity(_argument_).
-      1. If _integer_ is −∞ or +∞ , then
+      1. If _integer_ is -∞ or +∞ , then
         1. Throw a *RangeError* exception.
       1. Return _integer_.
     </emu-alg>
@@ -1570,7 +1570,7 @@
     </dl>
     <emu-alg>
       1. Let _number_ be ? ToNumber(_argument_).
-      1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, or *−0*<sub>𝔽</sub> return 0.
+      1. If _number_ is *NaN*, *+0*<sub>𝔽</sub>, or *-0*<sub>𝔽</sub> return 0.
       1. If IsIntegralNumber(_number_) is *false*, throw a *RangeError* exception.
       1. Return ℝ(_number_).
     </emu-alg>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -445,7 +445,7 @@
       <h1>IsISOLeapYear ( _year_ )</h1>
       <emu-alg>
         1. Assert: _year_ is an integer.
-        1. If _year_ modulo 4 ≠ 0, return *false*.
+        1. If _year_ modulo 4 &ne; 0, return *false*.
         1. If _year_ modulo 400 = 0, return *true*.
         1. If _year_ modulo 100 = 0, return *false*.
         1. Return *true*.
@@ -539,7 +539,7 @@
         1. Let _numberPart_ be the substring of _monthCode_ from 1.
         1. Set _numberPart_ to ! ToIntegerOrInfinity(_numberPart_).
         1. If _numberPart_ &lt; 1 or _numberPart_ &gt; 12, throw a *RangeError* exception.
-        1. If _month_ is not *undefined*, and _month_ ≠ _numberPart_, then
+        1. If _month_ is not *undefined*, and _month_ &ne; _numberPart_, then
           1. Throw a *RangeError* exception.
         1. If SameValueNonNumeric(_monthCode_, ! BuildISOMonthCode(_numberPart_)) is *false*, then
           1. Throw a *RangeError* exception.

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -466,7 +466,7 @@
       <h1>ISODaysInMonth ( _year_, _month_ )</h1>
       <emu-alg>
         1. Assert: _year_ is an integer.
-        1. Assert: _month_ is an integer, _month_ ≥ 1, and _month_ ≤ 12.
+        1. Assert: _month_ is an integer, _month_ &ge; 1, and _month_ &le; 12.
         1. If _month_ is 1, 3, 5, 7, 8, 10, or 12, return 31.
         1. If _month_ is 4, 6, 9, or 11, return 30.
         1. If ! IsISOLeapYear(_year_) is *true*, return 29.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1180,7 +1180,7 @@
         <dd>It computes an integer number of nanoseconds from the given units, applying a given time zone offset shift in nanoseconds when converting from days to hours.</dd>
       </dl>
       <emu-alg>
-        1. If _days_ ≠ 0, then
+        1. If _days_ &ne; 0, then
           1. Set _nanoseconds_ to _nanoseconds_ - _offsetShift_.
         1. Set _hours_ to _hours_ + _days_ &times; 24.
         1. Set _minutes_ to _minutes_ + _hours_ &times; 60.
@@ -1285,7 +1285,7 @@
         1. If _largestUnit_ is *"year"*, or _years_, _months_, _weeks_, and _days_ are all 0, then
           1. Return ! CreateDateDurationRecord(_years_, _months_, _weeks_, _days_).
         1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
-        1. Assert: _sign_ ≠ 0.
+        1. Assert: _sign_ &ne; 0.
         1. Let _oneYear_ be ! CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _oneMonth_ be ! CreateTemporalDuration(0, _sign_, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, _sign_, 0, 0, 0, 0, 0, 0, 0).
@@ -1299,7 +1299,7 @@
             1. Throw a *RangeError* exception.
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
           1. Let _dateUntil_ be ? GetMethod(_calendar_, *"dateUntil"*).
-          1. Repeat, while _years_ ≠ 0,
+          1. Repeat, while _years_ &ne; 0,
             1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, *undefined*, _dateAdd_).
             1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
             1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
@@ -1311,12 +1311,12 @@
         1. Else if _largestUnit_ is *"week"*, then
           1. If _calendar_ is *undefined*, then
             1. Throw a *RangeError* exception.
-          1. Repeat, while _years_ ≠ 0,
+          1. Repeat, while _years_ &ne; 0,
             1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
             1. Set _years_ to _years_ - _sign_.
-          1. Repeat, while _months_ ≠ 0,
+          1. Repeat, while _months_ &ne; 0,
             1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
@@ -1325,17 +1325,17 @@
           1. If any of _years_, _months_, and _weeks_ are not zero, then
             1. If _calendar_ is *undefined*, then
               1. Throw a *RangeError* exception.
-            1. Repeat, while _years_ ≠ 0,
+            1. Repeat, while _years_ &ne; 0,
               1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
               1. Set _days_ to _days_ + _moveResult_.[[Days]].
               1. Set _years_ to _years_ - _sign_.
-            1. Repeat, while _months_ ≠ 0,
+            1. Repeat, while _months_ &ne; 0,
               1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
               1. Set _days_ to _days_ +_moveResult_.[[Days]].
               1. Set _months_ to _months_ - _sign_.
-            1. Repeat, while _weeks_ ≠ 0,
+            1. Repeat, while _weeks_ &ne; 0,
               1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
               1. Set _days_ to _days_ + _moveResult_.[[Days]].
@@ -1364,7 +1364,7 @@
           1. [id="step-balance-duration-relative-early-return"] Return ! CreateDateDurationRecord(_years_, _months_, _weeks_, _days_).
         1. Assert: _relativeTo_ is not *undefined*, because callers of this operation ensure _relativeTo_ is required in conditions where this algorithm does not return in step <emu-xref href="#step-balance-duration-relative-early-return"></emu-xref>.
         1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
-        1. Assert: _sign_ ≠ 0.
+        1. Assert: _sign_ &ne; 0.
         1. Let _oneYear_ be ! CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _oneMonth_ be ! CreateTemporalDuration(0, _sign_, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, _sign_, 0, 0, 0, 0, 0, 0, 0).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1182,12 +1182,12 @@
       <emu-alg>
         1. If _days_ ≠ 0, then
           1. Set _nanoseconds_ to _nanoseconds_ - _offsetShift_.
-        1. Set _hours_ to _hours_ + _days_ × 24.
-        1. Set _minutes_ to _minutes_ + _hours_ × 60.
-        1. Set _seconds_ to _seconds_ + _minutes_ × 60.
-        1. Set _milliseconds_ to _milliseconds_ + _seconds_ × 1000.
-        1. Set _microseconds_ to _microseconds_ + _milliseconds_ × 1000.
-        1. Return _nanoseconds_ + _microseconds_ × 1000.
+        1. Set _hours_ to _hours_ + _days_ &times; 24.
+        1. Set _minutes_ to _minutes_ + _hours_ &times; 60.
+        1. Set _seconds_ to _seconds_ + _minutes_ &times; 60.
+        1. Set _milliseconds_ to _milliseconds_ + _seconds_ &times; 1000.
+        1. Set _microseconds_ to _microseconds_ + _milliseconds_ &times; 1000.
+        1. Return _nanoseconds_ + _microseconds_ &times; 1000.
       </emu-alg>
     </emu-clause>
 
@@ -1262,7 +1262,7 @@
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
         1. Else,
           1. Assert: _largestUnit_ is *"nanosecond"*.
-        1. Return ? CreateTimeDurationRecord(_days_, _hours_ × _sign_, _minutes_ × _sign_, _seconds_ × _sign_, _milliseconds_ × _sign_, _microseconds_ × _sign_, _nanoseconds_ × _sign_).
+        1. Return ? CreateTimeDurationRecord(_days_, _hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
       </emu-alg>
     </emu-clause>
 
@@ -1489,7 +1489,7 @@
         1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZone_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, *"halfExpand"*).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_diffNs_) ≤ 1.728 × 10<sup>22</sup>.
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_diffNs_) ≤ 1.728 &times; 10<sup>22</sup>.
           1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _diffNs_, _largestUnit_).
           1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Return ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_).
@@ -1605,7 +1605,7 @@
           1. Set _days_ to _days_ + _result_.[[Days]] + _result_.[[Nanoseconds]] / _result_.[[DayLength]].
           1. Set _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else,
-          1. Let _fractionalSeconds_ be _nanoseconds_ × 10<sup>-9</sup> + _microseconds_ × 10<sup>-6</sup> + _milliseconds_ × 10<sup>-3</sup> + _seconds_.
+          1. Let _fractionalSeconds_ be _nanoseconds_ &times; 10<sup>-9</sup> + _microseconds_ &times; 10<sup>-6</sup> + _milliseconds_ &times; 10<sup>-3</sup> + _seconds_.
         1. Let _remainder_ be *undefined*.
         1. If _unit_ is *"year"*, then
           1. Let _yearsDuration_ be ! CreateTemporalDuration(_years_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
@@ -1695,12 +1695,12 @@
           1. Set _remainder_ to _fractionalSeconds_ - _seconds_.
           1. Set _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"millisecond"*, then
-          1. Let _fractionalMilliseconds_ be _nanoseconds_ × 10<sup>-6</sup> + _microseconds_ × 10<sup>-3</sup> + _milliseconds_.
+          1. Let _fractionalMilliseconds_ be _nanoseconds_ &times; 10<sup>-6</sup> + _microseconds_ &times; 10<sup>-3</sup> + _milliseconds_.
           1. Set _milliseconds_ to ! RoundNumberToIncrement(_fractionalMilliseconds_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalMilliseconds_ - _milliseconds_.
           1. Set _microseconds_ and _nanoseconds_ to 0.
         1. Else if _unit_ is *"microsecond"*, then
-          1. Let _fractionalMicroseconds_ be _nanoseconds_ × 10<sup>-3</sup> + _microseconds_.
+          1. Let _fractionalMicroseconds_ be _nanoseconds_ &times; 10<sup>-3</sup> + _microseconds_.
           1. Set _microseconds_ to ! RoundNumberToIncrement(_fractionalMicroseconds_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalMicroseconds_ - _microseconds_.
           1. Set _nanoseconds_ to 0.
@@ -1754,7 +1754,7 @@
         1. Let _dayStart_ be ? AddZonedDateTime(_relativeTo_.[[Nanoseconds]], _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
         1. Let _dayEnd_ be ? AddZonedDateTime(_dayStart_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0).
         1. Let _dayLengthNs_ be ℝ(_dayEnd_ - _dayStart_).
-        1. If (_timeRemainderNs_ - _dayLengthNs_) × _direction_ &lt; 0, then
+        1. If (_timeRemainderNs_ - _dayLengthNs_) &times; _direction_ &lt; 0, then
           1. Return ! CreateDurationRecord(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Set _timeRemainderNs_ to ! RoundTemporalInstant(ℤ(_timeRemainderNs_ - _dayLengthNs_), _increment_, _unit_, _roundingMode_).
         1. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, _relativeTo_).
@@ -1828,7 +1828,7 @@
         1. If _minutes_ is not 0, then
           1. Set _timePart_ to the string concatenation of _timePart_, abs(_minutes_) formatted as a decimal number, and the code unit 0x004D (LATIN CAPITAL LETTER M).
         1. If any of _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are not 0; or _years_, _months_, _weeks_, _days_, _hours_, and _minutes_ are all 0; or _precision_ is not *"auto"*, then
-          1. Let _fraction_ be abs(_milliseconds_) × 10<sup>6</sup> + abs(_microseconds_) × 10<sup>3</sup> + abs(_nanoseconds_).
+          1. Let _fraction_ be abs(_milliseconds_) &times; 10<sup>6</sup> + abs(_microseconds_) &times; 10<sup>3</sup> + abs(_nanoseconds_).
           1. Let _decimalPart_ be ToZeroPaddedDecimalString(_fraction_, 9).
           1. If _precision_ is *"auto"*, then
             1. Set _decimalPart_ to the longest possible substring of _decimalPart_ starting at position 0 and not ending with the code unit 0x0030 (DIGIT ZERO).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -111,7 +111,7 @@
         1. Let _ns1_ be ! TotalDurationNanoseconds(_days1_, _one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]], _shift1_).
         1. Let _ns2_ be ! TotalDurationNanoseconds(_days2_, _two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]], _shift2_).
         1. If _ns1_ &gt; _ns2_, return *1*<sub>𝔽</sub>.
-        1. If _ns1_ &lt; _ns2_, return *−1*<sub>𝔽</sub>.
+        1. If _ns1_ &lt; _ns2_, return *-1*<sub>𝔽</sub>.
         1. Return *+0*<sub>𝔽</sub>.
       </emu-alg>
     </emu-clause>
@@ -403,7 +403,7 @@
         1. Set _other_ to ? ToTemporalDurationRecord(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _relativeTo_ be ? ToRelativeTemporalObject(_options_).
-        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], −_other_.[[Years]], −_other_.[[Months]], −_other_.[[Weeks]], −_other_.[[Days]], −_other_.[[Hours]], −_other_.[[Minutes]], −_other_.[[Seconds]], −_other_.[[Milliseconds]], −_other_.[[Microseconds]], −_other_.[[Nanoseconds]], _relativeTo_).
+        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], -_other_.[[Years]], -_other_.[[Months]], -_other_.[[Weeks]], -_other_.[[Days]], -_other_.[[Hours]], -_other_.[[Minutes]], -_other_.[[Seconds]], -_other_.[[Milliseconds]], -_other_.[[Microseconds]], -_other_.[[Nanoseconds]], _relativeTo_).
         1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -979,11 +979,11 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns 1 if the most significant non-zero element in its arguments is positive, and −1 if the most significant non-zero element is negative. If all of its arguments are zero, it returns 0.</dd>
+        <dd>It returns 1 if the most significant non-zero element in its arguments is positive, and -1 if the most significant non-zero element is negative. If all of its arguments are zero, it returns 0.</dd>
       </dl>
       <emu-alg>
         1. For each value _v_ of « _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ », do
-          1. If _v_ &lt; 0, return −1.
+          1. If _v_ &lt; 0, return -1.
           1. If _v_ &gt; 0, return 1.
         1. Return 0.
       </emu-alg>
@@ -1127,7 +1127,7 @@
         <dd>It returns a new Temporal.Duration instance that is the negation of _duration_.</dd>
       </dl>
       <emu-alg>
-        1. Return ! CreateTemporalDuration(−_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_duration_.[[Days]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]]).
+        1. Return ! CreateTemporalDuration(-_duration_.[[Years]], -_duration_.[[Months]], -_duration_.[[Weeks]], -_duration_.[[Days]], -_duration_.[[Hours]], -_duration_.[[Minutes]], -_duration_.[[Seconds]], -_duration_.[[Milliseconds]], -_duration_.[[Microseconds]], -_duration_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -1158,7 +1158,7 @@
         1. Let _after_ be ? AddZonedDateTime(_relativeTo_.[[Nanoseconds]], _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], _y_, _mon_, _w_, _d_, _h_, _min_, _s_, _ms_, _mus_, _ns_).
         1. Let _instantAfter_ be ! CreateTemporalInstant(_after_).
         1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_relativeTo_.[[TimeZone]], _instantAfter_).
-        1. Return _offsetAfter_ − _offsetBefore_.
+        1. Return _offsetAfter_ - _offsetBefore_.
       </emu-alg>
     </emu-clause>
 
@@ -1181,7 +1181,7 @@
       </dl>
       <emu-alg>
         1. If _days_ ≠ 0, then
-          1. Set _nanoseconds_ to _nanoseconds_ − _offsetShift_.
+          1. Set _nanoseconds_ to _nanoseconds_ - _offsetShift_.
         1. Set _hours_ to _hours_ + _days_ × 24.
         1. Set _minutes_ to _minutes_ + _hours_ × 60.
         1. Set _seconds_ to _seconds_ + _minutes_ × 60.
@@ -1213,7 +1213,7 @@
         1. If _relativeTo_ is not present, set _relativeTo_ to *undefined*.
         1. If Type(_relativeTo_) is Object and _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Let _endNs_ be ? AddZonedDateTime(_relativeTo_.[[Nanoseconds]], _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-          1. Set _nanoseconds_ to ℝ(_endNs_ − _relativeTo_.[[Nanoseconds]]).
+          1. Set _nanoseconds_ to ℝ(_endNs_ - _relativeTo_.[[Nanoseconds]]).
         1. Else,
           1. Set _nanoseconds_ to ! TotalDurationNanoseconds(_days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, 0).
         1. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
@@ -1223,7 +1223,7 @@
         1. Else,
           1. Set _days_ to 0.
         1. Set _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ to 0.
-        1. If _nanoseconds_ &lt; 0, let _sign_ be −1; else, let _sign_ be 1.
+        1. If _nanoseconds_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
         1. Set _nanoseconds_ to abs(_nanoseconds_).
         1. If _largestUnit_ is *"year"*, *"month"*, *"week"*, *"day"*, or *"hour"*, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
@@ -1306,7 +1306,7 @@
             1. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
             1. Let _oneYearMonths_ be _untilResult_.[[Months]].
             1. Set _relativeTo_ to _newRelativeTo_.
-            1. Set _years_ to _years_ − _sign_.
+            1. Set _years_ to _years_ - _sign_.
             1. Set _months_ to _months_ + _oneYearMonths_.
         1. Else if _largestUnit_ is *"week"*, then
           1. If _calendar_ is *undefined*, then
@@ -1315,12 +1315,12 @@
             1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
-            1. Set _years_ to _years_ − _sign_.
+            1. Set _years_ to _years_ - _sign_.
           1. Repeat, while _months_ ≠ 0,
             1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
-            1. Set _months_ to _months_ − _sign_.
+            1. Set _months_ to _months_ - _sign_.
         1. Else,
           1. If any of _years_, _months_, and _weeks_ are not zero, then
             1. If _calendar_ is *undefined*, then
@@ -1329,17 +1329,17 @@
               1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
               1. Set _days_ to _days_ + _moveResult_.[[Days]].
-              1. Set _years_ to _years_ − _sign_.
+              1. Set _years_ to _years_ - _sign_.
             1. Repeat, while _months_ ≠ 0,
               1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
               1. Set _days_ to _days_ +_moveResult_.[[Days]].
-              1. Set _months_ to _months_ − _sign_.
+              1. Set _months_ to _months_ - _sign_.
             1. Repeat, while _weeks_ ≠ 0,
               1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
               1. Set _days_ to _days_ + _moveResult_.[[Days]].
-              1. Set _weeks_ to _weeks_ − _sign_.
+              1. Set _weeks_ to _weeks_ - _sign_.
         1. Return ! CreateDateDurationRecord(_years_, _months_, _weeks_, _days_).
       </emu-alg>
     </emu-clause>
@@ -1375,7 +1375,7 @@
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) ≥ abs(_oneYearDays_),
-            1. Set _days_ to _days_ − _oneYearDays_.
+            1. Set _days_ to _days_ - _oneYearDays_.
             1. Set _years_ to _years_ + _sign_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
@@ -1384,7 +1384,7 @@
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) ≥ abs(_oneMonthDays_),
-            1. Set _days_ to _days_ − _oneMonthDays_.
+            1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _months_ to _months_ + _sign_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
@@ -1397,7 +1397,7 @@
           1. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
           1. Let _oneYearMonths_ be _untilResult_.[[Months]].
           1. Repeat, while abs(_months_) ≥ abs(_oneYearMonths_),
-            1. Set _months_ to _months_ − _oneYearMonths_.
+            1. Set _months_ to _months_ - _oneYearMonths_.
             1. Set _years_ to _years_ + _sign_.
             1. Set _relativeTo_ to _newRelativeTo_.
             1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, *undefined*, _dateAdd_).
@@ -1410,7 +1410,7 @@
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) ≥ abs(_oneMonthDays_),
-            1. Set _days_ to _days_ − _oneMonthDays_.
+            1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _months_ to _months_ + _sign_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
@@ -1421,7 +1421,7 @@
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneWeekDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) ≥ abs(_oneWeekDays_),
-            1. Set _days_ to _days_ − _oneWeekDays_.
+            1. Set _days_ to _days_ - _oneWeekDays_.
             1. Set _weeks_ to _weeks_ + _sign_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
@@ -1605,7 +1605,7 @@
           1. Set _days_ to _days_ + _result_.[[Days]] + _result_.[[Nanoseconds]] / _result_.[[DayLength]].
           1. Set _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else,
-          1. Let _fractionalSeconds_ be _nanoseconds_ × 10<sup>−9</sup> + _microseconds_ × 10<sup>−6</sup> + _milliseconds_ × 10<sup>−3</sup> + _seconds_.
+          1. Let _fractionalSeconds_ be _nanoseconds_ × 10<sup>-9</sup> + _microseconds_ × 10<sup>-6</sup> + _milliseconds_ × 10<sup>-3</sup> + _seconds_.
         1. Let _remainder_ be *undefined*.
         1. If _unit_ is *"year"*, then
           1. Let _yearsDuration_ be ! CreateTemporalDuration(_years_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
@@ -1628,7 +1628,7 @@
           1. Set _relativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsDuration_, *undefined*, _dateAdd_).
           1. Let _daysPassed_ be ! DaysUntil(_oldRelativeTo_, _relativeTo_).
           1. Set _days_ to _days_ - _daysPassed_.
-          1. If _days_ &lt; 0, let _sign_ be −1; else, let _sign_ be 1.
+          1. If _days_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneYear_ be ! CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
@@ -1645,14 +1645,14 @@
           1. Let _weeksInDays_ be ! DaysUntil(_yearsMonthsLater_, _yearsMonthsWeeksLater_).
           1. Set _relativeTo_ to _yearsMonthsLater_.
           1. Let _days_ be _days_ + _weeksInDays_.
-          1. If _days_ &lt; 0, let _sign_ be −1; else, let _sign_ be 1.
+          1. If _days_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneMonth_ be ! CreateTemporalDuration(0, _sign_, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) ≥ abs(_oneMonthDays_),
             1. Set _months_ to _months_ + _sign_.
-            1. Set _days_ to _days_ − _oneMonthDays_.
+            1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
@@ -1661,14 +1661,14 @@
           1. Set _remainder_ to _fractionalMonths_ - _months_.
           1. Set _weeks_ and _days_ to 0.
         1. Else if _unit_ is *"week"*, then
-          1. If _days_ &lt; 0, let _sign_ be −1; else, let _sign_ be 1.
+          1. If _days_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, _sign_, 0, 0, 0, 0, 0, 0, 0).
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneWeekDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) ≥ abs(_oneWeekDays_),
             1. Set _weeks_ to _weeks_ + _sign_.
-            1. Set _days_ to _days_ − _oneWeekDays_.
+            1. Set _days_ to _days_ - _oneWeekDays_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneWeekDays_ to _moveResult_.[[Days]].
@@ -1695,12 +1695,12 @@
           1. Set _remainder_ to _fractionalSeconds_ - _seconds_.
           1. Set _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
         1. Else if _unit_ is *"millisecond"*, then
-          1. Let _fractionalMilliseconds_ be _nanoseconds_ × 10<sup>−6</sup> + _microseconds_ × 10<sup>−3</sup> + _milliseconds_.
+          1. Let _fractionalMilliseconds_ be _nanoseconds_ × 10<sup>-6</sup> + _microseconds_ × 10<sup>-3</sup> + _milliseconds_.
           1. Set _milliseconds_ to ! RoundNumberToIncrement(_fractionalMilliseconds_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalMilliseconds_ - _milliseconds_.
           1. Set _microseconds_ and _nanoseconds_ to 0.
         1. Else if _unit_ is *"microsecond"*, then
-          1. Let _fractionalMicroseconds_ be _nanoseconds_ × 10<sup>−3</sup> + _microseconds_.
+          1. Let _fractionalMicroseconds_ be _nanoseconds_ × 10<sup>-3</sup> + _microseconds_.
           1. Set _microseconds_ to ! RoundNumberToIncrement(_fractionalMicroseconds_, _increment_, _roundingMode_).
           1. Set _remainder_ to _fractionalMicroseconds_ - _microseconds_.
           1. Set _nanoseconds_ to 0.
@@ -1708,7 +1708,7 @@
           1. Assert: _unit_ is *"nanosecond"*.
           1. Set _remainder_ to _nanoseconds_.
           1. Set _nanoseconds_ to ! RoundNumberToIncrement(_nanoseconds_, _increment_, _roundingMode_).
-          1. Set _remainder_ to _remainder_ − _nanoseconds_.
+          1. Set _remainder_ to _remainder_ - _nanoseconds_.
         1. Let _duration_ be ! CreateDurationRecord(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Return the Record {
           [[DurationRecord]]: _duration_,
@@ -1749,14 +1749,14 @@
           1. Return ! CreateDurationRecord(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Let _timeRemainderNs_ be ! TotalDurationNanoseconds(0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, 0).
         1. If _timeRemainderNs_ = 0, let _direction_ be 0.
-        1. Else if _timeRemainderNs_ &lt; 0, let _direction_ be −1.
+        1. Else if _timeRemainderNs_ &lt; 0, let _direction_ be -1.
         1. Else, let _direction_ be 1.
         1. Let _dayStart_ be ? AddZonedDateTime(_relativeTo_.[[Nanoseconds]], _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
         1. Let _dayEnd_ be ? AddZonedDateTime(_dayStart_, _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0).
-        1. Let _dayLengthNs_ be ℝ(_dayEnd_ − _dayStart_).
-        1. If (_timeRemainderNs_ − _dayLengthNs_) × _direction_ &lt; 0, then
+        1. Let _dayLengthNs_ be ℝ(_dayEnd_ - _dayStart_).
+        1. If (_timeRemainderNs_ - _dayLengthNs_) × _direction_ &lt; 0, then
           1. Return ! CreateDurationRecord(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Set _timeRemainderNs_ to ! RoundTemporalInstant(ℤ(_timeRemainderNs_ − _dayLengthNs_), _increment_, _unit_, _roundingMode_).
+        1. Set _timeRemainderNs_ to ! RoundTemporalInstant(ℤ(_timeRemainderNs_ - _dayLengthNs_), _increment_, _unit_, _roundingMode_).
         1. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, _relativeTo_).
         1. Let _adjustedTimeDuration_ be ? BalanceDuration(0, 0, 0, 0, 0, 0, _timeRemainderNs_, *"hour"*).
         1. Return ! CreateDurationRecord(_adjustedDateDuration_.[[Years]], _adjustedDateDuration_.[[Months]], _adjustedDateDuration_.[[Weeks]], _adjustedDateDuration_.[[Days]], _adjustedTimeDuration_.[[Hours]], _adjustedTimeDuration_.[[Minutes]], _adjustedTimeDuration_.[[Seconds]], _adjustedTimeDuration_.[[Milliseconds]], _adjustedTimeDuration_.[[Microseconds]], _adjustedTimeDuration_.[[Nanoseconds]]).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1374,7 +1374,7 @@
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
-          1. Repeat, while abs(_days_) ≥ abs(_oneYearDays_),
+          1. Repeat, while abs(_days_) &ge; abs(_oneYearDays_),
             1. Set _days_ to _days_ - _oneYearDays_.
             1. Set _years_ to _years_ + _sign_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
@@ -1383,7 +1383,7 @@
           1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
-          1. Repeat, while abs(_days_) ≥ abs(_oneMonthDays_),
+          1. Repeat, while abs(_days_) &ge; abs(_oneMonthDays_),
             1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _months_ to _months_ + _sign_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
@@ -1396,7 +1396,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
           1. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
           1. Let _oneYearMonths_ be _untilResult_.[[Months]].
-          1. Repeat, while abs(_months_) ≥ abs(_oneYearMonths_),
+          1. Repeat, while abs(_months_) &ge; abs(_oneYearMonths_),
             1. Set _months_ to _months_ - _oneYearMonths_.
             1. Set _years_ to _years_ + _sign_.
             1. Set _relativeTo_ to _newRelativeTo_.
@@ -1409,7 +1409,7 @@
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
-          1. Repeat, while abs(_days_) ≥ abs(_oneMonthDays_),
+          1. Repeat, while abs(_days_) &ge; abs(_oneMonthDays_),
             1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _months_ to _months_ + _sign_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
@@ -1420,7 +1420,7 @@
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneWeekDays_ be _moveResult_.[[Days]].
-          1. Repeat, while abs(_days_) ≥ abs(_oneWeekDays_),
+          1. Repeat, while abs(_days_) &ge; abs(_oneWeekDays_),
             1. Set _days_ to _days_ - _oneWeekDays_.
             1. Set _weeks_ to _weeks_ + _sign_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
@@ -1489,7 +1489,7 @@
         1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZone_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, *"halfExpand"*).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_diffNs_) ≤ 1.728 &times; 10<sup>22</sup>.
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_diffNs_) &le; 1.728 &times; 10<sup>22</sup>.
           1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _diffNs_, _largestUnit_).
           1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Return ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_).
@@ -1650,7 +1650,7 @@
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
-          1. Repeat, while abs(_days_) ≥ abs(_oneMonthDays_),
+          1. Repeat, while abs(_days_) &ge; abs(_oneMonthDays_),
             1. Set _months_ to _months_ + _sign_.
             1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
@@ -1666,7 +1666,7 @@
           1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneWeekDays_ be _moveResult_.[[Days]].
-          1. Repeat, while abs(_days_) ≥ abs(_oneWeekDays_),
+          1. Repeat, while abs(_days_) &ge; abs(_oneWeekDays_),
             1. Set _weeks_ to _weeks_ + _sign_.
             1. Set _days_ to _days_ - _oneWeekDays_.
             1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -71,7 +71,7 @@
       <emu-alg>
         1. Set _epochSeconds_ to ? ToNumber(_epochSeconds_).
         1. Set _epochSeconds_ to ? NumberToBigInt(_epochSeconds_).
-        1. Let _epochNanoseconds_ be _epochSeconds_ × *10<sup>9</sup>*<sub>ℤ</sub>.
+        1. Let _epochNanoseconds_ be _epochSeconds_ &times; *10<sup>9</sup>*<sub>ℤ</sub>.
         1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
@@ -86,7 +86,7 @@
       <emu-alg>
         1. Set _epochMilliseconds_ to ? ToNumber(_epochMilliseconds_).
         1. Set _epochMilliseconds_ to ? NumberToBigInt(_epochMilliseconds_).
-        1. Let _epochNanoseconds_ be _epochMilliseconds_ × *10<sup>6</sup>*<sub>ℤ</sub>.
+        1. Let _epochNanoseconds_ be _epochMilliseconds_ &times; *10<sup>6</sup>*<sub>ℤ</sub>.
         1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
@@ -100,7 +100,7 @@
       </p>
       <emu-alg>
         1. Set _epochMicroseconds_ to ? ToBigInt(_epochMicroseconds_).
-        1. Let _epochNanoseconds_ be _epochMicroseconds_ × *1000*<sub>ℤ</sub>.
+        1. Let _epochNanoseconds_ be _epochMicroseconds_ &times; *1000*<sub>ℤ</sub>.
         1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
@@ -266,7 +266,7 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _roundedNs_ be ! DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) ≤ 1.728 × 10<sup>22</sup>.
+        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) ≤ 1.728 &times; 10<sup>22</sup>.
         1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
@@ -291,7 +291,7 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _roundedNs_ be ! DifferenceInstant(_other_.[[Nanoseconds]], _instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) ≤ 1.728 × 10<sup>22</sup>.
+        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) ≤ 1.728 &times; 10<sup>22</sup>.
         1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
@@ -324,12 +324,12 @@
         1. Else if _smallestUnit_ is *"second"*, then
           1. Let _maximum_ be 86400.
         1. Else if _smallestUnit_ is *"millisecond"*, then
-          1. Let _maximum_ be 8.64 × 10<sup>7</sup>.
+          1. Let _maximum_ be 8.64 &times; 10<sup>7</sup>.
         1. Else if _smallestUnit_ is *"microsecond"*, then
-          1. Let _maximum_ be 8.64 × 10<sup>10</sup>.
+          1. Let _maximum_ be 8.64 &times; 10<sup>10</sup>.
         1. Else,
           1. Assert: _smallestUnit_ is *"nanosecond"*.
-          1. Let _maximum_ be 8.64 × 10<sup>13</sup>.
+          1. Let _maximum_ be 8.64 &times; 10<sup>13</sup>.
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_, _maximum_, *true*).
         1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalInstant(_roundedNs_).
@@ -502,7 +502,7 @@
       </p>
       <emu-alg>
         1. Assert: Type(_epochNanoseconds_) is BigInt.
-        1. If _epochNanoseconds_ &lt; *-86400*<sub>ℤ</sub> × *10<sup>17</sup>*<sub>ℤ</sub> or _epochNanoseconds_ &gt; *86400*<sub>ℤ</sub> × *10<sup>17</sup>*<sub>ℤ</sub>, then
+        1. If _epochNanoseconds_ &lt; *-86400*<sub>ℤ</sub> &times; *10<sup>17</sup>*<sub>ℤ</sub> or _epochNanoseconds_ &gt; *86400*<sub>ℤ</sub> &times; *10<sup>17</sup>*<sub>ℤ</sub>, then
           1. Return *false*.
         1. Return *true*.
       </emu-alg>
@@ -545,7 +545,7 @@
         1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
         1. Assert: _offsetString_ is not *undefined*.
         1. Let _utc_ be GetEpochFromISOParts(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
-        1. If ℝ(_utc_) &lt; -8.64 × 10<sup>21</sup> or ℝ(_utc_) &gt; 8.64 × 10<sup>21</sup>, then
+        1. If ℝ(_utc_) &lt; -8.64 &times; 10<sup>21</sup> or ℝ(_utc_) &gt; 8.64 &times; 10<sup>21</sup>, then
           1. Throw a *RangeError* exception.
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
         1. Let _result_ be _utc_ - ℤ(_offsetNanoseconds_).
@@ -582,11 +582,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be _epochNanoseconds_ + ℤ(_nanoseconds_) +
-            ℤ(_microseconds_) × *1000*<sub>ℤ</sub> +
-            ℤ(_milliseconds_) × *10<sup>6</sup>*<sub>ℤ</sub> +
-            ℤ(_seconds_) × *10<sup>9</sup>*<sub>ℤ</sub> +
-            ℤ(_minutes_) × *60*<sub>ℤ</sub> × *10<sup>9</sup>*<sub>ℤ</sub> +
-            ℤ(_hours_) × *3600*<sub>ℤ</sub> × *10<sup>9</sup>*<sub>ℤ</sub>.
+            ℤ(_microseconds_) &times; *1000*<sub>ℤ</sub> +
+            ℤ(_milliseconds_) &times; *10<sup>6</sup>*<sub>ℤ</sub> +
+            ℤ(_seconds_) &times; *10<sup>9</sup>*<sub>ℤ</sub> +
+            ℤ(_minutes_) &times; *60*<sub>ℤ</sub> &times; *10<sup>9</sup>*<sub>ℤ</sub> +
+            ℤ(_hours_) &times; *3600*<sub>ℤ</sub> &times; *10<sup>9</sup>*<sub>ℤ</sub>.
         1. If ! IsValidEpochNanoseconds(_result_) is *false*, throw a *RangeError* exception.
         1. Return _result_.
       </emu-alg>
@@ -612,15 +612,15 @@
       <emu-alg>
         1. Assert: Type(_ns_) is BigInt.
         1. If _unit_ is *"hour"*, then
-          1. Let _incrementNs_ be _increment_ × 3.6 × 10<sup>12</sup>.
+          1. Let _incrementNs_ be _increment_ &times; 3.6 &times; 10<sup>12</sup>.
         1. Else if _unit_ is *"minute"*, then
-          1. Let _incrementNs_ be _increment_ × 6 × 10<sup>10</sup>.
+          1. Let _incrementNs_ be _increment_ &times; 6 &times; 10<sup>10</sup>.
         1. Else if _unit_ is *"second"*, then
-          1. Let _incrementNs_ be _increment_ × 10<sup>9</sup>.
+          1. Let _incrementNs_ be _increment_ &times; 10<sup>9</sup>.
         1. Else if _unit_ is *"millisecond"*, then
-          1. Let _incrementNs_ be _increment_ × 10<sup>6</sup>.
+          1. Let _incrementNs_ be _increment_ &times; 10<sup>6</sup>.
         1. Else if _unit_ is *"microsecond"*, then
-          1. Let _incrementNs_ be _increment_ × 10<sup>3</sup>.
+          1. Let _incrementNs_ be _increment_ &times; 10<sup>3</sup>.
         1. Else,
           1. Assert: _unit_ is *"nanosecond"*.
           1. Let _incrementNs_ be _increment_.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -242,7 +242,7 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « *"years"*, *"months"*, *"weeks"*, *"days"* »).
-        1. Let _ns_ be ? AddInstant(_instant_.[[Nanoseconds]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]]).
+        1. Let _ns_ be ? AddInstant(_instant_.[[Nanoseconds]], -_duration_.[[Hours]], -_duration_.[[Minutes]], -_duration_.[[Seconds]], -_duration_.[[Milliseconds]], -_duration_.[[Microseconds]], -_duration_.[[Nanoseconds]]).
         1. Return ! CreateTemporalInstant(_ns_).
       </emu-alg>
     </emu-clause>
@@ -502,7 +502,7 @@
       </p>
       <emu-alg>
         1. Assert: Type(_epochNanoseconds_) is BigInt.
-        1. If _epochNanoseconds_ &lt; *−86400*<sub>ℤ</sub> × *10<sup>17</sup>*<sub>ℤ</sub> or _epochNanoseconds_ &gt; *86400*<sub>ℤ</sub> × *10<sup>17</sup>*<sub>ℤ</sub>, then
+        1. If _epochNanoseconds_ &lt; *-86400*<sub>ℤ</sub> × *10<sup>17</sup>*<sub>ℤ</sub> or _epochNanoseconds_ &gt; *86400*<sub>ℤ</sub> × *10<sup>17</sup>*<sub>ℤ</sub>, then
           1. Return *false*.
         1. Return *true*.
       </emu-alg>
@@ -545,10 +545,10 @@
         1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
         1. Assert: _offsetString_ is not *undefined*.
         1. Let _utc_ be GetEpochFromISOParts(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
-        1. If ℝ(_utc_) &lt; −8.64 × 10<sup>21</sup> or ℝ(_utc_) &gt; 8.64 × 10<sup>21</sup>, then
+        1. If ℝ(_utc_) &lt; -8.64 × 10<sup>21</sup> or ℝ(_utc_) &gt; 8.64 × 10<sup>21</sup>, then
           1. Throw a *RangeError* exception.
         1. Let _offsetNanoseconds_ be ? ParseTimeZoneOffsetString(_offsetString_).
-        1. Let _result_ be _utc_ − ℤ(_offsetNanoseconds_).
+        1. Let _result_ be _utc_ - ℤ(_offsetNanoseconds_).
         1. If ! IsValidEpochNanoseconds(_result_) is *false*, then
           1. Throw a *RangeError* exception.
         1. Return _result_.
@@ -600,7 +600,7 @@
       <emu-alg>
         1. Assert: Type(_ns1_) is BigInt.
         1. Assert: Type(_ns2_) is BigInt.
-        1. Return ! RoundTemporalInstant(_ns2_ − _ns1_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Return ! RoundTemporalInstant(_ns2_ - _ns1_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -266,7 +266,7 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _roundedNs_ be ! DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) ≤ 1.728 &times; 10<sup>22</sup>.
+        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 1.728 &times; 10<sup>22</sup>.
         1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
@@ -291,7 +291,7 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _roundedNs_ be ! DifferenceInstant(_other_.[[Nanoseconds]], _instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) ≤ 1.728 &times; 10<sup>22</sup>.
+        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 1.728 &times; 10<sup>22</sup>.
         1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -346,7 +346,7 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _other_ to ? ToTemporalInstant(_other_).
-        1. If _instant_.[[Nanoseconds]] ≠ _other_.[[Nanoseconds]], return *false*.
+        1. If _instant_.[[Nanoseconds]] &ne; _other_.[[Nanoseconds]], return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -387,7 +387,7 @@
             1. Append a new Record { [[Type]]: *"literal"*, [[Value]]: _patternPart_.[[Value]] } as the last element of the list _result_.
           1. Else if _p_ is equal to *"fractionalSecondDigits"*, then
             1. Let _v_ be _tm_.[[Millisecond]].
-            1. Let _v_ be floor(_v_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
+            1. Let _v_ be floor(_v_ &times; 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
             1. Let _fv_ be FormatNumeric(_nf3_, _v_).
             1. Append a new Record { [[Type]]: *"fractionalSecond"*, [[Value]]: _fv_ } as the last element of _result_.
           1. Else if _p_ is equal to *"dayPeriod"*, then
@@ -557,8 +557,8 @@
                 1. Set _fractionalSecondDigits_ to 3.
               1. Let _v1_ be _tm1_.[[Millisecond]].
               1. Let _v2_ be _tm2_.[[Millisecond]].
-              1. Let _v1_ be floor(_v1_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
-              1. Let _v2_ be floor(_v2_ × 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
+              1. Let _v1_ be floor(_v1_ &times; 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
+              1. Let _v2_ be floor(_v2_ &times; 10<sup>( _fractionalSecondDigits_ - 3 )</sup>).
               1. If _v1_ is not equal to _v2_, then
                 1. Set _dateFieldsPracticallyEqual_ to *false*.
               1. Let _rangePattern_ be _rp_.
@@ -914,7 +914,7 @@
         1. Set _x_ to ? ToNumber(_x_).
       1. Set _x_ to TimeClip(_x_).
       1. If _x_ is *NaN*, throw a *RangeError* exception.
-      1. Let _epochNanoseconds_ be ℤ(_x_) × *10<sup>6</sup>*<sub>ℤ</sub>.
+      1. Let _epochNanoseconds_ be ℤ(_x_) &times; *10<sup>6</sup>*<sub>ℤ</sub>.
       1. Return the Record {
           [[pattern]]: _pattern_,
           [[rangePatterns]]: _rangePatterns_,

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -403,7 +403,7 @@
             1. If _rangeFormatOptions_ is not *undefined*, let _f_ be the value of _rangeFormatOptions_'s field whose name matches _p_.
             1. Else, let _f_ be <del>the value of _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the matching row</del><ins>_pattern_.[[&lt;_p_&gt;]]</ins>.
             1. Let _v_ be the value of _tm_'s field whose name is the Internal Slot column of the matching row.
-            1. If _p_ is *"year"* and _v_ ≤ 0, let _v_ be 1 - _v_.
+            1. If _p_ is *"year"* and _v_ &le; 0, let _v_ be 1 - _v_.
             1. If _p_ is *"month"*, increase _v_ by 1.
             1. If _p_ is *"hour"* and <del>_dateTimeFormat_.[[HourCycle]]</del><ins>_pattern_.[[hourCycle]]</ins> is *"h11"* or *"h12"*, then
               1. Let _v_ be _v_ modulo 12.

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -54,7 +54,7 @@
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
-          1. Let _ns_ be ? NumberToBigInt(_t_) × 10<sup>6</sup>.
+          1. Let _ns_ be ? NumberToBigInt(_t_) &times; 10<sup>6</sup>.
           1. Return ! CreateTemporalInstant(_ns_).
         </emu-alg>
       </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -427,7 +427,7 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
-        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ ≠ 1, then
+        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ &ne; 1, then
           1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _temporalDate_)).[[DurationRecord]].
         1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>
@@ -455,7 +455,7 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
-        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ ≠ 1, then
+        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ &ne; 1, then
           1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _temporalDate_)).[[DurationRecord]].
         1. Return ! CreateTemporalDuration(-_result_.[[Years]], -_result_.[[Months]], -_result_.[[Weeks]], -_result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>
@@ -471,9 +471,9 @@
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Set _other_ to ? ToTemporalDate(_other_).
-        1. If _temporalDate_.[[ISOYear]] ≠ _other_.[[ISOYear]], return *false*.
-        1. If _temporalDate_.[[ISOMonth]] ≠ _other_.[[ISOMonth]], return *false*.
-        1. If _temporalDate_.[[ISODay]] ≠ _other_.[[ISODay]], return *false*.
+        1. If _temporalDate_.[[ISOYear]] &ne; _other_.[[ISOYear]], return *false*.
+        1. If _temporalDate_.[[ISOMonth]] &ne; _other_.[[ISOMonth]], return *false*.
+        1. If _temporalDate_.[[ISODay]] &ne; _other_.[[ISODay]], return *false*.
         1. Return ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]).
       </emu-alg>
     </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -873,7 +873,7 @@
       <h1>PadISOYear ( _y_ )</h1>
       <emu-alg>
         1. Assert: _y_ is an integer.
-        1. If _y_ ≥ 0 and _y_ ≤ 9999, then
+        1. If _y_ &ge; 0 and _y_ &le; 9999, then
           1. Return ToZeroPaddedDecimalString(_y_, 4).
         1. If _y_ &gt; 0, let _yearSign_ be *"+"*; otherwise, let _yearSign_ be *"-"*.
         1. Let _year_ be ToZeroPaddedDecimalString(abs(_y_), 6).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -457,7 +457,7 @@
         1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
         1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ ≠ 1, then
           1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _temporalDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], −_result_.[[Weeks]], −_result_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Return ! CreateTemporalDuration(-_result_.[[Years]], -_result_.[[Months]], -_result_.[[Weeks]], -_result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
 
@@ -724,13 +724,13 @@
           1. If _sign_ is 0, return ! CreateDateDurationRecord(0, 0, 0, 0).
           1. Let _start_ be the Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
           1. Let _end_ be the Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
-          1. Let _years_ be _end_.[[Year]] − _start_.[[Year]].
+          1. Let _years_ be _end_.[[Year]] - _start_.[[Year]].
           1. Let _mid_ be ! AddISODate(_y1_, _m1_, _d1_, _years_, 0, 0, 0, *"constrain"*).
           1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
             1. If _largestUnit_ is *"year"*, return ! CreateDateDurationRecord(_years_, 0, 0, 0).
             1. Return ! CreateDateDurationRecord(0, _years_ × 12, 0, 0).
-          1. Let _months_ be _end_.[[Month]] − _start_.[[Month]].
+          1. Let _months_ be _end_.[[Month]] - _start_.[[Month]].
           1. If _midSign_ is not equal to _sign_, then
             1. Set _years_ to _years_ - _sign_.
             1. Set _months_ to _months_ + _sign_ × 12.
@@ -763,8 +763,8 @@
           1. Else,
             1. Let _smaller_ be the Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
             1. Let _greater_ be the Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
-            1. Let _sign_ be −1.
-          1. Let _days_ be ! ToISODayOfYear(_greater_.[[Year]], _greater_.[[Month]], _greater_.[[Day]]) − ! ToISODayOfYear(_smaller_.[[Year]], _smaller_.[[Month]], _smaller_.[[Day]]).
+            1. Let _sign_ be -1.
+          1. Let _days_ be ! ToISODayOfYear(_greater_.[[Year]], _greater_.[[Month]], _greater_.[[Day]]) - ! ToISODayOfYear(_smaller_.[[Year]], _smaller_.[[Month]], _smaller_.[[Day]]).
           1. Let _year_ be _smaller_.[[Year]].
           1. Repeat, while _year_ &lt; _greater_.[[Year]],
             1. Set _days_ to _days_ + ! ISODaysInYear(_year_).
@@ -834,30 +834,30 @@
         1. Let _balancedYearMonth_ be ! BalanceISOYearMonth(_year_, _month_).
         1. Set _month_ to _balancedYearMonth_.[[Month]].
         1. Set _year_ to _balancedYearMonth_.[[Year]].
-        1. NOTE: To deal with negative numbers of days whose absolute value is greater than the number of days in a year, the following section subtracts years and adds days until the number of days is greater than −366 or −365.
+        1. NOTE: To deal with negative numbers of days whose absolute value is greater than the number of days in a year, the following section subtracts years and adds days until the number of days is greater than -366 or -365.
         1. If _month_ &gt; 2, then
           1. Let _testYear_ be _year_.
         1. Else,
-          1. Let _testYear_ be _year_ − 1.
-        1. Repeat, while _day_ &lt; −1 × ! ISODaysInYear(_testYear_),
+          1. Let _testYear_ be _year_ - 1.
+        1. Repeat, while _day_ &lt; -1 × ! ISODaysInYear(_testYear_),
           1. Set _day_ to _day_ + ! ISODaysInYear(_testYear_).
-          1. Set _year_ to _year_ − 1.
-          1. Set _testYear_ to _testYear_ − 1.
+          1. Set _year_ to _year_ - 1.
+          1. Set _testYear_ to _testYear_ - 1.
         1. NOTE: To deal with numbers of days greater than the number of days in a year, the following section adds years and subtracts days until the number of days is less than 366 or 365.
         1. Set _testYear_ to _testYear_ + 1.
         1. Repeat, while _day_ &gt; ! ISODaysInYear(_testYear_),
-          1. Set _day_ to _day_ − ! ISODaysInYear(_testYear_).
+          1. Set _day_ to _day_ - ! ISODaysInYear(_testYear_).
           1. Set _year_ to _year_ + 1.
           1. Set _testYear_ to _testYear_ + 1.
         1. NOTE: To deal with negative numbers of days whose absolute value is greater than the number of days in the current month, the following section subtracts months and adds days until the number of days is greater than 0.
         1. Repeat, while _day_ &lt; 1,
-          1. Set _balancedYearMonth_ to ! BalanceISOYearMonth(_year_, _month_ − 1).
+          1. Set _balancedYearMonth_ to ! BalanceISOYearMonth(_year_, _month_ - 1).
           1. Set _year_ to _balancedYearMonth_.[[Year]].
           1. Set _month_ to _balancedYearMonth_.[[Month]].
           1. Set _day_ to _day_ + ! ISODaysInMonth(_year_, _month_).
         1. NOTE: To deal with numbers of days greater than the number of days in the current month, the following section adds months and subtracts days until the number of days is less than the number of days in the month.
         1. Repeat, while _day_ &gt; ! ISODaysInMonth(_year_, _month_),
-          1. Set _day_ to _day_ − ! ISODaysInMonth(_year_, _month_).
+          1. Set _day_ to _day_ - ! ISODaysInMonth(_year_, _month_).
           1. Set _balancedYearMonth_ to ! BalanceISOYearMonth(_year_, _month_ + 1).
           1. Set _year_ to _balancedYearMonth_.[[Year]].
           1. Set _month_ to _balancedYearMonth_.[[Month]].

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -729,21 +729,21 @@
           1. Let _midSign_ be -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
             1. If _largestUnit_ is *"year"*, return ! CreateDateDurationRecord(_years_, 0, 0, 0).
-            1. Return ! CreateDateDurationRecord(0, _years_ × 12, 0, 0).
+            1. Return ! CreateDateDurationRecord(0, _years_ &times; 12, 0, 0).
           1. Let _months_ be _end_.[[Month]] - _start_.[[Month]].
           1. If _midSign_ is not equal to _sign_, then
             1. Set _years_ to _years_ - _sign_.
-            1. Set _months_ to _months_ + _sign_ × 12.
+            1. Set _months_ to _months_ + _sign_ &times; 12.
           1. Set _mid_ to ! AddISODate(_y1_, _m1_, _d1_, _years_, _months_, 0, 0, *"constrain"*).
           1. Set _midSign_ to -(! CompareISODate(_mid_.[[Year]], _mid_.[[Month]], _mid_.[[Day]], _y2_, _m2_, _d2_)).
           1. If _midSign_ is 0, then
             1. If _largestUnit_ is *"year"*, return ! CreateDateDurationRecord(_years_, _months_, 0, 0).
-            1. Return ! CreateDateDurationRecord(0, _months_ + _years_ × 12, 0, 0).
+            1. Return ! CreateDateDurationRecord(0, _months_ + _years_ &times; 12, 0, 0).
           1. If _midSign_ is not equal to _sign_, then
             1. Set _months_ to _months_ - _sign_.
             1. If _months_ is equal to -_sign_, then
               1. Set _years_ to _years_ - _sign_.
-              1. Set _months_ to 11 × _sign_.
+              1. Set _months_ to 11 &times; _sign_.
             1. Set _mid_ to ! AddISODate(_y1_, _m1_, _d1_, _years_, _months_, 0, 0, *"constrain"*).
           1. Let _days_ be 0.
           1. If _mid_.[[Month]] = _end_.[[Month]], then
@@ -752,7 +752,7 @@
           1. Else if _sign_ &lt; 0, set _days_ to -_mid_.[[Day]] - (! ISODaysInMonth(_end_.[[Year]], _end_.[[Month]]) - _end_.[[Day]]).
           1. Else, set _days_ to _end_.[[Day]] + (! ISODaysInMonth(_mid_.[[Year]], _mid_.[[Month]]) - _mid_.[[Day]]).
           1. If _largestUnit_ is *"month"*, then
-            1. Set _months_ to _months_ + _years_ × 12.
+            1. Set _months_ to _months_ + _years_ &times; 12.
             1. Set _years_ to 0.
           1. Return ! CreateDateDurationRecord(_years_, _months_, 0, _days_).
         1. If _largestUnit_ is *"day"* or *"week"*, then
@@ -773,7 +773,7 @@
           1. If _largestUnit_ is *"week"*, then
             1. Set _weeks_ to floor(_days_ / 7).
             1. Set _days_ to _days_ modulo 7.
-          1. Return ! CreateDateDurationRecord(0, 0, _weeks_ × _sign_, _days_ × _sign_).
+          1. Return ! CreateDateDurationRecord(0, 0, _weeks_ &times; _sign_, _days_ &times; _sign_).
       </emu-alg>
     </emu-clause>
 
@@ -839,7 +839,7 @@
           1. Let _testYear_ be _year_.
         1. Else,
           1. Let _testYear_ be _year_ - 1.
-        1. Repeat, while _day_ &lt; -1 × ! ISODaysInYear(_testYear_),
+        1. Repeat, while _day_ &lt; -1 &times; ! ISODaysInYear(_testYear_),
           1. Set _day_ to _day_ + ! ISODaysInYear(_testYear_).
           1. Set _year_ to _year_ - 1.
           1. Set _testYear_ to _testYear_ - 1.
@@ -902,7 +902,7 @@
         1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. Let _intermediate_ be ! BalanceISOYearMonth(_year_ + _years_, _month_ + _months_).
         1. Let _intermediate_ be ? RegulateISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _day_, _overflow_).
-        1. Set _days_ to _days_ + 7 × _weeks_.
+        1. Set _days_ to _days_ + 7 &times; _weeks_.
         1. Let _d_ be _intermediate_.[[Day]] + _days_.
         1. Let _intermediate_ be ! BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _d_).
         1. Return ? RegulateISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]], _overflow_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -472,7 +472,7 @@
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _result_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], −_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_duration_.[[Days]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]], _options_).
+        1. Let _result_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], -_duration_.[[Years]], -_duration_.[[Months]], -_duration_.[[Weeks]], -_duration_.[[Days]], -_duration_.[[Hours]], -_duration_.[[Minutes]], -_duration_.[[Seconds]], -_duration_.[[Milliseconds]], -_duration_.[[Microseconds]], -_duration_.[[Nanoseconds]], _options_).
         1. Assert: IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
         1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
@@ -530,7 +530,7 @@
         1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
         1. Let _roundResult_ be (? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].
         1. Let _result_ be ? BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
-        1. Return ! CreateTemporalDuration(−_roundResult_.[[Years]], −_roundResult_.[[Months]], −_roundResult_.[[Weeks]], −_result_.[[Days]], −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]]).
+        1. Return ! CreateTemporalDuration(-_roundResult_.[[Years]], -_roundResult_.[[Months]], -_roundResult_.[[Weeks]], -_result_.[[Days]], -_result_.[[Hours]], -_result_.[[Minutes]], -_result_.[[Seconds]], -_result_.[[Milliseconds]], -_result_.[[Microseconds]], -_result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -860,7 +860,7 @@
       </dl>
       <emu-alg>
         1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.
-        1. Let _date_ be MakeDay(𝔽(_year_), 𝔽(_month_ − 1), 𝔽(_day_)).
+        1. Let _date_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
         1. Let _time_ be MakeTime(𝔽(_hour_), 𝔽(_minute_), 𝔽(_second_), 𝔽(_millisecond_)).
         1. Let _ms_ be MakeDate(_date_, _time_).
         1. Assert: _ms_ is finite.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -894,9 +894,9 @@
       </emu-note>
       <emu-alg>
         1. Let _ns_ be ℝ(GetEpochFromISOParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_)).
-        1. If _ns_ ≤ -8.64 &times; 10<sup>21</sup> - 8.64 &times; 10<sup>13</sup>, then
+        1. If _ns_ &le; -8.64 &times; 10<sup>21</sup> - 8.64 &times; 10<sup>13</sup>, then
           1. Return *false*.
-        1. If _ns_ ≥ 8.64 &times; 10<sup>21</sup> + 8.64 &times; 10<sup>13</sup>, then
+        1. If _ns_ &ge; 8.64 &times; 10<sup>21</sup> + 8.64 &times; 10<sup>13</sup>, then
           1. Return *false*.
         1. Return *true*.
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -864,7 +864,7 @@
         1. Let _time_ be MakeTime(𝔽(_hour_), 𝔽(_minute_), 𝔽(_second_), 𝔽(_millisecond_)).
         1. Let _ms_ be MakeDate(_date_, _time_).
         1. Assert: _ms_ is finite.
-        1. Return ℤ(ℝ(_ms_) × 10<sup>6</sup> + _microsecond_ × 10<sup>3</sup> + _nanosecond_).
+        1. Return ℤ(ℝ(_ms_) &times; 10<sup>6</sup> + _microsecond_ &times; 10<sup>3</sup> + _nanosecond_).
       </emu-alg>
     </emu-clause>
 
@@ -888,15 +888,15 @@
       </dl>
       <emu-note>
         <p>
-          Temporal.PlainDateTime objects can represent points in time within 24 hours (8.64 × 10<sup>13</sup> nanoseconds) of the Temporal.Instant boundaries.
+          Temporal.PlainDateTime objects can represent points in time within 24 hours (8.64 &times; 10<sup>13</sup> nanoseconds) of the Temporal.Instant boundaries.
           This ensures that a Temporal.Instant object can be converted into a Temporal.PlainDateTime object using any time zone.
         </p>
       </emu-note>
       <emu-alg>
         1. Let _ns_ be ℝ(GetEpochFromISOParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_)).
-        1. If _ns_ ≤ -8.64 × 10<sup>21</sup> - 8.64 × 10<sup>13</sup>, then
+        1. If _ns_ ≤ -8.64 &times; 10<sup>21</sup> - 8.64 &times; 10<sup>13</sup>, then
           1. Return *false*.
-        1. If _ns_ ≥ 8.64 × 10<sup>21</sup> + 8.64 × 10<sup>13</sup>, then
+        1. If _ns_ ≥ 8.64 &times; 10<sup>21</sup> + 8.64 &times; 10<sup>13</sup>, then
           1. Return *false*.
         1. Return *true*.
       </emu-alg>
@@ -1087,7 +1087,7 @@
       </p>
       <emu-alg>
         1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integers.
-        1. If _dayLength_ is not present, set _dayLength_ to 8.64 × 10<sup>13</sup>.
+        1. If _dayLength_ is not present, set _dayLength_ to 8.64 &times; 10<sup>13</sup>.
         1. Let _roundedTime_ be ! RoundTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_, _dayLength_).
         1. Let _balanceResult_ be ! BalanceISODate(_year_, _month_, _day_ + _roundedTime_.[[Days]]).
         1. Return the Record {

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -170,9 +170,9 @@
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Set _other_ to ? ToTemporalMonthDay(_other_).
-        1. If _monthDay_.[[ISOMonth]] ≠ _other_.[[ISOMonth]], return *false*.
-        1. If _monthDay_.[[ISODay]] ≠ _other_.[[ISODay]], return *false*.
-        1. If _monthDay_.[[ISOYear]] ≠ _other_.[[ISOYear]], return *false*.
+        1. If _monthDay_.[[ISOMonth]] &ne; _other_.[[ISOMonth]], return *false*.
+        1. If _monthDay_.[[ISODay]] &ne; _other_.[[ISODay]], return *false*.
+        1. If _monthDay_.[[ISOYear]] &ne; _other_.[[ISOYear]], return *false*.
         1. Return ? CalendarEquals(_monthDay_.[[Calendar]], _other_.[[Calendar]]).
       </emu-alg>
     </emu-clause>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -614,8 +614,8 @@
         1. Let _microseconds_ be _mus2_ - _mus1_.
         1. Let _nanoseconds_ be _ns2_ - _ns1_.
         1. Let _sign_ be ! DurationSign(0, 0, 0, 0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Let _bt_ be ! BalanceTime(_hours_ × _sign_, _minutes_ × _sign_, _seconds_ × _sign_, _milliseconds_ × _sign_, _microseconds_ × _sign_, _nanoseconds_ × _sign_).
-        1. Return ! CreateTimeDurationRecord(_bt_.[[Days]] × _sign_, _bt_.[[Hour]] × _sign_, _bt_.[[Minute]] × _sign_, _bt_.[[Second]] × _sign_, _bt_.[[Millisecond]] × _sign_, _bt_.[[Microsecond]] × _sign_, _bt_.[[Nanosecond]] × _sign_).
+        1. Let _bt_ be ! BalanceTime(_hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
+        1. Return ! CreateTimeDurationRecord(_bt_.[[Days]] &times; _sign_, _bt_.[[Hour]] &times; _sign_, _bt_.[[Minute]] &times; _sign_, _bt_.[[Second]] &times; _sign_, _bt_.[[Millisecond]] &times; _sign_, _bt_.[[Microsecond]] &times; _sign_, _bt_.[[Nanosecond]] &times; _sign_).
       </emu-alg>
     </emu-clause>
 
@@ -921,10 +921,10 @@
       </p>
       <emu-alg>
         1. Assert: _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, and _increment_ are integers.
-        1. Let _fractionalSecond_ be _nanosecond_ × 10<sup>-9</sup> + _microsecond_ × 10<sup>-6</sup> + _millisecond_ × 10<sup>-3</sup> + _second_.
+        1. Let _fractionalSecond_ be _nanosecond_ &times; 10<sup>-9</sup> + _microsecond_ &times; 10<sup>-6</sup> + _millisecond_ &times; 10<sup>-3</sup> + _second_.
         1. If _unit_ is *"day"*, then
-          1. If _dayLengthNs_ is not present, set _dayLengthNs_ to 8.64 × 10<sup>13</sup>.
-          1. Let _quantity_ be (((((_hour_ × 60 + _minute_) × 60 + _second_) × 1000 + _millisecond_) × 1000 + _microsecond_) × 1000 + _nanosecond_) / _dayLengthNs_.
+          1. If _dayLengthNs_ is not present, set _dayLengthNs_ to 8.64 &times; 10<sup>13</sup>.
+          1. Let _quantity_ be (((((_hour_ &times; 60 + _minute_) &times; 60 + _second_) &times; 1000 + _millisecond_) &times; 1000 + _microsecond_) &times; 1000 + _nanosecond_) / _dayLengthNs_.
         1. Else if _unit_ is *"hour"*, then
           1. Let _quantity_ be (_fractionalSecond_ / 60 + _minute_) / 60 + _hour_.
         1. Else if _unit_ is *"minute"*, then
@@ -932,9 +932,9 @@
         1. Else if _unit_ is *"second"*, then
           1. Let _quantity_ be _fractionalSecond_.
         1. Else if _unit_ is *"millisecond"*, then
-          1. Let _quantity_ be _nanosecond_ × 10<sup>-6</sup> + _microsecond_ × 10<sup>-3</sup> + _millisecond_.
+          1. Let _quantity_ be _nanosecond_ &times; 10<sup>-6</sup> + _microsecond_ &times; 10<sup>-3</sup> + _millisecond_.
         1. Else if _unit_ is *"microsecond"*, then
-          1. Let _quantity_ be _nanosecond_ × 10<sup>-3</sup> + _microsecond_.
+          1. Let _quantity_ be _nanosecond_ &times; 10<sup>-3</sup> + _microsecond_.
         1. Else,
           1. Assert: _unit_ is *"nanosecond"*.
           1. Let _quantity_ be _nanosecond_.

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -227,7 +227,7 @@
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
-        1. Let _result_ be ! AddTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]]).
+        1. Let _result_ be ! AddTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], -_duration_.[[Hours]], -_duration_.[[Minutes]], -_duration_.[[Seconds]], -_duration_.[[Milliseconds]], -_duration_.[[Microseconds]], -_duration_.[[Nanoseconds]]).
         1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ? CreateTemporalTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
@@ -320,8 +320,8 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _result_ be ! DifferenceTime(_other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]]).
-        1. Set _result_ to (? RoundDuration(0, 0, 0, 0, −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
-        1. Set _result_ to ? BalanceDuration(0, −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]], _largestUnit_).
+        1. Set _result_ to (? RoundDuration(0, 0, 0, 0, -_result_.[[Hours]], -_result_.[[Minutes]], -_result_.[[Seconds]], -_result_.[[Milliseconds]], -_result_.[[Microseconds]], -_result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
+        1. Set _result_ to ? BalanceDuration(0, -_result_.[[Hours]], -_result_.[[Minutes]], -_result_.[[Seconds]], -_result_.[[Milliseconds]], -_result_.[[Microseconds]], -_result_.[[Nanoseconds]], _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -607,12 +607,12 @@
         <dd>It returns a Time Duration Record with the elapsed duration from a first wall-clock time, until a second wall-clock time.</dd>
       </dl>
       <emu-alg>
-        1. Let _hours_ be _h2_ − _h1_.
-        1. Let _minutes_ be _min2_ − _min1_.
-        1. Let _seconds_ be _s2_ − _s1_.
-        1. Let _milliseconds_ be _ms2_ − _ms1_.
-        1. Let _microseconds_ be _mus2_ − _mus1_.
-        1. Let _nanoseconds_ be _ns2_ − _ns1_.
+        1. Let _hours_ be _h2_ - _h1_.
+        1. Let _minutes_ be _min2_ - _min1_.
+        1. Let _seconds_ be _s2_ - _s1_.
+        1. Let _milliseconds_ be _ms2_ - _ms1_.
+        1. Let _microseconds_ be _mus2_ - _mus1_.
+        1. Let _nanoseconds_ be _ns2_ - _ns1_.
         1. Let _sign_ be ! DurationSign(0, 0, 0, 0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Let _bt_ be ! BalanceTime(_hours_ × _sign_, _minutes_ × _sign_, _seconds_ × _sign_, _milliseconds_ × _sign_, _microseconds_ × _sign_, _nanoseconds_ × _sign_).
         1. Return ! CreateTimeDurationRecord(_bt_.[[Days]] × _sign_, _bt_.[[Hour]] × _sign_, _bt_.[[Minute]] × _sign_, _bt_.[[Second]] × _sign_, _bt_.[[Millisecond]] × _sign_, _bt_.[[Microsecond]] × _sign_, _bt_.[[Nanosecond]] × _sign_).
@@ -921,7 +921,7 @@
       </p>
       <emu-alg>
         1. Assert: _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, and _increment_ are integers.
-        1. Let _fractionalSecond_ be _nanosecond_ × 10<sup>−9</sup> + _microsecond_ × 10<sup>−6</sup> + _millisecond_ × 10<sup>−3</sup> + _second_.
+        1. Let _fractionalSecond_ be _nanosecond_ × 10<sup>-9</sup> + _microsecond_ × 10<sup>-6</sup> + _millisecond_ × 10<sup>-3</sup> + _second_.
         1. If _unit_ is *"day"*, then
           1. If _dayLengthNs_ is not present, set _dayLengthNs_ to 8.64 × 10<sup>13</sup>.
           1. Let _quantity_ be (((((_hour_ × 60 + _minute_) × 60 + _second_) × 1000 + _millisecond_) × 1000 + _microsecond_) × 1000 + _nanosecond_) / _dayLengthNs_.
@@ -932,9 +932,9 @@
         1. Else if _unit_ is *"second"*, then
           1. Let _quantity_ be _fractionalSecond_.
         1. Else if _unit_ is *"millisecond"*, then
-          1. Let _quantity_ be _nanosecond_ × 10<sup>−6</sup> + _microsecond_ × 10<sup>−3</sup> + _millisecond_.
+          1. Let _quantity_ be _nanosecond_ × 10<sup>-6</sup> + _microsecond_ × 10<sup>-3</sup> + _millisecond_.
         1. Else if _unit_ is *"microsecond"*, then
-          1. Let _quantity_ be _nanosecond_ × 10<sup>−3</sup> + _microsecond_.
+          1. Let _quantity_ be _nanosecond_ × 10<sup>-3</sup> + _microsecond_.
         1. Else,
           1. Assert: _unit_ is *"nanosecond"*.
           1. Let _quantity_ be _nanosecond_.

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -368,12 +368,12 @@
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Set _other_ to ? ToTemporalTime(_other_).
-        1. If _temporalTime_.[[ISOHour]] ≠ _other_.[[ISOHour]], return *false*.
-        1. If _temporalTime_.[[ISOMinute]] ≠ _other_.[[ISOMinute]], return *false*.
-        1. If _temporalTime_.[[ISOSecond]] ≠ _other_.[[ISOSecond]], return *false*.
-        1. If _temporalTime_.[[ISOMillisecond]] ≠ _other_.[[ISOMillisecond]], return *false*.
-        1. If _temporalTime_.[[ISOMicrosecond]] ≠ _other_.[[ISOMicrosecond]], return *false*.
-        1. If _temporalTime_.[[ISONanosecond]] ≠ _other_.[[ISONanosecond]], return *false*.
+        1. If _temporalTime_.[[ISOHour]] &ne; _other_.[[ISOHour]], return *false*.
+        1. If _temporalTime_.[[ISOMinute]] &ne; _other_.[[ISOMinute]], return *false*.
+        1. If _temporalTime_.[[ISOSecond]] &ne; _other_.[[ISOSecond]], return *false*.
+        1. If _temporalTime_.[[ISOMillisecond]] &ne; _other_.[[ISOMillisecond]], return *false*.
+        1. If _temporalTime_.[[ISOMicrosecond]] &ne; _other_.[[ISOMicrosecond]], return *false*.
+        1. If _temporalTime_.[[ISONanosecond]] &ne; _other_.[[ISONanosecond]], return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -376,9 +376,9 @@
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
         1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
-          1. Return ! CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Return ! CreateTemporalDuration(-_result_.[[Years]], -_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _result_ be (? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Return ! CreateTemporalDuration(-_result_.[[Years]], -_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
 
@@ -628,9 +628,9 @@
       </emu-note>
       <emu-alg>
         1. Assert: _year_ and _month_ are integers.
-        1. If _year_ &lt; −271821 or _year_ &gt; 275760, then
+        1. If _year_ &lt; -271821 or _year_ &gt; 275760, then
           1. Return *false*.
-        1. If _year_ is −271821 and _month_ &lt; 4, then
+        1. If _year_ is -271821 and _month_ &lt; 4, then
           1. Return *false*.
         1. If _year_ is 275760 and _month_ &gt; 9, then
           1. Return *false*.
@@ -643,7 +643,7 @@
       <emu-alg>
         1. Assert: _year_ and _month_ are integers.
         1. Set _year_ to _year_ + floor((_month_ - 1) / 12).
-        1. Set _month_ to (_month_ − 1) modulo 12 + 1.
+        1. Set _month_ to (_month_ - 1) modulo 12 + 1.
         1. Return the Record {
             [[Year]]: _year_,
             [[Month]]: _month_

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -392,9 +392,9 @@
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Set _other_ to ? ToTemporalYearMonth(_other_).
-        1. If _yearMonth_.[[ISOYear]] ≠ _other_.[[ISOYear]], return *false*.
-        1. If _yearMonth_.[[ISOMonth]] ≠ _other_.[[ISOMonth]], return *false*.
-        1. If _yearMonth_.[[ISODay]] ≠ _other_.[[ISODay]], return *false*.
+        1. If _yearMonth_.[[ISOYear]] &ne; _other_.[[ISOYear]], return *false*.
+        1. If _yearMonth_.[[ISOMonth]] &ne; _other_.[[ISOMonth]], return *false*.
+        1. If _yearMonth_.[[ISODay]] &ne; _other_.[[ISODay]], return *false*.
         1. Return ? CalendarEquals(_yearMonth_.[[Calendar]], _other_.[[Calendar]]).
       </emu-alg>
     </emu-clause>

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -211,7 +211,7 @@
       <h1>SystemUTCEpochNanoseconds ( )</h1>
       <emu-alg>
         1. Let _ns_ be the approximate current UTC date and time, in nanoseconds since the epoch.
-        1. [id="step-temporal-systemutcepochnanoseconds-clamp"] Set _ns_ to the result of clamping _ns_ between −8.64 × 10<sup>21</sup> and 8.64 × 10<sup>21</sup>.
+        1. [id="step-temporal-systemutcepochnanoseconds-clamp"] Set _ns_ to the result of clamping _ns_ between -8.64 × 10<sup>21</sup> and 8.64 × 10<sup>21</sup>.
         1. Return ℤ(_ns_).
       </emu-alg>
       <emu-note>

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -211,7 +211,7 @@
       <h1>SystemUTCEpochNanoseconds ( )</h1>
       <emu-alg>
         1. Let _ns_ be the approximate current UTC date and time, in nanoseconds since the epoch.
-        1. [id="step-temporal-systemutcepochnanoseconds-clamp"] Set _ns_ to the result of clamping _ns_ between -8.64 × 10<sup>21</sup> and 8.64 × 10<sup>21</sup>.
+        1. [id="step-temporal-systemutcepochnanoseconds-clamp"] Set _ns_ to the result of clamping _ns_ between -8.64 &times; 10<sup>21</sup> and 8.64 &times; 10<sup>21</sup>.
         1. Return ℤ(_ns_).
       </emu-alg>
       <emu-note>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -578,11 +578,11 @@
         1. Let _h_ be ToZeroPaddedDecimalString(_hours_, 2).
         1. Let _m_ be ToZeroPaddedDecimalString(_minutes_, 2).
         1. Let _s_ be ToZeroPaddedDecimalString(_seconds_, 2).
-        1. If _nanoseconds_ ≠ 0, then
+        1. If _nanoseconds_ &ne; 0, then
           1. Let _fraction_ be ToZeroPaddedDecimalString(_nanoseconds_, 9).
           1. Set _fraction_ to the longest possible substring of _fraction_ starting at position 0 and not ending with the code unit 0x0030 (DIGIT ZERO).
           1. Let _post_ be the string-concatenation of the code unit 0x003A (COLON), _s_, the code unit 0x002E (FULL STOP), and _fraction_.
-        1. Else if seconds ≠ 0, then
+        1. Else if seconds &ne; 0, then
           1. Let _post_ be the string-concatenation of the code unit 0x003A (COLON) and _s_.
         1. Else,
           1. Let _post_ be the empty String.
@@ -621,7 +621,7 @@
         1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_identifier_).
         1. If _parseResult_.[[Name]] is not *undefined*, then
           1. If ParseText(StringToCodePoints(_parseResult_.[[Name]], |TimeZoneNumericUTCOffset|)) is not a List of errors, then
-            1. If _parseResult_.[[OffsetString]] is not *undefined*, and ! ParseTimeZoneOffsetString(_parseResult_.[[OffsetString]]) ≠ ! ParseTimeZoneOffsetString(_parseResult_.[[Name]]), throw a *RangeError* exception.
+            1. If _parseResult_.[[OffsetString]] is not *undefined*, and ! ParseTimeZoneOffsetString(_parseResult_.[[OffsetString]]) &ne; ! ParseTimeZoneOffsetString(_parseResult_.[[Name]]), throw a *RangeError* exception.
           1. Else,
             1. If ! IsValidTimeZoneName(_parseResult_.[[Name]]) is *false*, throw a *RangeError* exception.
           1. Return ! CreateTemporalTimeZone(! CanonicalizeTimeZoneName(_parseResult_.[[Name]])).
@@ -693,7 +693,7 @@
         1. Let _n_ be _possibleInstants_'s length.
         1. If _n_ = 1, then
           1. Return _possibleInstants_[0].
-        1. If _n_ ≠ 0, then
+        1. If _n_ &ne; 0, then
           1. If _disambiguation_ is *"earlier"* or *"compatible"*, then
             1. Return _possibleInstants_[0].
           1. If _disambiguation_ is *"later"*, then

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -561,7 +561,7 @@
           1. Set _nanoseconds_ to ! ToIntegerOrInfinity(_nanoseconds_).
         1. Else,
           1. Let _nanoseconds_ be 0.
-        1. Return _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).
+        1. Return _sign_ &times; (((_hours_ &times; 60 + _minutes_) &times; 60 + _seconds_) &times; 10<sup>9</sup> + _nanoseconds_).
       </emu-alg>
     </emu-clause>
 
@@ -573,8 +573,8 @@
         1. Let _offsetNanoseconds_ be abs(_offsetNanoseconds_).
         1. Let _nanoseconds_ be _offsetNanoseconds_ modulo 10<sup>9</sup>.
         1. Let _seconds_ be floor(_offsetNanoseconds_ / 10<sup>9</sup>) modulo 60.
-        1. Let _minutes_ be floor(_offsetNanoseconds_ / (6 × 10<sup>10</sup>)) modulo 60.
-        1. Let _hours_ be floor(_offsetNanoseconds_ / (3.6 × 10<sup>12</sup>)).
+        1. Let _minutes_ be floor(_offsetNanoseconds_ / (6 &times; 10<sup>10</sup>)) modulo 60.
+        1. Let _hours_ be floor(_offsetNanoseconds_ / (3.6 &times; 10<sup>12</sup>)).
         1. Let _h_ be ToZeroPaddedDecimalString(_hours_, 2).
         1. Let _m_ be ToZeroPaddedDecimalString(_minutes_, 2).
         1. Let _s_ be ToZeroPaddedDecimalString(_seconds_, 2).
@@ -597,11 +597,11 @@
       </p>
       <emu-alg>
         1. Assert: _offsetNanoseconds_ is an integer.
-        1. Set _offsetNanoseconds_ to ! RoundNumberToIncrement(_offsetNanoseconds_, 60 × 10<sup>9</sup>, *"halfExpand"*).
+        1. Set _offsetNanoseconds_ to ! RoundNumberToIncrement(_offsetNanoseconds_, 60 &times; 10<sup>9</sup>, *"halfExpand"*).
         1. If _offsetNanoseconds_ ≥ 0, let _sign_ be *"+"*; otherwise, let _sign_ be *"-"*.
         1. Set _offsetNanoseconds_ to abs(_offsetNanoseconds_).
-        1. Let _minutes_ be _offsetNanoseconds_ / (60 × 10<sup>9</sup>) modulo 60.
-        1. Let _hours_ be floor(_offsetNanoseconds_ / (3600 × 10<sup>9</sup>)).
+        1. Let _minutes_ be _offsetNanoseconds_ / (60 &times; 10<sup>9</sup>) modulo 60.
+        1. Let _hours_ be floor(_offsetNanoseconds_ / (3600 &times; 10<sup>9</sup>)).
         1. Let _h_ be ToZeroPaddedDecimalString(_hours_, 2).
         1. Let _m_ be ToZeroPaddedDecimalString(_minutes_, 2).
         1. Return the string-concatenation of _sign_, _h_, the code unit 0x003A (COLON), and _m_.
@@ -638,7 +638,7 @@
         1. If Type(_offsetNanoseconds_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_offsetNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Set _offsetNanoseconds_ to ℝ(_offsetNanoseconds_).
-        1. If abs(_offsetNanoseconds_) &gt; 86400 × 10<sup>9</sup>, throw a *RangeError* exception.
+        1. If abs(_offsetNanoseconds_) &gt; 86400 &times; 10<sup>9</sup>, throw a *RangeError* exception.
         1. Return _offsetNanoseconds_.
       </emu-alg>
     </emu-clause>
@@ -704,8 +704,8 @@
         1. If _disambiguation_ is *"reject"*, then
           1. Throw a *RangeError* exception.
         1. Let _epochNanoseconds_ be GetEpochFromISOParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
-        1. Let _dayBefore_ be ! CreateTemporalInstant(_epochNanoseconds_ - *8.64 × 10<sup>13</sup>*<sub>ℤ</sub>).
-        1. Let _dayAfter_ be ! CreateTemporalInstant(_epochNanoseconds_ + *8.64 × 10<sup>13</sup>*<sub>ℤ</sub>).
+        1. Let _dayBefore_ be ! CreateTemporalInstant(_epochNanoseconds_ - *8.64 &times; 10<sup>13</sup>*<sub>ℤ</sub>).
+        1. Let _dayAfter_ be ! CreateTemporalInstant(_epochNanoseconds_ + *8.64 &times; 10<sup>13</sup>*<sub>ℤ</sub>).
         1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayBefore_).
         1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayAfter_).
         1. Let _nanoseconds_ be _offsetAfter_ - _offsetBefore_.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -569,7 +569,7 @@
       <h1>FormatTimeZoneOffsetString ( _offsetNanoseconds_ )</h1>
       <emu-alg>
         1. Assert: _offsetNanoseconds_ is an integer.
-        1. If _offsetNanoseconds_ ≥ 0, let _sign_ be *"+"*; otherwise, let _sign_ be *"-"*.
+        1. If _offsetNanoseconds_ &ge; 0, let _sign_ be *"+"*; otherwise, let _sign_ be *"-"*.
         1. Let _offsetNanoseconds_ be abs(_offsetNanoseconds_).
         1. Let _nanoseconds_ be _offsetNanoseconds_ modulo 10<sup>9</sup>.
         1. Let _seconds_ be floor(_offsetNanoseconds_ / 10<sup>9</sup>) modulo 60.
@@ -598,7 +598,7 @@
       <emu-alg>
         1. Assert: _offsetNanoseconds_ is an integer.
         1. Set _offsetNanoseconds_ to ! RoundNumberToIncrement(_offsetNanoseconds_, 60 &times; 10<sup>9</sup>, *"halfExpand"*).
-        1. If _offsetNanoseconds_ ≥ 0, let _sign_ be *"+"*; otherwise, let _sign_ be *"-"*.
+        1. If _offsetNanoseconds_ &ge; 0, let _sign_ be *"+"*; otherwise, let _sign_ be *"-"*.
         1. Set _offsetNanoseconds_ to abs(_offsetNanoseconds_).
         1. Let _minutes_ be _offsetNanoseconds_ / (60 &times; 10<sup>9</sup>) modulo 60.
         1. Let _hours_ be floor(_offsetNanoseconds_ / (3600 &times; 10<sup>9</sup>)).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -281,7 +281,7 @@
         1. Set _dateTime_ to ? ToTemporalDateTime(_dateTime_).
         1. If _timeZone_.[[OffsetNanoseconds]] is not *undefined*, then
           1. Let _epochNanoseconds_ be GetEpochFromISOParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
-          1. Let _instant_ be ! CreateTemporalInstant(_epochNanoseconds_ − ℤ(_timeZone_.[[OffsetNanoseconds]])).
+          1. Let _instant_ be ! CreateTemporalInstant(_epochNanoseconds_ - ℤ(_timeZone_.[[OffsetNanoseconds]])).
           1. Return CreateArrayFromList(« _instant_ »).
         1. Let _possibleEpochNanoseconds_ be GetIANATimeZoneEpochValue(_timeZone_.[[Identifier]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
         1. Let _possibleInstants_ be a new empty List.
@@ -434,7 +434,7 @@
       <emu-alg>
         1. Assert: ! IsValidEpochNanoseconds(ℤ(_epochNanoseconds_)) is *true*.
         1. Let _remainderNs_ be _epochNanoseconds_ modulo 10<sup>6</sup>.
-        1. Let _epochMilliseconds_ be 𝔽((_epochNanoseconds_ − _remainderNs_) / 10<sup>6</sup>).
+        1. Let _epochMilliseconds_ be 𝔽((_epochNanoseconds_ - _remainderNs_) / 10<sup>6</sup>).
         1. Let _year_ be ℝ(! YearFromTime(_epochMilliseconds_)).
         1. Let _month_ be ℝ(! MonthFromTime(_epochMilliseconds_)) + 1.
         1. Let _day_ be ℝ(! DateFromTime(_epochMilliseconds_)).
@@ -549,7 +549,7 @@
         1. Assert: _sign_ is not *undefined*.
         1. Assert: _hours_ is not *undefined*.
         1. If _sign_ is the code unit 0x002D (HYPHEN-MINUS) or 0x2212 (MINUS SIGN), then
-          1. Set _sign_ to −1.
+          1. Set _sign_ to -1.
         1. Else,
           1. Set _sign_ to 1.
         1. Set _hours_ to ! ToIntegerOrInfinity(_hours_).
@@ -697,20 +697,20 @@
           1. If _disambiguation_ is *"earlier"* or *"compatible"*, then
             1. Return _possibleInstants_[0].
           1. If _disambiguation_ is *"later"*, then
-            1. Return _possibleInstants_[_n_ − 1].
+            1. Return _possibleInstants_[_n_ - 1].
           1. Assert: _disambiguation_ is *"reject"*.
           1. Throw a *RangeError* exception.
         1. Assert: _n_ = 0.
         1. If _disambiguation_ is *"reject"*, then
           1. Throw a *RangeError* exception.
         1. Let _epochNanoseconds_ be GetEpochFromISOParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
-        1. Let _dayBefore_ be ! CreateTemporalInstant(_epochNanoseconds_ − *8.64 × 10<sup>13</sup>*<sub>ℤ</sub>).
+        1. Let _dayBefore_ be ! CreateTemporalInstant(_epochNanoseconds_ - *8.64 × 10<sup>13</sup>*<sub>ℤ</sub>).
         1. Let _dayAfter_ be ! CreateTemporalInstant(_epochNanoseconds_ + *8.64 × 10<sup>13</sup>*<sub>ℤ</sub>).
         1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayBefore_).
         1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayAfter_).
-        1. Let _nanoseconds_ be _offsetAfter_ − _offsetBefore_.
+        1. Let _nanoseconds_ be _offsetAfter_ - _offsetBefore_.
         1. If _disambiguation_ is *"earlier"*, then
-          1. Let _earlier_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, −_nanoseconds_, *undefined*).
+          1. Let _earlier_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], 0, 0, 0, 0, 0, 0, 0, 0, 0, -_nanoseconds_, *undefined*).
           1. Let _earlierDateTime_ be ! CreateTemporalDateTime(_earlier_.[[Year]], _earlier_.[[Month]], _earlier_.[[Day]], _earlier_.[[Hour]], _earlier_.[[Minute]], _earlier_.[[Second]], _earlier_.[[Millisecond]], _earlier_.[[Microsecond]], _earlier_.[[Nanosecond]], _dateTime_.[[Calendar]]).
           1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
           1. If _possibleInstants_ is empty, throw a *RangeError* exception.
@@ -721,7 +721,7 @@
         1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
         1. Set _n_ to _possibleInstants_'s length.
         1. If _n_ = 0, throw a *RangeError* exception.
-        1. Return _possibleInstants_[_n_ − 1].
+        1. Return _possibleInstants_[_n_ - 1].
       </emu-alg>
     </emu-clause>
 

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -436,7 +436,7 @@
         1. Let _todayInstant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _today_, *"compatible"*).
         1. Let _tomorrowInstant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _tomorrow_, *"compatible"*).
         1. Let _diffNs_ be _tomorrowInstant_.[[Nanoseconds]] - _todayInstant_.[[Nanoseconds]].
-        1. Return 𝔽(_diffNs_ / (3.6 × 10<sup>12</sup>)).
+        1. Return 𝔽(_diffNs_ / (3.6 &times; 10<sup>12</sup>)).
       </emu-alg>
     </emu-clause>
 
@@ -716,7 +716,7 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) ≤ 1.728 × 10<sup>22</sup>.
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) ≤ 1.728 &times; 10<sup>22</sup>.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
@@ -752,7 +752,7 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) ≤ 1.728 × 10<sup>22</sup>.
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) ≤ 1.728 &times; 10<sup>22</sup>.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, -_balanceResult_.[[Hours]], -_balanceResult_.[[Minutes]], -_balanceResult_.[[Seconds]], -_balanceResult_.[[Milliseconds]], -_balanceResult_.[[Microseconds]], -_balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
@@ -1128,7 +1128,7 @@
           1. If _candidateNanoseconds_ = _offsetNanoseconds_, then
             1. Return _candidate_.[[Nanoseconds]].
           1. If _matchBehaviour_ is ~match minutes~, then
-            1. Let _roundedCandidateNanoseconds_ be ! RoundNumberToIncrement(_candidateNanoseconds_, 60 × 10<sup>9</sup>, *"halfExpand"*).
+            1. Let _roundedCandidateNanoseconds_ be ! RoundNumberToIncrement(_candidateNanoseconds_, 60 &times; 10<sup>9</sup>, *"halfExpand"*).
             1. If _roundedCandidateNanoseconds_ = _offsetNanoseconds_, then
               1. Return _candidate_.[[Nanoseconds]].
         1. If _offsetOption_ is *"reject"*, throw a *RangeError* exception.
@@ -1358,14 +1358,14 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _dayLengthNs_ be 8.64 × 10<sup>13</sup>.
+        1. Let _dayLengthNs_ be 8.64 &times; 10<sup>13</sup>.
         1. If _nanoseconds_ = 0, then
           1. Return the Record { [[Days]]: 0, [[Nanoseconds]]: 0, [[DayLength]]: _dayLengthNs_ }.
         1. If _nanoseconds_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
         1. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Return the Record {
             [[Days]]: RoundTowardsZero(_nanoseconds_ / _dayLengthNs_),
-            [[Nanoseconds]]: (abs(_nanoseconds_) modulo _dayLengthNs_) × _sign_,
+            [[Nanoseconds]]: (abs(_nanoseconds_) modulo _dayLengthNs_) &times; _sign_,
             [[DayLength]]: _dayLengthNs_
             }.
         1. Let _startNs_ be ℝ(_relativeTo_.[[Nanoseconds]]).
@@ -1386,7 +1386,7 @@
         1. Repeat, while _done_ is *false*,
           1. Let _oneDayFartherNs_ be ℝ(? AddZonedDateTime(ℤ(_intermediateNs_), _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _sign_, 0, 0, 0, 0, 0, 0)).
           1. Set _dayLengthNs_ to _oneDayFartherNs_ - _intermediateNs_.
-          1. If (_nanoseconds_ - _dayLengthNs_) × _sign_ ≥ 0, then
+          1. If (_nanoseconds_ - _dayLengthNs_) &times; _sign_ ≥ 0, then
             1. Set _nanoseconds_ to _nanoseconds_ - _dayLengthNs_.
             1. Set _intermediateNs_ to _oneDayFartherNs_.
             1. Set _days_ to _days_ + _sign_.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -435,7 +435,7 @@
         1. Let _tomorrow_ be ? CreateTemporalDateTime(_tomorrowFields_.[[Year]], _tomorrowFields_.[[Month]], _tomorrowFields_.[[Day]], 0, 0, 0, 0, 0, 0, _isoCalendar_).
         1. Let _todayInstant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _today_, *"compatible"*).
         1. Let _tomorrowInstant_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _tomorrow_, *"compatible"*).
-        1. Let _diffNs_ be _tomorrowInstant_.[[Nanoseconds]] − _todayInstant_.[[Nanoseconds]].
+        1. Let _diffNs_ be _tomorrowInstant_.[[Nanoseconds]] - _todayInstant_.[[Nanoseconds]].
         1. Return 𝔽(_diffNs_ / (3.6 × 10<sup>12</sup>)).
       </emu-alg>
     </emu-clause>
@@ -689,7 +689,7 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZone_, _calendar_, −_duration_.[[Years]], −_duration_.[[Months]], −_duration_.[[Weeks]], −_duration_.[[Days]], −_duration_.[[Hours]], −_duration_.[[Minutes]], −_duration_.[[Seconds]], −_duration_.[[Milliseconds]], −_duration_.[[Microseconds]], −_duration_.[[Nanoseconds]], _options_).
+        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZone_, _calendar_, -_duration_.[[Years]], -_duration_.[[Months]], -_duration_.[[Weeks]], -_duration_.[[Days]], -_duration_.[[Hours]], -_duration_.[[Minutes]], -_duration_.[[Seconds]], -_duration_.[[Milliseconds]], -_duration_.[[Microseconds]], -_duration_.[[Nanoseconds]], _options_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -754,14 +754,14 @@
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) ≤ 1.728 × 10<sup>22</sup>.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
-          1. Return ! CreateTemporalDuration(0, 0, 0, 0, −_balanceResult_.[[Hours]], −_balanceResult_.[[Minutes]], −_balanceResult_.[[Seconds]], −_balanceResult_.[[Milliseconds]], −_balanceResult_.[[Microseconds]], −_balanceResult_.[[Nanoseconds]]).
+          1. Return ! CreateTemporalDuration(0, 0, 0, 0, -_balanceResult_.[[Hours]], -_balanceResult_.[[Minutes]], -_balanceResult_.[[Seconds]], -_balanceResult_.[[Milliseconds]], -_balanceResult_.[[Microseconds]], -_balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_, _untilOptions_).
         1. Let _roundResult_ be (? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_)).[[DurationRecord]].
         1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
-        1. Return ! CreateTemporalDuration(−_result_.[[Years]], −_result_.[[Months]], −_result_.[[Weeks]], −_result_.[[Days]], −_result_.[[Hours]], −_result_.[[Minutes]], −_result_.[[Seconds]], −_result_.[[Milliseconds]], −_result_.[[Microseconds]], −_result_.[[Nanoseconds]]).
+        1. Return ! CreateTemporalDuration(-_result_.[[Years]], -_result_.[[Months]], -_result_.[[Weeks]], -_result_.[[Days]], -_result_.[[Hours]], -_result_.[[Minutes]], -_result_.[[Seconds]], -_result_.[[Milliseconds]], -_result_.[[Microseconds]], -_result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -795,7 +795,7 @@
         1. Let _instantStart_ be ? BuiltinTimeZoneGetInstantFor(_timeZone_, _dtStart_, *"compatible"*).
         1. Let _startNs_ be _instantStart_.[[Nanoseconds]].
         1. Let _endNs_ be ? AddZonedDateTime(_startNs_, _timeZone_, _zonedDateTime_.[[Calendar]], 0, 0, 0, 1, 0, 0, 0, 0, 0, 0).
-        1. Let _dayLengthNs_ be ℝ(_endNs_ − _startNs_).
+        1. Let _dayLengthNs_ be ℝ(_endNs_ - _startNs_).
         1. If _dayLengthNs_ is 0, then
           1. Throw a *RangeError* exception.
         1. Let _roundResult_ be ! RoundISODateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dayLengthNs_).
@@ -1119,7 +1119,7 @@
           1. Return _instant_.[[Nanoseconds]].
         1. If _offsetBehaviour_ is ~exact~, or _offsetOption_ is *"use"*, then
           1. Let _epochNanoseconds_ be GetEpochFromISOParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
-          1. Return _epochNanoseconds_ − ℤ(_offsetNanoseconds_).
+          1. Return _epochNanoseconds_ - ℤ(_offsetNanoseconds_).
         1. Assert: _offsetBehaviour_ is ~option~.
         1. Assert: _offsetOption_ is *"prefer"* or *"reject"*.
         1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
@@ -1335,7 +1335,7 @@
         1. Let _endDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _endInstant_, _calendar_).
         1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
         1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZone_, _calendar_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], 0, 0, 0, 0, 0, 0, 0).
-        1. Let _timeRemainderNs_ be _ns2_ − _intermediateNs_.
+        1. Let _timeRemainderNs_ be _ns2_ - _intermediateNs_.
         1. Let _intermediate_ be ! CreateTemporalZonedDateTime(_intermediateNs_, _timeZone_, _calendar_).
         1. Let _result_ be ? NanosecondsToDays(ℝ(_timeRemainderNs_), _intermediate_).
         1. Let _timeDifference_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], *"hour"*).
@@ -1361,7 +1361,7 @@
         1. Let _dayLengthNs_ be 8.64 × 10<sup>13</sup>.
         1. If _nanoseconds_ = 0, then
           1. Return the Record { [[Days]]: 0, [[Nanoseconds]]: 0, [[DayLength]]: _dayLengthNs_ }.
-        1. If _nanoseconds_ &lt; 0, let _sign_ be −1; else, let _sign_ be 1.
+        1. If _nanoseconds_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
         1. If Type(_relativeTo_) is not Object or _relativeTo_ does not have an [[InitializedTemporalZonedDateTime]] internal slot, then
           1. Return the Record {
             [[Days]]: RoundTowardsZero(_nanoseconds_ / _dayLengthNs_),
@@ -1379,15 +1379,15 @@
         1. Let _intermediateNs_ be ℝ(? AddZonedDateTime(ℤ(_startNs_), _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, 0, 0, 0, 0, 0, 0)).
         1. If _sign_ is 1, then
           1. Repeat, while _days_ &gt; 0 and _intermediateNs_ &gt; _endNs_,
-            1. Set _days_ to _days_ − 1.
+            1. Set _days_ to _days_ - 1.
             1. Set _intermediateNs_ to ℝ(? AddZonedDateTime(ℤ(_startNs_), _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, 0, 0, 0, 0, 0, 0)).
-        1. Set _nanoseconds_ to _endNs_ − _intermediateNs_.
+        1. Set _nanoseconds_ to _endNs_ - _intermediateNs_.
         1. Let _done_ be *false*.
         1. Repeat, while _done_ is *false*,
           1. Let _oneDayFartherNs_ be ℝ(? AddZonedDateTime(ℤ(_intermediateNs_), _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _sign_, 0, 0, 0, 0, 0, 0)).
-          1. Set _dayLengthNs_ to _oneDayFartherNs_ − _intermediateNs_.
-          1. If (_nanoseconds_ − _dayLengthNs_) × _sign_ ≥ 0, then
-            1. Set _nanoseconds_ to _nanoseconds_ − _dayLengthNs_.
+          1. Set _dayLengthNs_ to _oneDayFartherNs_ - _intermediateNs_.
+          1. If (_nanoseconds_ - _dayLengthNs_) × _sign_ ≥ 0, then
+            1. Set _nanoseconds_ to _nanoseconds_ - _dayLengthNs_.
             1. Set _intermediateNs_ to _oneDayFartherNs_.
             1. Set _days_ to _days_ + _sign_.
           1. Else,

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -815,7 +815,7 @@
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Set _other_ to ? ToTemporalZonedDateTime(_other_).
-        1. If _zonedDateTime_.[[Nanoseconds]] ≠ _other_.[[Nanoseconds]], return *false*.
+        1. If _zonedDateTime_.[[Nanoseconds]] &ne; _other_.[[Nanoseconds]], return *false*.
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, return *false*.
         1. Return ? CalendarEquals(_zonedDateTime_.[[Calendar]], _other_.[[Calendar]]).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -716,7 +716,7 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) ≤ 1.728 &times; 10<sup>22</sup>.
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 1.728 &times; 10<sup>22</sup>.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
@@ -752,7 +752,7 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) ≤ 1.728 &times; 10<sup>22</sup>.
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 1.728 &times; 10<sup>22</sup>.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, -_balanceResult_.[[Hours]], -_balanceResult_.[[Minutes]], -_balanceResult_.[[Seconds]], -_balanceResult_.[[Milliseconds]], -_balanceResult_.[[Microseconds]], -_balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
@@ -1386,7 +1386,7 @@
         1. Repeat, while _done_ is *false*,
           1. Let _oneDayFartherNs_ be ℝ(? AddZonedDateTime(ℤ(_intermediateNs_), _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _sign_, 0, 0, 0, 0, 0, 0)).
           1. Set _dayLengthNs_ to _oneDayFartherNs_ - _intermediateNs_.
-          1. If (_nanoseconds_ - _dayLengthNs_) &times; _sign_ ≥ 0, then
+          1. If (_nanoseconds_ - _dayLengthNs_) &times; _sign_ &ge; 0, then
             1. Set _nanoseconds_ to _nanoseconds_ - _dayLengthNs_.
             1. Set _intermediateNs_ to _oneDayFartherNs_.
             1. Set _days_ to _days_ + _sign_.


### PR DESCRIPTION
Fixes #1548
Ref https://github.com/tc39/ecma262/pull/2730

* subtraction and negation as `-` (U+002D HYPHEN-MINUS) rather than `−` (U+2212 MINUS SIGN)
* multiplication as `&times;`
* loose inequality as `&le;`/`&ge;`
* inequality as `&ne;`
* infinity as `&infin;`