### PR TITLE
Normative: Check for invalid epoch nanoseconds in NanosecondsToDays

### DIFF
--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1316,6 +1316,7 @@
         1. Let _startInstant_ be ! CreateTemporalInstant(ℤ(_startNs_)).
         1. Let _startDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_relativeTo_.[[TimeZone]], _startInstant_, _relativeTo_.[[Calendar]]).
         1. Let _endNs_ be _startNs_ + _nanoseconds_.
+        1. If ! IsValidEpochNanoseconds(ℤ(_endNs_)) is *false*, throw a *RangeError* exception.
         1. Let _endInstant_ be ! CreateTemporalInstant(ℤ(_endNs_)).
         1. Let _endDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_relativeTo_.[[TimeZone]], _endInstant_, _relativeTo_.[[Calendar]]).
         1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*).


### PR DESCRIPTION
Fixes #2237