### PR TITLE
Editorial: Revert normative changes from #2243

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -282,9 +282,9 @@
             [[Unit]]: *"nanosecond"*,
             [[Increment]]: 1
           }.
-      1. If _fractionalDigitsVal_ is *NaN*, throw a *RangeError* exception.
-      1. Set _fractionalDigitCount_ to ? ToIntegerThrowOnInfinity(_fractionalDigitsVal_).
-      1. If _fractionalDigitCount_ &lt; 0 or _fractionalDigitCount_ &gt; 9, throw a *RangeError* exception.
+      1. If _fractionalDigitsVal_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
+      1. If ℝ(_fractionalDigitsVal_) &lt; 0 or ℝ(_fractionalDigitsVal_) > 9, throw a *RangeError* exception.
+      1. Let _fractionalDigitCount_ be floor(ℝ(_fractionalDigitsVal_)).
       1. If _fractionalDigitCount_ is 0, then
         1. Return the Record {
             [[Precision]]: 0,


### PR DESCRIPTION
Ensure inputs like `-0.5` and `9.1` are still throwing a RangeError instead of being treated as `0`.