### PR TITLE
Editorial: Remove unnecessary checks for undefined before ToPositiveInteger

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -166,7 +166,6 @@
       <emu-alg>
         1. Assert: Type(_calendar_) is Object.
         1. Let _result_ be ? Invoke(_calendar_, *"month"*, « _dateLike_ »).
-        1. If _result_ is *undefined*, throw a *RangeError* exception.
         1. Return ? ToPositiveInteger(_result_).
       </emu-alg>
     </emu-clause>
@@ -192,7 +191,6 @@
       <emu-alg>
         1. Assert: Type(_calendar_) is Object.
         1. Let _result_ be ? Invoke(_calendar_, *"day"*, « _dateLike_ »).
-        1. If _result_ is *undefined*, throw a *RangeError* exception.
         1. Return ? ToPositiveInteger(_result_).
       </emu-alg>
     </emu-clause>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -168,6 +168,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"month"*, « _dateLike_ »).
         1. Return ? ToPositiveInteger(_result_).
       </emu-alg>
+      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarmonthcode" aoid="CalendarMonthCode">
@@ -193,6 +194,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"day"*, « _dateLike_ »).
         1. Return ? ToPositiveInteger(_result_).
       </emu-alg>
+      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardayofweek" aoid="CalendarDayOfWeek">


### PR DESCRIPTION
`ToPositiveInteger(undefined)` calls `ToIntegerThrowOnInfinity(undefined)`, which in turn calls `ToIntegerOrInfinity(undefined)`, which in turn calls `ToNumber(undefined)`. `ToNumber` returns `NaN`, `ToIntegerOrInfinity` then returns `0`, `ToIntegerThrowOnInfinity` returns `0` unchanged, and finally `ToPositiveInteger` will throw a RangeError for `0`. That means it's not necessary to handle `undefined` before calling `ToPositiveInteger`.

----

Split from #2265.