### PR TITLE
A few editorial improvements

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1383,14 +1383,14 @@ export const ES = ObjectAssign({}, ES2022, {
       ES.Call(ArrayPrototypePush, fieldNames, ['timeZone', 'offset']);
       const fields = ES.PrepareTemporalFields(item, fieldNames, ['timeZone']);
       timeZone = ES.ToTemporalTimeZone(fields.timeZone);
-      ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
-        ES.InterpretTemporalDateTimeFields(calendar, fields, options));
       offset = fields.offset;
       if (offset === undefined) {
         offsetBehaviour = 'wall';
       } else {
         offset = ES.ToString(offset);
       }
+      ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
+        ES.InterpretTemporalDateTimeFields(calendar, fields, options));
     } else {
       ES.ToTemporalOverflow(options); // validate and ignore
       let ianaName, z;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -766,7 +766,7 @@ export const ES = ObjectAssign({}, ES2022, {
   ToShowCalendarOption: (options) => {
     return ES.GetOption(options, 'calendarName', ['auto', 'always', 'never', 'critical'], 'auto');
   },
-  ToShowTimeZoneNameOption: (options) => {
+  ToTimeZoneNameOption: (options) => {
     return ES.GetOption(options, 'timeZoneName', ['auto', 'never', 'critical'], 'auto');
   },
   ToShowOffsetOption: (options) => {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -763,7 +763,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (options === undefined) return fallback;
     return ES.GetOption(options, 'offset', ['prefer', 'use', 'ignore', 'reject'], fallback);
   },
-  ToShowCalendarOption: (options) => {
+  ToCalendarNameOption: (options) => {
     return ES.GetOption(options, 'calendarName', ['auto', 'always', 'never', 'critical'], 'auto');
   },
   ToTimeZoneNameOption: (options) => {

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -154,7 +154,7 @@ export class PlainDate {
   toString(options = undefined) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
-    const showCalendar = ES.ToShowCalendarOption(options);
+    const showCalendar = ES.ToCalendarNameOption(options);
     return ES.TemporalDateToString(this, showCalendar);
   }
   toJSON() {

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -363,7 +363,7 @@ export class PlainDateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
     const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
-    const showCalendar = ES.ToShowCalendarOption(options);
+    const showCalendar = ES.ToCalendarNameOption(options);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     return ES.TemporalDateTimeToString(this, precision, showCalendar, { unit, increment, roundingMode });
   }

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -70,7 +70,7 @@ export class PlainMonthDay {
   toString(options = undefined) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
-    const showCalendar = ES.ToShowCalendarOption(options);
+    const showCalendar = ES.ToCalendarNameOption(options);
     return ES.TemporalMonthDayToString(this, showCalendar);
   }
   toJSON() {

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -113,7 +113,7 @@ export class PlainYearMonth {
   toString(options = undefined) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
-    const showCalendar = ES.ToShowCalendarOption(options);
+    const showCalendar = ES.ToCalendarNameOption(options);
     return ES.TemporalYearMonthToString(this, showCalendar);
   }
   toJSON() {

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -423,7 +423,7 @@ export class ZonedDateTime {
     const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const showCalendar = ES.ToShowCalendarOption(options);
-    const showTimeZone = ES.ToShowTimeZoneNameOption(options);
+    const showTimeZone = ES.ToTimeZoneNameOption(options);
     const showOffset = ES.ToShowOffsetOption(options);
     return ES.TemporalZonedDateTimeToString(this, precision, showCalendar, showTimeZone, showOffset, {
       unit,

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -422,7 +422,7 @@ export class ZonedDateTime {
     options = ES.GetOptionsObject(options);
     const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
-    const showCalendar = ES.ToShowCalendarOption(options);
+    const showCalendar = ES.ToCalendarNameOption(options);
     const showTimeZone = ES.ToTimeZoneNameOption(options);
     const showOffset = ES.ToShowOffsetOption(options);
     return ES.TemporalZonedDateTimeToString(this, precision, showCalendar, showTimeZone, showOffset, {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -141,11 +141,16 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-toshowcalendaroption" aoid="ToShowCalendarOption">
-    <h1>ToShowCalendarOption ( _normalizedOptions_ )</h1>
-    <p>
-      The abstract operation ToShowCalendarOption extracts the value of the property named *"calendarName"* from _normalizedOptions_ and makes sure it is a valid value for the option.
-    </p>
+  <emu-clause id="sec-temporal-tocalendarnameoption" type="abstract operation">
+    <h1>
+      ToCalendarNameOption (
+        _normalizedOptions_: an Object,
+      ): either a normal completion containing a String, or an abrupt completion
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It extracts the value of the property named *"calendarName"* from _normalizedOptions_ and makes sure it is a valid value for the option.</dd>
+    </dl>
     <emu-note>
       This property is used in `toString` methods in Temporal to control whether a calendar annotation should be output.
     </emu-note>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -154,11 +154,16 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-toshowtimezonenameoption" aoid="ToShowTimeZoneNameOption">
-    <h1>ToShowTimeZoneNameOption ( _normalizedOptions_ )</h1>
-    <p>
-      The abstract operation ToShowTimeZoneNameOption extracts the value of the property named *"timeZoneName"* from _normalizedOptions_ and makes sure it is a valid value for the option.
-    </p>
+  <emu-clause id="sec-temporal-totimezonenameoption" type="abstract operation">
+    <h1>
+      ToTimeZoneNameOption (
+        _normalizedOptions_: an Object,
+      ): either a normal completion containing a String, or an abrupt completion
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It extracts the value of the property named *"timeZoneName"* from _normalizedOptions_ and makes sure it is a valid value for the option.</dd>
+    </dl>
     <emu-note>
       This property is used in `Temporal.ZonedDateTime.prototype.toString()`.
       It is different from the `timeZone` property passed to `Temporal.ZonedDateTime.from()` and from the `timeZone` property in the options passed to `Temporal.Instant.prototype.toString()`.

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -879,10 +879,10 @@
       <h1>Temporal.Calendar.prototype.dateFromFields ( _fields_ [ , _options_ ] )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.dateFromFields` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.dateFromFields` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.dateFromFields` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -899,10 +899,10 @@
       <h1>Temporal.Calendar.prototype.yearMonthFromFields ( _fields_ [ , _options_ ] )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.yearMonthFromFields` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.yearMonthFromFields` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.yearMonthFromFields` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -919,10 +919,10 @@
       <h1>Temporal.Calendar.prototype.monthDayFromFields ( _fields_ [ , _options_ ] )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.monthDayFromFields` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.monthDayFromFields` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.monthDayFromFields` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -939,10 +939,10 @@
       <h1>Temporal.Calendar.prototype.dateAdd ( _date_, _duration_ [ , _options_ ] )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.dateAdd` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.dateAdd` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.dateAdd` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -962,10 +962,10 @@
       <h1>Temporal.Calendar.prototype.dateUntil ( _one_, _two_ [ , _options_ ] )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.dateUntil` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.dateUntil` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.dateUntil` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -985,10 +985,10 @@
       <h1>Temporal.Calendar.prototype.year ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.year` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.year` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.year` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1005,10 +1005,10 @@
       <h1>Temporal.Calendar.prototype.month ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.month` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.month` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.month` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1027,10 +1027,10 @@
       <h1>Temporal.Calendar.prototype.monthCode ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.monthCode` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.monthCode` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.monthCode` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1047,10 +1047,10 @@
       <h1>Temporal.Calendar.prototype.day ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.day` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.day` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.day` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1067,10 +1067,10 @@
       <h1>Temporal.Calendar.prototype.dayOfWeek ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.dayOfWeek` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.dayOfWeek` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.dayOfWeek` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1085,10 +1085,10 @@
       <h1>Temporal.Calendar.prototype.dayOfYear ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.dayOfYear` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.dayOfYear` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.dayOfYear` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1103,10 +1103,10 @@
       <h1>Temporal.Calendar.prototype.weekOfYear ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.weekOfYear` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.weekOfYear` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.weekOfYear` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1121,10 +1121,10 @@
       <h1>Temporal.Calendar.prototype.daysInWeek ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.daysInWeek` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.daysInWeek` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.daysInWeek` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1139,10 +1139,10 @@
       <h1>Temporal.Calendar.prototype.daysInMonth ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.daysInMonth` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.daysInMonth` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.daysInMonth` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1158,10 +1158,10 @@
       <h1>Temporal.Calendar.prototype.daysInYear ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.daysInYear` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.daysInYear` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.daysInYear` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1177,10 +1177,10 @@
       <h1>Temporal.Calendar.prototype.monthsInYear ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.monthsInYear` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.monthsInYear` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.monthsInYear` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1196,10 +1196,10 @@
       <h1>Temporal.Calendar.prototype.inLeapYear ( _temporalDateLike_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.inLeapYear` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.inLeapYear` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.inLeapYear` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1216,10 +1216,10 @@
       <h1>Temporal.Calendar.prototype.fields ( _fields_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.fields` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.fields` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.fields` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.
@@ -1250,10 +1250,10 @@
       <h1>Temporal.Calendar.prototype.mergeFields ( _fields_, _additionalFields_ )</h1>
       <p>
         An ECMAScript implementation that includes the ECMA-402 Internationalization API must implement the `Temporal.Calendar.prototype.mergeFields` method as specified in the ECMA-402 specification.
-        If an ECMAScript implementation does not include the ECMA-402 API the following specification of the `Temporal.Calendar.prototype.mergeFields` method is used.
       </p>
       <p>
-        The `Temporal.Calendar.prototype.mergeFields` method performs the following steps when called:
+        An ECMAScript implementation that does not include the ECMA-402 API, may still include support for built-in calendars (see <emu-xref href="#sec-calendar-types"></emu-xref>).
+        The minimum implementation of this method for ECMAScript implementations that do not include the ECMA-402 API and do not support built-in calendars other than *"iso8601"* performs the following steps when called:
       </p>
       <emu-alg>
         1. Let _calendar_ be the *this* value.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -500,7 +500,7 @@
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _showCalendar_ be ? ToShowCalendarOption(_options_).
+        1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Return ? TemporalDateToString(_temporalDate_, _showCalendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -535,7 +535,7 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _showCalendar_ be ? ToShowCalendarOption(_options_).
+        1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ? TemporalDateTimeToString(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]], _precision_.[[Precision]], _showCalendar_).
       </emu-alg>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -183,7 +183,7 @@
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _showCalendar_ be ? ToShowCalendarOption(_options_).
+        1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Return ? TemporalMonthDayToString(_monthDay_, _showCalendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -312,7 +312,7 @@
         1. Let _yearMonth_ be the *this* value.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _showCalendar_ be ? ToShowCalendarOption(_options_).
+        1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Return ? TemporalYearMonthToString(_yearMonth_, _showCalendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -765,7 +765,7 @@
         1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _showCalendar_ be ? ToShowCalendarOption(_options_).
-        1. Let _showTimeZone_ be ? ToShowTimeZoneNameOption(_options_).
+        1. Let _showTimeZone_ be ? ToTimeZoneNameOption(_options_).
         1. Let _showOffset_ be ? ToShowOffsetOption(_options_).
         1. Return ? TemporalZonedDateTimeToString(_zonedDateTime_, _precision_.[[Precision]], _showCalendar_, _showTimeZone_, _showOffset_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -764,7 +764,7 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _showCalendar_ be ? ToShowCalendarOption(_options_).
+        1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Let _showTimeZone_ be ? ToTimeZoneNameOption(_options_).
         1. Let _showOffset_ be ? ToShowOffsetOption(_options_).
         1. Return ? TemporalZonedDateTimeToString(_zonedDateTime_, _precision_.[[Precision]], _showCalendar_, _showTimeZone_, _showOffset_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).


### PR DESCRIPTION
- Fix a bug in the reference code so that it's compliant with the spec text
- Fix faulty assertions in Calendar methods (#2384) (cc @rkirsling)
- Give a couple of AOs clearer names (#2223)