### PR TITLE
Normative: Consistently check overflow options

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1023,6 +1023,7 @@ export const ES = ObjectAssign({}, ES2020, {
     if (ES.Type(item) === 'Object') {
       if (ES.IsTemporalDate(item)) return item;
       if (ES.IsTemporalZonedDateTime(item)) {
+        ES.ToTemporalOverflow(options); // validate and ignore
         item = ES.BuiltinTimeZoneGetPlainDateTimeFor(
           GetSlot(item, TIME_ZONE),
           GetSlot(item, INSTANT),
@@ -1030,6 +1031,7 @@ export const ES = ObjectAssign({}, ES2020, {
         );
       }
       if (ES.IsTemporalDateTime(item)) {
+        ES.ToTemporalOverflow(options); // validate and ignore
         return ES.CreateTemporalDate(
           GetSlot(item, ISO_YEAR),
           GetSlot(item, ISO_MONTH),
@@ -1071,6 +1073,7 @@ export const ES = ObjectAssign({}, ES2020, {
     if (ES.Type(item) === 'Object') {
       if (ES.IsTemporalDateTime(item)) return item;
       if (ES.IsTemporalZonedDateTime(item)) {
+        ES.ToTemporalOverflow(options); // validate and ignore
         return ES.BuiltinTimeZoneGetPlainDateTimeFor(
           GetSlot(item, TIME_ZONE),
           GetSlot(item, INSTANT),
@@ -1078,6 +1081,7 @@ export const ES = ObjectAssign({}, ES2020, {
         );
       }
       if (ES.IsTemporalDate(item)) {
+        ES.ToTemporalOverflow(options); // validate and ignore
         return ES.CreateTemporalDateTime(
           GetSlot(item, ISO_YEAR),
           GetSlot(item, ISO_MONTH),

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -710,10 +710,12 @@
           1. If _item_ has an [[InitializedTemporalDate]] internal slot, then
             1. Return _item_.
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+            1. Perform ? ToTemporalOverflow(_options_).
             1. Let _instant_ be ! CreateTemporalInstant(_item_.[[Nanoseconds]]).
             1. Let _plainDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_item_.[[TimeZone]], _instant_, _item_.[[Calendar]]).
             1. Return ! CreateTemporalDate(_plainDateTime_.[[ISOYear]], _plainDateTime_.[[ISOMonth]], _plainDateTime_.[[ISODay]], _plainDateTime_.[[Calendar]]).
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
+            1. Perform ? ToTemporalOverflow(_options_).
             1. Return ! CreateTemporalDate(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[Calendar]]).
           1. Let _calendar_ be ? GetTemporalCalendarWithISODefault(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -899,9 +899,11 @@
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
             1. Return _item_.
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+            1. Perform ? ToTemporalOverflow(_options_).
             1. Let _instant_ be ! CreateTemporalInstant(_item_.[[Nanoseconds]]).
             1. Return ? BuiltinTimeZoneGetPlainDateTimeFor(_item_.[[TimeZone]], _instant_, _item_.[[Calendar]]).
           1. If _item_ has an [[InitializedTemporalDate]] internal slot, then
+            1. Perform ? ToTemporalOverflow(_options_).
             1. Return ? CreateTemporalDateTime(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], 0, 0, 0, 0, 0, 0, _item_.[[Calendar]]).
           1. Let _calendar_ be ? GetTemporalCalendarWithISODefault(_item_).
           1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).


### PR DESCRIPTION
In the fast paths for Temporal objects in ToTemporalDate and
ToTemporalDateTime, the overflow option should be validated (even though
it isn't used.) We do this for property bags and also for the case where
we call Temporal.PlainDate.from(plainDate) and
Temporal.PlainDateTime.from(plainDateTime), so it should be consistent.

The status quo wasn't the result of any decision, it was an oversight.

Closes: #2220