### PR TITLE
Normative: Avoid `ToString(calendar)` when the calendar-id is unused

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -278,6 +278,10 @@ export const ES = ObjectAssign({}, ES2020, {
     if (z) return 'UTC';
     return offset; // if !ianaName && !z then offset must be present
   },
+  MaybeFormatCalendarAnnotation: (calendar, showCalendar) => {
+    if (showCalendar === 'never') return '';
+    return ES.FormatCalendarAnnotation(ES.ToString(calendar), showCalendar);
+  },
   FormatCalendarAnnotation: (id, showCalendar) => {
     if (showCalendar === 'never') return '';
     if (showCalendar === 'auto' && id === 'iso8601') return '';
@@ -2024,8 +2028,7 @@ export const ES = ObjectAssign({}, ES2020, {
     const year = ES.ISOYearString(GetSlot(date, ISO_YEAR));
     const month = ES.ISODateTimePartString(GetSlot(date, ISO_MONTH));
     const day = ES.ISODateTimePartString(GetSlot(date, ISO_DAY));
-    const calendarID = ES.ToString(GetSlot(date, CALENDAR));
-    const calendar = ES.FormatCalendarAnnotation(calendarID, showCalendar);
+    const calendar = ES.MaybeFormatCalendarAnnotation(GetSlot(date, CALENDAR), showCalendar);
     return `${year}-${month}-${day}${calendar}`;
   },
   TemporalDateTimeToString: (dateTime, precision, showCalendar = 'auto', options = undefined) => {
@@ -2063,8 +2066,7 @@ export const ES = ObjectAssign({}, ES2020, {
     hour = ES.ISODateTimePartString(hour);
     minute = ES.ISODateTimePartString(minute);
     const seconds = ES.FormatSecondsStringPart(second, millisecond, microsecond, nanosecond, precision);
-    const calendarID = ES.ToString(GetSlot(dateTime, CALENDAR));
-    const calendar = ES.FormatCalendarAnnotation(calendarID, showCalendar);
+    const calendar = ES.MaybeFormatCalendarAnnotation(GetSlot(dateTime, CALENDAR), showCalendar);
     return `${year}-${month}-${day}T${hour}:${minute}${seconds}${calendar}`;
   },
   TemporalMonthDayToString: (monthDay, showCalendar = 'auto') => {
@@ -2134,8 +2136,7 @@ export const ES = ObjectAssign({}, ES2020, {
       result += ES.FormatISOTimeZoneOffsetString(offsetNs);
     }
     if (showTimeZone !== 'never') result += `[${tz}]`;
-    const calendarID = ES.ToString(GetSlot(zdt, CALENDAR));
-    result += ES.FormatCalendarAnnotation(calendarID, showCalendar);
+    result += ES.MaybeFormatCalendarAnnotation(GetSlot(zdt, CALENDAR), showCalendar);
     return result;
   },
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -389,21 +389,53 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-formatcalendarannotation" aoid="FormatCalendarAnnotation">
-      <h1>FormatCalendarAnnotation ( _id_, _showCalendar_ )</h1>
-      <p>
-        The abstract operation FormatCalendarAnnotation returns a string with a calendar annotation suitable for concatenating to the end of an ISO 8601 string.
-        Depending on the given _id_ and value of _showCalendar_, the string may be empty if no calendar annotation need be included.
-      </p>
-      <emu-note type="editor">
-        The exact form this annotation will take is undergoing a standardization process in the IETF; it is being discussed in the Internet Draft <a href="https://ryzokuken.dev/draft-ryzokuken-datetime-extended/documents/rfc-3339.html#name-internet-date-time-format">Date and Time on the Internet: Timestamps with additional information</a>.
-      </emu-note>
+    <emu-clause id="sec-temporal-maybeformatcalendarannotation" type="abstract operation">
+      <h1>
+        MaybeFormatCalendarAnnotation (
+          _calendarObject_: an Object,
+          _showCalendar_: one of *"auto"*, *"always"*, or *"never"*,
+        ): either a normal completion containing a String, or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It returns a string with a calendar annotation suitable for concatenating to the end of an ISO 8601 string.
+          Depending on the given _calendarObject_ and the value of _showCalendar_, the string may be empty if no calendar annotation need be included.
+          This operation may invoke an observable ToString operation on _calendarObject_, but not if _showCalendar_ is *"never"*.
+        </dd>
+      </dl>
       <emu-alg>
-        1. Assert: _showCalendar_ is *"auto"*, *"always"*, or *"never"*.
+        1. If _showCalendar_ is *"never"*, return the empty String.
+        1. Let _calendarID_ be ? ToString(_calendarObject_).
+        1. Return FormatCalendarAnnotation(_calendarID_, _showCalendar_).
+      </emu-alg>
+      <emu-note type="editor">
+        The exact form this annotation will take is undergoing a standardization process in the IETF; it is being discussed in the Internet Draft <a href="https://datatracker.ietf.org/doc/html/draft-ietf-sedate-datetime-extended">Date and Time on the Internet: Timestamps with additional information</a>.
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-formatcalendarannotation" type="abstract operation">
+      <h1>
+        FormatCalendarAnnotation (
+          _id_: a String,
+          _showCalendar_: one of *"auto"*, *"always"*, or *"never"*,
+        ): a String
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It returns a string with a calendar annotation suitable for concatenating to the end of an ISO 8601 string.
+          Depending on the given _id_ and value of _showCalendar_, the string may be empty if no calendar annotation need be included.
+        </dd>
+      </dl>
+      <emu-alg>
         1. If _showCalendar_ is *"never"*, return the empty String.
         1. If _showCalendar_ is *"auto"* and _id_ is *"iso8601"*, return the empty String.
         1. Return the string-concatenation of *"[u-ca="*, _id_, and *"]"*.
       </emu-alg>
+      <emu-note type="editor">
+        The exact form this annotation will take is undergoing a standardization process in the IETF; it is being discussed in the Internet Draft <a href="https://datatracker.ietf.org/doc/html/draft-ietf-sedate-datetime-extended">Date and Time on the Internet: Timestamps with additional information</a>.
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarequals" aoid="CalendarEquals">

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -887,11 +887,7 @@
         1. Let _year_ be ! PadISOYear(_temporalDate_.[[ISOYear]]).
         1. Let _month_ be ToZeroPaddedDecimalString(_temporalDate_.[[ISOMonth]], 2).
         1. Let _day_ be ToZeroPaddedDecimalString(_temporalDate_.[[ISODay]], 2).
-        1. If _showCalendar_ is *"never"*, then
-          1. Let _calendar_ be the empty String.
-        1. Else,
-          1. Let _calendarID_ be ? ToString(_temporalDate_.[[Calendar]]).
-          1. Let _calendar_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
+        1. Let _calendar_ be ? MaybeFormatCalendarAnnotation(_temporalDate_.[[Calendar]], _showCalendar_).
         1. Return the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), _month_, the code unit 0x002D (HYPHEN-MINUS), _day_, and _calendar_.
       </emu-alg>
     </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -887,8 +887,11 @@
         1. Let _year_ be ! PadISOYear(_temporalDate_.[[ISOYear]]).
         1. Let _month_ be ToZeroPaddedDecimalString(_temporalDate_.[[ISOMonth]], 2).
         1. Let _day_ be ToZeroPaddedDecimalString(_temporalDate_.[[ISODay]], 2).
-        1. Let _calendarID_ be ? ToString(_temporalDate_.[[Calendar]]).
-        1. Let _calendar_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
+        1. If _showCalendar_ is *"never"*, then
+          1. Let _calendar_ be the empty String.
+        1. Else,
+          1. Let _calendarID_ be ? ToString(_temporalDate_.[[Calendar]]).
+          1. Let _calendar_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
         1. Return the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), _month_, the code unit 0x002D (HYPHEN-MINUS), _day_, and _calendar_.
       </emu-alg>
     </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -964,8 +964,11 @@
         1. Let _hour_ be ToZeroPaddedDecimalString(_hour_, 2).
         1. Let _minute_ be ToZeroPaddedDecimalString(_minute_, 2).
         1. Let _seconds_ be ! FormatSecondsStringPart(_second_, _millisecond_, _microsecond_, _nanosecond_, _precision_).
-        1. Let _calendarID_ be ? ToString(_calendar_).
-        1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
+        1. If _showCalendar_ is *"never"*, then
+          1. Let _calendarString_ be the empty String.
+        1. Else,
+          1. Let _calendarID_ be ? ToString(_calendar_).
+          1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
         1. Return the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), _month_, the code unit 0x002D (HYPHEN-MINUS), _day_, 0x0054 (LATIN CAPITAL LETTER T), _hour_, the code unit 0x003A (COLON), _minute_, _seconds_, and _calendarString_.
       </emu-alg>
     </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -964,11 +964,7 @@
         1. Let _hour_ be ToZeroPaddedDecimalString(_hour_, 2).
         1. Let _minute_ be ToZeroPaddedDecimalString(_minute_, 2).
         1. Let _seconds_ be ! FormatSecondsStringPart(_second_, _millisecond_, _microsecond_, _nanosecond_, _precision_).
-        1. If _showCalendar_ is *"never"*, then
-          1. Let _calendarString_ be the empty String.
-        1. Else,
-          1. Let _calendarID_ be ? ToString(_calendar_).
-          1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
+        1. Let _calendarString_ be ? MaybeFormatCalendarAnnotation(_calendar_, _showCalendar_).
         1. Return the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), _month_, the code unit 0x002D (HYPHEN-MINUS), _day_, 0x0054 (LATIN CAPITAL LETTER T), _hour_, the code unit 0x003A (COLON), _minute_, _seconds_, and _calendarString_.
       </emu-alg>
     </emu-clause>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -411,7 +411,7 @@
         1. If _showCalendar_ is *"always"* or if _calendarID_ is not *"iso8601"*, then
           1. Let _year_ be ! PadISOYear(_monthDay_.[[ISOYear]]).
           1. Set _result_ to the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _result_.
-        1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
+        1. Let _calendarString_ be FormatCalendarAnnotation(_calendarID_, _showCalendar_).
         1. Set _result_ to the string-concatenation of _result_ and _calendarString_.
         1. Return _result_.
       </emu-alg>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -590,7 +590,7 @@
         1. If _showCalendar_ is *"always"* or if _calendarID_ is not *"iso8601"*, then
           1. Let _day_ be ToZeroPaddedDecimalString(_yearMonth_.[[ISODay]], 2).
           1. Set _result_ to the string-concatenation of _result_, the code unit 0x002D (HYPHEN-MINUS), and _day_.
-        1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
+        1. Let _calendarString_ be FormatCalendarAnnotation(_calendarID_, _showCalendar_).
         1. Set _result_ to the string-concatenation of _result_ and _calendarString_.
         1. Return _result_.
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1196,11 +1196,7 @@
         1. Else,
           1. Let _timeZoneID_ be ? ToString(_timeZone_).
           1. Let _timeZoneString_ be the string-concatenation of the code unit 0x005B (LEFT SQUARE BRACKET), _timeZoneID_, and the code unit 0x005D (RIGHT SQUARE BRACKET).
-        1. If _showCalendar_ is *"never"*, then
-          1. Let _calendarString_ be the empty String.
-        1. Else,
-          1. Let _calendarID_ be ? ToString(_zonedDateTime_.[[Calendar]]).
-          1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
+        1. Let _calendarString_ be ? MaybeFormatCalendarAnnotation(_zonedDateTime_.[[Calendar]], _showCalendar_).
         1. Return the string-concatenation of _dateTimeString_, _offsetString_, _timeZoneString_, and _calendarString_.
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1196,8 +1196,11 @@
         1. Else,
           1. Let _timeZoneID_ be ? ToString(_timeZone_).
           1. Let _timeZoneString_ be the string-concatenation of the code unit 0x005B (LEFT SQUARE BRACKET), _timeZoneID_, and the code unit 0x005D (RIGHT SQUARE BRACKET).
-        1. Let _calendarID_ be ? ToString(_zonedDateTime_.[[Calendar]]).
-        1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
+        1. If _showCalendar_ is *"never"*, then
+          1. Let _calendarString_ be the empty String.
+        1. Else,
+          1. Let _calendarID_ be ? ToString(_zonedDateTime_.[[Calendar]]).
+          1. Let _calendarString_ be ! FormatCalendarAnnotation(_calendarID_, _showCalendar_).
         1. Return the string-concatenation of _dateTimeString_, _offsetString_, _timeZoneString_, and _calendarString_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
`TemporalZonedDateTimeToString` doesn't call `ToString(timeZone)` when
`showTimeZone == "never"`. Do the same for `ToString(calendar)`.

`TemporalYearMonthToString` and `TemporalMonthDayToString` weren't
changed because both have to special-case non-ISO-8601 calendars.