### PR TITLE
Add note about docs/ja

### DIFF
--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,5 +1,7 @@
 # Temporal
 
+> **注:** このドキュメントは[原文](https://tc39.es/proposal-temporal/docs/index.html)を部分的に日本語に翻訳したものです。全てのドキュメント，および最新の内容を確認したい場合は[原文](https://tc39.es/proposal-temporal/docs/index.html)を参照してください。
+
 <details>
   <summary><strong>Table of Contents</strong></summary>
 <!-- toc -->


### PR DESCRIPTION
The added note means as follows:

> NOTE: This documentation is a partial translation of the original into Japanese. If you'd like to read the complete documentation and the most up-to-date information, please refer to the original.