### PR TITLE
Normative: Fix rounding in DifferenceInstant

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1501,9 +1501,7 @@
         1. Let _intermediateNs_ be ? AddZonedDateTime(_relativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
         1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZone_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-          1. Let _diffNs_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, *"halfExpand"*).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_diffNs_) &le; 2 &times; nsMaxInstant.
-          1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _diffNs_, _largestUnit_).
+          1. Let _result_ be ! DifferenceInstant(_relativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, _largestUnit_, *"halfExpand"*).
           1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Return ? DifferenceZonedDateTime(_relativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_, OrdinaryObjectCreate(*null*)).
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -569,14 +569,17 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-differenceinstant" aoid="DifferenceInstant">
-      <h1>DifferenceInstant ( _ns1_, _ns2_, _roundingIncrement_, _smallestUnit_, _roundingMode_ )</h1>
+      <h1>DifferenceInstant ( _ns1_, _ns2_, _roundingIncrement_, _smallestUnit_, _largestUnit_, _roundingMode_ )</h1>
       <p>
         The abstract operation DifferenceInstant computes the difference between two exact times expressed in nanoseconds since the Unix epoch, and rounds the result according to the given parameters.
       </p>
       <emu-alg>
         1. Assert: Type(_ns1_) is BigInt.
         1. Assert: Type(_ns2_) is BigInt.
-        1. Return ! RoundTemporalInstant(_ns2_ - _ns1_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Assert: The following step cannot fail due to overflow in the Number domain because abs(_ns2_ - _ns1_) &le; 2 &times; nsMaxInstant.
+        1. Let _roundResult_ be ! RoundDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, _ns2_ - _ns1_, _roundingIncrement_, _smallestUnit_, _roundingMode_).[[DurationRecord]].
+        1. Assert: _roundResult_.[[Days]] is 0.
+        1. Return ! BalanceDuration(0, _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
       </emu-alg>
     </emu-clause>
 
@@ -640,9 +643,7 @@
         1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalInstant(_other_).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _options_, ~time~, &laquo; &raquo;, *"nanosecond"*, *"second"*).
-        1. Let _roundedNs_ be ! DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_roundedNs_) &le; 2 &times; nsMaxInstant.
-        1. Let _result_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _roundedNs_, _settings_.[[LargestUnit]]).
+        1. Let _result_ be ! DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[LargestUnit]], _settings_.[[RoundingMode]]).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1354,9 +1354,7 @@
           1. Throw a *RangeError* exception.
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _options_, ~datetime~, &laquo; &raquo;, *"nanosecond"*, *"hour"*).
         1. If _settings_.[[LargestUnit]] is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-          1. Let _differenceNs_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-          1. Assert: The following steps cannot fail due to overflow in the Number domain because abs(_differenceNs_) &le; 2 &times; nsMaxInstant.
-          1. Let _balanceResult_ be ! BalanceDuration(0, 0, 0, 0, 0, 0, _differenceNs_, _settings_.[[LargestUnit]]).
+          1. Let _result_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[LargestUnit]], _settings_.[[RoundingMode]]).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _balanceResult_.[[Hours]], _sign_ &times; _balanceResult_.[[Minutes]], _sign_ &times; _balanceResult_.[[Seconds]], _sign_ &times; _balanceResult_.[[Milliseconds]], _sign_ &times; _balanceResult_.[[Microseconds]], _sign_ &times; _balanceResult_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.


### PR DESCRIPTION
In DifferenceInstant, the difference between the two epoch nanoseconds values is conceptually a Duration. It's not correct to call RoundTemporalInstant on it. This normative change brings the spec text in line with what was intended (and is currently tested in test262, which means those [failing tests](https://github.com/tc39/proposal-temporal/pull/2210) should pass if the change in this PR is made.)

Closes: #2320