### PR TITLE
Editorial: Correct TimeZoneNumericUTCOffsetNotAmbiguousWithDayOfMonth

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1050,7 +1050,7 @@
           UTCDesignator
 
       TimeZoneNumericUTCOffsetNotAmbiguousWithDayOfMonth :
-          TimeZoneUTCOffset but not `-` TimeZoneUTCOffsetHour
+          TimeZoneNumericUTCOffset but not `-` TimeZoneUTCOffsetHour
 
       TimeZoneNumericUTCOffsetNotAmbiguousWithMonth :
           TimeZoneNumericUTCOffsetNotAmbiguousWithDayOfMonth


### PR DESCRIPTION
This was typo'd by accident while refactoring in ccef468, and therefore included the UTCDesignator production as well.

Closes #2342.