### PR TITLE
Editorial: MergeLargestUnitOption is always called with an Object options value

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -505,7 +505,7 @@
   <emu-clause id="sec-temporal-mergelargestunitoption" type="abstract operation">
     <h1>
       MergeLargestUnitOption (
-        _options_: an Object or *undefined*,
+        _options_: an Object,
         _largestUnit_: a String,
       ): either a normal completion containing an Object, or an abrupt completion
     </h1>
@@ -514,7 +514,6 @@
       <dd>It returns a new plain Object with enumerable own String properties copied from the _options_ Object, and the `largestUnit` property set to _largestUnit_.</dd>
     </dl>
     <emu-alg>
-      1. If _options_ is *undefined*, set _options_ to OrdinaryObjectCreate(*null*).
       1. Let _merged_ be OrdinaryObjectCreate(%Object.prototype%).
       1. Let _keys_ be ? EnumerableOwnPropertyNames(_options_, ~key~).
       1. For each element _nextKey_ of _keys_, do

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1271,8 +1271,6 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _options_ is not present, set _options_ to *undefined*.
-        1. Assert: Type(_options_) is Object or Undefined.
         1. If _ns1_ is _ns2_, then
           1. Return ! CreateDurationRecord(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _startInstant_ be ! CreateTemporalInstant(_ns1_).


### PR DESCRIPTION
`MergeLargestUnitOption` is no longer called with `options == undefined`.