### PR TITLE
Editorial: Align `DifferenceTemporalInstant` with similar AOs

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -652,24 +652,21 @@
         <dd>It computes the difference between the two times represented by _instant_ and _other_, optionally rounds it, and returns it as a Temporal.Duration object.</dd>
       </dl>
       <emu-alg>
+        1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalInstant(_other_).
-        1. If _operation_ is ~until~, then
-          1. Let _first_ be _instant_.
-          1. Let _second_ be _other_.
-        1. Else,
-          1. Let _first_ be _other_.
-          1. Let _second_ be _instant_.
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).
         1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, _defaultLargestUnit_).
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
+        1. If _operation_ is ~since~, then
+          1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
-        1. Let _roundedNs_ be ! DifferenceInstant(_first_.[[Nanoseconds]], _second_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Let _roundedNs_ be ! DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 2 &times; nsMaxInstant.
-        1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
+        1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _sign_ &times; _roundedNs_, _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -666,8 +666,8 @@
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
         1. Let _roundedNs_ be ! DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 2 &times; nsMaxInstant.
-        1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _sign_ &times; _roundedNs_, _largestUnit_).
-        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _largestUnit_).
+        1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
     <emu-clause id="sec-temporal-adddurationtoorsubtractdurationfrominstant" type="abstract operation">


### PR DESCRIPTION
This commit editorially refactors `DifferenceTemporalInstant` to use a similar algorithm to what's used in other `Difference*` AOs like `DifferenceTemporalPlainTime` and `DifferenceTemporalPlainDateTime`.