### PR TITLE
Normative: Fast-path ToTemporal{Calendar,TimeZone} when the object is already an instance

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1693,6 +1693,7 @@ export const ES = ObjectAssign({}, ES2022, {
 
   ToTemporalTimeZone: (temporalTimeZoneLike) => {
     if (ES.Type(temporalTimeZoneLike) === 'Object') {
+      if (ES.IsTemporalTimeZone(temporalTimeZoneLike)) return temporalTimeZoneLike;
       if (ES.IsTemporalZonedDateTime(temporalTimeZoneLike)) return GetSlot(temporalTimeZoneLike, TIME_ZONE);
       if (!('timeZone' in temporalTimeZoneLike)) return temporalTimeZoneLike;
       temporalTimeZoneLike = temporalTimeZoneLike.timeZone;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1630,6 +1630,7 @@ export const ES = ObjectAssign({}, ES2022, {
 
   ToTemporalCalendar: (calendarLike) => {
     if (ES.Type(calendarLike) === 'Object') {
+      if (ES.IsTemporalCalendar(calendarLike)) return calendarLike;
       if (HasSlot(calendarLike, CALENDAR)) return GetSlot(calendarLike, CALENDAR);
       if (!('calendar' in calendarLike)) return calendarLike;
       calendarLike = calendarLike.calendar;

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -141,15 +141,9 @@ export class Instant {
     const timeZone = ES.ToTemporalTimeZone(temporalTimeZoneLike);
     return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, calendar);
   }
-  toZonedDateTimeISO(item) {
+  toZonedDateTimeISO(timeZone) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(item) === 'Object') {
-      const timeZoneProperty = item.timeZone;
-      if (timeZoneProperty !== undefined) {
-        item = timeZoneProperty;
-      }
-    }
-    const timeZone = ES.ToTemporalTimeZone(item);
+    timeZone = ES.ToTemporalTimeZone(timeZone);
     const calendar = ES.GetISO8601Calendar();
     return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, calendar);
   }

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -203,12 +203,16 @@ export class PlainDate {
 
     let timeZone, temporalTime;
     if (ES.Type(item) === 'Object') {
-      let timeZoneLike = item.timeZone;
-      if (timeZoneLike === undefined) {
-        timeZone = ES.ToTemporalTimeZone(item);
+      if (ES.IsTemporalTimeZone(item)) {
+        timeZone = item;
       } else {
-        timeZone = ES.ToTemporalTimeZone(timeZoneLike);
-        temporalTime = item.plainTime;
+        let timeZoneLike = item.timeZone;
+        if (timeZoneLike === undefined) {
+          timeZone = ES.ToTemporalTimeZone(item);
+        } else {
+          timeZone = ES.ToTemporalTimeZone(timeZoneLike);
+          temporalTime = item.plainTime;
+        }
       }
     } else {
       timeZone = ES.ToTemporalTimeZone(item);

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -363,6 +363,8 @@
       <h1>ToTemporalCalendar ( _temporalCalendarLike_ )</h1>
       <emu-alg>
         1. If Type(_temporalCalendarLike_) is Object, then
+          1. If _temporalCalendarLike_ has an [[InitializedTemporalCalendar]] internal slot, then
+            1. Return _temporalCalendarLike_.
           1. If _temporalCalendarLike_ has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalTime]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Return _temporalCalendarLike_.[[Calendar]].
           1. If ? HasProperty(_temporalCalendarLike_, *"calendar"*) is *false*, return _temporalCalendarLike_.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -394,18 +394,14 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal.instant.prototype.tozoneddatetimeiso">
-      <h1>Temporal.Instant.prototype.toZonedDateTimeISO ( _item_ )</h1>
+      <h1>Temporal.Instant.prototype.toZonedDateTimeISO ( _timeZone_ )</h1>
       <p>
         This method performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. If Type(_item_) is Object, then
-          1. Let _timeZoneProperty_ be ? Get(_item_, *"timeZone"*).
-          1. If _timeZoneProperty_ is not *undefined*, then
-            1. Set _item_ to _timeZoneProperty_.
-        1. Let _timeZone_ be ? ToTemporalTimeZone(_item_).
+        1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
         1. Let _calendar_ be ! GetISO8601Calendar().
         1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _calendar_).
       </emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -467,13 +467,17 @@
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. If Type(_item_) is Object, then
-          1. Let _timeZoneLike_ be ? Get(_item_, *"timeZone"*).
-          1. If _timeZoneLike_ is *undefined*, then
-            1. Let _timeZone_ be ? ToTemporalTimeZone(_item_).
+          1. If _item_ has an [[InitializedTemporalTimeZone]] internal slot, then
+            1. Let _timeZone_ be _item_.
             1. Let _temporalTime_ be *undefined*.
           1. Else,
-            1. Let _timeZone_ be ? ToTemporalTimeZone(_timeZoneLike_).
-            1. Let _temporalTime_ be ? Get(_item_, *"plainTime"*).
+            1. Let _timeZoneLike_ be ? Get(_item_, *"timeZone"*).
+            1. If _timeZoneLike_ is *undefined*, then
+              1. Let _timeZone_ be ? ToTemporalTimeZone(_item_).
+              1. Let _temporalTime_ be *undefined*.
+            1. Else,
+              1. Let _timeZone_ be ? ToTemporalTimeZone(_timeZoneLike_).
+              1. Let _temporalTime_ be ? Get(_item_, *"plainTime"*).
         1. Else,
           1. Let _timeZone_ be ? ToTemporalTimeZone(_item_).
           1. Let _temporalTime_ be *undefined*.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -535,6 +535,8 @@
       <h1>ToTemporalTimeZone ( _temporalTimeZoneLike_ )</h1>
       <emu-alg>
         1. If Type(_temporalTimeZoneLike_) is Object, then
+          1. If _temporalTimeZoneLike_ has an [[InitializedTemporalTimeZone]] internal slot, then
+            1. Return _temporalTimeZoneLike_.
           1. If _temporalTimeZoneLike_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Return _temporalTimeZoneLike_.[[TimeZone]].
           1. If ? HasProperty(_temporalTimeZoneLike_, *"timeZone"*) is *false*, return _temporalTimeZoneLike_.


### PR DESCRIPTION
The current spec requires an unnecessary observable HasProperty operation when you call `Temporal.Calendar.from(temporalCalendarInstance)` and likewise for TimeZone. This change adds a fast path for these objects.

Closes: #2355