### PR TITLE
Editorial: Generalize CalendarMergeFieldNames out of Temporal

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -651,29 +651,6 @@
         1. Return _merged_.
       </emu-alg>
     </emu-clause>
-
-    <emu-clause id="sec-temporal-mergelists" type="abstract operation">
-      <h1>
-        MergeLists (
-          _a_: a List,
-          _b_: a List,
-        ): a List
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns the list-concatenation of its arguments, with duplicate elements removed.</dd>
-      </dl>
-      <emu-alg>
-        1. Let _merged_ be a new empty List.
-        1. For each element _element_ of _a_, do
-          1. If _merged_ does not contain _element_, then
-            1. Append _element_ to _merged_.
-        1. For each element _element_ of _b_, do
-          1. If _merged_ does not contain _element_, then
-            1. Append _element_ to _merged_.
-        1. Return _merged_.
-      </emu-alg>
-    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-temporal-calendar-constructor">

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -652,25 +652,25 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-calendarmergefieldnames" type="abstract operation">
+    <emu-clause id="sec-temporal-mergelists" type="abstract operation">
       <h1>
-        CalendarMergeFieldNames (
-          _receiverFieldNames_: a List,
-          _inputFieldNames_: a List,
+        MergeLists (
+          _a_: a List,
+          _b_: a List,
         ): a List
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the List containing all the elements of _receiverFieldNames_ followed by all the elements of _inputFieldNames_, with duplicate elements removed.</dd>
+        <dd>It returns the list-concatenation of its arguments, with duplicate elements removed.</dd>
       </dl>
       <emu-alg>
         1. Let _merged_ be a new empty List.
-        1. For each element _name_ of _receiverFieldNames_, do
-          1. If _merged_ does not contain _name_, then
-            1. Append _name_ to _merged_.
-        1. For each element _name_ of _inputFieldNames_, do
-          1. If _merged_ does not contain _name_, then
-            1. Append _name_ to _merged_.
+        1. For each element _element_ of _a_, do
+          1. If _merged_ does not contain _element_, then
+            1. Append _element_ to _merged_.
+        1. For each element _element_ of _b_, do
+          1. If _merged_ does not contain _element_, then
+            1. Append _element_ to _merged_.
         1. Return _merged_.
       </emu-alg>
     </emu-clause>

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -11,6 +11,31 @@
     </p>
   </emu-note>
 
+  <ins class="block">
+    <emu-clause id="sec-temporal-mergelists" type="abstract operation">
+      <h1>
+        MergeLists (
+          _a_: a List,
+          _b_: a List,
+        ): a List
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the list-concatenation of its arguments, with duplicate elements removed.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _merged_ be a new empty List.
+        1. For each element _element_ of _a_, do
+          1. If _merged_ does not contain _element_, then
+            1. Append _element_ to _merged_.
+        1. For each element _element_ of _b_, do
+          1. If _merged_ does not contain _element_, then
+            1. Append _element_ to _merged_.
+        1. Return _merged_.
+      </emu-alg>
+    </emu-clause>
+  </ins>
+
   <emu-clause id="sec-literals-numeric-literals">
     <h1><a href="https://tc39.es/ecma262/#sec-literals-numeric-literals">Numeric Literals</a></h1>
     <emu-note type="editor">

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -247,7 +247,7 @@
         1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"year"* »).
         1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
         1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
-        1. Let _mergedFieldNames_ be CalendarMergeFieldNames(_receiverFieldNames_, _inputFieldNames_).
+        1. Let _mergedFieldNames_ be MergeLists(_receiverFieldNames_, _inputFieldNames_).
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _mergedFieldNames_, «»).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -381,7 +381,7 @@
         1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"day"* »).
         1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
         1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
-        1. Let _mergedFieldNames_ be CalendarMergeFieldNames(_receiverFieldNames_, _inputFieldNames_).
+        1. Let _mergedFieldNames_ be MergeLists(_receiverFieldNames_, _inputFieldNames_).
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _mergedFieldNames_, «»).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).


### PR DESCRIPTION
* ~~Refactor CalendarFields for better linearity~~
* Generalize CalendarMergeFieldNames into non-Temporal ECMA-262 amendments