### PR TITLE
Polyfill: Implement early return in UnbalanceDurationRelative as per spec

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2775,6 +2775,7 @@ export const ES = ObjectAssign({}, ES2022, {
   UnbalanceDurationRelative: (years, months, weeks, days, largestUnit, relativeTo) => {
     const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+    if (sign === 0) return { years, months, weeks, days };
 
     let calendar;
     if (relativeTo) {


### PR DESCRIPTION
This early return is present in the spec text but was missing from the reference code. No change in the spec text, this just brings the code in line with the specification.

A test for this is in https://github.com/tc39/test262/pull/3686, we'll need to update the pinned test262 version before merging this, since otherwise the (faulty) existing test will break.