### PR TITLE
Editorial: Reorder table fields by magnitude

### DIFF
--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -14,7 +14,7 @@ As the only `Temporal` type that persists a time zone, `Temporal.ZonedDateTime` 
 - Creating derived values (e.g. change time to 2:30AM) can avoid worrying that the result will be invalid due to the time zone's DST rules.
 - Properties are available to easily measure attributes like "length of day" or "starting time of day" which may not be the same on all days in all time zones due to DST transitions or political changes to the definitions of time zones.
 - It's easy to flip back and forth between a human-readable representation (like `Temporal.PlainDateTime`) and the UTC timeline (like `Temporal.Instant`) without having to do any work to keep the two in sync.
-- A date/time, an offset, a time zone, and an optional calendar can be persisted in a single string that can be sorted alphabetically by the exact time they happened.
+- A date/time, an offset, a time zone, and an optional calendar can be persisted in a single string.
   This behavior is also be helpful for developers who are not sure which of those components will be needed by later readers of this data.
 - Multiple time-zone-sensitive operations can be performed in a chain without having to repeatedly provide the same time zone.
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -58,8 +58,7 @@
         1. Assert: _calendars_ contains *"iso8601"*.
         1. [declared="S"] Assert: _calendars_ does not contain any element _S_ for which the ASCII-lowercase of _S_ is not _S_.
         1. Assert: _calendars_ does not contain any element that does not identify a calendar type in the <a href="https://cldr.unicode.org/">Unicode Common Locale Data Repository (CLDR)</a>.
-        1. [declared="comparefn"] Sort _calendars_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
-        1. Return _calendars_.
+        1. Return SortStringListByCodeUnit(_calendars_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -689,6 +689,30 @@
             <th>Meaning</th>
           </tr>
           <tr>
+            <td>[[Years]]</td>
+            <td>*"years"*</td>
+            <td>a float64-representable integer</td>
+            <td>
+              The number of years in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Months]]</td>
+            <td>*"months"*</td>
+            <td>a float64-representable integer</td>
+            <td>
+              The number of months in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Weeks]]</td>
+            <td>*"weeks"*</td>
+            <td>a float64-representable integer</td>
+            <td>
+              The number of weeks in the duration.
+            </td>
+          </tr>
+          <tr>
             <td>[[Days]]</td>
             <td>*"days"*</td>
             <td>a float64-representable integer</td>
@@ -705,43 +729,11 @@
             </td>
           </tr>
           <tr>
-            <td>[[Microseconds]]</td>
-            <td>*"microseconds"*</td>
-            <td>a float64-representable integer</td>
-            <td>
-              The number of microseconds in the duration.
-            </td>
-          </tr>
-          <tr>
-            <td>[[Milliseconds]]</td>
-            <td>*"milliseconds"*</td>
-            <td>a float64-representable integer</td>
-            <td>
-              The number of milliseconds in the duration.
-            </td>
-          </tr>
-          <tr>
             <td>[[Minutes]]</td>
             <td>*"minutes"*</td>
             <td>a float64-representable integer</td>
             <td>
               The number of minutes in the duration.
-            </td>
-          </tr>
-          <tr>
-            <td>[[Months]]</td>
-            <td>*"months"*</td>
-            <td>a float64-representable integer</td>
-            <td>
-              The number of months in the duration.
-            </td>
-          </tr>
-          <tr>
-            <td>[[Nanoseconds]]</td>
-            <td>*"nanoseconds"*</td>
-            <td>a float64-representable integer</td>
-            <td>
-              The number of nanoseconds in the duration.
             </td>
           </tr>
           <tr>
@@ -753,19 +745,27 @@
             </td>
           </tr>
           <tr>
-            <td>[[Weeks]]</td>
-            <td>*"weeks"*</td>
+            <td>[[Milliseconds]]</td>
+            <td>*"milliseconds"*</td>
             <td>a float64-representable integer</td>
             <td>
-              The number of weeks in the duration.
+              The number of milliseconds in the duration.
             </td>
           </tr>
           <tr>
-            <td>[[Years]]</td>
-            <td>*"years"*</td>
+            <td>[[Microseconds]]</td>
+            <td>*"microseconds"*</td>
             <td>a float64-representable integer</td>
             <td>
-              The number of years in the duration.
+              The number of microseconds in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Nanoseconds]]</td>
+            <td>*"nanoseconds"*</td>
+            <td>a float64-representable integer</td>
+            <td>
+              The number of nanoseconds in the duration.
             </td>
           </tr>
         </table>
@@ -931,7 +931,7 @@
           1. Return ! CreateDurationRecord(_temporalDurationLike_.[[Years]], _temporalDurationLike_.[[Months]], _temporalDurationLike_.[[Weeks]], _temporalDurationLike_.[[Days]], _temporalDurationLike_.[[Hours]], _temporalDurationLike_.[[Minutes]], _temporalDurationLike_.[[Seconds]], _temporalDurationLike_.[[Milliseconds]], _temporalDurationLike_.[[Microseconds]], _temporalDurationLike_.[[Nanoseconds]]).
         1. Let _result_ be a new Duration Record with each field set to 0.
         1. Let _partial_ be ? ToTemporalPartialDurationRecord(_temporalDurationLike_).
-        1. For each row of <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>, except the header row, in table order, do
+        1. For each row of <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>, except the header row, do
           1. Let _fieldName_ be the Field Name value of the current row.
           1. Let _value_ be the value of the field of _partial_ whose name is _fieldName_.
           1. If _value_ is not *undefined*, then
@@ -1045,13 +1045,16 @@
           1. Throw a *TypeError* exception.
         1. Let _result_ be a new partial Duration Record with each field set to *undefined*.
         1. Let _any_ be *false*.
-        1. For each row of <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>, except the header row, in table order, do
-          1. Let _property_ be the Property Name value of the current row.
+        1. Let _propertyNames_ be a new empty List.
+        1. For each row of <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>, except the header row, do
+          1. Append the property name in the Property Name column of the row to _propertyNames_.
+        1. Let _sortedPropertyNames_ be SortStringListByCodeUnit(_propertyNames_).
+        1. For each property name _property_ of _sortedPropertyNames_, do
           1. Let _value_ be ? Get(_temporalDurationLike_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
             1. Set _value_ to ? ToIntegerIfIntegral(_value_).
-            1. Let _fieldName_ be the Field Name value of the current row.
+            1. Let _fieldName_ be the field name named in the Field Name column in <emu-xref href="#table-temporal-duration-record-fields"></emu-xref> for Property Name _property_.
             1. Set the field of _result_ whose name is _fieldName_ to _value_.
         1. If _any_ is *false*, then
           1. Throw a *TypeError* exception.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -931,11 +931,16 @@
           1. Return ! CreateDurationRecord(_temporalDurationLike_.[[Years]], _temporalDurationLike_.[[Months]], _temporalDurationLike_.[[Weeks]], _temporalDurationLike_.[[Days]], _temporalDurationLike_.[[Hours]], _temporalDurationLike_.[[Minutes]], _temporalDurationLike_.[[Seconds]], _temporalDurationLike_.[[Milliseconds]], _temporalDurationLike_.[[Microseconds]], _temporalDurationLike_.[[Nanoseconds]]).
         1. Let _result_ be a new Duration Record with each field set to 0.
         1. Let _partial_ be ? ToTemporalPartialDurationRecord(_temporalDurationLike_).
-        1. For each row of <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>, except the header row, do
-          1. Let _fieldName_ be the Field Name value of the current row.
-          1. Let _value_ be the value of the field of _partial_ whose name is _fieldName_.
-          1. If _value_ is not *undefined*, then
-            1. Set the field of _result_ whose name is _fieldName_ to _value_.
+        1. If _partial_.[[Years]] is not *undefined*, set _result_.[[Years]] to _partial_.[[Years]].
+        1. If _partial_.[[Months]] is not *undefined*, set _result_.[[Months]] to _partial_.[[Months]].
+        1. If _partial_.[[Weeks]] is not *undefined*, set _result_.[[Weeks]] to _partial_.[[Weeks]].
+        1. If _partial_.[[Days]] is not *undefined*, set _result_.[[Days]] to _partial_.[[Days]].
+        1. If _partial_.[[Hours]] is not *undefined*, set _result_.[[Hours]] to _partial_.[[Hours]].
+        1. If _partial_.[[Minutes]] is not *undefined*, set _result_.[[Minutes]] to _partial_.[[Minutes]].
+        1. If _partial_.[[Seconds]] is not *undefined*, set _result_.[[Seconds]] to _partial_.[[Seconds]].
+        1. If _partial_.[[Milliseconds]] is not *undefined*, set _result_.[[Milliseconds]] to _partial_.[[Milliseconds]].
+        1. If _partial_.[[Microseconds]] is not *undefined*, set _result_.[[Microseconds]] to _partial_.[[Microseconds]].
+        1. If _partial_.[[Nanoseconds]] is not *undefined*, set _result_.[[Nanoseconds]] to _partial_.[[Nanoseconds]].
         1. If ! IsValidDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]) is *false*, then
           1. Throw a *RangeError* exception.
         1. Return _result_.
@@ -1044,20 +1049,27 @@
         1. If Type(_temporalDurationLike_) is not Object, then
           1. Throw a *TypeError* exception.
         1. Let _result_ be a new partial Duration Record with each field set to *undefined*.
-        1. Let _any_ be *false*.
-        1. Let _propertyNames_ be a new empty List.
-        1. For each row of <emu-xref href="#table-temporal-duration-record-fields"></emu-xref>, except the header row, do
-          1. Append the property name in the Property Name column of the row to _propertyNames_.
-        1. Let _sortedPropertyNames_ be SortStringListByCodeUnit(_propertyNames_).
-        1. For each property name _property_ of _sortedPropertyNames_, do
-          1. Let _value_ be ? Get(_temporalDurationLike_, _property_).
-          1. If _value_ is not *undefined*, then
-            1. Set _any_ to *true*.
-            1. Set _value_ to ? ToIntegerIfIntegral(_value_).
-            1. Let _fieldName_ be the field name named in the Field Name column in <emu-xref href="#table-temporal-duration-record-fields"></emu-xref> for Property Name _property_.
-            1. Set the field of _result_ whose name is _fieldName_ to _value_.
-        1. If _any_ is *false*, then
-          1. Throw a *TypeError* exception.
+        1. Let _days_ be ? Get(_temporalDurationLike_, *"days"*).
+        1. If _days_ is not *undefined*, set _result_.[[Days]] to ? ToIntegerIfIntegral(_days_).
+        1. Let _hours_ be ? Get(_temporalDurationLike_, *"hours"*).
+        1. If _hours_ is not *undefined*, set _result_.[[Hours]] to ? ToIntegerIfIntegral(_hours_).
+        1. Let _microseconds_ be ? Get(_temporalDurationLike_, *"microseconds"*).
+        1. If _microseconds_ is not *undefined*, set _result_.[[Microseconds]] to ? ToIntegerIfIntegral(_microseconds_).
+        1. Let _milliseconds_ be ? Get(_temporalDurationLike_, *"milliseconds"*).
+        1. If _milliseconds_ is not *undefined*, set _result_.[[Milliseconds]] to ? ToIntegerIfIntegral(_milliseconds_).
+        1. Let _minutes_ be ? Get(_temporalDurationLike_, *"minutes"*).
+        1. If _minutes_ is not *undefined*, set _result_.[[Minutes]] to ? ToIntegerIfIntegral(_minutes_).
+        1. Let _months_ be ? Get(_temporalDurationLike_, *"months"*).
+        1. If _months_ is not *undefined*, set _result_.[[Months]] to ? ToIntegerIfIntegral(_months_).
+        1. Let _nanoseconds_ be ? Get(_temporalDurationLike_, *"nanoseconds"*).
+        1. If _nanoseconds_ is not *undefined*, set _result_.[[Nanoseconds]] to ? ToIntegerIfIntegral(_nanoseconds_).
+        1. Let _seconds_ be ? Get(_temporalDurationLike_, *"seconds"*).
+        1. If _seconds_ is not *undefined*, set _result_.[[Seconds]] to ? ToIntegerIfIntegral(_seconds_).
+        1. Let _weeks_ be ? Get(_temporalDurationLike_, *"weeks"*).
+        1. If _weeks_ is not *undefined*, set _result_.[[Weeks]] to ? ToIntegerIfIntegral(_weeks_).
+        1. Let _years_ be ? Get(_temporalDurationLike_, *"years"*).
+        1. If _years_ is not *undefined*, set _result_.[[Years]] to ? ToIntegerIfIntegral(_years_).
+        1. If _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are all *undefined*, throw a *TypeError* exception.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -917,11 +917,11 @@
       <h1>
         ToTemporalDurationRecord (
           _temporalDurationLike_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a Duration Record, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _temporalDurationLike_ to a Duration Record and returns it.</dd>
+        <dd>The returned Record has its fields set according to the properties of _temporalDurationLike_, with absent or undefined properties corresponding to fields containing 0.</dd>
       </dl>
       <emu-alg>
         1. If Type(_temporalDurationLike_) is not Object, then
@@ -1034,11 +1034,11 @@
       <h1>
         ToTemporalPartialDurationRecord (
           _temporalDurationLike_: an ECMAScript language value,
-        )
+        ): either a normal completion containing a partial Duration Record, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a partial Duration Record with fields set according to the properties of _temporalDurationLike_.</dd>
+        <dd>The returned Record has its fields set according to the properties of _temporalDurationLike_.</dd>
       </dl>
       <emu-alg>
         1. If Type(_temporalDurationLike_) is not Object, then

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -115,8 +115,7 @@
           1. Let _timeZones_ be a List containing the String value of each Zone or Link name in the IANA Time Zone Database that is supported by the implementation.
           1. Assert: _timeZones_ contains *"UTC"*.
           1. Assert: _timeZones_ does not contain any element that does not identify a Zone or Link name in the IANA Time Zone Database.
-          1. [declared="comparefn"] Sort _timeZones_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
-          1. Return _timeZones_.
+          1. Return SortStringListByCodeUnit(_timeZones_).
         </emu-alg>
 
         <p>This definition supersedes the definition provided in <emu-xref href="#sec-availabletimezones"></emu-xref>.</p>
@@ -1688,8 +1687,8 @@
               1. Let _result_ be ? ISODateFromFields(_fields_, _options_).
             1. Else,
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
-              1. [declared="comparefn"] Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
+              1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _sortedFieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
@@ -1711,8 +1710,8 @@
               1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _options_).
             1. Else,
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"month"*, *"monthCode"*, *"year"* »).
-              1. [declared="comparefn"] Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
+              1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _sortedFieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISODay]] to _result_.[[Day]].
@@ -1735,8 +1734,8 @@
               1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _options_).
             1. Else,
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
-              1. [declared="comparefn"] Sort _fieldNames_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
+              1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _sortedFieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISOYear]] to _result_.[[Year]].

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -60,6 +60,25 @@
     </emu-clause>
   </ins>
 
+  <ins class="block">
+    <emu-clause id="sec-sortstringlistbycodeunit" type="abstract operation">
+      <h1>
+        SortStringListByCodeUnit (
+          _strings_: a List of Strings,
+        ): a List of Strings
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The returned List contains the same Strings as _strings_, but sorted lexicographically by UTF-16 code unit in ascending order.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _result_ be a copy of _strings_.
+        1. [declared="comparefn"] Sort _result_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+  </ins>
+
   <emu-clause id="sec-literals-numeric-literals">
     <h1><a href="https://tc39.es/ecma262/#sec-literals-numeric-literals">Numeric Literals</a></h1>
     <emu-note type="editor">

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -744,7 +744,7 @@
         1. If _completeness_ is not present, set _completeness_ to ~complete~.
         1. Let _partial_ be ? PrepareTemporalFields(_temporalTimeLike_, « *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"nanosecond"*, *"second"* », ~partial~).
         1. Let _result_ be a new TemporalTimeLike Record with each field set to *undefined*.
-        1. For each row of <emu-xref href="#table-temporal-temporaltimelike-record-fields"></emu-xref>, except the header row, in table order, do
+        1. For each row of <emu-xref href="#table-temporal-temporaltimelike-record-fields"></emu-xref>, except the header row, do
           1. Let _field_ be the Field Name value of the current row.
           1. Let _propertyName_ be the Property Name value of the current row.
           1. Let _valueDesc_ be OrdinaryGetOwnProperty(_partial_, _propertyName_).
@@ -772,8 +772,13 @@
             </tr>
 
             <tr>
-              <td>[[Microsecond]]</td>
-              <td>*"microsecond"*</td>
+              <td>[[Minute]]</td>
+              <td>*"minute"*</td>
+            </tr>
+
+            <tr>
+              <td>[[Second]]</td>
+              <td>*"second"*</td>
             </tr>
 
             <tr>
@@ -782,18 +787,13 @@
             </tr>
 
             <tr>
-              <td>[[Minute]]</td>
-              <td>*"minute"*</td>
+              <td>[[Microsecond]]</td>
+              <td>*"microsecond"*</td>
             </tr>
 
             <tr>
               <td>[[Nanosecond]]</td>
               <td>*"nanosecond"*</td>
-            </tr>
-
-            <tr>
-              <td>[[Second]]</td>
-              <td>*"second"*</td>
             </tr>
           </tbody>
         </table>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -743,16 +743,34 @@
       <emu-alg>
         1. If _completeness_ is not present, set _completeness_ to ~complete~.
         1. Let _partial_ be ? PrepareTemporalFields(_temporalTimeLike_, « *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"nanosecond"*, *"second"* », ~partial~).
-        1. Let _result_ be a new TemporalTimeLike Record with each field set to *undefined*.
-        1. For each row of <emu-xref href="#table-temporal-temporaltimelike-record-fields"></emu-xref>, except the header row, do
-          1. Let _field_ be the Field Name value of the current row.
-          1. Let _propertyName_ be the Property Name value of the current row.
-          1. Let _valueDesc_ be OrdinaryGetOwnProperty(_partial_, _propertyName_).
-          1. If _valueDesc_ is not *undefined*, then
-            1. Assert: _valueDesc_ is a data Property Descriptor.
-            1. Set the field of _result_ whose name is _field_ to ℝ(_valueDesc_.[[Value]]).
-          1. Else if _completeness_ is ~complete~, then
-            1. Set the field of _result_ whose name is _field_ to 0.
+        1. If _completeness_ is ~complete~, then
+          1. Let _result_ be a new TemporalTimeLike Record with each field set to 0.
+        1. Else,
+          1. Let _result_ be a new TemporalTimeLike Record with each field set to *undefined*.
+        1. Let _hourDesc_ be OrdinaryGetOwnProperty(_partial_, *"hour"*).
+        1. If _hourDesc_ is not *undefined*, then
+          1. Assert: _hourDesc_ is a data Property Descriptor.
+          1. Set _result_.[[Hour]] to ℝ(_hourDesc_.[[Value]]).
+        1. Let _minuteDesc_ be OrdinaryGetOwnProperty(_partial_, *"minute"*).
+        1. If _minuteDesc_ is not *undefined*, then
+          1. Assert: _minuteDesc_ is a data Property Descriptor.
+          1. Set _result_.[[Minute]] to ℝ(_minuteDesc_.[[Value]]).
+        1. Let _secondDesc_ be OrdinaryGetOwnProperty(_partial_, *"second"*).
+        1. If _secondDesc_ is not *undefined*, then
+          1. Assert: _secondDesc_ is a data Property Descriptor.
+          1. Set _result_.[[Second]] to ℝ(_secondDesc_.[[Value]]).
+        1. Let _millisecondDesc_ be OrdinaryGetOwnProperty(_partial_, *"millisecond"*).
+        1. If _millisecondDesc_ is not *undefined*, then
+          1. Assert: _millisecondDesc_ is a data Property Descriptor.
+          1. Set _result_.[[Millisecond]] to ℝ(_millisecondDesc_.[[Value]]).
+        1. Let _microsecondDesc_ be OrdinaryGetOwnProperty(_partial_, *"microsecond"*).
+        1. If _microsecondDesc_ is not *undefined*, then
+          1. Assert: _microsecondDesc_ is a data Property Descriptor.
+          1. Set _result_.[[Microsecond]] to ℝ(_microsecondDesc_.[[Value]]).
+        1. Let _nanosecondDesc_ be OrdinaryGetOwnProperty(_partial_, *"nanosecond"*).
+        1. If _nanosecondDesc_ is not *undefined*, then
+          1. Assert: _nanosecondDesc_ is a data Property Descriptor.
+          1. Set _result_.[[Nanosecond]] to ℝ(_nanosecondDesc_.[[Value]]).
         1. Return _result_.
       </emu-alg>
 

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -736,7 +736,7 @@
         ToTemporalTimeRecord (
           _temporalTimeLike_: an Object,
           optional _completeness_: ~partial~ or ~complete~,
-        ): either a normal completion containing an Object, or an abrupt completion
+        ): either a normal completion containing a TemporalTimeLike Record, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -93,8 +93,7 @@
       <emu-alg>
         1. Let _timeZones_ be the List of String values representing time zones supported by the implementation.
         1. Assert: _timeZones_ contains *"UTC"*.
-        1. [declared="comparefn"] Sort _timeZones_ in order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
-        1. Return _timeZones_.
+        1. Return SortStringListByCodeUnit(_timeZones_).
       </emu-alg>
       <emu-note><p>
         For example, an ECMAScript implementation that does not include local political rules for any time zone could return a List with the single String *"UTC"* here.


### PR DESCRIPTION
This implements the part of #2254 that is possible to do without any changes that are observable from JS. It reorders the tables of Duration Record fields and TemporalTimeLike Record fields so that the fields are in magnitude order, and enforces the property access in alphabetical order by sorting the list of fields. The net result is that nothing changes, but the spec text is more robust against accidental observable modifications.

Also includes some minor editorial and docs fixes.