### PR TITLE
Editorial: Refactor common alg of since/until into AOs

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -643,7 +643,7 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _roundedNs_ be ! DifferenceInstant(_first_.[[Nanoseconds]], _second_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) ≤ 1.728 × 10<sup>22</sup>.
+        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 1.728 &times; 10<sup>22</sup>.
         1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -629,7 +629,7 @@
           _operation_: ~since~ or ~until~,
           _instant_: a Temporal.Instant,
           _other_: an ECMAScript language value,
-          _options_: an Object or *undefined*,
+          _options_: an ECMAScript language value,
         ): either a normal completion containing a Temporal.Duration or an abrupt completion
       </h1>
       <dl class="header">

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -640,7 +640,7 @@
         1. Set _other_ to ? ToTemporalInstant(_other_).
         1. If _operation_ is ~until~, then,
           1. Let _first_ be _instant_.
-          1. Let _second_ be _other__.
+          1. Let _second_ be _other_.
         else.
           1. Let _first_ be _other_.
           1. Let _second_ be _instant__.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -658,7 +658,5 @@
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
-      </emu-alg>
-    </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -641,9 +641,9 @@
         1. If _operation_ is ~until~, then,
           1. Let _first_ be _instant_.
           1. Let _second_ be _other_.
-        else.
+        1. Else,
           1. Let _first_ be _other_.
-          1. Let _second_ be _instant__.
+          1. Let _second_ be _instant_.
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -631,7 +631,7 @@
           _first_: a Temporal.Instant,
           _second_: a Temporal.Instant,
           _options_: an Object or *undefined*,
-        )
+        ): a Temporal.Duration
       </h1>
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -257,18 +257,7 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _other_ to ? ToTemporalInstant(_other_).
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _roundedNs_ be ! DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 1.728 &times; 10<sup>22</sup>.
-        1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
-        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Return ? DifferenceTemporalInstant(_instant_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -282,18 +271,7 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _other_ to ? ToTemporalInstant(_other_).
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _roundedNs_ be ! DifferenceInstant(_other_.[[Nanoseconds]], _instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 1.728 &times; 10<sup>22</sup>.
-        1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
-        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Return ? DifferenceTemporalInstant(_other_, _instant_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -645,6 +623,31 @@
           1. Let _offsetNs_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
           1. Let _timeZoneString_ be ! FormatISOTimeZoneOffsetString(_offsetNs_).
         1. Return the string-concatenation of _dateTimeString_ and _timeZoneString_.
+      </emu-alg>
+    </emu-clause>
+    <emu-clause id="sec-temporal-differencetemporalinstant" aoid="DifferenceTemporalInstant">
+      <h1>
+        DifferenceTemporalInstant (
+          _first_: a Temporal.Instant,
+          _second_: a Temporal.Instant,
+          _options_: an Object or *undefined*,
+        )
+      </h1>
+      <emu-alg>
+        1. Set _options_ to ? GetOptionsObject(_options_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, _defaultLargestUnit_).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
+        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. Let _roundedNs_ be ! DifferenceInstant(_first_.[[Nanoseconds]], _second_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) ≤ 1.728 × 10<sup>22</sup>.
+        1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
+        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+      </emu-alg>
+    </emu-clause>
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -256,8 +256,7 @@
       <emu-alg>
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. Set _other_ to ? ToTemporalInstant(_other_).
-        1. Return ? DifferenceTemporalInstant(_instant_, _other_, _options_).
+        1. Return ? DifferenceTemporalInstant(~until~, _instant_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -270,8 +269,7 @@
       <emu-alg>
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. Set _other_ to ? ToTemporalInstant(_other_).
-        1. Return ? DifferenceTemporalInstant(_other_, _instant_, _options_).
+        1. Return ? DifferenceTemporalInstant(~since~, _instant_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -625,15 +623,27 @@
         1. Return the string-concatenation of _dateTimeString_ and _timeZoneString_.
       </emu-alg>
     </emu-clause>
-    <emu-clause id="sec-temporal-differencetemporalinstant" aoid="DifferenceTemporalInstant">
+    <emu-clause id="sec-temporal-differencetemporalinstant" type="abstract operation">
       <h1>
         DifferenceTemporalInstant (
-          _first_: a Temporal.Instant,
-          _second_: a Temporal.Instant,
+          _operation_: ~since~ or ~until~,
+          _instant_: a Temporal.Instant,
+          _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        ): a Temporal.Duration
+        ): either a normal completion containing a Temporal.Duration or an abrupt completion
       </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It computes the difference between the two times represented by _instant_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
+      </dl>
       <emu-alg>
+        1. Set _other_ to ? ToTemporalInstant(_other_).
+        1. If _operation_ is ~until~, then,
+          1. Let _first_ be _instant_.
+          1. Let _second_ be _other__.
+        else.
+          1. Let _first_ be _other_.
+          1. Let _second_ be _instant__.
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -638,7 +638,7 @@
       </dl>
       <emu-alg>
         1. Set _other_ to ? ToTemporalInstant(_other_).
-        1. If _operation_ is ~until~, then,
+        1. If _operation_ is ~until~, then
           1. Let _first_ be _instant_.
           1. Let _second_ be _other_.
         1. Else,

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -415,21 +415,7 @@
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Set _other_ to ? ToTemporalDate(_other_).
-        1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"day"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
-        1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
-        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ &ne; 1, then
-          1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _temporalDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Return ? DifferenceTemporalPlainDate(1, _temporalDate_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -442,22 +428,7 @@
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Set _other_ to ? ToTemporalDate(_other_).
-        1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"day"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
-        1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
-        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ &ne; 1, then
-          1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _temporalDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(-_result_.[[Years]], -_result_.[[Months]], -_result_.[[Weeks]], -_result_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Return ? DifferenceTemporalPlainDate(-1, _temporalDate_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -920,6 +891,35 @@
         1. If _d1_ &gt; _d2_, return 1.
         1. If _d1_ &lt; _d2_, return -1.
         1. Return 0.
+      </emu-alg>
+      </emu-clause>
+      <emu-clause id="sec-temporal-differencetemporalplaindate" aoid="DifferenceTemporalPlainDate">
+      <h1>
+        DifferenceTemporalPlainDate (
+          _direction_: an integer, 1 or -1,
+          _temporalDate_: a Temporal.PlainDate,
+          _other_: an ECMAScript language value,
+          _options_: an Object or *undefined*,
+        )
+      </h1>
+      <emu-alg>
+        1. Set _other_ to ? ToTemporalDate(_other_).
+        1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
+        1. Set _options_ to ? GetOptionsObject(_options_).
+        1. Let _disallowedUnits_ be « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"day"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, _defaultLargestUnit_).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
+        1. If _direction_ &lt; 0, then
+          1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
+        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+        1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
+        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ ≠ 1, then
+          1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _temporalDate_)).[[DurationRecord]].
+        1. Return ! CreateTemporalDuration(_direction_ × _result_.[[Years]], _direction_ × _result_.[[Months]], _direction_ × _result_.[[Weeks]], _direction_ × _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -896,7 +896,7 @@
       <emu-clause id="sec-temporal-differencetemporalplaindate" aoid="DifferenceTemporalPlainDate">
       <h1>
         DifferenceTemporalPlainDate (
-          _direction_: an integer, 1 or -1,
+          _direction_: 1 or -1,
           _temporalDate_: a Temporal.PlainDate,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
@@ -917,9 +917,9 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
-        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ ≠ 1, then
+        1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ &ne; 1, then
           1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _temporalDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(_direction_ × _result_.[[Years]], _direction_ × _result_.[[Months]], _direction_ × _result_.[[Weeks]], _direction_ × _result_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Return ! CreateTemporalDuration(_direction_ &times; _result_.[[Years]], _direction_ &times; _result_.[[Months]], _direction_ &times; _result_.[[Weeks]], _direction_ &times; _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -899,7 +899,7 @@
           _operation_: ~since~ or ~until~,
           _temporalDate_: a Temporal.PlainDate,
           _other_: an ECMAScript language value,
-          _options_: an Object or *undefined*,
+          _options_: an ECMAScript language value,
         ): either a normal completion containing a Temporal.Duration or an abrupt completion
       </h1>
       <dl class="header">

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -415,7 +415,7 @@
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Return ? DifferenceTemporalPlainDate(1, _temporalDate_, _other_, _options_).
+        1. Return ? DifferenceTemporalPlainDate(~until~, _temporalDate_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -428,7 +428,7 @@
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Return ? DifferenceTemporalPlainDate(-1, _temporalDate_, _other_, _options_).
+        1. Return ? DifferenceTemporalPlainDate(~since~, _temporalDate_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -893,16 +893,22 @@
         1. Return 0.
       </emu-alg>
       </emu-clause>
-      <emu-clause id="sec-temporal-differencetemporalplaindate" aoid="DifferenceTemporalPlainDate">
+      <emu-clause id="sec-temporal-differencetemporalplaindate" type="abstract operation">
       <h1>
         DifferenceTemporalPlainDate (
-          _direction_: 1 or -1,
+          _operation_: ~since~ or ~until~,
           _temporalDate_: a Temporal.PlainDate,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        ): a Temporal.Duration
+        ): either a normal completion containing a Temporal.Duration or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It computes the difference between the two times represented by _temporalDate_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
+      </dl>
       </h1>
       <emu-alg>
+        1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalDate(_other_).
         1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
@@ -912,14 +918,14 @@
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. If _direction_ &lt; 0, then
+        1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
         1. If _smallestUnit_ is not *"day"* or _roundingIncrement_ &ne; 1, then
           1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _temporalDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(_direction_ &times; _result_.[[Years]], _direction_ &times; _result_.[[Months]], _direction_ &times; _result_.[[Weeks]], _direction_ &times; _result_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], _sign_ &times; _result_.[[Weeks]], _sign_ &times; _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -906,7 +906,6 @@
         <dt>description</dt>
         <dd>It computes the difference between the two times represented by _temporalDate_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
       </dl>
-      </h1>
       <emu-alg>
         1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalDate(_other_).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -900,7 +900,7 @@
           _temporalDate_: a Temporal.PlainDate,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        )
+        ): a Temporal.Duration
       </h1>
       <emu-alg>
         1. Set _other_ to ? ToTemporalDate(_other_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -488,21 +488,7 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Set _other_ to ? ToTemporalDateTime(_other_).
-        1. If ? CalendarEquals(_dateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
-        1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
-        1. Let _roundResult_ be (? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].
-        1. Let _result_ be ? BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
-        1. Return ! CreateTemporalDuration(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Return ? DifferenceTemporalPlainDateTime(1, _dateTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -515,22 +501,7 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Set _other_ to ? ToTemporalDateTime(_other_).
-        1. If ? CalendarEquals(_dateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
-        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
-        1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
-        1. Let _roundResult_ be (? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].
-        1. Let _result_ be ? BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
-        1. Return ! CreateTemporalDuration(-_roundResult_.[[Years]], -_roundResult_.[[Months]], -_roundResult_.[[Weeks]], -_result_.[[Days]], -_result_.[[Hours]], -_result_.[[Minutes]], -_result_.[[Seconds]], -_result_.[[Milliseconds]], -_result_.[[Microseconds]], -_result_.[[Nanoseconds]]).
+        1. Return ? DifferenceTemporalPlainDateTime(-1, _dateTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -1155,6 +1126,35 @@
         1. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
         1. Let _balanceResult_ be ? BalanceDuration(_dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
         1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
+      </emu-alg>
+    </emu-clause>
+    <emu-clause id="sec-temporal-differencetemporalplaindatetime" aoid="DifferenceTemporalPlainDateTime">
+      <h1>
+        DifferenceTemporalPlainDateTime (
+          _direction_: an integer, 1 or -1,
+          _dateTime_: a Temporal.PlainDateTime,
+          _other_: an ECMAScript language value,
+          _options_: an Object or *undefined*,
+        )
+      </h1>
+      <emu-alg>
+        1. Set _other_ to ? ToTemporalDateTime(_other_).
+        1. If ? CalendarEquals(_dateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
+        1. Set _options_ to ? GetOptionsObject(_options_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
+        1. If _direction_ &lt; 0, then
+          1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
+        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _largestUnit_, _options_).
+        1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
+        1. Let _roundResult_ be (? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].
+        1. Let _result_ be ? BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
+        1. Return ! CreateTemporalDuration(_direction_ × _roundResult_.[[Years]], _direction_ × _roundResult_.[[Months]], _direction_ × _roundResult_.[[Weeks]], _direction_ × _result_.[[Days]], _direction_ × _result_.[[Hours]], _direction_ × _result_.[[Minutes]], _direction_ × _result_.[[Seconds]], _direction_ × _result_.[[Milliseconds]], _direction_ × _result_.[[Microseconds]], _direction_ × _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -488,7 +488,7 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Return ? DifferenceTemporalPlainDateTime(1, _dateTime_, _other_, _options_).
+        1. Return ? DifferenceTemporalPlainDateTime(~until~, _dateTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -501,7 +501,7 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Return ? DifferenceTemporalPlainDateTime(-1, _dateTime_, _other_, _options_).
+        1. Return ? DifferenceTemporalPlainDateTime(~since~, _dateTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -1128,16 +1128,21 @@
         1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
-    <emu-clause id="sec-temporal-differencetemporalplaindatetime" aoid="DifferenceTemporalPlainDateTime">
+    <emu-clause id="sec-temporal-differencetemporalplaindatetime" type="abstract operation">
       <h1>
         DifferenceTemporalPlainDateTime (
-          _direction_: 1 or -1,
+          _operation_: ~since~ or ~until~,
           _dateTime_: a Temporal.PlainDateTime,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        ): a Temporal.Duration
+        ): either a normal completion containing a Temporal.Duration or an abrupt completion
       </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It computes the difference between the two times represented by _dateTime_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
+      </dl>
       <emu-alg>
+        1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalDateTime(_other_).
         1. If ? CalendarEquals(_dateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
@@ -1146,7 +1151,7 @@
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. If _direction_ &lt; 0, then
+        1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
@@ -1154,7 +1159,7 @@
         1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
         1. Let _roundResult_ be (? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].
         1. Let _result_ be ? BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
-        1. Return ! CreateTemporalDuration(_direction_ &times; _roundResult_.[[Years]], _direction_ &times; _roundResult_.[[Months]], _direction_ &times; _roundResult_.[[Weeks]], _direction_ &times; _result_.[[Days]], _direction_ &times; _result_.[[Hours]], _direction_ &times; _result_.[[Minutes]], _direction_ &times; _result_.[[Seconds]], _direction_ &times; _result_.[[Milliseconds]], _direction_ &times; _result_.[[Microseconds]], _direction_ &times; _result_.[[Nanoseconds]]).
+        1. Return ! CreateTemporalDuration(_sign_ &times; _roundResult_.[[Years]], _sign_ &times; _roundResult_.[[Months]], _sign_ &times; _roundResult_.[[Weeks]], _sign_ &times; _result_.[[Days]], _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1131,7 +1131,7 @@
     <emu-clause id="sec-temporal-differencetemporalplaindatetime" aoid="DifferenceTemporalPlainDateTime">
       <h1>
         DifferenceTemporalPlainDateTime (
-          _direction_: an integer, 1 or -1,
+          _direction_: 1 or -1,
           _dateTime_: a Temporal.PlainDateTime,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
@@ -1154,7 +1154,7 @@
         1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
         1. Let _roundResult_ be (? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].
         1. Let _result_ be ? BalanceDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
-        1. Return ! CreateTemporalDuration(_direction_ × _roundResult_.[[Years]], _direction_ × _roundResult_.[[Months]], _direction_ × _roundResult_.[[Weeks]], _direction_ × _result_.[[Days]], _direction_ × _result_.[[Hours]], _direction_ × _result_.[[Minutes]], _direction_ × _result_.[[Seconds]], _direction_ × _result_.[[Milliseconds]], _direction_ × _result_.[[Microseconds]], _direction_ × _result_.[[Nanoseconds]]).
+        1. Return ! CreateTemporalDuration(_direction_ &times; _roundResult_.[[Years]], _direction_ &times; _roundResult_.[[Months]], _direction_ &times; _roundResult_.[[Weeks]], _direction_ &times; _result_.[[Days]], _direction_ &times; _result_.[[Hours]], _direction_ &times; _result_.[[Minutes]], _direction_ &times; _result_.[[Seconds]], _direction_ &times; _result_.[[Milliseconds]], _direction_ &times; _result_.[[Microseconds]], _direction_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1135,7 +1135,7 @@
           _dateTime_: a Temporal.PlainDateTime,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        )
+        ): a Temporal.Duration
       </h1>
       <emu-alg>
         1. Set _other_ to ? ToTemporalDateTime(_other_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1134,7 +1134,7 @@
           _operation_: ~since~ or ~until~,
           _dateTime_: a Temporal.PlainDateTime,
           _other_: an ECMAScript language value,
-          _options_: an Object or *undefined*,
+          _options_: an ECMAScript language value,
         ): either a normal completion containing a Temporal.Duration or an abrupt completion
       </h1>
       <dl class="header">

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -947,7 +947,7 @@
           _temporalTime_: a Temporal.PlainTime,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        )
+        ): a Temporal.Duration
       </h1>
       <emu-alg>
         1. Set _other_ to ? ToTemporalTime(_other_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -946,7 +946,7 @@
           _operation_: ~since~ or ~until~,
           _temporalTime_: a Temporal.PlainTime,
           _other_: an ECMAScript language value,
-          _options_: an Object or *undefined*,
+          _options_: an ECMAScript language value,
         ): either a normal completion containing a Temporal.Duration or an abrupt completion
       </h1>
       <dl class="header">

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -962,7 +962,7 @@
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, *"hour"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. If _operation_ is _since_, then
+        1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -943,7 +943,7 @@
     <emu-clause id="sec-temporal-differencetemporalplaintime" aoid="DifferenceTemporalPlainTime">
       <h1>
         DifferenceTemporalPlainTime (
-          _direction_: an integer, 1 or -1,
+          _direction_: 1 or -1,
           _temporalTime_: a Temporal.PlainTime,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
@@ -961,8 +961,8 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _result_ be ! DifferenceTime(_other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]]).
-        1. Set _result_ to (? RoundDuration(0, 0, 0, 0, _direction_ × _result_.[[Hours]], _direction_ × _result_.[[Minutes]], _direction_ × _result_.[[Seconds]], _direction_ × _result_.[[Milliseconds]], _direction_ × _result_.[[Microseconds]], _direction_ × _result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
-        1. Set _result_ to ? BalanceDuration(0, _direction_ × _result_.[[Hours]], _direction_ × _result_.[[Minutes]], _direction_ × _result_.[[Seconds]], _direction_ × _result_.[[Milliseconds]], _direction_ × _result_.[[Microseconds]], _direction_ × _result_.[[Nanoseconds]], _largestUnit_).
+        1. Set _result_ to (? RoundDuration(0, 0, 0, 0, _direction_ &times; _result_.[[Hours]], _direction_ &times; _result_.[[Minutes]], _direction_ &times; _result_.[[Seconds]], _direction_ &times; _result_.[[Milliseconds]], _direction_ &times; _result_.[[Microseconds]], _direction_ &times; _result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
+        1. Set _result_ to ? BalanceDuration(0, _direction_ &times; _result_.[[Hours]], _direction_ &times; _result_.[[Minutes]], _direction_ &times; _result_.[[Seconds]], _direction_ &times; _result_.[[Milliseconds]], _direction_ &times; _result_.[[Microseconds]], _direction_ &times; _result_.[[Nanoseconds]], _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -286,7 +286,7 @@
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. Return ? DifferenceTemporalPlainTime(1, _temporalTime_, _other_, _options_).
+        1. Return ? DifferenceTemporalPlainTime(~since~, _temporalTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -299,7 +299,7 @@
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. Return ? DifferenceTemporalPlainTime(-1, _temporalTime_, _other_, _options_).
+        1. Return ? DifferenceTemporalPlainTime(~until~, _temporalTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -940,29 +940,35 @@
         1. Return ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _result_).
       </emu-alg>
     </emu-clause>
-    <emu-clause id="sec-temporal-differencetemporalplaintime" aoid="DifferenceTemporalPlainTime">
+    <emu-clause id="sec-temporal-differencetemporalplaintime" type="abstract operation">
       <h1>
         DifferenceTemporalPlainTime (
-          _direction_: 1 or -1,
+          _operation_: ~since~ or ~until~,
           _temporalTime_: a Temporal.PlainTime,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        ): a Temporal.Duration
+        ): either a normal completion containing a Temporal.Duration or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It computes the difference between the two times represented by _temporalTime_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
+      </dl>
       </h1>
       <emu-alg>
+        1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalTime(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, *"hour"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. If _direction_ &lt; 0, then
+        1. If _operation_ is _since_, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _result_ be ! DifferenceTime(_other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]]).
-        1. Set _result_ to (? RoundDuration(0, 0, 0, 0, _direction_ &times; _result_.[[Hours]], _direction_ &times; _result_.[[Minutes]], _direction_ &times; _result_.[[Seconds]], _direction_ &times; _result_.[[Milliseconds]], _direction_ &times; _result_.[[Microseconds]], _direction_ &times; _result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
-        1. Set _result_ to ? BalanceDuration(0, _direction_ &times; _result_.[[Hours]], _direction_ &times; _result_.[[Minutes]], _direction_ &times; _result_.[[Seconds]], _direction_ &times; _result_.[[Milliseconds]], _direction_ &times; _result_.[[Microseconds]], _direction_ &times; _result_.[[Nanoseconds]], _largestUnit_).
+        1. Set _result_ to (? RoundDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
+        1. Set _result_ to ? BalanceDuration(0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]], _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -953,7 +953,6 @@
         <dt>description</dt>
         <dd>It computes the difference between the two times represented by _temporalTime_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
       </dl>
-      </h1>
       <emu-alg>
         1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalTime(_other_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -286,18 +286,7 @@
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. Set _other_ to ? ToTemporalTime(_other_).
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, *"hour"*).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _result_ be ! DifferenceTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]]).
-        1. Set _result_ to (? RoundDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
-        1. Set _result_ to ? BalanceDuration(0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _largestUnit_).
-        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Return ? DifferenceTemporalPlainTime(1, _temporalTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -310,19 +299,7 @@
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. Set _other_ to ? ToTemporalTime(_other_).
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, *"hour"*).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
-        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _result_ be ! DifferenceTime(_other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]]).
-        1. Set _result_ to (? RoundDuration(0, 0, 0, 0, -_result_.[[Hours]], -_result_.[[Minutes]], -_result_.[[Seconds]], -_result_.[[Milliseconds]], -_result_.[[Microseconds]], -_result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
-        1. Set _result_ to ? BalanceDuration(0, -_result_.[[Hours]], -_result_.[[Minutes]], -_result_.[[Seconds]], -_result_.[[Milliseconds]], -_result_.[[Microseconds]], -_result_.[[Nanoseconds]], _largestUnit_).
-        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Return ? DifferenceTemporalPlainTime(-1, _temporalTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -961,6 +938,32 @@
           1. Return ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _result_, 0).
         1. Assert: _unit_ is *"nanosecond"*.
         1. Return ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _result_).
+      </emu-alg>
+    </emu-clause>
+    <emu-clause id="sec-temporal-differencetemporalplaintime" aoid="DifferenceTemporalPlainTime">
+      <h1>
+        DifferenceTemporalPlainTime (
+          _direction_: an integer, 1 or -1,
+          _temporalTime_: a Temporal.PlainTime,
+          _other_: an ECMAScript language value,
+          _options_: an Object or *undefined*,
+        )
+      </h1>
+      <emu-alg>
+        1. Set _other_ to ? ToTemporalTime(_other_).
+        1. Set _options_ to ? GetOptionsObject(_options_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, *"hour"*).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
+        1. If _direction_ &lt; 0, then
+          1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
+        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. Let _result_ be ! DifferenceTime(_other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]]).
+        1. Set _result_ to (? RoundDuration(0, 0, 0, 0, _direction_ × _result_.[[Hours]], _direction_ × _result_.[[Minutes]], _direction_ × _result_.[[Seconds]], _direction_ × _result_.[[Milliseconds]], _direction_ × _result_.[[Microseconds]], _direction_ × _result_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_)).[[DurationRecord]].
+        1. Set _result_ to ? BalanceDuration(0, _direction_ × _result_.[[Hours]], _direction_ × _result_.[[Minutes]], _direction_ × _result_.[[Seconds]], _direction_ × _result_.[[Milliseconds]], _direction_ × _result_.[[Microseconds]], _direction_ × _result_.[[Nanoseconds]], _largestUnit_).
+        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -659,7 +659,7 @@
           _yearMonth_: a Temporal.PlainYearMonth,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        )
+        ): a Temporal.Duration
       </h1>
       <emu-alg>
         1. Set _other_ to ? ToTemporalYearMonth(_other_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -320,7 +320,7 @@
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
-        1. Return ? DifferenceTemporalPlainYearMonth(1, _yearMonth_, _other_, _options_).
+        1. Return ? DifferenceTemporalPlainYearMonth(~until~, _yearMonth_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -333,7 +333,7 @@
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
-        1. Return ? DifferenceTemporalPlainYearMonth(-1, _yearMonth_, _other_, _options_).
+        1. Return ? DifferenceTemporalPlainYearMonth(~since~, _yearMonth_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -652,16 +652,22 @@
         1. Return _result_.
       </emu-alg>
     </emu-clause>
-    <emu-clause id="sec-temporal-differencetemporalplainyearmonth" aoid="DifferenceTemporalPlainYearMonth">
+    <emu-clause id="sec-temporal-differencetemporalplainyearmonth" type="abstract operation">
       <h1>
         DifferenceTemporalPlainYearMonth (
-          _direction_: 1 or -1,
+          _operation_: ~since~ or ~until~,
           _yearMonth_: a Temporal.PlainYearMonth,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        ): a Temporal.Duration
+        ): either a normal completion containing a Temporal.Duration or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It computes the difference between the two times represented by _yearMonth_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
+      </dl>
       </h1>
       <emu-alg>
+        1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalYearMonth(_other_).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
@@ -671,7 +677,7 @@
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"year"*).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. If _direction_ &lt; 0, then
+        1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
@@ -685,7 +691,7 @@
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
         1. If _smallestUnit_ is not *"month"* or _roundingIncrement_ &ne; 1, then
           1. Let _result_ be (? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(_direction_ &times; _result_.[[Years]], _direction_ &times; _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -658,7 +658,7 @@
           _operation_: ~since~ or ~until~,
           _yearMonth_: a Temporal.PlainYearMonth,
           _other_: an ECMAScript language value,
-          _options_: an Object or *undefined*,
+          _options_: an ECMAScript language value,
         ): either a normal completion containing a Temporal.Duration or an abrupt completion
       </h1>
       <dl class="header">

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -320,29 +320,7 @@
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
-        1. Set _other_ to ? ToTemporalYearMonth(_other_).
-        1. Let _calendar_ be _yearMonth_.[[Calendar]].
-        1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"week"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"month"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"year"*).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
-        1. Let _otherFields_ be ? PrepareTemporalFields(_other_, _fieldNames_, «»).
-        1. Perform ! CreateDataPropertyOrThrow(_otherFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _otherDate_ be ? CalendarDateFromFields(_calendar_, _otherFields_).
-        1. Let _thisFields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
-        1. Perform ! CreateDataPropertyOrThrow(_thisFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _thisDate_ be ? CalendarDateFromFields(_calendar_, _thisFields_).
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
-        1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
-        1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
-          1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
-        1. Let _result_ be (? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Return ? DifferenceTemporalPlainYearMonth(1, _yearMonth_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -355,30 +333,7 @@
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
-        1. Set _other_ to ? ToTemporalYearMonth(_other_).
-        1. Let _calendar_ be _yearMonth_.[[Calendar]].
-        1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"week"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"month"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"year"*).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
-        1. Let _otherFields_ be ? PrepareTemporalFields(_other_, _fieldNames_, «»).
-        1. Perform ! CreateDataPropertyOrThrow(_otherFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _otherDate_ be ? CalendarDateFromFields(_calendar_, _otherFields_).
-        1. Let _thisFields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
-        1. Perform ! CreateDataPropertyOrThrow(_thisFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _thisDate_ be ? CalendarDateFromFields(_calendar_, _thisFields_).
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
-        1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
-        1. If _smallestUnit_ is *"month"* and _roundingIncrement_ = 1, then
-          1. Return ! CreateTemporalDuration(-_result_.[[Years]], -_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
-        1. Let _result_ be (? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(-_result_.[[Years]], -_result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Return ? DifferenceTemporalPlainYearMonth(-1, _yearMonth_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -695,6 +650,42 @@
         1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
         1. Set _result_ to the string-concatenation of _result_ and _calendarString_.
         1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+    <emu-clause id="sec-temporal-differencetemporalplainyearmonth" aoid="DifferenceTemporalPlainYearMonth">
+      <h1>
+        DifferenceTemporalPlainYearMonth (
+          _direction_: an integer, 1 or -1,
+          _yearMonth_: a Temporal.PlainYearMonth,
+          _other_: an ECMAScript language value,
+          _options_: an Object or *undefined*,
+        )
+      </h1>
+      <emu-alg>
+        1. Set _other_ to ? ToTemporalYearMonth(_other_).
+        1. Let _calendar_ be _yearMonth_.[[Calendar]].
+        1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
+        1. Set _options_ to ? GetOptionsObject(_options_).
+        1. Let _disallowedUnits_ be « *"week"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"month"*).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"year"*).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
+        1. If _direction_ &lt; 0, then
+          1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, *undefined*, *false*).
+        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
+        1. Let _otherFields_ be ? PrepareTemporalFields(_other_, _fieldNames_, «»).
+        1. Perform ! CreateDataPropertyOrThrow(_otherFields_, *"day"*, *1*<sub>𝔽</sub>).
+        1. Let _otherDate_ be ? CalendarDateFromFields(_calendar_, _otherFields_).
+        1. Let _thisFields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
+        1. Perform ! CreateDataPropertyOrThrow(_thisFields_, *"day"*, *1*<sub>𝔽</sub>).
+        1. Let _thisDate_ be ? CalendarDateFromFields(_calendar_, _thisFields_).
+        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+        1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
+        1. If _smallestUnit_ is not *"month"* or _roundingIncrement_ ≠ 1, then
+          1. Let _result_ be (? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_)).[[DurationRecord]].
+        1. Return ! CreateTemporalDuration(_direction_ × _result_.[[Years]], _direction_ × _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -665,7 +665,6 @@
         <dt>description</dt>
         <dd>It computes the difference between the two times represented by _yearMonth_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
       </dl>
-      </h1>
       <emu-alg>
         1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalYearMonth(_other_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -655,7 +655,7 @@
     <emu-clause id="sec-temporal-differencetemporalplainyearmonth" aoid="DifferenceTemporalPlainYearMonth">
       <h1>
         DifferenceTemporalPlainYearMonth (
-          _direction_: an integer, 1 or -1,
+          _direction_: 1 or -1,
           _yearMonth_: a Temporal.PlainYearMonth,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
@@ -683,9 +683,9 @@
         1. Let _thisDate_ be ? CalendarDateFromFields(_calendar_, _thisFields_).
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
-        1. If _smallestUnit_ is not *"month"* or _roundingIncrement_ ≠ 1, then
+        1. If _smallestUnit_ is not *"month"* or _roundingIncrement_ &ne; 1, then
           1. Let _result_ be (? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_)).[[DurationRecord]].
-        1. Return ! CreateTemporalDuration(_direction_ × _result_.[[Years]], _direction_ × _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Return ! CreateTemporalDuration(_direction_ &times; _result_.[[Years]], _direction_ &times; _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -690,7 +690,7 @@
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
         1. If _smallestUnit_ is not *"month"* or _roundingIncrement_ &ne; 1, then
-          1. Let _result_ be (? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_)).[[DurationRecord]].
+          1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _roundingIncrement_, _smallestUnit_, _roundingMode_, _thisDate_)).[[DurationRecord]].
         1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1360,7 +1360,7 @@
           _operation_: ~until~ or ~since~,
           _zonedDateTime_: a Temporal.ZonedDateTime,
           _other_: an ECMAScript language value,
-          _options_: an Object or *undefined*,
+          _options_: an ECMAScript language value,
         ): either a normal completion containing a Temporal.Duration or an abrupt completion
       </h1>
       <dl class="header">

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1357,7 +1357,7 @@
     <emu-clause id="sec-temporal-differencetemporalzoneddatetime" aoid="DifferenceTemporalZonedDateTime">
       <h1>
         DifferenceTemporalZonedDateTime (
-          _direction_: an integer, 1 or -1,
+          _direction_: 1 or -1,
           _zonedDateTime_: a Temporal.ZonedDateTime,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
@@ -1379,16 +1379,16 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) ≤ 1.728 × 10<sup>22</sup>.
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 1.728 &times; 10<sup>22</sup>.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
-          1. Return ! CreateTemporalDuration(0, 0, 0, 0, _direction_ × _balanceResult_.[[Hours]], _direction_ × _balanceResult_.[[Minutes]], _direction_ × _balanceResult_.[[Seconds]], _direction_ × _balanceResult_.[[Milliseconds]], _direction_ × _balanceResult_.[[Microseconds]], _direction_ × _balanceResult_.[[Nanoseconds]]).
+          1. Return ! CreateTemporalDuration(0, 0, 0, 0, _direction_ &times; _balanceResult_.[[Hours]], _direction_ &times; _balanceResult_.[[Minutes]], _direction_ &times; _balanceResult_.[[Seconds]], _direction_ &times; _balanceResult_.[[Milliseconds]], _direction_ &times; _balanceResult_.[[Microseconds]], _direction_ &times; _balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_, _untilOptions_).
         1. Let _roundResult_ be (? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_)).[[DurationRecord]].
         1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
-        1. Return ! CreateTemporalDuration(_direction_ × _result_.[[Years]], _direction_ × _result_.[[Months]], _direction_ × _result_.[[Weeks]], _direction_ × _result_.[[Days]], _direction_ × _result_.[[Hours]], _direction_ × _result_.[[Minutes]], _direction_ × _result_.[[Seconds]], _direction_ × _result_.[[Milliseconds]], _direction_ × _result_.[[Microseconds]], _direction_ × _result_.[[Nanoseconds]]).
+        1. Return ! CreateTemporalDuration(_direction_ &times; _result_.[[Years]], _direction_ &times; _result_.[[Months]], _direction_ &times; _result_.[[Weeks]], _direction_ &times; _result_.[[Days]], _direction_ &times; _result_.[[Hours]], _direction_ &times; _result_.[[Minutes]], _direction_ &times; _result_.[[Seconds]], _direction_ &times; _result_.[[Milliseconds]], _direction_ &times; _result_.[[Microseconds]], _direction_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -703,29 +703,7 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Set _other_ to ? ToTemporalZonedDateTime(_other_).
-        1. If ? CalendarEquals(_zonedDateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, then
-          1. Throw a *RangeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"hour"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-          1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 1.728 &times; 10<sup>22</sup>.
-          1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
-          1. Return ! CreateTemporalDuration(0, 0, 0, 0, _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
-        1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
-          1. Throw a *RangeError* exception.
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
-        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_, _untilOptions_).
-        1. Let _roundResult_ be (? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_)).[[DurationRecord]].
-        1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
-        1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Return ? DifferenceTemporalZonedDateTime(1, _zonedDateTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -738,30 +716,7 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Set _other_ to ? ToTemporalZonedDateTime(_other_).
-        1. If ? CalendarEquals(_zonedDateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, then
-          1. Throw a *RangeError* exception.
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
-        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"hour"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
-        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-          1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 1.728 &times; 10<sup>22</sup>.
-          1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
-          1. Return ! CreateTemporalDuration(0, 0, 0, 0, -_balanceResult_.[[Hours]], -_balanceResult_.[[Minutes]], -_balanceResult_.[[Seconds]], -_balanceResult_.[[Milliseconds]], -_balanceResult_.[[Microseconds]], -_balanceResult_.[[Nanoseconds]]).
-        1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
-          1. Throw a *RangeError* exception.
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
-        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_, _untilOptions_).
-        1. Let _roundResult_ be (? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_)).[[DurationRecord]].
-        1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
-        1. Return ! CreateTemporalDuration(-_result_.[[Years]], -_result_.[[Months]], -_result_.[[Weeks]], -_result_.[[Days]], -_result_.[[Hours]], -_result_.[[Minutes]], -_result_.[[Seconds]], -_result_.[[Milliseconds]], -_result_.[[Microseconds]], -_result_.[[Nanoseconds]]).
+        1. Return ? DifferenceTemporalZonedDateTime(-1, _zonedDateTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -1397,6 +1352,43 @@
           [[Nanoseconds]]: _nanoseconds_,
           [[DayLength]]: abs(_dayLengthNs_)
           }.
+      </emu-alg>
+    </emu-clause>
+    <emu-clause id="sec-temporal-differencetemporalzoneddatetime" aoid="DifferenceTemporalZonedDateTime">
+      <h1>
+        DifferenceTemporalZonedDateTime (
+          _direction_: an integer, 1 or -1,
+          _zonedDateTime_: a Temporal.ZonedDateTime,
+          _other_: an ECMAScript language value,
+          _options_: an Object or *undefined*,
+        )
+      </h1>
+      <emu-alg>
+        1. Set _other_ to ? ToTemporalZonedDateTime(_other_).
+        1. If ? CalendarEquals(_zonedDateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, then
+          1. Throw a *RangeError* exception.
+        1. Set _options_ to ? GetOptionsObject(_options_).
+        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
+        1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"hour"*, _smallestUnit_).
+        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
+        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
+        1. If _direction_ &lt; 0, then
+          1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
+        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+        1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+          1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) ≤ 1.728 × 10<sup>22</sup>.
+          1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
+          1. Return ! CreateTemporalDuration(0, 0, 0, 0, _direction_ × _balanceResult_.[[Hours]], _direction_ × _balanceResult_.[[Minutes]], _direction_ × _balanceResult_.[[Seconds]], _direction_ × _balanceResult_.[[Milliseconds]], _direction_ × _balanceResult_.[[Microseconds]], _direction_ × _balanceResult_.[[Nanoseconds]]).
+        1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
+          1. Throw a *RangeError* exception.
+        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
+        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_, _untilOptions_).
+        1. Let _roundResult_ be (? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_)).[[DurationRecord]].
+        1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
+        1. Return ! CreateTemporalDuration(_direction_ × _result_.[[Years]], _direction_ × _result_.[[Months]], _direction_ × _result_.[[Weeks]], _direction_ × _result_.[[Days]], _direction_ × _result_.[[Hours]], _direction_ × _result_.[[Minutes]], _direction_ × _result_.[[Seconds]], _direction_ × _result_.[[Milliseconds]], _direction_ × _result_.[[Microseconds]], _direction_ × _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -703,7 +703,7 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Return ? DifferenceTemporalZonedDateTime(1, _zonedDateTime_, _other_, _options_).
+        1. Return ? DifferenceTemporalZonedDateTime(~until~, _zonedDateTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -716,7 +716,7 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Return ? DifferenceTemporalZonedDateTime(-1, _zonedDateTime_, _other_, _options_).
+        1. Return ? DifferenceTemporalZonedDateTime(~since~, _zonedDateTime_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -1354,16 +1354,21 @@
           }.
       </emu-alg>
     </emu-clause>
-    <emu-clause id="sec-temporal-differencetemporalzoneddatetime" aoid="DifferenceTemporalZonedDateTime">
+    <emu-clause id="sec-temporal-differencetemporalzoneddatetime" type="abstract operation">
       <h1>
         DifferenceTemporalZonedDateTime (
-          _direction_: 1 or -1,
+          _operation_: ~until~ or ~since~,
           _zonedDateTime_: a Temporal.ZonedDateTime,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        ): a Temporal.Duration
+        ): either a normal completion containing a Temporal.Duration or an abrupt completion
       </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It computes the difference between the two times represented by _zonedDateTime_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
+      </dl>
       <emu-alg>
+        1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalZonedDateTime(_other_).
         1. If ? CalendarEquals(_zonedDateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, then
           1. Throw a *RangeError* exception.
@@ -1373,7 +1378,7 @@
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. If _direction_ &lt; 0, then
+        1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
@@ -1381,14 +1386,14 @@
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 1.728 &times; 10<sup>22</sup>.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
-          1. Return ! CreateTemporalDuration(0, 0, 0, 0, _direction_ &times; _balanceResult_.[[Hours]], _direction_ &times; _balanceResult_.[[Minutes]], _direction_ &times; _balanceResult_.[[Seconds]], _direction_ &times; _balanceResult_.[[Milliseconds]], _direction_ &times; _balanceResult_.[[Microseconds]], _direction_ &times; _balanceResult_.[[Nanoseconds]]).
+          1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _balanceResult_.[[Hours]], _sign_ &times; _balanceResult_.[[Minutes]], _sign_ &times; _balanceResult_.[[Seconds]], _sign_ &times; _balanceResult_.[[Milliseconds]], _sign_ &times; _balanceResult_.[[Microseconds]], _sign_ &times; _balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _largestUnit_).
         1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _largestUnit_, _untilOptions_).
         1. Let _roundResult_ be (? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_)).[[DurationRecord]].
         1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedDateTime_).
-        1. Return ! CreateTemporalDuration(_direction_ &times; _result_.[[Years]], _direction_ &times; _result_.[[Months]], _direction_ &times; _result_.[[Weeks]], _direction_ &times; _result_.[[Days]], _direction_ &times; _result_.[[Hours]], _direction_ &times; _result_.[[Minutes]], _direction_ &times; _result_.[[Seconds]], _direction_ &times; _result_.[[Milliseconds]], _direction_ &times; _result_.[[Microseconds]], _direction_ &times; _result_.[[Nanoseconds]]).
+        1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], _sign_ &times; _result_.[[Weeks]], _sign_ &times; _result_.[[Days]], _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1361,7 +1361,7 @@
           _zonedDateTime_: a Temporal.ZonedDateTime,
           _other_: an ECMAScript language value,
           _options_: an Object or *undefined*,
-        )
+        ): a Temporal.Duration
       </h1>
       <emu-alg>
         1. Set _other_ to ? ToTemporalZonedDateTime(_other_).


### PR DESCRIPTION
Most of the operations between until and since are the same except negative value. Refactor to shared AOs between them with a direction which either 1 or -1.