### PR TITLE
Normative: Allow annotations after YYYY-MM and MM-DD

### DIFF
--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -23,24 +23,45 @@ export const datesplit = new RegExp(
 );
 const timesplit = /(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?|(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?/;
 export const offset = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5][0-9])(?:[.,](\d{1,9}))?)?)?/;
-const zonesplit = new RegExp(`(?:([zZ])|(?:${offset.source})?)(?:\\[!?(${timeZoneID.source})\\])?`);
+const offsetpart = new RegExp(`([zZ])|${offset.source}?`);
 export const annotation = /\[(!)?([a-z_][a-z0-9_-]*)=([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\]/g;
 
 export const zoneddatetime = new RegExp(
-  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?${zonesplit.source}((?:${annotation.source})*)$`,
+  [
+    `^${datesplit.source}`,
+    `(?:(?:T|\\s+)${timesplit.source}(?:${offsetpart.source})?)?`,
+    `(?:\\[!?(${timeZoneID.source})\\])?`,
+    `((?:${annotation.source})*)$`
+  ].join(''),
   'i'
 );
 
-export const time = new RegExp(`^T?${timesplit.source}(?:${zonesplit.source})?((?:${annotation.source})*)$`, 'i');
+export const time = new RegExp(
+  [
+    `^T?${timesplit.source}`,
+    `(?:${offsetpart.source})?`,
+    `(?:\\[!?${timeZoneID.source}\\])?`,
+    `((?:${annotation.source})*)$`
+  ].join(''),
+  'i'
+);
 
-// The short forms of YearMonth and MonthDay are only for the ISO calendar.
+// The short forms of YearMonth and MonthDay are only for the ISO calendar, but
+// annotations are still allowed, and will throw if the calendar annotation is
+// not ISO.
 // Non-ISO calendar YearMonth and MonthDay have to parse as a Temporal.PlainDate,
 // with the reference fields.
 // YYYYMM forbidden by ISO 8601 because ambiguous with YYMMDD, but allowed by
 // RFC 3339 and we don't allow 2-digit years, so we allow it.
 // Not ambiguous with HHMMSS because that requires a 'T' prefix
-export const yearmonth = new RegExp(`^(${yearpart.source})-?(${monthpart.source})$`);
-export const monthday = new RegExp(`^(?:--)?(${monthpart.source})-?(${daypart.source})$`);
+// UTC offsets are not allowed, because they are not allowed with any date-only
+// format; also, YYYY-MM-UU is ambiguous with YYYY-MM-DD
+export const yearmonth = new RegExp(
+  `^(${yearpart.source})-?(${monthpart.source})(?:\\[!?${timeZoneID.source}\\])?((?:${annotation.source})*)$`
+);
+export const monthday = new RegExp(
+  `^(?:--)?(${monthpart.source})-?(${daypart.source})(?:\\[!?${timeZoneID.source}\\])?((?:${annotation.source})*)$`
+);
 
 const fraction = /(\d+)(?:[.,](\d{1,9}))?/;
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -809,7 +809,6 @@
         Time zone and <a href="https://tools.ietf.org/html/bcp47#section-2.1">BCP 47 calendar</a> suffixes are the only recognized ones.
         Others are ignored, unless they are marked with a *!*, in which case they are rejected.
       </li>
-      <li>A time zone suffix may be instead of or in addition to a UTC offset.</li>
       <li>A space may be used to separate the date and time in a combined date / time representation, but not in a duration.</li>
       <li>Alphabetic designators may be in lower or upper case.</li>
       <li>Period or comma may be used as the decimal separator.</li>
@@ -1032,18 +1031,8 @@
           TimeZoneIANAName
           TimeZoneUTCOffsetName
 
-      TimeZoneBracketedAnnotation :
+      TimeZoneAnnotation :
           `[` AnnotationCriticalFlag? TimeZoneIdentifier `]`
-
-      TimeZoneOffsetRequired :
-          TimeZoneUTCOffset TimeZoneBracketedAnnotation?
-
-      TimeZoneNameRequired :
-          TimeZoneUTCOffset? TimeZoneBracketedAnnotation
-
-      TimeZone :
-          TimeZoneUTCOffset TimeZoneBracketedAnnotation?
-          TimeZoneBracketedAnnotation
 
       AKeyLeadingChar :
           LowercaseAlpha
@@ -1087,24 +1076,28 @@
           TimeHour `:` TimeMinute `:` TimeSecond TimeFraction?
           TimeHour TimeMinute TimeSecond TimeFraction?
 
-      TimeSpecWithOptionalTimeZoneNotAmbiguous :
-          TimeSpec TimeZone? but not one of ValidMonthDay or DateSpecYearMonth
-
-      TimeSpecSeparator :
-          DateTimeSeparator TimeSpec
+      TimeSpecWithOptionalOffsetNotAmbiguous :
+          TimeSpec TimeZoneUTCOffset? but not one of ValidMonthDay or DateSpecYearMonth
 
       DateTime :
-          Date TimeSpecSeparator? TimeZone?
+          Date
+          Date DateTimeSeparator TimeSpec TimeZoneUTCOffset?
 
       AnnotatedTime :
-          TimeDesignator TimeSpec TimeZone? Annotations?
-          TimeSpecWithOptionalTimeZoneNotAmbiguous Annotations?
+          TimeDesignator TimeSpec TimeZoneUTCOffset? TimeZoneAnnotation? Annotations?
+          TimeSpecWithOptionalOffsetNotAmbiguous TimeZoneAnnotation? Annotations?
 
       AnnotatedDateTime:
-          DateTime Annotations?
+          DateTime TimeZoneAnnotation? Annotations?
 
       AnnotatedDateTimeTimeRequired :
-          Date TimeSpecSeparator TimeZone? Annotations?
+          Date DateTimeSeparator TimeSpec TimeZoneUTCOffset? TimeZoneAnnotation? Annotations?
+
+      AnnotatedYearMonth:
+          DateSpecYearMonth TimeZoneAnnotation? Annotations?
+
+      AnnotatedMonthDay:
+          DateSpecMonthDay TimeZoneAnnotation? Annotations?
 
       DurationWholeSeconds :
           DecimalDigits[~Sep]
@@ -1177,7 +1170,7 @@
           Sign? DurationDesignator DurationTime
 
       TemporalInstantString :
-          Date TimeSpecSeparator? TimeZoneOffsetRequired Annotations?
+          Date DateTimeSeparator TimeSpec TimeZoneUTCOffset TimeZoneAnnotation? Annotations?
 
       TemporalDateTimeString :
           AnnotatedDateTime
@@ -1186,7 +1179,7 @@
           Duration
 
       TemporalMonthDayString :
-          DateSpecMonthDay
+          AnnotatedMonthDay
           AnnotatedDateTime
 
       TemporalTimeString :
@@ -1194,11 +1187,11 @@
           AnnotatedDateTimeTimeRequired
 
       TemporalYearMonthString :
-          DateSpecYearMonth
+          AnnotatedYearMonth
           AnnotatedDateTime
 
       TemporalZonedDateTimeString :
-          Date TimeSpecSeparator? TimeZoneNameRequired Annotations?
+          DateTime TimeZoneAnnotation Annotations?
     </emu-grammar>
 
     <emu-clause id="sec-temporal-iso8601grammar-early-errors">
@@ -1228,8 +1221,16 @@
     <emu-note>The value of ! ToIntegerOrInfinity(*undefined*) is 0.</emu-note>
     <emu-alg>
       1. Let _parseResult_ be ~empty~.
-      1. For each nonterminal _goal_ of &laquo; |TemporalDateTimeString|, |TemporalInstantString|, |TemporalMonthDayString|, |TemporalTimeString|, |TemporalYearMonthString|, |TemporalZonedDateTimeString| &raquo;, do
+      1. For each nonterminal _goal_ of &laquo; |TemporalDateTimeString|, |TemporalInstantString|, |TemporalTimeString|, |TemporalZonedDateTimeString| &raquo;, do
         1. If _parseResult_ is not a Parse Node, set _parseResult_ to ParseText(StringToCodePoints(_isoString_), _goal_).
+      1. For each nonterminal _goal_ of &laquo; |TemporalMonthDayString|, |TemporalYearMonthString| &raquo;, do
+        1. If _parseResult_ is not a Parse Node, then
+          1. Set _parseResult_ to ParseText(StringToCodePoints(_isoString_), _goal_).
+          1. If _parseResult_ is a Parse Node, then
+            1. For each |Annotation| Parse Node _annotation_ contained within _parseResult_, do
+              1. Let _key_ be the source text matched by the |AnnotationKey| Parse Node contained within _annotation_.
+              1. Let _value_ be the source text matched by the |AnnotationValue| Parse Node contained within _annotation_.
+              1. If CodePointsToString(_key_) is *"u-ca"* and the ASCII-lowercase of CodePointsToString(_value_) is not *"iso8601"*, throw a *RangeError* exception.
       1. If _parseResult_ is not a Parse Node, throw a *RangeError* exception.
       1. Let each of _year_, _month_, _day_, _hour_, _minute_, _second_, and _fSeconds_ be the source text matched by the respective |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, and |TimeFraction| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
       1. If the first code point of _year_ is U+2212 (MINUS SIGN), replace the first code point with U+002D (HYPHEN-MINUS).
@@ -1500,7 +1501,7 @@
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalDateTimeString|).
       1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
-      1. If _parseResult_ contains a |UTCDesignator| ParseNode but no |TimeZoneBracketedAnnotation| Parse Node, throw a *RangeError* exception.
+      1. If _parseResult_ contains a |UTCDesignator| ParseNode but no |TimeZoneAnnotation| Parse Node, throw a *RangeError* exception.
       1. Return ? ParseISODateTime(_isoString_).
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
Summary of discussion from https://github.com/tc39/proposal-temporal/issues/2379#issuecomment-1248557100:

In keeping with the IXDTF format which extends the grammar of RFC 3339 with any number of annotations, we should allow annotations after the short YYYY-MM PlainYearMonth and MM-DD PlainMonthDay forms.

If we were to allow UTC offsets ±UU[:UU] alongside the time zone annotation, that would be ambiguous in one case: YYYY-MM-UU would be ambiguous with YYYY-MM-DD. This forced us to take another look at ISO 8601 and realize that YYYY-MM-DD-UU and YYYY-MM-DDZ are actually not defined by ISO 8601. Although they are not forbidden either, but we don't have any reason to introduce this notation given the set of Temporal types. Therefore, UTC offsets are disallowed after any date-only notation (that is, YYYY-MM-DD, YYYY-MM, and MM-DD.)

The normative change to the proposal is in the first commit, which is what will be presented for consensus at the next TC39 meeting. The second commit implements the change in the reference code, for informational and testing purposes.

Closes: #2379