### PR TITLE
Normative: yearOfWeek support

### DIFF
--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -199,6 +199,8 @@ When subclassing `Temporal.Calendar`, this property doesn't need to be overridde
 
 ### calendar.**weekOfYear**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | object | string): number
 
+### calendar.**yearOfWeek**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | object | string): number
+
 ### calendar.**daysInWeek**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | object | string): number
 
 ### calendar.**daysInMonth**(_date_: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime | Temporal.PlainYearMonth | object | string): number

--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -255,13 +255,24 @@ For the ISO 8601 calendar, this is normally a value between 1 and 52, but in a f
 ISO week 1 is the week containing the first Thursday of the year.
 For more information on ISO week numbers, see for example the Wikipedia article on [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date).
 
+When combining the week number with a year number, make sure to use `date.yearOfWeek` instead of `date.year`.
+This is because the first few days of a calendar year may be part of the last week of the previous year, and the last few days of a calendar year may be part of the first week of the new year, depending on which year the first Thursday falls in.
+
 Usage example:
 
 ```javascript
-date = Temporal.PlainDate.from('2006-08-24');
+date = Temporal.PlainDate.from('2022-01-01');
 // ISO week date
-console.log(date.year, date.weekOfYear, date.dayOfWeek); // => '2006 34 4'
+console.log(date.yearOfWeek, date.weekOfYear, date.dayOfWeek); // => '2021 52 6'
 ```
+
+### date.**yearOfWeek** : number
+
+The `yearOfWeek` read-only property gives the ISO "week calendar year" of the date, which is the year number corresponding to the ISO week number.
+For the ISO 8601 calendar, this is normally the same as `date.year`, but in a few cases it may be the previous or following year.
+For more information on ISO week numbers, see for example the Wikipedia article on [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date).
+
+See `weekOfYear` for a usage example.
 
 ### date.**daysInWeek** : number
 

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -346,13 +346,24 @@ For the ISO 8601 calendar, this is normally a value between 1 and 52, but in a f
 ISO week 1 is the week containing the first Thursday of the year.
 For more information on ISO week numbers, see for example the Wikipedia article on [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date).
 
+When combining the week number with a year number, make sure to use `datetime.yearOfWeek` instead of `datetime.year`.
+This is because the first few days of a calendar year may be part of the last week of the previous year, and the last few days of a calendar year may be part of the first week of the new year, depending on which year the first Thursday falls in.
+
 Usage example:
 
 ```javascript
-dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
+dt = Temporal.PlainDateTime.from('2022-01-01T03:24:30.000003500');
 // ISO week date
-console.log(dt.year, dt.weekOfYear, dt.dayOfWeek); // => '1995 49 4'
+console.log(dt.yearOfWeek, dt.weekOfYear, dt.dayOfWeek); // => '2021 52 6'
 ```
+
+### datetime.**yearOfWeek** : number
+
+The `yearOfWeek` read-only property gives the ISO "week calendar year" of the date, which is the year number corresponding to the ISO week number.
+For the ISO 8601 calendar, this is normally the same as `datetime.year`, but in a few cases it may be the previous or following year.
+For more information on ISO week numbers, see for example the Wikipedia article on [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date).
+
+See `weekOfYear` for a usage example.
 
 ### datetime.**daysInWeek** : number
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -513,13 +513,24 @@ For the ISO 8601 calendar, this is normally a value between 1 and 52, but in a f
 ISO week 1 is the week containing the first Thursday of the year.
 For more information on ISO week numbers, see for example the Wikipedia article on [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date).
 
+When combining the week number with a year number, make sure to use `zonedDateTime.yearOfWeek` instead of `zonedDateTime.year`.
+This is because the first few days of a calendar year may be part of the last week of the previous year, and the last few days of a calendar year may be part of the first week of the new year, depending on which year the first Thursday falls in.
+
 Usage example:
 
 ```javascript
-zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24-08:00[America/Los_Angeles]');
+zdt = Temporal.ZonedDateTime.from('2022-01-01T03:24-08:00[America/Los_Angeles]');
 // ISO week date
-console.log(zdt.year, zdt.weekOfYear, zdt.dayOfWeek); // => '1995 49 4'
+console.log(zdt.yearOfWeek, zdt.weekOfYear, zdt.dayOfWeek); // => '2021 52 6'
 ```
+
+### zonedDateTime.**yearOfWeek** : number
+
+The `yearOfWeek` read-only property gives the ISO "week calendar year" of the date, which is the year number corresponding to the ISO week number.
+For the ISO 8601 calendar, this is normally the same as `zonedDateTime.year`, but in a few cases it may be the previous or following year.
+For more information on ISO week numbers, see for example the Wikipedia article on [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date).
+
+See `weekOfYear` for a usage example.
 
 ### zonedDateTime.**daysInWeek** : number
 

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -190,6 +190,11 @@ export class Calendar {
     date = ES.ToTemporalDate(date);
     return impl[GetSlot(this, CALENDAR_ID)].weekOfYear(date);
   }
+  yearOfWeek(date) {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
+    date = ES.ToTemporalDate(date);
+    return impl[GetSlot(this, CALENDAR_ID)].yearOfWeek(date);
+  }
   daysInWeek(date) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     date = ES.ToTemporalDate(date);
@@ -321,7 +326,10 @@ impl['iso8601'] = {
     return ES.DayOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
   },
   weekOfYear(date) {
-    return ES.WeekOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY));
+    return ES.WeekOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY)).week;
+  },
+  yearOfWeek(date) {
+    return ES.WeekOfYear(GetSlot(date, ISO_YEAR), GetSlot(date, ISO_MONTH), GetSlot(date, ISO_DAY)).year;
   },
   daysInWeek() {
     return 7;
@@ -2004,6 +2012,9 @@ const nonIsoGeneralImpl = {
   },
   weekOfYear(date) {
     return impl['iso8601'].weekOfYear(date);
+  },
+  yearOfWeek(date) {
+    return impl['iso8601'].yearOfWeek(date);
   },
   daysInWeek(date) {
     return impl['iso8601'].daysInWeek(date);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1664,6 +1664,14 @@ export const ES = ObjectAssign({}, ES2022, {
     const weekOfYear = ES.GetMethod(calendar, 'weekOfYear');
     return ES.ToPositiveInteger(ES.Call(weekOfYear, calendar, [dateLike]));
   },
+  CalendarYearOfWeek: (calendar, dateLike) => {
+    const yearOfWeek = ES.GetMethod(calendar, 'yearOfWeek');
+    const result = ES.Call(yearOfWeek, calendar, [dateLike]);
+    if (result === undefined) {
+      throw new RangeError('calendar yearOfWeek result must be an integer');
+    }
+    return ES.ToIntegerThrowOnInfinity(result);
+  },
   CalendarDaysInWeek: (calendar, dateLike) => {
     const daysInWeek = ES.GetMethod(calendar, 'daysInWeek');
     return ES.ToPositiveInteger(ES.Call(daysInWeek, calendar, [dateLike]));
@@ -2489,18 +2497,18 @@ export const ES = ObjectAssign({}, ES2022, {
 
     if (week < 1) {
       if (doj === 5 || (doj === 6 && ES.LeapYear(year - 1))) {
-        return 53;
+        return { week: 53, year: year - 1 };
       } else {
-        return 52;
+        return { week: 52, year: year - 1 };
       }
     }
     if (week === 53) {
       if ((ES.LeapYear(year) ? 366 : 365) - doy < 4 - dow) {
-        return 1;
+        return { week: 1, year: year + 1 };
       }
     }
 
-    return week;
+    return { week, year };
   },
   DurationSign: (y, mon, w, d, h, min, s, ms, µs, ns) => {
     const fields = [y, mon, w, d, h, min, s, ms, µs, ns];

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -73,6 +73,10 @@ export class PlainDate {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     return ES.CalendarWeekOfYear(GetSlot(this, CALENDAR), this);
   }
+  get yearOfWeek() {
+    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarYearOfWeek(GetSlot(this, CALENDAR), this);
+  }
   get daysInWeek() {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     return ES.CalendarDaysInWeek(GetSlot(this, CALENDAR), this);

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -129,6 +129,10 @@ export class PlainDateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return ES.CalendarWeekOfYear(GetSlot(this, CALENDAR), this);
   }
+  get yearOfWeek() {
+    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarYearOfWeek(GetSlot(this, CALENDAR), this);
+  }
   get daysInWeek() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return ES.CalendarDaysInWeek(GetSlot(this, CALENDAR), this);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -125,6 +125,10 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return ES.CalendarWeekOfYear(GetSlot(this, CALENDAR), dateTime(this));
   }
+  get yearOfWeek() {
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    return ES.CalendarYearOfWeek(GetSlot(this, CALENDAR), dateTime(this));
+  }
   get hoursInDay() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const dt = dateTime(this);

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -579,14 +579,11 @@
           _year_: an integer,
           _month_: an integer,
           _day_: an integer,
-        ): a Record with fields [[Week]] (a positive integer) and [[Year]] (an integer)
+        ): a Year-Week Record
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>
-          It determines where a calendar day falls in the ISO 8601 week calendar and calculates its <em>calendar week of year</em>, which is the 1-based ordinal number of its calendar week within the corresponding <em>week calendar year</em> (which may differ from _year_ by up to 1 in either direction).
-          The returned Record contains the calendar week of year in the [[Week]] field, and the week calendar year in the [[Year]] field.
-        </dd>
+        <dd>It determines where a calendar day falls in the ISO 8601 week calendar and calculates its <em>calendar week of year</em>, which is the 1-based ordinal number of its calendar week within the corresponding <em>week calendar year</em> (which may differ from _year_ by up to 1 in either direction).</dd>
       </dl>
       <emu-alg>
         1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.
@@ -603,17 +600,17 @@
           1. NOTE: This is the last week of the previous year.
           1. Let _dayOfJan1st_ be ToISODayOfWeek(_year_, 1, 1).
           1. If _dayOfJan1st_ is _friday_, then
-            1. Return { [[Week]]: _maxWeekNumber_, [[Year]]: _year_ - 1 }.
+            1. Return the Year-Week Record { [[Week]]: _maxWeekNumber_, [[Year]]: _year_ - 1 }.
           1. If _dayOfJan1st_ is _saturday_, and InLeapYear(TimeFromYear(𝔽(_year_ - 1))) is *1*<sub>𝔽</sub>, then
-            1. Return { [[Week]]: _maxWeekNumber_. [[Year]]: _year_ - 1 }.
-          1. Return { [[Week]]: _maxWeekNumber_ - 1, [[Year]]: _year_ - 1 }.
+            1. Return the Year-Week Record { [[Week]]: _maxWeekNumber_. [[Year]]: _year_ - 1 }.
+          1. Return the Year-Week Record { [[Week]]: _maxWeekNumber_ - 1, [[Year]]: _year_ - 1 }.
         1. If _week_ is _maxWeekNumber_, then
           1. Let _daysInYear_ be DaysInYear(𝔽(_year_)).
           1. Let _daysLaterInYear_ be _daysInYear_ - _dayOfYear_.
           1. Let _daysAfterThursday_ be _thursday_ - _dayOfWeek_.
           1. If _daysLaterInYear_ &lt; _daysAfterThursday_, then
-            1. Return { [[Week]]: 1, [[Year]]: _year_ + 1 }.
-        1. Return the Record { [[Week]]: _week_, [[Year]]: _year_ }.
+            1. Return the Year-Week Record { [[Week]]: 1, [[Year]]: _year_ + 1 }.
+        1. Return the Year-Week Record { [[Week]]: _week_, [[Year]]: _year_ }.
       </emu-alg>
       <emu-note>In the ISO 8601 week calendar, calendar week number 1 of a calendar year is the week including the first Thursday of that year (based on the principle that a week belongs to the same calendar year as the majority of its calendar days), which always includes January 4 and starts on the Monday on or immediately before then. Because of this, some calendar days of the first calendar week of a calendar year may be part of the _preceding_ [proleptic Gregorian] date calendar year, and some calendar days of the last calendar week of a calendar year may be part of the _following_ [proleptic Gregorian] date calendar year. See ISO 8601 for details.</emu-note>
       <emu-note>For example, week calendar year 2020 includes both 31 December 2019 (a Tuesday belonging to its calendar week 1) and 1 January 2021 (a Friday belonging to its calendar week 53).</emu-note>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -271,6 +271,24 @@
       <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-calendaryearofweek" type="abstract operation">
+      <h1>
+        CalendarYearOfWeek (
+          _calendar_: an Object,
+          _dateLike_: a Temporal.PlainDateTime or Temporal.PlainDate,
+        ): either a normal completion containing an integer, or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It calls the given _calendar_'s `yearOfWeek()` method and validates the result.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _result_ be ? Invoke(_calendar_, *"yearOfWeek"*, « _dateLike_ »).
+        1. If _result_ is *undefined*, throw a *RangeError* exception.
+        1. Return ? ToIntegerThrowOnInfinity(_result_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-calendardaysinweek" type="abstract operation">
       <h1>
         CalendarDaysInWeek (
@@ -561,11 +579,14 @@
           _year_: an integer,
           _month_: an integer,
           _day_: an integer,
-        ): an integer
+        ): a Record with fields [[Week]] (a positive integer) and [[Year]] (an integer)
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It determines where a calendar day falls in the ISO 8601 week calendar and returns its <em>calendar week of year</em>, which is the 1-based ordinal number of its calendar week within the corresponding calendar year (which may differ from _year_ by up to 1 in either direction).</dd>
+        <dd>
+          It determines where a calendar day falls in the ISO 8601 week calendar and calculates its <em>calendar week of year</em>, which is the 1-based ordinal number of its calendar week within the corresponding <em>week calendar year</em> (which may differ from _year_ by up to 1 in either direction).
+          The returned Record contains the calendar week of year in the [[Week]] field, and the week calendar year in the [[Year]] field.
+        </dd>
       </dl>
       <emu-alg>
         1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.
@@ -582,17 +603,17 @@
           1. NOTE: This is the last week of the previous year.
           1. Let _dayOfJan1st_ be ToISODayOfWeek(_year_, 1, 1).
           1. If _dayOfJan1st_ is _friday_, then
-            1. Return _maxWeekNumber_.
+            1. Return { [[Week]]: _maxWeekNumber_, [[Year]]: _year_ - 1 }.
           1. If _dayOfJan1st_ is _saturday_, and InLeapYear(TimeFromYear(𝔽(_year_ - 1))) is *1*<sub>𝔽</sub>, then
-            1. Return _maxWeekNumber_.
-          1. Return _maxWeekNumber_ - 1.
+            1. Return { [[Week]]: _maxWeekNumber_. [[Year]]: _year_ - 1 }.
+          1. Return { [[Week]]: _maxWeekNumber_ - 1, [[Year]]: _year_ - 1 }.
         1. If _week_ is _maxWeekNumber_, then
           1. Let _daysInYear_ be DaysInYear(𝔽(_year_)).
           1. Let _daysLaterInYear_ be _daysInYear_ - _dayOfYear_.
           1. Let _daysAfterThursday_ be _thursday_ - _dayOfWeek_.
           1. If _daysLaterInYear_ &lt; _daysAfterThursday_, then
-            1. Return 1.
-        1. Return _week_.
+            1. Return { [[Week]]: 1, [[Year]]: _year_ + 1 }.
+        1. Return the Record { [[Week]]: _week_, [[Year]]: _year_ }.
       </emu-alg>
       <emu-note>In the ISO 8601 week calendar, calendar week number 1 of a calendar year is the week including the first Thursday of that year (based on the principle that a week belongs to the same calendar year as the majority of its calendar days), which always includes January 4 and starts on the Monday on or immediately before then. Because of this, some calendar days of the first calendar week of a calendar year may be part of the _preceding_ [proleptic Gregorian] date calendar year, and some calendar days of the last calendar week of a calendar year may be part of the _following_ [proleptic Gregorian] date calendar year. See ISO 8601 for details.</emu-note>
       <emu-note>For example, week calendar year 2020 includes both 31 December 2019 (a Tuesday belonging to its calendar week 1) and 1 January 2021 (a Friday belonging to its calendar week 53).</emu-note>
@@ -1114,7 +1135,27 @@
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _temporalDate_ be ? ToTemporalDate(_temporalDateLike_).
-        1. Return 𝔽(ToISOWeekOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]])).
+        1. Let _isoYearWeek_ be ToISOWeekOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
+        1. Return 𝔽(_isoYearWeek_.[[Week]]).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal.calendar.prototype.yearofweek">
+      <h1>Temporal.Calendar.prototype.yearOfWeek ( _temporalDateLike_ )</h1>
+      <p>
+        An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement this method as specified in the ECMA-402 specification.
+        If an ECMAScript implementation does not include the ECMA-402 API the following specification of this method is used.
+      </p>
+      <p>
+        This method performs the following steps when called:
+      </p>
+      <emu-alg>
+        1. Let _calendar_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
+        1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
+        1. Let _temporalDate_ be ? ToTemporalDate(_temporalDateLike_).
+        1. Let _isoYearWeek_ be ToISOWeekOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
+        1. Return 𝔽(_isoYearWeek_.[[Year]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1562,7 +1562,7 @@
             CalendarDateWeekOfYear (
               _calendar_: a String,
               _date_: a Temporal.PlainDateTime or Temporal.PlainDate,
-            ): a Record with fields [[Week]] (a positive integer) and [[Year]] (an integer)
+            ): a Year-Week Record
           </h1>
           <dl class="header">
             <dt>description</dt>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1562,12 +1562,22 @@
             CalendarDateWeekOfYear (
               _calendar_: a String,
               _date_: a Temporal.PlainDateTime or Temporal.PlainDate,
-            )
+            ): a Record with fields [[Week]] (a positive integer) and [[Year]] (an integer)
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It takes a date-like object _date_ and returns the week of the year in the calendar represented by _calendar_. The return value should be 1-based.</dd>
+            <dd>It takes a date-like object _date_ and calculates the <em>calendar week of year</em>, and the corresponding <em>week calendar year</em>, in the calendar represented by _calendar_.</dd>
           </dl>
+          <p>
+            The value in the [[Week]] field should be 1-based.
+          </p>
+          <p>
+            The value in the [[Year]] field is relative to the first day of a calendar-specific "epoch year", as in CalendarDateYear, not relative to an era as in CalendarDateEraYear.
+          </p>
+          <p>
+            Usually the [[Year]] field will contain the same value given by CalendarDateYear, but may contain the previous or next year if the week number in the [[Week]] field overlaps two different years.
+            See also ToISOWeekOfYear.
+          </p>
         </emu-clause>
 
         <emu-clause id="sec-temporal-calendardatedaysinweek" type="abstract operation">
@@ -1952,9 +1962,28 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. Let _temporalDate_ be ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Return 𝔽(ToISOWeekOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]])).
-            1. Let _weekOfYear_ be ! CalendarDateWeekOfYear(_calendar_.[[Identifier]], _temporalDate_).
-            1. Return 𝔽(_weekOfYear_).
+              1. Let _yearWeek_ be ToISOWeekOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
+            1. Else,
+              1. Let _yearWeek_ be CalendarDateWeekOfYear(_calendar_.[[Identifier]], _temporalDate_).
+            1. Return 𝔽(_yearWeek_.[[Week]]).
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sup-temporal.calendar.prototype.yearofweek">
+          <h1>Temporal.Calendar.prototype.yearOfWeek ( _temporalDateLike_ )</h1>
+          <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.calendar.prototype.yearofweek"></emu-xref>.</p>
+          <p>
+            This method performs the following steps when called:
+          </p>
+          <emu-alg>
+            1. Let _calendar_ be the *this* value.
+            1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
+            1. Let _temporalDate_ be ? ToTemporalDate(_temporalDateLike_).
+            1. If _calendar_.[[Identifier]] is *"iso8601"*, then
+              1. Let _yearWeek_ be ToISOWeekOfYear(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
+            1. Else,
+              1. Let _yearWeek_ be CalendarDateWeekOfYear(_calendar_.[[Identifier]], _temporalDate_).
+            1. Return 𝔽(_yearWeek_.[[Year]]).
           </emu-alg>
         </emu-clause>
 

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -36,6 +36,42 @@
   </emu-clause>
 
   <ins class="block">
+    <emu-clause id="sec-year-week-record-specification-type">
+      <h1>The Year-Week Record Specification Type</h1>
+      <p>
+        The <dfn variants="Year-Week Records">Year-Week Record</dfn> specification type is returned by the week number calculation in ToISOWeekOfYear, and the corresponding calculations for other calendars if applicable.
+        It comprises a <em>calendar week of year</em> with the corresponding <em>week calendar year</em>.
+      </p>
+      <p>Year-Week Records have the fields listed in table <emu-xref href="#table-year-week-record"></emu-xref>.
+      </p>
+      <emu-table id="table-year-week-record">
+        <emu-caption>Year-Week Record Fields</emu-caption>
+        <table class="real-table">
+          <thead>
+            <tr>
+              <th>Field Name</th>
+              <th>Value</th>
+              <th>Meaning</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>[[Week]]</td>
+              <td>a positive integer</td>
+              <td>The calendar week of year.</td>
+            </tr>
+            <tr>
+              <td>[[Year]]</td>
+              <td>an integer</td>
+              <td>The week calendar year.</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </ins>
+
+  <ins class="block">
     <emu-clause id="sec-temporal-mergelists" type="abstract operation">
       <h1>
         MergeLists (

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -219,6 +219,20 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.plaindate.prototype.yearofweek">
+      <h1>get Temporal.PlainDate.prototype.yearOfWeek</h1>
+      <p>
+        `Temporal.PlainDate.prototype.yearOfWeek` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Let _temporalDate_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
+        1. Let _calendar_ be _temporalDate_.[[Calendar]].
+        1. Return 𝔽(? CalendarYearOfWeek(_calendar_, _temporalDate_)).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-get-temporal.plaindate.prototype.daysinweek">
       <h1>get Temporal.PlainDate.prototype.daysInWeek</h1>
       <p>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -300,6 +300,20 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.plaindatetime.prototype.yearofweek">
+      <h1>get Temporal.PlainDateTime.prototype.yearOfWeek</h1>
+      <p>
+        `Temporal.PlainDateTime.prototype.yearOfWeek` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Let _dateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
+        1. Let _calendar_ be _dateTime_.[[Calendar]].
+        1. Return 𝔽(? CalendarYearOfWeek(_calendar_, _dateTime_)).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-get-temporal.plaindatetime.prototype.daysinweek">
       <h1>get Temporal.PlainDateTime.prototype.daysInWeek</h1>
       <p>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -412,6 +412,23 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-get-temporal.zoneddatetime.prototype.yearofweek">
+      <h1>get Temporal.ZonedDateTime.prototype.yearOfWeek</h1>
+      <p>
+        `Temporal.ZonedDateTime.prototype.yearOfWeek` is an accessor property whose set accessor function is *undefined*.
+        Its get accessor function performs the following steps:
+      </p>
+      <emu-alg>
+        1. Let _zonedDateTime_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
+        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
+        1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
+        1. Let _temporalDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Return 𝔽(? CalendarYearOfWeek(_calendar_, _temporalDateTime_)).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-get-temporal.zoneddatetime.prototype.hoursinday">
       <h1>get Temporal.ZonedDateTime.prototype.hoursInDay</h1>
       <p>


### PR DESCRIPTION
This implements the yearOfWeek support that we discussed in the Temporal champions meeting of 2022-10-13: https://github.com/tc39/proposal-temporal/issues/2405#issuecomment-1279342034

Test262 tests are in https://github.com/tc39/test262/pull/3696

I've split it into 3 separate commits (normative change, docs, reference code) for ease of review. For the TC39 plenary, only the first commit is the normative change that we are discussing; the rest is informational.

Closes: #2405