### PR TITLE
Editorial: Simplify ISO calendar operations

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -554,12 +554,12 @@
         1. Assert: Type(_monthCode_) is String.
         1. If the length of _monthCode_ is not 3, throw a *RangeError* exception.
         1. If the first code unit of _monthCode_ is not 0x004D (LATIN CAPITAL LETTER M), throw a *RangeError* exception.
-        1. Let _numberPart_ be the substring of _monthCode_ from 1.
-        1. If ParseText(StringToCodePoints(_numberPart_), |DateMonth|) is a List of errors, throw a *RangeError* exception.
-        1. Set _numberPart_ to ! ToIntegerOrInfinity(_numberPart_).
-        1. Assert: SameValue(_monthCode_, ! BuildISOMonthCode(_numberPart_)) is *true*.
-        1. If _month_ is not *undefined* and SameValue(_month_, _numberPart_) is *false*, throw a *RangeError* exception.
-        1. Return _numberPart_.
+        1. Let _monthCodeDigits_ be the substring of _monthCode_ from 1.
+        1. If ParseText(StringToCodePoints(_monthCodeDigits_), |DateMonth|) is a List of errors, throw a *RangeError* exception.
+        1. Let _monthCodeNumber_ be ! ToIntegerOrInfinity(_monthCodeDigits_).
+        1. Assert: SameValue(_monthCode_, ! BuildISOMonthCode(_monthCodeNumber_)) is *true*.
+        1. If _month_ is not *undefined* and SameValue(_month_, _monthCodeNumber_) is *false*, throw a *RangeError* exception.
+        1. Return _monthCodeNumber_.
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -529,7 +529,7 @@
     <emu-clause id="sec-temporal-isomonthcode" type="abstract operation">
       <h1>
         ISOMonthCode (
-          _month_: an integer between 1 and 12 inclusive,
+          _month_: an integer in the inclusive interval from 1 to 12,
         ): a String
       </h1>
       <dl class="header">

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -546,21 +546,19 @@
       <emu-alg>
         1. Assert: _fields_ is an ordinary object with no more and no less than the own data properties listed in <emu-xref href="#table-temporal-field-requirements"></emu-xref>.
         1. Let _month_ be ! Get(_fields_, *"month"*).
+        1. Assert: _month_ is *undefined* or _month_ is a Number.
         1. Let _monthCode_ be ! Get(_fields_, *"monthCode"*).
         1. If _monthCode_ is *undefined*, then
           1. If _month_ is *undefined*, throw a *TypeError* exception.
-          1. Assert: Type(_month_) is Number.
           1. Return ℝ(_month_).
         1. Assert: Type(_monthCode_) is String.
-        1. Let _monthLength_ be the length of _monthCode_.
-        1. If _monthLength_ is not 3, throw a *RangeError* exception.
+        1. If the length of _monthCode_ is not 3, throw a *RangeError* exception.
+        1. If the first code unit of _monthCode_ is not 0x004D (LATIN CAPITAL LETTER M), throw a *RangeError* exception.
         1. Let _numberPart_ be the substring of _monthCode_ from 1.
+        1. If ParseText(StringToCodePoints(_numberPart_), |DateMonth|) is a List of errors, throw a *RangeError* exception.
         1. Set _numberPart_ to ! ToIntegerOrInfinity(_numberPart_).
-        1. If _numberPart_ &lt; 1 or _numberPart_ &gt; 12, throw a *RangeError* exception.
-        1. If _month_ is not *undefined* and _month_ &ne; _numberPart_, then
-          1. Throw a *RangeError* exception.
-        1. If SameValueNonNumeric(_monthCode_, ! BuildISOMonthCode(_numberPart_)) is *false*, then
-          1. Throw a *RangeError* exception.
+        1. Assert: SameValue(_monthCode_, ! BuildISOMonthCode(_numberPart_)) is *true*.
+        1. If _month_ is not *undefined* and SameValue(_month_, _numberPart_) is *false*, throw a *RangeError* exception.
         1. Return _numberPart_.
       </emu-alg>
     </emu-clause>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -526,11 +526,16 @@
       <emu-note>For example, week calendar year 2020 includes both 31 December 2019 (a Tuesday belonging to its calendar week 1) and 1 January 2021 (a Friday belonging to its calendar week 53).</emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-buildisomonthcode" aoid="BuildISOMonthCode">
-      <h1>BuildISOMonthCode ( _month_ )</h1>
-      <p>
-        The abstract operation BuildISOMonthCode returns the corresponding string month code, given the numeric ISO calendar month _month_, which must be an integer between 1 and 12, inclusive.
-      </p>
+    <emu-clause id="sec-temporal-isomonthcode" type="abstract operation">
+      <h1>
+        ISOMonthCode (
+          _month_: an integer between 1 and 12 inclusive,
+        ): a String
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the string month code for a month in the ISO 8601 calendar.</dd>
+      </dl>
       <emu-alg>
         1. Let _numberPart_ be ToZeroPaddedDecimalString(_month_, 2).
         1. Return the string-concatenation of *"M"* and _numberPart_.
@@ -557,7 +562,7 @@
         1. Let _monthCodeDigits_ be the substring of _monthCode_ from 1.
         1. If ParseText(StringToCodePoints(_monthCodeDigits_), |DateMonth|) is a List of errors, throw a *RangeError* exception.
         1. Let _monthCodeNumber_ be ! ToIntegerOrInfinity(_monthCodeDigits_).
-        1. Assert: SameValue(_monthCode_, ! BuildISOMonthCode(_monthCodeNumber_)) is *true*.
+        1. Assert: SameValue(_monthCode_, ISOMonthCode(_monthCodeNumber_)) is *true*.
         1. If _month_ is not *undefined* and SameValue(_month_, _monthCodeNumber_) is *false*, throw a *RangeError* exception.
         1. Return _monthCodeNumber_.
       </emu-alg>
@@ -653,17 +658,6 @@
       <emu-alg>
         1. Assert: _temporalObject_ has an [[ISOMonth]] internal slot.
         1. Return 𝔽(_temporalObject_.[[ISOMonth]]).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-isomonthcode" aoid="ISOMonthCode">
-      <h1>ISOMonthCode ( _temporalObject_ )</h1>
-      <p>
-        The ISOMonthCode abstract operation implements the calendar-specific logic in the `Temporal.Calendar.prototype.monthCode` method for the ISO 8601 calendar.
-      </p>
-      <emu-alg>
-        1. Assert: _temporalObject_ has an [[ISOMonth]] internal slot.
-        1. Return ! BuildISOMonthCode(_temporalObject_.[[ISOMonth]]).
       </emu-alg>
     </emu-clause>
 
@@ -1014,7 +1008,8 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], or [[InitializedTemporalYearMonth]] internal slot, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
-        1. Return ! ISOMonthCode(_temporalDateLike_).
+        1. Assert: _temporalDateLike_ has an [[ISOMonth]] internal slot.
+        1. Return ISOMonthCode(_temporalDateLike_.[[ISOMonth]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -639,39 +639,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-isoyear" aoid="ISOYear">
-      <h1>ISOYear ( _temporalObject_ )</h1>
-      <p>
-        The ISOYear abstract operation implements the calendar-specific logic in the `Temporal.Calendar.prototype.year` method for the ISO 8601 calendar.
-      </p>
-      <emu-alg>
-        1. Assert: _temporalObject_ has an [[ISOYear]] internal slot.
-        1. Return 𝔽(_temporalObject_.[[ISOYear]]).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-isomonth" aoid="ISOMonth">
-      <h1>ISOMonth ( _temporalObject_ )</h1>
-      <p>
-        The ISOMonth abstract operation implements the calendar-specific logic in the `Temporal.Calendar.prototype.month` method for the ISO 8601 calendar.
-      </p>
-      <emu-alg>
-        1. Assert: _temporalObject_ has an [[ISOMonth]] internal slot.
-        1. Return 𝔽(_temporalObject_.[[ISOMonth]]).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-isoday" aoid="ISODay">
-      <h1>ISODay ( _temporalObject_ )</h1>
-      <p>
-        The ISODay abstract operation implements the calendar-specific logic in the `Temporal.Calendar.prototype.day` method for the ISO 8601 calendar.
-      </p>
-      <emu-alg>
-        1. Assert: _temporalObject_ has an [[ISODay]] internal slot.
-        1. Return 𝔽(_temporalObject_.[[ISODay]]).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-defaultmergecalendarfields" type="abstract operation">
       <h1>
         DefaultMergeCalendarFields (
@@ -968,7 +935,8 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
-        1. Return ! ISOYear(_temporalDateLike_).
+        1. Assert: _temporalDateLike_ has an [[ISOYear]] internal slot.
+        1. Return 𝔽(_temporalDateLike_.[[ISOYear]]).
       </emu-alg>
     </emu-clause>
 
@@ -989,7 +957,8 @@
           1. Throw a *TypeError* exception.
         1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
-        1. Return ! ISOMonth(_temporalDateLike_).
+        1. Assert: _temporalDateLike_ has an [[ISOMonth]] internal slot.
+        1. Return 𝔽(_temporalDateLike_.[[ISOMonth]]).
       </emu-alg>
     </emu-clause>
 
@@ -1028,7 +997,8 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalMonthDay]] internal slot, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
-        1. Return ! ISODay(_temporalDateLike_).
+        1. Assert: _temporalDateLike_ has an [[ISODay]] internal slot.
+        1. Return 𝔽(_temporalDateLike_.[[ISODay]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1839,7 +1839,8 @@
             1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], or [[InitializedTemporalYearMonth]] internal slot, then
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _monthCode_ be ! ISOMonthCode(_temporalDateLike_).
+              1. Assert: _temporalDateLike_ has an [[ISOMonth]] internal slot.
+              1. Let _monthCode_ be ISOMonthCode(_temporalDateLike_.[[ISOMonth]]).
             1. Else,
               1. Let _monthCode_ be ! CalendarDateMonthCode(_calendar_.[[Identifier]], _temporalDateLike_).
             1. Return _monthCode_.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1799,7 +1799,8 @@
             1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _year_ be ! ISOYear(_temporalDateLike_).
+              1. Assert: _temporalDateLike_ has an [[ISOYear]] internal slot.
+              1. Let _year_ be _temporalDateLike_.[[ISOYear]].
             1. Else,
               1. Let _year_ be ! CalendarDateYear(_calendar_.[[Identifier]], _temporalDateLike_).
             1. Return 𝔽(_year_).
@@ -1820,7 +1821,8 @@
             1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _month_ be ! ISOMonth(_temporalDateLike_).
+              1. Assert: _temporalDateLike_ has an [[ISOMonth]] internal slot.
+              1. Let _month_ be _temporalDateLike_.[[ISOMonth]].
             1. Else,
               1. Let _month_ be ! CalendarDateMonth(_calendar_.[[Identifier]], _temporalDateLike_).
             1. Return 𝔽(_month_).
@@ -1859,7 +1861,8 @@
             1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalMonthDay]] internal slot, then
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _day_ be ! ISODay(_temporalDateLike_).
+              1. Assert: _temporalDateLike_ has an [[ISODay]] internal slot.
+              1. Let _day_ be _temporalDateLike_.[[ISODay]].
             1. Else,
               1. Let _day_ be ! CalendarDateDay(_calendar_.[[Identifier]], _temporalDateLike_).
             1. Return 𝔽(_day_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -504,24 +504,11 @@
             }.
         1. Else,
           1. Assert: _overflow_ is *"reject"*.
-          1. If ! IsValidISOMonth(_month_) is *false*, throw a *RangeError* exception.
+          1. If _month_ &lt; 1 or _month_ &gt; 12, throw a *RangeError* exception.
           1. Return the Record {
               [[Year]]: _year_,
               [[Month]]: _month_
             }.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-isvalidisomonth" aoid="IsValidISOMonth">
-      <h1>IsValidISOMonth ( _month_ )</h1>
-      <p>
-        The abstract operation IsValidISOMonth returns *true* if its argument is a valid month in the ISO 8601 calendar, and *false* otherwise.
-      </p>
-      <emu-alg>
-        1. Assert: _month_ is an integer.
-        1. If _month_ &lt; 1 or _month_ &gt; 12, then
-          1. Return *false*.
-        1. Return *true*.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
* Simplify ResolveISOMonth
* Improve alias names in ResolveISOMonth
* Merge ISOMonthCode and BuildISOMonthCode
* Remove trivial operation IsValidISOMonth
* Remove trivial operations ISO{Year,Month,Day}