### PR TITLE
Editorial: Accommodate calendar-specific fields in non-ISO ...FromFields() methods

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -25,6 +25,7 @@ import {
 
 const ArrayIncludes = Array.prototype.includes;
 const ArrayPrototypePush = Array.prototype.push;
+const ArrayPrototypeSort = Array.prototype.sort;
 const IntlDateTimeFormat = globalThis.Intl.DateTimeFormat;
 const ArraySort = Array.prototype.sort;
 const MathAbs = Math.abs;
@@ -1875,8 +1876,9 @@ const nonIsoGeneralImpl = {
   dateFromFields(fields, options, calendar) {
     const overflow = ES.ToTemporalOverflow(options);
     const cache = new OneObjectCache();
-    // Intentionally alphabetical
-    fields = ES.PrepareTemporalFields(fields, ['day', 'era', 'eraYear', 'month', 'monthCode', 'year'], ['day']);
+    const fieldNames = this.fields(['day', 'month', 'monthCode', 'year']);
+    ES.Call(ArrayPrototypeSort, fieldNames, []);
+    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
     const { year, month, day } = this.helper.calendarToIsoDate(fields, overflow, cache);
     const result = ES.CreateTemporalDate(year, month, day, calendar);
     cache.setObject(result);
@@ -1885,8 +1887,9 @@ const nonIsoGeneralImpl = {
   yearMonthFromFields(fields, options, calendar) {
     const overflow = ES.ToTemporalOverflow(options);
     const cache = new OneObjectCache();
-    // Intentionally alphabetical
-    fields = ES.PrepareTemporalFields(fields, ['era', 'eraYear', 'month', 'monthCode', 'year'], []);
+    const fieldNames = this.fields(['month', 'monthCode', 'year']);
+    ES.Call(ArrayPrototypeSort, fieldNames, []);
+    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
     const { year, month, day } = this.helper.calendarToIsoDate({ ...fields, day: 1 }, overflow, cache);
     const result = ES.CreateTemporalYearMonth(year, month, calendar, /* referenceISODay = */ day);
     cache.setObject(result);
@@ -1894,12 +1897,12 @@ const nonIsoGeneralImpl = {
   },
   monthDayFromFields(fields, options, calendar) {
     const overflow = ES.ToTemporalOverflow(options);
-    // All built-in calendars require `day`, but some allow other fields to be
-    // substituted for `month`. And for lunisolar calendars, either `monthCode`
-    // or `year` must be provided because `month` is ambiguous without a year or
-    // a code.
     const cache = new OneObjectCache();
-    fields = ES.PrepareTemporalFields(fields, ['day', 'era', 'eraYear', 'month', 'monthCode', 'year'], ['day']);
+    // For lunisolar calendars, either `monthCode` or `year` must be provided
+    // because `month` is ambiguous without a year or a code.
+    const fieldNames = this.fields(['day', 'month', 'monthCode', 'year']);
+    ES.Call(ArrayPrototypeSort, fieldNames, []);
+    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
     const { year, month, day } = this.helper.monthDayFromFields(fields, overflow, cache);
     // `year` is a reference year where this month/day exists in this calendar
     const result = ES.CreateTemporalMonthDay(month, day, calendar, /* referenceISOYear = */ year);

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1357,7 +1357,7 @@
           <h1>
             CalendarDateToISO (
               _calendar_: a String,
-              _fields_: an ordinary Object with one or more of the own data properties listed in <emu-xref href="#table-temporal-field-requirements"></emu-xref>,
+              _fields_: an ordinary Object with one or more own data properties,
               _overflow_: a String,
             ): either a normal completion containing an ISO Date Record, or an abrupt completion
           </h1>
@@ -1650,7 +1650,9 @@
               1. Let _result_ be ? ISODateFromFields(_fields_, _options_).
             1. Else,
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
+              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+              1. Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
           </emu-alg>
@@ -1671,7 +1673,9 @@
               1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _options_).
             1. Else,
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « »).
+              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"month"*, *"monthCode"*, *"year"* »).
+              1. Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISODay]] to _result_.[[Day]].
             1. Return ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[ReferenceISODay]]).
@@ -1692,7 +1696,9 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _options_).
             1. Else,
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"era"*, *"eraYear"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
+              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+              1. Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISOYear]] to _result_.[[Year]].


### PR DESCRIPTION
Previously, the spec hardcoded "era" and "eraYear" as extra fields that
should be accessed on the property bags passed to the dateFromFields(),
yearMonthFromFields(), and monthDayFromFields() methods of
Temporal.Calendar.

Instead, the extra fields should be obtained by ~~calling~~consulting the calendar's
fields() method. This accommodates calendars that require additional extra
fields, beyond "era" and "eraYear".

~~I'm not sure whether this is ultimately a normative change or not, but if
it, is then we can also fix an observable inconsistency in the order of
operations between the three ...FromFields() methods, while we are here
anyway. (If not, then revert that line before submitting this.)~~ (I'm moving the normative change to another PR.)

Closes: #1789