### PR TITLE
Normative: Adjust order of operations in ISO{Date,MonthDay}FromFields

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -510,13 +510,11 @@
       <emu-alg>
         1. Assert: Type(_fields_) is Object.
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », «»).
+        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », « *"year"*, *"day"* »).
         1. Let _year_ be ! Get(_fields_, *"year"*).
-        1. If _year_ is *undefined*, throw a *TypeError* exception.
         1. Assert: Type(_year_) is Number.
         1. Let _month_ be ? ResolveISOMonth(_fields_).
         1. Let _day_ be ! Get(_fields_, *"day"*).
-        1. If _day_ is *undefined*, throw a *TypeError* exception.
         1. Assert: Type(_day_) is Number.
         1. Return ? RegulateISODate(ℝ(_year_), _month_, ℝ(_day_), _overflow_).
       </emu-alg>
@@ -552,7 +550,7 @@
       <emu-alg>
         1. Assert: Type(_fields_) is Object.
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », «»).
+        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
         1. Let _month_ be ! Get(_fields_, *"month"*).
         1. Let _monthCode_ be ! Get(_fields_, *"monthCode"*).
         1. Let _year_ be ! Get(_fields_, *"year"*).
@@ -560,7 +558,6 @@
           1. Throw a *TypeError* exception.
         1. Set _month_ to ? ResolveISOMonth(_fields_).
         1. Let _day_ be ! Get(_fields_, *"day"*).
-        1. If _day_ is *undefined*, throw a *TypeError* exception.
         1. Assert: Type(_day_) is Number.
         1. Let _referenceISOYear_ be 1972 (the first leap year after the Unix epoch).
         1. If _monthCode_ is *undefined*, then


### PR DESCRIPTION
This was a request from Kevin during editor review prior to Stage 3. I had
overlooked that it would cause an observable change, so I had prioritized
it for later.
However, Ms2ger pointed out that it is unfortunately a normative change
in these two cases (but not in the case of ISOYearMonthFromFields.)

I checked for other uses of PrepareTemporalFields where we could be using
the requiredFields argument. It appears to be only these three, and
ISOYearMonthFromFields is not an observable change.

Closes: #2099