### PR TITLE
Use ToTemporalDuration in AddDurationToOrSubtractDurationFromPlainYearMonth 

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1115,6 +1115,21 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-createnegateddurationrecord" type="abstract operation">
+      <h1>
+        CreateNegatedDurationRecord (
+          _duration_: a Duration Record,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a Duration Record that is the negation of _duration_.</dd>
+      </dl>
+      <emu-alg>
+        1. Return ! CreateDurationRecord(-_duration_.[[Years]], -_duration_.[[Months]], -_duration_.[[Weeks]], -_duration_.[[Days]], -_duration_.[[Hours]], -_duration_.[[Minutes]], -_duration_.[[Seconds]], -_duration_.[[Milliseconds]], -_duration_.[[Microseconds]], -_duration_.[[Nanoseconds]]).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-calculateoffsetshift" type="abstract operation">
       <h1>
         CalculateOffsetShift (

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1115,21 +1115,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-createnegateddurationrecord" type="abstract operation">
-      <h1>
-        CreateNegatedDurationRecord (
-          _duration_: a Duration Record,
-        )
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns a Duration Record that is the negation of _duration_.</dd>
-      </dl>
-      <emu-alg>
-        1. Return ! CreateDurationRecord(-_duration_.[[Years]], -_duration_.[[Months]], -_duration_.[[Weeks]], -_duration_.[[Days]], -_duration_.[[Hours]], -_duration_.[[Minutes]], -_duration_.[[Seconds]], -_duration_.[[Milliseconds]], -_duration_.[[Microseconds]], -_duration_.[[Nanoseconds]]).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-calculateoffsetshift" type="abstract operation">
       <h1>
         CalculateOffsetShift (

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -668,7 +668,7 @@
       <emu-alg>
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
         1. If _operation_ is ~subtract~, then
-          1. Set _duration_ to ! CreateNegatedTemporalDuration(_duration_).
+          1. Set _duration_ to ! CreateNegatedDurationRecord(_duration_).
         1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -668,7 +668,7 @@
       <emu-alg>
         1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. If _operation_ is ~subtract~, then
-          1. Set _duration_ to ! CreateNegatedDurationRecord(_duration_).
+          1. Set _duration_ to ! CreateNegatedTemporalDuration(_duration_).
         1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -666,7 +666,7 @@
         <dd>It adds/subtracts _temporalDurationLike_ to/from _yearMonth_, returning a point in time that is in the future/past relative to _yearMonth_.</dd>
       </dl>
       <emu-alg>
-        1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
+        1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. If _operation_ is ~subtract~, then
           1. Set _duration_ to ! CreateNegatedDurationRecord(_duration_).
         1. Let _balanceResult_ be ? BalanceDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).


### PR DESCRIPTION
AddDurationToOrSubtractDurationFromPlainYearMonth before this fix pass
a Duration Record to CreateNegatedTemporalDuration which expect the
input as Temporal.Duration (but not Duration Record) and output
is Temporal.Duration. This also cause the duration in
AddDurationToOrSubtractDurationFromPlainYearMonth could be either
a Temporal.Duration or a Duration Record. Change the first call to call ToTemporalDuration instead
