### PR TITLE
Normative: Remove "60" from TimeMinuteNotValidDay

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -973,7 +973,6 @@
           `39`
           `4` DecimalDigit
           `5` DecimalDigit
-          `60`
 
       TimeMinuteThirtyOnly :
           `30`


### PR DESCRIPTION
This is probably non-normative, because "60" is already rejected in
`ParseISODateTime` when `IsValidTime` gets called.

Fixes #2238