### PR TITLE
Editorial: Remove unnecessary exception rule

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1093,7 +1093,7 @@
 
       TimeZoneIANAName :
           `Etc/GMT` ASCIISign UnpaddedHour
-          TimeZoneIANANameTail but not `Etc/GMT` ASCIISign UnpaddedHour
+          TimeZoneIANANameTail
           TimeZoneIANALegacyName
 
       TimeZoneIdentifier :


### PR DESCRIPTION
Remove the unnecessary " but not `Etc/GMT` ASCIISign UnpaddedHour" from TimeZoneIANANameTail line for TimeZoneIANAName :
because TimeZoneIANANameTail is defined as 
TimeZoneIANANameComponent
TimeZoneIANANameComponent / TimeZoneIANANameTail

and  "`GMT` ASCIISign UnpaddedHour" does not match TimeZoneIANANameComponent anyway with ASCIISign and UnpaddedHour


@ptomato @ryzokuken @sffc 