### PR TITLE
Editorial: Sync the set of rounding modes for RoundNumberToIncrementAsIfPositive

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -783,7 +783,7 @@
       RoundNumberToIncrementAsIfPositive (
         _x_: a mathematical value,
         _increment_: an integer,
-        _roundingMode_: *"ceil"*, *"floor"*, *"trunc"*, or *"halfExpand"*,
+        _roundingMode_: *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, or *"halfEven"*,
       ): an integer
     </h1>
     <dl class="header">


### PR DESCRIPTION
This was forgotten in 96133586f0f413f27a037a68301c83409df723d3

I'm not sure if this is editorial or normative. I went for editorial as it's just changing the accepted values in the parameter and was not observably enforced elsewhere.