### PR TITLE
Editorial: Rename DefaultMergeFields to DefaultMergeCalendarFields

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -615,11 +615,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-defaultmergefields" aoid="DefaultMergeCalendarFields">
-      <h1>DefaultMergeCalendarFields ( _fields_, _additionalFields_ )</h1>
-      <p>
-        The abstract operation DefaultMergeCalendarFields implements the default logic for the `Temporal.Calendar.mergeFields` method, which is used as a fallback if the method is not present on a calendar, and also for the ISO 8601 calendar.
-      </p>
+    <emu-clause id="sec-temporal-defaultmergefields" type="abstract operation">
+      <h1>
+        DefaultMergeCalendarFields (
+          _fields_: an Object,
+          _additionalFields_: an Object,
+        ): either a normal completion containing an Object or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It implements the default logic for the `Temporal.Calendar.mergeFields` method, which is used for the ISO 8601 calendar and as a fallback if the method is not present on a calendar.</dd>
+      </dl>
       <emu-alg>
         1. Let _merged_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _originalKeys_ be ? EnumerableOwnPropertyNames(_fields_, ~key~).

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -615,7 +615,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-defaultmergefields" type="abstract operation">
+    <emu-clause id="sec-temporal-defaultmergecalendarfields" type="abstract operation">
       <h1>
         DefaultMergeCalendarFields (
           _fields_: an Object,
@@ -624,7 +624,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It implements the default logic for the `Temporal.Calendar.mergeFields` method, which is used for the ISO 8601 calendar and as a fallback if the method is not present on a calendar.</dd>
+        <dd>It implements the default logic for the `Temporal.Calendar.prototype.mergeFields` method, which is used for the ISO 8601 calendar and as a fallback if the method is not present on a calendar.</dd>
       </dl>
       <emu-alg>
         1. Let _merged_ be OrdinaryObjectCreate(%Object.prototype%).

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -115,7 +115,7 @@
       <emu-alg>
         1. Let _mergeFields_ be ? GetMethod(_calendar_, *"mergeFields"*).
         1. If _mergeFields_ is *undefined*, then
-          1. Return ? DefaultMergeFields(_fields_, _additionalFields_).
+          1. Return ? DefaultMergeCalendarFields(_fields_, _additionalFields_).
         1. Let _result_ be ? Call(_mergeFields_, _calendar_, « _fields_, _additionalFields_ »).
         1. If Type(_result_) is not Object, throw a *TypeError* exception.
         1. Return _result_.
@@ -615,10 +615,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-defaultmergefields" aoid="DefaultMergeFields">
-      <h1>DefaultMergeFields ( _fields_, _additionalFields_ )</h1>
+    <emu-clause id="sec-temporal-defaultmergefields" aoid="DefaultMergeCalendarFields">
+      <h1>DefaultMergeCalendarFields ( _fields_, _additionalFields_ )</h1>
       <p>
-        The abstract operation DefaultMergeFields implements the default logic for the `Temporal.Calendar.mergeFields` method, which is used as a fallback if the method is not present on a calendar, and also for the ISO 8601 calendar.
+        The abstract operation DefaultMergeCalendarFields implements the default logic for the `Temporal.Calendar.mergeFields` method, which is used as a fallback if the method is not present on a calendar, and also for the ISO 8601 calendar.
       </p>
       <emu-alg>
         1. Let _merged_ be OrdinaryObjectCreate(%Object.prototype%).
@@ -1129,7 +1129,7 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Set _fields_ to ? ToObject(_fields_).
         1. Set _additionalFields_ to ? ToObject(_additionalFields_).
-        1. Return ? DefaultMergeFields(_fields_, _additionalFields_).
+        1. Return ? DefaultMergeCalendarFields(_fields_, _additionalFields_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2064,7 +2064,7 @@
             1. Set _fields_ to ? ToObject(_fields_).
             1. Set _additionalFields_ to ? ToObject(_additionalFields_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Return ? DefaultMergeFields(_fields_, _additionalFields_).
+              1. Return ? DefaultMergeCalendarFields(_fields_, _additionalFields_).
             1. Let _fieldsKeys_ be ? EnumerableOwnPropertyNames(_fields_, ~key~).
             1. Let _fieldsCopied_ be OrdinaryObjectCreate(%Object.prototype%).
             1. For each element _key_ of _fieldsKeys_, do


### PR DESCRIPTION
For clarity in the resulting state of ECMA-262.