### PR TITLE
Editorial: Consistent prose for functions and methods

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -26,7 +26,7 @@
     <emu-clause id="sec-temporal.instant">
       <h1>Temporal.Instant ( _epochNanoseconds_ )</h1>
       <p>
-        When the `Temporal.Instant` function is called, the following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. If NewTarget is *undefined*, then
@@ -52,8 +52,7 @@
     <emu-clause id="sec-temporal.instant.from">
       <h1>Temporal.Instant.from ( _item_ )</h1>
       <p>
-        The `from` method takes one argument _item_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. If Type(_item_) is Object and _item_ has an [[InitializedTemporalInstant]] internal slot, then
@@ -65,8 +64,7 @@
     <emu-clause id="sec-temporal.instant.fromepochseconds">
       <h1>Temporal.Instant.fromEpochSeconds ( _epochSeconds_ )</h1>
       <p>
-        The `fromEpochSeconds` method takes one argument _epochSeconds_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _epochSeconds_ to ? ToNumber(_epochSeconds_).
@@ -80,8 +78,7 @@
     <emu-clause id="sec-temporal.instant.fromepochmilliseconds">
       <h1>Temporal.Instant.fromEpochMilliseconds ( _epochMilliseconds_ )</h1>
       <p>
-        The `fromEpochMilliseconds` method takes one argument _epochMilliseconds_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _epochMilliseconds_ to ? ToNumber(_epochMilliseconds_).
@@ -95,8 +92,7 @@
     <emu-clause id="sec-temporal.instant.fromepochmicroseconds">
       <h1>Temporal.Instant.fromEpochMicroseconds ( _epochMicroseconds_ )</h1>
       <p>
-        The `fromEpochMicroseconds` method takes one argument _epochMicroseconds_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _epochMicroseconds_ to ? ToBigInt(_epochMicroseconds_).
@@ -109,8 +105,7 @@
     <emu-clause id="sec-temporal.instant.fromepochnanoseconds">
       <h1>Temporal.Instant.fromEpochNanoseconds ( _epochNanoseconds_ )</h1>
       <p>
-        The `fromEpochNanoseconds` method takes one argument _epochNanoseconds_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _epochNanoseconds_ to ? ToBigInt(_epochNanoseconds_).
@@ -122,8 +117,7 @@
     <emu-clause id="sec-temporal.instant.compare">
       <h1>Temporal.Instant.compare ( _one_, _two_ )</h1>
       <p>
-        The `compare` method takes two arguments, _one_ and _two_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _one_ to ? ToTemporalInstant(_one_).
@@ -220,8 +214,7 @@
     <emu-clause id="sec-temporal.instant.prototype.add">
       <h1>Temporal.Instant.prototype.add ( _temporalDurationLike_ )</h1>
       <p>
-        The `add` method takes one argument _temporalDurationLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -233,8 +226,7 @@
     <emu-clause id="sec-temporal.instant.prototype.subtract">
       <h1>Temporal.Instant.prototype.subtract ( _temporalDurationLike_ )</h1>
       <p>
-        The `subtract` method takes one argument _temporalDurationLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -246,8 +238,7 @@
     <emu-clause id="sec-temporal.instant.prototype.until">
       <h1>Temporal.Instant.prototype.until ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `until` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -259,8 +250,7 @@
     <emu-clause id="sec-temporal.instant.prototype.since">
       <h1>Temporal.Instant.prototype.since ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `since` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -272,8 +262,7 @@
     <emu-clause id="sec-temporal.instant.prototype.round">
       <h1>Temporal.Instant.prototype.round ( _roundTo_ )</h1>
       <p>
-        The `round` method takes one argument _roundTo_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -310,8 +299,7 @@
     <emu-clause id="sec-temporal.instant.prototype.equals">
       <h1>Temporal.Instant.prototype.equals ( _other_ )</h1>
       <p>
-        The `equals` method takes one argument _other_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -325,8 +313,7 @@
     <emu-clause id="sec-temporal.instant.prototype.tostring">
       <h1>Temporal.Instant.prototype.toString ( [ _options_ ] )</h1>
       <p>
-        The `toString` method takes one argument _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -346,11 +333,14 @@
     <emu-clause id="sec-temporal.instant.prototype.tolocalestring">
       <h1>Temporal.Instant.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
       <p>
-        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Instant.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.
       </p>
       <p>
-        The `toLocaleString` method takes two arguments, _locales_ and _options_.
-        The following steps are taken:
+        The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.
+      </p>
+      <p>
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -362,7 +352,7 @@
     <emu-clause id="sec-temporal.instant.prototype.tojson">
       <h1>Temporal.Instant.prototype.toJSON ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -374,7 +364,7 @@
     <emu-clause id="sec-temporal.instant.prototype.valueof">
       <h1>Temporal.Instant.prototype.valueOf ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Throw a *TypeError* exception.
@@ -384,8 +374,7 @@
     <emu-clause id="sec-temporal.instant.prototype.tozoneddatetime">
       <h1>Temporal.Instant.prototype.toZonedDateTime ( _item_ )</h1>
       <p>
-        The `toZonedDateTime` method takes one argument _item_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
@@ -407,8 +396,7 @@
     <emu-clause id="sec-temporal.instant.prototype.tozoneddatetimeiso">
       <h1>Temporal.Instant.prototype.toZonedDateTimeISO ( _item_ )</h1>
       <p>
-        The `toZonedDateTimeISO` method takes one argument _item_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1639,7 +1639,7 @@
           <h1>Temporal.Calendar.prototype.dateFromFields ( _fields_ [ , _options_ ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.datefromfields"></emu-xref>.</p>
           <p>
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1660,7 +1660,7 @@
           <h1>Temporal.Calendar.prototype.yearMonthFromFields ( _fields_ [ , _options_ ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.yearmonthfromfields"></emu-xref>.</p>
           <p>
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1682,7 +1682,7 @@
           <h1>Temporal.Calendar.prototype.monthDayFromFields ( _fields_ [ , _options_ ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.monthdayfromfields"></emu-xref>.</p>
           <p>
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1704,7 +1704,7 @@
           <h1>Temporal.Calendar.prototype.dateAdd ( _date_, _duration_ [ , _options_ ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.dateadd"></emu-xref>.</p>
           <p>
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1727,8 +1727,7 @@
           <h1>Temporal.Calendar.prototype.dateUntil ( _one_, _two_ [ , _options_ ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.dateuntil"></emu-xref>.</p>
           <p>
-            The `dateUntil` method takes three arguments, _one_, _two_, and _options_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1750,8 +1749,7 @@
         <emu-clause id="sec-temporal.calendar.prototype.era">
           <h1>Temporal.Calendar.prototype.era ( _temporalDateLike_ )</h1>
           <p>
-            The `era` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1767,8 +1765,7 @@
         <emu-clause id="sec-temporal.calendar.prototype.erayear">
           <h1>Temporal.Calendar.prototype.eraYear ( _temporalDateLike_ )</h1>
           <p>
-            The `eraYear` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1788,8 +1785,7 @@
           <h1>Temporal.Calendar.prototype.year ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.year"></emu-xref>.</p>
           <p>
-            The `year` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1808,8 +1804,7 @@
           <h1>Temporal.Calendar.prototype.month ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.month"></emu-xref>.</p>
           <p>
-            The `month` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1830,8 +1825,7 @@
           <h1>Temporal.Calendar.prototype.monthCode ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.monthcode"></emu-xref>.</p>
           <p>
-            The `monthCode` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1850,8 +1844,7 @@
           <h1>Temporal.Calendar.prototype.day ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.day"></emu-xref>.</p>
           <p>
-            The `day` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1870,8 +1863,7 @@
           <h1>Temporal.Calendar.prototype.dayOfWeek ( _dateOrDateTime_ )</h1>
           <p>This definition supersedes the definition _temporalDateLike_ in <emu-xref href="#sec-temporal.calendar.prototype.dayofweek"></emu-xref>.</p>
           <p>
-            The `dayOfWeek` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1892,8 +1884,7 @@
           <h1>Temporal.Calendar.prototype.dayOfYear ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.dayofyear"></emu-xref>.</p>
           <p>
-            The `dayOfYear` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1912,8 +1903,7 @@
           <h1>Temporal.Calendar.prototype.weekOfYear ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.weekofyear"></emu-xref>.</p>
           <p>
-            The `weekOfYear` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1931,8 +1921,7 @@
           <h1>Temporal.Calendar.prototype.daysInWeek ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.daysinweek"></emu-xref>.</p>
           <p>
-            The `daysInWeek` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1950,8 +1939,7 @@
           <h1>Temporal.Calendar.prototype.daysInMonth ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.daysinmonth"></emu-xref>.</p>
           <p>
-            The `daysInMonth` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1970,8 +1958,7 @@
           <h1>Temporal.Calendar.prototype.daysInYear ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.daysinyear"></emu-xref>.</p>
           <p>
-            The `daysInYear` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -1989,8 +1976,7 @@
           <h1>Temporal.Calendar.prototype.monthsInYear ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.monthsinyear"></emu-xref>.</p>
           <p>
-            The `monthsInYear` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -2009,8 +1995,7 @@
           <h1>Temporal.Calendar.prototype.inLeapYear ( _temporalDateLike_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.inleapyear"></emu-xref>.</p>
           <p>
-            The `inLeapYear` method takes one argument _temporalDateLike_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -2032,8 +2017,7 @@
           <h1>Temporal.Calendar.prototype.fields ( _fields_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.fields"></emu-xref>.</p>
           <p>
-            The `fields` method takes one argument _fields_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -2067,8 +2051,7 @@
           <h1>Temporal.Calendar.prototype.mergeFields ( _fields_, _additionalFields_ )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.mergefields"></emu-xref>.</p>
           <p>
-            The `mergeFields` method takes two arguments, _fields_ and _additionalFields_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _calendar_ be the *this* value.
@@ -2113,8 +2096,7 @@
           <h1>Temporal.Instant.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.instant.prototype.tolocalestring"></emu-xref>.</p>
           <p>
-            The `toLocaleString` method takes two arguments, _locales_ and _options_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _instant_ be the *this* value.
@@ -2131,8 +2113,7 @@
           <h1>Temporal.PlainDate.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.plaindate.prototype.tolocalestring"></emu-xref>.</p>
           <p>
-            The `toLocaleString` method takes two arguments, _locales_ and _options_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _temporalDate_ be the *this* value.
@@ -2177,8 +2158,7 @@
           <h1>Temporal.PlainDateTime.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.plaindatetime.prototype.tolocalestring"></emu-xref>.</p>
           <p>
-            The `toLocaleString` method takes two arguments, _locales_ and _options_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _dateTime_ be the *this* value.
@@ -2223,8 +2203,7 @@
           <h1>Temporal.PlainMonthDay.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.plainmonthday.prototype.tolocalestring"></emu-xref>.</p>
           <p>
-            The `toLocaleString` method takes two arguments, _locales_ and _options_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _monthDay_ be the *this* value.
@@ -2241,8 +2220,7 @@
           <h1>Temporal.PlainTime.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.plaintime.prototype.tolocalestring"></emu-xref>.</p>
           <p>
-            The `toLocaleString` method takes two arguments, _locales_ and _options_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _temporalTime_ be the *this* value.
@@ -2259,8 +2237,7 @@
           <h1>Temporal.PlainYearMonth.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.plainyearmonth.prototype.tolocalestring"></emu-xref>.</p>
           <p>
-            The `toLocaleString` method takes two arguments, _locales_ and _options_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _yearMonth_ be the *this* value.
@@ -2305,8 +2282,7 @@
           <h1>Temporal.ZonedDateTime.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
           <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.zoneddatetime.prototype.tolocalestring"></emu-xref>.</p>
           <p>
-            The `toLocaleString` method takes two arguments, _locales_ and _options_.
-            The following steps are taken:
+            This method performs the following steps when called:
           </p>
           <emu-alg>
             1. Let _zonedDateTime_ be the *this* value.

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -76,7 +76,7 @@
     <ins class="block">
       <emu-clause id="sec-date.prototype.totemporalinstant">
         <h1>Date.prototype.toTemporalInstant ( )</h1>
-        <p>The following steps are performed:</p>
+        <p>This method performs the following steps when called:</p>
         <emu-alg>
           1. Let _t_ be ? thisTimeValue(*this* value).
           1. Let _ns_ be ? NumberToBigInt(_t_) &times; ℤ(10<sup>6</sup>).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -28,7 +28,7 @@
     <emu-clause id="sec-temporal.plaindate">
       <h1>Temporal.PlainDate ( _isoYear_, _isoMonth_, _isoDay_ [ , _calendarLike_ ] )</h1>
       <p>
-        When the `Temporal.PlainDate` function is called, the following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
@@ -59,8 +59,7 @@
     <emu-clause id="sec-temporal.plaindate.from">
       <h1>Temporal.PlainDate.from ( _item_ [ , _options_ ] )</h1>
       <p>
-        The `from` method takes two arguments, _item_ and _options_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
@@ -74,8 +73,7 @@
     <emu-clause id="sec-temporal.plaindate.compare">
       <h1>Temporal.PlainDate.compare ( _one_, _two_ )</h1>
       <p>
-        The `compare` method takes two arguments, _one_ and _two_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _one_ to ? ToTemporalDate(_one_).
@@ -294,7 +292,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.toplainyearmonth">
       <h1>Temporal.PlainDate.prototype.toPlainYearMonth ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -309,7 +307,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.toplainmonthday">
       <h1>Temporal.PlainDate.prototype.toPlainMonthDay ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -324,7 +322,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.getisofields">
       <h1>Temporal.PlainDate.prototype.getISOFields ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -341,8 +339,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.add">
       <h1>Temporal.PlainDate.prototype.add ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>
-        The `add` method takes two arguments, _temporalDurationLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -356,8 +353,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.subtract">
       <h1>Temporal.PlainDate.prototype.subtract ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>
-        The `subtract` method takes two arguments, _temporalDurationLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -372,8 +368,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.with">
       <h1>Temporal.PlainDate.prototype.with ( _temporalDateLike_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _temporalDateLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -395,8 +390,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.withcalendar">
       <h1>Temporal.PlainDate.prototype.withCalendar ( _calendarLike_ )</h1>
       <p>
-        The `withCalendar` method takes one argument _calendarLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -409,8 +403,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.until">
       <h1>Temporal.PlainDate.prototype.until ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `until` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -422,8 +415,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.since">
       <h1>Temporal.PlainDate.prototype.since ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `since` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -435,8 +427,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.equals">
       <h1>Temporal.PlainDate.prototype.equals ( _other_ )</h1>
       <p>
-        The `equals` method takes one argument _other_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -452,8 +443,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.toplaindatetime">
       <h1>Temporal.PlainDate.prototype.toPlainDateTime ( [ _temporalTime_ ] )</h1>
       <p>
-        The `toPlainDateTime` method takes one argument _temporalTime_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -471,8 +461,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.tozoneddatetime">
       <h1>Temporal.PlainDate.prototype.toZonedDateTime ( _item_ )</h1>
       <p>
-        The `toZonedDateTime` method takes one argument _item_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -501,8 +490,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.tostring">
       <h1>Temporal.PlainDate.prototype.toString ( [ _options_ ] )</h1>
       <p>
-        The `toString` method takes one argument _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -516,11 +504,14 @@
     <emu-clause id="sec-temporal.plaindate.prototype.tolocalestring">
       <h1>Temporal.PlainDate.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
       <p>
-        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.PlainDate.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.
       </p>
       <p>
-        The `toLocaleString` method takes two arguments, _locales_ and _options_.
-        The following steps are taken:
+        The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.
+      </p>
+      <p>
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -532,7 +523,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.tojson">
       <h1>Temporal.PlainDate.prototype.toJSON ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
@@ -544,7 +535,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype.valueof">
       <h1>Temporal.PlainDate.prototype.valueOf ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Throw a *TypeError* exception.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -26,7 +26,7 @@
     <emu-clause id="sec-temporal.plaindatetime">
       <h1>Temporal.PlainDateTime ( _isoYear_, _isoMonth_, _isoDay_ [ , _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ [ , _microsecond_ [ , _nanosecond_ [ , _calendarLike_ ] ] ] ] ] ] ] )</h1>
       <p>
-        When the `Temporal.PlainDateTime` function is called, the following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
@@ -61,8 +61,7 @@
     <emu-clause id="sec-temporal.plaindatetime.from">
       <h1>Temporal.PlainDateTime.from ( _item_ [ , _options_ ] )</h1>
       <p>
-        The `from` method takes two arguments, _item_ and _options_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
@@ -76,8 +75,7 @@
     <emu-clause id="sec-temporal.plaindatetime.compare">
       <h1>Temporal.PlainDateTime.compare ( _one_, _two_ )</h1>
       <p>
-        The `compare` method takes two arguments, _one_ and _two_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _one_ to ? ToTemporalDateTime(_one_).
@@ -375,8 +373,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.with">
       <h1>Temporal.PlainDateTime.prototype.with ( _temporalDateTimeLike_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _temporalDateTimeLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -401,8 +398,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.withplaintime">
       <h1>Temporal.PlainDateTime.prototype.withPlainTime ( [ _plainTimeLike_ ] )</h1>
       <p>
-        The `withPlainTime` method takes one argument _plainTimeLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -417,8 +413,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.withplaindate">
       <h1>Temporal.PlainDateTime.prototype.withPlainDate ( _plainDateLike_ )</h1>
       <p>
-        The `withPlainDate` method takes one argument _plainDateLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -432,8 +427,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.withcalendar">
       <h1>Temporal.PlainDateTime.prototype.withCalendar ( _calendarLike_ )</h1>
       <p>
-        The `withCalendar` method takes one argument _calendarLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -446,8 +440,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.add">
       <h1>Temporal.PlainDateTime.prototype.add ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>
-        The `add` method takes two arguments, _temporalDurationLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -459,8 +452,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.subtract">
       <h1>Temporal.PlainDateTime.prototype.subtract ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>
-        The `subtract` method takes two arguments, _temporalDurationLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -472,8 +464,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.until">
       <h1>Temporal.PlainDateTime.prototype.until ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `until` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -485,8 +476,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.since">
       <h1>Temporal.PlainDateTime.prototype.since ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `since` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -498,8 +488,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.round">
       <h1>Temporal.PlainDateTime.prototype.round ( _roundTo_ )</h1>
       <p>
-        The `round` method takes one argument _roundTo_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -523,8 +512,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.equals">
       <h1>Temporal.PlainDateTime.prototype.equals ( _other_ )</h1>
       <p>
-        The `equals` method takes one argument _other_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -539,8 +527,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.tostring">
       <h1>Temporal.PlainDateTime.prototype.toString ( [ _options_ ] )</h1>
       <p>
-        The `toString` method takes one argument _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -557,11 +544,14 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.tolocalestring">
       <h1>Temporal.PlainDateTime.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
       <p>
-        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.PlainDateTime.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.
       </p>
       <p>
-        The `toLocaleString` method takes two arguments, _locales_ and _options_.
-        The following steps are taken:
+        The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.
+      </p>
+      <p>
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -573,7 +563,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.tojson">
       <h1>Temporal.PlainDateTime.prototype.toJSON ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -585,7 +575,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.valueof">
       <h1>Temporal.PlainDateTime.prototype.valueOf ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Throw a *TypeError* exception.
@@ -595,8 +585,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.tozoneddatetime">
       <h1>Temporal.PlainDateTime.prototype.toZonedDateTime ( _temporalTimeZoneLike_ [ , _options_ ] )</h1>
       <p>
-        The `toZonedDateTime` method takes two arguments, _temporalTimeZoneLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -612,7 +601,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.toplaindate">
       <h1>Temporal.PlainDateTime.prototype.toPlainDate ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -624,7 +613,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.toplainyearmonth">
       <h1>Temporal.PlainDateTime.prototype.toPlainYearMonth ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -639,7 +628,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.toplainmonthday">
       <h1>Temporal.PlainDateTime.prototype.toPlainMonthDay ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -654,7 +643,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.toplaintime">
       <h1>Temporal.PlainDateTime.prototype.toPlainTime ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
@@ -666,7 +655,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype.getisofields">
       <h1>Temporal.PlainDateTime.prototype.getISOFields ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be the *this* value.

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -26,7 +26,7 @@
     <emu-clause id="sec-temporal.plainmonthday">
       <h1>Temporal.PlainMonthDay ( _isoMonth_, _isoDay_ [ , _calendarLike_ [ , _referenceISOYear_ ] ] )</h1>
       <p>
-        When the `Temporal.PlainMonthDay` function is called, the following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
@@ -58,8 +58,7 @@
     <emu-clause id="sec-temporal.plainmonthday.from">
       <h1>Temporal.PlainMonthDay.from ( _item_ [ , _options_ ] )</h1>
       <p>
-        The `from` method takes two arguments, _item_ and _options_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
@@ -140,8 +139,7 @@
     <emu-clause id="sec-temporal.plainmonthday.prototype.with">
       <h1>Temporal.PlainMonthDay.prototype.with ( _temporalMonthDayLike_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _temporalMonthDayLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
@@ -163,8 +161,7 @@
     <emu-clause id="sec-temporal.plainmonthday.prototype.equals">
       <h1>Temporal.PlainMonthDay.prototype.equals ( _other_ )</h1>
       <p>
-        The `equals` method takes one argument _other_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
@@ -180,8 +177,7 @@
     <emu-clause id="sec-temporal.plainmonthday.prototype.tostring">
       <h1>Temporal.PlainMonthDay.prototype.toString ( [ _options_ ] )</h1>
       <p>
-        The `toString` method takes one argument _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
@@ -195,11 +191,14 @@
     <emu-clause id="sec-temporal.plainmonthday.prototype.tolocalestring">
       <h1>Temporal.PlainMonthDay.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
       <p>
-        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.PlainMonthDay.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.
       </p>
       <p>
-        The `toLocaleString` method takes two arguments, _locales_ and _options_.
-        The following steps are taken:
+        The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.
+      </p>
+      <p>
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
@@ -211,7 +210,7 @@
     <emu-clause id="sec-temporal.plainmonthday.prototype.tojson">
       <h1>Temporal.PlainMonthDay.prototype.toJSON ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
@@ -223,7 +222,7 @@
     <emu-clause id="sec-temporal.plainmonthday.prototype.valueof">
       <h1>Temporal.PlainMonthDay.prototype.valueOf ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Throw a *TypeError* exception.
@@ -233,8 +232,7 @@
     <emu-clause id="sec-temporal.plainmonthday.prototype.toplaindate">
       <h1>Temporal.PlainMonthDay.prototype.toPlainDate ( _item_ )</h1>
       <p>
-        The `toPlainDate` method takes one argument _item_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
@@ -258,7 +256,7 @@
     <emu-clause id="sec-temporal.plainmonthday.prototype.getisofields">
       <h1>Temporal.PlainMonthDay.prototype.getISOFields ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _monthDay_ be the *this* value.

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -27,7 +27,7 @@
     <emu-clause id="sec-temporal.plaintime">
       <h1>Temporal.PlainTime ( [ _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ [ , _microsecond_ [ , _nanosecond_ ] ] ] ] ] ] )</h1>
       <p>
-        When the `Temporal.PlainTime` function is called, the following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
@@ -59,8 +59,7 @@
     <emu-clause id="sec-temporal.plaintime.from">
       <h1>Temporal.PlainTime.from ( _item_ [ , _options_ ] )</h1>
       <p>
-        The `from` method takes two arguments, _item_ and _options_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
@@ -74,8 +73,7 @@
     <emu-clause id="sec-temporal.plaintime.compare">
       <h1>Temporal.PlainTime.compare ( _one_, _two_ )</h1>
       <p>
-        The `compare` method takes two arguments, _one_ and _two_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _one_ to ? ToTemporalTime(_one_).
@@ -204,8 +202,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.add">
       <h1>Temporal.PlainTime.prototype.add ( _temporalDurationLike_ )</h1>
       <p>
-        The `add` method takes one argument _temporalDurationLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -217,8 +214,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.subtract">
       <h1>Temporal.PlainTime.prototype.subtract ( _temporalDurationLike_ )</h1>
       <p>
-        The `subtract` method takes one argument _temporalDurationLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -230,8 +226,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.with">
       <h1>Temporal.PlainTime.prototype.with ( _temporalTimeLike_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _temporalTimeLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -274,8 +269,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.until">
       <h1>Temporal.PlainTime.prototype.until ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `until` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -287,8 +281,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.since">
       <h1>Temporal.PlainTime.prototype.since ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `since` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -300,8 +293,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.round">
       <h1>Temporal.PlainTime.prototype.round ( _roundTo_ )</h1>
       <p>
-        The `round` method takes one argument _roundTo_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -326,8 +318,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.equals">
       <h1>Temporal.PlainTime.prototype.equals ( _other_ )</h1>
       <p>
-        The `equals` method takes one argument _other_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -346,8 +337,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.toplaindatetime">
       <h1>Temporal.PlainTime.prototype.toPlainDateTime ( _temporalDate_ )</h1>
       <p>
-        The `toPlainDateTime` method takes one argument _temporalDate_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -363,8 +353,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.tozoneddatetime">
       <h1>Temporal.PlainTime.prototype.toZonedDateTime ( _item_ )</h1>
       <p>
-        The `toZonedDateTime` method takes one argument _item_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -388,7 +377,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.getisofields">
       <h1>Temporal.PlainTime.prototype.getISOFields ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -408,8 +397,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.tostring">
       <h1>Temporal.PlainTime.prototype.toString ( [ _options_ ] )</h1>
       <p>
-        The `toString` method takes one argument _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -425,11 +413,14 @@
     <emu-clause id="sec-temporal.plaintime.prototype.tolocalestring">
       <h1>Temporal.PlainTime.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
       <p>
-        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.PlainTime.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.
       </p>
       <p>
-        The `toLocaleString` method takes two arguments, _locales_ and _options_.
-        The following steps are taken:
+        The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.
+      </p>
+      <p>
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -441,7 +432,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.tojson">
       <h1>Temporal.PlainTime.prototype.toJSON ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _temporalTime_ be the *this* value.
@@ -453,7 +444,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype.valueof">
       <h1>Temporal.PlainTime.prototype.valueOf ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Throw a *TypeError* exception.

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -26,7 +26,7 @@
     <emu-clause id="sec-temporal.plainyearmonth">
       <h1>Temporal.PlainYearMonth ( _isoYear_, _isoMonth_ [ , _calendarLike_ [ , _referenceISODay_ ] ] )</h1>
       <p>
-        When the `Temporal.PlainYearMonth` function is called, the following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
       <emu-alg>
@@ -57,8 +57,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.from">
       <h1>Temporal.PlainYearMonth.from ( _item_ [ , _options_ ] )</h1>
       <p>
-        The `from` method takes two arguments, _item_ and _options_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
@@ -72,8 +71,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.compare">
       <h1>Temporal.PlainYearMonth.compare ( _one_, _two_ )</h1>
       <p>
-        The `compare` method takes two arguments, _one_ and _two_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _one_ to ? ToTemporalYearMonth(_one_).
@@ -222,8 +220,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.with">
       <h1>Temporal.PlainYearMonth.prototype.with ( _temporalYearMonthLike_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _temporalYearMonthLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -245,8 +242,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.add">
       <h1>Temporal.PlainYearMonth.prototype.add ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>
-        The `add` method takes two arguments, _temporalDurationLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -258,8 +254,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.subtract">
       <h1>Temporal.PlainYearMonth.prototype.subtract ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>
-        The `subtract` method takes two arguments, _temporalDurationLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -271,8 +266,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.until">
       <h1>Temporal.PlainYearMonth.prototype.until ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `until` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -284,8 +278,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.since">
       <h1>Temporal.PlainYearMonth.prototype.since ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `since` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -297,8 +290,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.equals">
       <h1>Temporal.PlainYearMonth.prototype.equals ( _other_ )</h1>
       <p>
-        The `equals` method takes one argument _other_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -314,8 +306,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.tostring">
       <h1>Temporal.PlainYearMonth.prototype.toString ( [ _options_ ] )</h1>
       <p>
-        The `toString` method takes one argument _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -329,11 +320,14 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.tolocalestring">
       <h1>Temporal.PlainYearMonth.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
       <p>
-        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.PlainYearMonth.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.
       </p>
       <p>
-        The `toLocaleString` method takes two arguments, _locales_ and _options_.
-        The following steps are taken:
+        The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.
+      </p>
+      <p>
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -345,7 +339,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.tojson">
       <h1>Temporal.PlainYearMonth.prototype.toJSON ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -357,7 +351,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.valueof">
       <h1>Temporal.PlainYearMonth.prototype.valueOf ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Throw a *TypeError* exception.
@@ -367,8 +361,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.toplaindate">
       <h1>Temporal.PlainYearMonth.prototype.toPlainDate ( _item_ )</h1>
       <p>
-        The `toPlainDate` method takes one argument _item_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.
@@ -392,7 +385,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype.getisofields">
       <h1>Temporal.PlainYearMonth.prototype.getISOFields ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _yearMonth_ be the *this* value.

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -94,7 +94,7 @@
     <emu-clause id="sec-temporal.now.timezone">
       <h1>Temporal.Now.timeZone ( )</h1>
       <p>
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Return ! SystemTimeZone().
@@ -104,7 +104,7 @@
     <emu-clause id="sec-temporal.now.instant">
       <h1>Temporal.Now.instant ( )</h1>
       <p>
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Return ! SystemInstant().
@@ -114,8 +114,7 @@
     <emu-clause id="sec-temporal.now.plaindatetime">
       <h1>Temporal.Now.plainDateTime ( _calendarLike_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `plainDateTime` method takes two arguments, _calendarLike_ and _temporalTimeZoneLike_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Return ? SystemDateTime(_temporalTimeZoneLike_, _calendarLike_).
@@ -125,8 +124,7 @@
     <emu-clause id="sec-temporal.now.plaindatetimeiso">
       <h1>Temporal.Now.plainDateTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `plainDateTimeISO` method takes one argument _temporalTimeZoneLike_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be ! GetISO8601Calendar().
@@ -137,8 +135,7 @@
     <emu-clause id="sec-temporal.now.zoneddatetime">
       <h1>Temporal.Now.zonedDateTime ( _calendarLike_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `zonedDateTime` method takes two arguments, _calendarLike_ and _temporalTimeZoneLike_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_, _calendarLike_).
@@ -148,8 +145,7 @@
     <emu-clause id="sec-temporal.now.zoneddatetimeiso">
       <h1>Temporal.Now.zonedDateTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `zonedDateTimeISO` method takes one argument _temporalTimeZoneLike_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be ! GetISO8601Calendar().
@@ -160,8 +156,7 @@
     <emu-clause id="sec-temporal.now.plaindate">
       <h1>Temporal.Now.plainDate ( _calendarLike_ [ , _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `plainDate` method takes two arguments, _calendarLike_ and _temporalTimeZoneLike_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendarLike_).
@@ -172,8 +167,7 @@
     <emu-clause id="sec-temporal.now.plaindateiso">
       <h1>Temporal.Now.plainDateISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `plainDateISO` method takes one argument _temporalTimeZoneLike_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be ! GetISO8601Calendar().
@@ -185,8 +179,7 @@
     <emu-clause id="sec-temporal.now.plaintimeiso">
       <h1>Temporal.Now.plainTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
-        The `plainTimeISO` method takes one argument _temporalTimeZoneLike_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be ! GetISO8601Calendar().

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -129,7 +129,7 @@
     <emu-clause id="sec-temporal.timezone">
       <h1>Temporal.TimeZone ( _identifier_ )</h1>
       <p>
-        When the `Temporal.TimeZone` function is called, the following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. If NewTarget is *undefined*, then
@@ -159,8 +159,7 @@
     <emu-clause id="sec-temporal.timezone.from">
       <h1>Temporal.TimeZone.from ( _item_ )</h1>
       <p>
-        The `from` method takes one argument _item_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Return ? ToTemporalTimeZone(_item_).
@@ -209,8 +208,7 @@
     <emu-clause id="sec-temporal.timezone.prototype.getoffsetnanosecondsfor">
       <h1>Temporal.TimeZone.prototype.getOffsetNanosecondsFor ( _instant_ )</h1>
       <p>
-        The `getOffsetNanosecondsFor` method takes one argument _instant_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
@@ -227,8 +225,7 @@
     <emu-clause id="sec-temporal.timezone.prototype.getoffsetstringfor">
       <h1>Temporal.TimeZone.prototype.getOffsetStringFor ( _instant_ )</h1>
       <p>
-        The `getOffsetStringFor` method takes one argument _instant_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
@@ -241,8 +238,7 @@
     <emu-clause id="sec-temporal.timezone.prototype.getplaindatetimefor">
       <h1>Temporal.TimeZone.prototype.getPlainDateTimeFor ( _instant_ [ , _calendarLike_ ] )</h1>
       <p>
-        The `getPlainDateTimeFor` method takes two arguments, _instant_ and _calendarLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
@@ -256,8 +252,7 @@
     <emu-clause id="sec-temporal.timezone.prototype.getinstantfor">
       <h1>Temporal.TimeZone.prototype.getInstantFor ( _dateTime_ [ , _options_ ] )</h1>
       <p>
-        The `getInstantFor` method takes two arguments, _dateTime_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
@@ -272,8 +267,7 @@
     <emu-clause id="sec-temporal.timezone.prototype.getpossibleinstantsfor">
       <h1>Temporal.TimeZone.prototype.getPossibleInstantsFor ( _dateTime_ )</h1>
       <p>
-        The `getPossibleInstantsFor` method takes one argument _dateTime_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
@@ -298,8 +292,7 @@
     <emu-clause id="sec-temporal.timezone.prototype.getnexttransition">
       <h1>Temporal.TimeZone.prototype.getNextTransition ( _startingPoint_ )</h1>
       <p>
-        The `getNextTransition` method takes one argument _startingPoint_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
@@ -315,8 +308,7 @@
     <emu-clause id="sec-temporal.timezone.prototype.getprevioustransition">
       <h1>Temporal.TimeZone.prototype.getPreviousTransition ( _startingPoint_ )</h1>
       <p>
-        The `getPreviousTransition` method takes one argument _startingPoint_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
@@ -332,7 +324,7 @@
     <emu-clause id="sec-temporal.timezone.prototype.tostring">
       <h1>Temporal.TimeZone.prototype.toString ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
@@ -344,7 +336,7 @@
     <emu-clause id="sec-temporal.timezone.prototype.tojson">
       <h1>Temporal.TimeZone.prototype.toJSON ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _timeZone_ be the *this* value.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -28,7 +28,7 @@
     <emu-clause id="sec-temporal.zoneddatetime">
       <h1>Temporal.ZonedDateTime ( _epochNanoseconds_, _timeZoneLike_ [ , _calendarLike_ ] )</h1>
       <p>
-        When the `Temporal.ZonedDateTime` function is called, the following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. If NewTarget is *undefined*, then
@@ -56,8 +56,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.from">
       <h1>Temporal.ZonedDateTime.from ( _item_ [ , _options_ ] )</h1>
       <p>
-        The `from` method takes two arguments, _item_ and _options_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
@@ -73,8 +72,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.compare">
       <h1>Temporal.ZonedDateTime.compare ( _one_, _two_ )</h1>
       <p>
-        The `compare` method takes two arguments, _one_ and _two_.
-        The following steps are taken:
+        This function performs the following steps when called:
       </p>
       <emu-alg>
         1. Set _one_ to ? ToTemporalZonedDateTime(_one_).
@@ -557,8 +555,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.with">
       <h1>Temporal.ZonedDateTime.prototype.with ( _temporalZonedDateTimeLike_ [ , _options_ ] )</h1>
       <p>
-        The `with` method takes two arguments, _temporalZonedDateTimeLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -590,8 +587,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.withplaintime">
       <h1>Temporal.ZonedDateTime.prototype.withPlainTime ( [ _plainTimeLike_ ] )</h1>
       <p>
-        The `withPlainTime` method takes one argument _plainTimeLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -613,8 +609,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.withplaindate">
       <h1>Temporal.ZonedDateTime.prototype.withPlainDate ( _plainDateLike_ )</h1>
       <p>
-        The `withPlainDate` method takes one argument _plainDateLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -633,8 +628,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.withtimezone">
       <h1>Temporal.ZonedDateTime.prototype.withTimeZone ( _timeZoneLike_ )</h1>
       <p>
-        The `withTimeZone` method takes one argument _timeZoneLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -647,8 +641,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.withcalendar">
       <h1>Temporal.ZonedDateTime.prototype.withCalendar ( _calendarLike_ )</h1>
       <p>
-        The `withCalendar` method takes one argument _calendarLike_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -661,8 +654,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.add">
       <h1>Temporal.ZonedDateTime.prototype.add ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>
-        The `add` method takes two arguments, _temporalDurationLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -674,8 +666,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.subtract">
       <h1>Temporal.ZonedDateTime.prototype.subtract ( _temporalDurationLike_ [ , _options_ ] )</h1>
       <p>
-        The `subtract` method takes two arguments, _temporalDurationLike_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -687,8 +678,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.until">
       <h1>Temporal.ZonedDateTime.prototype.until ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `until` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -700,8 +690,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.since">
       <h1>Temporal.ZonedDateTime.prototype.since ( _other_ [ , _options_ ] )</h1>
       <p>
-        The `since` method takes two arguments, _other_ and _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -713,8 +702,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.round">
       <h1>Temporal.ZonedDateTime.prototype.round ( _roundTo_ )</h1>
       <p>
-        The `round` method takes one argument _roundTo_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -752,8 +740,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.equals">
       <h1>Temporal.ZonedDateTime.prototype.equals ( _other_ )</h1>
       <p>
-        The `equals` method takes one argument _other_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -768,8 +755,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.tostring">
       <h1>Temporal.ZonedDateTime.prototype.toString ( [ _options_ ] )</h1>
       <p>
-        The `toString` method takes one argument _options_.
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -787,11 +773,14 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.tolocalestring">
       <h1>Temporal.ZonedDateTime.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
       <p>
-        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.ZonedDateTime.prototype.toLocaleString` method as specified in the ECMA-402 specification. If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `toLocaleString` method is used.
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.
       </p>
       <p>
-        The `toLocaleString` method takes two arguments, _locales_ and _options_.
-        The following steps are taken:
+        The meanings of the optional parameters to this method are defined in the ECMA-402 specification; implementations that do not include ECMA-402 support must not use those parameter positions for anything else.
+      </p>
+      <p>
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -803,7 +792,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.tojson">
       <h1>Temporal.ZonedDateTime.prototype.toJSON ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -815,7 +804,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.valueof">
       <h1>Temporal.ZonedDateTime.prototype.valueOf ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Throw a *TypeError* exception.
@@ -825,7 +814,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.startofday">
       <h1>Temporal.ZonedDateTime.prototype.startOfDay ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -843,7 +832,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.toinstant">
       <h1>Temporal.ZonedDateTime.prototype.toInstant ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -855,7 +844,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.toplaindate">
       <h1>Temporal.ZonedDateTime.prototype.toPlainDate ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -871,7 +860,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.toplaintime">
       <h1>Temporal.ZonedDateTime.prototype.toPlainTime ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -887,7 +876,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.toplaindatetime">
       <h1>Temporal.ZonedDateTime.prototype.toPlainDateTime ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -901,7 +890,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.toplainyearmonth">
       <h1>Temporal.ZonedDateTime.prototype.toPlainYearMonth ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -919,7 +908,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.toplainmonthday">
       <h1>Temporal.ZonedDateTime.prototype.toPlainMonthDay ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
@@ -937,7 +926,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype.getisofields">
       <h1>Temporal.ZonedDateTime.prototype.getISOFields ( )</h1>
       <p>
-        The following steps are taken:
+        This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.


### PR DESCRIPTION
Split out from #2207, this applies the agreed-upon standard wording for functions and methods. (See https://github.com/tc39/ecma262/issues/2304#issuecomment-1157129964 and https://github.com/tc39/ecma262/pull/2592)

Closes: #1465 