### PR TITLE
Normative: Sync the set of RoundingMode

### DIFF
--- a/docs/duration.md
+++ b/docs/duration.md
@@ -404,7 +404,7 @@ d.abs(); // PT8H30M
     - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
       The default is 1.
     - `roundingMode` (string): How to handle the remainder, if rounding.
-      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
       The default is `'halfExpand'`.
     - `relativeTo` (`Temporal.PlainDate`, `Temporal.ZonedDateTime`, or value convertible to one of those): The starting point to use when converting between years, months, weeks, and days.
 
@@ -585,7 +585,7 @@ d.total({
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`.
 
 **Returns:** the duration as an ISO 8601 string.

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -445,13 +445,20 @@ The `roundingMode` option controls how the rounding is performed.
 
 - `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round away from zero like `ceil` for positive durations and like `floor` for negative durations.
+  This is the default, and matches the behaviour of `Math.round()`.
 - `ceil`: Always round towards positive infinity.
   For negative durations this option will decrease the absolute value of the duration which may be unexpected.
-  To round away from zero, use `ceil` for positive durations and `floor` for negative durations.
+  To round away from zero, use `expand`.
+- `expand`:  Always round away from from zero like `ceil` for positive durations and like `floor` for negative durations.
 - `trunc`: Always round towards zero, chopping off the part after the decimal point.
 - `floor`: Always round down, towards negative infinity.
   This mode acts the same as `trunc` for positive durations but for negative durations it will increase the absolute value of the result which may be unexpected.
   For this reason, `trunc` is recommended for most "round down" use cases.
+- `halfCeil`: Round to the nearest of the allowed values like `halfExpand`, but when there is a tie, round towards positive infinity like `ceil`.
+- `halfFloor`: Round to the nearest of the allowed values like `halfExpand`, but when there is a tie, round towards negative infinity like `floor`.
+- `halfTrunc`: Round to the nearest of the allowed values like `halfExpand`, but when there is a tie, round towards zero like `trunc`.
+- `halfEven`: Round to the nearest of the allowed values like `halfExpand`, but when there is a tie, round towards the value that is an even multiple of the `roundingIncrement`.
+  For example, with a `roundingIncrement` of 2, the number 7 would round up to 8 instead of down to 6, because 8 is an even multiple of 2 (2 × 4 = 8, and 4 is even), whereas 6 is an odd multiple (2 × 3 = 6, and 3 is odd).
 
 The `relativeTo` option gives the starting point used when converting between or rounding to years, months, weeks, or days.
 It may be a `Temporal.ZonedDateTime` in which case time zone offset changes will be taken into account when converting between days and hours. If `relativeTo` is omitted or is a `Temporal.PlainDate`, then days are always considered equal to 24 hours.

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -418,7 +418,7 @@ Temporal.Now.instant().subtract(oneHour);
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the difference between `instant` and `other`.
@@ -508,7 +508,7 @@ epoch.toZonedDateTimeISO('UTC').until(
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the difference between `instant` and `other`.
@@ -542,7 +542,7 @@ billion.since(epoch); // => PT1000000000S
     - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
       The default is 1.
     - `roundingMode` (string): How to handle the remainder.
-      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
       The default is `'halfExpand'`.
 
 **Returns:** a new `Temporal.Instant` object which is `instant` rounded to `roundTo` (if a string parameter is used) or `roundingIncrement` of `smallestUnit` (if an object parameter is used).
@@ -629,7 +629,7 @@ one.equals(one); // => true
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`.
 
 **Returns:** a string in the ISO 8601 date format representing `instant`.

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -562,11 +562,15 @@ The combination of `roundingIncrement` and `smallestUnit` must make an increment
 
 The `roundingMode` option controls how the rounding is performed.
 
-- `ceil`: Always round up, towards the end of time.
+- `ceil`, `expand`: Always round up, towards the end of time.
 - `floor`, `trunc`: Always round down, towards the beginning of time.
-  (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
-- `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+- `halfCeil`, `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `ceil`.
+- `halfFloor`, `halfTrunc`: Round to the nearest of the allowed values, like `halfExpand`, but when there is a tie, round down, like `floor`.
+- `halfEven`: Round to the nearest of the allowed values, but when there is a tie, round towards the value that is an even multiple of `roundingIncrement`.
+  For example, with a `roundingIncrement` of 2, the number 7 would round up to 8 instead of down to 6, because 8 is an even multiple of 2 (2 × 4 = 8, and 4 is even), whereas 6 is an odd multiple (2 × 3 = 6, and 3 is odd).
+
+Several pairs of modes behave the same as each other, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.
 
 As expected for a method named "round", the default rounding mode is `'halfExpand'` to match the behavior of `Math.round`.
 Note that this is different than the `'trunc'` default used by `until` and `since` options because rounding up would be an unexpected default for those operations.

--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -490,7 +490,7 @@ date.subtract({ months: 1 }, { overflow: 'reject' }); // => throws
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the time elapsed after `date` and until `other`.
@@ -567,7 +567,7 @@ newyear.until('2020-01-17', { smallestUnit: 'month', roundingMode: 'halfExpand' 
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the time elapsed before `date` and since `other`.

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -789,11 +789,15 @@ If `smallestUnit` is `'day'`, then 1 is the only allowed value for `roundingIncr
 
 The `roundingMode` option controls how the rounding is performed.
 
-- `ceil`: Always round up, towards the end of time.
+- `ceil`, `expand`: Always round up, towards the end of time.
 - `floor`, `trunc`: Always round down, towards the beginning of time.
-  (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
-- `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+- `halfCeil`, `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `ceil`.
+- `halfFloor`, `halfTrunc`: Round to the nearest of the allowed values, like `halfExpand`, but when there is a tie, round down, like `floor`.
+- `halfEven`: Round to the nearest of the allowed values, but when there is a tie, round towards the value that is an even multiple of `roundingIncrement`.
+  For example, with a `roundingIncrement` of 2, the number 7 would round up to 8 instead of down to 6, because 8 is an even multiple of 2 (2 × 4 = 8, and 4 is even), whereas 6 is an odd multiple (2 × 3 = 6, and 3 is odd).
+
+Several pairs of modes behave the same as each other, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.
 
 As expected for a method named "round", the default rounding mode is `'halfExpand'` to match the behavior of `Math.round`.
 Note that this is different than the `'trunc'` default used by `until` and `since` options because rounding up would be an unexpected default for those operations.

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -653,7 +653,7 @@ dt.subtract({ months: 1 }, { overflow: 'reject' }); // => throws
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `datetime` and until `other`.
@@ -732,7 +732,7 @@ jan1.until(mar1);                            // => P60D
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `datetime` and since `other`.
@@ -766,7 +766,7 @@ dt2.since(dt1); // => P8456DT12H5M29.9999965S
     - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
       The default is 1.
     - `roundingMode` (string): How to handle the remainder.
-      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
       The default is `'halfExpand'`.
 
 **Returns:** a new `Temporal.PlainDateTime` object which is `datetime` rounded to `roundTo` (if a string parameter is used) or `roundingIncrement` of `smallestUnit` (if an object parameter is used).
@@ -859,7 +859,7 @@ dt1.equals(dt1); // => true
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`.
 
 **Returns:** a string in the ISO 8601 date format representing `datetime`.

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -411,11 +411,15 @@ Instead of 60 minutes, use 1 hour.)
 
 The `roundingMode` option controls how the rounding is performed.
 
-- `ceil`: Always round up, towards 23:59:59.999999999.
-- `floor`, `trunc`: Always round down, 00:00.
-  (These two modes behave the same, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.)
-- `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+- `ceil`, `expand`: Always round up, towards 23:59:59.999999999.
+- `floor`, `trunc`: Always round down, towards 00:00.
+- `halfCeil`, `halfExpand`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `ceil`.
+- `halfFloor`, `halfTrunc`: Round to the nearest of the allowed values, like `halfExpand`, but when there is a tie, round down, like `floor`.
+- `halfEven`: Round to the nearest of the allowed values, but when there is a tie, round towards the value that is an even multiple of `roundingIncrement`.
+  For example, with a `roundingIncrement` of 2, the number 7 would round up to 8 instead of down to 6, because 8 is an even multiple of 2 (2 × 4 = 8, and 4 is even), whereas 6 is an odd multiple (2 × 3 = 6, and 3 is odd).
+
+Several pairs of modes behave the same as each other, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.
 
 As expected for a method named "round", the default rounding mode is `'halfExpand'` to match the behavior of `Math.round`.
 Note that this is different than the `'trunc'` default used by `until` and `since` options because rounding up would be an unexpected default for those operations.

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -302,7 +302,7 @@ time.subtract({ minutes: 5, nanoseconds: 800 }); // => 19:34:09.068345405
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `time` and until `other`.
@@ -356,7 +356,7 @@ time.until(Temporal.PlainTime.from('22:39:09.068346205'), { smallestUnit: 'secon
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `time` and since `other`.
@@ -390,7 +390,7 @@ time.since(Temporal.PlainTime.from('22:39:09.068346205')); // => -PT2H25M48.0969
     - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
       The default is 1.
     - `roundingMode` (string): How to handle the remainder.
-      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
       The default is `'halfExpand'`.
 
 **Returns:** a new `Temporal.PlainTime` object which is `time` rounded to `roundTo` (if a string parameter is used) or `roundingIncrement` of `smallestUnit` (if an object parameter is used).
@@ -476,7 +476,7 @@ time.equals(time); // => true
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`.
 
 **Returns:** a string in the ISO 8601 time format representing `time`.

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -394,7 +394,7 @@ ym.subtract({ years: 20, months: 4 }); // => 1999-02
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `yearMonth` and until `other`.
@@ -455,7 +455,7 @@ ym.toPlainDate({ day: 1 }).until(other.toPlainDate({ day: 1 }), { largestUnit: '
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `yearMonth` and since `other`.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1168,11 +1168,15 @@ If `smallestUnit` is `'day'`, then 1 is the only allowed value for `roundingIncr
 
 The `roundingMode` option controls how the rounding is performed.
 
-- `'ceil'`: Always round up, towards the end of time.
+- `'ceil'`, `'expand'`: Always round up, towards the end of time.
 - `'floor'`, `'trunc'`: Always round down, towards the beginning of time.
-  (These two modes behave the same, but are both included for consistency with `Temporal.Duration.prototype.round()`, where they are not the same.)
-- `'halfExpand'`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
+- `'halfCeil'`, `'halfExpand'`: Round to the nearest of the values allowed by `roundingIncrement` and `smallestUnit`.
   When there is a tie, round up, like `'ceil'`.
+- `'halfFloor'`, `'halfTrunc'`: Round to the nearest of the allowed values, like `'halfExpand'`, but when there is a tie, round down, like `'floor'`.
+- `'halfEven'`: Round to the nearest of the allowed values, but when there is a tie, round towards the value that is an even multiple of `roundingIncrement`.
+  For example, with a `roundingIncrement` of 2, the number 7 would round up to 8 instead of down to 6, because 8 is an even multiple of 2 (2 × 4 = 8, and 4 is even), whereas 6 is an odd multiple (2 × 3 = 6, and 3 is odd).
+
+Several pairs of modes behave the same as each other, but are both included for consistency with `Temporal.Duration.round()`, where they are not the same.
 
 As expected for a method named "round", the default rounding mode is `'halfExpand'` to match the behavior of `Math.round`.
 Note that this is different than the `'trunc'` default used by `until` and `since` options because rounding up would be an unexpected default for those operations.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1015,7 +1015,7 @@ earlierHours.since(zdt, { largestUnit: 'hour' }).hours; // => -24
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time after `zonedDateTime` and until `other`.
@@ -1111,7 +1111,7 @@ jan1.until(mar1, { largestUnit: 'day' }); // => P60D
   - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
     The default is 1.
   - `roundingMode` (string): How to handle the remainder, if rounding.
-    Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`, which truncates any remainder towards zero.
 
 **Returns:** a `Temporal.Duration` representing the elapsed time before `zonedDateTime` and since `other`.
@@ -1145,7 +1145,7 @@ zdt2.since(zdt1); // => PT202956H5M29.9999965S
     - `roundingIncrement` (number): The granularity to round to, of the unit given by `smallestUnit`.
       The default is 1.
     - `roundingMode` (string): How to handle the remainder.
-      Valid values are `'halfExpand'`, `'ceil'`, `'trunc'`, and `'floor'`.
+      Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
       The default is `'halfExpand'`.
 
 **Returns:** a new `Temporal.ZonedDateTime` object which is `zonedDateTime` rounded to `roundTo` (if a string parameter is used) or `roundingIncrement` of `smallestUnit` (if an object parameter is used).
@@ -1257,7 +1257,7 @@ zdt1.equals(zdt1); // => true
     This option overrides `fractionalSecondDigits` if both are given.
     Valid values are `'minute'`, `'second'`, `'millisecond'`, `'microsecond'`, and `'nanosecond'`.
   - `roundingMode` (string): How to handle the remainder.
-    Valid values are `'ceil'`, `'floor'`, `'trunc'`, and `'halfExpand'`.
+    Valid values are `'ceil'`, `'floor'`, `'expand'`, `'trunc'`, `'halfCeil'`, `'halfFloor'`, `'halfExpand'`, `'halfTrunc'`, and `'halfEven'`.
     The default is `'trunc'`.
 
 **Returns:** a string containing an ISO 8601 date+time+offset format, a bracketed time zone suffix, and (if the calendar is not `iso8601`) a calendar suffix.

--- a/polyfill/test/ecmascript.mjs
+++ b/polyfill/test/ecmascript.mjs
@@ -5,7 +5,9 @@ import Pretty from '@pipobscure/demitasse-pretty';
 const { reporter } = Pretty;
 
 import { strict as assert } from 'assert';
-const { deepEqual, throws } = assert;
+const { deepEqual, equal, throws } = assert;
+
+import bigInt from 'big-integer';
 
 import { ES } from '../lib/ecmascript.mjs';
 import { GetSlot, TIMEZONE_ID } from '../lib/slots.mjs';
@@ -34,6 +36,33 @@ describe('ECMAScript', () => {
         throws(() => ES.GetOptionsObject(options), TypeError)
       );
     });
+  });
+
+  describe('RoundNumberToIncrement', () => {
+    const increment = bigInt(100);
+    const testValues = [-150, -100, -80, -50, -30, 0, 30, 50, 80, 100, 150];
+    const expectations = {
+      ceil: [-100, -100, 0, 0, 0, 0, 100, 100, 100, 100, 200],
+      floor: [-200, -100, -100, -100, -100, 0, 0, 0, 0, 100, 100],
+      trunc: [-100, -100, 0, 0, 0, 0, 0, 0, 0, 100, 100],
+      expand: [-200, -100, -100, -100, -100, 0, 100, 100, 100, 100, 200],
+      halfCeil: [-100, -100, -100, 0, 0, 0, 0, 100, 100, 100, 200],
+      halfFloor: [-200, -100, -100, -100, 0, 0, 0, 0, 100, 100, 100],
+      halfTrunc: [-100, -100, -100, 0, 0, 0, 0, 0, 100, 100, 100],
+      halfExpand: [-200, -100, -100, -100, 0, 0, 0, 100, 100, 100, 200],
+      halfEven: [-200, -100, -100, 0, 0, 0, 0, 0, 100, 100, 200]
+    };
+    for (const roundingMode of Object.keys(expectations)) {
+      describe(roundingMode, () => {
+        testValues.forEach((value, ix) => {
+          const expected = expectations[roundingMode][ix];
+          it(`rounds ${value} to ${expected}`, () => {
+            const result = ES.RoundNumberToIncrement(bigInt(value), increment, roundingMode);
+            equal(result.toJSNumber(), expected);
+          });
+        });
+      });
+    }
   });
 });
 

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -71,3 +71,4 @@ intl402/Temporal/Calendar/calendar-case-insensitive.js
 intl402/Temporal/Calendar/from/calendar-case-insensitive.js
 intl402/Temporal/Calendar/prototype/era/argument-propertybag-calendar-case-insensitive.js
 intl402/Temporal/Calendar/prototype/eraYear/argument-propertybag-calendar-case-insensitive.js
+intl402/Temporal/ZonedDateTime/prototype/withCalendar/calendar-case-insensitive.js

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -106,7 +106,7 @@
       </p>
     </emu-note>
     <emu-alg>
-      1. Return ? GetOption(_normalizedOptions_, *"roundingMode"*, *"string"*, « *"ceil"*, *"floor"*, *"trunc"*, *"halfExpand"* », _fallback_).
+      1. Return ? GetOption(_normalizedOptions_, *"roundingMode"*, *"string"*, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », _fallback_).
     </emu-alg>
   </emu-clause>
 
@@ -123,6 +123,8 @@
     <emu-alg>
       1. If _roundingMode_ is *"ceil"*, return *"floor"*.
       1. If _roundingMode_ is *"floor"*, return *"ceil"*.
+      1. If _roundingMode_ is *"halfCeil"*, return *"halfFloor"*.
+      1. If _roundingMode_ is *"halfFloor"*, return *"halfCeil"*.
       1. Return _roundingMode_.
     </emu-alg>
   </emu-clause>
@@ -748,7 +750,7 @@
       RoundNumberToIncrement (
         _x_: a mathematical value,
         _increment_: an integer,
-        _roundingMode_: *"ceil"*, *"floor"*, *"trunc"*, or *"halfExpand"*,
+        _roundingMode_: *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, or *"halfEven"*,
       ): an integer
     </h1>
     <dl class="header">

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1167,7 +1167,7 @@
           _showOffset_: one of *"auto"* or *"never"*,
           optional _increment_: an integer,
           optional _unit_: one of *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
-          optional _roundingMode_: one of *"ceil"*, *"floor"*, *"trunc"*, or *"halfExpand"*,
+          optional _roundingMode_: one of *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, or *"halfEven"*,
         ): either a normal completion containing a String or an abrupt completion
       </h1>
       <dl class="header">


### PR DESCRIPTION
after the landing of https://github.com/tc39/proposal-temporal/pull/2207
 GetUnsignedRoundingMode now includes additional RoundingModes
expand, halfCeil, halfFloor, halfTrunc and halfEven.
Sync spec text in RoundNumberToIncrement, ToTemporalRoundingMode,
NegateTemporalRoundingMode to match it.

@sffc @ptomato 
