### PR TITLE
Normative: Use null-prototype objects in a few more places

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -912,7 +912,7 @@ export const ES = ObjectAssign({}, ES2020, {
   },
   MergeLargestUnitOption: (options, largestUnit) => {
     if (options === undefined) options = ObjectCreate(null);
-    return { ...options, largestUnit };
+    return ObjectAssign(ObjectCreate(null), options, { largestUnit });
   },
   PrepareTemporalFields: (
     bag,
@@ -920,7 +920,7 @@ export const ES = ObjectAssign({}, ES2020, {
     completeness = 'complete',
     { emptySourceErrorMessage = 'no supported properties found' } = {}
   ) => {
-    const result = {};
+    const result = ObjectCreate(null);
     let any = false;
     for (const fieldRecord of fields) {
       // Unlike the spec, this interface supports field defaults via [field, default] pairs.
@@ -3631,9 +3631,11 @@ export const ES = ObjectAssign({}, ES2020, {
 
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const otherFields = ES.ToTemporalYearMonthFields(other, fieldNames);
+    otherFields.day = 1;
     const thisFields = ES.ToTemporalYearMonthFields(yearMonth, fieldNames);
-    const otherDate = ES.CalendarDateFromFields(calendar, { ...otherFields, day: 1 });
-    const thisDate = ES.CalendarDateFromFields(calendar, { ...thisFields, day: 1 });
+    thisFields.day = 1;
+    const otherDate = ES.CalendarDateFromFields(calendar, otherFields);
+    const thisDate = ES.CalendarDateFromFields(calendar, thisFields);
 
     const untilOptions = ES.MergeLargestUnitOption(options, largestUnit);
     let { years, months } = ES.CalendarDateUntil(calendar, thisDate, otherDate, untilOptions);
@@ -4215,9 +4217,9 @@ export const ES = ObjectAssign({}, ES2020, {
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const fields = ES.ToTemporalYearMonthFields(yearMonth, fieldNames);
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
-    const day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, yearMonth)) : 1;
-    const startDate = ES.CalendarDateFromFields(calendar, { ...fields, day });
-    const optionsCopy = { ...options };
+    fields.day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, yearMonth)) : 1;
+    const startDate = ES.CalendarDateFromFields(calendar, fields);
+    const optionsCopy = ObjectAssign(ObjectCreate(null), options);
     const addedDate = ES.CalendarDateAdd(calendar, startDate, { ...duration, days }, options);
     const addedDateFields = ES.ToTemporalYearMonthFields(addedDate, fieldNames);
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -511,10 +511,10 @@
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It returns a new plain Object with enumerable own String properties copied from the _options_ Object, and the `largestUnit` property set to _largestUnit_.</dd>
+      <dd>It returns a new null-prototype Object with enumerable own String properties copied from the _options_ Object, and the `largestUnit` property set to _largestUnit_.</dd>
     </dl>
     <emu-alg>
-      1. Let _merged_ be OrdinaryObjectCreate(%Object.prototype%).
+      1. Let _merged_ be OrdinaryObjectCreate(*null*).
       1. Let _keys_ be ? EnumerableOwnPropertyNames(_options_, ~key~).
       1. For each element _nextKey_ of _keys_, do
         1. Let _propValue_ be ? Get(_options_, _nextKey_).
@@ -1735,13 +1735,13 @@
     <dl class="header">
       <dt>description</dt>
       <dd>
-        The returned Object has an own data property for each element of _fieldNames_ that corresponds with a non-*undefined* property of the same name on _fields_ used as the input for relevant conversion.
+        The returned Object has a null prototype, and an own data property for each element of _fieldNames_ that corresponds with a non-*undefined* property of the same name on _fields_ used as the input for relevant conversion.
         When _requiredFields_ is ~partial~, this operation throws if none of the properties are present with a non-*undefined* value.
         When _requiredFields_ is a List, this operation throws if any of the properties named by it are absent or undefined, and otherwise substitutes a relevant default for any absent or undefined non-required property (ensuring that the returned object has a property for each element of _fieldNames_).
       </dd>
     </dl>
     <emu-alg>
-      1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
+      1. Let _result_ be OrdinaryObjectCreate(*null*).
       1. Let _any_ be *false*.
       1. For each property name _property_ of _fieldNames_, do
         1. Let _value_ be ? Get(_fields_, _property_).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2347,7 +2347,7 @@
           <dd>true</dd>
         </dl>
         <emu-alg>
-          1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _result_ be OrdinaryObjectCreate(*null*).
           1. Let _any_ be *false*.
           1. For each property name _property_ of _fieldNames_, do
             1. Let _value_ be ? Get(_fields_, _property_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -659,7 +659,7 @@
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, 𝔽(_day_)).
         1. Let _date_ be ? CalendarDateFromFields(_calendar_, _fields_).
         1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
-        1. Let _optionsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _optionsCopy_ be OrdinaryObjectCreate(*null*).
         1. Let _entries_ be ? EnumerableOwnPropertyNames(_options_, ~key+value~).
         1. For each element _entry_ of _entries_, do
           1. Perform ! CreateDataPropertyOrThrow(_optionsCopy_, _entry_[0], _entry_[1]).


### PR DESCRIPTION
Use OrdinaryObjectCreate(null) in a few more places where we are creating
a plain object and then looking up properties on it, in order to avoid
prototype pollution. This is for consistency with most places where
GetOptionsObject is used.

Use it for fields objects as well, even though those are not passed to
user code; properties are still looked up on them, which may be observable
in the case of partial fields objects (in the with() methods).

Closes: #2098 