### PR TITLE
Editorial: Improve the spec for Intl operations

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1402,7 +1402,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the era for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The value should be a lowercase string identifier for calendars that have eras and *undefined* otherwise.</dd>
+            <dd>It performs implementation-defined processing to find the era for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns a lowercase String value representing that era, or *undefined* for calendars that do not have eras.</dd>
           </dl>
         </emu-clause>
 
@@ -1415,7 +1415,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the year of the current era for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The value should be an integer for calendars that have eras and *undefined* otherwise.</dd>
+            <dd>It performs implementation-defined processing to find the era for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns an integer representing the ordinal position of the year of _date_ in that era, or *undefined* for calendars that do not have eras.</dd>
           </dl>
         </emu-clause>
 
@@ -1443,7 +1443,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The value should be a 1-based integer.</dd>
+            <dd>It performs implementation-defined processing to find the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns an integer representing the 1-based ordinal position of that month in the corresponding year of the calendar.</dd>
           </dl>
           <emu-note>
             The return value represents the ordinal index of the month in the current year. This means that for lunisolar calendars, the same month can return a different index depending on whether it's in a leap year.
@@ -1459,7 +1459,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the monthCode corresponding to the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The value should be a string identifier that starts with the literal grapheme *"M"* followed by two graphemes representing the zero-padded month number of the current month in a normal (non-leap) year and suffixed by an optional literal grapheme *"L"* if this is a leap month in a lunisolar calendar.</dd>
+            <dd>It performs implementation-defined processing to find the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns its month code. The month code for a month that is not a leap month and whose 1-based ordinal position in a common year of the calendar (i.e., a year that is not a leap year) is _n_ should be the string-concatenation of *"M"* and ToZeroPaddedDecimalString(_n_, 2), and the month code for a month that is a leap month inserted after a month whose 1-based ordinal position in a common year of the calendar is _p_ should be the string-concatenation of *"M"*, ToZeroPaddedDecimalString(_p_, 2), and *"L"*.</dd>
           </dl>
         </emu-clause>
 
@@ -1472,7 +1472,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the day of the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The return value should be 1-based.</dd>
+            <dd>It performs implementation-defined processing to find the day of the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns an integer representing the 1-based ordinal position of that day in the corresponding month.</dd>
           </dl>
         </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1417,6 +1417,9 @@
             <dt>description</dt>
             <dd>It performs implementation-defined processing to find the era for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns an integer representing the ordinal position of the year of _date_ in that era, or *undefined* for calendars that do not have eras.</dd>
           </dl>
+          <emu-note>
+            Era years are 1-indexed for many calendars, but not all (e.g., the eras of the Burmese calendar each start with a year 0). Years can also advance opposite the flow of time (as for BCE years in the Gregorian calendar).
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-temporal-calendardateyear" type="abstract operation">

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1353,7 +1353,7 @@
           <dl class="header">
             <dt>description</dt>
             <dd>
-              It performs implementation-defined processing to convert _fields_ that describes a date in the calendar represented by the string _calendar_ to the ISO calendar and returns the corresponding day, month and year values as an ISO Date Record.
+              It performs implementation-defined processing to convert _fields_ that describes a date in the calendar represented by _calendar_ to the ISO calendar and returns the corresponding day, month and year values as an ISO Date Record.
               It may throw a *TypeError* exception if the own data properties present on _fields_ are insufficient to calculate an ISO date in _calendar_.
               It may throw a *RangeError* exception if the values of the own data properties of _fields_ are out of range for _calendar_ and _overflow_ is *"reject"*, or if the date described by _fields_ forms a date outside the range allowed by ISODateTimeWithinLimits.
             </dd>
@@ -1372,7 +1372,7 @@
           <dl class="header">
             <dt>description</dt>
             <dd>
-              It performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by the string _calendar_ and returns the corresponding day, month and year of the result in the ISO calendar values as an ISO Date Record.
+              It performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by _calendar_ and returns the corresponding day, month and year of the result in the ISO calendar values as an ISO Date Record.
               It may throw a *RangeError* exception if _overflow_ is *"reject"* and the resulting month or day would need to be clamped in order to form a valid date in _calendar_, or if the date resulting from the addition is outside the range allowed by ISODateTimeWithinLimits.
             </dd>
           </dl>
@@ -1389,7 +1389,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the difference between the two dates _one_ and _two_ in the context of the calendar represented by the string _calendar_ and returns the corresponding years, months, weeks and days as a Date Duration Record.</dd>
+            <dd>It performs implementation-defined processing to find the difference between the two dates _one_ and _two_ in the context of the calendar represented by _calendar_ and returns the corresponding years, months, weeks and days as a Date Duration Record.</dd>
           </dl>
         </emu-clause>
 
@@ -1402,7 +1402,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the era for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a lowercase string identifier for calendars that have eras and *undefined* otherwise.</dd>
+            <dd>It performs implementation-defined processing to find the era for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The value should be a lowercase string identifier for calendars that have eras and *undefined* otherwise.</dd>
           </dl>
         </emu-clause>
 
@@ -1415,7 +1415,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the year of the current era for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be an integer for calendars that have eras and *undefined* otherwise.</dd>
+            <dd>It performs implementation-defined processing to find the year of the current era for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The value should be an integer for calendars that have eras and *undefined* otherwise.</dd>
           </dl>
         </emu-clause>
 
@@ -1428,7 +1428,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the year for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a signed integer relative to the first day of a calendar-specific "epoch year".</dd>
+            <dd>It performs implementation-defined processing to find the year for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The value should be a signed integer relative to the first day of a calendar-specific "epoch year".</dd>
           </dl>
 
           <emu-note>The year is relative to the first day of the calendar's epoch year, so if the epoch era starts in the middle of the year, the year will be the same value before and after the start date of the era.</emu-note>
@@ -1443,7 +1443,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the month for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a 1-based integer.</dd>
+            <dd>It performs implementation-defined processing to find the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The value should be a 1-based integer.</dd>
           </dl>
           <emu-note>
             The return value represents the ordinal index of the month in the current year. This means that for lunisolar calendars, the same month can return a different index depending on whether it's in a leap year.
@@ -1459,7 +1459,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the monthCode corresponding to the month for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a string identifier that starts with the literal grapheme *"M"* followed by two graphemes representing the zero-padded month number of the current month in a normal (non-leap) year and suffixed by an optional literal grapheme *"L"* if this is a leap month in a lunisolar calendar.</dd>
+            <dd>It performs implementation-defined processing to find the monthCode corresponding to the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The value should be a string identifier that starts with the literal grapheme *"M"* followed by two graphemes representing the zero-padded month number of the current month in a normal (non-leap) year and suffixed by an optional literal grapheme *"L"* if this is a leap month in a lunisolar calendar.</dd>
           </dl>
         </emu-clause>
 
@@ -1472,7 +1472,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the day of the month for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The return value should be 1-based.</dd>
+            <dd>It performs implementation-defined processing to find the day of the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns it. The return value should be 1-based.</dd>
           </dl>
         </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1402,7 +1402,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the era for the date corresponding to _datetime_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a lowercase string identifier for calendars that have eras and *undefined* otherwise.</dd>
+            <dd>It performs implementation-defined processing to find the era for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a lowercase string identifier for calendars that have eras and *undefined* otherwise.</dd>
           </dl>
         </emu-clause>
 
@@ -1415,7 +1415,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the year of the current era for the date corresponding to _datetime_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be an integer for calendars that have eras and *undefined* otherwise.</dd>
+            <dd>It performs implementation-defined processing to find the year of the current era for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be an integer for calendars that have eras and *undefined* otherwise.</dd>
           </dl>
         </emu-clause>
 
@@ -1428,7 +1428,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the year for the date corresponding to _datetime_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a signed integer relative to the first day of a calendar-specific "epoch year".</dd>
+            <dd>It performs implementation-defined processing to find the year for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a signed integer relative to the first day of a calendar-specific "epoch year".</dd>
           </dl>
 
           <emu-note>The year is relative to the first day of the calendar's epoch year, so if the epoch era starts in the middle of the year, the year will be the same value before and after the start date of the era.</emu-note>
@@ -1443,7 +1443,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the month for the date corresponding to _datetime_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a 1-based integer.</dd>
+            <dd>It performs implementation-defined processing to find the month for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a 1-based integer.</dd>
           </dl>
           <emu-note>
             The return value represents the ordinal index of the month in the current year. This means that for lunisolar calendars, the same month can return a different index depending on whether it's in a leap year.
@@ -1459,7 +1459,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the monthCode corresponding to the month for the date corresponding to _datetime_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a string identifier that starts with the literal grapheme *"M"* followed by two graphemes representing the zero-padded month number of the current month in a normal (non-leap) year and suffixed by an optional literal grapheme *"L"* if this is a leap month in a lunisolar calendar.</dd>
+            <dd>It performs implementation-defined processing to find the monthCode corresponding to the month for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The value should be a string identifier that starts with the literal grapheme *"M"* followed by two graphemes representing the zero-padded month number of the current month in a normal (non-leap) year and suffixed by an optional literal grapheme *"L"* if this is a leap month in a lunisolar calendar.</dd>
           </dl>
         </emu-clause>
 
@@ -1472,7 +1472,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It performs implementation-defined processing to find the day of the month for the date corresponding to _datetime_ in the context of the calendar represented by the string _calendar_ and returns it. The return value should be 1-based.</dd>
+            <dd>It performs implementation-defined processing to find the day of the month for the date corresponding to _date_ in the context of the calendar represented by the string _calendar_ and returns it. The return value should be 1-based.</dd>
           </dl>
         </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1446,7 +1446,7 @@
             <dd>It performs implementation-defined processing to find the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns an integer representing the 1-based ordinal position of that month in the corresponding year of the calendar.</dd>
           </dl>
           <emu-note>
-            The return value represents the ordinal index of the month in the current year. This means that for lunisolar calendars, the same month can return a different index depending on whether it's in a leap year.
+            When the number of months in a year of the identified calendar is variable, a different value can be returned for dates that are part of the same month in different years. For example, in the Hebrew calendar, 1 Nisan 5781 is associated with value 7 while 1 Nisan 5782 is associated with value 8 because 5782 is a leap year and Nisan follows the insertion of Adar I.
           </emu-note>
         </emu-clause>
 
@@ -1461,6 +1461,9 @@
             <dt>description</dt>
             <dd>It performs implementation-defined processing to find the month for the date corresponding to _date_ in the context of the calendar represented by _calendar_ and returns its month code. The month code for a month that is not a leap month and whose 1-based ordinal position in a common year of the calendar (i.e., a year that is not a leap year) is _n_ should be the string-concatenation of *"M"* and ToZeroPaddedDecimalString(_n_, 2), and the month code for a month that is a leap month inserted after a month whose 1-based ordinal position in a common year of the calendar is _p_ should be the string-concatenation of *"M"*, ToZeroPaddedDecimalString(_p_, 2), and *"L"*.</dd>
           </dl>
+          <emu-note>
+            For example, in the Hebrew calendar, the month code of Adar (and Adar II, in leap years) is *"M06"* and the month code of Adar I (the leap month inserted before Adar II) is *"M05L"*. In a calendar with a leap month at the start of some years, the month code of that month would be *"M00L"*.
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-temporal-calendardateday" type="abstract operation">


### PR DESCRIPTION
* Reference arguments by the correct name
* Remove redundant operation argument type qualification
* Clarify the description of return values
* Add more helpful notes for month number/code operations