### PR TITLE
Normative: Improve the "NotAmbiguous" grammar

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -937,6 +937,9 @@
           `11`
           `12`
 
+      DateMonthWithThirtyOneDays : one of
+          `01` `03` `05` `07` `08` `10` `12`
+
       DateDay :
           `0` NonZeroDigit
           `1` DecimalDigit
@@ -952,6 +955,13 @@
 
       DateSpecMonthDay :
           TwoDashes? DateMonth `-`? DateDay
+
+      ValidMonthDay :
+          DateMonth `-`? `0` NonZeroDigit
+          DateMonth `-`? `1` DecimalDigit
+          DateMonth `-`? `2` DecimalDigit
+          DateMonth `-`? `30` but not one of `0230` or `02-30`
+          DateMonthWithThirtyOneDays `-`? `31`
 
       Date :
           DateYear `-` DateMonth `-` DateDay
@@ -1144,14 +1154,7 @@
           TimeHourTwoOnly TimeMinuteThirtyOnly
 
       TimeSpecWithOptionalTimeZoneNotAmbiguous :
-          TimeHour TimeZoneNumericUTCOffsetNotAmbiguousWithDayOfMonth? TimeZoneBracketedAnnotation?
-          TimeHourNotValidMonth TimeZone
-          TimeHour `:` TimeMinute TimeZone?
-          TimeHourMinuteBasicFormatNotAmbiguousWithMonthDay TimeZoneBracketedAnnotation?
-          TimeHour TimeMinute TimeZoneNumericUTCOffsetNotAmbiguousWithMonth TimeZoneBracketedAnnotation?
-          TimeHour `:` TimeMinute `:` TimeSecond TimeFraction? TimeZone?
-          TimeHour TimeMinute TimeSecondNotValidMonth TimeZone?
-          TimeHour TimeMinute TimeSecond TimeFraction TimeZone?
+          TimeSpec TimeZone? but not one of ValidMonthDay or DateSpecYearMonth
 
       TimeSpecSeparator :
           DateTimeSeparator TimeSpec

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -977,50 +977,6 @@
           MinuteSecond
           `60`
 
-      TimeHourNotValidMonth : one of
-          `00` `13` `14` `15` `16` `17` `18` `19` `20` `21` `23`
-
-      TimeHourNotThirtyOneDayMonth : one of
-          `02` `04` `06` `09` `11`
-
-      TimeHourTwoOnly :
-          `02`
-
-      TimeMinuteNotValidDay :
-          `00`
-          `32`
-          `33`
-          `34`
-          `35`
-          `36`
-          `37`
-          `38`
-          `39`
-          `4` DecimalDigit
-          `5` DecimalDigit
-          `60`
-
-      TimeMinuteThirtyOnly :
-          `30`
-
-      TimeMinuteThirtyOneOnly :
-          `31`
-
-      TimeSecondNotValidMonth :
-          `00`
-          `13`
-          `14`
-          `15`
-          `16`
-          `17`
-          `18`
-          `19`
-          `2` DecimalDigit
-          `3` DecimalDigit
-          `4` DecimalDigit
-          `5` DecimalDigit
-          `60`
-
       FractionalPart :
           DecimalDigit DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit?
 
@@ -1058,13 +1014,6 @@
       TimeZoneUTCOffset :
           TimeZoneNumericUTCOffset
           UTCDesignator
-
-      TimeZoneNumericUTCOffsetNotAmbiguousWithDayOfMonth :
-          TimeZoneNumericUTCOffset but not `-` TimeZoneUTCOffsetHour
-
-      TimeZoneNumericUTCOffsetNotAmbiguousWithMonth :
-          TimeZoneNumericUTCOffsetNotAmbiguousWithDayOfMonth
-          `-` TimeHourNotValidMonth
 
       TimeZoneUTCOffsetName :
           Sign Hour
@@ -1146,12 +1095,6 @@
           TimeHour TimeMinute
           TimeHour `:` TimeMinute `:` TimeSecond TimeFraction?
           TimeHour TimeMinute TimeSecond TimeFraction?
-
-      TimeHourMinuteBasicFormatNotAmbiguousWithMonthDay :
-          TimeHourNotValidMonth TimeMinute
-          TimeHour TimeMinuteNotValidDay
-          TimeHourNotThirtyOneDayMonth TimeMinuteThirtyOneOnly
-          TimeHourTwoOnly TimeMinuteThirtyOnly
 
       TimeSpecWithOptionalTimeZoneNotAmbiguous :
           TimeSpec TimeZone? but not one of ValidMonthDay or DateSpecYearMonth
@@ -1302,10 +1245,7 @@
       1. For each nonterminal _goal_ of &laquo; |TemporalDateTimeString|, |TemporalInstantString|, |TemporalMonthDayString|, |TemporalTimeString|, |TemporalYearMonthString|, |TemporalZonedDateTimeString| &raquo;, do
         1. If _parseResult_ is not a Parse Node, set _parseResult_ to ParseText(StringToCodePoints(_isoString_), _goal_).
       1. Assert: _parseResult_ is a Parse Node.
-      1. Let each of _year_, _month_, _day_, _fSeconds_, and _calendar_ be the source text matched by the respective |DateYear|, |DateMonth|, |DateDay|, |TimeFraction|, and |CalendarName| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
-      1. Let _hour_ be the source text matched by the |TimeHour|, |TimeHourNotValidMonth|, |TimeHourNotThirtyOneDayMonth|, or |TimeHourTwoOnly| Parse Node contained within _parseResult_, or an empty sequence of code points if none of those are present.
-      1. Let _minute_ be the source text matched by the |TimeMinute|, |TimeMinuteNotValidDay|, |TimeMinuteThirtyOnly|, or |TimeMinuteThirtyOneOnly| Parse Node contained within _parseResult_, or an empty sequence of code points if none of those are present.
-      1. Let _second_ be the source text matched by the |TimeSecond| or |TimeSecondNotValidMonth| Parse Node contained within _parseResult_, or an empty sequence of code points if neither of those are present.
+      1. Let each of _year_, _month_, _day_, _hour_, _minute_, _second_, _fSeconds_, and _calendar_ be the source text matched by the respective |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, |TimeFraction|, and |CalendarName| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
       1. If the first code point of _year_ is U+2212 (MINUS SIGN), replace the first code point with U+002D (HYPHEN-MINUS).
       1. Let _yearMV_ be ! ToIntegerOrInfinity(CodePointsToString(_year_)).
       1. If _month_ is empty, then


### PR DESCRIPTION
Technically normative in adding support for edge case like the following:
* HHMMSS[timeZoneName] where HHMMSS on its own is ambiguous with YYYYMM
  (e.g. "112312[America/New_York]")
* HHMM-HH[timeZoneName] where HHMM-HH on its own is ambiguous with YYYY-MM
  (e.g., "1001-12[-00:01]")

...but the polyfill already works like that.