### PR TITLE
Implement IETF SEDATE conclusions

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -621,7 +621,7 @@ date.equals(date); // => true
 - `options` (optional object): An object with properties influencing the formatting.
   The following options are recognized:
   - `calendarName` (string): Whether to show the calendar annotation in the return value.
-    Valid values are `'auto'`, `'always'`, and `'never'`.
+    Valid values are `'auto'`, `'always'`, `'never'`, and `'critical'`.
     The default is `'auto'`.
 
 **Returns:** a string in the ISO 8601 date format representing `date`.
@@ -631,6 +631,7 @@ The string can be passed to `Temporal.PlainDate.from()` to create a new `Tempora
 
 Normally, a calendar annotation is shown when `date`'s calendar is not the ISO 8601 calendar.
 By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+Normally not necessary, a value of `'critical'` is equivalent to `'always'` but the annotation will contain an additional `!` for certain interoperation use cases.
 For more information on the calendar annotation, see [the `Temporal` string formats documentation](./strings.md#calendar-systems).
 
 Example usage:

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -854,7 +854,7 @@ dt1.equals(dt1); // => true
 - `options` (optional object): An object with properties representing options for the operation.
   The following options are recognized:
   - `calendarName` (string): Whether to show the calendar annotation in the return value.
-    Valid values are `'auto'`, `'always'`, and `'never'`.
+    Valid values are `'auto'`, `'always'`, `'never'`, and `'critical'`.
     The default is `'auto'`.
   - `fractionalSecondDigits` (number or string): How many digits to print after the decimal point in the output string.
     Valid values are `'auto'`, 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9.
@@ -879,6 +879,7 @@ Note that rounding may change the value of other units as well.
 
 Normally, a calendar annotation is shown when `datetime`'s calendar is not the ISO 8601 calendar.
 By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+Normally not necessary, a value of `'critical'` is equivalent to `'always'` but the annotation will contain an additional `!` for certain interoperation use cases.
 For more information on the calendar annotation, see [the `Temporal` string formats documentation](./strings.md#calendar-systems).
 
 Example usage:

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -247,7 +247,7 @@ md2.equals({ monthCode: 'M02', day: 29 }); // => true
 - `options` (optional object): An object with properties influencing the formatting.
   The following options are recognized:
   - `calendarName` (string): Whether to show the calendar annotation in the return value.
-    Valid values are `'auto'`, `'always'`, and `'never'`.
+    Valid values are `'auto'`, `'always'`, `'never'`, and `'critical'`.
     The default is `'auto'`.
 
 **Returns:** a string in the ISO 8601 date format representing `monthDay`.
@@ -257,6 +257,7 @@ The string can be passed to `Temporal.PlainMonthDay.from()` to create a new `Tem
 
 Normally, a calendar annotation is shown when `monthDay`'s calendar is not the ISO 8601 calendar.
 By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+Normally not necessary, a value of `'critical'` is equivalent to `'always'` but the annotation will contain an additional `!` for certain interoperation use cases.
 For more information on the calendar annotation, see [the `Temporal` string formats documentation](./strings.md#calendar-systems).
 
 Example usage:

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -509,7 +509,7 @@ ym.equals(ym); // => true
 - `options` (optional object): An object with properties influencing the formatting.
   The following options are recognized:
   - `calendarName` (string): Whether to show the calendar annotation in the return value.
-    Valid values are `'auto'`, `'always'`, and `'never'`.
+    Valid values are `'auto'`, `'always'`, `'never'`, and `'critical'`.
     The default is `'auto'`.
 
 **Returns:** a string in the ISO 8601 date format representing `yearMonth`.
@@ -519,6 +519,7 @@ The string can be passed to `Temporal.PlainYearMonth.from()` to create a new `Te
 
 Normally, a calendar annotation is shown when `yearMonth`'s calendar is not the ISO 8601 calendar.
 By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+Normally not necessary, a value of `'critical'` is equivalent to `'always'` but the annotation will contain an additional `!` for certain interoperation use cases.
 For more information on the calendar annotation, see [the `Temporal` string formats documentation](./strings.md#calendar-systems).
 
 Example usage:

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1252,7 +1252,7 @@ zdt1.equals(zdt1); // => true
     Valid values are `'auto'` and `'never'`.
     The default is `'auto'`.
   - `calendarName` (string): Whether to show the calendar annotation in the return value.
-    Valid values are `'auto'`, `'always'`, and `'never'`.
+    Valid values are `'auto'`, `'always'`, `'never'`, and `'critical'`.
     The default is `'auto'`.
   - `fractionalSecondDigits` (number or string): How many digits to print after the decimal point in the output string.
     Valid values are `'auto'`, 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9.
@@ -1283,6 +1283,7 @@ Note that rounding may change the value of other units as well.
 
 Normally, a calendar annotation is shown when `zonedDateTime`'s calendar is not the ISO 8601 calendar.
 By setting the `calendarName` option to `'always'` or `'never'` this can be overridden to always or never show the annotation, respectively.
+Normally not necessary, a value of `'critical'` is equivalent to `'always'` but the annotation will contain an additional `!` for certain interoperation use cases.
 For more information on the calendar annotation, see [ISO string extensions](./strings.md#calendar-systems).
 
 Likewise, passing `'never'` to the `timeZoneName` or `offset` options controls whether the time zone offset (`+01:00`) or name annotation (`[Europe/Paris]`) are shown.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1249,7 +1249,7 @@ zdt1.equals(zdt1); // => true
     Valid values are `'auto'` and `'never'`.
     The default is `'auto'`.
   - `timeZoneName` (string): Whether to show the time zone name annotation in the return value.
-    Valid values are `'auto'` and `'never'`.
+    Valid values are `'auto'`, `'never'`, and `'critical'`.
     The default is `'auto'`.
   - `calendarName` (string): Whether to show the calendar annotation in the return value.
     Valid values are `'auto'`, `'always'`, `'never'`, and `'critical'`.
@@ -1288,8 +1288,9 @@ For more information on the calendar annotation, see [ISO string extensions](./s
 
 Likewise, passing `'never'` to the `timeZoneName` or `offset` options controls whether the time zone offset (`+01:00`) or name annotation (`[Europe/Paris]`) are shown.
 If the time zone offset is shown, it is always shown rounded to the nearest minute.
+The `timeZoneName` option can additionally be `'critical'` which will add an additional `!` to the annotation, similar to `calendarName`.
 
-The string format output by this method can be parsed by [`java.time.ZonedDateTime`](https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html) as long as the calendar annotation is not output.
+The string format output by this method can be parsed by [`java.time.ZonedDateTime`](https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html) as long as the calendar annotation is not output and `'critical'` is not used.
 For more information on `Temporal`'s extensions to the ISO 8601 / RFC 3339 string format and the progress towards becoming a published standard, see [String Parsing, Serialization, and Formatting](./strings.md).
 
 Example usage:

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -850,6 +850,10 @@ export const ES = ObjectAssign({}, ES2022, {
           offsetBehaviour = 'wall';
         }
         matchMinutes = true;
+      } else if (z) {
+        throw new RangeError(
+          'Z designator not supported for PlainDate relativeTo; either remove the Z or add a bracketed time zone'
+        );
       }
       if (!calendar) calendar = ES.GetISO8601Calendar();
       calendar = ES.ToTemporalCalendar(calendar);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -710,7 +710,7 @@ export const ES = ObjectAssign({}, ES2022, {
     return ES.GetOption(options, 'calendarName', ['auto', 'always', 'never', 'critical'], 'auto');
   },
   ToShowTimeZoneNameOption: (options) => {
-    return ES.GetOption(options, 'timeZoneName', ['auto', 'never'], 'auto');
+    return ES.GetOption(options, 'timeZoneName', ['auto', 'never', 'critical'], 'auto');
   },
   ToShowOffsetOption: (options) => {
     return ES.GetOption(options, 'offset', ['auto', 'never'], 'auto');
@@ -2151,7 +2151,10 @@ export const ES = ObjectAssign({}, ES2022, {
       const offsetNs = ES.GetOffsetNanosecondsFor(tz, instant);
       result += ES.FormatISOTimeZoneOffsetString(offsetNs);
     }
-    if (showTimeZone !== 'never') result += `[${tz}]`;
+    if (showTimeZone !== 'never') {
+      const flag = showTimeZone === 'critical' ? '!' : '';
+      result += `[${flag}${tz}]`;
+    }
     result += ES.MaybeFormatCalendarAnnotation(GetSlot(zdt, CALENDAR), showCalendar);
     return result;
   },

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -285,7 +285,8 @@ export const ES = ObjectAssign({}, ES2022, {
   FormatCalendarAnnotation: (id, showCalendar) => {
     if (showCalendar === 'never') return '';
     if (showCalendar === 'auto' && id === 'iso8601') return '';
-    return `[u-ca=${id}]`;
+    const flag = showCalendar === 'critical' ? '!' : '';
+    return `[${flag}u-ca=${id}]`;
   },
   ParseISODateTime: (isoString) => {
     // ZDT is the superset of fields for every other Temporal type
@@ -706,7 +707,7 @@ export const ES = ObjectAssign({}, ES2022, {
     return ES.GetOption(options, 'offset', ['prefer', 'use', 'ignore', 'reject'], fallback);
   },
   ToShowCalendarOption: (options) => {
-    return ES.GetOption(options, 'calendarName', ['auto', 'always', 'never'], 'auto');
+    return ES.GetOption(options, 'calendarName', ['auto', 'always', 'never', 'critical'], 'auto');
   },
   ToShowTimeZoneNameOption: (options) => {
     return ES.GetOption(options, 'timeZoneName', ['auto', 'never'], 'auto');
@@ -2090,7 +2091,7 @@ export const ES = ObjectAssign({}, ES2022, {
     let resultString = `${month}-${day}`;
     const calendar = GetSlot(monthDay, CALENDAR);
     const calendarID = ES.ToString(calendar);
-    if (showCalendar === 'always' || calendarID !== 'iso8601') {
+    if (showCalendar === 'always' || showCalendar === 'critical' || calendarID !== 'iso8601') {
       const year = ES.ISOYearString(GetSlot(monthDay, ISO_YEAR));
       resultString = `${year}-${resultString}`;
     }
@@ -2104,7 +2105,7 @@ export const ES = ObjectAssign({}, ES2022, {
     let resultString = `${year}-${month}`;
     const calendar = GetSlot(yearMonth, CALENDAR);
     const calendarID = ES.ToString(calendar);
-    if (showCalendar === 'always' || calendarID !== 'iso8601') {
+    if (showCalendar === 'always' || showCalendar === 'critical' || calendarID !== 'iso8601') {
       const day = ES.ISODateTimePartString(GetSlot(yearMonth, ISO_DAY));
       resultString += `-${day}`;
     }

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -15,9 +15,6 @@ export const timeZoneID = new RegExp(
     ')'
 );
 
-const calComponent = /[A-Za-z0-9]{3,8}/;
-export const calendarID = new RegExp(`(?:${calComponent.source}(?:-${calComponent.source})*)`);
-
 const yearpart = /(?:[+\u2212-]\d{6}|\d{4})/;
 const monthpart = /(?:0[1-9]|1[0-2])/;
 const daypart = /(?:0[1-9]|[12]\d|3[01])/;
@@ -26,15 +23,15 @@ export const datesplit = new RegExp(
 );
 const timesplit = /(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?|(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?/;
 export const offset = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5][0-9])(?:[.,](\d{1,9}))?)?)?/;
-const zonesplit = new RegExp(`(?:([zZ])|(?:${offset.source})?)(?:\\[(${timeZoneID.source})\\])?`);
-const calendar = new RegExp(`\\[u-ca=(${calendarID.source})\\]`);
+const zonesplit = new RegExp(`(?:([zZ])|(?:${offset.source})?)(?:\\[!?(${timeZoneID.source})\\])?`);
+export const annotation = /\[(!)?([a-z_][a-z0-9_-]*)=([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\]/g;
 
 export const zoneddatetime = new RegExp(
-  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?${zonesplit.source}(?:${calendar.source})?$`,
+  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?${zonesplit.source}((?:${annotation.source})*)$`,
   'i'
 );
 
-export const time = new RegExp(`^T?${timesplit.source}(?:${zonesplit.source})?(?:${calendar.source})?$`, 'i');
+export const time = new RegExp(`^T?${timesplit.source}(?:${zonesplit.source})?((?:${annotation.source})*)$`, 'i');
 
 // The short forms of YearMonth and MonthDay are only for the ISO calendar.
 // Non-ISO calendar YearMonth and MonthDay have to parse as a Temporal.PlainDate,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -150,7 +150,7 @@
       This property is used in `toString` methods in Temporal to control whether a calendar annotation should be output.
     </emu-note>
     <emu-alg>
-      1. Return ? GetOption(_normalizedOptions_, *"calendarName"*, *"string"*, « *"auto"*, *"always"*, *"never"* », *"auto"*).
+      1. Return ? GetOption(_normalizedOptions_, *"calendarName"*, *"string"*, « *"auto"*, *"always"*, *"never"*, *"critical"* », *"auto"*).
     </emu-alg>
   </emu-clause>
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -814,8 +814,12 @@
       <li>Fractional parts may have 1 through 9 decimal places.</li>
       <li>In time representations, only seconds are allowed to have a fractional part.</li>
       <li>In duration representations, only hours, minutes, and seconds are allowed to have a fractional part.</li>
-      <li>The time zone may be given by a suffixed <a href="https://www.iana.org/time-zones">IANA time zone name</a> in square brackets, instead of or in addition to a UTC offset.</li>
-      <li>The calendar may be given by a suffixed <a href="https://tools.ietf.org/html/bcp47#section-2.1">BCP 47 key</a> in square brackets.</li>
+      <li>Any number of conforming <a href="https://datatracker.ietf.org/doc/html/draft-ietf-sedate-datetime-extended#section-3.1">suffixes in square brackets</a> are allowed.</li>
+      <li>
+        Time zone and <a href="https://tools.ietf.org/html/bcp47#section-2.1">BCP 47 calendar</a> suffixes are the only recognized ones.
+        Others are ignored, unless they are marked with a *!*, in which case they are rejected.
+      </li>
+      <li>A time zone suffix may be instead of or in addition to a UTC offset.</li>
       <li>A space may be used to separate the date and time in a combined date / time representation, but not in a duration.</li>
       <li>Alphabetic designators may be in lower or upper case.</li>
       <li>Period or comma may be used as the decimal separator.</li>
@@ -837,6 +841,10 @@
       Alpha : one of
           `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M`
           `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
+          `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`
+          `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
+
+      LowercaseAlpha : one of
           `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`
           `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
 
@@ -908,6 +916,9 @@
 
       UTCDesignator : one of
           `Z` `z`
+
+      AnnotationCriticalFlag :
+          `!`
 
       DateFourDigitYear :
           DecimalDigit DecimalDigit DecimalDigit DecimalDigit
@@ -1023,7 +1034,7 @@
           TimeZoneUTCOffsetName
 
       TimeZoneBracketedAnnotation :
-          `[` TimeZoneIdentifier `]`
+          `[` AnnotationCriticalFlag? TimeZoneIdentifier `]`
 
       TimeZoneOffsetRequired :
           TimeZoneUTCOffset TimeZoneBracketedAnnotation?
@@ -1035,22 +1046,40 @@
           TimeZoneUTCOffset TimeZoneBracketedAnnotation?
           TimeZoneBracketedAnnotation
 
-      CalChar :
+      AKeyLeadingChar :
+          LowercaseAlpha
+          `_`
+
+      AKeyChar :
+          AKeyLeadingChar
+          DecimalDigit
+          `-`
+
+      AValChar :
           Alpha
           DecimalDigit
 
-      CalendarNameComponent :
-          CalChar CalChar CalChar CalChar? CalChar? CalChar? CalChar? CalChar?
+      AnnotationKeyTail :
+          AKeyChar AnnotationKeyTail?
 
-      CalendarNameTail :
-          CalendarNameComponent
-          CalendarNameComponent `-` CalendarNameTail
+      AnnotationKey :
+          AKeyLeadingChar AnnotationKeyTail?
 
-      CalendarName :
-          CalendarNameTail
+      AnnotationValueComponent :
+          AValChar AnnotationValueComponent?
 
-      Calendar :
-          `[u-ca=` CalendarName `]`
+      AnnotationValueTail :
+          AnnotationValueComponent
+          AnnotationValueComponent `-` AnnotationValueTail
+
+      AnnotationValue :
+          AnnotationValueTail
+
+      Annotation :
+          `[` AnnotationCriticalFlag? AnnotationKey `=` AnnotationValue `]`
+
+      Annotations :
+          Annotation Annotations?
 
       TimeSpec :
           TimeHour
@@ -1068,15 +1097,15 @@
       DateTime :
           Date TimeSpecSeparator? TimeZone?
 
-      CalendarTime :
-          TimeDesignator TimeSpec TimeZone? Calendar?
-          TimeSpecWithOptionalTimeZoneNotAmbiguous Calendar?
+      AnnotatedTime :
+          TimeDesignator TimeSpec TimeZone? Annotations?
+          TimeSpecWithOptionalTimeZoneNotAmbiguous Annotations?
 
-      CalendarDateTime:
-          DateTime Calendar?
+      AnnotatedDateTime:
+          DateTime Annotations?
 
-      CalendarDateTimeTimeRequired :
-          Date TimeSpecSeparator TimeZone? Calendar?
+      AnnotatedDateTimeTimeRequired :
+          Date TimeSpecSeparator TimeZone? Annotations?
 
       DurationWholeSeconds :
           DecimalDigits[~Sep]
@@ -1149,28 +1178,28 @@
           Sign? DurationDesignator DurationTime
 
       TemporalInstantString :
-          Date TimeSpecSeparator? TimeZoneOffsetRequired Calendar?
+          Date TimeSpecSeparator? TimeZoneOffsetRequired Annotations?
 
       TemporalDateTimeString :
-          CalendarDateTime
+          AnnotatedDateTime
 
       TemporalDurationString :
           Duration
 
       TemporalMonthDayString :
           DateSpecMonthDay
-          CalendarDateTime
+          AnnotatedDateTime
 
       TemporalTimeString :
-          CalendarTime
-          CalendarDateTimeTimeRequired
+          AnnotatedTime
+          AnnotatedDateTimeTimeRequired
 
       TemporalYearMonthString :
           DateSpecYearMonth
-          CalendarDateTime
+          AnnotatedDateTime
 
       TemporalZonedDateTimeString :
-          Date TimeSpecSeparator? TimeZoneNameRequired Calendar?
+          Date TimeSpecSeparator? TimeZoneNameRequired Annotations?
     </emu-grammar>
 
     <emu-clause id="sec-temporal-iso8601grammar-early-errors">
@@ -1203,7 +1232,7 @@
       1. For each nonterminal _goal_ of &laquo; |TemporalDateTimeString|, |TemporalInstantString|, |TemporalMonthDayString|, |TemporalTimeString|, |TemporalYearMonthString|, |TemporalZonedDateTimeString| &raquo;, do
         1. If _parseResult_ is not a Parse Node, set _parseResult_ to ParseText(StringToCodePoints(_isoString_), _goal_).
       1. If _parseResult_ is not a Parse Node, throw a *RangeError* exception.
-      1. Let each of _year_, _month_, _day_, _hour_, _minute_, _second_, _fSeconds_, and _calendar_ be the source text matched by the respective |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, |TimeFraction|, and |CalendarName| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
+      1. Let each of _year_, _month_, _day_, _hour_, _minute_, _second_, and _fSeconds_ be the source text matched by the respective |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, and |TimeFraction| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
       1. If the first code point of _year_ is U+2212 (MINUS SIGN), replace the first code point with U+002D (HYPHEN-MINUS).
       1. Let _yearMV_ be ! ToIntegerOrInfinity(CodePointsToString(_year_)).
       1. If _month_ is empty, then
@@ -1244,10 +1273,15 @@
         1. If _parseResult_ contains a |UTCOffset| Parse Node, then
           1. Let _offset_ be the source text matched by the |UTCOffset| Parse Node contained within _parseResult_.
           1. Set _timeZoneResult_.[[OffsetString]] to CodePointsToString(_offset_).
-      1. If _calendar_ is empty, then
-        1. Let _calendarVal_ be *undefined*.
-      1. Else,
-        1. Let _calendarVal_ be CodePointsToString(_calendar_).
+      1. Let _calendar_ be *undefined*.
+      1. For each |Annotation| Parse Node _annotation_ contained within _parseResult_, do
+        1. Let _key_ be the source text matched by the |AnnotationKey| Parse Node contained within _annotation_.
+        1. If CodePointsToString(_key_) is *"u-ca"*, then
+          1. If _calendar_ is *undefined*, then
+            1. Let _value_ be the source text matched by the |AnnotationValue| Parse Node contained within _annotation_.
+            1. Let _calendar_ be CodePointsToString(_value_).
+        1. Else,
+          1. If _annotation_ contains an |AnnotationCriticalFlag| Parse Node, throw a *RangeError* exception.
       1. Return the Record {
           [[Year]]: _yearMV_,
           [[Month]]: _monthMV_,
@@ -1259,7 +1293,7 @@
           [[Microsecond]]: _microsecondMV_,
           [[Nanosecond]]: _nanosecondMV_,
           [[TimeZone]]: _timeZoneResult_,
-          [[Calendar]]: _calendarVal_,
+          [[Calendar]]: _calendar_
         }.
     </emu-alg>
   </emu-clause>
@@ -1329,7 +1363,7 @@
         1. If _calendar_ is *undefined*, return *"iso8601"*.
         1. Else, return _calendar_.
       1. Else,
-        1. Set _parseResult_ to ParseText(StringToCodePoints(_isoString_), |CalendarName|).
+        1. Set _parseResult_ to ParseText(StringToCodePoints(_isoString_), |AnnotationValue|).
         1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
         1. Else, return _isoString_.
     </emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1465,7 +1465,9 @@
       <dd>It parses the argument as an ISO 8601 string and returns the information needed to construct either a Temporal.ZonedDateTime or a Temporal.PlainDate instance, e.g. as the value of a `relativeTo` option.</dd>
     </dl>
     <emu-alg>
-      1. If ParseText(StringToCodePoints(_isoString_), |TemporalDateTimeString|) is a List of errors, throw a *RangeError* exception.
+      1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalDateTimeString|).
+      1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
+      1. If _parseResult_ contains a |UTCDesignator| ParseNode but no |TimeZoneBracketedAnnotation| Parse Node, throw a *RangeError* exception.
       1. Return ? ParseISODateTime(_isoString_).
     </emu-alg>
   </emu-clause>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -164,7 +164,7 @@
       It is different from the `timeZone` property passed to `Temporal.ZonedDateTime.from()` and from the `timeZone` property in the options passed to `Temporal.Instant.prototype.toString()`.
     </emu-note>
     <emu-alg>
-      1. Return ? GetOption(_normalizedOptions_, *"timeZoneName"*, *"string"*, « *"auto"*, *"never"* », *"auto"*).
+      1. Return ? GetOption(_normalizedOptions_, *"timeZoneName"*, *"string"*, « *"auto"*, *"never"*, *"critical"* », *"auto"*).
     </emu-alg>
   </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -466,7 +466,7 @@
       <h1>
         MaybeFormatCalendarAnnotation (
           _calendarObject_: an Object or *undefined*,
-          _showCalendar_: one of *"auto"*, *"always"*, or *"never"*,
+          _showCalendar_: one of *"auto"*, *"always"*, *"never"*, or *"critical"*,
         ): either a normal completion containing a String, or an abrupt completion
       </h1>
       <dl class="header">
@@ -492,7 +492,7 @@
       <h1>
         FormatCalendarAnnotation (
           _id_: a String,
-          _showCalendar_: one of *"auto"*, *"always"*, or *"never"*,
+          _showCalendar_: one of *"auto"*, *"always"*, *"never"*, or *"critical"*,
         ): a String
       </h1>
       <dl class="header">
@@ -505,7 +505,8 @@
       <emu-alg>
         1. If _showCalendar_ is *"never"*, return the empty String.
         1. If _showCalendar_ is *"auto"* and _id_ is *"iso8601"*, return the empty String.
-        1. Return the string-concatenation of *"[u-ca="*, _id_, and *"]"*.
+        1. If _showCalendar_ is *"critical"*, let _flag_ be *"!"*; else, let flag be the empty String.
+        1. Return the string-concatenation of *"["*, _flag_, *"u-ca="*, _id_, and *"]"*.
       </emu-alg>
       <emu-note type="editor">
         The exact form this annotation will take is undergoing a standardization process in the IETF; it is being discussed in the Internet Draft <a href="https://datatracker.ietf.org/doc/html/draft-ietf-sedate-datetime-extended">Date and Time on the Internet: Timestamps with additional information</a>.

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -483,9 +483,6 @@
         1. Let _calendarID_ be ? ToString(_calendarObject_).
         1. Return FormatCalendarAnnotation(_calendarID_, _showCalendar_).
       </emu-alg>
-      <emu-note type="editor">
-        The exact form this annotation will take is undergoing a standardization process in the IETF; it is being discussed in the Internet Draft <a href="https://datatracker.ietf.org/doc/html/draft-ietf-sedate-datetime-extended">Date and Time on the Internet: Timestamps with additional information</a>.
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-formatcalendarannotation" type="abstract operation">
@@ -508,9 +505,6 @@
         1. If _showCalendar_ is *"critical"*, let _flag_ be *"!"*; else, let flag be the empty String.
         1. Return the string-concatenation of *"["*, _flag_, *"u-ca="*, _id_, and *"]"*.
       </emu-alg>
-      <emu-note type="editor">
-        The exact form this annotation will take is undergoing a standardization process in the IETF; it is being discussed in the Internet Draft <a href="https://datatracker.ietf.org/doc/html/draft-ietf-sedate-datetime-extended">Date and Time on the Internet: Timestamps with additional information</a>.
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarequals" aoid="CalendarEquals">

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -408,7 +408,7 @@
         1. Let _day_ be ToZeroPaddedDecimalString(_monthDay_.[[ISODay]], 2).
         1. Let _result_ be the string-concatenation of _month_, the code unit 0x002D (HYPHEN-MINUS), and _day_.
         1. Let _calendarID_ be ? ToString(_monthDay_.[[Calendar]]).
-        1. If _showCalendar_ is *"always"* or if _calendarID_ is not *"iso8601"*, then
+        1. If _showCalendar_ is one of *"always"* or *"critical"*, or if _calendarID_ is not *"iso8601"*, then
           1. Let _year_ be ! PadISOYear(_monthDay_.[[ISOYear]]).
           1. Set _result_ to the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _result_.
         1. Let _calendarString_ be FormatCalendarAnnotation(_calendarID_, _showCalendar_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -574,7 +574,7 @@
         1. Let _month_ be ToZeroPaddedDecimalString(_yearMonth_.[[ISOMonth]], 2).
         1. Let _result_ be the string-concatenation of _year_, the code unit 0x002D (HYPHEN-MINUS), and _month_.
         1. Let _calendarID_ be ? ToString(_yearMonth_.[[Calendar]]).
-        1. If _showCalendar_ is *"always"* or if _calendarID_ is not *"iso8601"*, then
+        1. If _showCalendar_ is one of *"always"* or *"critical"*, or if _calendarID_ is not *"iso8601"*, then
           1. Let _day_ be ToZeroPaddedDecimalString(_yearMonth_.[[ISODay]], 2).
           1. Set _result_ to the string-concatenation of _result_, the code unit 0x002D (HYPHEN-MINUS), and _day_.
         1. Let _calendarString_ be FormatCalendarAnnotation(_calendarID_, _showCalendar_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1165,7 +1165,7 @@
         TemporalZonedDateTimeToString (
           _zonedDateTime_: a Temporal.ZonedDateTime,
           _precision_: one of *"auto"*, *"minute"*, or an integer between 0 and 9 inclusive,
-          _showCalendar_: one of *"auto"*, *"always"*, or *"never"*,
+          _showCalendar_: one of *"auto"*, *"always"*, *"never"*, or *"critical"*,
           _showTimeZone_: one of *"auto"* or *"never"*,
           _showOffset_: one of *"auto"* or *"never"*,
           optional _increment_: an integer,

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1166,7 +1166,7 @@
           _zonedDateTime_: a Temporal.ZonedDateTime,
           _precision_: one of *"auto"*, *"minute"*, or an integer between 0 and 9 inclusive,
           _showCalendar_: one of *"auto"*, *"always"*, *"never"*, or *"critical"*,
-          _showTimeZone_: one of *"auto"* or *"never"*,
+          _showTimeZone_: one of *"auto"*, *"never"*, or *"critical"*,
           _showOffset_: one of *"auto"* or *"never"*,
           optional _increment_: an integer,
           optional _unit_: one of *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
@@ -1198,7 +1198,8 @@
           1. Let _timeZoneString_ be the empty String.
         1. Else,
           1. Let _timeZoneID_ be ? ToString(_timeZone_).
-          1. Let _timeZoneString_ be the string-concatenation of the code unit 0x005B (LEFT SQUARE BRACKET), _timeZoneID_, and the code unit 0x005D (RIGHT SQUARE BRACKET).
+          1. If _showTimeZone_ is *"critical"*, let _flag_ be *"!"*; else let _flag_ be the empty String.
+          1. Let _timeZoneString_ be the string-concatenation of the code unit 0x005B (LEFT SQUARE BRACKET), _flag_, _timeZoneID_, and the code unit 0x005D (RIGHT SQUARE BRACKET).
         1. Let _calendarString_ be ? MaybeFormatCalendarAnnotation(_zonedDateTime_.[[Calendar]], _showCalendar_).
         1. Return the string-concatenation of _dateTimeString_, _offsetString_, _timeZoneString_, and _calendarString_.
       </emu-alg>


### PR DESCRIPTION
The IETF SEDATE Working Group Internet-Draft, "Date and Time on the Internet: Timestamps with additional information" has reached agreement on all the open issues. This implements the conclusions of that draft RFC, which defines a date-time format called Internet Extended Date-Time Format (abbreviated IXDTF).

IXDTF defines a grammar and semantics for annotations that can be appended to RFC 3339 strings. We were already using these annotations informally in Temporal for time zones and calendars. The main things that have to change are that annotations can have a "critical" flag ("!") which in Temporal has no effect on time zone and calendar annotations; and that multiple annotations are possible, where unknown ones are ignored unless they are marked critical.

As part of this, the last two commits add `"critical"` as a recognized value for the `timeZoneName` and `calendarName` options in various `toString()` methods, so that the critical flag can be output for interoperability purposes.

Also fixes an oversight in parsing of `relativeTo` strings that I noticed while implementing this.

See: #1450
(does not close the issue; it should be closed when the final administrative blockers to publishing the draft are cleared)