### PR TITLE
Editorial: Use consistent invocations of Difference{Zoned,ISO}DateTime and alias names for object-copy steps

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2600,7 +2600,8 @@ export const ES = ObjectAssign({}, ES2020, {
       GetSlot(dtEnd, ISO_MICROSECOND),
       GetSlot(dtEnd, ISO_NANOSECOND),
       calendar,
-      'day'
+      'day',
+      ObjectCreate(null)
     );
     let intermediateNs = ES.AddZonedDateTime(start, timeZone, calendar, 0, 0, 0, days, 0, 0, 0, 0, 0, 0);
     // may disambiguate
@@ -3927,7 +3928,14 @@ export const ES = ObjectAssign({}, ES2020, {
         ));
       } else {
         ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
-          ES.DifferenceZonedDateTime(GetSlot(relativeTo, EPOCHNANOSECONDS), endNs, timeZone, calendar, largestUnit));
+          ES.DifferenceZonedDateTime(
+            GetSlot(relativeTo, EPOCHNANOSECONDS),
+            endNs,
+            timeZone,
+            calendar,
+            largestUnit,
+            ObjectCreate(null)
+          ));
       }
     }
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -634,18 +634,18 @@
       </dl>
       <emu-alg>
         1. Let _merged_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _originalKeys_ be ? EnumerableOwnPropertyNames(_fields_, ~key~).
-        1. For each element _nextKey_ of _originalKeys_, do
-          1. If _nextKey_ is not *"month"* or *"monthCode"*, then
-            1. Let _propValue_ be ? Get(_fields_, _nextKey_).
+        1. Let _fieldsKeys_ be ? EnumerableOwnPropertyNames(_fields_, ~key~).
+        1. For each element _key_ of _fieldsKeys_, do
+          1. If _key_ is not *"month"* or *"monthCode"*, then
+            1. Let _propValue_ be ? Get(_fields_, _key_).
             1. If _propValue_ is not *undefined*, then
-              1. Perform ! CreateDataPropertyOrThrow(_merged_, _nextKey_, _propValue_).
-        1. Let _newKeys_ be ? EnumerableOwnPropertyNames(_additionalFields_, ~key~).
-        1. For each element _nextKey_ of _newKeys_, do
-          1. Let _propValue_ be ? Get(_additionalFields_, _nextKey_).
+              1. Perform ! CreateDataPropertyOrThrow(_merged_, _key_, _propValue_).
+        1. Let _additionalFieldsKeys_ be ? EnumerableOwnPropertyNames(_additionalFields_, ~key~).
+        1. For each element _key_ of _additionalFieldsKeys_, do
+          1. Let _propValue_ be ? Get(_additionalFields_, _key_).
           1. If _propValue_ is not *undefined*, then
-            1. Perform ! CreateDataPropertyOrThrow(_merged_, _nextKey_, _propValue_).
-        1. If _newKeys_ does not contain either *"month"* or *"monthCode"*, then
+            1. Perform ! CreateDataPropertyOrThrow(_merged_, _key_, _propValue_).
+        1. If _additionalFieldsKeys_ does not contain either *"month"* or *"monthCode"*, then
           1. Let _month_ be ? Get(_fields_, *"month"*).
           1. If _month_ is not *undefined*, then
             1. Perform ! CreateDataPropertyOrThrow(_merged_, *"month"*, _month_).

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1139,9 +1139,9 @@
       <emu-alg>
         1. Let _calendar_ be the *this* value.
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-        1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Set _fields_ to ? ToObject(_fields_).
         1. Set _additionalFields_ to ? ToObject(_additionalFields_).
+        1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Return ? DefaultMergeCalendarFields(_fields_, _additionalFields_).
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1465,7 +1465,7 @@
           1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_diffNs_) &le; 2 &times; nsMaxInstant.
           1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _diffNs_, _largestUnit_).
           1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
-        1. Return ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_).
+        1. Return ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_, OrdinaryObjectCreate(*null*)).
       </emu-alg>
     </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2104,14 +2104,14 @@
             1. Set _additionalFields_ to ? ToObject(_additionalFields_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return ? DefaultMergeCalendarFields(_fields_, _additionalFields_).
-            1. Let _fieldsKeys_ be ? EnumerableOwnPropertyNames(_fields_, ~key~).
             1. Let _fieldsCopied_ be OrdinaryObjectCreate(%Object.prototype%).
+            1. Let _fieldsKeys_ be ? EnumerableOwnPropertyNames(_fields_, ~key~).
             1. For each element _key_ of _fieldsKeys_, do
               1. Let _propValue_ be ? Get(_fields_, _key_).
               1. If _propValue_ is not *undefined*, then
                 1. Perform ! CreateDataPropertyOrThrow(_fieldsCopied_, _key_, _propValue_).
-            1. Let _additionalFieldsKeys_ be ? EnumerableOwnPropertyNames(_additionalFields_, ~key~).
             1. Let _additionalFieldsCopied_ be OrdinaryObjectCreate(%Object.prototype%).
+            1. Let _additionalFieldsKeys_ be ? EnumerableOwnPropertyNames(_additionalFields_, ~key~).
             1. For each element _key_ of _additionalFieldsKeys_, do
               1. Let _propValue_ be ? Get(_additionalFields_, _key_).
               1. If _propValue_ is not *undefined*, then

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2104,19 +2104,19 @@
             1. Set _additionalFields_ to ? ToObject(_additionalFields_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Return ? DefaultMergeCalendarFields(_fields_, _additionalFields_).
-            1. Let _fieldsCopied_ be OrdinaryObjectCreate(%Object.prototype%).
+            1. Let _fieldsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
             1. Let _fieldsKeys_ be ? EnumerableOwnPropertyNames(_fields_, ~key~).
             1. For each element _key_ of _fieldsKeys_, do
               1. Let _propValue_ be ? Get(_fields_, _key_).
               1. If _propValue_ is not *undefined*, then
-                1. Perform ! CreateDataPropertyOrThrow(_fieldsCopied_, _key_, _propValue_).
-            1. Let _additionalFieldsCopied_ be OrdinaryObjectCreate(%Object.prototype%).
+                1. Perform ! CreateDataPropertyOrThrow(_fieldsCopy_, _key_, _propValue_).
+            1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
             1. Let _additionalFieldsKeys_ be ? EnumerableOwnPropertyNames(_additionalFields_, ~key~).
             1. For each element _key_ of _additionalFieldsKeys_, do
               1. Let _propValue_ be ? Get(_additionalFields_, _key_).
               1. If _propValue_ is not *undefined*, then
-                1. Perform ! CreateDataPropertyOrThrow(_additionalFieldsCopied_, _key_, _propValue_).
-            1. Return ! CalendarDateMergeFields(_calendar_.[[Identifier]], _fieldsCopied_, _additionalFieldsCopied_).
+                1. Perform ! CreateDataPropertyOrThrow(_additionalFieldsCopy_, _key_, _propValue_).
+            1. Return ! CalendarDateMergeFields(_calendar_.[[Identifier]], _fieldsCopy_, _additionalFieldsCopy_).
           </emu-alg>
         </emu-clause>
       </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1087,7 +1087,7 @@
           _ns2_: an integer between 0 and 999 inclusive,
           _calendar_: an Object,
           _largestUnit_: a String,
-          optional _options_: an Object,
+          _options_: an Object,
         )
       </h1>
       <dl class="header">
@@ -1099,8 +1099,6 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _options_ is not present, set _options_ to *undefined*.
-        1. Assert: Type(_options_) is Object or Undefined.
         1. Let _timeDifference_ be ! DifferenceTime(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. Let _timeSign_ be ! DurationSign(0, 0, 0, _timeDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]]).
         1. Let _dateSign_ be ! CompareISODate(_y2_, _mon2_, _d2_, _y1_, _mon1_, _d1_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -678,8 +678,8 @@
         1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _optionsCopy_ be OrdinaryObjectCreate(%Object.prototype%).
         1. Let _entries_ be ? EnumerableOwnPropertyNames(_options_, ~key+value~).
-        1. For each element _nextEntry_ of _entries_, do
-          1. Perform ! CreateDataPropertyOrThrow(_optionsCopy_, _nextEntry_[0], _nextEntry_[1]).
+        1. For each element _entry_ of _entries_, do
+          1. Perform ! CreateDataPropertyOrThrow(_optionsCopy_, _entry_[0], _entry_[1]).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _options_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).
         1. Return ? CalendarYearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1261,7 +1261,7 @@
           _timeZone_: an Object,
           _calendar_: an Object,
           _largestUnit_: a String,
-          optional _options_: an Object,
+          _options_: an Object,
         ): either a normal completion containing a Duration Record or an abrupt completion
       </h1>
       <dl class="header">
@@ -1320,7 +1320,7 @@
         1. Let _endNs_ be _startNs_ + _nanoseconds_.
         1. Let _endInstant_ be ! CreateTemporalInstant(ℤ(_endNs_)).
         1. Let _endDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_relativeTo_.[[TimeZone]], _endInstant_, _relativeTo_.[[Calendar]]).
-        1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*).
+        1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*, OrdinaryObjectCreate(*null*)).
         1. Let _days_ be _dateDifference_.[[Days]].
         1. Let _intermediateNs_ be ℝ(? AddZonedDateTime(ℤ(_startNs_), _relativeTo_.[[TimeZone]], _relativeTo_.[[Calendar]], 0, 0, 0, _days_, 0, 0, 0, 0, 0, 0)).
         1. If _sign_ is 1, then


### PR DESCRIPTION
This extracts the editorial aspects of #2245.