### PR TITLE
Editorial: Bring reference code in line with spec re. precision

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3851,12 +3851,12 @@ export const ES = ObjectAssign({}, ES2020, {
       years = months = weeks = 0;
       ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
         d1 + d2,
-        h1 + h2,
-        min1 + min2,
-        s1 + s2,
-        ms1 + ms2,
-        µs1 + µs2,
-        ns1 + ns2,
+        bigInt(h1).add(h2),
+        bigInt(min1).add(min2),
+        bigInt(s1).add(s2),
+        bigInt(ms1).add(ms2),
+        bigInt(µs1).add(µs2),
+        bigInt(ns1).add(ns2),
         largestUnit
       ));
     } else if (ES.IsTemporalDate(relativeTo)) {
@@ -3876,12 +3876,12 @@ export const ES = ObjectAssign({}, ES2020, {
       // Signs of date part and time part may not agree; balance them together
       ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
         days,
-        h1 + h2,
-        min1 + min2,
-        s1 + s2,
-        ms1 + ms2,
-        µs1 + µs2,
-        ns1 + ns2,
+        bigInt(h1).add(h2),
+        bigInt(min1).add(min2),
+        bigInt(s1).add(s2),
+        bigInt(ms1).add(ms2),
+        bigInt(µs1).add(µs2),
+        bigInt(ns1).add(ns2),
         largestUnit
       ));
     } else {

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -1,17 +1,3 @@
-# https://github.com/tc39/test262/pull/3548
-built-ins/Temporal/Duration/compare/argument-string-negative-fractional-units.js
-built-ins/Temporal/Duration/from/argument-string-negative-fractional-units.js
-built-ins/Temporal/Duration/prototype/add/argument-string-negative-fractional-units.js
-built-ins/Temporal/Duration/prototype/subtract/argument-string-negative-fractional-units.js
-built-ins/Temporal/Instant/prototype/add/argument-string-negative-fractional-units.js
-built-ins/Temporal/Instant/prototype/subtract/argument-string-negative-fractional-units.js
-built-ins/Temporal/PlainDateTime/prototype/add/argument-string-negative-fractional-units.js
-built-ins/Temporal/PlainDateTime/prototype/subtract/argument-string-negative-fractional-units.js
-built-ins/Temporal/PlainTime/prototype/add/argument-string-negative-fractional-units.js
-built-ins/Temporal/PlainTime/prototype/subtract/argument-string-negative-fractional-units.js
-built-ins/Temporal/ZonedDateTime/prototype/add/argument-string-negative-fractional-units.js
-built-ins/Temporal/ZonedDateTime/prototype/subtract/argument-string-negative-fractional-units.js
-
 intl402/Temporal/TimeZone/prototype/getNextTransition/transition-at-instant-boundaries.js
 intl402/Temporal/TimeZone/prototype/getPreviousTransition/transition-at-instant-boundaries.js
 

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -380,7 +380,7 @@ const timeItems = ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'na
 const comparisonItems = {
   Instant: [...dateItems, ...timeItems, 'offset'],
   Date: [...dateItems, 'calendar'],
-  DateTime: [...dateItems, ...timeItems],
+  DateTime: [...dateItems, ...timeItems, 'calendar'],
   Duration: [
     'years',
     'months',

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1211,11 +1211,19 @@
       TemporalZonedDateTimeString :
           Date TimeSpecSeparator? TimeZoneNameRequired Calendar?
     </emu-grammar>
-    <ul>
-      <li>
-        It is a Syntax Error if |DateExtendedYear| is *"-000000"* or *"−000000"* (U+2212 MINUS SIGN followed by `000000`).
-      </li>
-    </ul>
+
+    <emu-clause id="sec-temporal-iso8601grammar-early-errors">
+      <h1>Early errors</h1>
+      <emu-grammar>
+        DateExtendedYear :
+          Sign DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+      </emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if |DateExtendedYear| is *"-000000"* or *"−000000"* (U+2212 MINUS SIGN followed by `000000`).
+        </li>
+      </ul>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-temporal-parseisodatetime" type="abstract operation">


### PR DESCRIPTION
- Several changes to the reference code to avoid precision loss or rounding errors due to the use of Numbers, in cases where the spec uses reals and therefore doesn't lose precision. Hopefully this will be helpful to implementors as well. Thanks to @anba who wrote a bunch of tests exercising these cases.
- Other minor changes.