### PR TITLE
Normative: Always use CopyDataProperties for object copy/merge

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -32,7 +32,6 @@ const MathAbs = Math.abs;
 const MathFloor = Math.floor;
 const ObjectAssign = Object.assign;
 const ObjectEntries = Object.entries;
-const ObjectKeys = Object.keys;
 
 const impl = {};
 
@@ -265,23 +264,17 @@ impl['iso8601'] = {
     return fields;
   },
   mergeFields(fields, additionalFields) {
+    fields = ES.ToObject(fields);
+    additionalFields = ES.ToObject(additionalFields);
     const merged = {};
-    const keys = ObjectKeys(fields);
-    for (let index = 0; index < keys.length; index++) {
-      const nextKey = keys[index];
-      if (nextKey === 'month' || nextKey === 'monthCode') continue;
-      merged[nextKey] = fields[nextKey];
+    ES.CopyDataProperties(merged, fields, [], [undefined]);
+    const additionalFieldsCopy = {};
+    ES.CopyDataProperties(additionalFieldsCopy, additionalFields, [], [undefined]);
+    if ('month' in additionalFieldsCopy || 'monthCode' in additionalFieldsCopy) {
+      delete merged.month;
+      delete merged.monthCode;
     }
-    const newKeys = ObjectKeys(additionalFields);
-    for (let index = 0; index < newKeys.length; index++) {
-      const nextKey = newKeys[index];
-      merged[nextKey] = additionalFields[nextKey];
-    }
-    if (!ES.Call(ArrayIncludes, newKeys, ['month']) && !ES.Call(ArrayIncludes, newKeys, ['monthCode'])) {
-      const { month, monthCode } = fields;
-      if (month !== undefined) merged.month = month;
-      if (monthCode !== undefined) merged.monthCode = monthCode;
-    }
+    ES.CopyDataProperties(merged, additionalFieldsCopy, []);
     return merged;
   },
   dateAdd(date, years, months, weeks, days, overflow, calendar) {
@@ -1917,8 +1910,13 @@ const nonIsoGeneralImpl = {
     return fields;
   },
   mergeFields(fields, additionalFields) {
-    const fieldsCopy = { ...fields };
-    const additionalFieldsCopy = { ...additionalFields };
+    fields = ES.ToObject(fields);
+    additionalFields = ES.ToObject(additionalFields);
+    const fieldsCopy = {};
+    ES.CopyDataProperties(fieldsCopy, fields, [], [undefined]);
+    const additionalFieldsCopy = {};
+    ES.CopyDataProperties(additionalFieldsCopy, additionalFields, [], [undefined]);
+
     // era and eraYear are intentionally unused
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { month, monthCode, year, era, eraYear, ...original } = fieldsCopy;

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -31,6 +31,7 @@ const ArraySort = Array.prototype.sort;
 const MathAbs = Math.abs;
 const MathFloor = Math.floor;
 const ObjectAssign = Object.assign;
+const ObjectCreate = Object.create;
 const ObjectEntries = Object.entries;
 
 const impl = {};
@@ -268,7 +269,7 @@ impl['iso8601'] = {
     additionalFields = ES.ToObject(additionalFields);
     const merged = {};
     ES.CopyDataProperties(merged, fields, [], [undefined]);
-    const additionalFieldsCopy = {};
+    const additionalFieldsCopy = ObjectCreate(null);
     ES.CopyDataProperties(additionalFieldsCopy, additionalFields, [], [undefined]);
     if ('month' in additionalFieldsCopy || 'monthCode' in additionalFieldsCopy) {
       delete merged.month;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3418,7 +3418,7 @@ export const ES = ObjectAssign({}, ES2022, {
     const date1 = ES.CreateTemporalDate(y1, mon1, d1, calendar);
     const date2 = ES.CreateTemporalDate(y2, mon2, d2, calendar);
     const dateLargestUnit = ES.LargerOfTwoTemporalUnits('day', largestUnit);
-    const untilOptions = {};
+    const untilOptions = ObjectCreate(null);
     ES.CopyDataProperties(untilOptions, options, []);
     untilOptions.largestUnit = dateLargestUnit;
     let { years, months, weeks, days } = ES.CalendarDateUntil(calendar, date1, date2, untilOptions);
@@ -3562,7 +3562,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (operation === 'since') roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
 
-    const untilOptions = {};
+    const untilOptions = ObjectCreate(null);
     ES.CopyDataProperties(untilOptions, options, []);
     untilOptions.largestUnit = largestUnit;
     let { years, months, weeks, days } = ES.CalendarDateUntil(calendar, plainDate, other, untilOptions);
@@ -3797,7 +3797,7 @@ export const ES = ObjectAssign({}, ES2022, {
     thisFields.day = 1;
     const thisDate = ES.CalendarDateFromFields(calendar, thisFields);
 
-    const untilOptions = {};
+    const untilOptions = ObjectCreate(null);
     ES.CopyDataProperties(untilOptions, options, []);
     untilOptions.largestUnit = largestUnit;
     let { years, months } = ES.CalendarDateUntil(calendar, thisDate, otherDate, untilOptions);
@@ -3871,7 +3871,7 @@ export const ES = ObjectAssign({}, ES2022, {
             'or smaller because day lengths can vary between time zones due to DST or time zone offset changes.'
         );
       }
-      const untilOptions = {};
+      const untilOptions = ObjectCreate(null);
       ES.CopyDataProperties(untilOptions, options, []);
       untilOptions.largestUnit = largestUnit;
       ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -271,12 +271,10 @@ export const ES = ObjectAssign({}, ES2022, {
         return SameValue(e, nextKey) === true;
       });
 
-      var enumerable = $isEnumerable(from, nextKey) || (
-      // this is to handle string keys being non-enumerable in older engines
-        typeof source === 'string'
-              && nextKey >= 0
-              && IsIntegralNumber(ToNumber(nextKey))
-      );
+      var enumerable =
+        $isEnumerable(from, nextKey) ||
+        // this is to handle string keys being non-enumerable in older engines
+        (typeof source === 'string' && nextKey >= 0 && IsIntegralNumber(ToNumber(nextKey)));
       if (excluded === false && enumerable) {
         var propValue = Get(from, nextKey);
         if (excludedValues !== undefined) {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -21,6 +21,7 @@ const StringPrototypeSlice = String.prototype.slice;
 
 import bigInt from 'big-integer';
 import Call from 'es-abstract/2022/Call.js';
+import CopyDataProperties from 'es-abstract/2022/CopyDataProperties.js';
 import GetMethod from 'es-abstract/2022/GetMethod.js';
 import IsIntegralNumber from 'es-abstract/2022/IsIntegralNumber.js';
 import ToIntegerOrInfinity from 'es-abstract/2022/ToIntegerOrInfinity.js';
@@ -199,6 +200,7 @@ import * as PARSE from './regex.mjs';
 
 const ES2022 = {
   Call,
+  CopyDataProperties,
   GetMethod,
   HasOwnProperty,
   IsIntegralNumber,
@@ -930,10 +932,6 @@ export const ES = ObjectAssign({}, ES2022, {
   LargerOfTwoTemporalUnits: (unit1, unit2) => {
     if (UNITS_DESCENDING.indexOf(unit1) > UNITS_DESCENDING.indexOf(unit2)) return unit2;
     return unit1;
-  },
-  MergeLargestUnitOption: (options, largestUnit) => {
-    if (options === undefined) options = ObjectCreate(null);
-    return ObjectAssign(ObjectCreate(null), options, { largestUnit });
   },
   PrepareTemporalFields: (
     bag,
@@ -3364,7 +3362,9 @@ export const ES = ObjectAssign({}, ES2022, {
     const date1 = ES.CreateTemporalDate(y1, mon1, d1, calendar);
     const date2 = ES.CreateTemporalDate(y2, mon2, d2, calendar);
     const dateLargestUnit = ES.LargerOfTwoTemporalUnits('day', largestUnit);
-    const untilOptions = ES.MergeLargestUnitOption(options, dateLargestUnit);
+    const untilOptions = {};
+    ES.CopyDataProperties(untilOptions, options, []);
+    untilOptions.largestUnit = dateLargestUnit;
     let { years, months, weeks, days } = ES.CalendarDateUntil(calendar, date1, date2, untilOptions);
     // Signs of date part and time part may not agree; balance them together
     ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
@@ -3506,7 +3506,9 @@ export const ES = ObjectAssign({}, ES2022, {
     if (operation === 'since') roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
 
-    const untilOptions = ES.MergeLargestUnitOption(options, largestUnit);
+    const untilOptions = {};
+    ES.CopyDataProperties(untilOptions, options, []);
+    untilOptions.largestUnit = largestUnit;
     let { years, months, weeks, days } = ES.CalendarDateUntil(calendar, plainDate, other, untilOptions);
 
     if (smallestUnit !== 'day' || roundingIncrement !== 1) {
@@ -3739,7 +3741,9 @@ export const ES = ObjectAssign({}, ES2022, {
     thisFields.day = 1;
     const thisDate = ES.CalendarDateFromFields(calendar, thisFields);
 
-    const untilOptions = ES.MergeLargestUnitOption(options, largestUnit);
+    const untilOptions = {};
+    ES.CopyDataProperties(untilOptions, options, []);
+    untilOptions.largestUnit = largestUnit;
     let { years, months } = ES.CalendarDateUntil(calendar, thisDate, otherDate, untilOptions);
 
     if (smallestUnit !== 'month' || roundingIncrement !== 1) {
@@ -3811,7 +3815,9 @@ export const ES = ObjectAssign({}, ES2022, {
             'or smaller because day lengths can vary between time zones due to DST or time zone offset changes.'
         );
       }
-      const untilOptions = ES.MergeLargestUnitOption(options, largestUnit);
+      const untilOptions = {};
+      ES.CopyDataProperties(untilOptions, options, []);
+      untilOptions.largestUnit = largestUnit;
       ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
         ES.DifferenceZonedDateTime(ns1, ns2, timeZone, calendar, largestUnit, untilOptions));
       ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -63,6 +63,7 @@
   ],
   "dependencies": {
     "big-integer": "^1.6.51",
+    "call-bind": "^1.0.2",
     "es-abstract": "^1.20.4"
   },
   "devDependencies": {

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -81,6 +81,7 @@
     "js-yaml": "^4.1.0",
     "progress": "^2.0.3",
     "rollup": "^2.68.0",
+    "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.2",
     "tiny-glob": "^0.2.9"
   },

--- a/polyfill/rollup.config.js
+++ b/polyfill/rollup.config.js
@@ -1,4 +1,5 @@
 import commonjs from '@rollup/plugin-commonjs';
+import nodePolyfills from 'rollup-plugin-node-polyfills';
 import resolve from '@rollup/plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
 import replace from '@rollup/plugin-replace';
@@ -27,6 +28,7 @@ export default [
     plugins: [
       replace({ ...replaceConfig, __debug__: false, __isTest262__: isTest262 }),
       commonjs(),
+      nodePolyfills(),
       resolve(resolveConfig)
     ],
     output: {
@@ -47,6 +49,7 @@ export default [
     plugins: [
       replace({ ...replaceConfig, __debug__: true, __isTest262__: false }),
       commonjs(),
+      nodePolyfills(),
       resolve(resolveConfig),
       babel(babelConfig)
     ]

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -505,27 +505,6 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-mergelargestunitoption" type="abstract operation">
-    <h1>
-      MergeLargestUnitOption (
-        _options_: an Object,
-        _largestUnit_: a String,
-      ): either a normal completion containing an Object, or an abrupt completion
-    </h1>
-    <dl class="header">
-      <dt>description</dt>
-      <dd>It returns a new null-prototype Object with enumerable own String properties copied from the _options_ Object, and the `largestUnit` property set to _largestUnit_.</dd>
-    </dl>
-    <emu-alg>
-      1. Let _merged_ be OrdinaryObjectCreate(*null*).
-      1. Let _entries_ be ? EnumerableOwnProperties(_options_, ~key+value~).
-      1. For each element _entry_ of _entries_, do
-        1. Perform ! CreateDataPropertyOrThrow(_merged_, _entry_[0], _entry_[1]).
-      1. Perform ! CreateDataPropertyOrThrow(_merged_, *"largestUnit"*, _largestUnit_).
-      1. Return _merged_.
-    </emu-alg>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-maximumtemporaldurationroundingincrement" aoid="MaximumTemporalDurationRoundingIncrement">
     <h1>MaximumTemporalDurationRoundingIncrement ( _unit_ )</h1>
     <emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -518,10 +518,9 @@
     </dl>
     <emu-alg>
       1. Let _merged_ be OrdinaryObjectCreate(*null*).
-      1. Let _keys_ be ? EnumerableOwnProperties(_options_, ~key~).
-      1. For each element _nextKey_ of _keys_, do
-        1. Let _propValue_ be ? Get(_options_, _nextKey_).
-        1. Perform ! CreateDataPropertyOrThrow(_merged_, _nextKey_, _propValue_).
+      1. Let _entries_ be ? EnumerableOwnProperties(_options_, ~key+value~).
+      1. For each element _entry_ of _entries_, do
+        1. Perform ! CreateDataPropertyOrThrow(_merged_, _entry_[0], _entry_[1]).
       1. Perform ! CreateDataPropertyOrThrow(_merged_, *"largestUnit"*, _largestUnit_).
       1. Return _merged_.
     </emu-alg>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -723,24 +723,19 @@
       </dl>
       <emu-alg>
         1. Let _merged_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _fieldsKeys_ be ? EnumerableOwnProperties(_fields_, ~key~).
-        1. For each element _key_ of _fieldsKeys_, do
-          1. If _key_ is not *"month"* or *"monthCode"*, then
-            1. Let _propValue_ be ? Get(_fields_, _key_).
-            1. If _propValue_ is not *undefined*, then
-              1. Perform ! CreateDataPropertyOrThrow(_merged_, _key_, _propValue_).
-        1. Let _additionalFieldsKeys_ be ? EnumerableOwnProperties(_additionalFields_, ~key~).
-        1. For each element _key_ of _additionalFieldsKeys_, do
-          1. Let _propValue_ be ? Get(_additionalFields_, _key_).
-          1. If _propValue_ is not *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_merged_, _key_, _propValue_).
-        1. If _additionalFieldsKeys_ does not contain either *"month"* or *"monthCode"*, then
-          1. Let _month_ be ? Get(_fields_, *"month"*).
-          1. If _month_ is not *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_merged_, *"month"*, _month_).
-          1. Let _monthCode_ be ? Get(_fields_, *"monthCode"*).
-          1. If _monthCode_ is not *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_merged_, *"monthCode"*, _monthCode_).
+        1. Let _fieldsEntries_ be ? EnumerableOwnProperties(_fields_, ~key+value~).
+        1. For each element _entry_ of _fieldsEntries_, do
+          1. If _entry_[1] is not *undefined*, then
+            1. Perform ! CreateDataPropertyOrThrow(_merged_, _entry_[0], _entry_[1]).
+        1. Let _monthOverride_ be *false*.
+        1. Let _additionalFieldsEntries_ be ? EnumerableOwnProperties(_additionalFields_, ~key+value~).
+        1. For each element _entry_ of _additionalFieldsEntries_, do
+          1. If _entry_[1] is not *undefined*, then
+            1. If _monthOverride_ is *false* and _entry_[0] is *"month"* or *"monthCode"*, then
+              1. Perform ! DeletePropertyOrThrow(_merged_, *"month"*).
+              1. Perform ! DeletePropertyOrThrow(_merged_, *"monthCode"*).
+              1. Set _monthOverride_ to *true*.
+            1. Perform ! CreateDataPropertyOrThrow(_merged_, _entry_[0], _entry_[1]).
         1. Return _merged_.
       </emu-alg>
     </emu-clause>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -723,19 +723,14 @@
       </dl>
       <emu-alg>
         1. Let _merged_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _fieldsEntries_ be ? EnumerableOwnProperties(_fields_, ~key+value~).
-        1. For each element _entry_ of _fieldsEntries_, do
-          1. If _entry_[1] is not *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_merged_, _entry_[0], _entry_[1]).
-        1. Let _monthOverride_ be *false*.
-        1. Let _additionalFieldsEntries_ be ? EnumerableOwnProperties(_additionalFields_, ~key+value~).
-        1. For each element _entry_ of _additionalFieldsEntries_, do
-          1. If _entry_[1] is not *undefined*, then
-            1. If _monthOverride_ is *false* and _entry_[0] is *"month"* or *"monthCode"*, then
-              1. Perform ! DeletePropertyOrThrow(_merged_, *"month"*).
-              1. Perform ! DeletePropertyOrThrow(_merged_, *"monthCode"*).
-              1. Set _monthOverride_ to *true*.
-            1. Perform ! CreateDataPropertyOrThrow(_merged_, _entry_[0], _entry_[1]).
+        1. Perform ? CopyDataProperties(_merged_, _fields_, « », « *undefined* »).
+        1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Perform ? CopyDataProperties(_additionalFieldsCopy_, _additionalFields_, « », « *undefined* »).
+        1. NOTE: Every property of _additionalFieldsCopy_ is a data property with non-*undefined* value, but some property keys may be Symbols.
+        1. If ! _additionalFieldsCopy_.[[OwnPropertyKeys]]() contains *"month"* or *"monthCode"*, then
+          1. Perform ! DeletePropertyOrThrow(_merged_, *"month"*).
+          1. Perform ! DeletePropertyOrThrow(_merged_, *"monthCode"*).
+        1. Perform ? CopyDataProperties(_merged_, _additionalFieldsCopy_, « »).
         1. Return _merged_.
       </emu-alg>
     </emu-clause>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -724,7 +724,7 @@
       <emu-alg>
         1. Let _merged_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Perform ? CopyDataProperties(_merged_, _fields_, « », « *undefined* »).
-        1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(*null*).
         1. Perform ? CopyDataProperties(_additionalFieldsCopy_, _additionalFields_, « », « *undefined* »).
         1. NOTE: Every property of _additionalFieldsCopy_ is a data property with non-*undefined* value, but some property keys may be Symbols.
         1. If ! _additionalFieldsCopy_.[[OwnPropertyKeys]]() contains *"month"* or *"monthCode"*, then

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2076,17 +2076,15 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return ? DefaultMergeCalendarFields(_fields_, _additionalFields_).
             1. Let _fieldsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
-            1. Let _fieldsKeys_ be ? EnumerableOwnProperties(_fields_, ~key~).
-            1. For each element _key_ of _fieldsKeys_, do
-              1. Let _propValue_ be ? Get(_fields_, _key_).
-              1. If _propValue_ is not *undefined*, then
-                1. Perform ! CreateDataPropertyOrThrow(_fieldsCopy_, _key_, _propValue_).
+            1. Let _fieldsEntries_ be ? EnumerableOwnProperties(_fields_, ~key+value~).
+            1. For each element _entry_ of _fieldsEntries_, do
+              1. If _entry_[1] is not *undefined*, then
+                1. Perform ! CreateDataPropertyOrThrow(_fieldsCopy_, _entry_[0], _entry_[1]).
             1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
-            1. Let _additionalFieldsKeys_ be ? EnumerableOwnProperties(_additionalFields_, ~key~).
-            1. For each element _key_ of _additionalFieldsKeys_, do
-              1. Let _propValue_ be ? Get(_additionalFields_, _key_).
-              1. If _propValue_ is not *undefined*, then
-                1. Perform ! CreateDataPropertyOrThrow(_additionalFieldsCopy_, _key_, _propValue_).
+            1. Let _additionalFieldsEntries_ be ? EnumerableOwnProperties(_additionalFields_, ~key+value~).
+            1. For each element _entry_ of _additionalFieldsEntries_, do
+              1. If _entry_[1] is not *undefined*, then
+                1. Perform ! CreateDataPropertyOrThrow(_additionalFieldsCopy_, _entry_[0], _entry_[1]).
             1. Return CalendarDateMergeFields(_calendar_.[[Identifier]], _fieldsCopy_, _additionalFieldsCopy_).
           </emu-alg>
         </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2076,15 +2076,9 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return ? DefaultMergeCalendarFields(_fields_, _additionalFields_).
             1. Let _fieldsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
-            1. Let _fieldsEntries_ be ? EnumerableOwnProperties(_fields_, ~key+value~).
-            1. For each element _entry_ of _fieldsEntries_, do
-              1. If _entry_[1] is not *undefined*, then
-                1. Perform ! CreateDataPropertyOrThrow(_fieldsCopy_, _entry_[0], _entry_[1]).
+            1. Perform ? CopyDataProperties(_fieldsCopy_, _fields_, « », « *undefined* »).
             1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
-            1. Let _additionalFieldsEntries_ be ? EnumerableOwnProperties(_additionalFields_, ~key+value~).
-            1. For each element _entry_ of _additionalFieldsEntries_, do
-              1. If _entry_[1] is not *undefined*, then
-                1. Perform ! CreateDataPropertyOrThrow(_additionalFieldsCopy_, _entry_[0], _entry_[1]).
+            1. Perform ? CopyDataProperties(_additionalFieldsCopy_, _additionalFields_, « », « *undefined* »).
             1. Return CalendarDateMergeFields(_calendar_.[[Identifier]], _fieldsCopy_, _additionalFieldsCopy_).
           </emu-alg>
         </emu-clause>

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -90,7 +90,7 @@
         1. Let _excluded_ be *false*.
         1. For each element _e_ of <del>_excludedItems_</del><ins>_excludedKeys_</ins>, do
           1. If SameValue(_e_, _nextKey_) is *true*, then
-            1. Set _excluded_ to *true*.            
+            1. Set _excluded_ to *true*.
         1. If _excluded_ is *false*, then
           1. Let _desc_ be ? <emu-meta effects="user-code">_from_.[[GetOwnProperty]]</emu-meta>(_nextKey_).
           1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -70,6 +70,43 @@
     <p>[...]</p>
   </emu-clause>
 
+  <emu-clause id="sec-copydataproperties" type="abstract operation">
+    <h1>
+      CopyDataProperties (
+        _target_: an Object,
+        _source_: an ECMAScript language value,
+        <del>_excludedItems_: a List of property keys,</del>
+        <ins>_excludedKeys_: a List of property keys,</ins>
+        <ins>optional _excludedValues_: a List of ECMAScript language values,</ins>
+      ): either a normal completion containing ~unused~ or a throw completion
+    </h1>
+    <dl class="header">
+    </dl>
+    <emu-alg>
+      1. If _source_ is *undefined* or *null*, return ~unused~.
+      1. Let _from_ be ! ToObject(_source_).
+      1. Let _keys_ be ? <emu-meta effects="user-code">_from_.[[OwnPropertyKeys]]</emu-meta>().
+      1. For each element _nextKey_ of _keys_, do
+        1. Let _excluded_ be *false*.
+        1. For each element _e_ of <del>_excludedItems_</del><ins>_excludedKeys_</ins>, do
+          1. If SameValue(_e_, _nextKey_) is *true*, then
+            1. Set _excluded_ to *true*.            
+        1. If _excluded_ is *false*, then
+          1. Let _desc_ be ? <emu-meta effects="user-code">_from_.[[GetOwnProperty]]</emu-meta>(_nextKey_).
+          1. If _desc_ is not *undefined* and _desc_.[[Enumerable]] is *true*, then
+            1. Let _propValue_ be ? Get(_from_, _nextKey_).
+            1. <ins>If _excludedValues_ is present, then</ins>
+              1. <ins>For each element _e_ of _excludedValues_, do</ins>
+                1. <ins>If SameValue(_e_, _propValue_) is *true*, then</ins>
+                  1. <ins>Set _excluded_ to *true*.</ins>
+            1. <del>Perform</del><ins>If _excluded_ is *false*, perform</ins> ! CreateDataPropertyOrThrow(_target_, _nextKey_, _propValue_).
+      1. Return ~unused~.
+    </emu-alg>
+    <emu-note>
+      <p>The target passed in here is always a newly created object which is not directly accessible in case of an error being thrown.</p>
+    </emu-note>
+  </emu-clause>
+
   <emu-clause id="sec-temporal-properties-of-the-legacy-date-prototype-object">
     <h1><a href="https://tc39.es/ecma262/#sec-properties-of-the-date-prototype-object">Properties of the Date Prototype Object</a></h1>
 

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -940,7 +940,9 @@
         1. Set _other_ to ? ToTemporalDate(_other_).
         1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _options_, ~date~, &laquo; &raquo;, *"day"*, *"day"*).
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_settings_.[[Options]], _settings_.[[LargestUnit]]).
+        1. Let _untilOptions_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Perform ? CopyDataProperties(_untilOptions_, _settings_.[[Options]], « »).
+        1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).
         1. If _settings_.[[SmallestUnit]] is not *"day"* or _settings_.[[RoundingIncrement]] &ne; 1, then
           1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _temporalDate_)).[[DurationRecord]].

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -940,7 +940,7 @@
         1. Set _other_ to ? ToTemporalDate(_other_).
         1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _options_, ~date~, &laquo; &raquo;, *"day"*, *"day"*).
-        1. Let _untilOptions_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
         1. Perform ? CopyDataProperties(_untilOptions_, _settings_.[[Options]], « »).
         1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _untilOptions_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1076,7 +1076,7 @@
         1. Let _date1_ be ! CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendar_).
         1. Let _date2_ be ! CreateTemporalDate(_y2_, _mon2_, _d2_, _calendar_).
         1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
-        1. Let _untilOptions_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
         1. Perform ? CopyDataProperties(_untilOptions_, _options_, « »).
         1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _dateLargestUnit_).
         1. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1076,7 +1076,9 @@
         1. Let _date1_ be ! CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendar_).
         1. Let _date2_ be ! CreateTemporalDate(_y2_, _mon2_, _d2_, _calendar_).
         1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_options_, _dateLargestUnit_).
+        1. Let _untilOptions_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Perform ? CopyDataProperties(_untilOptions_, _options_, « »).
+        1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _dateLargestUnit_).
         1. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
         1. Let _balanceResult_ be ? BalanceDuration(_dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
         1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -608,7 +608,9 @@
         1. Let _thisFields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
         1. Perform ! CreateDataPropertyOrThrow(_thisFields_, *"day"*, *1*<sub>𝔽</sub>).
         1. Let _thisDate_ be ? CalendarDateFromFields(_calendar_, _thisFields_).
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_settings_.[[Options]], _settings_.[[LargestUnit]]).
+        1. Let _untilOptions_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Perform ? CopyDataProperties(_untilOptions_, _settings_.[[Options]], « »).
+        1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).
         1. If _settings_.[[SmallestUnit]] is not *"month"* or _settings_.[[RoundingIncrement]] &ne; 1, then
           1. Set _result_ to (? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _thisDate_)).[[DurationRecord]].

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -608,7 +608,7 @@
         1. Let _thisFields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
         1. Perform ! CreateDataPropertyOrThrow(_thisFields_, *"day"*, *1*<sub>𝔽</sub>).
         1. Let _thisDate_ be ? CalendarDateFromFields(_calendar_, _thisFields_).
-        1. Let _untilOptions_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
         1. Perform ? CopyDataProperties(_untilOptions_, _settings_.[[Options]], « »).
         1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _untilOptions_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -648,9 +648,7 @@
         1. Let _date_ be ? CalendarDateFromFields(_calendar_, _fields_).
         1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _optionsCopy_ be OrdinaryObjectCreate(*null*).
-        1. Let _entries_ be ? EnumerableOwnProperties(_options_, ~key+value~).
-        1. For each element _entry_ of _entries_, do
-          1. Perform ! CreateDataPropertyOrThrow(_optionsCopy_, _entry_[0], _entry_[1]).
+        1. Perform ? CopyDataProperties(_optionsCopy_, _options_, « »).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _options_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).
         1. Return ? CalendarYearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1362,7 +1362,9 @@
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
-        1. Let _untilOptions_ be ? MergeLargestUnitOption(_settings_.[[Options]], _settings_.[[LargestUnit]]).
+        1. Let _untilOptions_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Perform ? CopyDataProperties(_untilOptions_, _settings_.[[Options]], « »).
+        1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _untilOptions_).
         1. Let _roundResult_ be (? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _zonedDateTime_)).[[DurationRecord]].
         1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _zonedDateTime_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1362,7 +1362,7 @@
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
-        1. Let _untilOptions_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
         1. Perform ? CopyDataProperties(_untilOptions_, _settings_.[[Options]], « »).
         1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _untilOptions_).


### PR DESCRIPTION
The first three commits are editorial cleanup, while the rest include technically normative changes (albeit minor).

This stemmed from the surprising observation that [AddDurationToOrSubtractDurationFromPlainYearMonth](https://tc39.es/proposal-temporal/#sec-temporal-adddurationtoorsubtractdurationfromplainyearmonth) uses `key+value` enumeration to clone _options_, while [MergeLargestUnitOption](https://tc39.es/proposal-temporal/#sec-temporal-mergelargestunitoption) and [ECMA-402 Temporal.Calendar.prototype.mergeFields](https://tc39.es/proposal-temporal/#sup-temporal.calendar.prototype.mergefields) and [DefaultMergeFields](https://tc39.es/proposal-temporal/#sec-temporal-defaultmergefields) use `key` enumeration followed by a for-each loop that Gets each source property in analogous copy/merge steps (and DefaultMergeFields in particular has further out-of-order steps related to overriding "month" and "monthCode" properties). The difference between the two is observable by ECMAScript code.

This seems unnecessarily convoluted and confusing, and very likely to result in unintentional implementation divergence. It would be simpler and more comprehensible to **always** read all properties and all values from source objects in any copy/merge operation, which is what this PR proposes. But because that order is observable (`key` enumeration followed by the for-each Get calls is a sequence of [[GetOwnProperty]]s followed by a sequence of [[Get]]s, while `key+value` enumeration is a sequence of [[GetOwnProperty]] + [[Get]] pairs) and so is inclusion of Symbol-valued keys, the change is normative, even though it will not affect expected normal code. That is also true even of the slightly more substantial changes in DefaultMergeFields, and actually improves the behavior AFAICT—`Temporal.Calendar.from("iso8601").mergeFields({year: 2022, month: 5, day: 31}, {year: undefined, month: undefined, day: undefined})` will now produce `{year: 2022, month: 5, day: 31}` rather than `{year: 2022, day: 31}` (which is missing "month" because per the [current algorithm](https://tc39.es/proposal-temporal/#sec-temporal-defaultmergefields) its undefined value in _additionalFields_ suppresses copy from there, while its mere presence suppresses copy from _fields_).