### PR TITLE
Editorial: Simplify operations

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -137,12 +137,8 @@ export class Calendar {
     one = ES.ToTemporalDate(one);
     two = ES.ToTemporalDate(two);
     options = ES.GetOptionsObject(options);
-    const largestUnit = ES.ToLargestTemporalUnit(
-      options,
-      'auto',
-      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'],
-      'day'
-    );
+    let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'date', 'auto');
+    if (largestUnit === 'auto') largestUnit = 'day';
     const { years, months, weeks, days } = impl[GetSlot(this, CALENDAR_ID)].dateUntil(one, two, largestUnit);
     const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -230,7 +230,7 @@ export class Duration {
     } else {
       roundTo = ES.GetOptionsObject(roundTo);
     }
-    let smallestUnit = ES.ToSmallestTemporalUnit(roundTo, undefined);
+    let smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'datetime', undefined);
     let smallestUnitPresent = true;
     if (!smallestUnit) {
       smallestUnitPresent = false;

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -339,8 +339,7 @@ export class Duration {
     } else {
       totalOf = ES.GetOptionsObject(totalOf);
     }
-    const unit = ES.ToTemporalDurationTotalUnit(totalOf, undefined);
-    if (unit === undefined) throw new RangeError('unit option is required');
+    const unit = ES.GetTemporalUnit(totalOf, 'unit', 'datetime', ES.REQUIRED);
     const relativeTo = ES.ToRelativeTemporalObject(totalOf);
 
     // Convert larger units down to days

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -237,7 +237,13 @@ export class Duration {
       smallestUnit = 'nanosecond';
     }
     defaultLargestUnit = ES.LargerOfTwoTemporalUnits(defaultLargestUnit, smallestUnit);
-    let largestUnit = ES.ToLargestTemporalUnit(roundTo, undefined);
+    let largestUnit = ES.GetTemporalUnit(
+      roundTo,
+      'largestUnit',
+      'datetime',
+      undefined,
+      ['auto']
+    );
     let largestUnitPresent = true;
     if (!largestUnit) {
       largestUnitPresent = false;

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -253,7 +253,9 @@ export class Duration {
     if (!smallestUnitPresent && !largestUnitPresent) {
       throw new RangeError('at least one of smallestUnit or largestUnit is required');
     }
-    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
+    if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+    }
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(roundTo, smallestUnit);
     let relativeTo = ES.ToRelativeTemporalObject(roundTo);

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -237,13 +237,7 @@ export class Duration {
       smallestUnit = 'nanosecond';
     }
     defaultLargestUnit = ES.LargerOfTwoTemporalUnits(defaultLargestUnit, smallestUnit);
-    let largestUnit = ES.GetTemporalUnit(
-      roundTo,
-      'largestUnit',
-      'datetime',
-      undefined,
-      ['auto']
-    );
+    let largestUnit = ES.GetTemporalUnit(roundTo, 'largestUnit', 'datetime', undefined, ['auto']);
     let largestUnitPresent = true;
     if (!largestUnit) {
       largestUnitPresent = false;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -155,18 +155,6 @@ const BUILTIN_CASTS = new Map([
   ['offset', ToString]
 ]);
 
-const ALLOWED_UNITS = [
-  'year',
-  'month',
-  'week',
-  'day',
-  'hour',
-  'minute',
-  'second',
-  'millisecond',
-  'microsecond',
-  'nanosecond'
-];
 // each item is [plural, singular, category]
 const SINGULAR_PLURAL_UNITS = [
   ['years', 'year', 'date'],
@@ -182,6 +170,7 @@ const SINGULAR_PLURAL_UNITS = [
 ];
 const SINGULAR_FOR = new Map(SINGULAR_PLURAL_UNITS);
 const PLURAL_FOR = new Map(SINGULAR_PLURAL_UNITS.map(([p, s]) => [s, p]));
+const UNITS_DESCENDING = SINGULAR_PLURAL_UNITS.map(([p, s]) => s);
 
 import * as PARSE from './regex.mjs';
 
@@ -872,7 +861,7 @@ export const ES = ObjectAssign({}, ES2020, {
     return 'nanosecond';
   },
   LargerOfTwoTemporalUnits: (unit1, unit2) => {
-    if (ALLOWED_UNITS.indexOf(unit1) > ALLOWED_UNITS.indexOf(unit2)) return unit2;
+    if (UNITS_DESCENDING.indexOf(unit1) > UNITS_DESCENDING.indexOf(unit2)) return unit2;
     return unit1;
   },
   MergeLargestUnitOption: (options, largestUnit) => {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -855,7 +855,6 @@ export const ES = ObjectAssign({}, ES2020, {
     microseconds,
     nanoseconds
   ) => {
-    const singular = new Map(SINGULAR_PLURAL_UNITS);
     for (const [prop, v] of ObjectEntries({
       years,
       months,
@@ -868,7 +867,7 @@ export const ES = ObjectAssign({}, ES2020, {
       microseconds,
       nanoseconds
     })) {
-      if (v !== 0) return singular.get(prop);
+      if (v !== 0) return SINGULAR_FOR.get(prop);
     }
     return 'nanosecond';
   },

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -170,7 +170,7 @@ const SINGULAR_PLURAL_UNITS = [
 ];
 const SINGULAR_FOR = new Map(SINGULAR_PLURAL_UNITS);
 const PLURAL_FOR = new Map(SINGULAR_PLURAL_UNITS.map(([p, s]) => [s, p]));
-const UNITS_DESCENDING = SINGULAR_PLURAL_UNITS.map(([p, s]) => s);
+const UNITS_DESCENDING = SINGULAR_PLURAL_UNITS.map(([, s]) => s);
 
 import * as PARSE from './regex.mjs';
 
@@ -685,13 +685,10 @@ export const ES = ObjectAssign({}, ES2020, {
   ToSecondsStringPrecision: (options) => {
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') {
-      const ALLOWED_UNITS = SINGULAR_PLURAL_UNITS.reduce(
-        (allowed, [p, s, c]) => {
-          if (c === 'time' && s !== 'hour') allowed.push(s, p);
-          return allowed;
-        },
-        []
-      );
+      const ALLOWED_UNITS = SINGULAR_PLURAL_UNITS.reduce((allowed, [p, s, c]) => {
+        if (c === 'time' && s !== 'hour') allowed.push(s, p);
+        return allowed;
+      }, []);
       throw new RangeError(`smallestUnit must be one of ${ALLOWED_UNITS.join(', ')}, not ${smallestUnit}`);
     }
     switch (smallestUnit) {
@@ -738,7 +735,7 @@ export const ES = ObjectAssign({}, ES2020, {
   REQUIRED: Symbol('~required~'),
   GetTemporalUnit: (options, key, unitGroup, requiredOrDefault, extraValues = []) => {
     const allowedSingular = [];
-    for (const [plural, singular, category] of SINGULAR_PLURAL_UNITS) {
+    for (const [, singular, category] of SINGULAR_PLURAL_UNITS) {
       if (unitGroup === 'datetime' || unitGroup === category) {
         allowedSingular.push(singular);
       }
@@ -3566,13 +3563,10 @@ export const ES = ObjectAssign({}, ES2020, {
       );
     }
     options = ES.GetOptionsObject(options);
-    const ALLOWED_UNITS = SINGULAR_PLURAL_UNITS.reduce(
-      (allowed, [p, s, c]) => {
-        if (c === 'date' && s !== 'week' && s !== 'day') allowed.push(s, p);
-        return allowed;
-      },
-      []
-    );
+    const ALLOWED_UNITS = SINGULAR_PLURAL_UNITS.reduce((allowed, [p, s, c]) => {
+      if (c === 'date' && s !== 'week' && s !== 'day') allowed.push(s, p);
+      return allowed;
+    }, []);
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'date', 'month');
     if (smallestUnit === 'week' || smallestUnit === 'day') {
       throw new RangeError(`smallestUnit must be one of ${ALLOWED_UNITS.join(', ')}, not ${smallestUnit}`);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -694,7 +694,17 @@ export const ES = ObjectAssign({}, ES2020, {
     return ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
   },
   ToSecondsStringPrecision: (options) => {
-    let smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week', 'day', 'hour']);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
+    if (smallestUnit === 'hour') {
+      const ALLOWED_UNITS = SINGULAR_PLURAL_UNITS.reduce(
+        (allowed, [p, s, c]) => {
+          if (c === 'time' && s !== 'hour') allowed.push(s, p);
+          return allowed;
+        },
+        []
+      );
+      throw new RangeError(`smallestUnit must be one of ${ALLOWED_UNITS.join(', ')}, not ${smallestUnit}`);
+    }
     switch (smallestUnit) {
       case 'minute':
         return { precision: 'minute', unit: 'minute', increment: 1 };
@@ -762,16 +772,6 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     if (SINGULAR_FOR.has(retval)) retval = SINGULAR_FOR.get(retval);
     return retval;
-  },
-  ToSmallestTemporalUnit: (options, fallback, disallowedStrings = []) => {
-    const singular = new Map(SINGULAR_PLURAL_UNITS.filter(([, sing]) => !disallowedStrings.includes(sing)));
-    const allowed = new Set(ALLOWED_UNITS);
-    for (const s of disallowedStrings) {
-      allowed.delete(s);
-    }
-    const value = ES.GetOption(options, 'smallestUnit', [...allowed, ...singular.keys()], fallback);
-    if (singular.has(value)) return singular.get(value);
-    return value;
   },
   ToTemporalDurationTotalUnit: (options) => {
     // This AO is identical to ToSmallestTemporalUnit, except:
@@ -3328,8 +3328,7 @@ export const ES = ObjectAssign({}, ES2020, {
       [first, second] = [other, instant];
     }
     options = ES.GetOptionsObject(options);
-    const DISALLOWED_UNITS = ['year', 'month', 'week', 'day'];
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond', DISALLOWED_UNITS);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', 'nanosecond');
     const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('second', smallestUnit);
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'time', 'auto');
     if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
@@ -3379,8 +3378,7 @@ export const ES = ObjectAssign({}, ES2020, {
     }
 
     options = ES.GetOptionsObject(options);
-    const DISALLOWED_UNITS = ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'];
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'day', DISALLOWED_UNITS);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'date', 'day');
     const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('day', smallestUnit);
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'date', 'auto');
     if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
@@ -3425,7 +3423,7 @@ export const ES = ObjectAssign({}, ES2020, {
       throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
     }
     options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond');
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'datetime', 'nanosecond');
     const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('day', smallestUnit);
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'datetime', 'auto');
     if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
@@ -3506,10 +3504,9 @@ export const ES = ObjectAssign({}, ES2020, {
     const sign = operation === 'since' ? -1 : 1;
     other = ES.ToTemporalTime(other);
     options = ES.GetOptionsObject(options);
-    const DISALLOWED_UNITS = ['year', 'month', 'week', 'day'];
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'time', 'auto');
     if (largestUnit === 'auto') largestUnit = 'hour';
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond', DISALLOWED_UNITS);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', 'nanosecond');
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
     let roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     if (operation === 'since') roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
@@ -3588,18 +3585,20 @@ export const ES = ObjectAssign({}, ES2020, {
       );
     }
     options = ES.GetOptionsObject(options);
-    const DISALLOWED_UNITS = ['week', 'day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'];
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'month', DISALLOWED_UNITS);
+    const ALLOWED_UNITS = SINGULAR_PLURAL_UNITS.reduce(
+      (allowed, [p, s, c]) => {
+        if (c === 'date' && s !== 'week' && s !== 'day') allowed.push(s, p);
+        return allowed;
+      },
+      []
+    );
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'date', 'month');
+    if (smallestUnit === 'week' || smallestUnit === 'day') {
+      throw new RangeError(`smallestUnit must be one of ${ALLOWED_UNITS.join(', ')}, not ${smallestUnit}`);
+    }
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'date', 'auto');
     if (largestUnit === 'week' || largestUnit === 'day') {
-      const allowed = SINGULAR_PLURAL_UNITS.reduce(
-        (allowed, [p, s, c]) => {
-          if (c === 'date' && s !== 'week' && s !== 'day') allowed.push(s, p);
-          return allowed;
-        },
-        []
-      );
-      throw new RangeError(`largestUnit must be one of ${allowed.join(', ')}, not ${largestUnit}`);
+      throw new RangeError(`largestUnit must be one of ${ALLOWED_UNITS.join(', ')}, not ${largestUnit}`);
     }
     if (largestUnit === 'auto') largestUnit = 'year';
     ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
@@ -3649,7 +3648,7 @@ export const ES = ObjectAssign({}, ES2020, {
       throw new RangeError(`cannot compute difference between dates of ${calendarId} and ${otherCalendarId} calendars`);
     }
     options = ES.GetOptionsObject(options);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, 'nanosecond');
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'datetime', 'nanosecond');
     const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('hour', smallestUnit);
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'datetime', 'auto');
     if (largestUnit === 'auto') largestUnit = defaultLargestUnit;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -773,16 +773,6 @@ export const ES = ObjectAssign({}, ES2020, {
     if (SINGULAR_FOR.has(retval)) retval = SINGULAR_FOR.get(retval);
     return retval;
   },
-  ToTemporalDurationTotalUnit: (options) => {
-    // This AO is identical to ToSmallestTemporalUnit, except:
-    // - default is always `undefined` (caller will throw if omitted)
-    // - option is named `unit` (not `smallestUnit`)
-    // - all units are valid (no `disallowedStrings`)
-    const singular = new Map(SINGULAR_PLURAL_UNITS);
-    const value = ES.GetOption(options, 'unit', [...singular.values(), ...singular.keys()], undefined);
-    if (singular.has(value)) return singular.get(value);
-    return value;
-  },
   ToRelativeTemporalObject: (options) => {
     const relativeTo = options.relativeTo;
     if (relativeTo === undefined) return relativeTo;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -763,17 +763,6 @@ export const ES = ObjectAssign({}, ES2020, {
     if (SINGULAR_FOR.has(retval)) retval = SINGULAR_FOR.get(retval);
     return retval;
   },
-  ToLargestTemporalUnit: (options, fallback, disallowedStrings = [], autoValue) => {
-    const singular = new Map(SINGULAR_PLURAL_UNITS.filter(([, sing]) => !disallowedStrings.includes(sing)));
-    const allowed = new Set(ALLOWED_UNITS);
-    for (const s of disallowedStrings) {
-      allowed.delete(s);
-    }
-    const retval = ES.GetOption(options, 'largestUnit', ['auto', ...allowed, ...singular.keys()], fallback);
-    if (retval === 'auto' && autoValue !== undefined) return autoValue;
-    if (singular.has(retval)) return singular.get(retval);
-    return retval;
-  },
   ToSmallestTemporalUnit: (options, fallback, disallowedStrings = []) => {
     const singular = new Map(SINGULAR_PLURAL_UNITS.filter(([, sing]) => !disallowedStrings.includes(sing)));
     const allowed = new Set(ALLOWED_UNITS);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -843,11 +843,6 @@ export const ES = ObjectAssign({}, ES2020, {
     }
     return ES.CreateTemporalDate(year, month, day, calendar);
   },
-  ValidateTemporalUnitRange: (largestUnit, smallestUnit) => {
-    if (ALLOWED_UNITS.indexOf(largestUnit) > ALLOWED_UNITS.indexOf(smallestUnit)) {
-      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
-    }
-  },
   DefaultTemporalLargestUnit: (
     years,
     months,
@@ -3322,7 +3317,9 @@ export const ES = ObjectAssign({}, ES2020, {
     const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('second', smallestUnit);
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'time', 'auto');
     if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
-    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
+    if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+    }
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const MAX_DIFFERENCE_INCREMENTS = {
       hour: 24,
@@ -3372,7 +3369,9 @@ export const ES = ObjectAssign({}, ES2020, {
     const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('day', smallestUnit);
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'date', 'auto');
     if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
-    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
+    if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+    }
     let roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     if (operation === 'since') roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
@@ -3417,7 +3416,9 @@ export const ES = ObjectAssign({}, ES2020, {
     const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('day', smallestUnit);
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'datetime', 'auto');
     if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
-    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
+    if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+    }
     let roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     if (operation === 'since') roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);
@@ -3497,7 +3498,9 @@ export const ES = ObjectAssign({}, ES2020, {
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'time', 'auto');
     if (largestUnit === 'auto') largestUnit = 'hour';
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', 'nanosecond');
-    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
+    if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+    }
     let roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     if (operation === 'since') roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
     const MAX_INCREMENTS = {
@@ -3591,7 +3594,9 @@ export const ES = ObjectAssign({}, ES2020, {
       throw new RangeError(`largestUnit must be one of ${ALLOWED_UNITS.join(', ')}, not ${largestUnit}`);
     }
     if (largestUnit === 'auto') largestUnit = 'year';
-    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
+    if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+    }
     let roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     if (operation === 'since') roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
     const roundingIncrement = ES.ToTemporalRoundingIncrement(options, undefined, false);
@@ -3642,7 +3647,9 @@ export const ES = ObjectAssign({}, ES2020, {
     const defaultLargestUnit = ES.LargerOfTwoTemporalUnits('hour', smallestUnit);
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'datetime', 'auto');
     if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
-    ES.ValidateTemporalUnitRange(largestUnit, smallestUnit);
+    if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
+      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+    }
     let roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     if (operation === 'since') roundingMode = ES.NegateTemporalRoundingMode(roundingMode);
     const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(options, smallestUnit);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -79,9 +79,7 @@ export class Instant {
     } else {
       roundTo = ES.GetOptionsObject(roundTo);
     }
-    const DISALLOWED_UNITS = ['year', 'month', 'week', 'day'];
-    const smallestUnit = ES.ToSmallestTemporalUnit(roundTo, undefined, DISALLOWED_UNITS);
-    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
+    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED);
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
     const maximumIncrements = {
       hour: 24,

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -295,8 +295,7 @@ export class PlainDateTime {
     } else {
       roundTo = ES.GetOptionsObject(roundTo);
     }
-    const smallestUnit = ES.ToSmallestTemporalUnit(roundTo, undefined, ['year', 'month', 'week']);
-    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
+    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED, ['day']);
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
     const maximumIncrements = {
       day: 1,

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -171,9 +171,7 @@ export class PlainTime {
     } else {
       roundTo = ES.GetOptionsObject(roundTo);
     }
-    const DISALLOWED_UNITS = ['year', 'month', 'week', 'day'];
-    const smallestUnit = ES.ToSmallestTemporalUnit(roundTo, undefined, DISALLOWED_UNITS);
-    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
+    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED);
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
     const MAX_INCREMENTS = {
       hour: 24,

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -350,8 +350,7 @@ export class ZonedDateTime {
     } else {
       roundTo = ES.GetOptionsObject(roundTo);
     }
-    const smallestUnit = ES.ToSmallestTemporalUnit(roundTo, undefined, ['year', 'month', 'week']);
-    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
+    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED, ['day']);
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
     const maximumIncrements = {
       day: 1,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -348,25 +348,6 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-totemporaldurationtotalunit" aoid="ToTemporalDurationTotalUnit">
-    <h1>ToTemporalDurationTotalUnit ( _normalizedOptions_ )</h1>
-    <p>
-      The abstract operation ToTemporalDurationTotalUnit consults the `unit` property of the Object _normalizedOptions_, and checks that it is a valid unit.
-      It throws if the property is not present.
-    </p>
-    <p>
-      Both singular and plural unit names are accepted, but only the singular form is returned.
-    </p>
-    <emu-alg>
-      1. Let _unit_ be ? GetOption(_normalizedOptions_, *"unit"*, « String », « *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », *undefined*).
-      1. If _unit_ is *undefined*, then
-        1. Throw a *RangeError* exception.
-      1. If _unit_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
-        1. Set _unit_ to the corresponding Singular value of the same row.
-      1. Return _unit_.
-    </emu-alg>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-singular-and-plural-units">
     <h1>Singular and plural units</h1>
     <p>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -329,13 +329,13 @@
         _normalizedOptions_: an Object,
         _key_: a property key,
         _unitGroup_: ~date~, ~time~, or ~datetime~,
-        _defaultValue_: an ECMAScript language value,
+        _default_: ~required~ or an ECMAScript language value,
         optional _extraValues_: a List of ECMAScript language values,
       ): either a normal completion containing an ECMAScript language value, or an abrupt completion
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It attempts to read from the specified property of _normalizedOptions_ a Temporal unit that is covered by the union of _unitGroup_ and _extraValues_, substituting _defaultValue_ if the property value is *undefined*.</dd>
+      <dd>It attempts to read from the specified property of _normalizedOptions_ a Temporal unit that is covered by the union of _unitGroup_ and _extraValues_, substituting _default_ if the property value is *undefined*.</dd>
     </dl>
     <p>
       Both singular and plural unit names are accepted, but only the singular form is returned.
@@ -348,9 +348,14 @@
         1. Set _allowedValues_ to the list-concatenation of _allowedValues_ and « *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* ».
       1. If _extraValues_ is present, then
         1. Set _allowedValues_ to the list-concatenation of _allowedValues_ and _extraValues_.
-      1. If _defaultValue_ is not *undefined* and _allowedValues_ does not contain _defaultValue_, then
-        1. Append _defaultValue_ to _allowedValues_.
+      1. If _default_ is ~required~, then
+        1. Let _defaultValue_ be *undefined*.
+      1. Else,
+        1. Let _defaultValue_ be _default_.
+        1. If _defaultValue_ is not *undefined* and _allowedValues_ does not contain _defaultValue_, then
+          1. Append _defaultValue_ to _allowedValues_.
       1. Let _value_ be ? GetOption(_normalizedOptions_, _key_, « String », _allowedValues_, _defaultValue_).
+      1. If _value_ is *undefined* and _default_ is ~required~, throw a *RangeError* exception.
       1. If _value_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
         1. Set _value_ to the corresponding Singular value of the same row.
       1. Return _value_.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -335,28 +335,31 @@
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It attempts to read from the specified property of _normalizedOptions_ a Temporal unit that is covered by the union of _unitGroup_ and _extraValues_, substituting _default_ if the property value is *undefined*.</dd>
+      <dd>It attempts to read from the specified property of _normalizedOptions_ a Temporal unit that is <emu-not-ref>covered</emu-not-ref> by the union of _unitGroup_ and _extraValues_, substituting _default_ if the property value is *undefined*.</dd>
     </dl>
     <p>
       Both singular and plural unit names are accepted, but only the singular form is used internally.
     </p>
     <emu-alg>
-      1. Let _allowedValues_ be a new empty List.
+      1. Let _singularNames_ be a new empty List.
       1. For each row of <emu-xref href="#table-temporal-units"></emu-xref>, except the header row, in table order, do
-        1. Let _applicable_ be *false*.
-        1. If the Category column of the row is ~date~ and _unitGroup_ is ~date~ or ~datetime~, set _applicable_ to *true*.
-        1. Else if the Category column of the row is ~time~ and _unitGroup_ is ~time~ or ~datetime~, set _applicable_ to *true*.
-        1. If _applicable_ is *true*, then
-          1. Append the value in the Singular column of the row to _allowedValues_.
-          1. Append the value in the Plural column of the row to _allowedValues_.
+        1. Let _unit_ be the value in the Singular column of the row.
+        1. If the Category column of the row is ~date~ and _unitGroup_ is ~date~ or ~datetime~, append _unit_ to _singularNames_.
+        1. Else if the Category column of the row is ~time~ and _unitGroup_ is ~time~ or ~datetime~, append _unit_ to _singularNames_.
       1. If _extraValues_ is present, then
-        1. Set _allowedValues_ to the list-concatenation of _allowedValues_ and _extraValues_.
+        1. Set _singularNames_ to the list-concatenation of _singularNames_ and _extraValues_.
       1. If _default_ is ~required~, then
         1. Let _defaultValue_ be *undefined*.
       1. Else,
         1. Let _defaultValue_ be _default_.
-        1. If _defaultValue_ is not *undefined* and _allowedValues_ does not contain _defaultValue_, then
-          1. Append _defaultValue_ to _allowedValues_.
+        1. If _defaultValue_ is not *undefined* and _singularNames_ does not contain _defaultValue_, then
+          1. Append _defaultValue_ to _singularNames_.
+      1. Let _allowedValues_ be a copy of _singularNames_.
+      1. For each element _singularName_ of _singularNames_, do
+        1. If _singularName_ is listed in the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>, then
+          1. Let _pluralName_ be the value in the Plural column of the corresponding row.
+          1. Append _pluralName_ to _allowedValues_.
+      1. NOTE: For each singular Temporal unit name that is contained within _allowedValues_, the corresponding plural name is also contained within it.
       1. Let _value_ be ? GetOption(_normalizedOptions_, _key_, « String », _allowedValues_, _defaultValue_).
       1. If _value_ is *undefined* and _default_ is ~required~, throw a *RangeError* exception.
       1. If _value_ is listed in the Plural column of <emu-xref href="#table-temporal-units"></emu-xref>, then

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -364,7 +364,7 @@
       1. Return _value_.
     </emu-alg>
     <emu-table id="table-temporal-units">
-      <emu-caption>Temporal units</emu-caption>
+      <emu-caption>Temporal units by descending magnitude</emu-caption>
       <table class="real-table">
         <thead>
           <tr>
@@ -503,43 +503,25 @@
   <emu-clause id="sec-temporal-validatetemporalunitrange" aoid="ValidateTemporalUnitRange">
     <h1>ValidateTemporalUnitRange ( _largestUnit_, _smallestUnit_ )</h1>
     <emu-alg>
-      1. If _smallestUnit_ is *"year"* and _largestUnit_ is not *"year"*, then
-        1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"month"* and _largestUnit_ is not *"year"* or *"month"*, then
-        1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"week"* and _largestUnit_ is not one of *"year"*, *"month"*, or *"week"*, then
-        1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"day"* and _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-        1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"hour"* and _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, *"day"*, or *"hour"*, then
-        1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"minute"* and _largestUnit_ is *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*, then
-        1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"second"* and _largestUnit_ is *"millisecond"*, *"microsecond"*, or *"nanosecond"*, then
-        1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"millisecond"* and _largestUnit_ is *"microsecond"* or *"nanosecond"*, then
-        1. Throw a *RangeError* exception.
-      1. If _smallestUnit_ is *"microsecond"* and _largestUnit_ is *"nanosecond"*, then
-        1. Throw a *RangeError* exception.
+      1. Assert: Both _largestUnit_ and _smallestUnit_ are listed in the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>.
+      1. For each row of <emu-xref href="#table-temporal-units"></emu-xref>, except the header row, in table order, do
+        1. Let _unit_ be the value in the Singular column of the row.
+        1. If SameValue(_largestUnit_, _unit_) is *true*, return ~unused~.
+        1. If SameValue(_smallestUnit_, _unit_) is *true*, throw a *RangeError* exception.
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-temporal-largeroftwotemporalunits" aoid="LargerOfTwoTemporalUnits">
     <h1>LargerOfTwoTemporalUnits ( _u1_, _u2_ )</h1>
     <p>
-      The abstract operation LargerOfTwoTemporalUnits, given two strings representing units of time, returns the string representing the larger of the two units.
+      The abstract operation LargerOfTwoTemporalUnits, given two strings representing Temporal units, returns the string representing the larger of the two units.
     </p>
     <emu-alg>
-      1. If either _u1_ or _u2_ is *"year"*, return *"year"*.
-      1. If either _u1_ or _u2_ is *"month"*, return *"month"*.
-      1. If either _u1_ or _u2_ is *"week"*, return *"week"*.
-      1. If either _u1_ or _u2_ is *"day"*, return *"day"*.
-      1. If either _u1_ or _u2_ is *"hour"*, return *"hour"*.
-      1. If either _u1_ or _u2_ is *"minute"*, return *"minute"*.
-      1. If either _u1_ or _u2_ is *"second"*, return *"second"*.
-      1. If either _u1_ or _u2_ is *"millisecond"*, return *"millisecond"*.
-      1. If either _u1_ or _u2_ is *"microsecond"*, return *"microsecond"*.
-      1. Return *"nanosecond"*.
+      1. Assert: Both _u1_ and _u2_ are listed in the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>.
+      1. For each row of <emu-xref href="#table-temporal-units"></emu-xref>, except the header row, in table order, do
+        1. Let _unit_ be the value in the Singular column of the row.
+        1. If SameValue(_u1_, _unit_) is *true*, return _unit_.
+        1. If SameValue(_u2_, _unit_) is *true*, return _unit_.
     </emu-alg>
   </emu-clause>
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -256,7 +256,8 @@
       The precision may be an integer 0 through 9 signifying a number of digits after the decimal point in the seconds, the string *"minute"* signifying not to print seconds at all, or the string *"auto"* signifying to drop trailing zeroes after the decimal point.
     </p>
     <emu-alg>
-      1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_normalizedOptions_, « *"year"*, *"month"*, *"week"*, *"day"*, *"hour"* », *undefined*).
+      1. Let _smallestUnit_ be ? GetTemporalUnit(_normalizedOptions_, *"smallestUnit"*, ~time~, *undefined*).
+      1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
       1. If _smallestUnit_ is *"minute"*, then
         1. Return the Record {
             [[Precision]]: *"minute"*,
@@ -344,26 +345,6 @@
       1. If _value_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
         1. Set _value_ to the corresponding Singular value of the same row.
       1. Return _value_.
-    </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-temporal-tosmallesttemporalunit" aoid="ToSmallestTemporalUnit">
-    <h1>ToSmallestTemporalUnit ( _normalizedOptions_, _disallowedUnits_, _fallback_ )</h1>
-    <p>
-      The abstract operation ToSmallestTemporalUnit consults the `smallestUnit` property of the Object _normalizedOptions_, and checks that it is a valid unit and not one of a List of _disallowedUnits_.
-      It returns a _fallback_ value if the property is not present.
-    </p>
-    <p>
-      Both singular and plural unit names are accepted, but only the singular form is returned.
-    </p>
-    <emu-alg>
-      1. Assert: _disallowedUnits_ does not contain _fallback_.
-      1. Let _smallestUnit_ be ? GetOption(_normalizedOptions_, *"smallestUnit"*, « String », « *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
-      1. If _smallestUnit_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
-        1. Set _smallestUnit_ to the corresponding Singular value of the same row.
-      1. If _disallowedUnits_ contains _smallestUnit_, then
-        1. Throw a *RangeError* exception.
-      1. Return _smallestUnit_.
     </emu-alg>
   </emu-clause>
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -338,7 +338,7 @@
       <dd>It attempts to read from the specified property of _normalizedOptions_ a Temporal unit that is covered by the union of _unitGroup_ and _extraValues_, substituting _default_ if the property value is *undefined*.</dd>
     </dl>
     <p>
-      Both singular and plural unit names are accepted, but only the singular form is returned.
+      Both singular and plural unit names are accepted, but only the singular form is used internally.
     </p>
     <emu-alg>
       1. Let _allowedValues_ be a new empty List.
@@ -360,14 +360,6 @@
         1. Set _value_ to the corresponding Singular value of the same row.
       1. Return _value_.
     </emu-alg>
-  </emu-clause>
-
-  <emu-clause id="sec-temporal-singular-and-plural-units">
-    <h1>Singular and plural units</h1>
-    <p>
-      Where possible, the `smallestUnit`, `largestUnit`, and `unit` options accept both singular and plural forms.
-      Only the singular form is used internally.
-    </p>
     <emu-table id="table-temporal-singular-and-plural-units">
       <emu-caption>Singular and plural units</emu-caption>
       <table class="real-table">

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -342,10 +342,13 @@
     </p>
     <emu-alg>
       1. Let _allowedValues_ be a new empty List.
-      1. If _unitGroup_ is ~date~ or ~datetime~, then
-        1. Set _allowedValues_ to the list-concatenation of _allowedValues_ and « *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"* ».
-      1. If _unitGroup_ is ~time~ or ~datetime~, then
-        1. Set _allowedValues_ to the list-concatenation of _allowedValues_ and « *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* ».
+      1. For each row of <emu-xref href="#table-temporal-units"></emu-xref>, except the header row, in table order, do
+        1. Let _applicable_ be *false*.
+        1. If the Category column of the row is ~date~ and _unitGroup_ is ~date~ or ~datetime~, set _applicable_ to *true*.
+        1. Else if the Category column of the row is ~time~ and _unitGroup_ is ~time~ or ~datetime~, set _applicable_ to *true*.
+        1. If _applicable_ is *true*, then
+          1. Append the value in the Singular column of the row to _allowedValues_.
+          1. Append the value in the Plural column of the row to _allowedValues_.
       1. If _extraValues_ is present, then
         1. Set _allowedValues_ to the list-concatenation of _allowedValues_ and _extraValues_.
       1. If _default_ is ~required~, then
@@ -356,68 +359,79 @@
           1. Append _defaultValue_ to _allowedValues_.
       1. Let _value_ be ? GetOption(_normalizedOptions_, _key_, « String », _allowedValues_, _defaultValue_).
       1. If _value_ is *undefined* and _default_ is ~required~, throw a *RangeError* exception.
-      1. If _value_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
-        1. Set _value_ to the corresponding Singular value of the same row.
+      1. If _value_ is listed in the Plural column of <emu-xref href="#table-temporal-units"></emu-xref>, then
+        1. Set _value_ to the value in the Singular value of the corresponding row.
       1. Return _value_.
     </emu-alg>
-    <emu-table id="table-temporal-singular-and-plural-units">
-      <emu-caption>Singular and plural units</emu-caption>
+    <emu-table id="table-temporal-units">
+      <emu-caption>Temporal units</emu-caption>
       <table class="real-table">
         <thead>
           <tr>
             <th>Singular</th>
             <th>Plural</th>
+            <th>Category</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>*"year"*</td>
             <td>*"years"*</td>
+            <td>~date~</td>
           </tr>
 
           <tr>
             <td>*"month"*</td>
             <td>*"months"*</td>
+            <td>~date~</td>
           </tr>
 
           <tr>
             <td>*"week"*</td>
             <td>*"weeks"*</td>
+            <td>~date~</td>
           </tr>
 
           <tr>
             <td>*"day"*</td>
             <td>*"days"*</td>
+            <td>~date~</td>
           </tr>
 
           <tr>
             <td>*"hour"*</td>
             <td>*"hours"*</td>
+            <td>~time~</td>
           </tr>
 
           <tr>
             <td>*"minute"*</td>
             <td>*"minutes"*</td>
+            <td>~time~</td>
           </tr>
 
           <tr>
             <td>*"second"*</td>
             <td>*"seconds"*</td>
+            <td>~time~</td>
           </tr>
 
           <tr>
             <td>*"millisecond"*</td>
             <td>*"milliseconds"*</td>
+            <td>~time~</td>
           </tr>
 
           <tr>
             <td>*"microsecond"*</td>
             <td>*"microseconds"*</td>
+            <td>~time~</td>
           </tr>
 
           <tr>
             <td>*"nanosecond"*</td>
             <td>*"nanoseconds"*</td>
+            <td>~time~</td>
           </tr>
         </tbody>
       </table>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -323,11 +323,20 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-gettemporalunit" aoid="GetTemporalUnit">
-    <h1>GetTemporalUnit ( _normalizedOptions_, _key_, _unitGroup_, _defaultValue_ [ , _extraValues_ ] )</h1>
-    <p>
-      The abstract operation GetTemporalUnit attempts to read from the specified property of the Object _normalizedOptions_ a Temporal unit that is covered by the union of _unitGroup_ (~date~, ~time~, or ~datetime~) and _extraValues_, substituting _defaultValue_ if the property value is *undefined*.
-    </p>
+  <emu-clause id="sec-temporal-gettemporalunit" type="abstract operation">
+    <h1>
+      GetTemporalUnit (
+        _normalizedOptions_: an Object,
+        _key_: a property key,
+        _unitGroup_: ~date~, ~time~, or ~datetime~,
+        _defaultValue_: an ECMAScript language value,
+        optional _extraValues_: a List of ECMAScript language values,
+      ): either a normal completion containing an ECMAScript language value, or an abrupt completion
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It attempts to read from the specified property of _normalizedOptions_ a Temporal unit that is covered by the union of _unitGroup_ and _extraValues_, substituting _defaultValue_ if the property value is *undefined*.</dd>
+    </dl>
     <p>
       Both singular and plural unit names are accepted, but only the singular form is returned.
     </p>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -503,17 +503,6 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-validatetemporalunitrange" aoid="ValidateTemporalUnitRange">
-    <h1>ValidateTemporalUnitRange ( _largestUnit_, _smallestUnit_ )</h1>
-    <emu-alg>
-      1. Assert: Both _largestUnit_ and _smallestUnit_ are listed in the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>.
-      1. For each row of <emu-xref href="#table-temporal-units"></emu-xref>, except the header row, in table order, do
-        1. Let _unit_ be the value in the Singular column of the row.
-        1. If SameValue(_largestUnit_, _unit_) is *true*, return ~unused~.
-        1. If SameValue(_smallestUnit_, _unit_) is *true*, throw a *RangeError* exception.
-    </emu-alg>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-largeroftwotemporalunits" aoid="LargerOfTwoTemporalUnits">
     <h1>LargerOfTwoTemporalUnits ( _u1_, _u2_ )</h1>
     <p>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -322,29 +322,28 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-tolargesttemporalunit" aoid="ToLargestTemporalUnit">
-    <h1>ToLargestTemporalUnit ( _normalizedOptions_, _disallowedUnits_, _fallback_ [ , _autoValue_ ] )</h1>
+  <emu-clause id="sec-temporal-gettemporalunit" aoid="GetTemporalUnit">
+    <h1>GetTemporalUnit ( _normalizedOptions_, _key_, _unitGroup_, _defaultValue_ [ , _extraValues_ ] )</h1>
     <p>
-      The abstract operation ToLargestTemporalUnit consults the `largestUnit` property of the Object _normalizedOptions_, and checks that it is a valid unit and not one of a List of _disallowedUnits_.
-      It returns a _fallback_ value if the property is not present.
-      Optionally, if an _autoValue_ is provided, then a value of *"auto"* is replaced with this value.
+      The abstract operation GetTemporalUnit attempts to read from the specified property of the Object _normalizedOptions_ a Temporal unit that is covered by the union of _unitGroup_ (~date~, ~time~, or ~datetime~) and _extraValues_, substituting _defaultValue_ if the property value is *undefined*.
     </p>
     <p>
       Both singular and plural unit names are accepted, but only the singular form is returned.
     </p>
     <emu-alg>
-      1. Assert: _disallowedUnits_ does not contain _fallback_.
-      1. Assert: _disallowedUnits_ does not contain *"auto"*.
-      1. Assert: _autoValue_ is not present or _fallback_ is *"auto"*.
-      1. Assert: _autoValue_ is not present or _disallowedUnits_ does not contain _autoValue_.
-      1. Let _largestUnit_ be ? GetOption(_normalizedOptions_, *"largestUnit"*, « String », « *"auto"*, *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"*, *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* », _fallback_).
-      1. If _largestUnit_ is *"auto"* and _autoValue_ is present, then
-        1. Return _autoValue_.
-      1. If _largestUnit_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
-        1. Set _largestUnit_ to the corresponding Singular value of the same row.
-      1. If _disallowedUnits_ contains _largestUnit_, then
-        1. Throw a *RangeError* exception.
-      1. Return _largestUnit_.
+      1. Let _allowedValues_ be a new empty List.
+      1. If _unitGroup_ is ~date~ or ~datetime~, then
+        1. Set _allowedValues_ to the list-concatenation of _allowedValues_ and « *"year"*, *"years"*, *"month"*, *"months"*, *"week"*, *"weeks"*, *"day"*, *"days"* ».
+      1. If _unitGroup_ is ~time~ or ~datetime~, then
+        1. Set _allowedValues_ to the list-concatenation of _allowedValues_ and « *"hour"*, *"hours"*, *"minute"*, *"minutes"*, *"second"*, *"seconds"*, *"millisecond"*, *"milliseconds"*, *"microsecond"*, *"microseconds"*, *"nanosecond"*, *"nanoseconds"* ».
+      1. If _extraValues_ is present, then
+        1. Set _allowedValues_ to the list-concatenation of _allowedValues_ and _extraValues_.
+      1. If _defaultValue_ is not *undefined* and _allowedValues_ does not contain _defaultValue_, then
+        1. Append _defaultValue_ to _allowedValues_.
+      1. Let _value_ be ? GetOption(_normalizedOptions_, _key_, « String », _allowedValues_, _defaultValue_).
+      1. If _value_ is in the Plural column of <emu-xref href="#table-temporal-singular-and-plural-units"></emu-xref>, then
+        1. Set _value_ to the corresponding Singular value of the same row.
+      1. Return _value_.
     </emu-alg>
   </emu-clause>
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -363,7 +363,7 @@
       1. Let _value_ be ? GetOption(_normalizedOptions_, _key_, « String », _allowedValues_, _defaultValue_).
       1. If _value_ is *undefined* and _default_ is ~required~, throw a *RangeError* exception.
       1. If _value_ is listed in the Plural column of <emu-xref href="#table-temporal-units"></emu-xref>, then
-        1. Set _value_ to the value in the Singular value of the corresponding row.
+        1. Set _value_ to the value in the Singular column of the corresponding row.
       1. Return _value_.
     </emu-alg>
     <emu-table id="table-temporal-units">

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -841,7 +841,8 @@
         1. Set _one_ to ? ToTemporalDate(_one_).
         1. Set _two_ to ? ToTemporalDate(_two_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* », *"auto"*, *"day"*).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~date~, *"auto"*).
+        1. If _largestUnit_ is *"auto"*, set _largestUnit_ to *"day"*.
         1. Let _result_ be DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
         1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -413,7 +413,7 @@
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnitPresent_ be *true*.
         1. Let _largestUnitPresent_ be *true*.
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « », *undefined*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~datetime~, *undefined*).
         1. If _smallestUnit_ is *undefined*, then
           1. Set _smallestUnitPresent_ to *false*.
           1. Set _smallestUnit_ to *"nanosecond"*.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -427,7 +427,7 @@
           1. Set _largestUnit_ to _defaultLargestUnit_.
         1. If _smallestUnitPresent_ is *false* and _largestUnitPresent_ is *false*, then
           1. Throw a *RangeError* exception.
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_, _maximum_, *false*).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -419,7 +419,7 @@
           1. Set _smallestUnit_ to *"nanosecond"*.
         1. Let _defaultLargestUnit_ be ! DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
         1. Set _defaultLargestUnit_ to ! LargerOfTwoTemporalUnits(_defaultLargestUnit_, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_roundTo_, « », *undefined*).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_roundTo_, *"largestUnit"*, ~datetime~, *undefined*, « *"auto"* »).
         1. If _largestUnit_ is *undefined*, then
           1. Set _largestUnitPresent_ to *false*.
           1. Set _largestUnit_ to _defaultLargestUnit_.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -459,7 +459,8 @@
         1. Else,
           1. Set _totalOf_ to ? GetOptionsObject(_totalOf_).
         1. Let _relativeTo_ be ? ToRelativeTemporalObject(_totalOf_).
-        1. Let _unit_ be ? ToTemporalDurationTotalUnit(_totalOf_).
+        1. Let _unit_ be ? GetTemporalUnit(_totalOf_, *"unit"*, ~datetime~, *undefined*).
+        1. If _unit_ is *undefined*, throw a *RangeError* exception.
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _relativeTo_).
         1. Let _intermediate_ be *undefined*.
         1. If _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -459,8 +459,7 @@
         1. Else,
           1. Set _totalOf_ to ? GetOptionsObject(_totalOf_).
         1. Let _relativeTo_ be ? ToRelativeTemporalObject(_totalOf_).
-        1. Let _unit_ be ? GetTemporalUnit(_totalOf_, *"unit"*, ~datetime~, *undefined*).
-        1. If _unit_ is *undefined*, throw a *RangeError* exception.
+        1. Let _unit_ be ? GetTemporalUnit(_totalOf_, *"unit"*, ~datetime~, ~required~).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _relativeTo_).
         1. Let _intermediate_ be *undefined*.
         1. If _relativeTo_ has an [[InitializedTemporalZonedDateTime]] internal slot, then

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -286,7 +286,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
@@ -660,7 +660,7 @@
           1. Let _first_ be _other_.
           1. Let _second_ be _instant_.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *"nanosecond"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~time~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -286,8 +286,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, *undefined*).
-        1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
           1. Let _maximum_ be HoursPerDay.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -663,7 +663,7 @@
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~time~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -662,7 +662,8 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"second"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, _defaultLargestUnit_).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~time~, *"auto"*).
+        1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1725,7 +1725,8 @@
             1. Set _one_ to ? ToTemporalDate(_one_).
             1. Set _two_ to ? ToTemporalDate(_two_).
             1. Set _options_ to ? GetOptionsObject(_options_).
-            1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* », *"auto"*, *"day"*).
+            1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~date~, *"auto"*).
+            1. If _largestUnit_ is *"auto"*, set _largestUnit_ to *"day"*.
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be DifferenceISODate(_one_.[[ISOYear]], _one_.[[ISOMonth]], _one_.[[ISODay]], _two_.[[ISOYear]], _two_.[[ISOMonth]], _two_.[[ISODay]], _largestUnit_).
             1. Else,

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -944,8 +944,7 @@
         1. Set _other_ to ? ToTemporalDate(_other_).
         1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"day"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~date~, *"day"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~date~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -948,7 +948,7 @@
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~date~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -947,7 +947,8 @@
         1. Let _disallowedUnits_ be « *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"day"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, _defaultLargestUnit_).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~date~, *"auto"*).
+        1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -512,7 +512,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"* », *undefined*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, *undefined*, « *"day"* »).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
@@ -1136,7 +1136,7 @@
         1. Set _other_ to ? ToTemporalDateTime(_other_).
         1. If ? CalendarEquals(_dateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~datetime~, *"nanosecond"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~datetime~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -512,8 +512,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, *undefined*, « *"day"* »).
-        1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1138,7 +1138,8 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~datetime~, *"auto"*).
+        1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1139,7 +1139,7 @@
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _smallestUnit_).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~datetime~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -953,7 +953,7 @@
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *"nanosecond"*).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~time~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to *"hour"*.
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -952,7 +952,8 @@
         1. Set _other_ to ? ToTemporalTime(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"auto"*, *"hour"*).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~time~, *"auto"*).
+        1. If _largestUnit_ is *"auto"*, set _largestUnit_ to *"hour"*.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -314,7 +314,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"*, *"day"* », *undefined*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
@@ -951,7 +951,7 @@
         1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalTime(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « *"year"*, *"month"*, *"week"*, *"day"* », *"nanosecond"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *"nanosecond"*).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~time~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to *"hour"*.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -314,8 +314,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, *undefined*).
-        1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. If _smallestUnit_ is *"hour"*, then
           1. Let _maximum_ be 24.

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -628,10 +628,10 @@
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disallowedUnits_ be « *"week"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"month"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~date~, *"month"*).
+        1. If _smallestUnit_ is *"week"* or *"day"*, throw a *RangeError* exception.
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~date~, *"auto"*).
-        1. If _disallowedUnits_ contains _largestUnit_, throw a *RangeError* exception.
+        1. If _largestUnit_ is *"week"* or *"day"*, throw a *RangeError* exception.
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to *"year"*.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -630,7 +630,9 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _disallowedUnits_ be « *"week"*, *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"* ».
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, _disallowedUnits_, *"month"*).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, _disallowedUnits_, *"auto"*, *"year"*).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~date~, *"auto"*).
+        1. If _disallowedUnits_ contains _largestUnit_, throw a *RangeError* exception.
+        1. If _largestUnit_ is *"auto"*, set _largestUnit_ to *"year"*.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -633,7 +633,7 @@
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~date~, *"auto"*).
         1. If _largestUnit_ is *"week"* or *"day"*, throw a *RangeError* exception.
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to *"year"*.
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1365,7 +1365,8 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"hour"*, _smallestUnit_).
-        1. Let _largestUnit_ be ? ToLargestTemporalUnit(_options_, « », *"auto"*, _defaultLargestUnit_).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~datetime~, *"auto"*).
+        1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
         1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -727,8 +727,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, *undefined*, « *"day"* »).
-        1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -727,7 +727,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_roundTo_, « *"year"*, *"month"*, *"week"* », *undefined*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, *undefined*, « *"day"* »).
         1. If _smallestUnit_ is *undefined*, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
@@ -1363,7 +1363,7 @@
         1. If ? CalendarEquals(_zonedDateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _smallestUnit_ be ? ToSmallestTemporalUnit(_options_, « », *"nanosecond"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~datetime~, *"nanosecond"*).
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"hour"*, _smallestUnit_).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~datetime~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1366,7 +1366,7 @@
         1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(*"hour"*, _smallestUnit_).
         1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, ~datetime~, *"auto"*).
         1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
-        1. Perform ? ValidateTemporalUnitRange(_largestUnit_, _smallestUnit_).
+        1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. If _operation_ is ~since~, then
           1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).


### PR DESCRIPTION
The [Abstract operations](https://tc39.es/proposal-temporal/#sec-temporal-abstract-ops) section has gotten rather unwieldy, and this is an attempt to pare it back a bit.

* Replace the narrow ToLargestTemporalUnit, ToSmallestTemporalUnit, and ToTemporalDurationTotalUnit operations with a single GetTemporalUnit.
* Move the Temporal units table into that operation.
* Leverage the units table in GetTemporalUnit and other operations.

Further tweaking could also simplify e.g. [DefaultTemporalLargestUnit](https://tc39.es/proposal-temporal/#sec-temporal-defaulttemporallargestunit).