### PR TITLE
Editorial: Use time value operations in date calculations

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -452,16 +452,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-isodaysinyear" aoid="ISODaysInYear">
-      <h1>ISODaysInYear ( _year_ )</h1>
-      <emu-alg>
-        1. Assert: _year_ is an integer.
-        1. If ! IsISOLeapYear(_year_) is *true*, then
-          1. Return 366.
-        1. Return 365.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-isodaysinmonth" aoid="ISODaysInMonth">
       <h1>ISODaysInMonth ( _year_, _month_ )</h1>
       <emu-alg>
@@ -1089,7 +1079,7 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] or [[InitializedTemporalYearMonth]] internal slot, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
-        1. Return 𝔽(! ISODaysInYear(_temporalDateLike_.[[ISOYear]])).
+        1. Return DaysInYear(𝔽(_temporalDateLike_.[[ISOYear]])).
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -441,17 +441,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-isisoleapyear" aoid="IsISOLeapYear">
-      <h1>IsISOLeapYear ( _year_ )</h1>
-      <emu-alg>
-        1. Assert: _year_ is an integer.
-        1. If _year_ modulo 4 &ne; 0, return *false*.
-        1. If _year_ modulo 400 = 0, return *true*.
-        1. If _year_ modulo 100 = 0, return *false*.
-        1. Return *true*.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-isodaysinmonth" aoid="ISODaysInMonth">
       <h1>ISODaysInMonth ( _year_, _month_ )</h1>
       <emu-alg>
@@ -459,8 +448,7 @@
         1. Assert: _month_ is an integer, _month_ &ge; 1, and _month_ &le; 12.
         1. If _month_ is 1, 3, 5, 7, 8, 10, or 12, return 31.
         1. If _month_ is 4, 6, 9, or 11, return 30.
-        1. If ! IsISOLeapYear(_year_) is *true*, return 29.
-        1. Return 28.
+        1. Return 28 + ℝ(InLeapYear(TimeFromYear(𝔽(_year_)))).
       </emu-alg>
     </emu-clause>
 
@@ -1119,7 +1107,8 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] or [[InitializedTemporalYearMonth]] internal slot, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
-        1. Return ! IsISOLeapYear(_temporalDateLike_.[[ISOYear]]).
+        1. If InLeapYear(TimeFromYear(𝔽(_temporalDateLike_.[[ISOYear]]))) is *1*<sub>𝔽</sub>, return *true*.
+        1. Return *false*.
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -890,7 +890,7 @@
         1. Set _two_ to ? ToTemporalDate(_two_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* », *"auto"*, *"day"*).
-        1. Let _result_ be ! DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
+        1. Let _result_ be DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
         1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>
     </emu-clause>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -464,17 +464,6 @@
       <emu-note>Monday is 1 and Sunday is 7.</emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-toisodayofyear" aoid="ToISODayOfYear">
-      <h1>ToISODayOfYear ( _year_, _month_, _day_ )</h1>
-      <emu-alg>
-        1. Assert: _year_ is an integer.
-        1. Assert: _month_ is an integer.
-        1. Assert: _day_ is an integer.
-        1. Let _date_ be the date given by _year_, _month_, and _day_.
-        1. Return _date_'s ordinal date in the year according to ISO-8601 as an integer.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-toisoweekofyear" aoid="ToISOWeekOfYear">
       <h1>ToISOWeekOfYear ( _year_, _month_, _day_ )</h1>
       <emu-alg>
@@ -989,7 +978,9 @@
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _temporalDate_ be ? ToTemporalDate(_temporalDateLike_).
-        1. Return 𝔽(! ToISODayOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]])).
+        1. Let _epochDays_ be MakeDay(𝔽(_temporalDate_.[[ISOYear]]), 𝔽(_temporalDate_.[[ISOMonth]] - 1), 𝔽(_temporalDate_.[[ISODay]])).
+        1. Assert: _epochDays_ is finite.
+        1. Return DayWithinYear(MakeDate(_epochDays_, *+0*<sub>𝔽</sub>)).
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -452,18 +452,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-toisodayofweek" aoid="ToISODayOfWeek">
-      <h1>ToISODayOfWeek ( _year_, _month_, _day_ )</h1>
-      <emu-alg>
-        1. Assert: _year_ is an integer.
-        1. Assert: _month_ is an integer.
-        1. Assert: _day_ is an integer.
-        1. Let _date_ be the date given by _year_, _month_, and _day_.
-        1. Return _date_'s day of the week according to ISO-8601 as an integer.
-      </emu-alg>
-      <emu-note>Monday is 1 and Sunday is 7.</emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-toisoweekofyear" aoid="ToISOWeekOfYear">
       <h1>ToISOWeekOfYear ( _year_, _month_, _day_ )</h1>
       <emu-alg>
@@ -959,7 +947,11 @@
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _temporalDate_ be ? ToTemporalDate(_temporalDateLike_).
-        1. Return 𝔽(! ToISODayOfWeek(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]])).
+        1. Let _epochDays_ be MakeDay(𝔽(_temporalDate_.[[ISOYear]]), 𝔽(_temporalDate_.[[ISOMonth]] - 1), 𝔽(_temporalDate_.[[ISODay]])).
+        1. Assert: _epochDays_ is finite.
+        1. Let _dayOfWeek_ be WeekDay(MakeDate(_epochDays_, *+0*<sub>𝔽</sub>)).
+        1. If _dayOfWeek_ = *+0*<sub>𝔽</sub>, return *7*<sub>𝔽</sub>.
+        1. Return _dayOfWeek_.
       </emu-alg>
     </emu-clause>
 

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1493,16 +1493,19 @@
         DaysUntil (
           _earlier_: a Temporal.PlainDate,
           _later_: a Temporal.PlainDate,
-        )
+        ): an integer
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the integer number of days elapsed between the calendar dates of two Temporal object instances _earlier_ and _later_.
+        <dd>The returned value is the number of days elapsed between the calendar dates of two Temporal.PlainDate instances _earlier_ and _later_.
         If _earlier_ is later than _later_, then the result is negative.</dd>
       </dl>
       <emu-alg>
-        1. Let _difference_ be ! DifferenceISODate(_earlier_.[[ISOYear]], _earlier_.[[ISOMonth]], _earlier_.[[ISODay]], _later_.[[ISOYear]], _later_.[[ISOMonth]], _later_.[[ISODay]], *"day"*).
-        1. Return _difference_.[[Days]].
+        1. Let _epochDays1_ be MakeDay(𝔽(_earlier_.[[ISOYear]]), 𝔽(_earlier_.[[ISOMonth]] - 1), 𝔽(_earlier_.[[ISODay]])).
+        1. Assert: _epochDays1_ is finite.
+        1. Let _epochDays2_ be MakeDay(𝔽(_later_.[[ISOYear]]), 𝔽(_later_.[[ISOMonth]] - 1), 𝔽(_later_.[[ISODay]])).
+        1. Assert: _epochDays2_ is finite.
+        1. Return ℝ(_epochDays2_) - ℝ(_epochDays1_).
       </emu-alg>
     </emu-clause>
 
@@ -1523,7 +1526,7 @@
       </dl>
       <emu-alg>
         1. Let _newDate_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _duration_).
-        1. Let _days_ be ! DaysUntil(_relativeTo_, _newDate_).
+        1. Let _days_ be DaysUntil(_relativeTo_, _newDate_).
         1. Return the Record {
             [[RelativeTo]]: _newDate_,
             [[Days]]: _days_
@@ -1605,7 +1608,7 @@
           1. Let _yearsLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsDuration_, *undefined*, _dateAdd_).
           1. Let _yearsMonthsWeeks_ be ! CreateTemporalDuration(_years_, _months_, _weeks_, 0, 0, 0, 0, 0, 0, 0).
           1. Let _yearsMonthsWeeksLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsMonthsWeeks_, *undefined*, _dateAdd_).
-          1. Let _monthsWeeksInDays_ be ! DaysUntil(_yearsLater_, _yearsMonthsWeeksLater_).
+          1. Let _monthsWeeksInDays_ be DaysUntil(_yearsLater_, _yearsMonthsWeeksLater_).
           1. Set _relativeTo_ to _yearsLater_.
           1. Let _days_ be _days_ + _monthsWeeksInDays_.
           1. Let _daysDuration_ be ? CreateTemporalDuration(0, 0, 0, _days_, 0, 0, 0, 0, 0, 0).
@@ -1618,7 +1621,7 @@
           1. Let _oldRelativeTo_ be _relativeTo_.
           1. Let _yearsDuration_ be ! CreateTemporalDuration(_yearsPassed_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Set _relativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsDuration_, *undefined*, _dateAdd_).
-          1. Let _daysPassed_ be ! DaysUntil(_oldRelativeTo_, _relativeTo_).
+          1. Let _daysPassed_ be DaysUntil(_oldRelativeTo_, _relativeTo_).
           1. Set _days_ to _days_ - _daysPassed_.
           1. If _days_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneYear_ be ! CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
@@ -1634,7 +1637,7 @@
           1. Let _yearsMonthsLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsMonths_, *undefined*, _dateAdd_).
           1. Let _yearsMonthsWeeks_ be ! CreateTemporalDuration(_years_, _months_, _weeks_, 0, 0, 0, 0, 0, 0, 0).
           1. Let _yearsMonthsWeeksLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _yearsMonthsWeeks_, *undefined*, _dateAdd_).
-          1. Let _weeksInDays_ be ! DaysUntil(_yearsMonthsLater_, _yearsMonthsWeeksLater_).
+          1. Let _weeksInDays_ be DaysUntil(_yearsMonthsLater_, _yearsMonthsWeeksLater_).
           1. Set _relativeTo_ to _yearsMonthsLater_.
           1. Let _days_ be _days_ + _weeksInDays_.
           1. If _days_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1871,9 +1871,10 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. Let _temporalDate_ be ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _dayOfYear_ be ! ToISODayOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
-            1. Else,
-              1. Let _dayOfYear_ be ! CalendarDateDayOfYear(_calendar_.[[Identifier]], _temporalDate_).
+              1. Let _epochDays_ be MakeDay(𝔽(_temporalDate_.[[ISOYear]]), 𝔽(_temporalDate_.[[ISOMonth]] - 1), 𝔽(_temporalDate_.[[ISODay]])).
+              1. Assert: _epochDays_ is finite.
+              1. Return DayWithinYear(MakeDate(_epochDays_, *+0*<sub>𝔽</sub>)).
+            1. Let _dayOfYear_ be ! CalendarDateDayOfYear(_calendar_.[[Identifier]], _temporalDate_).
             1. Return 𝔽(_dayOfYear_).
           </emu-alg>
         </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1852,9 +1852,12 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. Let _temporalDate_ be ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _dayOfWeek_ be ! ToISODayOfWeek(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
-            1. Else,
-              1. Let _dayOfWeek_ be ! CalendarDateDayOfWeek(_calendar_.[[Identifier]], _temporalDate_).
+              1. Let _epochDays_ be MakeDay(𝔽(_temporalDate_.[[ISOYear]]), 𝔽(_temporalDate_.[[ISOMonth]] - 1), 𝔽(_temporalDate_.[[ISODay]])).
+              1. Assert: _epochDays_ is finite.
+              1. Let _dayOfWeek_ be WeekDay(MakeDate(_epochDays_, *+0*<sub>𝔽</sub>)).
+              1. If _dayOfWeek_ = *+0*<sub>𝔽</sub>, return *7*<sub>𝔽</sub>.
+              1. Return _dayOfWeek_.
+            1. Let _dayOfWeek_ be ! CalendarDateDayOfWeek(_calendar_.[[Identifier]], _temporalDate_).
             1. Return 𝔽(_dayOfWeek_).
           </emu-alg>
         </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1949,9 +1949,8 @@
             1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _daysInYear_ be ! ISODaysInYear(_temporalDateLike_.[[ISOYear]]).
-            1. Else,
-              1. Let _daysInYear_ be ! CalendarDateDaysInYear(_calendar_.[[Identifier]], _temporalDateLike_).
+              1. Return DaysInYear(𝔽(_temporalDateLike_.[[ISOYear]])).
+            1. Let _daysInYear_ be ! CalendarDateDaysInYear(_calendar_.[[Identifier]], _temporalDateLike_).
             1. Return 𝔽(_daysInYear_).
           </emu-alg>
         </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1988,7 +1988,10 @@
             1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _inLeapYear_ be ! IsISOLeapYear(_temporalDateLike_.[[ISOYear]]).
+              1. If InLeapYear(TimeFromYear(𝔽(_temporalDateLike_.[[ISOYear]]))) is *1*<sub>𝔽</sub>, then
+                1. Let _inLeapYear_ be *true*.
+              1. Else,
+                1. Let _inLeapYear_ be *false*.
             1. Else,
               1. Let _inLeapYear_ be ! CalendarDateInLeapYear(_calendar_.[[Identifier]], _temporalDateLike_).
             1. Return _inLeapYear_.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1713,7 +1713,7 @@
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* », *"auto"*, *"day"*).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _result_ be ! DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
+              1. Let _result_ be DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
             1. Else,
               1. Let _result_ be ! CalendarDateDifference(_calendar_.[[Identifier]], _one_, _two_, _largestUnit_).
               1. Assert: ! IsValidDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0) is *true*.

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -54,7 +54,7 @@
         <p>The following steps are performed:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
-          1. Let _ns_ be ? NumberToBigInt(_t_) &times; 10<sup>6</sup>.
+          1. Let _ns_ be ? NumberToBigInt(_t_) &times; ℤ(10<sup>6</sup>).
           1. Return ! CreateTemporalInstant(_ns_).
         </emu-alg>
       </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -817,7 +817,6 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Assert: _year_, _month_, and _day_ are integers.
         1. If _month_ &lt; 1 or _month_ &gt; 12, then
           1. Return *false*.
         1. Let _daysInMonth_ be ! ISODaysInMonth(_year_, _month_).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -826,44 +826,27 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-balanceisodate" aoid="BalanceISODate">
-      <h1>BalanceISODate ( _year_, _month_, _day_ )</h1>
+    <emu-clause id="sec-temporal-balanceisodate" type="abstract operation">
+      <h1>BalanceISODate (
+        _year_: an integer,
+        _month_: an integer,
+        _day_: an integer,
+      ): a Record with fields [[Year]] (an integer), [[Month]] (an integer between 1 and 12 inclusive), and [[Day]] (an integer between 1 and 31 inclusive)</h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It converts the given _year_, _month_, and _day_ into a valid calendar date in the ISO 8601 calendar as given by IsValidISODate, by overflowing out-of-range _month_ or _day_ values into the next-highest unit.
+          This date may be outside the range given by ISODateTimeWithinLimits.
+        </dd>
+      </dl>
       <emu-alg>
-        1. Assert: _year_, _month_, and _day_ are integers.
-        1. Let _balancedYearMonth_ be ! BalanceISOYearMonth(_year_, _month_).
-        1. Set _month_ to _balancedYearMonth_.[[Month]].
-        1. Set _year_ to _balancedYearMonth_.[[Year]].
-        1. NOTE: To deal with negative numbers of days whose absolute value is greater than the number of days in a year, the following section subtracts years and adds days until the number of days is greater than -366 or -365.
-        1. If _month_ &gt; 2, then
-          1. Let _testYear_ be _year_.
-        1. Else,
-          1. Let _testYear_ be _year_ - 1.
-        1. Repeat, while _day_ &lt; -1 &times; ! ISODaysInYear(_testYear_),
-          1. Set _day_ to _day_ + ! ISODaysInYear(_testYear_).
-          1. Set _year_ to _year_ - 1.
-          1. Set _testYear_ to _testYear_ - 1.
-        1. NOTE: To deal with numbers of days greater than the number of days in a year, the following section adds years and subtracts days until the number of days is less than 366 or 365.
-        1. Set _testYear_ to _testYear_ + 1.
-        1. Repeat, while _day_ &gt; ! ISODaysInYear(_testYear_),
-          1. Set _day_ to _day_ - ! ISODaysInYear(_testYear_).
-          1. Set _year_ to _year_ + 1.
-          1. Set _testYear_ to _testYear_ + 1.
-        1. NOTE: To deal with negative numbers of days whose absolute value is greater than the number of days in the current month, the following section subtracts months and adds days until the number of days is greater than 0.
-        1. Repeat, while _day_ &lt; 1,
-          1. Set _balancedYearMonth_ to ! BalanceISOYearMonth(_year_, _month_ - 1).
-          1. Set _year_ to _balancedYearMonth_.[[Year]].
-          1. Set _month_ to _balancedYearMonth_.[[Month]].
-          1. Set _day_ to _day_ + ! ISODaysInMonth(_year_, _month_).
-        1. NOTE: To deal with numbers of days greater than the number of days in the current month, the following section adds months and subtracts days until the number of days is less than the number of days in the month.
-        1. Repeat, while _day_ &gt; ! ISODaysInMonth(_year_, _month_),
-          1. Set _day_ to _day_ - ! ISODaysInMonth(_year_, _month_).
-          1. Set _balancedYearMonth_ to ! BalanceISOYearMonth(_year_, _month_ + 1).
-          1. Set _year_ to _balancedYearMonth_.[[Year]].
-          1. Set _month_ to _balancedYearMonth_.[[Month]].
+        1. Let _epochDays_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
+        1. Assert: _epochDays_ is finite.
+        1. Let _ms_ be MakeDate(_epochDays_, *+0*<sub>𝔽</sub>).
         1. Return the Record {
-          [[Year]]: _year_,
-          [[Month]]: _month_,
-          [[Day]]: _day_
+            [[Year]]: ℝ(YearFromTime(_ms_)),
+            [[Month]]: ℝ(MonthFromTime(_ms_)) + 1,
+            [[Day]]: ℝ(DateFromTime(_ms_))
           }.
       </emu-alg>
     </emu-clause>
@@ -903,7 +886,7 @@
         1. Let _intermediate_ be ? RegulateISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _day_, _overflow_).
         1. Set _days_ to _days_ + 7 &times; _weeks_.
         1. Let _d_ be _intermediate_.[[Day]] + _days_.
-        1. Let _intermediate_ be ! BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _d_).
+        1. Let _intermediate_ be BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _d_).
         1. Return ? RegulateISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]], _overflow_).
       </emu-alg>
     </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -707,18 +707,17 @@
           _y2_: an integer,
           _m2_: an integer,
           _d2_: an integer,
-          _largestUnit_: a String,
-        )
+          _largestUnit_: *"year"*, *"month"*, *"week"*, or *"day"*,
+        ): a Date Duration Record
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It returns a Date Duration Record with the elapsed duration from a first date until a second date, according to the reckoning of the ISO 8601 calendar.
+          The return value is the elapsed duration from a first date until a second date, according to the reckoning of the ISO 8601 calendar.
           No fields larger than _largestUnit_ will be non-zero in the resulting Date Duration Record.
         </dd>
       </dl>
       <emu-alg>
-        1. Assert: _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*.
         1. If _largestUnit_ is *"year"* or *"month"*, then
           1. Let _sign_ be -(! CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_)).
           1. If _sign_ is 0, return ! CreateDateDurationRecord(0, 0, 0, 0).
@@ -756,24 +755,16 @@
             1. Set _years_ to 0.
           1. Return ! CreateDateDurationRecord(_years_, _months_, 0, _days_).
         1. If _largestUnit_ is *"day"* or *"week"*, then
-          1. If ! CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_) &lt; 0, then
-            1. Let _smaller_ be the Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
-            1. Let _greater_ be the Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
-            1. Let _sign_ be 1.
-          1. Else,
-            1. Let _smaller_ be the Record { [[Year]]: _y2_, [[Month]]: _m2_, [[Day]]: _d2_ }.
-            1. Let _greater_ be the Record { [[Year]]: _y1_, [[Month]]: _m1_, [[Day]]: _d1_ }.
-            1. Let _sign_ be -1.
-          1. Let _days_ be ! ToISODayOfYear(_greater_.[[Year]], _greater_.[[Month]], _greater_.[[Day]]) - ! ToISODayOfYear(_smaller_.[[Year]], _smaller_.[[Month]], _smaller_.[[Day]]).
-          1. Let _year_ be _smaller_.[[Year]].
-          1. Repeat, while _year_ &lt; _greater_.[[Year]],
-            1. Set _days_ to _days_ + ! ISODaysInYear(_year_).
-            1. Set _year_ to _year_ + 1.
+          1. Let _epochDays1_ be MakeDay(𝔽(_y1_), 𝔽(_m1_ - 1), 𝔽(_d1_)).
+          1. Assert: _epochDays1_ is finite.
+          1. Let _epochDays2_ be MakeDay(𝔽(_y2_), 𝔽(_m2_ - 1), 𝔽(_d2_)).
+          1. Assert: _epochDays2_ is finite.
+          1. Let _days_ be ℝ(_epochDays2_) - ℝ(_epochDays1_).
           1. Let _weeks_ be 0.
           1. If _largestUnit_ is *"week"*, then
-            1. Set _weeks_ to floor(_days_ / 7).
-            1. Set _days_ to _days_ modulo 7.
-          1. Return ! CreateDateDurationRecord(0, 0, _weeks_ &times; _sign_, _days_ &times; _sign_).
+            1. Set _weeks_ to RoundTowardsZero(_days_ / 7).
+            1. Set _days_ to remainder(_days_, 7).
+          1. Return ! CreateDateDurationRecord(0, 0, _weeks_, _days_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -952,7 +952,7 @@
       <emu-alg>
         1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integers.
         1. Let _balancedTime_ be ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
-        1. Let _balancedDate_ be ! BalanceISODate(_year_, _month_, _day_ + _balancedTime_.[[Days]]).
+        1. Let _balancedDate_ be BalanceISODate(_year_, _month_, _day_ + _balancedTime_.[[Days]]).
         1. Return the Record {
             [[Year]]: _balancedDate_.[[Year]],
             [[Month]]: _balancedDate_.[[Month]],
@@ -1079,7 +1079,7 @@
         1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integers.
         1. If _dayLength_ is not present, set _dayLength_ to nsPerDay.
         1. Let _roundedTime_ be ! RoundTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_, _dayLength_).
-        1. Let _balanceResult_ be ! BalanceISODate(_year_, _month_, _day_ + _roundedTime_.[[Days]]).
+        1. Let _balanceResult_ be BalanceISODate(_year_, _month_, _day_ + _roundedTime_.[[Days]]).
         1. Return the Record {
             [[Year]]: _balanceResult_.[[Year]],
             [[Month]]: _balanceResult_.[[Month]],
@@ -1134,9 +1134,9 @@
         1. Let _timeDifference_ be ! DifferenceTime(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. Let _timeSign_ be ! DurationSign(0, 0, 0, _timeDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]]).
         1. Let _dateSign_ be ! CompareISODate(_y2_, _mon2_, _d2_, _y1_, _mon1_, _d1_).
-        1. Let _adjustedDate_ be ! BalanceISODate(_y1_, _mon1_, _d1_ + _timeDifference_.[[Days]]).
+        1. Let _adjustedDate_ be BalanceISODate(_y1_, _mon1_, _d1_ + _timeDifference_.[[Days]]).
         1. If _timeSign_ is -_dateSign_, then
-          1. Set _adjustedDate_ to ! BalanceISODate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]] - _timeSign_).
+          1. Set _adjustedDate_ to BalanceISODate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]] - _timeSign_).
           1. Set _timeDifference_ to ? BalanceDuration(-_timeSign_, _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
         1. Let _date1_ be ? CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendar_).
         1. Let _date2_ be ? CreateTemporalDate(_y2_, _mon2_, _d2_, _calendar_).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -409,7 +409,7 @@
       <emu-alg>
         1. If _newTarget_ is not present, set _newTarget_ to %Temporal.TimeZone%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.TimeZone.prototype%"*, « [[InitializedTemporalTimeZone]], [[Identifier]], [[OffsetNanoseconds]] »).
-        1. Let _offsetNanosecondsResult_ be ParseTimeZoneOffsetString(_identifier_).
+        1. Let _offsetNanosecondsResult_ be Completion(ParseTimeZoneOffsetString(_identifier_)).
         1. If _offsetNanosecondsResult_ is an abrupt completion, then
           1. Assert: ! CanonicalizeTimeZoneName(_identifier_) is _identifier_.
           1. Set _object_.[[Identifier]] to _identifier_.


### PR DESCRIPTION
This reuses several of the ECMA-262 operations dealing with time values, instead of duplicating the logic or resorting to a handwavy description. If the spec already contains this logic, we may as well use it, even if it means some awkward conversions between the ℝ and 𝔽 domains. Overall, it seems simpler.

See: #1641 (but doesn't close the issue, as there is still no reference yet for an ISO week-of-year algorithm)