### PR TITLE
Editorial: use 2 × nsMaxInstant for the maximum difference of two Instants

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1481,7 +1481,7 @@
         1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZone_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, *"halfExpand"*).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_diffNs_) &le; 1.728 &times; 10<sup>22</sup>.
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_diffNs_) &le; 2 &times; nsMaxInstant.
           1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _diffNs_, _largestUnit_).
           1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Return ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -668,7 +668,7 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _roundedNs_ be ! DifferenceInstant(_first_.[[Nanoseconds]], _second_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 1.728 &times; 10<sup>22</sup>.
+        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 2 &times; nsMaxInstant.
         1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1374,7 +1374,7 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 1.728 &times; 10<sup>22</sup>.
+          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 2 &times; nsMaxInstant.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _largestUnit_).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _balanceResult_.[[Hours]], _sign_ &times; _balanceResult_.[[Minutes]], _sign_ &times; _balanceResult_.[[Seconds]], _sign_ &times; _balanceResult_.[[Milliseconds]], _sign_ &times; _balanceResult_.[[Microseconds]], _sign_ &times; _balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then


### PR DESCRIPTION
This replaces more magic numbers with meaningful constants. (I missed this when I was grepping for "864" and "8.64")