### PR TITLE
Editorial: Remove undefined variables in BalancePossiblyInfiniteDuration

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1264,7 +1264,7 @@
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
         1. Else,
           1. Assert: _largestUnit_ is *"nanosecond"*.
-        1. For each value _v_ of « _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ », do
+        1. For each value _v_ of « _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ », do
           1. If 𝔽(_v_) is not finite, then
             1. If _sign_ = 1, then
               1. Return ~positive overflow~.


### PR DESCRIPTION
The first three variables 'years', 'months', and 'weeks' of the infinity check added in 10e0ab3 are not defined anywhere, only 'days' and onward.