### PR TITLE
Normative: Fix production for time zone name in time zone strings

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1633,7 +1633,7 @@
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalTimeZoneString|).
       1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
-      1. Let each of _z_, _offsetString_, and _name_ be the source text matched by the respective |UTCDesignator|, |TimeZoneNumericUTCOffset|, and |TimeZoneIANAName| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
+      1. Let each of _z_, _offsetString_, and _name_ be the source text matched by the respective |UTCDesignator|, |TimeZoneNumericUTCOffset|, and |TimeZoneIdentifier| Parse Nodes contained within _parseResult_, or an empty sequence of code points if not present.
       1. If _name_ is empty, then
         1. Set _name_ to *undefined*.
       1. Else,

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -617,9 +617,7 @@
         1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_identifier_).
         1. If _parseResult_.[[Name]] is not *undefined*, then
           1. Let _name_ be _parseResult_.[[Name]].
-          1. If ParseText(StringToCodePoints(_name_, |TimeZoneNumericUTCOffset|)) is not a List of errors, then
-            1. If _parseResult_.[[OffsetString]] is not *undefined*, and ! ParseTimeZoneOffsetString(_parseResult_.[[OffsetString]]) &ne; ! ParseTimeZoneOffsetString(_name_), throw a *RangeError* exception.
-          1. Else,
+          1. If ParseText(StringToCodePoints(_name_, |TimeZoneNumericUTCOffset|)) is a List of errors, then
             1. If ! IsValidTimeZoneName(_name_) is *false*, throw a *RangeError* exception.
             1. Set _name_ to ! CanonicalizeTimeZoneName(_name_).
           1. Return ! CreateTemporalTimeZone(_name_).


### PR DESCRIPTION
ParseTemporalTimeZoneString erroneously assumed that any bare time zone
identifier or bracketed name would be an IANA name. That is not the case,
it can be a UTC offset name as well.

Closes: #1805