### PR TITLE
Normative: Support IANA legacy names

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1071,9 +1071,20 @@
           TimeZoneIANANameComponent
           TimeZoneIANANameComponent `/` TimeZoneIANANameTail
 
+      TimeZoneIANALegacyName :
+          `Etc/GMT0`
+          `GMT0`
+          `GMT-0`
+          `GMT+0`
+          `EST5EDT`
+          `CST6CDT`
+          `MST7MDT`
+          `PST8PDT`
+
       TimeZoneIANAName :
           `Etc/GMT` ASCIISign UnpaddedHour
           TimeZoneIANANameTail but not `Etc/GMT` ASCIISign UnpaddedHour
+          TimeZoneIANALegacyName
 
       TimeZoneIdentifier :
           TimeZoneIANAName


### PR DESCRIPTION
The IANA time zone database contains some legacy names which don't
follow the normal identifier guidelines, see <https://data.iana.org/time-zones/theory.html#naming>.

From <https://github.com/eggert/tz/blob/main/etcetera>, add:
- `Etc/GMT0`

From <https://github.com/eggert/tz/blob/main/backward>, add:
- `GMT0`
- `GMT-0`
- `GMT+0`

From <https://github.com/eggert/tz/blob/main/northamerica>, add:
- `EST5EDT`
- `CST6CDT`
- `MST7MDT`
- `PST8PDT`

But DO NOT add other names which don't follow normal identifier guidelines, like `SystemV/PST8PDT` or `Canada/East-Saskatchewan`, from <https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/tzcode/icuzones>.

This changes ensures that `Temporal.TimeZone.from("PST8PDT")` works in addition to the already suppported `new Temporal.TimeZone("PST8PDT")`.

Note: `Temporal.TimeZone.from("pst8pdt")` is still not accepted even though `new Temporal.TimeZone("pst8pdt")` works, but that's consistent with how `new Temporal.TimeZone("etc/gmt+1")` is treated differently than `Temporal.TimeZone.from("etc/gmt+1")`.