### PR TITLE
Normative: Avoid observable prototype lookups in PrepareTemporalFields

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2365,8 +2365,14 @@
                 1. Let _Conversion_ represent the abstract operation named by the Conversion value of the same row.
                 1. Set _value_ to ? _Conversion_(_value_).
             1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-          1. Let _era_ be ? Get(_result_, *"era"*).
-          1. Let _eraYear_ be ? Get(_result_, *"eraYear"*).
+          1. If ! HasOwnProperty(_result_, *"era"*) is *true*, then
+            1. Let _era_ be ! Get(_result_, *"era"*).
+          1. Else,
+            1. Let _era_ be *undefined*.
+          1. If ! HasOwnProperty(_result_, *"eraYear"*) is *true*, then
+            1. Let _eraYear_ be ! Get(_result_, *"eraYear"*).
+          1. Else,
+            1. Let _eraYear_ be *undefined*.
           1. If _era_ is *undefined* and _eraYear_ is not *undefined*, or if _era_ is not *undefined* and _eraYear_ is *undefined*, then
             1. Throw a *RangeError* exception.
           1. Return _result_.


### PR DESCRIPTION
`result` inherits from `%Object.prototype%`, so both `Get()` calls can
trigger user-defined accessor properties on `%Object.prototype%`. To
avoid this issue, guard the `Get()` call with `HasOwnProperty()`.

The `Get()` calls are now also infallible, because `result` is an ordinary
object and the properties are guaranteed to be own data properties.