### PR TITLE
Normative: Validation of NanosecondsToDays and getOffsetNanoseconds

### DIFF
--- a/docs/cookbook/stockExchangeTimeZone.mjs
+++ b/docs/cookbook/stockExchangeTimeZone.mjs
@@ -203,3 +203,19 @@ openInstant = date.toZonedDateTime(tzNYSE).toInstant();
 closeInstant = date.toZonedDateTime(tzNYSE).timeZone.getNextTransition(openInstant);
 assert.equal(openInstant.toZonedDateTimeISO('America/New_York').toPlainTime().toString(), '09:30:00');
 assert.equal(closeInstant.toZonedDateTimeISO('America/New_York').toPlainTime().toString(), '16:00:00');
+
+// 6. How many hours does a particular market day last?
+// (shows examples of arithmetic)
+
+// Monday lasts 24 hours
+const monday = Temporal.ZonedDateTime.from('2022-08-22T09:30[America/New_York]').withTimeZone(tzNYSE);
+assert.equal(monday.hoursInDay, 24);
+
+// Friday lasts 72 hours, until Monday starts again
+const friday = monday.add({ days: 4 });
+assert.equal(friday.hoursInDay, 72);
+
+// Adding 1 day to Friday gets you the next Monday
+assert.equal(friday.add({ days: 1 }).toString(), '2022-08-29T09:30:00-04:00[NYSE]');
+// Adding 3 days to Friday also gets you the next Monday
+assert.equal(friday.add({ days: 3 }).toString(), '2022-08-29T09:30:00-04:00[NYSE]');

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2685,6 +2685,12 @@ export const ES = ObjectAssign({}, ES2022, {
         days = days.add(sign);
       }
     } while (isOverflow);
+    if (!days.isZero() && MathSign(days.toJSNumber()) != sign) {
+      throw new RangeError('Time zone or calendar converted nanoseconds into a number of days with the opposite sign');
+    }
+    if (!nanoseconds.isZero() && MathSign(nanoseconds.toJSNumber()) != sign) {
+      throw new RangeError('Time zone or calendar ended up with a remainder of nanoseconds with the opposite sign');
+    }
     return { days: days.toJSNumber(), nanoseconds, dayLengthNs: MathAbs(dayLengthNs) };
   },
   BalanceDuration: (

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2691,6 +2691,9 @@ export const ES = ObjectAssign({}, ES2022, {
     if (!nanoseconds.isZero() && MathSign(nanoseconds.toJSNumber()) != sign) {
       throw new RangeError('Time zone or calendar ended up with a remainder of nanoseconds with the opposite sign');
     }
+    if (nanoseconds.abs().geq(MathAbs(dayLengthNs))) {
+      throw new RangeError('Time zone or calendar ended up with a remainder of nanoseconds longer than the day length');
+    }
     return { days: days.toJSNumber(), nanoseconds, dayLengthNs: MathAbs(dayLengthNs) };
   },
   BalanceDuration: (

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1331,6 +1331,10 @@
             1. Set _days_ to _days_ + _sign_.
           1. Else,
             1. Set _done_ to *true*.
+        1. If _days_ &lt; 0 and _sign_ = 1, throw a *RangeError* exception.
+        1. If _days_ &gt; 0 and _sign_ = -1, throw a *RangeError* exception.
+        1. If _nanoseconds_ &lt; 0 and _sign_ = 1, throw a *RangeError* exception.
+        1. If _nanoseconds_ &gt; 0 and _sign_ = -1, throw a *RangeError* exception.
         1. Return the Record {
           [[Days]]: _days_,
           [[Nanoseconds]]: _nanoseconds_,

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1335,6 +1335,7 @@
         1. If _days_ &gt; 0 and _sign_ = -1, throw a *RangeError* exception.
         1. If _nanoseconds_ &lt; 0 and _sign_ = 1, throw a *RangeError* exception.
         1. If _nanoseconds_ &gt; 0 and _sign_ = -1, throw a *RangeError* exception.
+        1. If abs(_nanoseconds_) &ge; abs(_dayLengthNs_), throw a *RangeError* exception.
         1. Return the Record {
           [[Days]]: _days_,
           [[Nanoseconds]]: _nanoseconds_,


### PR DESCRIPTION
- Stricter validation for values returned from NanosecondsToDays AO, to protect against custom time zones / calendars doing inconsistent things
- ~~Removal of 24-hour limit for getOffsetNanoseconds - this limit was leading to inconsistencies in custom time zones (see cookbook example)~~
- Add some code to the NYSE custom time zone cookbook example that exercises these corners

Closes: #2357 