### PR TITLE
Normative: Reject an ambiguous time string even with a calendar

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -18,9 +18,9 @@ const ObjectDefineProperty = Object.defineProperty;
 const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const ObjectIs = Object.is;
 const ObjectEntries = Object.entries;
-const StringPrototypeSlice = String.prototype.slice;
 
 import bigInt from 'big-integer';
+import callBound from 'call-bind/callBound';
 import Call from 'es-abstract/2020/Call.js';
 import GetMethod from 'es-abstract/2020/GetMethod.js';
 import IsInteger from 'es-abstract/2020/IsInteger.js';
@@ -67,6 +67,8 @@ import {
   MICROSECONDS,
   NANOSECONDS
 } from './slots.mjs';
+
+const $stringSlice = callBound('String.prototype.slice');
 
 const DAY_SECONDS = 86400;
 const DAY_NANOS = bigInt(DAY_SECONDS).multiply(1e9);
@@ -400,7 +402,7 @@ export const ES = ObjectAssign({}, ES2020, {
     // and must be stripped so presence of a calendar doesn't result in interpretation
     // of otherwise ambiguous input as a time.
     const isoStringWithoutCalendar = calendar
-      ? StringPrototypeSlice.call(isoString, 0, isoString.length - calendar.length - 7)
+      ? $stringSlice(isoString, 0, isoString.length - calendar.length - 7)
       : isoString;
     try {
       const { month, day } = ES.ParseTemporalMonthDayString(isoStringWithoutCalendar);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -18,9 +18,9 @@ const ObjectDefineProperty = Object.defineProperty;
 const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const ObjectIs = Object.is;
 const ObjectEntries = Object.entries;
+const StringPrototypeSlice = String.prototype.slice;
 
 import bigInt from 'big-integer';
-import callBound from 'call-bind/callBound';
 import Call from 'es-abstract/2020/Call.js';
 import GetMethod from 'es-abstract/2020/GetMethod.js';
 import IsInteger from 'es-abstract/2020/IsInteger.js';
@@ -67,8 +67,6 @@ import {
   MICROSECONDS,
   NANOSECONDS
 } from './slots.mjs';
-
-const $stringSlice = callBound('String.prototype.slice');
 
 const DAY_SECONDS = 86400;
 const DAY_NANOS = bigInt(DAY_SECONDS).multiply(1e9);
@@ -402,7 +400,7 @@ export const ES = ObjectAssign({}, ES2020, {
     // and must be stripped so presence of a calendar doesn't result in interpretation
     // of otherwise ambiguous input as a time.
     const isoStringWithoutCalendar = calendar
-      ? $stringSlice(isoString, 0, isoString.length - calendar.length - 7)
+      ? ES.Call(StringPrototypeSlice, isoString, [0, -(calendar.length + 7)])
       : isoString;
     try {
       const { month, day } = ES.ParseTemporalMonthDayString(isoStringWithoutCalendar);

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -63,7 +63,6 @@
   ],
   "dependencies": {
     "big-integer": "^1.6.51",
-    "call-bind": "^1.0.2",
     "es-abstract": "^1.19.1"
   },
   "devDependencies": {
@@ -82,7 +81,6 @@
     "js-yaml": "^4.1.0",
     "progress": "^2.0.3",
     "rollup": "^2.68.0",
-    "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.2",
     "tiny-glob": "^0.2.9"
   },

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -63,6 +63,7 @@
   ],
   "dependencies": {
     "big-integer": "^1.6.51",
+    "call-bind": "^1.0.2",
     "es-abstract": "^1.19.1"
   },
   "devDependencies": {
@@ -81,6 +82,7 @@
     "js-yaml": "^4.1.0",
     "progress": "^2.0.3",
     "rollup": "^2.68.0",
+    "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.2",
     "tiny-glob": "^0.2.9"
   },

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -304,8 +304,7 @@ const calendarDateTime = seq(dateTime, [calendar]);
 const calendarDateTimeTimeRequired = seq(date, timeSpecSeparator, [timeZone], [calendar]);
 const calendarTime = choice(
   seq(timeDesignator, timeSpec, [timeZone], [calendar]),
-  seq(timeSpec, [timeZone], calendar),
-  seq(timeSpecWithOptionalTimeZoneNotAmbiguous)
+  seq(timeSpecWithOptionalTimeZoneNotAmbiguous, [calendar])
 );
 
 const durationFractionalPart = withCode(between(1, 9, digit()), (data, result) => {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1107,8 +1107,7 @@
 
       CalendarTime :
           TimeDesignator TimeSpec TimeZone? Calendar?
-          TimeSpec TimeZone? Calendar
-          TimeSpecWithOptionalTimeZoneNotAmbiguous
+          TimeSpecWithOptionalTimeZoneNotAmbiguous Calendar?
 
       CalendarDateTime:
           DateTime Calendar?


### PR DESCRIPTION
Fixes #2285