### PR TITLE
Normative: Add "22" to `TimeHourNotValidMonth`

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -953,7 +953,7 @@
           `60`
 
       TimeHourNotValidMonth : one of
-          `00` `13` `14` `15` `16` `17` `18` `19` `20` `21` `23`
+          `00` `13` `14` `15` `16` `17` `18` `19` `20` `21` `22` `23`
 
       TimeHourNotThirtyOneDayMonth : one of
           `02` `04` `06` `09` `11`


### PR DESCRIPTION
Likely an unintentional omission, but still a normative change.

Fixes #2239