### PR TITLE
Normative: Allow annotations after YYYY-MM and MM-DD

### DIFF
--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -36,14 +36,21 @@ export const zoneddatetime = new RegExp(
 
 export const time = new RegExp(`^T?${timesplit.source}(?:${zonesplit.source})?(?:${calendar.source})?$`, 'i');
 
-// The short forms of YearMonth and MonthDay are only for the ISO calendar.
+// The short forms of YearMonth and MonthDay are only for the ISO calendar, but
+// a calendar annotation is still allowed and will throw if not ISO.
 // Non-ISO calendar YearMonth and MonthDay have to parse as a Temporal.PlainDate,
 // with the reference fields.
 // YYYYMM forbidden by ISO 8601 because ambiguous with YYMMDD, but allowed by
 // RFC 3339 and we don't allow 2-digit years, so we allow it.
 // Not ambiguous with HHMMSS because that requires a 'T' prefix
-export const yearmonth = new RegExp(`^(${yearpart.source})-?(${monthpart.source})$`);
-export const monthday = new RegExp(`^(?:--)?(${monthpart.source})-?(${daypart.source})$`);
+// In YearMonth, a time zone annotation is allowed but no UTC offset, because
+// YYYY-MM-UU is ambiguous with YYYY-MM-DD
+export const yearmonth = new RegExp(
+  `^(${yearpart.source})-?(${monthpart.source})(?:\\[${timeZoneID.source}\\])?(?:${calendar.source})?$`
+);
+export const monthday = new RegExp(
+  `^(?:--)?(${monthpart.source})-?(${daypart.source})(?:${zonesplit.source})?(?:${calendar.source})?$`
+);
 
 const fraction = /(\d+)(?:[.,](\d{1,9}))?/;
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1096,8 +1096,14 @@
           TimeHour `:` TimeMinute `:` TimeSecond TimeFraction?
           TimeHour TimeMinute TimeSecond TimeFraction?
 
+      AmbiguousMonthDay :
+          ValidMonthDay TimeZone?
+
+      AmbiguousYearMonth :
+          DateSpecYearMonth TimeZoneBracketedAnnotation?
+
       TimeSpecWithOptionalTimeZoneNotAmbiguous :
-          TimeSpec TimeZone? but not one of ValidMonthDay or DateSpecYearMonth
+          TimeSpec TimeZone? but not one of AmbiguousMonthDay or AmbiguousYearMonth
 
       TimeSpecSeparator :
           DateTimeSeparator TimeSpec
@@ -1114,6 +1120,12 @@
 
       CalendarDateTimeTimeRequired :
           Date TimeSpecSeparator TimeZone? Calendar?
+
+      AnnotatedYearMonth:
+          DateSpecYearMonth TimeZoneBracketedAnnotation? Calendar?
+
+      AnnotatedMonthDay:
+          DateSpecMonthDay TimeZone? Calendar?
 
       DurationWholeSeconds :
           DecimalDigits[~Sep]
@@ -1195,7 +1207,7 @@
           Duration
 
       TemporalMonthDayString :
-          DateSpecMonthDay
+          AnnotatedMonthDay
           CalendarDateTime
 
       TemporalTimeString :
@@ -1203,7 +1215,7 @@
           CalendarDateTimeTimeRequired
 
       TemporalYearMonthString :
-          DateSpecYearMonth
+          AnnotatedYearMonth
           CalendarDateTime
 
       TemporalZonedDateTimeString :
@@ -1214,8 +1226,8 @@
           TemporalInstantString
           CalendarDateTime
           CalendarTime
-          DateSpecYearMonth
-          DateSpecMonthDay
+          AnnotatedYearMonth
+          AnnotatedMonthDay
     </emu-grammar>
     <ul>
       <li>
@@ -1237,8 +1249,13 @@
     <emu-note>The value of ! ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
     <emu-alg>
       1. Let _parseResult_ be ~empty~.
-      1. For each nonterminal _goal_ of &laquo; |TemporalDateTimeString|, |TemporalInstantString|, |TemporalMonthDayString|, |TemporalTimeString|, |TemporalYearMonthString|, |TemporalZonedDateTimeString| &raquo;, do
+      1. For each nonterminal _goal_ of &laquo; |TemporalDateTimeString|, |TemporalInstantString|, |TemporalTimeString|, |TemporalZonedDateTimeString| &raquo;, do
         1. If _parseResult_ is not a Parse Node, set _parseResult_ to ParseText(StringToCodePoints(_isoString_), _goal_).
+      1. For each nonterminal _goal_ of &laquo; |TemporalMonthDayString|, |TemporalYearMonthString| &raquo;, do
+        1. If _parseResult_ is not a Parse Node, then
+          1. Set _parseResult_ to ParseText(StringToCodePoints(_isoString_), _goal_).
+          1. If _parseResult_ contains a |CalendarName| Parse Node _c_, and CodePointsToString(_c_) is not *"iso8601"*, then
+            1. Throw a *RangeError* exception.
       1. If _parseResult_ is not a Parse Node, throw a *RangeError* exception.
       1. Let each of _year_, _month_, _day_, _hour_, _minute_, _second_, _fSeconds_, and _calendar_ be the source text matched by the respective |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, |TimeFraction|, and |CalendarName| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
       1. If the first code point of _year_ is U+2212 (MINUS SIGN), replace the first code point with U+002D (HYPHEN-MINUS).


### PR DESCRIPTION
In keeping with the IXDTF format which extends the grammar of RFC 3339
with any number of annotations, we should allow annotations (time zone,
calendar, and unknown after #2397 lands) after the short YYYY-MM
PlainYearMonth and MM-DD PlainMonthDay forms.

If we were to allow UTC offsets ±UU[:UU] alongside the time zone
annotation, that would be ambiguous in one case: YYYY-MM-UU would be
ambiguous with YYYY-MM-DD. This PR makes the following choices:

- UTC offset is allowed after MM-DD
- UTC offset is disallowed after YYYY-MM (even if it is positive, or
  contains a minute component, which would not be ambiguous)

Other choices are certainly possible.

Closes: #2379