### PR TITLE
Normative: Correct edge case with nested calendar properties

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1705,6 +1705,10 @@ export const ES = ObjectAssign({}, ES2020, {
       if (!('calendar' in calendarLike)) return calendarLike;
       calendarLike = calendarLike.calendar;
       if (ES.Type(calendarLike) === 'Object' && !('calendar' in calendarLike)) return calendarLike;
+      const identifier = ES.ToString(calendarLike);
+      if (!ES.IsBuiltinCalendar(identifier)) throw new RangeError(`Invalid built-in calendar name: ${identifier}`);
+      const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');
+      return new TemporalCalendar(identifier);
     }
     const identifier = ES.ToString(calendarLike);
     const TemporalCalendar = GetIntrinsic('%Temporal.Calendar%');

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -294,6 +294,9 @@
           1. If ? HasProperty(_temporalCalendarLike_, *"calendar"*) is *false*, return _temporalCalendarLike_.
           1. Set _temporalCalendarLike_ to ? Get(_temporalCalendarLike_, *"calendar"*).
           1. If Type(_temporalCalendarLike_) is Object and ? HasProperty(_temporalCalendarLike_, *"calendar"*) is *false*, return _temporalCalendarLike_.
+          1. Let _identifier_ be ? ToString(_temporalCalendarLike_).
+          1. If IsBuiltinCalendar(_identifier_) is *false*, throw a *RangeError* exception.
+          1. Return ! CreateTemporalCalendar(_identifier_).
         1. Let _identifier_ be ? ToString(_temporalCalendarLike_).
         1. If IsBuiltinCalendar(_identifier_) is *false*, then
           1. Set _identifier_ to ? ParseTemporalCalendarString(_identifier_).


### PR DESCRIPTION
Nested properties like e.g. { calendar: { calendar: plainDate } } should
not be accepted, since we already disallow nested calendar properties in
property bags elsewhere.

Closes: #2104