### PR TITLE
Editorial: Pass Duration Records rather than individual components

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -211,18 +211,7 @@ export class Duration {
     let microseconds = GetSlot(this, MICROSECONDS);
     let nanoseconds = GetSlot(this, NANOSECONDS);
 
-    const existingLargestUnit = ES.DefaultTemporalLargestUnit(
-      years,
-      months,
-      weeks,
-      days,
-      hours,
-      minutes,
-      seconds,
-      milliseconds,
-      microseconds,
-      nanoseconds
-    );
+    const existingLargestUnit = ES.DefaultTemporalLargestUnit(this);
     if (ES.Type(roundTo) === 'String') {
       const stringParam = roundTo;
       roundTo = ObjectCreate(null);
@@ -466,18 +455,7 @@ export class Duration {
 
     if (unit !== 'nanosecond' || increment !== 1) {
       let norm = TimeDuration.normalize(hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
-      const largestUnit = ES.DefaultTemporalLargestUnit(
-        years,
-        months,
-        weeks,
-        days,
-        hours,
-        minutes,
-        seconds,
-        milliseconds,
-        microseconds,
-        nanoseconds
-      );
+      const largestUnit = ES.DefaultTemporalLargestUnit(this);
       ({ norm } = ES.RoundTimeDuration(0, norm, increment, unit, roundingMode));
       let deltaDays;
       ({

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -269,7 +269,13 @@ export class Duration {
       const timeZone = GetSlot(zonedRelativeTo, TIME_ZONE);
       const calendar = GetSlot(zonedRelativeTo, CALENDAR);
       const relativeEpochNs = GetSlot(zonedRelativeTo, EPOCHNANOSECONDS);
-      const targetEpochNs = ES.AddZonedDateTime(relativeEpochNs, timeZone, calendar, years, months, weeks, days, norm);
+      const targetEpochNs = ES.AddZonedDateTime(relativeEpochNs, timeZone, calendar, {
+        years,
+        months,
+        weeks,
+        days,
+        norm
+      });
       ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
         ES.DifferenceZonedDateTimeWithRounding(
           relativeEpochNs,
@@ -366,7 +372,13 @@ export class Duration {
       const timeZone = GetSlot(zonedRelativeTo, TIME_ZONE);
       const calendar = GetSlot(zonedRelativeTo, CALENDAR);
       const relativeEpochNs = GetSlot(zonedRelativeTo, EPOCHNANOSECONDS);
-      const targetEpochNs = ES.AddZonedDateTime(relativeEpochNs, timeZone, calendar, years, months, weeks, days, norm);
+      const targetEpochNs = ES.AddZonedDateTime(relativeEpochNs, timeZone, calendar, {
+        years,
+        months,
+        weeks,
+        days,
+        norm
+      });
       const { total } = ES.DifferenceZonedDateTimeWithRounding(
         relativeEpochNs,
         targetEpochNs,
@@ -588,9 +600,11 @@ export class Duration {
       const epochNs = GetSlot(zonedRelativeTo, EPOCHNANOSECONDS);
 
       const norm1 = TimeDuration.normalize(h1, min1, s1, ms1, µs1, ns1);
+      const duration1 = { years: y1, months: mon1, weeks: w1, days: d1, norm: norm1 };
       const norm2 = TimeDuration.normalize(h2, min2, s2, ms2, µs2, ns2);
-      const after1 = ES.AddZonedDateTime(epochNs, timeZone, calendar, y1, mon1, w1, d1, norm1);
-      const after2 = ES.AddZonedDateTime(epochNs, timeZone, calendar, y2, mon2, w2, d2, norm2);
+      const duration2 = { years: y2, months: mon2, weeks: w2, days: d2, norm: norm2 };
+      const after1 = ES.AddZonedDateTime(epochNs, timeZone, calendar, duration1);
+      const after2 = ES.AddZonedDateTime(epochNs, timeZone, calendar, duration2);
       return ES.ComparisonResult(after1.minus(after2).toJSNumber());
     }
 

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4198,42 +4198,38 @@ export function AddZonedDateTime(
 }
 
 export function AddDurations(operation, duration, other) {
-  const sign = operation === 'subtract' ? -1 : 1;
-  other = ToTemporalDurationRecord(other);
+  other = ToTemporalDuration(other);
+  if (operation === 'subtract') other = CreateNegatedTemporalDuration(other);
 
-  const d1 = GetSlot(duration, DAYS);
-  const h1 = GetSlot(duration, HOURS);
-  const min1 = GetSlot(duration, MINUTES);
-  const s1 = GetSlot(duration, SECONDS);
-  const ms1 = GetSlot(duration, MILLISECONDS);
-  const µs1 = GetSlot(duration, MICROSECONDS);
-  const ns1 = GetSlot(duration, NANOSECONDS);
-  const y2 = sign * other.years;
-  const mon2 = sign * other.months;
-  const w2 = sign * other.weeks;
-  const d2 = sign * other.days;
-  const h2 = sign * other.hours;
-  const min2 = sign * other.minutes;
-  const s2 = sign * other.seconds;
-  const ms2 = sign * other.milliseconds;
-  const µs2 = sign * other.microseconds;
-  const ns2 = sign * other.nanoseconds;
-
-  const Duration = GetIntrinsic('%Temporal.Duration%');
   const largestUnit1 = DefaultTemporalLargestUnit(duration);
-  const largestUnit2 = DefaultTemporalLargestUnit(new Duration(y2, mon2, w2, d2, h2, min2, s2, ms2, µs2, ns2));
+  const largestUnit2 = DefaultTemporalLargestUnit(other);
   const largestUnit = LargerOfTwoTemporalUnits(largestUnit1, largestUnit2);
 
-  const norm1 = TimeDuration.normalize(h1, min1, s1, ms1, µs1, ns1);
-  const norm2 = TimeDuration.normalize(h2, min2, s2, ms2, µs2, ns2);
+  const norm1 = TimeDuration.normalize(
+    GetSlot(duration, HOURS),
+    GetSlot(duration, MINUTES),
+    GetSlot(duration, SECONDS),
+    GetSlot(duration, MILLISECONDS),
+    GetSlot(duration, MICROSECONDS),
+    GetSlot(duration, NANOSECONDS)
+  );
+  const norm2 = TimeDuration.normalize(
+    GetSlot(other, HOURS),
+    GetSlot(other, MINUTES),
+    GetSlot(other, SECONDS),
+    GetSlot(other, MILLISECONDS),
+    GetSlot(other, MICROSECONDS),
+    GetSlot(other, NANOSECONDS)
+  );
 
   if (IsCalendarUnit(largestUnit)) {
     throw new RangeError('For years, months, or weeks arithmetic, use date arithmetic relative to a starting point');
   }
   const { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(
-    norm1.add(norm2).add24HourDays(d1 + d2),
+    norm1.add(norm2).add24HourDays(GetSlot(duration, DAYS) + GetSlot(other, DAYS)),
     largestUnit
   );
+  const Duration = GetIntrinsic('%Temporal.Duration%');
   return new Duration(0, 0, 0, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 }
 

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4166,11 +4166,7 @@ export function AddZonedDateTime(
   epochNs,
   timeZone,
   calendar,
-  years,
-  months,
-  weeks,
-  days,
-  norm,
+  { years, months, weeks, days, norm },
   overflow = 'constrain'
 ) {
   // If only time is to be added, then use Instant math. It's not OK to fall
@@ -4394,30 +4390,33 @@ export function AddDurationToOrSubtractDurationFromPlainYearMonth(operation, yea
 }
 
 export function AddDurationToOrSubtractDurationFromZonedDateTime(operation, zonedDateTime, durationLike, options) {
-  const sign = operation === 'subtract' ? -1 : 1;
-  const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
-    ToTemporalDurationRecord(durationLike);
+  let duration = ToTemporalDuration(durationLike);
+  if (operation === 'subtract') duration = CreateNegatedTemporalDuration(duration);
+
   options = GetOptionsObject(options);
   const overflow = GetTemporalOverflowOption(options);
   const timeZone = GetSlot(zonedDateTime, TIME_ZONE);
   const calendar = GetSlot(zonedDateTime, CALENDAR);
   const norm = TimeDuration.normalize(
-    sign * hours,
-    sign * minutes,
-    sign * seconds,
-    sign * milliseconds,
-    sign * microseconds,
-    sign * nanoseconds
+    GetSlot(duration, HOURS),
+    GetSlot(duration, MINUTES),
+    GetSlot(duration, SECONDS),
+    GetSlot(duration, MILLISECONDS),
+    GetSlot(duration, MICROSECONDS),
+    GetSlot(duration, NANOSECONDS)
   );
+  const normalized = {
+    years: GetSlot(duration, YEARS),
+    months: GetSlot(duration, MONTHS),
+    weeks: GetSlot(duration, WEEKS),
+    days: GetSlot(duration, DAYS),
+    norm
+  };
   const epochNanoseconds = AddZonedDateTime(
     GetSlot(zonedDateTime, EPOCHNANOSECONDS),
     timeZone,
     calendar,
-    sign * years,
-    sign * months,
-    sign * weeks,
-    sign * days,
-    norm,
+    normalized,
     overflow
   );
   return CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar);

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -105,9 +105,11 @@
           1. Let _timeZone_ be _zonedRelativeTo_.[[TimeZone]].
           1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
           1. Let _norm1_ be NormalizeTimeDuration(_one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]]).
+          1. Let _duration1_ be ! CreateNormalizedDurationRecord(_one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], _norm1_).
           1. Let _norm2_ be NormalizeTimeDuration(_two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]]).
-          1. Let _after1_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], _norm1_).
-          1. Let _after2_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], _norm2_).
+          1. Let _duration2_ be ! CreateNormalizedDurationRecord(_two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], _norm2_).
+          1. Let _after1_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _duration1_).
+          1. Let _after2_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _duration2_).
           1. If _after1_ &gt; _after2_, return *1*<sub>𝔽</sub>.
           1. If _after1_ &lt; _after2_, return *-1*<sub>𝔽</sub>.
           1. Return *+0*<sub>𝔽</sub>.
@@ -455,7 +457,8 @@
           1. Let _timeZone_ be _zonedRelativeTo_.[[TimeZone]].
           1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
           1. Let _relativeEpochNs_ be _zonedRelativeTo_.[[Nanoseconds]].
-          1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _norm_).
+          1. Let _normalizedDuration_ be ! CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _norm_).
+          1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _normalizedDuration_).
           1. Let _roundRecord_ be ? DifferenceZonedDateTimeWithRounding(_relativeEpochNs_, _targetEpochNs_, _calendar_, _timeZone_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
         1. Else if _plainRelativeTo_ is not *undefined*, then
@@ -503,7 +506,8 @@
           1. Let _timeZone_ be _zonedRelativeTo_.[[TimeZone]].
           1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
           1. Let _relativeEpochNs_ be _zonedRelativeTo_.[[Nanoseconds]].
-          1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _norm_).
+          1. Let _normalizedDuration_ be ! CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _norm_).
+          1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _normalizedDuration_).
           1. Let _roundRecord_ be ? DifferenceZonedDateTimeWithRounding(_relativeEpochNs_, _targetEpochNs_, _calendar_, _timeZone_, _unit_, 1, _unit_, *"trunc"*).
         1. Else if _plainRelativeTo_ is not *undefined*, then
           1. Let _targetTime_ be AddTime(0, 0, 0, 0, 0, 0, _norm_).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -2115,34 +2115,16 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
-        1. Set _other_ to ? ToTemporalDurationRecord(_other_).
-        1. Let _d1_ be _duration_.[[Days]].
-        1. Let _h1_ be _duration_.[[Hours]].
-        1. Let _min1_ be _duration_.[[Minutes]].
-        1. Let _s1_ be _duration_.[[Seconds]].
-        1. Let _ms1_ be _duration_.[[Milliseconds]].
-        1. Let _mus1_ be _duration_.[[Microseconds]].
-        1. Let _ns1_ be _duration_.[[Nanoseconds]].
-        1. Let _y2_ be _sign_ × _other_.[[Years]].
-        1. Let _mon2_ be _sign_ × _other_.[[Months]].
-        1. Let _w2_ be _sign_ × _other_.[[Weeks]].
-        1. Let _d2_ be _sign_ × _other_.[[Days]].
-        1. Let _h2_ be _sign_ × _other_.[[Hours]].
-        1. Let _min2_ be _sign_ × _other_.[[Minutes]].
-        1. Let _s2_ be _sign_ × _other_.[[Seconds]].
-        1. Let _ms2_ be _sign_ × _other_.[[Milliseconds]].
-        1. Let _mus2_ be _sign_ × _other_.[[Microseconds]].
-        1. Let _ns2_ be _sign_ × _other_.[[Nanoseconds]].
-        1. Let _duration2_ be ! CreateTemporalDuration(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Set _other_ to ? ToTemporalDuration(_other_).
+        1. If _operation_ is ~subtract~, set _other_ to CreateNegatedTemporalDuration(_other_).
         1. Let _largestUnit1_ be DefaultTemporalLargestUnit(_duration_).
-        1. Let _largestUnit2_ be DefaultTemporalLargestUnit(_duration2_).
+        1. Let _largestUnit2_ be DefaultTemporalLargestUnit(_other_).
         1. Let _largestUnit_ be LargerOfTwoTemporalUnits(_largestUnit1_, _largestUnit2_).
-        1. Let _norm1_ be NormalizeTimeDuration(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
-        1. Let _norm2_ be NormalizeTimeDuration(_h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _norm1_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Let _norm2_ be NormalizeTimeDuration(_other_.[[Hours]], _other_.[[Minutes]], _other_.[[Seconds]], _other_.[[Milliseconds]], _other_.[[Microseconds]], _other_.[[Nanoseconds]]).
         1. If IsCalendarUnit(_largestUnit_), throw a *RangeError* exception.
         1. Let _normResult_ be ? AddNormalizedTimeDuration(_norm1_, _norm2_).
-        1. Set _normResult_ to ? Add24HourDaysToNormalizedTimeDuration(_normResult_, _d1_ + _d2_).
+        1. Set _normResult_ to ? Add24HourDaysToNormalizedTimeDuration(_normResult_, _duration_.[[Days]] + _other_.[[Days]]).
         1. Let _result_ be ? BalanceTimeDuration(_normResult_, _largestUnit_).
         1. Return ! CreateTemporalDuration(0, 0, 0, _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -436,7 +436,7 @@
         1. If _smallestUnit_ is *undefined*, then
           1. Set _smallestUnitPresent_ to *false*.
           1. Set _smallestUnit_ to *"nanosecond"*.
-        1. Let _existingLargestUnit_ be DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
+        1. Let _existingLargestUnit_ be DefaultTemporalLargestUnit(_duration_).
         1. Let _defaultLargestUnit_ be LargerOfTwoTemporalUnits(_existingLargestUnit_, _smallestUnit_).
         1. If _largestUnit_ is *undefined*, then
           1. Set _largestUnitPresent_ to *false*.
@@ -539,7 +539,7 @@
         1. Let _precision_ be ToSecondsStringPrecisionRecord(_smallestUnit_, _digits_).
         1. If _precision_.[[Unit]] is not *"nanosecond"* or _precision_.[[Increment]] ≠ 1, then
           1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-          1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
+          1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_).
           1. Let _roundRecord_ be ? RoundTimeDuration(0, _norm_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
           1. Set _norm_ to _roundRecord_.[[NormalizedDuration]].[[NormalizedTime]].
           1. Let _result_ be ! BalanceTimeDuration(_norm_, LargerOfTwoTemporalUnits(_largestUnit_, *"second"*)).
@@ -1192,31 +1192,23 @@
     <emu-clause id="sec-temporal-defaulttemporallargestunit" type="abstract operation">
       <h1>
         DefaultTemporalLargestUnit (
-          _years_: an integer,
-          _months_: an integer,
-          _weeks_: an integer,
-          _days_: an integer,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
+          _duration_: a Temporal.Duration,
         ): a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It implements the logic used in the `Temporal.Duration.prototype.round()` method and elsewhere, where the `largestUnit` option, if not given explicitly, is set to the largest non-zero unit in the input Temporal.Duration.</dd>
+        <dd>It implements the logic used in the `Temporal.Duration.prototype.round()` method and elsewhere, where the `largestUnit` option, if not given explicitly, is set to the largest-magnitude non-zero unit.</dd>
       </dl>
       <emu-alg>
-        1. If _years_ ≠ 0, return *"year"*.
-        1. If _months_ ≠ 0, return *"month"*.
-        1. If _weeks_ ≠ 0, return *"week"*.
-        1. If _days_ ≠ 0, return *"day"*.
-        1. If _hours_ ≠ 0, return *"hour"*.
-        1. If _minutes_ ≠ 0, return *"minute"*.
-        1. If _seconds_ ≠ 0, return *"second"*.
-        1. If _milliseconds_ ≠ 0, return *"millisecond"*.
-        1. If _microseconds_ ≠ 0, return *"microsecond"*.
+        1. If _duration_.[[Years]] ≠ 0, return *"year"*.
+        1. If _duration_.[[Months]] ≠ 0, return *"month"*.
+        1. If _duration_.[[Weeks]] ≠ 0, return *"week"*.
+        1. If _duration_.[[Days]] ≠ 0, return *"day"*.
+        1. If _duration_.[[Hours]] ≠ 0, return *"hour"*.
+        1. If _duration_.[[Minutes]] ≠ 0, return *"minute"*.
+        1. If _duration_.[[Seconds]] ≠ 0, return *"second"*.
+        1. If _duration_.[[Milliseconds]] ≠ 0, return *"millisecond"*.
+        1. If _duration_.[[Microseconds]] ≠ 0, return *"microsecond"*.
         1. Return *"nanosecond"*.
       </emu-alg>
     </emu-clause>
@@ -2125,9 +2117,6 @@
       <emu-alg>
         1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalDurationRecord(_other_).
-        1. Let _y1_ be _duration_.[[Years]].
-        1. Let _mon1_ be _duration_.[[Months]].
-        1. Let _w1_ be _duration_.[[Weeks]].
         1. Let _d1_ be _duration_.[[Days]].
         1. Let _h1_ be _duration_.[[Hours]].
         1. Let _min1_ be _duration_.[[Minutes]].
@@ -2145,8 +2134,9 @@
         1. Let _ms2_ be _sign_ × _other_.[[Milliseconds]].
         1. Let _mus2_ be _sign_ × _other_.[[Microseconds]].
         1. Let _ns2_ be _sign_ × _other_.[[Nanoseconds]].
-        1. Let _largestUnit1_ be DefaultTemporalLargestUnit(_y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_).
-        1. Let _largestUnit2_ be DefaultTemporalLargestUnit(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_).
+        1. Let _duration2_ be ! CreateTemporalDuration(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _largestUnit1_ be DefaultTemporalLargestUnit(_duration_).
+        1. Let _largestUnit2_ be DefaultTemporalLargestUnit(_duration2_).
         1. Let _largestUnit_ be LargerOfTwoTemporalUnits(_largestUnit1_, _largestUnit2_).
         1. Let _norm1_ be NormalizeTimeDuration(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
         1. Let _norm2_ be NormalizeTimeDuration(_h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -614,13 +614,11 @@
         <dd>It adds/subtracts _temporalDurationLike_ to/from _instant_.</dd>
       </dl>
       <emu-alg>
-        1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
-        1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
-        1. If _duration_.[[Days]] is not 0, throw a *RangeError* exception.
-        1. If _duration_.[[Months]] is not 0, throw a *RangeError* exception.
-        1. If _duration_.[[Weeks]] is not 0, throw a *RangeError* exception.
-        1. If _duration_.[[Years]] is not 0, throw a *RangeError* exception.
-        1. Let _norm_ be NormalizeTimeDuration(_sign_ × _duration_.[[Hours]], _sign_ × _duration_.[[Minutes]], _sign_ × _duration_.[[Seconds]], _sign_ × _duration_.[[Milliseconds]], _sign_ × _duration_.[[Microseconds]], _sign_ × _duration_.[[Nanoseconds]]).
+        1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
+        1. If _operation_ is ~subtract~, set _duration_ to CreateNegatedTemporalDuration(_duration_).
+        1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_).
+        1. If IsCalendarUnit(_largestUnit_) is *true*, or _largestUnit_ is *"day"*, throw a *RangeError* exception.
+        1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. Let _ns_ be ? AddInstant(_instant_.[[Nanoseconds]], _norm_).
         1. Return ! CreateTemporalInstant(_ns_).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1143,11 +1143,7 @@
           _epochNanoseconds_: a BigInt,
           _timeZone_: a String,
           _calendar_: a String,
-          _years_: an integer,
-          _months_: an integer,
-          _weeks_: an integer,
-          _days_: an integer,
-          _norm_: a Normalized Time Duration Record,
+          _duration_: a Normalized Duration Record,
           optional _overflow_: *"constrain"* or *"reject"*,
         ): either a normal completion containing a BigInt or a throw completion
       </h1>
@@ -1160,16 +1156,16 @@
       </dl>
       <emu-alg>
         1. If _overflow_ is not present, set _overflow_ to *"constrain"*.
-        1. If _years_ = 0, _months_ = 0, _weeks_ = 0, and _days_ = 0, then
-          1. Return ? AddInstant(_epochNanoseconds_, _norm_).
+        1. If _duration_.[[Years]] = 0, and _duration_.[[Months]] = 0, and _duration_.[[Weeks]] = 0, and _duration_.[[Days]] = 0, then
+          1. Return ? AddInstant(_epochNanoseconds_, _duration_.[[NormalizedTime]]).
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _epochNanoseconds_).
         1. Let _datePart_ be ISODateTimeToDateRecord(_isoDateTime_).
-        1. Let _dateDuration_ be CreateDurationRecord(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
+        1. Let _dateDuration_ be ! CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]]).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _datePart_, _dateDuration_, _overflow_).
         1. Let _intermediateDateTime_ be CombineISODateAndTimeRecord(_addedDate_, _isoDateTime_).
         1. If ISODateTimeWithinLimits(_intermediateDateTime_.[[Year]], _intermediateDateTime_.[[Month]], _intermediateDateTime_.[[Day]], _intermediateDateTime_.[[Hour]], _intermediateDateTime_.[[Minute]], _intermediateDateTime_.[[Second]], _intermediateDateTime_.[[Millisecond]], _intermediateDateTime_.[[Microsecond]], _intermediateDateTime_.[[Nanosecond]]) is *false*, throw a *RangeError* exception.
         1. Let _intermediateNs_ be ! GetEpochNanosecondsFor(_timeZone_, _intermediateDateTime_, *"compatible"*).
-        1. Return ? AddInstant(_intermediateNs_, _norm_).
+        1. Return ? AddInstant(_intermediateNs_, _duration_.[[NormalizedTime]]).
       </emu-alg>
     </emu-clause>
 
@@ -1303,14 +1299,15 @@
         <dd>It adds/subtracts _temporalDurationLike_ to/from _zonedDateTime_.</dd>
       </dl>
       <emu-alg>
-        1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
-        1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
+        1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
+        1. If _operation_ is ~subtract~, set _duration_ to CreateNegatedTemporalDuration(_duration_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? GetTemporalOverflowOption(_options_).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
-        1. Let _norm_ be NormalizeTimeDuration(_sign_ × _duration_.[[Hours]], _sign_ × _duration_.[[Minutes]], _sign_ × _duration_.[[Seconds]], _sign_ × _duration_.[[Milliseconds]], _sign_ × _duration_.[[Microseconds]], _sign_ × _duration_.[[Nanoseconds]]).
-        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZone_, _calendar_, _sign_ × _duration_.[[Years]], _sign_ × _duration_.[[Months]], _sign_ × _duration_.[[Weeks]], _sign_ × _duration_.[[Days]], _norm_, _overflow_).
+        1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Set _duration_ to ! CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _norm_).
+        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZone_, _calendar_, _duration_, _overflow_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Many operations seem to be simplified by dealing with Duration Records rather than individual fields.

And I suspect that even further reform in this direction remains possible.