### PR TITLE
Editorial: Rename balanceResult to result on step 5.2 of DifferenceTemporalZonedDateTime

### DIFF
--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1355,7 +1355,7 @@
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _options_, ~datetime~, &laquo; &raquo;, *"nanosecond"*, *"hour"*).
         1. If _settings_.[[LargestUnit]] is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _result_ be ! DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[LargestUnit]], _settings_.[[RoundingMode]]).
-          1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _balanceResult_.[[Hours]], _sign_ &times; _balanceResult_.[[Minutes]], _sign_ &times; _balanceResult_.[[Seconds]], _sign_ &times; _balanceResult_.[[Milliseconds]], _sign_ &times; _balanceResult_.[[Microseconds]], _sign_ &times; _balanceResult_.[[Nanoseconds]]).
+          1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Let _untilOptions_ be ? MergeLargestUnitOption(_settings_.[[Options]], _settings_.[[LargestUnit]]).


### PR DESCRIPTION
Step 5.2 uses the non-existent "balanceResult", which was forgotten to be updated in e192f2c3a870c29be4d586d423f7f47361d88543.

This changes "balanceResult" to "result" to match all the other uses of DifferenceInstant.