### PR TITLE
Editorial: Remove unnecessary ToLimitedTemporalDuration

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1751,26 +1751,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-tolimitedtemporalduration" type="abstract operation">
-      <h1>
-        ToLimitedTemporalDuration (
-          _temporalDurationLike_: an ECMAScript value,
-        )
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It converts _temporalDurationLike_ to a Duration Record, and returns it, ensuring that [[Days]], [[Months]], [[Weeks]], and [[Years]] are all zeros.</dd>
-      </dl>
-      <emu-alg>
-        1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
-        1. If _duration_.[[Days]] is not 0, throw a *RangeError* exception.
-        1. If _duration_.[[Months]] is not 0, throw a *RangeError* exception.
-        1. If _duration_.[[Weeks]] is not 0, throw a *RangeError* exception.
-        1. If _duration_.[[Years]] is not 0, throw a *RangeError* exception.
-        1. Return _duration_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-temporaldurationtostring" type="abstract operation">
       <h1>
         TemporalDurationToString (

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1755,20 +1755,18 @@
       <h1>
         ToLimitedTemporalDuration (
           _temporalDurationLike_: an ECMAScript value,
-          _disallowedFields_: a List of Strings,
         )
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _temporalDurationLike_ to a Duration Record, and returns it, ensuring that all of the fields listed in _disallowedFields_ are zero.</dd>
+        <dd>It converts _temporalDurationLike_ to a Duration Record, and returns it, ensuring that [[Days]], [[Months]], [[Weeks]], and [[Years]] are all zeros.</dd>
       </dl>
       <emu-alg>
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
-        1. For each row of <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>, except the header row, in table order, do
-          1. Let _prop_ be the Property Name value of the current row.
-          1. Let _value_ be _duration_'s field whose name is the Field Name value of the current row.
-          1. If _value_ is not 0 and _disallowedFields_ contains _prop_, then
-            1. Throw a *RangeError* exception.
+        1. If _duration_.[[Days]] is not 0, throw a *RangeError* exception.
+        1. If _duration_.[[Months]] is not 0, throw a *RangeError* exception.
+        1. If _duration_.[[Weeks]] is not 0, throw a *RangeError* exception.
+        1. If _duration_.[[Years]] is not 0, throw a *RangeError* exception.
         1. Return _duration_.
       </emu-alg>
     </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -687,7 +687,11 @@
       </dl>
       <emu-alg>
         1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
-        1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_).
+        1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
+        1. If _duration_.[[Days]] is not 0, throw a *RangeError* exception.
+        1. If _duration_.[[Months]] is not 0, throw a *RangeError* exception.
+        1. If _duration_.[[Weeks]] is not 0, throw a *RangeError* exception.
+        1. If _duration_.[[Years]] is not 0, throw a *RangeError* exception.
         1. Let _ns_ be ? AddInstant(_instant_.[[Nanoseconds]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
         1. Return ! CreateTemporalInstant(_ns_).
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -687,7 +687,7 @@
       </dl>
       <emu-alg>
         1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
-        1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_, « *"years"*, *"months"*, *"weeks"*, *"days"* »).
+        1. Let _duration_ be ? ToLimitedTemporalDuration(_temporalDurationLike_).
         1. Let _ns_ be ? AddInstant(_instant_.[[Nanoseconds]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
         1. Return ! CreateTemporalInstant(_ns_).
       </emu-alg>


### PR DESCRIPTION
There is only one caller to ToLimitedTemporalDuration so there are no need to make it general and pass in a _disallowedFields_ 