### PR TITLE
Normative: Accept and ignore calendar annotation in Instant string

### DIFF
--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -359,7 +359,7 @@ const duration = seq(
   choice(durationDate, durationTime)
 );
 
-const instant = seq(date, [timeSpecSeparator], timeZoneOffsetRequired);
+const instant = seq(date, [timeSpecSeparator], timeZoneOffsetRequired, [calendar]);
 const zonedDateTime = seq(date, [timeSpecSeparator], timeZoneNameRequired, [calendar]);
 
 // goal elements

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1186,7 +1186,7 @@
           Sign? DurationDesignator DurationTime
 
       TemporalInstantString :
-          Date TimeSpecSeparator? TimeZoneOffsetRequired
+          Date TimeSpecSeparator? TimeZoneOffsetRequired Calendar?
 
       TemporalDateTimeString :
           CalendarDateTime


### PR DESCRIPTION
Parsing an Instant string already ignores the time zone name annotation if
one is present, and only takes the offset into account. It's inconsistent
to throw if a calendar annotation is present but not if a time zone name
annotation is present.

Closes: #2143