### PR TITLE
Editorial changes around ISO Date Records

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1360,18 +1360,21 @@
           </dl>
         </emu-clause>
 
-        <emu-clause id="sec-temporal-calendardateaddition" type="abstract operation">
+        <emu-clause id="sec-temporal-calendardateaddition" type="implementation-defined abstract operation">
           <h1>
             CalendarDateAddition (
               _calendar_: a String,
               _date_: a Temporal.PlainDate,
               _duration_: a Date Duration Record,
               _overflow_: a String,
-            )
+            ): either a normal completion containing an ISO Date Record, or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by the string _calendar_ and returns the corresponding day, month and year of the result in the ISO calendar values as an ISO Date Record.</dd>
+            <dd>
+              It performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by the string _calendar_ and returns the corresponding day, month and year of the result in the ISO calendar values as an ISO Date Record.
+              It may throw a *RangeError* exception if _overflow_ is *"reject"* and the resulting month or day would need to be clamped in order to form a valid date in _calendar_, or if the date resulting from the addition is outside the range allowed by ISODateTimeWithinLimits.
+            </dd>
           </dl>
         </emu-clause>
 
@@ -1698,7 +1701,7 @@
               1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_).
             1. Else,
               1. Let _balanceDuration_ be ! CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]]).
-              1. Let _result_ be ! CalendarDateAddition(_calendar_, _date_, _balanceDuration_, _overflow_).
+              1. Let _result_ be ? CalendarDateAddition(_calendar_, _date_, _balanceDuration_, _overflow_).
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
           </emu-alg>
         </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1352,7 +1352,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to convert _fields_ that describes a date in the calendar represented by the string _calendar_ to the ISO calendar and returns the corresponding day, month and year values as a Record with the fields [[Day]], [[Month]] and [[Year]] respectively.</dd>
+            <dd>It performs implementation-defined processing to convert _fields_ that describes a date in the calendar represented by the string _calendar_ to the ISO calendar and returns the corresponding day, month and year values as an ISO Date Record.</dd>
           </dl>
         </emu-clause>
 
@@ -1367,7 +1367,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by the string _calendar_ and returns the corresponding day, month and year of the result in the ISO calendar values as a Record with the fields [[Day]], [[Month]] and [[Year]] respectively.</dd>
+            <dd>It performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by the string _calendar_ and returns the corresponding day, month and year of the result in the ISO calendar values as an ISO Date Record.</dd>
           </dl>
         </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1342,17 +1342,21 @@
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-temporal-calendardatetoiso" type="abstract operation">
+        <emu-clause id="sec-temporal-calendardatetoiso" type="implementation-defined abstract operation">
           <h1>
             CalendarDateToISO (
               _calendar_: a String,
-              _fields_: an ordinary Object with the own data properties listed in <emu-xref href="#table-temporal-field-requirements"></emu-xref>,
+              _fields_: an ordinary Object with one or more of the own data properties listed in <emu-xref href="#table-temporal-field-requirements"></emu-xref>,
               _overflow_: a String,
-            )
+            ): either a normal completion containing an ISO Date Record, or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to convert _fields_ that describes a date in the calendar represented by the string _calendar_ to the ISO calendar and returns the corresponding day, month and year values as an ISO Date Record.</dd>
+            <dd>
+              It performs implementation-defined processing to convert _fields_ that describes a date in the calendar represented by the string _calendar_ to the ISO calendar and returns the corresponding day, month and year values as an ISO Date Record.
+              It may throw a *TypeError* exception if the own data properties present on _fields_ are insufficient to calculate an ISO date in _calendar_.
+              It may throw a *RangeError* exception if the values of the own data properties of _fields_ are out of range for _calendar_ and _overflow_ is *"reject"*, or if the date described by _fields_ forms a date outside the range allowed by ISODateTimeWithinLimits.
+            </dd>
           </dl>
         </emu-clause>
 
@@ -1627,7 +1631,7 @@
             1. Else,
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
-              1. Let _result_ be ! CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
+              1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
           </emu-alg>
         </emu-clause>
@@ -1648,7 +1652,7 @@
             1. Else,
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « »).
-              1. Let _result_ be ! CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
+              1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISODay]] to _result_.[[Day]].
             1. Return ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[ReferenceISODay]]).
           </emu-alg>
@@ -1670,7 +1674,7 @@
             1. Else,
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-              1. Let _result_ be ! CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
+              1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISOYear]] to _result_.[[Year]].
             1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _result_.[[ReferenceISOYear]]).
           </emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -617,6 +617,65 @@
   <emu-clause id="sec-temporal-plaindate-abstract-ops">
     <h1>Abstract Operations for Temporal.PlainDate Objects</h1>
 
+    <emu-clause id="sec-temporal-iso-date-records">
+      <h1>ISO Date Records</h1>
+      <p>
+        An <dfn variants="ISO Date Records">ISO Date Record</dfn> is a Record value used to represent a valid calendar date in the ISO 8601 calendar, although the year may be outside of the allowed range for Temporal.
+        ISO Date Records are produced by the abstract operation CreateISODateRecord.
+      </p>
+      <p>
+        ISO Date Records have the fields listed in <emu-xref href="#table-temporal-iso-date-record-fields"></emu-xref>.
+      </p>
+      <emu-table id="table-temporal-iso-date-record-fields" caption="ISO Date Record Fields">
+        <table class="real-table">
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td>[[Year]]</td>
+            <td>an integer</td>
+            <td>
+              The year in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Month]]</td>
+            <td>an integer between 1 and 12, inclusive</td>
+            <td>
+              The number of the month in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Day]]</td>
+            <td>an integer between 1 and 31, inclusive</td>
+            <td>
+              The number of the day of the month in the ISO 8601 calendar.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-create-iso-date-record" type="abstract operation">
+      <h1>
+        CreateISODateRecord (
+          _year_: an integer,
+          _month_: an integer between 1 and 12 inclusive,
+          _day_: an integer between 1 and 31 inclusive,
+        ): an ISO Date Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
+      </dl>
+      <emu-alg>
+        1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.
+        1. Return the Record { [[Year]]: _year_, [[Month]]: _month_, [[Day]]: _day_ }.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-createtemporaldate" aoid="CreateTemporalDate">
       <h1>CreateTemporalDate ( _isoYear_, _isoMonth_, _isoDay_, _calendar_ [ , _newTarget_ ] )</h1>
       <emu-alg>
@@ -739,27 +798,32 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-regulateisodate" aoid="RegulateISODate">
-      <h1>RegulateISODate ( _year_, _month_, _day_, _overflow_ )</h1>
+    <emu-clause id="sec-temporal-regulateisodate" type="abstract operation">
+      <h1>
+        RegulateISODate (
+          _year_: an integer,
+          _month_: an integer,
+          _day_: an integer,
+          _overflow_: *"constrain"* or *"reject"*,
+        ): either a normal completion containing an ISO Date Record, or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It performs the overflow correction given by _overflow_ on the values _year_, _month_, and _day_, in order to arrive at a valid date in the ISO 8601 calendar, as determined by IsValidISODate.
+          For *"reject"*, values that do not form a valid date cause an exception to be thrown.
+          For *"constrain"*, values that do not form a valid date are clamped to the correct range.
+        </dd>
+      </dl>
       <emu-alg>
-        1. Assert: _year_, _month_, and _day_ are integers.
-        1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. If _overflow_ is *"reject"*, then
           1. If IsValidISODate(_year_, _month_, _day_) is *false*, throw a *RangeError* exception.
-          1. Return the Record {
-            [[Year]]: _year_,
-            [[Month]]: _month_,
-            [[Day]]: _day_
-            }.
+          1. Return CreateISODateRecord(_year_, _month_, _day_).
         1. If _overflow_ is *"constrain"*, then
           1. Set _month_ to the result of clamping _month_ between 1 and 12.
           1. Let _daysInMonth_ be ! ISODaysInMonth(_year_, _month_).
           1. Set _day_ to the result of clamping _day_ between 1 and _daysInMonth_.
-          1. Return the Record {
-            [[Year]]: _year_,
-            [[Month]]: _month_,
-            [[Day]]: _day_
-            }.
+          1. Return CreateISODateRecord(_year_, _month_, _day_).
       </emu-alg>
     </emu-clause>
 
@@ -793,7 +857,7 @@
         _year_: an integer,
         _month_: an integer,
         _day_: an integer,
-      ): a Record with fields [[Year]] (an integer), [[Month]] (an integer between 1 and 12 inclusive), and [[Day]] (an integer between 1 and 31 inclusive)</h1>
+      ): an ISO Date Record</h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
@@ -805,11 +869,7 @@
         1. Let _epochDays_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
         1. Assert: _epochDays_ is finite.
         1. Let _ms_ be MakeDate(_epochDays_, *+0*<sub>𝔽</sub>).
-        1. Return the Record {
-            [[Year]]: ℝ(YearFromTime(_ms_)),
-            [[Month]]: ℝ(MonthFromTime(_ms_)) + 1,
-            [[Day]]: ℝ(DateFromTime(_ms_))
-          }.
+        1. Return CreateISODateRecord(ℝ(YearFromTime(_ms_)), ℝ(MonthFromTime(_ms_)) + 1, ℝ(DateFromTime(_ms_))).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
- Introduces an ISO Date Record type, to make it easier to write structured headers for PlainDate operations.
- Fixes some inadvertent consequences of #1928 by describing the circumstances under which the calendar-specific operations CalendarDateToISO and CalendarDateAddition may throw.