### PR TITLE
Editorial: Separate validation of roundingIncrement option

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -18,6 +18,7 @@ import {
   SetSlot
 } from './slots.mjs';
 
+const MathFloor = Math.floor;
 const ObjectCreate = Object.create;
 
 export class Duration {
@@ -255,7 +256,23 @@ export class Duration {
       throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
     }
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
-    const roundingIncrement = ES.ToTemporalDateTimeRoundingIncrement(roundTo, smallestUnit);
+
+    const maximumIncrements = {
+      hour: 24,
+      minute: 60,
+      second: 60,
+      millisecond: 1000,
+      microsecond: 1000,
+      nanosecond: 1000
+    };
+    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    const maximum = maximumIncrements[smallestUnit];
+    if (maximum == undefined) {
+      roundingIncrement = MathFloor(roundingIncrement);
+    } else {
+      roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false);
+    }
+
     let relativeTo = ES.ToRelativeTemporalObject(roundTo);
 
     ({ years, months, weeks, days } = ES.UnbalanceDurationRelative(

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1660,7 +1660,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (result === undefined) {
       throw new RangeError('calendar yearOfWeek result must be an integer');
     }
-    return ES.ToIntegerThrowOnInfinity(result);
+    return ES.ToIntegerWithTruncation(result);
   },
   CalendarDaysInWeek: (calendar, dateLike) => {
     const daysInWeek = ES.GetMethod(calendar, 'daysInWeek');

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -793,24 +793,6 @@ export const ES = ObjectAssign({}, ES2022, {
     }
     return increment;
   },
-  ToTemporalDateTimeRoundingIncrement: (options, smallestUnit) => {
-    const maximumIncrements = {
-      year: undefined,
-      month: undefined,
-      week: undefined,
-      day: undefined,
-      hour: 24,
-      minute: 60,
-      second: 60,
-      millisecond: 1000,
-      microsecond: 1000,
-      nanosecond: 1000
-    };
-    const increment = ES.ToTemporalRoundingIncrement(options);
-    const maximum = maximumIncrements[smallestUnit];
-    if (maximum == undefined) return MathFloor(increment);
-    return ES.ValidateTemporalRoundingIncrement(increment, maximum, false);
-  },
   ToSecondsStringPrecision: (options) => {
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') {

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -89,7 +89,8 @@ export class Instant {
       microsecond: 86400e6,
       nanosecond: 86400e9
     };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo, maximumIncrements[smallestUnit], true);
+    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], true);
     const ns = GetSlot(this, EPOCHNANOSECONDS);
     const roundedNs = ES.RoundInstant(ns, roundingIncrement, smallestUnit, roundingMode);
     return new Instant(roundedNs);

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -310,7 +310,8 @@ export class PlainDateTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo, maximumIncrements[smallestUnit], false);
+    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], false);
 
     let year = GetSlot(this, ISO_YEAR);
     let month = GetSlot(this, ISO_MONTH);

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -171,7 +171,8 @@ export class PlainTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo, MAX_INCREMENTS[smallestUnit], false);
+    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, MAX_INCREMENTS[smallestUnit], false);
 
     let hour = GetSlot(this, ISO_HOUR);
     let minute = GetSlot(this, ISO_MINUTE);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -346,7 +346,8 @@ export class ZonedDateTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo, maximumIncrements[smallestUnit], false);
+    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], false);
 
     // first, round the underlying DateTime fields
     const dt = dateTime(this);

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -196,31 +196,48 @@
     <h1>
       ToTemporalRoundingIncrement (
         _normalizedOptions_: an Object,
-        _dividend_: an integer or *undefined*,
-        _inclusive_: a Boolean,
-      )
+      ): either a normal completion containing a Number, or an abrupt completion
     </h1>
     <dl class="header">
       <dt>description</dt>
       <dd>
-        It extracts the value of the property named *"roundingIncrement"* from _normalizedOptions_, makes sure it is a valid value for the option, and returns that value rounded to an integer.
-        If _dividend_ is *undefined*, any non-zero positive value is valid.
-        Otherwise, the value must not be more than _dividend_ (or must be less than _dividend_, if _inclusive_ is *false*) and must divide evenly into _dividend_.
+        It extracts the value of the property named *"roundingIncrement"* from _normalizedOptions_, makes sure it is a finite Number greater than or equal to 1, and returns that value.
+        It performs no further validation.
       </dd>
     </dl>
     <emu-alg>
-      1. If _dividend_ is *undefined*, then
-        1. Let _maximum_ be *+&infin;*<sub>𝔽</sub>.
-      1. Else if _inclusive_ is *true*, then
+      1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
+      1. If _increment_ is not finite, throw a *RangeError* exception.
+      1. If _increment_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
+      1. Return _increment_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-validatetemporalroundingincrement" type="abstract operation">
+    <h1>
+      ValidateTemporalRoundingIncrement (
+        _increment_: a Number,
+        _dividend_: a positive integer,
+        _inclusive_: a Boolean,
+      ): either a normal completion containing an integer, or an abrupt completion
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>
+        It truncates an _increment_ from ToTemporalRoundingIncrement to an integer and returns the result if it evenly divides _dividend_, otherwise throwing a *RangeError*.
+        _dividend_ must be divided into more than one part unless _inclusive_ is *true*.
+      </dd>
+    </dl>
+    <emu-alg>
+      1. If _inclusive_ is *true*, then
         1. Let _maximum_ be 𝔽(_dividend_).
       1. Else if _dividend_ is more than 1, then
         1. Let _maximum_ be 𝔽(_dividend_ - 1).
       1. Else,
         1. Let _maximum_ be *1*<sub>𝔽</sub>.
-      1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
-      1. If _increment_ &lt; *1*<sub>𝔽</sub> or _increment_ &gt; _maximum_, throw a *RangeError* exception.
+      1. If _increment_ &gt; _maximum_, throw a *RangeError* exception.
       1. Set _increment_ to floor(ℝ(_increment_)).
-      1. If _dividend_ is not *undefined* and _dividend_ modulo _increment_ is not zero, then
+      1. If _dividend_ modulo _increment_ is not zero, then
         1. Throw a *RangeError* exception.
       1. Return _increment_.
     </emu-alg>
@@ -237,7 +254,8 @@
       1. Else,
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Assert: _maximum_ is not *undefined*.
-      1. Return ? ToTemporalRoundingIncrement(_normalizedOptions_, _maximum_, *false*).
+      1. Let _increment_ be ? ToTemporalRoundingIncrement(_normalizedOptions_).
+      1. Return ? ValidateTemporalRoundingIncrement(_increment_, _maximum_, *false*).
     </emu-alg>
   </emu-clause>
 
@@ -1794,7 +1812,11 @@
       1. If _operation_ is ~since~, then
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
       1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-      1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_, _maximum_, *false*).
+      1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_).
+      1. If _maximum_ is *undefined*, then
+        1. Set _roundingIncrement_ to floor(ℝ(_roundingIncrement_)).
+      1. Else,
+        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
       1. Return the Record {
             [[SmallestUnit]]: _smallestUnit_,
             [[LargestUnit]]: _largestUnit_,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -243,22 +243,6 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-totemporaldatetimeroundingincrement" aoid="ToTemporalDateTimeRoundingIncrement">
-    <h1>ToTemporalDateTimeRoundingIncrement ( _normalizedOptions_, _smallestUnit_ )</h1>
-    <p>
-      The abstract operation ToTemporalDateTimeRoundingIncrement extracts the value of the property named *"roundingIncrement"* from _normalizedOptions_ and makes sure it is a valid value for the option, setting the correct maximum for rounding Temporal.ZonedDateTime and Temporal.PlainDateTime.
-    </p>
-    <emu-alg>
-      1. If _smallestUnit_ is *"day"*, then
-        1. Let _maximum_ be 1.
-      1. Else,
-        1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Assert: _maximum_ is not *undefined*.
-      1. Let _increment_ be ? ToTemporalRoundingIncrement(_normalizedOptions_).
-      1. Return ? ValidateTemporalRoundingIncrement(_increment_, _maximum_, *false*).
-    </emu-alg>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-tosecondsstringprecision" aoid="ToSecondsStringPrecision">
     <h1>ToSecondsStringPrecision ( _normalizedOptions_ )</h1>
     <p>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -284,7 +284,7 @@
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"yearOfWeek"*, « _dateLike_ »).
         1. If _result_ is *undefined*, throw a *RangeError* exception.
-        1. Return ? ToIntegerThrowOnInfinity(_result_).
+        1. Return ? ToIntegerWithTruncation(_result_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -430,7 +430,11 @@
         1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_, _maximum_, *false*).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
+        1. If _maximum_ is *undefined*, then
+          1. Set _roundingIncrement_ to floor(ℝ(_roundingIncrement_)).
+        1. Else,
+          1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _relativeTo_ be ? ToRelativeTemporalObject(_roundTo_).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _relativeTo_).
         1. Let _roundResult_ be (? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -290,7 +290,8 @@
         1. Else,
           1. Assert: _smallestUnit_ is *"nanosecond"*.
           1. Let _maximum_ be nsPerDay.
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_, _maximum_, *true*).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
+        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *true*).
         1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalInstant(_roundedNs_).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -517,7 +517,13 @@
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
-        1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
+        1. If _smallestUnit_ is *"day"*, then
+          1. Let _maximum_ be 1.
+        1. Else,
+          1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
+          1. Assert: _maximum_ is not *undefined*.
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
+        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -309,7 +309,9 @@
         1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_, _maximum_, *false*).
+        1. Assert: _maximum_ is not *undefined*.
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
+        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _result_ be ! RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -735,7 +735,13 @@
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
-        1. Let _roundingIncrement_ be ? ToTemporalDateTimeRoundingIncrement(_roundTo_, _smallestUnit_).
+        1. If _smallestUnit_ is *"day"*, then
+          1. Let _maximum_ be 1.
+        1. Else,
+          1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
+          1. Assert: _maximum_ is not *undefined*.
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
+        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].


### PR DESCRIPTION
Previously, the abstract operation ToTemporalRoundingIncrement was technically unimplementable because of trying to calculate ℝ(infinity).

Address this by separating out the case where there is no maximum for roundingIncrement into a separate code path from the case where there is a maximum (which goes into a separate abstract operation, ValidateTemporalRoundingIncrement.)

The separation is a bit awkward; it would be better if the truncated integer was returned from ToTemporalRoundingIncrement, instead of the original Number value, but that's not possible without a normative change because currently, the range check is done with the original Number value. (This is inconsistent with fractionalSecondDigits, where the range check is done with the truncated integer.) I'm planning to make this normative change as part of #2254 since we are changing the order of observable property accesses on options bags anyway.

Closes: #2226