### PR TITLE
Normative: Check calendar in conversion to PlainTime

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1200,13 +1200,16 @@ export const ES = ObjectAssign({}, ES2020, {
     if (ES.Type(item) === 'Object') {
       if (ES.IsTemporalTime(item)) return item;
       if (ES.IsTemporalZonedDateTime(item)) {
-        item = ES.BuiltinTimeZoneGetPlainDateTimeFor(
-          GetSlot(item, TIME_ZONE),
-          GetSlot(item, INSTANT),
-          GetSlot(item, CALENDAR)
-        );
+        const calendar = GetSlot(item, CALENDAR);
+        if (ES.ToString(calendar) !== 'iso8601') {
+          throw new RangeError('PlainTime can only have iso8601 calendar');
+        }
+        item = ES.BuiltinTimeZoneGetPlainDateTimeFor(GetSlot(item, TIME_ZONE), GetSlot(item, INSTANT), calendar);
       }
       if (ES.IsTemporalDateTime(item)) {
+        if (ES.ToString(GetSlot(item, CALENDAR)) !== 'iso8601') {
+          throw new RangeError('PlainTime can only have iso8601 calendar');
+        }
         const TemporalPlainTime = GetIntrinsic('%Temporal.PlainTime%');
         return new TemporalPlainTime(
           GetSlot(item, ISO_HOUR),

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -414,6 +414,9 @@ export class PlainDateTime {
   }
   toPlainTime() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (ES.ToString(GetSlot(this, CALENDAR)) !== 'iso8601') {
+      throw new RangeError('PlainTime can only have iso8601 calendar');
+    }
     return ES.TemporalDateTimeToTime(this);
   }
   getISOFields() {

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -494,6 +494,9 @@ export class ZonedDateTime {
   }
   toPlainTime() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (ES.ToString(GetSlot(this, CALENDAR)) !== 'iso8601') {
+      throw new RangeError('PlainTime can only have iso8601 calendar');
+    }
     return ES.TemporalDateTimeToTime(dateTime(this));
   }
   toPlainDateTime() {

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -660,6 +660,8 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
+        1. If ? ToString(_dateTime_.[[Calendar]]) is not *"iso8601"*, then
+          1. Throw a *RangeError* exception.
         1. Return ? CreateTemporalTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
       </emu-alg>
     </emu-clause>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -602,10 +602,15 @@
           1. If _item_ has an [[InitializedTemporalTime]] internal slot, then
             1. Return _item_.
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+            1. Let _calendar_ be _item_.[[Calendar]].
+            1. If ? ToString(_calendar_) is not *"iso8601"*, then
+              1. Throw a *RangeError* exception.
             1. Let _instant_ be ! CreateTemporalInstant(_item_.[[Nanoseconds]]).
-            1. Set _plainDateTime_ to ? BuiltinTimeZoneGetPlainDateTimeFor(_item_.[[TimeZone]], _instant_, _item_.[[Calendar]]).
+            1. Set _plainDateTime_ to ? BuiltinTimeZoneGetPlainDateTimeFor(_item_.[[TimeZone]], _instant_, _calendar_).
             1. Return ! CreateTemporalTime(_plainDateTime_.[[ISOHour]], _plainDateTime_.[[ISOMinute]], _plainDateTime_.[[ISOSecond]], _plainDateTime_.[[ISOMillisecond]], _plainDateTime_.[[ISOMicrosecond]], _plainDateTime_.[[ISONanosecond]]).
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
+            1. If ? ToString(_item_.[[Calendar]]) is not *"iso8601"*, then
+              1. Throw a *RangeError* exception.
             1. Return ! CreateTemporalTime(_item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]]).
           1. Let _calendar_ be ? GetTemporalCalendarWithISODefault(_item_).
           1. If ? ToString(_calendar_) is not *"iso8601"*, then

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -880,6 +880,8 @@
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
+        1. If ? ToString(_calendar_) is not *"iso8601"*, then
+          1. Throw a *RangeError* exception.
         1. Let _temporalDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
         1. Return ? CreateTemporalTime(_temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]]).
       </emu-alg>


### PR DESCRIPTION
When converting a ZonedDateTime or PlainDateTime directly to a PlainTime,
we should throw if the calendar is something other than ISO 8601. We do
this check for a property bag, so it should also happen for a Temporal
object.

Additionally, if we don't do this check, then it would be web-incompatible
if we introduced time calendars in the future.

Closes: #2221