### PR TITLE
Normative: Refactor CalendarFields for better linearity

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1502,7 +1502,8 @@ export const ES = ObjectAssign({}, ES2022, {
   },
   CalendarFields: (calendar, fieldNames) => {
     const fields = ES.GetMethod(calendar, 'fields');
-    if (fields !== undefined) fieldNames = ES.Call(fields, calendar, [fieldNames]);
+    if (fields === undefined) return fieldNames;
+    fieldNames = ES.Call(fields, calendar, [fieldNames]);
     const result = [];
     for (const name of fieldNames) {
       if (ES.Type(name) !== 'String') throw new TypeError('bad return from calendar.fields()');

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -99,9 +99,8 @@
       </p>
       <emu-alg>
         1. Let _fields_ be ? GetMethod(_calendar_, *"fields"*).
-        1. Let _fieldsArray_ be CreateArrayFromList(_fieldNames_).
-        1. If _fields_ is not *undefined*, then
-          1. Set _fieldsArray_ to ? Call(_fields_, _calendar_, « _fieldsArray_ »).
+        1. If _fields_ is *undefined*, return _fieldNames_.
+        1. Let _fieldsArray_ be ? Call(_fields_, _calendar_, « CreateArrayFromList(_fieldNames_) »).
         1. Return ? IterableToListOfType(_fieldsArray_, « String »).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
...and to prevent unnecessarily-observable calls to iterator methods for purely internal purposes.