### PR TITLE
Normative: Check for invalid epoch nanoseconds in DisambiguatePossibleInstants

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -709,8 +709,12 @@
         1. If _disambiguation_ is *"reject"*, then
           1. Throw a *RangeError* exception.
         1. Let _epochNanoseconds_ be GetEpochFromISOParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
-        1. Let _dayBefore_ be ! CreateTemporalInstant(_epochNanoseconds_ - ℤ(nsPerDay)).
-        1. Let _dayAfter_ be ! CreateTemporalInstant(_epochNanoseconds_ + ℤ(nsPerDay)).
+        1. Let _dayBeforeNs_ be _epochNanoseconds_ - ℤ(nsPerDay).
+        1. If ! IsValidEpochNanoseconds(_dayBeforeNs_) is *false*, throw a *RangeError* exception.
+        1. Let _dayBefore_ be ! CreateTemporalInstant(_dayBeforeNs_).
+        1. Let _dayAfterNs_ be _epochNanoseconds_ + ℤ(nsPerDay).
+        1. If ! IsValidEpochNanoseconds(_dayAfterNs_) is *false*, throw a *RangeError* exception.
+        1. Let _dayAfter_ be ! CreateTemporalInstant(_dayAfterNs_).
         1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayBefore_).
         1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayAfter_).
         1. Let _nanoseconds_ be _offsetAfter_ - _offsetBefore_.


### PR DESCRIPTION
Fixes #2236