### PR TITLE
Normative: Check for invalid epoch nanoseconds in Temporal.TimeZone.prototype.getPossibleInstantsFor

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -291,9 +291,6 @@
           1. Append _instant_ to _possibleInstants_.
         1. Return CreateArrayFromList(_possibleInstants_).
       </emu-alg>
-      <p>
-        This function is the <dfn>%Temporal.TimeZone.prototype.getPossibleInstantsFor%</dfn> intrinsic object.
-      </p>
     </emu-clause>
 
     <emu-clause id="sec-temporal.timezone.prototype.getnexttransition">

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -281,9 +281,9 @@
         1. Set _dateTime_ to ? ToTemporalDateTime(_dateTime_).
         1. If _timeZone_.[[OffsetNanoseconds]] is not *undefined*, then
           1. Let _epochNanoseconds_ be GetEpochFromISOParts(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
-          1. Let _instant_ be ! CreateTemporalInstant(_epochNanoseconds_ - ℤ(_timeZone_.[[OffsetNanoseconds]])).
-          1. Return CreateArrayFromList(« _instant_ »).
-        1. Let _possibleEpochNanoseconds_ be GetIANATimeZoneEpochValue(_timeZone_.[[Identifier]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
+          1. Let _possibleEpochNanoseconds_ be « _epochNanoseconds_ - ℤ(_timeZone_.[[OffsetNanoseconds]]) ».
+        1. Else,
+          1. Let _possibleEpochNanoseconds_ be GetIANATimeZoneEpochValue(_timeZone_.[[Identifier]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
         1. Let _possibleInstants_ be a new empty List.
         1. For each value _epochNanoseconds_ in _possibleEpochNanoseconds_, do
           1. Let _instant_ be ! CreateTemporalInstant(_epochNanoseconds_).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -286,6 +286,7 @@
           1. Let _possibleEpochNanoseconds_ be GetIANATimeZoneEpochValue(_timeZone_.[[Identifier]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
         1. Let _possibleInstants_ be a new empty List.
         1. For each value _epochNanoseconds_ in _possibleEpochNanoseconds_, do
+          1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
           1. Let _instant_ be ! CreateTemporalInstant(_epochNanoseconds_).
           1. Append _instant_ to _possibleInstants_.
         1. Return CreateArrayFromList(_possibleInstants_).


### PR DESCRIPTION
Invalid epoch nanoseconds can be trivially created for offset-only timezones. And `GetIANATimeZoneEpochValue` can also return epoch nanoseconds values outside the valid range. Therefore we have to check `IsValidEpochNanoseconds` before calling `CreateTemporalInstant`.