### PR TITLE
Normative: Perform a single "dateAdd" lookup for MoveRelativeDate

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -339,8 +339,8 @@ export class Duration {
     } else {
       totalOf = ES.GetOptionsObject(totalOf);
     }
-    const unit = ES.GetTemporalUnit(totalOf, 'unit', 'datetime', ES.REQUIRED);
     const relativeTo = ES.ToRelativeTemporalObject(totalOf);
+    const unit = ES.GetTemporalUnit(totalOf, 'unit', 'datetime', ES.REQUIRED);
 
     // Convert larger units down to days
     ({ years, months, weeks, days } = ES.UnbalanceDurationRelative(years, months, weeks, days, unit, relativeTo));

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3598,9 +3598,9 @@ export const ES = ObjectAssign({}, ES2020, {
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
     const otherFields = ES.PrepareTemporalFields(other, fieldNames, []);
     otherFields.day = 1;
+    const otherDate = ES.CalendarDateFromFields(calendar, otherFields);
     const thisFields = ES.PrepareTemporalFields(yearMonth, fieldNames, []);
     thisFields.day = 1;
-    const otherDate = ES.CalendarDateFromFields(calendar, otherFields);
     const thisDate = ES.CalendarDateFromFields(calendar, thisFields);
 
     const untilOptions = ES.MergeLargestUnitOption(options, largestUnit);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1320,9 +1320,9 @@ export const ES = ObjectAssign({}, ES2020, {
       ]);
       ES.Call(ArrayPrototypePush, fieldNames, ['timeZone', 'offset']);
       const fields = ES.PrepareTemporalFields(item, fieldNames, ['timeZone']);
+      timeZone = ES.ToTemporalTimeZone(fields.timeZone);
       ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
         ES.InterpretTemporalDateTimeFields(calendar, fields, options));
-      timeZone = ES.ToTemporalTimeZone(fields.timeZone);
       offset = fields.offset;
       if (offset === undefined) {
         offsetBehaviour = 'wall';

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2758,49 +2758,54 @@ export const ES = ObjectAssign({}, ES2020, {
         }
         break;
       case 'week':
-        if (!calendar) throw new RangeError('a starting point is required for weeks balancing');
-        // balance years down to days
-        while (MathAbs(years) > 0) {
-          let oneYearDays;
-          ({ relativeTo, days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear));
-          days += oneYearDays;
-          years -= sign;
-        }
+        {
+          if (!calendar) throw new RangeError('a starting point is required for weeks balancing');
+          const dateAdd = ES.GetMethod(calendar, 'dateAdd');
+          // balance years down to days
+          while (MathAbs(years) > 0) {
+            let oneYearDays;
+            ({ relativeTo, days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear, dateAdd));
+            days += oneYearDays;
+            years -= sign;
+          }
 
-        // balance months down to days
-        while (MathAbs(months) > 0) {
-          let oneMonthDays;
-          ({ relativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth));
-          days += oneMonthDays;
-          months -= sign;
+          // balance months down to days
+          while (MathAbs(months) > 0) {
+            let oneMonthDays;
+            ({ relativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth, dateAdd));
+            days += oneMonthDays;
+            months -= sign;
+          }
         }
         break;
       default:
-        // balance years down to days
-        while (MathAbs(years) > 0) {
+        {
+          if (years == 0 && months == 0 && weeks == 0) break;
           if (!calendar) throw new RangeError('a starting point is required for balancing calendar units');
-          let oneYearDays;
-          ({ relativeTo, days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear));
-          days += oneYearDays;
-          years -= sign;
-        }
+          const dateAdd = ES.GetMethod(calendar, 'dateAdd');
+          // balance years down to days
+          while (MathAbs(years) > 0) {
+            let oneYearDays;
+            ({ relativeTo, days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear, dateAdd));
+            days += oneYearDays;
+            years -= sign;
+          }
 
-        // balance months down to days
-        while (MathAbs(months) > 0) {
-          if (!calendar) throw new RangeError('a starting point is required for balancing calendar units');
-          let oneMonthDays;
-          ({ relativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth));
-          days += oneMonthDays;
-          months -= sign;
-        }
+          // balance months down to days
+          while (MathAbs(months) > 0) {
+            let oneMonthDays;
+            ({ relativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth, dateAdd));
+            days += oneMonthDays;
+            months -= sign;
+          }
 
-        // balance weeks down to days
-        while (MathAbs(weeks) > 0) {
-          if (!calendar) throw new RangeError('a starting point is required for balancing calendar units');
-          let oneWeekDays;
-          ({ relativeTo, days: oneWeekDays } = ES.MoveRelativeDate(calendar, relativeTo, oneWeek));
-          days += oneWeekDays;
-          weeks -= sign;
+          // balance weeks down to days
+          while (MathAbs(weeks) > 0) {
+            let oneWeekDays;
+            ({ relativeTo, days: oneWeekDays } = ES.MoveRelativeDate(calendar, relativeTo, oneWeek, dateAdd));
+            days += oneWeekDays;
+            weeks -= sign;
+          }
         }
         break;
     }
@@ -2825,28 +2830,48 @@ export const ES = ObjectAssign({}, ES2020, {
     switch (largestUnit) {
       case 'year': {
         if (!calendar) throw new RangeError('a starting point is required for years balancing');
+        const dateAdd = ES.GetMethod(calendar, 'dateAdd');
         // balance days up to years
         let newRelativeTo, oneYearDays;
-        ({ relativeTo: newRelativeTo, days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear));
+        ({ relativeTo: newRelativeTo, days: oneYearDays } = ES.MoveRelativeDate(
+          calendar,
+          relativeTo,
+          oneYear,
+          dateAdd
+        ));
         while (MathAbs(days) >= MathAbs(oneYearDays)) {
           days -= oneYearDays;
           years += sign;
           relativeTo = newRelativeTo;
-          ({ relativeTo: newRelativeTo, days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear));
+          ({ relativeTo: newRelativeTo, days: oneYearDays } = ES.MoveRelativeDate(
+            calendar,
+            relativeTo,
+            oneYear,
+            dateAdd
+          ));
         }
 
         // balance days up to months
         let oneMonthDays;
-        ({ relativeTo: newRelativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth));
+        ({ relativeTo: newRelativeTo, days: oneMonthDays } = ES.MoveRelativeDate(
+          calendar,
+          relativeTo,
+          oneMonth,
+          dateAdd
+        ));
         while (MathAbs(days) >= MathAbs(oneMonthDays)) {
           days -= oneMonthDays;
           months += sign;
           relativeTo = newRelativeTo;
-          ({ relativeTo: newRelativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth));
+          ({ relativeTo: newRelativeTo, days: oneMonthDays } = ES.MoveRelativeDate(
+            calendar,
+            relativeTo,
+            oneMonth,
+            dateAdd
+          ));
         }
 
         // balance months up to years
-        const dateAdd = ES.GetMethod(calendar, 'dateAdd');
         newRelativeTo = ES.CalendarDateAdd(calendar, relativeTo, oneYear, undefined, dateAdd);
         const dateUntil = ES.GetMethod(calendar, 'dateUntil');
         const untilOptions = ObjectCreate(null);
@@ -2867,27 +2892,49 @@ export const ES = ObjectAssign({}, ES2020, {
       }
       case 'month': {
         if (!calendar) throw new RangeError('a starting point is required for months balancing');
+        const dateAdd = ES.GetMethod(calendar, 'dateAdd');
         // balance days up to months
         let newRelativeTo, oneMonthDays;
-        ({ relativeTo: newRelativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth));
+        ({ relativeTo: newRelativeTo, days: oneMonthDays } = ES.MoveRelativeDate(
+          calendar,
+          relativeTo,
+          oneMonth,
+          dateAdd
+        ));
         while (MathAbs(days) >= MathAbs(oneMonthDays)) {
           days -= oneMonthDays;
           months += sign;
           relativeTo = newRelativeTo;
-          ({ relativeTo: newRelativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth));
+          ({ relativeTo: newRelativeTo, days: oneMonthDays } = ES.MoveRelativeDate(
+            calendar,
+            relativeTo,
+            oneMonth,
+            dateAdd
+          ));
         }
         break;
       }
       case 'week': {
         if (!calendar) throw new RangeError('a starting point is required for weeks balancing');
+        const dateAdd = ES.GetMethod(calendar, 'dateAdd');
         // balance days up to weeks
         let newRelativeTo, oneWeekDays;
-        ({ relativeTo: newRelativeTo, days: oneWeekDays } = ES.MoveRelativeDate(calendar, relativeTo, oneWeek));
+        ({ relativeTo: newRelativeTo, days: oneWeekDays } = ES.MoveRelativeDate(
+          calendar,
+          relativeTo,
+          oneWeek,
+          dateAdd
+        ));
         while (MathAbs(days) >= MathAbs(oneWeekDays)) {
           days -= oneWeekDays;
           weeks += sign;
           relativeTo = newRelativeTo;
-          ({ relativeTo: newRelativeTo, days: oneWeekDays } = ES.MoveRelativeDate(calendar, relativeTo, oneWeek));
+          ({ relativeTo: newRelativeTo, days: oneWeekDays } = ES.MoveRelativeDate(
+            calendar,
+            relativeTo,
+            oneWeek,
+            dateAdd
+          ));
         }
         break;
       }
@@ -4617,12 +4664,13 @@ export const ES = ObjectAssign({}, ES2020, {
         // convert days to weeks in a loop as described above under 'years'.
         const sign = MathSign(days);
         const oneWeek = new TemporalDuration(0, 0, days < 0 ? -1 : 1);
+        const dateAdd = ES.GetMethod(calendar, 'dateAdd');
         let oneWeekDays;
-        ({ relativeTo, days: oneWeekDays } = ES.MoveRelativeDate(calendar, relativeTo, oneWeek));
+        ({ relativeTo, days: oneWeekDays } = ES.MoveRelativeDate(calendar, relativeTo, oneWeek, dateAdd));
         while (MathAbs(days) >= MathAbs(oneWeekDays)) {
           weeks += sign;
           days -= oneWeekDays;
-          ({ relativeTo, days: oneWeekDays } = ES.MoveRelativeDate(calendar, relativeTo, oneWeek));
+          ({ relativeTo, days: oneWeekDays } = ES.MoveRelativeDate(calendar, relativeTo, oneWeek, dateAdd));
         }
         oneWeekDays = MathAbs(oneWeekDays);
         const divisor = bigInt(oneWeekDays).multiply(dayLengthNs);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4393,7 +4393,7 @@ export const ES = ObjectAssign({}, ES2020, {
       'day'
     ).days;
   },
-  MoveRelativeDate: (calendar, relativeTo, duration, dateAdd = ES.GetMethod(calendar, 'dateAdd')) => {
+  MoveRelativeDate: (calendar, relativeTo, duration, dateAdd) => {
     const later = ES.CalendarDateAdd(calendar, relativeTo, duration, undefined, dateAdd);
     const days = ES.DaysUntil(relativeTo, later);
     return { relativeTo: later, days };

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4346,8 +4346,8 @@ export const ES = ObjectAssign({}, ES2020, {
       'day'
     ).days;
   },
-  MoveRelativeDate: (calendar, relativeTo, duration) => {
-    const later = ES.CalendarDateAdd(calendar, relativeTo, duration);
+  MoveRelativeDate: (calendar, relativeTo, duration, dateAdd = ES.GetMethod(calendar, 'dateAdd')) => {
+    const later = ES.CalendarDateAdd(calendar, relativeTo, duration, undefined, dateAdd);
     const days = ES.DaysUntil(relativeTo, later);
     return { relativeTo: later, days };
   },
@@ -4560,7 +4560,7 @@ export const ES = ObjectAssign({}, ES2020, {
         const daysPassed = ES.DaysUntil(oldRelativeTo, relativeTo);
         days -= daysPassed;
         const oneYear = new TemporalDuration(days < 0 ? -1 : 1);
-        let { days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear);
+        let { days: oneYearDays } = ES.MoveRelativeDate(calendar, relativeTo, oneYear, dateAdd);
 
         // Note that `nanoseconds` below (here and in similar code for months,
         // weeks, and days further below) isn't actually nanoseconds for the
@@ -4596,11 +4596,11 @@ export const ES = ObjectAssign({}, ES2020, {
         const sign = MathSign(days);
         const oneMonth = new TemporalDuration(0, days < 0 ? -1 : 1);
         let oneMonthDays;
-        ({ relativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth));
+        ({ relativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth, dateAdd));
         while (MathAbs(days) >= MathAbs(oneMonthDays)) {
           months += sign;
           days -= oneMonthDays;
-          ({ relativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth));
+          ({ relativeTo, days: oneMonthDays } = ES.MoveRelativeDate(calendar, relativeTo, oneMonth, dateAdd));
         }
         oneMonthDays = MathAbs(oneMonthDays);
         const divisor = bigInt(oneMonthDays).multiply(dayLengthNs);

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1538,7 +1538,7 @@
           _calendar_: an Object,
           _relativeTo_: a Temporal.PlainDate,
           _duration_: a Temporal.Duration,
-          optional _dateAdd_: a function object or *undefined*,
+          _dateAdd_: a function object or *undefined*,
         )
       </h1>
       <dl class="header">
@@ -1549,7 +1549,6 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _dateAdd_ is not present, set _dateAdd_ to ? GetMethod(_calendar_, *"dateAdd"*).
         1. Let _newDate_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _duration_, *undefined*, _dateAdd_).
         1. Let _days_ be DaysUntil(_relativeTo_, _newDate_).
         1. Return the Record {

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1534,6 +1534,7 @@
           _calendar_: an Object,
           _relativeTo_: a Temporal.PlainDate,
           _duration_: a Temporal.Duration,
+          optional _dateAdd_: a function object or *undefined*,
         )
       </h1>
       <dl class="header">
@@ -1544,7 +1545,8 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _newDate_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _duration_).
+        1. If _dateAdd_ is not present, set _dateAdd_ to ? GetMethod(_calendar_, *"dateAdd"*).
+        1. Let _newDate_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _duration_, *undefined*, _dateAdd_).
         1. Let _days_ be DaysUntil(_relativeTo_, _newDate_).
         1. Return the Record {
             [[RelativeTo]]: _newDate_,
@@ -1644,7 +1646,7 @@
           1. Set _days_ to _days_ - _daysPassed_.
           1. If _days_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneYear_ be ! CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_, _dateAdd_).
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
           1. Let _fractionalYears_ be _years_ + _days_ / abs(_oneYearDays_).
           1. Set _years_ to RoundNumberToIncrement(_fractionalYears_, _increment_, _roundingMode_).
@@ -1661,13 +1663,13 @@
           1. Let _days_ be _days_ + _weeksInDays_.
           1. If _days_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneMonth_ be ! CreateTemporalDuration(0, _sign_, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_, _dateAdd_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneMonthDays_),
             1. Set _months_ to _months_ + _sign_.
             1. Set _days_ to _days_ - _oneMonthDays_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_, _dateAdd_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
           1. Let _fractionalMonths_ be _months_ + _days_ / abs(_oneMonthDays_).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1319,13 +1319,14 @@
         1. Else if _largestUnit_ is *"week"*, then
           1. If _calendar_ is *undefined*, then
             1. Throw a *RangeError* exception.
+          1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
           1. Repeat, while _years_ &ne; 0,
-            1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
+            1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_, _dateAdd_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
             1. Set _years_ to _years_ - _sign_.
           1. Repeat, while _months_ &ne; 0,
-            1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
+            1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_, _dateAdd_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
             1. Set _months_ to _months_ - _sign_.
@@ -1333,18 +1334,19 @@
           1. If any of _years_, _months_, and _weeks_ are not zero, then
             1. If _calendar_ is *undefined*, then
               1. Throw a *RangeError* exception.
+            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
             1. Repeat, while _years_ &ne; 0,
-              1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
+              1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_, _dateAdd_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
               1. Set _days_ to _days_ + _moveResult_.[[Days]].
               1. Set _years_ to _years_ - _sign_.
             1. Repeat, while _months_ &ne; 0,
-              1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
+              1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_, _dateAdd_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
               1. Set _days_ to _days_ +_moveResult_.[[Days]].
               1. Set _months_ to _months_ - _sign_.
             1. Repeat, while _weeks_ &ne; 0,
-              1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
+              1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_, _dateAdd_).
               1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
               1. Set _days_ to _days_ + _moveResult_.[[Days]].
               1. Set _weeks_ to _weeks_ - _sign_.
@@ -1380,27 +1382,27 @@
         1. Set _relativeTo_ to ? ToTemporalDate(_relativeTo_).
         1. Let _calendar_ be _relativeTo_.[[Calendar]].
         1. If _largestUnit_ is *"year"*, then
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
+          1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_, _dateAdd_).
           1. Let _newRelativeTo_ be _moveResult_.[[RelativeTo]].
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneYearDays_),
             1. Set _days_ to _days_ - _oneYearDays_.
             1. Set _years_ to _years_ + _sign_.
             1. Set _relativeTo_ to _newRelativeTo_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneYear_, _dateAdd_).
             1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneYearDays_ to _moveResult_.[[Days]].
-          1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
+          1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_, _dateAdd_).
           1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneMonthDays_),
             1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _months_ to _months_ + _sign_.
             1. Set _relativeTo_ to _newRelativeTo_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_, _dateAdd_).
             1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
-          1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
           1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, *undefined*, _dateAdd_).
           1. Let _dateUntil_ be ? GetMethod(_calendar_, *"dateUntil"*).
           1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
@@ -1417,26 +1419,28 @@
             1. Set _untilResult_ to ? CalendarDateUntil(_calendar_, _relativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
             1. Set _oneYearMonths_ to _untilResult_.[[Months]].
         1. Else if _largestUnit_ is *"month"*, then
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
+          1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_, _dateAdd_).
           1. Let _newRelativeTo_ be _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneMonthDays_),
             1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _months_ to _months_ + _sign_.
             1. Set _relativeTo_ to _newRelativeTo_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneMonth_, _dateAdd_).
             1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
         1. Else,
           1. Assert: _largestUnit_ is *"week"*.
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
+          1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_, _dateAdd_).
           1. Let _newRelativeTo_ be _moveResult_.[[RelativeTo]].
           1. Let _oneWeekDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneWeekDays_),
             1. Set _days_ to _days_ - _oneWeekDays_.
             1. Set _weeks_ to _weeks_ + _sign_.
             1. Set _relativeTo_ to _newRelativeTo_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_, _dateAdd_).
             1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneWeekDays_ to _moveResult_.[[Days]].
         1. Return ! CreateDateDurationRecord(_years_, _months_, _weeks_, _days_).
@@ -1679,13 +1683,14 @@
         1. Else if _unit_ is *"week"*, then
           1. If _days_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, _sign_, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
+          1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_, _dateAdd_).
           1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneWeekDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneWeekDays_),
             1. Set _weeks_ to _weeks_ + _sign_.
             1. Set _days_ to _days_ - _oneWeekDays_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _relativeTo_, _oneWeek_, _dateAdd_).
             1. Set _relativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneWeekDays_ to _moveResult_.[[Days]].
           1. Let _fractionalWeeks_ be _weeks_ + _days_ / abs(_oneWeekDays_).


### PR DESCRIPTION
`CalendarDateAdd` was changed to avoid repeated lookups of `"dateAdd"`, but we still repeatedly lookup `"dateAdd"` when `CalendarDateAdd` is called from `MoveRelativeDate`.