### PR TITLE
Editorial: Consolidate partial operations

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -141,18 +141,22 @@ export class Duration {
   }
   with(durationLike) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    const props = ES.ToPartialRecord(durationLike, [
-      'days',
-      'hours',
-      'microseconds',
-      'milliseconds',
-      'minutes',
-      'months',
-      'nanoseconds',
-      'seconds',
-      'weeks',
-      'years'
-    ]);
+    const props = ES.PrepareTemporalFields(
+      durationLike,
+      [
+        'days',
+        'hours',
+        'microseconds',
+        'milliseconds',
+        'minutes',
+        'months',
+        'nanoseconds',
+        'seconds',
+        'weeks',
+        'years'
+      ],
+      'partial'
+    );
     if (!props) {
       throw new TypeError('invalid duration-like');
     }

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -102,7 +102,7 @@ export class PlainDate {
 
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);
-    const props = ES.ToPartialRecord(temporalDateLike, fieldNames);
+    const props = ES.PrepareTemporalFields(temporalDateLike, fieldNames, 'partial');
     if (!props) {
       throw new TypeError('invalid date-like');
     }

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -170,7 +170,7 @@ export class PlainDateTime {
       'second',
       'year'
     ]);
-    const props = ES.ToPartialRecord(temporalDateTimeLike, fieldNames);
+    const props = ES.PrepareTemporalFields(temporalDateTimeLike, fieldNames, 'partial');
     if (!props) {
       throw new TypeError('invalid date-time-like');
     }

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -45,7 +45,7 @@ export class PlainMonthDay {
 
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);
-    const props = ES.ToPartialRecord(temporalMonthDayLike, fieldNames);
+    const props = ES.PrepareTemporalFields(temporalMonthDayLike, fieldNames, 'partial');
     if (!props) {
       throw new TypeError('invalid month-day-like');
     }

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -118,22 +118,12 @@ export class PlainTime {
     }
     ES.RejectObjectWithCalendarOrTimeZone(temporalTimeLike);
 
+    const partialTime = ES.ToTemporalTimeRecord(temporalTimeLike, 'partial');
     options = ES.GetOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
 
-    const props = ES.ToPartialRecord(temporalTimeLike, [
-      'hour',
-      'microsecond',
-      'millisecond',
-      'minute',
-      'nanosecond',
-      'second'
-    ]);
-    if (!props) {
-      throw new TypeError('invalid time-like');
-    }
     const fields = ES.ToTemporalTimeRecord(this);
-    let { hour, minute, second, millisecond, microsecond, nanosecond } = ObjectAssign(fields, props);
+    let { hour, minute, second, millisecond, microsecond, nanosecond } = ObjectAssign(fields, partialTime);
     ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateTime(
       hour,
       minute,

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -71,7 +71,7 @@ export class PlainYearMonth {
 
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['month', 'monthCode', 'year']);
-    const props = ES.ToPartialRecord(temporalYearMonthLike, fieldNames);
+    const props = ES.PrepareTemporalFields(temporalYearMonthLike, fieldNames, 'partial');
     if (!props) {
       throw new TypeError('invalid year-month-like');
     }

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -194,7 +194,7 @@ export class ZonedDateTime {
       'year'
     ]);
     ArrayPrototypePush.call(fieldNames, 'offset');
-    const props = ES.ToPartialRecord(temporalZonedDateTimeLike, fieldNames);
+    const props = ES.PrepareTemporalFields(temporalZonedDateTimeLike, fieldNames, 'partial');
     if (!props) {
       throw new TypeError('invalid zoned-date-time-like');
     }

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1758,30 +1758,36 @@
       PrepareTemporalFields (
         _fields_: an Object,
         _fieldNames_: a List of property names,
-        _requiredFields_: a List of property names,
+        _requiredFields_: ~partial~ or a List of property names,
       ): either a normal completion containing an Object, or an abrupt completion
     </h1>
     <dl class="header">
       <dt>description</dt>
       <dd>
-        It reads the relevant properties of _fields_ given by _fieldNames_, and throws if any of the required properties given by _requiredFields_ are absent or undefined.
-        The returned Object has an own data property named by each element of _fieldNames_, with corresponding value converted from the value of an identically-named property on _fields_ or replaced with a default value.
+        The returned Object has an own data property for each element of _fieldNames_ that corresponds with a non-*undefined* property of the same name on _fields_ used as the input for relevant conversion.
+        When _requiredFields_ is ~partial~, this operation throws if none of the properties are present with a non-*undefined* value.
+        When _requiredFields_ is a List, this operation throws if any of the properties named by it are absent or undefined, and otherwise substitutes a relevant default for any absent or undefined non-required property (ensuring that the returned object has a property for each element of _fieldNames_).
       </dd>
     </dl>
     <emu-alg>
       1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
-      1. For each value _property_ of _fieldNames_, do
+      1. Let _any_ be *false*.
+      1. For each property name _property_ of _fieldNames_, do
         1. Let _value_ be ? Get(_fields_, _property_).
-        1. If _value_ is *undefined*, then
+        1. If _value_ is not *undefined*, then
+          1. Set _any_ to *true*.
+          1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
+            1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.
+            1. Set _value_ to ? _Conversion_(_value_).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+        1. Else if _requiredFields_ is a List, then
           1. If _requiredFields_ contains _property_, then
             1. Throw a *TypeError* exception.
           1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
             1. Set _value_ to the corresponding Default value of the same row.
-        1. Else,
-          1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
-            1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.
-            1. Set _value_ to ? _Conversion_(_value_).
-        1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+      1. If _requiredFields_ is ~partial~ and _any_ is *false*, then
+        1. Throw a *TypeError* exception.
       1. Return _result_.
     </emu-alg>
     <emu-note>The values of ! ToIntegerThrowOnInfinity(*undefined*) and ! ToPositiveInteger(*undefined*) are 0.</emu-note>
@@ -1869,38 +1875,5 @@
         </tbody>
       </table>
     </emu-table>
-  </emu-clause>
-
-  <emu-clause id="sec-temporal-preparepartialtemporalfields" type="abstract operation">
-    <h1>
-      PreparePartialTemporalFields (
-        _fields_: an Object,
-        _fieldNames_: a List of property names,
-      ): either a normal completion containing an Object, or an abrupt completion
-    </h1>
-    <dl class="header">
-      <dt>description</dt>
-      <dd>
-        It reads the relevant properties of _fields_ given by _fieldNames_.
-        The returned Object has an own data property named by each element of _fieldNames_ for which _fields_ has an identically-named property with non-**undefined** value, converted as appropriate.
-        Unlike PrepareTemporalFields, properties that are absent or undefined on _fields_ are absent on the returned Object as well.
-      </dd>
-    </dl>
-    <emu-alg>
-      1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
-      1. Let _any_ be *false*.
-      1. For each value _property_ of _fieldNames_, do
-        1. Let _value_ be ? Get(_fields_, _property_).
-        1. If _value_ is not *undefined*, then
-          1. Set _any_ to *true*.
-          1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
-            1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.
-            1. Set _value_ to ? _Conversion_(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-      1. If _any_ is *false*, then
-        1. Throw a *TypeError* exception.
-      1. Return _result_.
-    </emu-alg>
-    <emu-note>The values of ! ToIntegerThrowOnInfinity(*undefined*) and ! ToPositiveInteger(*undefined*) are 0.</emu-note>
   </emu-clause>
 </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -795,7 +795,6 @@
       <h1>Partial Duration Records</h1>
       <p>
         A <dfn variants="partial Duration Records">partial Duration Record</dfn> is a Record value used to represent a portion of a Temporal.Duration object, in which it is not required that all the fields be specified.
-        Partial Duration Records are produced by the abstract operation ToPartialTemporalDuration, among others.
       </p>
       <p>
         Partial Duration Records have the same fields listed in <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>.
@@ -927,19 +926,13 @@
           1. Return ? ParseTemporalDurationString(_string_).
         1. If _temporalDurationLike_ has an [[InitializedTemporalDuration]] internal slot, then
           1. Return ! CreateDurationRecord(_temporalDurationLike_.[[Years]], _temporalDurationLike_.[[Months]], _temporalDurationLike_.[[Weeks]], _temporalDurationLike_.[[Days]], _temporalDurationLike_.[[Hours]], _temporalDurationLike_.[[Minutes]], _temporalDurationLike_.[[Seconds]], _temporalDurationLike_.[[Milliseconds]], _temporalDurationLike_.[[Microseconds]], _temporalDurationLike_.[[Nanoseconds]]).
-        1. Let _result_ be a new Duration Record.
-        1. Let _any_ be *false*.
+        1. Let _result_ be a new Duration Record with each field set to 0.
+        1. Let _partial_ be ? ToPartialDuration(_temporalDurationLike_).
         1. For each row of <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>, except the header row, in table order, do
-          1. Let _prop_ be the Property Name value of the current row.
-          1. Let _val_ be ? Get(_temporalDurationLike_, _prop_).
-          1. If _val_ is *undefined*, then
-            1. Set _result_'s field whose name is the Field Name value of the current row to 0.
-          1. Else,
-            1. Set _any_ to *true*.
-            1. Let _val_ be ? ToIntegerWithoutRounding(_val_).
-            1. Set _result_'s field whose name is the Field Name value of the current row to _val_.
-        1. If _any_ is *false*, then
-          1. Throw a *TypeError* exception.
+          1. Let _fieldName_ be the Field Name value of the current row.
+          1. Let _value_ be the value of the field of _partial_ whose name is _fieldName_.
+          1. If _value_ is not *undefined*, then
+            1. Set the field of _result_ whose name is _fieldName_ to _value_.
         1. If ! IsValidDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]] _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Return _result_.
@@ -1055,7 +1048,8 @@
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
             1. Set _value_ to ? ToIntegerWithoutRounding(_value_).
-            1. Set _result_'s field whose name is the Field Name value of the current row to _value_.
+            1. Let _fieldName_ be the Field Name value of the current row.
+            1. Set the field of _result_ whose name is _fieldName_ to _value_.
         1. If _any_ is *false*, then
           1. Throw a *TypeError* exception.
         1. Return _result_.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -302,7 +302,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Let _temporalDurationLike_ be ? ToPartialDuration(_temporalDurationLike_).
+        1. Let _temporalDurationLike_ be ? ToTemporalPartialDurationRecord(_temporalDurationLike_).
         1. If _temporalDurationLike_.[[Years]] is not *undefined*, then
           1. Let _years_ be _temporalDurationLike_.[[Years]].
         1. Else,
@@ -927,7 +927,7 @@
         1. If _temporalDurationLike_ has an [[InitializedTemporalDuration]] internal slot, then
           1. Return ! CreateDurationRecord(_temporalDurationLike_.[[Years]], _temporalDurationLike_.[[Months]], _temporalDurationLike_.[[Weeks]], _temporalDurationLike_.[[Days]], _temporalDurationLike_.[[Hours]], _temporalDurationLike_.[[Minutes]], _temporalDurationLike_.[[Seconds]], _temporalDurationLike_.[[Milliseconds]], _temporalDurationLike_.[[Microseconds]], _temporalDurationLike_.[[Nanoseconds]]).
         1. Let _result_ be a new Duration Record with each field set to 0.
-        1. Let _partial_ be ? ToPartialDuration(_temporalDurationLike_).
+        1. Let _partial_ be ? ToTemporalPartialDurationRecord(_temporalDurationLike_).
         1. For each row of <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>, except the header row, in table order, do
           1. Let _fieldName_ be the Field Name value of the current row.
           1. Let _value_ be the value of the field of _partial_ whose name is _fieldName_.
@@ -1027,9 +1027,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-topartialduration" type="abstract operation">
+    <emu-clause id="sec-temporal-totemporalpartialdurationrecord" type="abstract operation">
       <h1>
-        ToPartialDuration (
+        ToTemporalPartialDurationRecord (
           _temporalDurationLike_: an ECMAScript language value,
         )
       </h1>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2345,25 +2345,39 @@
     <emu-clause id="sec-abstracts">
       <h1>Abstract Operations</h1>
 
-      <emu-clause id="sup-temporal-preparetemporalfields">
-        <h1>PrepareTemporalFields ( _fields_, _fieldNames_, _requiredFields_ )</h1>
-        <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-preparetemporalfields"></emu-xref>.</p>
+      <emu-clause id="sup-temporal-preparetemporalfields" type="abstract operation">
+        <h1>
+          PrepareTemporalFields (
+            _fields_: an Object,
+            _fieldNames_: a List of property names,
+            _requiredFields_: ~partial~ or a List of property names,
+          ): either a normal completion containing an Object, or an abrupt completion
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>This definition supersedes the definition provided in <emu-xref href="#sec-temporal-preparetemporalfields"></emu-xref>.</dd>
+          <dt>redefinition</dt>
+          <dd>true</dd>
+        </dl>
         <emu-alg>
-          1. Assert: Type(_fields_) is Object.
           1. Let _result_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. For each value _property_ of _fieldNames_, do
+          1. Let _any_ be *false*.
+          1. For each property name _property_ of _fieldNames_, do
             1. Let _value_ be ? Get(_fields_, _property_).
-            1. If _value_ is *undefined*, then
-              1. If _requiredFields_ contains _property_, then
-                1. Throw a *TypeError* exception.
-              1. Else,
-                1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
-                  1. Set _value_ to the corresponding Default value of the same row.
-            1. Else,
-              1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+            1. If _value_ is not *undefined*, then
+              1. Set _any_ to *true*.
+              1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
                 1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.
                 1. Set _value_ to ? _Conversion_(_value_).
-            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+              1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+            1. Else if _requiredFields_ is a List, then
+              1. If _requiredFields_ contains _property_, then
+                1. Throw a *TypeError* exception.
+              1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+                1. Set _value_ to the corresponding Default value of the same row.
+              1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+          1. If _requiredFields_ is ~partial~ and _any_ is *false*, then
+            1. Throw a *TypeError* exception.
           1. Let _era_ be ? Get(_result_, *"era"*).
           1. Let _eraYear_ be ? Get(_result_, *"eraYear"*).
           1. If _era_ is *undefined* and _eraYear_ is not *undefined*, or if _era_ is not *undefined* and _eraYear_ is *undefined*, then

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2378,10 +2378,11 @@
               1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
           1. If _requiredFields_ is ~partial~ and _any_ is *false*, then
             1. Throw a *TypeError* exception.
-          1. Let _era_ be ? Get(_result_, *"era"*).
-          1. Let _eraYear_ be ? Get(_result_, *"eraYear"*).
-          1. If _era_ is *undefined* and _eraYear_ is not *undefined*, or if _era_ is not *undefined* and _eraYear_ is *undefined*, then
-            1. Throw a *RangeError* exception.
+          1. If _requiredFields_ is not ~partial~, then
+            1. Let _era_ be ? Get(_result_, *"era"*).
+            1. Let _eraYear_ be ? Get(_result_, *"eraYear"*).
+            1. If _era_ is *undefined* and _eraYear_ is not *undefined*, or if _era_ is not *undefined* and _eraYear_ is *undefined*, then
+              1. Throw a *RangeError* exception.
           1. Return _result_.
         </emu-alg>
       </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -383,7 +383,7 @@
         1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalDateLike_).
         1. Let _calendar_ be _temporalDate_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
-        1. Let _partialDate_ be ? PreparePartialTemporalFields(_temporalDateLike_, _fieldNames_).
+        1. Let _partialDate_ be ? PrepareTemporalFields(_temporalDateLike_, _fieldNames_, ~partial~).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDate_, _fieldNames_, «»).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialDate_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -386,7 +386,7 @@
         1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalDateTimeLike_).
         1. Let _calendar_ be _dateTime_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
-        1. Let _partialDateTime_ be ? PreparePartialTemporalFields(_temporalDateTimeLike_, _fieldNames_).
+        1. Let _partialDateTime_ be ? PrepareTemporalFields(_temporalDateTimeLike_, _fieldNames_, ~partial~).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _fields_ be ? PrepareTemporalFields(_dateTime_, _fieldNames_, «»).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialDateTime_).

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -151,7 +151,7 @@
         1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalMonthDayLike_).
         1. Let _calendar_ be _monthDay_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
-        1. Let _partialMonthDay_ be ? PreparePartialTemporalFields(_temporalMonthDayLike_, _fieldNames_).
+        1. Let _partialMonthDay_ be ? PrepareTemporalFields(_temporalMonthDayLike_, _fieldNames_, ~partial~).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _fields_ be ? PrepareTemporalFields(_monthDay_, _fieldNames_, «»).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialMonthDay_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -239,7 +239,7 @@
         1. If Type(_temporalTimeLike_) is not Object, then
           1. Throw a *TypeError* exception.
         1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalTimeLike_).
-        1. Let _partialTime_ be ? ToPartialTime(_temporalTimeLike_).
+        1. Let _partialTime_ be ? ToTemporalTimeRecord(_temporalTimeLike_, ~partial~).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. If _partialTime_.[[Hour]] is not *undefined*, then
@@ -622,75 +622,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-topartialtime" aoid="ToPartialTime">
-      <h1>ToPartialTime ( _temporalTimeLike_ )</h1>
-      <emu-alg>
-        1. Assert: Type(_temporalTimeLike_) is Object.
-        1. Let _result_ be the Record {
-          [[Hour]]: *undefined*,
-          [[Minute]]: *undefined*,
-          [[Second]]: *undefined*,
-          [[Millisecond]]: *undefined*,
-          [[Microsecond]]: *undefined*,
-          [[Nanosecond]]: *undefined*
-          }.
-        1. Let _any_ be *false*.
-        1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _property_ be the Property value of the current row.
-          1. Let _value_ be ? Get(_temporalTimeLike_, _property_).
-          1. If _value_ is not *undefined*, then
-            1. Set _any_ to *true*.
-            1. Set _value_ to ? ToIntegerThrowOnInfinity(_value_).
-            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-        1. If _any_ is *false*, then
-          1. Throw a *TypeError* exception.
-        1. Return _result_.
-      </emu-alg>
-
-      <emu-table id="table-temporal-temporaltimelike-properties">
-        <emu-caption>Properties of a TemporalTimeLike</emu-caption>
-        <table class="real-table">
-          <thead>
-            <tr>
-              <th>Internal Slot</th>
-              <th>Property</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>[[Hour]]</td>
-              <td>*"hour"*</td>
-            </tr>
-
-            <tr>
-              <td>[[Microsecond]]</td>
-              <td>*"microsecond"*</td>
-            </tr>
-
-            <tr>
-              <td>[[Millisecond]]</td>
-              <td>*"millisecond"*</td>
-            </tr>
-
-            <tr>
-              <td>[[Minute]]</td>
-              <td>*"minute"*</td>
-            </tr>
-
-            <tr>
-              <td>[[Nanosecond]]</td>
-              <td>*"nanosecond"*</td>
-            </tr>
-
-            <tr>
-              <td>[[Second]]</td>
-              <td>*"second"*</td>
-            </tr>
-          </tbody>
-        </table>
-      </emu-table>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-regulatetime" aoid="RegulateTime">
       <h1>RegulateTime ( _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _overflow_ )</h1>
       <emu-alg>
@@ -813,11 +744,17 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-totemporaltimerecord" aoid="ToTemporalTimeRecord">
-      <h1>ToTemporalTimeRecord ( _temporalTimeLike_ )</h1>
-      <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
+    <emu-clause id="sec-temporal-totemporaltimerecord" type="abstract operation">
+      <h1>
+        ToTemporalTimeRecord (
+          _temporalTimeLike_: an Object,
+          optional _completeness_: ~partial~ or ~complete~,
+        ): either a normal completion containing an Object, or an abrupt completion
+      </h1>
+      <dl class="header">
+      </dl>
       <emu-alg>
-        1. Assert: Type(_temporalTimeLike_) is Object.
+        1. If _completeness_ is not present, set _completeness_ to ~complete~.
         1. Let _result_ be the Record {
           [[Hour]]: *undefined*,
           [[Minute]]: *undefined*,
@@ -830,14 +767,57 @@
         1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
           1. Let _property_ be the Property value of the current row.
           1. Let _value_ be ? Get(_temporalTimeLike_, _property_).
-          1. If _value_ is not *undefined*, then
-            1. Set _any_ to *true*.
-          1. Set _value_ to ? ToIntegerThrowOnInfinity(_value_).
-          1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
+          1. If _value_ is not *undefined*, set _any_ to *true*.
+          1. If _value_ is not *undefined* or _completeness_ is ~complete~, then
+            1. Set _value_ to ? ToIntegerThrowOnInfinity(_value_).
+            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
         1. If _any_ is *false*, then
           1. Throw a *TypeError* exception.
         1. Return _result_.
       </emu-alg>
+
+      <emu-table id="table-temporal-temporaltimelike-properties">
+        <emu-caption>Properties of a TemporalTimeLike</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Internal Slot</th>
+              <th>Property</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>[[Hour]]</td>
+              <td>*"hour"*</td>
+            </tr>
+
+            <tr>
+              <td>[[Microsecond]]</td>
+              <td>*"microsecond"*</td>
+            </tr>
+
+            <tr>
+              <td>[[Millisecond]]</td>
+              <td>*"millisecond"*</td>
+            </tr>
+
+            <tr>
+              <td>[[Minute]]</td>
+              <td>*"minute"*</td>
+            </tr>
+
+            <tr>
+              <td>[[Nanosecond]]</td>
+              <td>*"nanosecond"*</td>
+            </tr>
+
+            <tr>
+              <td>[[Second]]</td>
+              <td>*"second"*</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
     </emu-clause>
 
     <emu-clause id="sec-temporal-temporaltimetostring" aoid="TemporalTimeToString">

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -755,34 +755,27 @@
       </dl>
       <emu-alg>
         1. If _completeness_ is not present, set _completeness_ to ~complete~.
-        1. Let _result_ be the Record {
-          [[Hour]]: *undefined*,
-          [[Minute]]: *undefined*,
-          [[Second]]: *undefined*,
-          [[Millisecond]]: *undefined*,
-          [[Microsecond]]: *undefined*,
-          [[Nanosecond]]: *undefined*
-          }.
-        1. Let _any_ be *false*.
-        1. For each row of <emu-xref href="#table-temporal-temporaltimelike-properties"></emu-xref>, except the header row, in table order, do
-          1. Let _property_ be the Property value of the current row.
-          1. Let _value_ be ? Get(_temporalTimeLike_, _property_).
-          1. If _value_ is not *undefined*, set _any_ to *true*.
-          1. If _value_ is not *undefined* or _completeness_ is ~complete~, then
-            1. Set _value_ to ? ToIntegerThrowOnInfinity(_value_).
-            1. Set _result_'s internal slot whose name is the Internal Slot value of the current row to _value_.
-        1. If _any_ is *false*, then
-          1. Throw a *TypeError* exception.
+        1. Let _partial_ be ? PrepareTemporalFields(_temporalTimeLike_, « *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"nanosecond"*, *"second"* », ~partial~).
+        1. Let _result_ be a new TemporalTimeLike Record with each field set to *undefined*.
+        1. For each row of <emu-xref href="#table-temporal-temporaltimelike-record-fields"></emu-xref>, except the header row, in table order, do
+          1. Let _field_ be the Field Name value of the current row.
+          1. Let _propertyName_ be the Property Name value of the current row.
+          1. Let _valueDesc_ be OrdinaryGetOwnProperty(_partial_, _propertyName_).
+          1. If _valueDesc_ is not *undefined*, then
+            1. Assert: _valueDesc_ is a data Property Descriptor.
+            1. Set the field of _result_ whose name is _field_ to _valueDesc_.[[Value]].
+          1. Else if _completeness_ is ~complete~, then
+            1. Set the field of _result_ whose name is _field_ to 0.
         1. Return _result_.
       </emu-alg>
 
-      <emu-table id="table-temporal-temporaltimelike-properties">
-        <emu-caption>Properties of a TemporalTimeLike</emu-caption>
+      <emu-table id="table-temporal-temporaltimelike-record-fields">
+        <emu-caption>TemporalTimeLike Record Fields</emu-caption>
         <table class="real-table">
           <thead>
             <tr>
-              <th>Internal Slot</th>
-              <th>Property</th>
+              <th>Field Name</th>
+              <th>Property Name</th>
             </tr>
           </thead>
           <tbody>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -233,7 +233,7 @@
         1. Perform ? RejectObjectWithCalendarOrTimeZone(_temporalYearMonthLike_).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"monthCode"*, *"year"* »).
-        1. Let _partialYearMonth_ be ? PreparePartialTemporalFields(_temporalYearMonthLike_, _fieldNames_).
+        1. Let _partialYearMonth_ be ? PrepareTemporalFields(_temporalYearMonthLike_, _fieldNames_, ~partial~).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _fields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialYearMonth_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -569,7 +569,7 @@
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
         1. Append *"offset"* to _fieldNames_.
-        1. Let _partialZonedDateTime_ be ? PreparePartialTemporalFields(_temporalZonedDateTimeLike_, _fieldNames_).
+        1. Let _partialZonedDateTime_ be ? PrepareTemporalFields(_temporalZonedDateTimeLike_, _fieldNames_, ~partial~).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
         1. Let _offset_ be ? ToTemporalOffset(_options_, *"prefer"*).


### PR DESCRIPTION
There was a lot of redundancy between operations that construct "partial" vs. complete objects/records. These changes consolidate them with argument-based control, and leverage a single base PrepareTemporalFields wherever possible.