### PR TITLE
Editorial: split Assert into NOTE 

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1502,7 +1502,8 @@
         1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZone_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, *"halfExpand"*).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_diffNs_) &le; 2 &times; nsMaxInstant.
+          1. Assert: abs(_diffNs_) &le; 2 &times; nsMaxInstant.
+          1. NOTE: The following steps cannot fail due to overflow in the Number domain.
           1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _diffNs_, _largestUnit_).
           1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Return ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_, OrdinaryObjectCreate(*null*)).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1503,7 +1503,7 @@
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, *"halfExpand"*).
           1. Assert: abs(_diffNs_) &le; 2 &times; nsMaxInstant.
-          1. NOTE: The following steps cannot fail due to overflow in the Number domain.
+          1. NOTE: The following steps cannot fail due to overflow in the Number domain because of the previous assertion.
           1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _diffNs_, _largestUnit_).
           1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Return ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_, OrdinaryObjectCreate(*null*)).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -642,7 +642,7 @@
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _options_, ~time~, &laquo; &raquo;, *"nanosecond"*, *"second"*).
         1. Let _roundedNs_ be ! DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
         1. Assert: abs(_roundedNs_) &le; 2 &times; nsMaxInstant.
-        1. NOTE: The following steps cannot fail due to overflow in the Number domain. 
+        1. NOTE: The following steps cannot fail due to overflow in the Number domain because of the previous assertion.
         1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _settings_.[[LargestUnit]]).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -641,7 +641,8 @@
         1. Set _other_ to ? ToTemporalInstant(_other_).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _options_, ~time~, &laquo; &raquo;, *"nanosecond"*, *"second"*).
         1. Let _roundedNs_ be ! DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 2 &times; nsMaxInstant.
+        1. Assert: abs(_roundedNs_) &le; 2 &times; nsMaxInstant.
+        1. NOTE: The following steps cannot fail due to overflow in the Number domain. 
         1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _settings_.[[LargestUnit]]).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1355,7 +1355,8 @@
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _options_, ~datetime~, &laquo; &raquo;, *"nanosecond"*, *"hour"*).
         1. If _settings_.[[LargestUnit]] is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 2 &times; nsMaxInstant.
+          1. Assert: abs(_differenceNs_) &le; 2 &times; nsMaxInstant.
+          1. NOTE: The following steps cannot fail due to overflow in the Number domain.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _settings_.[[LargestUnit]]).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _balanceResult_.[[Hours]], _sign_ &times; _balanceResult_.[[Minutes]], _sign_ &times; _balanceResult_.[[Seconds]], _sign_ &times; _balanceResult_.[[Milliseconds]], _sign_ &times; _balanceResult_.[[Microseconds]], _sign_ &times; _balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1356,7 +1356,7 @@
         1. If _settings_.[[LargestUnit]] is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
           1. Assert: abs(_differenceNs_) &le; 2 &times; nsMaxInstant.
-          1. NOTE: The following steps cannot fail due to overflow in the Number domain.
+          1. NOTE: The following steps cannot fail due to overflow in the Number domain because of the previous assertion.
           1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _settings_.[[LargestUnit]]).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _balanceResult_.[[Hours]], _sign_ &times; _balanceResult_.[[Minutes]], _sign_ &times; _balanceResult_.[[Seconds]], _sign_ &times; _balanceResult_.[[Milliseconds]], _sign_ &times; _balanceResult_.[[Microseconds]], _sign_ &times; _balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then


### PR DESCRIPTION
The Assert in DifferenceTemporalInstant , DifferenceTemporalZonedDateTime and AddDuration is confusing because it is not clear which part is the invariant. Split that 3 Assert into a Assert + NOTE to make the invariant clear but also communicate the impact of that invariant.