### PR TITLE
Editorial change and reference code compliance

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3691,9 +3691,9 @@ export const ES = ObjectAssign({}, ES2022, {
     const sign = operation === 'since' ? -1 : 1;
     other = ES.ToTemporalTime(other);
     options = ES.GetOptionsObject(options);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', 'nanosecond');
     let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'time', 'auto');
     if (largestUnit === 'auto') largestUnit = 'hour';
-    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', 'nanosecond');
     if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
       throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
     }

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -363,8 +363,8 @@ export class PlainDateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
     const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
-    const showCalendar = ES.ToCalendarNameOption(options);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
+    const showCalendar = ES.ToCalendarNameOption(options);
     return ES.TemporalDateTimeToString(this, precision, showCalendar, { unit, increment, roundingMode });
   }
   toJSON() {

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -177,12 +177,6 @@ export class ZonedDateTime {
     }
     ES.RejectObjectWithCalendarOrTimeZone(temporalZonedDateTimeLike);
 
-    // TODO: Reorder according to spec.
-    options = ES.GetOptionsObject(options);
-    const disambiguation = ES.ToTemporalDisambiguation(options);
-    const offset = ES.ToTemporalOffset(options, 'prefer');
-
-    const timeZone = GetSlot(this, TIME_ZONE);
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, [
       'day',
@@ -198,6 +192,12 @@ export class ZonedDateTime {
     ]);
     ES.Call(ArrayPrototypePush, fieldNames, ['offset']);
     const props = ES.PrepareTemporalFields(temporalZonedDateTimeLike, fieldNames, 'partial');
+
+    options = ES.GetOptionsObject(options);
+    const disambiguation = ES.ToTemporalDisambiguation(options);
+    const offset = ES.ToTemporalOffset(options, 'prefer');
+
+    const timeZone = GetSlot(this, TIME_ZONE);
     ES.Call(ArrayPrototypePush, fieldNames, ['timeZone']);
     let fields = ES.PrepareTemporalFields(this, fieldNames, ['timeZone', 'offset']);
     fields = ES.CalendarMergeFields(calendar, fields, props);

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -614,7 +614,7 @@
           1. Set _outputTimeZone_ to ! CreateTemporalTimeZone(*"UTC"*).
         1. Let _isoCalendar_ be ! GetISO8601Calendar().
         1. Let _dateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_outputTimeZone_, _instant_, _isoCalendar_).
-        1. Let _dateTimeString_ be ? TemporalDateTimeToString(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], *undefined*, _precision_, *"never"*).
+        1. Let _dateTimeString_ be ! TemporalDateTimeToString(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], *undefined*, _precision_, *"never"*).
         1. If _timeZone_ is *undefined*, then
           1. Let _timeZoneString_ be *"Z"*.
         1. Else,

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1188,7 +1188,7 @@
         1. Let _instant_ be ! CreateTemporalInstant(_ns_).
         1. Let _isoCalendar_ be ! GetISO8601Calendar().
         1. Let _temporalDateTime_ be ? BuiltinTimeZoneGetPlainDateTimeFor(_timeZone_, _instant_, _isoCalendar_).
-        1. Let _dateTimeString_ be ? TemporalDateTimeToString(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _isoCalendar_, _precision_, *"never"*).
+        1. Let _dateTimeString_ be ! TemporalDateTimeToString(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _isoCalendar_, _precision_, *"never"*).
         1. If _showOffset_ is *"never"*, then
           1. Let _offsetString_ be the empty String.
         1. Else,


### PR DESCRIPTION
- Mark a few operations as infallible
- Fix a few places in the reference code where observable operations were ordered differently than in the spec