### PR TITLE
Normative: Check for invalid epoch nanoseconds in Temporal.TimeZone.prototype.get{Next,Previous}Transition

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -308,6 +308,7 @@
         1. If _timeZone_.[[OffsetNanoseconds]] is not *undefined*, return *null*.
         1. Let _transition_ be GetIANATimeZoneNextTransition(_startingPoint_.[[Nanoseconds]], _timeZone_.[[Identifier]]).
         1. If _transition_ is *null*, return *null*.
+        1. If ! IsValidEpochNanoseconds(_transition_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_transition_).
       </emu-alg>
     </emu-clause>
@@ -325,6 +326,7 @@
         1. If _timeZone_.[[OffsetNanoseconds]] is not *undefined*, return *null*.
         1. Let _transition_ be GetIANATimeZonePreviousTransition(_startingPoint_.[[Nanoseconds]], _timeZone_.[[Identifier]]).
         1. If _transition_ is *null*, return *null*.
+        1. If ! IsValidEpochNanoseconds(_transition_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_transition_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
`GetIANATimeZoneNextTransition` and `GetIANATimeZonePreviousTransition`
aren't required to return an epoch nanoseconds value which is within the
supported range, therefore we have to call `IsValidEpochNanoseconds`
before invoking `CreateTemporalInstant`.