### PR TITLE
Editorial: Replace magic nanosecond numbers with constants

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -318,18 +318,18 @@
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
-          1. Let _maximum_ be 24.
+          1. Let _maximum_ be HoursPerDay.
         1. Else if _smallestUnit_ is *"minute"*, then
-          1. Let _maximum_ be 1440.
+          1. Let _maximum_ be MinutesPerHour &times; HoursPerDay.
         1. Else if _smallestUnit_ is *"second"*, then
-          1. Let _maximum_ be 86400.
+          1. Let _maximum_ be SecondsPerMinute &times; MinutesPerHour &times; HoursPerDay.
         1. Else if _smallestUnit_ is *"millisecond"*, then
-          1. Let _maximum_ be 8.64 &times; 10<sup>7</sup>.
+          1. Let _maximum_ be ℝ(msPerDay).
         1. Else if _smallestUnit_ is *"microsecond"*, then
-          1. Let _maximum_ be 8.64 &times; 10<sup>10</sup>.
+          1. Let _maximum_ be 1000 &times; ℝ(msPerDay).
         1. Else,
           1. Assert: _smallestUnit_ is *"nanosecond"*.
-          1. Let _maximum_ be 8.64 &times; 10<sup>13</sup>.
+          1. Let _maximum_ be nsPerDay.
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_, _maximum_, *true*).
         1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalInstant(_roundedNs_).
@@ -490,6 +490,25 @@
         </tbody>
       </table>
     </emu-table>
+
+    <emu-clause id="sec-temporal-instant-range">
+      <h1>Temporal.Instant range</h1>
+
+      <p>
+        The [[Nanoseconds]] internal slot of a Temporal.Instant object supports a range of exactly -100,000,000 to 100,000,000 days relative to midnight at the beginning of 1 January 1970 UTC, as in <emu-xref href="#sec-time-values-and-time-range"></emu-xref>.
+      </p>
+      <p>
+        The exact moment of midnight at the beginning of 1 January 1970 UTC is represented by the value *0*<sub>ℤ</sub>.
+      </p>
+
+      <p>The maximum value is ℤ(nsMaxInstant), where</p>
+      <emu-eqn id="eqn-nsMaxInstant" aoid="nsMaxInstant">nsMaxInstant = 10<sup>8</sup> &times; nsPerDay = 8.64 &times; 10<sup>21</sup></emu-eqn>
+      <p>where the number of nanoseconds per day is</p>
+      <emu-eqn id="eqn-nsPerDay" aoid="nsPerDay">nsPerDay = 10<sup>6</sup> &times; ℝ(msPerDay) = 8.64 &times; 10<sup>13</sup></emu-eqn>
+
+      <p>The minimum value is ℤ(nsMinInstant), where</p>
+      <emu-eqn id="eqn-nsMinInstant" aoid="nsMinInstant">nsMinInstant = -nsMaxInstant = -8.64 &times; 10<sup>21</sup></emu-eqn>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-temporal-instant-abstract-ops">
@@ -502,7 +521,7 @@
       </p>
       <emu-alg>
         1. Assert: Type(_epochNanoseconds_) is BigInt.
-        1. If _epochNanoseconds_ &lt; *-86400*<sub>ℤ</sub> &times; *10<sup>17</sup>*<sub>ℤ</sub> or _epochNanoseconds_ &gt; *86400*<sub>ℤ</sub> &times; *10<sup>17</sup>*<sub>ℤ</sub>, then
+        1. If ℝ(_epochNanoseconds_) &lt; nsMinInstant or ℝ(_epochNanoseconds_) &gt; nsMaxInstant, then
           1. Return *false*.
         1. Return *true*.
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -326,7 +326,7 @@
         1. Else if _smallestUnit_ is *"millisecond"*, then
           1. Let _maximum_ be ℝ(msPerDay).
         1. Else if _smallestUnit_ is *"microsecond"*, then
-          1. Let _maximum_ be 1000 &times; ℝ(msPerDay).
+          1. Let _maximum_ be 10<sup>3</sup> &times; ℝ(msPerDay).
         1. Else,
           1. Assert: _smallestUnit_ is *"nanosecond"*.
           1. Let _maximum_ be nsPerDay.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -894,9 +894,9 @@
       </emu-note>
       <emu-alg>
         1. Let _ns_ be ℝ(GetEpochFromISOParts(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_)).
-        1. If _ns_ &le; -8.64 &times; 10<sup>21</sup> - 8.64 &times; 10<sup>13</sup>, then
+        1. If _ns_ &le; nsMinInstant - nsPerDay, then
           1. Return *false*.
-        1. If _ns_ &ge; 8.64 &times; 10<sup>21</sup> + 8.64 &times; 10<sup>13</sup>, then
+        1. If _ns_ &ge; nsMaxInstant + nsPerDay, then
           1. Return *false*.
         1. Return *true*.
       </emu-alg>
@@ -1087,7 +1087,7 @@
       </p>
       <emu-alg>
         1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integers.
-        1. If _dayLength_ is not present, set _dayLength_ to 8.64 &times; 10<sup>13</sup>.
+        1. If _dayLength_ is not present, set _dayLength_ to nsPerDay.
         1. Let _roundedTime_ be ! RoundTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_, _dayLength_).
         1. Let _balanceResult_ be ! BalanceISODate(_year_, _month_, _day_ + _roundedTime_.[[Days]]).
         1. Return the Record {

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -923,7 +923,7 @@
         1. Assert: _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, and _increment_ are integers.
         1. Let _fractionalSecond_ be _nanosecond_ &times; 10<sup>-9</sup> + _microsecond_ &times; 10<sup>-6</sup> + _millisecond_ &times; 10<sup>-3</sup> + _second_.
         1. If _unit_ is *"day"*, then
-          1. If _dayLengthNs_ is not present, set _dayLengthNs_ to 8.64 &times; 10<sup>13</sup>.
+          1. If _dayLengthNs_ is not present, set _dayLengthNs_ to nsPerDay.
           1. Let _quantity_ be (((((_hour_ &times; 60 + _minute_) &times; 60 + _second_) &times; 1000 + _millisecond_) &times; 1000 + _microsecond_) &times; 1000 + _nanosecond_) / _dayLengthNs_.
         1. Else if _unit_ is *"hour"*, then
           1. Let _quantity_ be (_fractionalSecond_ / 60 + _minute_) / 60 + _hour_.

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -211,7 +211,7 @@
       <h1>SystemUTCEpochNanoseconds ( )</h1>
       <emu-alg>
         1. Let _ns_ be the approximate current UTC date and time, in nanoseconds since the epoch.
-        1. [id="step-temporal-systemutcepochnanoseconds-clamp"] Set _ns_ to the result of clamping _ns_ between -8.64 &times; 10<sup>21</sup> and 8.64 &times; 10<sup>21</sup>.
+        1. [id="step-temporal-systemutcepochnanoseconds-clamp"] Set _ns_ to the result of clamping _ns_ between nsMinInstant and nsMaxInstant.
         1. Return ℤ(_ns_).
       </emu-alg>
       <emu-note>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -638,7 +638,7 @@
         1. If Type(_offsetNanoseconds_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_offsetNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Set _offsetNanoseconds_ to ℝ(_offsetNanoseconds_).
-        1. If abs(_offsetNanoseconds_) &gt; 86400 &times; 10<sup>9</sup>, throw a *RangeError* exception.
+        1. If abs(_offsetNanoseconds_) &gt; nsPerDay, throw a *RangeError* exception.
         1. Return _offsetNanoseconds_.
       </emu-alg>
     </emu-clause>
@@ -704,8 +704,8 @@
         1. If _disambiguation_ is *"reject"*, then
           1. Throw a *RangeError* exception.
         1. Let _epochNanoseconds_ be GetEpochFromISOParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
-        1. Let _dayBefore_ be ! CreateTemporalInstant(_epochNanoseconds_ - *8.64 &times; 10<sup>13</sup>*<sub>ℤ</sub>).
-        1. Let _dayAfter_ be ! CreateTemporalInstant(_epochNanoseconds_ + *8.64 &times; 10<sup>13</sup>*<sub>ℤ</sub>).
+        1. Let _dayBefore_ be ! CreateTemporalInstant(_epochNanoseconds_ - ℤ(nsPerDay)).
+        1. Let _dayAfter_ be ! CreateTemporalInstant(_epochNanoseconds_ + ℤ(nsPerDay)).
         1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayBefore_).
         1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayAfter_).
         1. Let _nanoseconds_ be _offsetAfter_ - _offsetBefore_.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1358,7 +1358,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _dayLengthNs_ be 8.64 &times; 10<sup>13</sup>.
+        1. Let _dayLengthNs_ be nsPerDay.
         1. If _nanoseconds_ = 0, then
           1. Return the Record { [[Days]]: 0, [[Nanoseconds]]: 0, [[DayLength]]: _dayLengthNs_ }.
         1. If _nanoseconds_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.


### PR DESCRIPTION
This introduces constants for 8.64 × 10^13 (nanoseconds per day) and
8.64 × 10^21 (max range of epoch nanoseconds) similar to msPerDay and
friends which are already in ECMA-262. ~~These constants are BigInt-valued.~~

Closes: #1589