### PR TITLE
Editorial: Changes around integer conversion operations

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -33,16 +33,16 @@ export class Duration {
     microseconds = 0,
     nanoseconds = 0
   ) {
-    years = ES.ToIntegerWithoutRounding(years);
-    months = ES.ToIntegerWithoutRounding(months);
-    weeks = ES.ToIntegerWithoutRounding(weeks);
-    days = ES.ToIntegerWithoutRounding(days);
-    hours = ES.ToIntegerWithoutRounding(hours);
-    minutes = ES.ToIntegerWithoutRounding(minutes);
-    seconds = ES.ToIntegerWithoutRounding(seconds);
-    milliseconds = ES.ToIntegerWithoutRounding(milliseconds);
-    microseconds = ES.ToIntegerWithoutRounding(microseconds);
-    nanoseconds = ES.ToIntegerWithoutRounding(nanoseconds);
+    years = ES.ToIntegerIfIntegral(years);
+    months = ES.ToIntegerIfIntegral(months);
+    weeks = ES.ToIntegerIfIntegral(weeks);
+    days = ES.ToIntegerIfIntegral(days);
+    hours = ES.ToIntegerIfIntegral(hours);
+    minutes = ES.ToIntegerIfIntegral(minutes);
+    seconds = ES.ToIntegerIfIntegral(seconds);
+    milliseconds = ES.ToIntegerIfIntegral(milliseconds);
+    microseconds = ES.ToIntegerIfIntegral(microseconds);
+    nanoseconds = ES.ToIntegerIfIntegral(nanoseconds);
 
     ES.RejectDuration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -126,18 +126,15 @@ const ToIntegerWithTruncation = (value) => {
   return integer;
 };
 
-const ToPositiveInteger = (value, property) => {
-  value = ToIntegerOrInfinity(value);
-  if (!NumberIsFinite(value)) {
-    throw new RangeError('infinity is out of range');
-  }
-  if (value < 1) {
+const ToPositiveIntegerWithTruncation = (value, property) => {
+  const integer = ToIntegerWithTruncation(value);
+  if (integer <= 0) {
     if (property !== undefined) {
       throw new RangeError(`property '${property}' cannot be a a number less than one`);
     }
     throw new RangeError('Cannot convert a number less than one to a positive integer');
   }
-  return value;
+  return integer;
 };
 const ToIntegerWithoutRounding = (value) => {
   value = ES.ToNumber(value);
@@ -153,9 +150,9 @@ const ToIntegerWithoutRounding = (value) => {
 
 const BUILTIN_CASTS = new Map([
   ['year', ToIntegerWithTruncation],
-  ['month', ToPositiveInteger],
+  ['month', ToPositiveIntegerWithTruncation],
   ['monthCode', ToString],
-  ['day', ToPositiveInteger],
+  ['day', ToPositiveIntegerWithTruncation],
   ['hour', ToIntegerWithTruncation],
   ['minute', ToIntegerWithTruncation],
   ['second', ToIntegerWithTruncation],
@@ -296,7 +293,7 @@ export const ES = ObjectAssign({}, ES2022, {
 
     return target;
   },
-  ToPositiveInteger: ToPositiveInteger,
+  ToPositiveIntegerWithTruncation,
   ToIntegerWithTruncation,
   ToIntegerWithoutRounding,
   IsTemporalInstant: (item) => HasSlot(item, EPOCHNANOSECONDS) && !HasSlot(item, TIME_ZONE, CALENDAR),
@@ -1624,7 +1621,7 @@ export const ES = ObjectAssign({}, ES2022, {
   CalendarMonth: (calendar, dateLike) => {
     const month = ES.GetMethod(calendar, 'month');
     const result = ES.Call(month, calendar, [dateLike]);
-    return ES.ToPositiveInteger(result);
+    return ES.ToPositiveIntegerWithTruncation(result);
   },
   CalendarMonthCode: (calendar, dateLike) => {
     const monthCode = ES.GetMethod(calendar, 'monthCode');
@@ -1637,7 +1634,7 @@ export const ES = ObjectAssign({}, ES2022, {
   CalendarDay: (calendar, dateLike) => {
     const day = ES.GetMethod(calendar, 'day');
     const result = ES.Call(day, calendar, [dateLike]);
-    return ES.ToPositiveInteger(result);
+    return ES.ToPositiveIntegerWithTruncation(result);
   },
   CalendarEra: (calendar, dateLike) => {
     const era = ES.GetMethod(calendar, 'era');
@@ -1657,31 +1654,31 @@ export const ES = ObjectAssign({}, ES2022, {
   },
   CalendarDayOfWeek: (calendar, dateLike) => {
     const dayOfWeek = ES.GetMethod(calendar, 'dayOfWeek');
-    return ES.ToPositiveInteger(ES.Call(dayOfWeek, calendar, [dateLike]));
+    return ES.ToPositiveIntegerWithTruncation(ES.Call(dayOfWeek, calendar, [dateLike]));
   },
   CalendarDayOfYear: (calendar, dateLike) => {
     const dayOfYear = ES.GetMethod(calendar, 'dayOfYear');
-    return ES.ToPositiveInteger(ES.Call(dayOfYear, calendar, [dateLike]));
+    return ES.ToPositiveIntegerWithTruncation(ES.Call(dayOfYear, calendar, [dateLike]));
   },
   CalendarWeekOfYear: (calendar, dateLike) => {
     const weekOfYear = ES.GetMethod(calendar, 'weekOfYear');
-    return ES.ToPositiveInteger(ES.Call(weekOfYear, calendar, [dateLike]));
+    return ES.ToPositiveIntegerWithTruncation(ES.Call(weekOfYear, calendar, [dateLike]));
   },
   CalendarDaysInWeek: (calendar, dateLike) => {
     const daysInWeek = ES.GetMethod(calendar, 'daysInWeek');
-    return ES.ToPositiveInteger(ES.Call(daysInWeek, calendar, [dateLike]));
+    return ES.ToPositiveIntegerWithTruncation(ES.Call(daysInWeek, calendar, [dateLike]));
   },
   CalendarDaysInMonth: (calendar, dateLike) => {
     const daysInMonth = ES.GetMethod(calendar, 'daysInMonth');
-    return ES.ToPositiveInteger(ES.Call(daysInMonth, calendar, [dateLike]));
+    return ES.ToPositiveIntegerWithTruncation(ES.Call(daysInMonth, calendar, [dateLike]));
   },
   CalendarDaysInYear: (calendar, dateLike) => {
     const daysInYear = ES.GetMethod(calendar, 'daysInYear');
-    return ES.ToPositiveInteger(ES.Call(daysInYear, calendar, [dateLike]));
+    return ES.ToPositiveIntegerWithTruncation(ES.Call(daysInYear, calendar, [dateLike]));
   },
   CalendarMonthsInYear: (calendar, dateLike) => {
     const monthsInYear = ES.GetMethod(calendar, 'monthsInYear');
-    return ES.ToPositiveInteger(ES.Call(monthsInYear, calendar, [dateLike]));
+    return ES.ToPositiveIntegerWithTruncation(ES.Call(monthsInYear, calendar, [dateLike]));
   },
   CalendarInLeapYear: (calendar, dateLike) => {
     const inLeapYear = ES.GetMethod(calendar, 'inLeapYear');

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -115,11 +115,14 @@ const BUILTIN_CALENDAR_IDS = [
   'gregory'
 ];
 
-const ToIntegerThrowOnInfinity = (value) => {
-  const integer = ToIntegerOrInfinity(value);
-  if (!NumberIsFinite(integer)) {
+const ToIntegerWithTruncation = (value) => {
+  const number = ToNumber(value);
+  if (NumberIsNaN(number) || number === 0) return 0;
+  if (!NumberIsFinite(number)) {
     throw new RangeError('infinity is out of range');
   }
+  const integer = MathTrunc(number);
+  if (integer === 0) return 0; // ℝ(value) in spec text; converts -0 to 0
   return integer;
 };
 
@@ -149,16 +152,16 @@ const ToIntegerWithoutRounding = (value) => {
 };
 
 const BUILTIN_CASTS = new Map([
-  ['year', ToIntegerThrowOnInfinity],
+  ['year', ToIntegerWithTruncation],
   ['month', ToPositiveInteger],
   ['monthCode', ToString],
   ['day', ToPositiveInteger],
-  ['hour', ToIntegerThrowOnInfinity],
-  ['minute', ToIntegerThrowOnInfinity],
-  ['second', ToIntegerThrowOnInfinity],
-  ['millisecond', ToIntegerThrowOnInfinity],
-  ['microsecond', ToIntegerThrowOnInfinity],
-  ['nanosecond', ToIntegerThrowOnInfinity],
+  ['hour', ToIntegerWithTruncation],
+  ['minute', ToIntegerWithTruncation],
+  ['second', ToIntegerWithTruncation],
+  ['millisecond', ToIntegerWithTruncation],
+  ['microsecond', ToIntegerWithTruncation],
+  ['nanosecond', ToIntegerWithTruncation],
   ['years', ToIntegerWithoutRounding],
   ['months', ToIntegerWithoutRounding],
   ['weeks', ToIntegerWithoutRounding],
@@ -294,7 +297,7 @@ export const ES = ObjectAssign({}, ES2022, {
     return target;
   },
   ToPositiveInteger: ToPositiveInteger,
-  ToIntegerThrowOnInfinity,
+  ToIntegerWithTruncation,
   ToIntegerWithoutRounding,
   IsTemporalInstant: (item) => HasSlot(item, EPOCHNANOSECONDS) && !HasSlot(item, TIME_ZONE, CALENDAR),
   IsTemporalTimeZone: (item) => HasSlot(item, TIMEZONE_ID),
@@ -1616,7 +1619,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (result === undefined) {
       throw new RangeError('calendar year result must be an integer');
     }
-    return ES.ToIntegerThrowOnInfinity(result);
+    return ES.ToIntegerWithTruncation(result);
   },
   CalendarMonth: (calendar, dateLike) => {
     const month = ES.GetMethod(calendar, 'month');
@@ -1648,7 +1651,7 @@ export const ES = ObjectAssign({}, ES2022, {
     const eraYear = ES.GetMethod(calendar, 'eraYear');
     let result = ES.Call(eraYear, calendar, [dateLike]);
     if (result !== undefined) {
-      result = ES.ToIntegerThrowOnInfinity(result);
+      result = ES.ToIntegerWithTruncation(result);
     }
     return result;
   },

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -136,16 +136,13 @@ const ToPositiveIntegerWithTruncation = (value, property) => {
   }
   return integer;
 };
-const ToIntegerWithoutRounding = (value) => {
-  value = ES.ToNumber(value);
-  if (NumberIsNaN(value)) return 0;
-  if (!NumberIsFinite(value)) {
-    throw new RangeError('infinity is out of range');
-  }
-  if (!IsIntegralNumber(value)) {
-    throw new RangeError(`unsupported fractional value ${value}`);
-  }
-  return ToIntegerOrInfinity(value); // ℝ(value) in spec text; converts -0 to 0
+const ToIntegerIfIntegral = (value) => {
+  const number = ES.ToNumber(value);
+  if (NumberIsNaN(number) || number === 0) return 0;
+  if (!NumberIsFinite(number)) throw new RangeError('infinity is out of range');
+  if (!IsIntegralNumber(number)) throw new RangeError(`unsupported fractional value ${value}`);
+  if (number === 0) return 0; // ℝ(value) in spec text; converts -0 to 0
+  return number;
 };
 
 const BUILTIN_CASTS = new Map([
@@ -159,16 +156,16 @@ const BUILTIN_CASTS = new Map([
   ['millisecond', ToIntegerWithTruncation],
   ['microsecond', ToIntegerWithTruncation],
   ['nanosecond', ToIntegerWithTruncation],
-  ['years', ToIntegerWithoutRounding],
-  ['months', ToIntegerWithoutRounding],
-  ['weeks', ToIntegerWithoutRounding],
-  ['days', ToIntegerWithoutRounding],
-  ['hours', ToIntegerWithoutRounding],
-  ['minutes', ToIntegerWithoutRounding],
-  ['seconds', ToIntegerWithoutRounding],
-  ['milliseconds', ToIntegerWithoutRounding],
-  ['microseconds', ToIntegerWithoutRounding],
-  ['nanoseconds', ToIntegerWithoutRounding],
+  ['years', ToIntegerIfIntegral],
+  ['months', ToIntegerIfIntegral],
+  ['weeks', ToIntegerIfIntegral],
+  ['days', ToIntegerIfIntegral],
+  ['hours', ToIntegerIfIntegral],
+  ['minutes', ToIntegerIfIntegral],
+  ['seconds', ToIntegerIfIntegral],
+  ['milliseconds', ToIntegerIfIntegral],
+  ['microseconds', ToIntegerIfIntegral],
+  ['nanoseconds', ToIntegerIfIntegral],
   ['era', ToString],
   ['eraYear', ToIntegerOrInfinity],
   ['offset', ToString]
@@ -295,7 +292,7 @@ export const ES = ObjectAssign({}, ES2022, {
   },
   ToPositiveIntegerWithTruncation,
   ToIntegerWithTruncation,
-  ToIntegerWithoutRounding,
+  ToIntegerIfIntegral,
   IsTemporalInstant: (item) => HasSlot(item, EPOCHNANOSECONDS) && !HasSlot(item, TIME_ZONE, CALENDAR),
   IsTemporalTimeZone: (item) => HasSlot(item, TIMEZONE_ID),
   IsTemporalCalendar: (item) => HasSlot(item, CALENDAR_ID),
@@ -714,7 +711,7 @@ export const ES = ObjectAssign({}, ES2022, {
       const value = temporalDurationLike[property];
       if (value !== undefined) {
         any = true;
-        result[property] = ES.ToIntegerWithoutRounding(value);
+        result[property] = ES.ToIntegerIfIntegral(value);
       }
     }
     if (!any) {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -531,11 +531,11 @@ export const ES = ObjectAssign({}, ES2022, {
       throw new RangeError(`invalid duration: ${isoString}`);
     }
     const sign = match[1] === '-' || match[1] === '\u2212' ? -1 : 1;
-    const years = ES.ToIntegerOrInfinity(match[2]) * sign;
-    const months = ES.ToIntegerOrInfinity(match[3]) * sign;
-    const weeks = ES.ToIntegerOrInfinity(match[4]) * sign;
-    const days = ES.ToIntegerOrInfinity(match[5]) * sign;
-    const hours = ES.ToIntegerOrInfinity(match[6]) * sign;
+    const years = ES.ToIntegerWithTruncation(match[2]) * sign;
+    const months = ES.ToIntegerWithTruncation(match[3]) * sign;
+    const weeks = ES.ToIntegerWithTruncation(match[4]) * sign;
+    const days = ES.ToIntegerWithTruncation(match[5]) * sign;
+    const hours = ES.ToIntegerWithTruncation(match[6]) * sign;
     let fHours = match[7];
     let minutesStr = match[8];
     let fMinutes = match[9];
@@ -550,18 +550,18 @@ export const ES = ObjectAssign({}, ES2022, {
       if (minutesStr ?? fMinutes ?? secondsStr ?? fSeconds ?? false) {
         throw new RangeError('only the smallest unit can be fractional');
       }
-      excessNanoseconds = ES.ToIntegerOrInfinity((fHours + '000000000').slice(0, 9)) * 3600 * sign;
+      excessNanoseconds = ES.ToIntegerWithTruncation((fHours + '000000000').slice(0, 9)) * 3600 * sign;
     } else {
-      minutes = ES.ToIntegerOrInfinity(minutesStr) * sign;
+      minutes = ES.ToIntegerWithTruncation(minutesStr) * sign;
       if (fMinutes !== undefined) {
         if (secondsStr ?? fSeconds ?? false) {
           throw new RangeError('only the smallest unit can be fractional');
         }
-        excessNanoseconds = ES.ToIntegerOrInfinity((fMinutes + '000000000').slice(0, 9)) * 60 * sign;
+        excessNanoseconds = ES.ToIntegerWithTruncation((fMinutes + '000000000').slice(0, 9)) * 60 * sign;
       } else {
-        seconds = ES.ToIntegerOrInfinity(secondsStr) * sign;
+        seconds = ES.ToIntegerWithTruncation(secondsStr) * sign;
         if (fSeconds !== undefined) {
-          excessNanoseconds = ES.ToIntegerOrInfinity((fSeconds + '000000000').slice(0, 9)) * sign;
+          excessNanoseconds = ES.ToIntegerWithTruncation((fSeconds + '000000000').slice(0, 9)) * sign;
         }
       }
     }
@@ -572,7 +572,6 @@ export const ES = ObjectAssign({}, ES2022, {
     seconds += MathTrunc(excessNanoseconds / 1e9) % 60;
     minutes += MathTrunc(excessNanoseconds / 6e10);
 
-    ES.RejectDuration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
     return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
   },
   ParseTemporalInstant: (isoString) => {

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -18,13 +18,13 @@ import {
 
 export class PlainDate {
   constructor(isoYear, isoMonth, isoDay, calendar = ES.GetISO8601Calendar()) {
-    isoYear = ES.ToIntegerThrowOnInfinity(isoYear);
-    isoMonth = ES.ToIntegerThrowOnInfinity(isoMonth);
-    isoDay = ES.ToIntegerThrowOnInfinity(isoDay);
+    isoYear = ES.ToIntegerWithTruncation(isoYear);
+    isoMonth = ES.ToIntegerWithTruncation(isoMonth);
+    isoDay = ES.ToIntegerWithTruncation(isoDay);
     calendar = ES.ToTemporalCalendar(calendar);
 
     // Note: if the arguments are not passed,
-    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
+    //       ToIntegerWithTruncation(undefined) will have returned 0, which will
     //       be rejected by RejectISODate in CreateTemporalDateSlots. This check
     //       exists only to improve the error message.
     if (arguments.length < 3) {

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -32,19 +32,19 @@ export class PlainDateTime {
     nanosecond = 0,
     calendar = ES.GetISO8601Calendar()
   ) {
-    isoYear = ES.ToIntegerThrowOnInfinity(isoYear);
-    isoMonth = ES.ToIntegerThrowOnInfinity(isoMonth);
-    isoDay = ES.ToIntegerThrowOnInfinity(isoDay);
-    hour = ES.ToIntegerThrowOnInfinity(hour);
-    minute = ES.ToIntegerThrowOnInfinity(minute);
-    second = ES.ToIntegerThrowOnInfinity(second);
-    millisecond = ES.ToIntegerThrowOnInfinity(millisecond);
-    microsecond = ES.ToIntegerThrowOnInfinity(microsecond);
-    nanosecond = ES.ToIntegerThrowOnInfinity(nanosecond);
+    isoYear = ES.ToIntegerWithTruncation(isoYear);
+    isoMonth = ES.ToIntegerWithTruncation(isoMonth);
+    isoDay = ES.ToIntegerWithTruncation(isoDay);
+    hour = ES.ToIntegerWithTruncation(hour);
+    minute = ES.ToIntegerWithTruncation(minute);
+    second = ES.ToIntegerWithTruncation(second);
+    millisecond = ES.ToIntegerWithTruncation(millisecond);
+    microsecond = ES.ToIntegerWithTruncation(microsecond);
+    nanosecond = ES.ToIntegerWithTruncation(nanosecond);
     calendar = ES.ToTemporalCalendar(calendar);
 
     // Note: if the arguments are not passed,
-    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
+    //       ToIntegerWithTruncation(undefined) will have returned 0, which will
     //       be rejected by RejectDateTime in CreateTemporalDateTimeSlots. This
     //       check exists only to improve the error message.
     if (arguments.length < 3) {

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -10,13 +10,13 @@ const SetPrototypeForEach = Set.prototype.forEach;
 
 export class PlainMonthDay {
   constructor(isoMonth, isoDay, calendar = ES.GetISO8601Calendar(), referenceISOYear = 1972) {
-    isoMonth = ES.ToIntegerThrowOnInfinity(isoMonth);
-    isoDay = ES.ToIntegerThrowOnInfinity(isoDay);
+    isoMonth = ES.ToIntegerWithTruncation(isoMonth);
+    isoDay = ES.ToIntegerWithTruncation(isoDay);
     calendar = ES.ToTemporalCalendar(calendar);
-    referenceISOYear = ES.ToIntegerThrowOnInfinity(referenceISOYear);
+    referenceISOYear = ES.ToIntegerWithTruncation(referenceISOYear);
 
     // Note: if the arguments are not passed,
-    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
+    //       ToIntegerWithTruncation(undefined) will have returned 0, which will
     //       be rejected by RejectISODate in CreateTemporalMonthDaySlots. This
     //       check exists only to improve the error message.
     if (arguments.length < 2) {

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -55,12 +55,12 @@ function TemporalTimeToString(time, precision, options = undefined) {
 
 export class PlainTime {
   constructor(isoHour = 0, isoMinute = 0, isoSecond = 0, isoMillisecond = 0, isoMicrosecond = 0, isoNanosecond = 0) {
-    isoHour = ES.ToIntegerThrowOnInfinity(isoHour);
-    isoMinute = ES.ToIntegerThrowOnInfinity(isoMinute);
-    isoSecond = ES.ToIntegerThrowOnInfinity(isoSecond);
-    isoMillisecond = ES.ToIntegerThrowOnInfinity(isoMillisecond);
-    isoMicrosecond = ES.ToIntegerThrowOnInfinity(isoMicrosecond);
-    isoNanosecond = ES.ToIntegerThrowOnInfinity(isoNanosecond);
+    isoHour = ES.ToIntegerWithTruncation(isoHour);
+    isoMinute = ES.ToIntegerWithTruncation(isoMinute);
+    isoSecond = ES.ToIntegerWithTruncation(isoSecond);
+    isoMillisecond = ES.ToIntegerWithTruncation(isoMillisecond);
+    isoMicrosecond = ES.ToIntegerWithTruncation(isoMicrosecond);
+    isoNanosecond = ES.ToIntegerWithTruncation(isoNanosecond);
 
     ES.RejectTime(isoHour, isoMinute, isoSecond, isoMillisecond, isoMicrosecond, isoNanosecond);
     CreateSlots(this);

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -10,13 +10,13 @@ const SetPrototypeForEach = Set.prototype.forEach;
 
 export class PlainYearMonth {
   constructor(isoYear, isoMonth, calendar = ES.GetISO8601Calendar(), referenceISODay = 1) {
-    isoYear = ES.ToIntegerThrowOnInfinity(isoYear);
-    isoMonth = ES.ToIntegerThrowOnInfinity(isoMonth);
+    isoYear = ES.ToIntegerWithTruncation(isoYear);
+    isoMonth = ES.ToIntegerWithTruncation(isoMonth);
     calendar = ES.ToTemporalCalendar(calendar);
-    referenceISODay = ES.ToIntegerThrowOnInfinity(referenceISODay);
+    referenceISODay = ES.ToIntegerWithTruncation(referenceISODay);
 
     // Note: if the arguments are not passed,
-    //       ToIntegerThrowOnInfinity(undefined) will have returned 0, which will
+    //       ToIntegerWithTruncation(undefined) will have returned 0, which will
     //       be rejected by RejectISODate in CreateTemporalYearMonthSlots. This
     //       check exists only to improve the error message.
     if (arguments.length < 2) {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1405,37 +1405,37 @@
       <dt>description</dt>
       <dd>It parses the argument as an ISO 8601 duration string and returns a Duration Record.</dd>
     </dl>
-    <emu-note>The value of ToIntegerOrInfinity(*""*) is 0.</emu-note>
+    <emu-note>The value of ToIntegerWithTruncation(*""*) is 0.</emu-note>
     <emu-note>Use of mathematical values rather than approximations is important to avoid off-by-one errors with input like "PT46H66M71.50040904S".</emu-note>
     <emu-alg>
       1. Let _duration_ be ParseText(StringToCodePoints(_isoString_), |TemporalDurationString|).
       1. If _duration_ is a List of errors, throw a *RangeError* exception.
       1. Let each of _sign_, _years_, _months_, _weeks_, _days_, _hours_, _fHours_, _minutes_, _fMinutes_, _seconds_, and _fSeconds_ be the source text matched by the respective |Sign|, |DurationYears|, |DurationMonths|, |DurationWeeks|, |DurationDays|, |DurationWholeHours|, |DurationHoursFraction|, |DurationWholeMinutes|, |DurationMinutesFraction|, |DurationWholeSeconds|, and |DurationSecondsFraction| Parse Node contained within _duration_, or an empty sequence of code points if not present.
-      1. Let _yearsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_years_)).
-      1. Let _monthsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_months_)).
-      1. Let _weeksMV_ be ! ToIntegerOrInfinity(CodePointsToString(_weeks_)).
-      1. Let _daysMV_ be ! ToIntegerOrInfinity(CodePointsToString(_days_)).
-      1. Let _hoursMV_ be ! ToIntegerOrInfinity(CodePointsToString(_hours_)).
+      1. Let _yearsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_years_)).
+      1. Let _monthsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_months_)).
+      1. Let _weeksMV_ be ? ToIntegerWithTruncation(CodePointsToString(_weeks_)).
+      1. Let _daysMV_ be ? ToIntegerWithTruncation(CodePointsToString(_days_)).
+      1. Let _hoursMV_ be ? ToIntegerWithTruncation(CodePointsToString(_hours_)).
       1. If _fHours_ is not empty, then
         1. If any of _minutes_, _fMinutes_, _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fHoursDigits_ be the substring of CodePointsToString(_fHours_) from 1.
         1. Let _fHoursScale_ be the length of _fHoursDigits_.
-        1. Let _minutesMV_ be ! ToIntegerOrInfinity(_fHoursDigits_) / 10<sup>_fHoursScale_</sup> &times; 60.
+        1. Let _minutesMV_ be ? ToIntegerWithTruncation(_fHoursDigits_) / 10<sup>_fHoursScale_</sup> &times; 60.
       1. Else,
-        1. Let _minutesMV_ be ! ToIntegerOrInfinity(CodePointsToString(_minutes_)).
+        1. Let _minutesMV_ be ? ToIntegerWithTruncation(CodePointsToString(_minutes_)).
       1. If _fMinutes_ is not empty, then
         1. If any of _seconds_, _fSeconds_ is not empty, throw a *RangeError* exception.
         1. Let _fMinutesDigits_ be the substring of CodePointsToString(_fMinutes_) from 1.
         1. Let _fMinutesScale_ be the length of _fMinutesDigits_.
-        1. Let _secondsMV_ be ! ToIntegerOrInfinity(_fMinutesDigits_) / 10<sup>_fMinutesScale_</sup> &times; 60.
+        1. Let _secondsMV_ be ? ToIntegerWithTruncation(_fMinutesDigits_) / 10<sup>_fMinutesScale_</sup> &times; 60.
       1. Else if _seconds_ is not empty, then
-        1. Let _secondsMV_ be ! ToIntegerOrInfinity(CodePointsToString(_seconds_)).
+        1. Let _secondsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_seconds_)).
       1. Else,
         1. Let _secondsMV_ be remainder(_minutesMV_, 1) &times; 60.
       1. If _fSeconds_ is not empty, then
         1. Let _fSecondsDigits_ be the substring of CodePointsToString(_fSeconds_) from 1.
         1. Let _fSecondsScale_ be the length of _fSecondsDigits_.
-        1. Let _millisecondsMV_ be ! ToIntegerOrInfinity(_fSecondsDigits_) / 10<sup>_fSecondsScale_</sup> &times; 1000.
+        1. Let _millisecondsMV_ be ? ToIntegerWithTruncation(_fSecondsDigits_) / 10<sup>_fSecondsScale_</sup> &times; 1000.
       1. Else,
         1. Let _millisecondsMV_ be remainder(_secondsMV_, 1) &times; 1000.
       1. Let _microsecondsMV_ be remainder(_millisecondsMV_, 1) &times; 1000.
@@ -1444,7 +1444,7 @@
         1. Let _factor_ be -1.
       1. Else,
         1. Let _factor_ be 1.
-      1. Return ? CreateDurationRecord(_yearsMV_ &times; _factor_, _monthsMV_ &times; _factor_, _weeksMV_ &times; _factor_, _daysMV_ &times; _factor_, _hoursMV_ &times; _factor_, floor(_minutesMV_) &times; _factor_, floor(_secondsMV_) &times; _factor_, floor(_millisecondsMV_) &times; _factor_, floor(_microsecondsMV_) &times; _factor_, floor(_nanosecondsMV_) &times; _factor_).
+      1. Return ! CreateDurationRecord(_yearsMV_ &times; _factor_, _monthsMV_ &times; _factor_, _weeksMV_ &times; _factor_, _daysMV_ &times; _factor_, _hoursMV_ &times; _factor_, floor(_minutesMV_) &times; _factor_, floor(_secondsMV_) &times; _factor_, floor(_millisecondsMV_) &times; _factor_, floor(_microsecondsMV_) &times; _factor_, floor(_nanosecondsMV_) &times; _factor_).
     </emu-alg>
   </emu-clause>
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1568,15 +1568,19 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-topositiveinteger" aoid="ToPositiveInteger">
-    <h1>ToPositiveInteger ( _argument_ )</h1>
-    <p>
-      The abstract operation ToPositiveInteger takes argument _argument_. It converts _argument_ to an integer _i_ for which <emu-eqn>0 &lt; _i_</emu-eqn>. It performs the following steps:
-    </p>
+  <emu-clause id="sec-topositiveintegerwithtruncation" type="abstract operation">
+    <h1>
+      ToPositiveIntegerWithTruncation (
+        _argument_: an ECMAScript language value,
+      ): either a normal completion containing a positive integer, or an abrupt completion
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It converts _argument_ to an integer representing its Number value with fractional part truncated (replacing *NaN* with 0), or throws a *RangeError* when that Number value is not finite or not positive.</dd>
+    </dl>
     <emu-alg>
       1. Let _integer_ be ? ToIntegerWithTruncation(_argument_).
-      1. If _integer_ &le; 0, then
-        1. Throw a *RangeError* exception.
+      1. If _integer_ &le; 0, throw a *RangeError* exception.
       1. Return _integer_.
     </emu-alg>
   </emu-clause>
@@ -1645,8 +1649,8 @@
             1. If _Conversion_ is ~ToIntegerWithTruncation~, then
               1. Set _value_ to ? ToIntegerWithTruncation(_value_).
               1. Set _value_ to 𝔽(_value_).
-            1. Else if _Conversion_ is ~ToPositiveInteger~, then
-              1. Set _value_ to ? ToPositiveInteger(_value_).
+            1. Else if _Conversion_ is ~ToPositiveIntegerWithTruncation~, then
+              1. Set _value_ to ? ToPositiveIntegerWithTruncation(_value_).
               1. Set _value_ to 𝔽(_value_).
             1. Else,
               1. Assert: _Conversion_ is ~ToString~.
@@ -1662,7 +1666,7 @@
         1. Throw a *TypeError* exception.
       1. Return _result_.
     </emu-alg>
-    <emu-note>The values of ! ToIntegerWithTruncation(*undefined*) and ! ToPositiveInteger(*undefined*) are 0.</emu-note>
+    <emu-note>The values of ! ToIntegerWithTruncation(*undefined*) and ! ToPositiveIntegerWithTruncation(*undefined*) are 0.</emu-note>
     <emu-table id="table-temporal-field-requirements">
       <emu-caption>Temporal field requirements</emu-caption>
       <table class="real-table">
@@ -1681,7 +1685,7 @@
           </tr>
           <tr>
             <td>*"month"*</td>
-            <td>~ToPositiveInteger~</td>
+            <td>~ToPositiveIntegerWithTruncation~</td>
             <td>*undefined*</td>
           </tr>
           <tr>
@@ -1691,7 +1695,7 @@
           </tr>
           <tr>
             <td>*"day"*</td>
-            <td>~ToPositiveInteger~</td>
+            <td>~ToPositiveIntegerWithTruncation~</td>
             <td>*undefined*</td>
           </tr>
           <tr>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1574,23 +1574,28 @@
       The abstract operation ToPositiveInteger takes argument _argument_. It converts _argument_ to an integer _i_ for which <emu-eqn>0 &lt; _i_</emu-eqn>. It performs the following steps:
     </p>
     <emu-alg>
-      1. Let _integer_ be ? ToIntegerThrowOnInfinity(_argument_).
+      1. Let _integer_ be ? ToIntegerWithTruncation(_argument_).
       1. If _integer_ &le; 0, then
         1. Throw a *RangeError* exception.
       1. Return _integer_.
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-tointegerthrowoninfinity" aoid="ToIntegerThrowOnInfinity">
-    <h1>ToIntegerThrowOnInfinity ( _argument_ )</h1>
-    <p>
-      The abstract operation ToIntegerThrowOnInfinity takes argument _argument_. It converts _argument_ to an integer. It performs the following steps:
-    </p>
+  <emu-clause id="sec-tointegerwithtruncation" type="abstract operation">
+    <h1>
+      ToIntegerWithTruncation (
+        _argument_: an ECMAScript language value,
+      ): either a normal completion containing an integer, or an abrupt completion
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It converts _argument_ to an integer representing its Number value with fractional part truncated (replacing *NaN* with 0), or throws a *RangeError* when that Number value is not finite.</dd>
+    </dl>
     <emu-alg>
-      1. Let _integer_ be ? ToIntegerOrInfinity(_argument_).
-      1. If _integer_ is -&infin; or +&infin;, then
-        1. Throw a *RangeError* exception.
-      1. Return _integer_.
+      1. Let _number_ be ? ToNumber(_argument_).
+      1. If _number_ is *NaN*, return 0.
+      1. If _number_ is *+&infin;*<sub>𝔽</sub> or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
+      1. Return truncate(ℝ(number)).
     </emu-alg>
   </emu-clause>
 
@@ -1637,8 +1642,8 @@
           1. Set _any_ to *true*.
           1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
             1. Let _Conversion_ be the Conversion value of the same row.
-            1. If _Conversion_ is ~ToIntegerThrowOnInfinity~, then
-              1. Set _value_ to ? ToIntegerThrowOnInfinity(_value_).
+            1. If _Conversion_ is ~ToIntegerWithTruncation~, then
+              1. Set _value_ to ? ToIntegerWithTruncation(_value_).
               1. Set _value_ to 𝔽(_value_).
             1. Else if _Conversion_ is ~ToPositiveInteger~, then
               1. Set _value_ to ? ToPositiveInteger(_value_).
@@ -1657,7 +1662,7 @@
         1. Throw a *TypeError* exception.
       1. Return _result_.
     </emu-alg>
-    <emu-note>The values of ! ToIntegerThrowOnInfinity(*undefined*) and ! ToPositiveInteger(*undefined*) are 0.</emu-note>
+    <emu-note>The values of ! ToIntegerWithTruncation(*undefined*) and ! ToPositiveInteger(*undefined*) are 0.</emu-note>
     <emu-table id="table-temporal-field-requirements">
       <emu-caption>Temporal field requirements</emu-caption>
       <table class="real-table">
@@ -1671,7 +1676,7 @@
         <tbody>
           <tr>
             <td>*"year"*</td>
-            <td>~ToIntegerThrowOnInfinity~</td>
+            <td>~ToIntegerWithTruncation~</td>
             <td>*undefined*</td>
           </tr>
           <tr>
@@ -1691,32 +1696,32 @@
           </tr>
           <tr>
             <td>*"hour"*</td>
-            <td>~ToIntegerThrowOnInfinity~</td>
+            <td>~ToIntegerWithTruncation~</td>
             <td>*+0*<sub>𝔽</sub></td>
           </tr>
           <tr>
             <td>*"minute"*</td>
-            <td>~ToIntegerThrowOnInfinity~</td>
+            <td>~ToIntegerWithTruncation~</td>
             <td>*+0*<sub>𝔽</sub></td>
           </tr>
           <tr>
             <td>*"second"*</td>
-            <td>~ToIntegerThrowOnInfinity~</td>
+            <td>~ToIntegerWithTruncation~</td>
             <td>*+0*<sub>𝔽</sub></td>
           </tr>
           <tr>
             <td>*"millisecond"*</td>
-            <td>~ToIntegerThrowOnInfinity~</td>
+            <td>~ToIntegerWithTruncation~</td>
             <td>*+0*<sub>𝔽</sub></td>
           </tr>
           <tr>
             <td>*"microsecond"*</td>
-            <td>~ToIntegerThrowOnInfinity~</td>
+            <td>~ToIntegerWithTruncation~</td>
             <td>*+0*<sub>𝔽</sub></td>
           </tr>
           <tr>
             <td>*"nanosecond"*</td>
-            <td>~ToIntegerThrowOnInfinity~</td>
+            <td>~ToIntegerWithTruncation~</td>
             <td>*+0*<sub>𝔽</sub></td>
           </tr>
           <tr>
@@ -1731,7 +1736,7 @@
           </tr>
           <tr>
             <td>*"eraYear"*</td>
-            <td>~ToIntegerThrowOnInfinity~</td>
+            <td>~ToIntegerWithTruncation~</td>
             <td>*undefined*</td>
           </tr>
           <tr>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1603,15 +1603,15 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-tointegerwithoutrounding" type="abstract operation">
+  <emu-clause id="sec-tointegerifintegral" type="abstract operation">
     <h1>
-      ToIntegerWithoutRounding (
+      ToIntegerIfIntegral (
         _argument_: an ECMAScript language value,
-      )
+      ): either a normal completion containing an integer, or an abrupt completion
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It converts _argument_ to an integer, throwing if doing so would require rounding.</dd>
+      <dd>It converts _argument_ to an integer representing its Number value (replacing *NaN* with 0), or throws a *RangeError* when that Number value is not a finite integral Number.</dd>
     </dl>
     <emu-alg>
       1. Let _number_ be ? ToNumber(_argument_).

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1666,7 +1666,10 @@
         1. Throw a *TypeError* exception.
       1. Return _result_.
     </emu-alg>
-    <emu-note>The values of ! ToIntegerWithTruncation(*undefined*) and ! ToPositiveIntegerWithTruncation(*undefined*) are 0.</emu-note>
+    <emu-note>
+      The value of ! ToIntegerWithTruncation(*undefined*) is 0.
+      ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.
+    </emu-note>
     <emu-table id="table-temporal-field-requirements">
       <emu-caption>Temporal field requirements</emu-caption>
       <table class="real-table">

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -159,7 +159,7 @@
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"year"*, « _dateLike_ »).
         1. If _result_ is *undefined*, throw a *RangeError* exception.
-        1. Return ? ToIntegerThrowOnInfinity(_result_).
+        1. Return ? ToIntegerWithTruncation(_result_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -176,9 +176,9 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"month"*, « _dateLike_ »).
-        1. Return ? ToPositiveInteger(_result_).
+        1. Return ? ToPositiveIntegerWithTruncation(_result_).
       </emu-alg>
-      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
+      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarmonthcode" type="abstract operation">
@@ -212,9 +212,9 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"day"*, « _dateLike_ »).
-        1. Return ? ToPositiveInteger(_result_).
+        1. Return ? ToPositiveIntegerWithTruncation(_result_).
       </emu-alg>
-      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
+      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardayofweek" type="abstract operation">
@@ -230,9 +230,9 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfWeek"*, « _dateLike_ »).
-        1. Return ? ToPositiveInteger(_result_).
+        1. Return ? ToPositiveIntegerWithTruncation(_result_).
       </emu-alg>
-      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
+      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardayofyear" type="abstract operation">
@@ -248,9 +248,9 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfYear"*, « _dateLike_ »).
-        1. Return ? ToPositiveInteger(_result_).
+        1. Return ? ToPositiveIntegerWithTruncation(_result_).
       </emu-alg>
-      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
+      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarweekofyear" type="abstract operation">
@@ -266,9 +266,9 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"weekOfYear"*, « _dateLike_ »).
-        1. Return ? ToPositiveInteger(_result_).
+        1. Return ? ToPositiveIntegerWithTruncation(_result_).
       </emu-alg>
-      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
+      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardaysinweek" type="abstract operation">
@@ -284,9 +284,9 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"daysInWeek"*, « _dateLike_ »).
-        1. Return ? ToPositiveInteger(_result_).
+        1. Return ? ToPositiveIntegerWithTruncation(_result_).
       </emu-alg>
-      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
+      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardaysinmonth" type="abstract operation">
@@ -302,9 +302,9 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"daysInMonth"*, « _dateLike_ »).
-        1. Return ? ToPositiveInteger(_result_).
+        1. Return ? ToPositiveIntegerWithTruncation(_result_).
       </emu-alg>
-      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
+      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardaysinyear" type="abstract operation">
@@ -320,9 +320,9 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"daysInYear"*, « _dateLike_ »).
-        1. Return ? ToPositiveInteger(_result_).
+        1. Return ? ToPositiveIntegerWithTruncation(_result_).
       </emu-alg>
-      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
+      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarmonthsinyear" type="abstract operation">
@@ -338,9 +338,9 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"monthsInYear"*, « _dateLike_ »).
-        1. Return ? ToPositiveInteger(_result_).
+        1. Return ? ToPositiveIntegerWithTruncation(_result_).
       </emu-alg>
-      <emu-note>ToPositiveInteger(*undefined*) will throw a *RangeError*.</emu-note>
+      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarinleapyear" type="abstract operation">

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -35,20 +35,20 @@
       <p>
         The `Temporal.Duration` function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerWithoutRounding(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerIfIntegral(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _y_ be ? ToIntegerWithoutRounding(_years_).
-        1. Let _mo_ be ? ToIntegerWithoutRounding(_months_).
-        1. Let _w_ be ? ToIntegerWithoutRounding(_weeks_).
-        1. Let _d_ be ? ToIntegerWithoutRounding(_days_).
-        1. Let _h_ be ? ToIntegerWithoutRounding(_hours_).
-        1. Let _m_ be ? ToIntegerWithoutRounding(_minutes_).
-        1. Let _s_ be ? ToIntegerWithoutRounding(_seconds_).
-        1. Let _ms_ be ? ToIntegerWithoutRounding(_milliseconds_).
-        1. Let _mis_ be ? ToIntegerWithoutRounding(_microseconds_).
-        1. Let _ns_ be ? ToIntegerWithoutRounding(_nanoseconds_).
+        1. Let _y_ be ? ToIntegerIfIntegral(_years_).
+        1. Let _mo_ be ? ToIntegerIfIntegral(_months_).
+        1. Let _w_ be ? ToIntegerIfIntegral(_weeks_).
+        1. Let _d_ be ? ToIntegerIfIntegral(_days_).
+        1. Let _h_ be ? ToIntegerIfIntegral(_hours_).
+        1. Let _m_ be ? ToIntegerIfIntegral(_minutes_).
+        1. Let _s_ be ? ToIntegerIfIntegral(_seconds_).
+        1. Let _ms_ be ? ToIntegerIfIntegral(_milliseconds_).
+        1. Let _mis_ be ? ToIntegerIfIntegral(_microseconds_).
+        1. Let _ns_ be ? ToIntegerIfIntegral(_nanoseconds_).
         1. Return ? CreateTemporalDuration(_y_, _mo_, _w_, _d_, _h_, _m_, _s_, _ms_, _mis_, _ns_, NewTarget).
       </emu-alg>
     </emu-clause>
@@ -1050,7 +1050,7 @@
           1. Let _value_ be ? Get(_temporalDurationLike_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
-            1. Set _value_ to ? ToIntegerWithoutRounding(_value_).
+            1. Set _value_ to ? ToIntegerIfIntegral(_value_).
             1. Let _fieldName_ be the Field Name value of the current row.
             1. Set the field of _result_ whose name is _fieldName_ to _value_.
         1. If _any_ is *false*, then

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1386,7 +1386,7 @@
           <emu-alg>
             1. Assert: Type(_calendar_) is Object.
             1. Let _result_ be ? Invoke(_calendar_, *"eraYear"*, « _dateLike_ »).
-            1. If _result_ is not *undefined*, set _result_ to ? ToIntegerThrowOnInfinity(_result_).
+            1. If _result_ is not *undefined*, set _result_ to ? ToIntegerWithTruncation(_result_).
             1. Return _result_.
           </emu-alg>
         </emu-clause>
@@ -2388,8 +2388,8 @@
               1. Set _any_ to *true*.
               1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
                 1. Let _Conversion_ be the Conversion value of the same row.
-                1. If _Conversion_ is ~ToIntegerThrowOnInfinity~, then
-                  1. Set _value_ to ? ToIntegerThrowOnInfinity(_value_).
+                1. If _Conversion_ is ~ToIntegerWithTruncation~, then
+                  1. Set _value_ to ? ToIntegerWithTruncation(_value_).
                   1. Set _value_ to 𝔽(_value_).
                 1. Else if _Conversion_ is ~ToPositiveInteger~, then
                   1. Set _value_ to ? ToPositiveInteger(_value_).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2391,8 +2391,8 @@
                 1. If _Conversion_ is ~ToIntegerWithTruncation~, then
                   1. Set _value_ to ? ToIntegerWithTruncation(_value_).
                   1. Set _value_ to 𝔽(_value_).
-                1. Else if _Conversion_ is ~ToPositiveInteger~, then
-                  1. Set _value_ to ? ToPositiveInteger(_value_).
+                1. Else if _Conversion_ is ~ToPositiveIntegerWithTruncation~, then
+                  1. Set _value_ to ? ToPositiveIntegerWithTruncation(_value_).
                   1. Set _value_ to 𝔽(_value_).
                 1. Else,
                   1. Assert: _Conversion_ is ~ToString~.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -30,12 +30,12 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _y_ be ? ToIntegerThrowOnInfinity(_isoYear_).
-        1. Let _m_ be ? ToIntegerThrowOnInfinity(_isoMonth_).
-        1. Let _d_ be ? ToIntegerThrowOnInfinity(_isoDay_).
+        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_).
+        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).
+        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
         1. Return ? CreateTemporalDate(_y_, _m_, _d_, _calendar_, NewTarget).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -28,19 +28,19 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _isoYear_ be ? ToIntegerThrowOnInfinity(_isoYear_).
-        1. Let _isoMonth_ be ? ToIntegerThrowOnInfinity(_isoMonth_).
-        1. Let _isoDay_ be ? ToIntegerThrowOnInfinity(_isoDay_).
-        1. Let _hour_ be ? ToIntegerThrowOnInfinity(_hour_).
-        1. Let _minute_ be ? ToIntegerThrowOnInfinity(_minute_).
-        1. Let _second_ be ? ToIntegerThrowOnInfinity(_second_).
-        1. Let _millisecond_ be ? ToIntegerThrowOnInfinity(_millisecond_).
-        1. Let _microsecond_ be ? ToIntegerThrowOnInfinity(_microsecond_).
-        1. Let _nanosecond_ be ? ToIntegerThrowOnInfinity(_nanosecond_).
+        1. Let _isoYear_ be ? ToIntegerWithTruncation(_isoYear_).
+        1. Let _isoMonth_ be ? ToIntegerWithTruncation(_isoMonth_).
+        1. Let _isoDay_ be ? ToIntegerWithTruncation(_isoDay_).
+        1. Let _hour_ be ? ToIntegerWithTruncation(_hour_).
+        1. Let _minute_ be ? ToIntegerWithTruncation(_minute_).
+        1. Let _second_ be ? ToIntegerWithTruncation(_second_).
+        1. Let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_).
+        1. Let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_).
+        1. Let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
         1. Return ? CreateTemporalDateTime(_isoYear_, _isoMonth_, _isoDay_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _calendar_, NewTarget).
       </emu-alg>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -28,16 +28,16 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. If _referenceISOYear_ is *undefined*, then
           1. Set _referenceISOYear_ to *1972*<sub>𝔽</sub>.
-        1. Let _m_ be ? ToIntegerThrowOnInfinity(_isoMonth_).
-        1. Let _d_ be ? ToIntegerThrowOnInfinity(_isoDay_).
+        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).
+        1. Let _d_ be ? ToIntegerWithTruncation(_isoDay_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-        1. Let _ref_ be ? ToIntegerThrowOnInfinity(_referenceISOYear_).
+        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISOYear_).
         1. Return ? CreateTemporalMonthDay(_m_, _d_, _calendar_, _ref_, NewTarget).
       </emu-alg>
       <emu-note>1972 is the first leap year after the Unix epoch.</emu-note>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -29,16 +29,16 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Let _hour_ be ? ToIntegerThrowOnInfinity(_hour_).
-        1. Let _minute_ be ? ToIntegerThrowOnInfinity(_minute_).
-        1. Let _second_ be ? ToIntegerThrowOnInfinity(_second_).
-        1. Let _millisecond_ be ? ToIntegerThrowOnInfinity(_millisecond_).
-        1. Let _microsecond_ be ? ToIntegerThrowOnInfinity(_microsecond_).
-        1. Let _nanosecond_ be ? ToIntegerThrowOnInfinity(_nanosecond_).
+        1. Let _hour_ be ? ToIntegerWithTruncation(_hour_).
+        1. Let _minute_ be ? ToIntegerWithTruncation(_minute_).
+        1. Let _second_ be ? ToIntegerWithTruncation(_second_).
+        1. Let _millisecond_ be ? ToIntegerWithTruncation(_millisecond_).
+        1. Let _microsecond_ be ? ToIntegerWithTruncation(_microsecond_).
+        1. Let _nanosecond_ be ? ToIntegerWithTruncation(_nanosecond_).
         1. Return ? CreateTemporalTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, NewTarget).
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -28,16 +28,16 @@
       <p>
         This function performs the following steps when called:
       </p>
-      <emu-note>The value of ! ToIntegerThrowOnInfinity(*undefined*) is 0.</emu-note>
+      <emu-note>The value of ! ToIntegerWithTruncation(*undefined*) is 0.</emu-note>
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. If _referenceISODay_ is *undefined*, then
           1. Set _referenceISODay_ to *1*<sub>𝔽</sub>.
-        1. Let _y_ be ? ToIntegerThrowOnInfinity(_isoYear_).
-        1. Let _m_ be ? ToIntegerThrowOnInfinity(_isoMonth_).
+        1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_).
+        1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).
         1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_calendarLike_).
-        1. Let _ref_ be ? ToIntegerThrowOnInfinity(_referenceISODay_).
+        1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISODay_).
         1. Return ? CreateTemporalYearMonth(_y_, _m_, _calendar_, _ref_, NewTarget).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
This implements the proposed renames of:
- ToIntegerThrowOnInfinity → ToTruncatedInteger
- ToPositiveInteger → ToTruncatedPositiveInteger
- ToIntegerWithoutRounding → ToEnforcedInteger

The abstract operations get structured headers and are rewritten so that they call ToNumber instead of ToIntegerOrInfinity, which should make it easier to tell what's going on when reading them.

Throws in a couple of fixes for editorial bugs that had to do with these integer conversion operations.

See: #2112
Closes: #2240 
Closes: #2389