### PR TITLE
Normative: Disallow negative day lengths

### DIFF
--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -741,7 +741,7 @@
         1. Let _startNs_ be _instantStart_.[[Nanoseconds]].
         1. Let _endNs_ be ? AddZonedDateTime(_startNs_, _timeZone_, _zonedDateTime_.[[Calendar]], 0, 0, 0, 1, 0, 0, 0, 0, 0, 0).
         1. Let _dayLengthNs_ be ℝ(_endNs_ - _startNs_).
-        1. If _dayLengthNs_ is 0, then
+        1. If _dayLengthNs_ &le; 0, then
           1. Throw a *RangeError* exception.
         1. Let _roundResult_ be ! RoundISODateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dayLengthNs_).
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).


### PR DESCRIPTION
User-defined time zones can produce negative day lengths.

```js
class TimeZone extends Temporal.TimeZone {
  #count = 0;
  #nanoseconds;

  constructor(nanoseconds) {
    super("UTC");
    this.#nanoseconds = nanoseconds;
  }
  getPossibleInstantsFor(dateTime) {
    if (++this.#count === 2) {
      return [new Temporal.Instant(this.#nanoseconds)];
    }
    return super.getPossibleInstantsFor(dateTime);
  }
}

function test(epochNanoseconds, tomorrowEpochNanoseconds, testCases) {
  for (let [roundingMode, expected] of Object.entries(testCases)) {
    let timeZone = new TimeZone(tomorrowEpochNanoseconds);
    let zoned = new Temporal.ZonedDateTime(epochNanoseconds, timeZone);
    let result = zoned.round({ smallestUnit: "days", roundingMode });
    console.log(result.epochNanoseconds, expected);
  }
}

const oneDay = 24n * 60n * 60n * 1000n * 1000n * 1000n;

test(3n, -10n, {
  ceil: 0n,
  floor: -oneDay,
  trunc: 0n,
  halfExpand: 0n,
});
test(-3n, -10n, {
  ceil: oneDay,
  floor: 0n,
  trunc: 0n,
  halfExpand: 0n,
});
```