### PR TITLE
Editorial: Fix duplicate 'Let newRelativeTo' in BalanceDurationRelative

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1401,7 +1401,7 @@
             1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
           1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, *undefined*, _dateAdd_).
+          1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendar_, _relativeTo_, _oneYear_, *undefined*, _dateAdd_).
           1. Let _dateUntil_ be ? GetMethod(_calendar_, *"dateUntil"*).
           1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).


### PR DESCRIPTION
The declaration of newRelativeTo in step 10.b. is still 'in scope', so step 10.j. should use 'Set ... to' instead of 'Let ... be', like the assignment to newRelativeTo in step 10.f.

![image](https://user-images.githubusercontent.com/19366641/182715645-4aea139d-a5a5-4c74-b4e3-6e203b1d91f0.png)
