### PR TITLE
Normative: Validate fractionalSecondDigits after truncation

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -749,10 +749,10 @@ export const ES = ObjectAssign({}, ES2020, {
       if (digits === 'auto') return { precision: 'auto', unit: 'nanosecond', increment: 1 };
       throw new RangeError(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digits}`);
     }
-    if (NumberIsNaN(digits) || digits < 0 || digits > 9) {
+    const precision = ES.ToInteger(digits);
+    if (!NumberIsFinite(digits) || precision < 0 || precision > 9) {
       throw new RangeError(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digits}`);
     }
-    const precision = MathFloor(digits);
     switch (precision) {
       case 0:
         return { precision, unit: 'second', increment: 1 };

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -749,8 +749,8 @@ export const ES = ObjectAssign({}, ES2020, {
       if (digits === 'auto') return { precision: 'auto', unit: 'nanosecond', increment: 1 };
       throw new RangeError(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digits}`);
     }
-    const precision = ES.ToInteger(digits);
-    if (!NumberIsFinite(digits) || precision < 0 || precision > 9) {
+    const precision = MathTrunc(digits);
+    if (!NumberIsFinite(precision) || precision < 0 || precision > 9) {
       throw new RangeError(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digits}`);
     }
     switch (precision) {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -279,7 +279,7 @@
             [[Increment]]: 1
           }.
       1. If _fractionalDigitsVal_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
-      1. Let _fractionalDigitCount_ be ! ToIntegerOrInfinity(_fractionalDigitsVal_).
+      1. Let _fractionalDigitCount_ be RoundTowardsZero(ℝ(_fractionalDigitsVal_)).
       1. If _fractionalDigitCount_ &lt; 0 or _fractionalDigitCount_ &gt; 9, throw a *RangeError* exception.
       1. If _fractionalDigitCount_ is 0, then
         1. Return the Record {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -279,7 +279,7 @@
             [[Increment]]: 1
           }.
       1. If _fractionalDigitsVal_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
-      1. Let _fractionalDigitCount_ be ! ToIntegerOrInfinity(_fractionalDigitsVal_)).
+      1. Let _fractionalDigitCount_ be ! ToIntegerOrInfinity(_fractionalDigitsVal_).
       1. If _fractionalDigitCount_ &lt; 0 or _fractionalDigitCount_ &gt; 9, throw a *RangeError* exception.
       1. If _fractionalDigitCount_ is 0, then
         1. Return the Record {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -279,8 +279,8 @@
             [[Increment]]: 1
           }.
       1. If _fractionalDigitsVal_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
-      1. If ℝ(_fractionalDigitsVal_) &lt; 0 or ℝ(_fractionalDigitsVal_) > 9, throw a *RangeError* exception.
-      1. Let _fractionalDigitCount_ be floor(ℝ(_fractionalDigitsVal_)).
+      1. Let _fractionalDigitCount_ be ! ToIntegerOrInfinity(_fractionalDigitsVal_)).
+      1. If _fractionalDigitCount_ &lt; 0 or _fractionalDigitCount_ &gt; 9, throw a *RangeError* exception.
       1. If _fractionalDigitCount_ is 0, then
         1. Return the Record {
             [[Precision]]: 0,


### PR DESCRIPTION
Fixes #2296

The result is consistent with my ECMA-402 proposal at https://github.com/tc39/ecma402/issues/691 (reject non-numeric input and perform validation of numeric input after truncation).