### PR TITLE
Editorial: Add an explicit operation for merging calendar field names

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -655,6 +655,29 @@
         1. Return _merged_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarmergefieldnames" type="abstract operation">
+      <h1>
+        CalendarMergeFieldNames (
+          _receiverFieldNames_: a List,
+          _inputFieldNames_: a List,
+        ): a List
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the List containing all the elements of _receiverFieldNames_ followed by all the elements of _inputFieldNames_, with duplicate elements removed.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _merged_ be a new empty List.
+        1. For each element _name_ of _receiverFieldNames_, do
+          1. If _merged_ does not contain _name_, then
+            1. Append _name_ to _merged_.
+        1. For each element _name_ of _inputFieldNames_, do
+          1. If _merged_ does not contain _name_, then
+            1. Append _name_ to _merged_.
+        1. Return _merged_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-temporal-calendar-constructor">

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -247,7 +247,7 @@
         1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"year"* »).
         1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
         1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
-        1. Let _mergedFieldNames_ be the List containing all the elements of _receiverFieldNames_ followed by all the elements of _inputFieldNames_, with duplicate elements removed.
+        1. Let _mergedFieldNames_ be CalendarMergeFieldNames(_receiverFieldNames_, _inputFieldNames_).
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _mergedFieldNames_, «»).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -381,7 +381,7 @@
         1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"day"* »).
         1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
         1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
-        1. Let _mergedFieldNames_ be the List containing all the elements of _receiverFieldNames_ followed by all the elements of _inputFieldNames_, with duplicate elements removed.
+        1. Let _mergedFieldNames_ be CalendarMergeFieldNames(_receiverFieldNames_, _inputFieldNames_).
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _mergedFieldNames_, «»).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).


### PR DESCRIPTION
"with duplicate elements removed" can be ambiguous, for example the result of `«"a", "b", "a"»` could either be `«"a", "b"»` or `«"b", "a"»`.

