### PR TITLE
Editorial: Simplify GetTemporalUnit by rename extraValues as extraValue and as a single item instead of a list

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -315,7 +315,7 @@
         _key_: a property key,
         _unitGroup_: ~date~, ~time~, or ~datetime~,
         _default_: ~required~ or an ECMAScript language value,
-        optional _extraValues_: a List of ECMAScript language values,
+        optional _extraValue_: an ECMAScript language value,
       ): either a normal completion containing an ECMAScript language value, or an abrupt completion
     </h1>
     <dl class="header">
@@ -331,8 +331,8 @@
         1. Let _unit_ be the value in the Singular column of the row.
         1. If the Category column of the row is ~date~ and _unitGroup_ is ~date~ or ~datetime~, append _unit_ to _singularNames_.
         1. Else if the Category column of the row is ~time~ and _unitGroup_ is ~time~ or ~datetime~, append _unit_ to _singularNames_.
-      1. If _extraValues_ is present, then
-        1. Set _singularNames_ to the list-concatenation of _singularNames_ and _extraValues_.
+      1. If _extraValue_ is present, then
+        1. Append _extraValue_ to _singularNames_.
       1. If _default_ is ~required~, then
         1. Let _defaultValue_ be *undefined*.
       1. Else,

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -419,7 +419,7 @@
           1. Set _smallestUnit_ to *"nanosecond"*.
         1. Let _defaultLargestUnit_ be ! DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
         1. Set _defaultLargestUnit_ to ! LargerOfTwoTemporalUnits(_defaultLargestUnit_, _smallestUnit_).
-        1. Let _largestUnit_ be ? GetTemporalUnit(_roundTo_, *"largestUnit"*, ~datetime~, *undefined*, « *"auto"* »).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_roundTo_, *"largestUnit"*, ~datetime~, *undefined*, *"auto"*).
         1. If _largestUnit_ is *undefined*, then
           1. Set _largestUnitPresent_ to *false*.
           1. Set _largestUnit_ to _defaultLargestUnit_.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -512,7 +512,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, *"day"*).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -727,7 +727,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, *"day"*).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].


### PR DESCRIPTION
There are no current usage passing more than one item in the list, make it general is overkill and introduce unncessary complexity.