### PR TITLE
Editorial: Upgrade to ecmarkup 15.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@tc39/ecma262-biblio": "=2.1.2458",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
         "@typescript-eslint/parser": "^5.12.1",
-        "ecmarkup": "^13.0.0",
+        "ecmarkup": "^15.0.2",
         "eslint": "^8.9.0",
         "eslint-config-prettier": "^8.4.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -959,25 +959,25 @@
       }
     },
     "node_modules/ecmarkdown": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.1.0.tgz",
-      "integrity": "sha512-xTrf1Qj6nCsHGSHaOrAPfALoEH2nPSs+wclpzXEsozVJbEYcTkims59rJiJQB6TxAW2J4oFfoaB2up1wbb9k4w==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.2.0.tgz",
+      "integrity": "sha512-p0C4SJCvnvtm0y9gPhXBb5DlNbHsNS44ihVKBw3MXviZG2QQpZNH4z/3PbkpgECOjKOeZI+m84ISHVV9WLECFQ==",
       "dev": true,
       "dependencies": {
         "escape-html": "^1.0.1"
       }
     },
     "node_modules/ecmarkup": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-13.0.0.tgz",
-      "integrity": "sha512-k3p1WL0PptR3PiBKpk1LzD/TszIfUb/MpDDWJ0XbK4DZHhzoEhYHaaytJxgQh8J5Lajo8bwo6+n/f0LWJ2as7w==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-15.0.2.tgz",
+      "integrity": "sha512-NdtoFlmebrv14IeGjc21VaeJH871UQbsqdzfSg9+RIvl4AaxVUkpD8LOMoczNzIPouvqke+DM4ktaY/MP0Rrpw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
-        "ecmarkdown": "^7.1.0",
+        "ecmarkdown": "^7.2.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
         "grammarkdown": "^3.2.0",
@@ -985,6 +985,7 @@
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
         "jsdom": "^19.0.0",
+        "nwsapi": "2.2.0",
         "parse5": "^6.0.1",
         "prex": "^0.4.7",
         "promise-debounce": "^1.0.1"
@@ -3398,25 +3399,25 @@
       }
     },
     "ecmarkdown": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.1.0.tgz",
-      "integrity": "sha512-xTrf1Qj6nCsHGSHaOrAPfALoEH2nPSs+wclpzXEsozVJbEYcTkims59rJiJQB6TxAW2J4oFfoaB2up1wbb9k4w==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.2.0.tgz",
+      "integrity": "sha512-p0C4SJCvnvtm0y9gPhXBb5DlNbHsNS44ihVKBw3MXviZG2QQpZNH4z/3PbkpgECOjKOeZI+m84ISHVV9WLECFQ==",
       "dev": true,
       "requires": {
         "escape-html": "^1.0.1"
       }
     },
     "ecmarkup": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-13.0.0.tgz",
-      "integrity": "sha512-k3p1WL0PptR3PiBKpk1LzD/TszIfUb/MpDDWJ0XbK4DZHhzoEhYHaaytJxgQh8J5Lajo8bwo6+n/f0LWJ2as7w==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-15.0.2.tgz",
+      "integrity": "sha512-NdtoFlmebrv14IeGjc21VaeJH871UQbsqdzfSg9+RIvl4AaxVUkpD8LOMoczNzIPouvqke+DM4ktaY/MP0Rrpw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
-        "ecmarkdown": "^7.1.0",
+        "ecmarkdown": "^7.2.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
         "grammarkdown": "^3.2.0",
@@ -3424,6 +3425,7 @@
         "html-escape": "^1.0.2",
         "js-yaml": "^3.13.1",
         "jsdom": "^19.0.0",
+        "nwsapi": "2.2.0",
         "parse5": "^6.0.1",
         "prex": "^0.4.7",
         "promise-debounce": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@tc39/ecma262-biblio": "=2.1.2458",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
-    "ecmarkup": "^13.0.0",
+    "ecmarkup": "^15.0.2",
     "eslint": "^8.9.0",
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -57,7 +57,7 @@
         1. Let _calendars_ be the List of String values representing calendar types supported by the implementation.
         1. Assert: _calendars_ contains *"iso8601"*.
         1. Assert: _calendars_ does not contain any element that does not identify a calendar type in the <a href="https://cldr.unicode.org/">Unicode Common Locale Data Repository (CLDR)</a>.
-        1. Sort _calendars_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+        1. [declared="comparefn"] Sort _calendars_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
         1. Return _calendars_.
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -89,7 +89,7 @@
           1. Let _timeZones_ be a List containing the String value of each Zone or Link name in the IANA Time Zone Database that is supported by the implementation.
           1. Assert: _timeZones_ contains *"UTC"*.
           1. Assert: _timeZones_ does not contain any element that does not identify a Zone or Link name in the IANA Time Zone Database.
-          1. Sort _timeZones_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+          1. [declared="comparefn"] Sort _timeZones_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
           1. Return _timeZones_.
         </emu-alg>
 
@@ -216,7 +216,7 @@
           1. Set _timeZone_ to DefaultTimeZone().
         1. Else,
           1. Set _timeZone_ to ? ToString(_timeZone_).
-          1. If <del>the result of IsValidTimeZoneName<!---->(_timeZone_)</del><ins>IsAvailableTimeZoneName(_timeZone_)</ins> is *false*, then
+          1. If <del>the result of IsValidTimeZoneName(_timeZone_)</del><ins>IsAvailableTimeZoneName(_timeZone_)</ins> is *false*, then
             1. Throw a *RangeError* exception.
           1. Set _timeZone_ to ! CanonicalizeTimeZoneName(_timeZone_).
         1. Set _dateTimeFormat_.[[TimeZone]] to _timeZone_.
@@ -256,7 +256,7 @@
             1. <del>Set _dateTimeFormat_'s internal slot whose name is the Internal Slot column of the row to _p_.</del>
         1. <del>If _dateTimeFormat_.[[Hour]] is *undefined*, then</del>
           1. <del>Set _dateTimeFormat_.[[HourCycle]] to *undefined*.</del>
-        1. <del>If _dateTimeformat_.[[HourCycle]] is *"h11"* or *"h12"*, then</del>
+        1. <del>If _dateTimeFormat_.[[HourCycle]] is *"h11"* or *"h12"*, then</del>
           1. <del>Let _pattern_ be _bestFormat_.[[pattern12]].</del>
           1. <del>Let _rangePatterns_ be _bestFormat_.[[rangePatterns12]].</del>
         1. <del>Else,</del>
@@ -974,7 +974,7 @@
       <emu-alg>
         1. Assert: Type(_t_) is <del>Number</del><ins>BigInt</ins>.
         1. If _calendar_ is *"gregory"*, then
-          1. <del>Let _timeZoneOffset_ be the value calculated according to LocalTZA<!---->(_t_, *true*) where the local time zone is replaced with timezone _timeZone_.</del>
+          1. <del>Let _timeZoneOffset_ be the value calculated according to LocalTZA(_t_, *true*) where the local time zone is replaced with timezone _timeZone_.</del>
           1. <ins>Let _timeZoneOffset_ be GetNamedTimeZoneOffsetNanoseconds(_timeZone_, _t_).</ins>
           1. Let _tz_ be <del>_t_</del><ins>ℝ(_t_)</ins> + _timeZoneOffset_.
           1. Return a record with fields calculated from _tz_ according to <del><emu-xref href="#table-datetimeformat-tolocaltime-record"></emu-xref></del><ins><emu-xref href="#table-temporal-plaindatetimeformat-tolocaltime-record"></emu-xref></ins>.
@@ -1662,7 +1662,7 @@
               1. Let _result_ be ? ISODateFromFields(_fields_, _options_).
             1. Else,
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
-              1. Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+              1. [declared="comparefn"] Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
@@ -1685,7 +1685,7 @@
               1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _options_).
             1. Else,
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"month"*, *"monthCode"*, *"year"* »).
-              1. Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+              1. [declared="comparefn"] Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
@@ -1709,7 +1709,7 @@
               1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _options_).
             1. Else,
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
-              1. Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+              1. [declared="comparefn"] Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
@@ -1945,7 +1945,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _daysInWeek_ be 7.
             1. Else,
-              1. Let _daysInWeek_ be ! CalendarDateDaysInWeek(_calendar_.[[Identifier]], _temporalDateLike_).
+              1. Let _daysInWeek_ be ! CalendarDateDaysInWeek(_calendar_.[[Identifier]], _temporalDate_).
             1. Return 𝔽(_daysInWeek_).
           </emu-alg>
         </emu-clause>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -589,7 +589,7 @@
             1. Return _item_.
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Let _instant_ be ! CreateTemporalInstant(_item_.[[Nanoseconds]]).
-            1. Set _plainDateTime_ to ? BuiltinTimeZoneGetPlainDateTimeFor(_item_.[[TimeZone]], _instant_, _item_.[[Calendar]]).
+            1. Let _plainDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_item_.[[TimeZone]], _instant_, _item_.[[Calendar]]).
             1. Return ! CreateTemporalTime(_plainDateTime_.[[ISOHour]], _plainDateTime_.[[ISOMinute]], _plainDateTime_.[[ISOSecond]], _plainDateTime_.[[ISOMillisecond]], _plainDateTime_.[[ISOMicrosecond]], _plainDateTime_.[[ISONanosecond]]).
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
             1. Return ! CreateTemporalTime(_item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]]).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -637,7 +637,7 @@
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
-        1. Set _sign_ to ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. If _sign_ &lt; 0, then
           1. Let _day_ be ? CalendarDaysInMonth(_calendar_, _yearMonth_).
         1. Else,

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -93,7 +93,7 @@
       <emu-alg>
         1. Let _timeZones_ be the List of String values representing time zones supported by the implementation.
         1. Assert: _timeZones_ contains *"UTC"*.
-        1. Sort _timeZones_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+        1. [declared="comparefn"] Sort _timeZones_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
         1. Return _timeZones_.
       </emu-alg>
       <emu-note><p>


### PR DESCRIPTION
This version of ecmarkup brings in a few linters which require some fixes in the spec text.

- Fixes for typos in variable names
- Fixes for "Set _x_ to" without a preceding "Let _x_ be"
- Add suppression for false-positive lines that refer to the _comparefn_ parameter of %Array.prototype.sort%
- Remove the <!----> workaround for avoiding auto-linking to deleted AOs