### PR TITLE
Normative: Alphabetize observable property accesses

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -25,7 +25,6 @@ import {
 
 const ArrayIncludes = Array.prototype.includes;
 const ArrayPrototypePush = Array.prototype.push;
-const ArrayPrototypeSort = Array.prototype.sort;
 const IntlDateTimeFormat = globalThis.Intl.DateTimeFormat;
 const ArraySort = Array.prototype.sort;
 const MathAbs = Math.abs;
@@ -1881,7 +1880,6 @@ const nonIsoGeneralImpl = {
   dateFromFields(fields, options, calendar) {
     const cache = new OneObjectCache();
     const fieldNames = this.fields(['day', 'month', 'monthCode', 'year']);
-    ES.Call(ArrayPrototypeSort, fieldNames, []);
     fields = ES.PrepareTemporalFields(fields, fieldNames, []);
     const overflow = ES.ToTemporalOverflow(options);
     const { year, month, day } = this.helper.calendarToIsoDate(fields, overflow, cache);
@@ -1892,7 +1890,6 @@ const nonIsoGeneralImpl = {
   yearMonthFromFields(fields, options, calendar) {
     const cache = new OneObjectCache();
     const fieldNames = this.fields(['month', 'monthCode', 'year']);
-    ES.Call(ArrayPrototypeSort, fieldNames, []);
     fields = ES.PrepareTemporalFields(fields, fieldNames, []);
     const overflow = ES.ToTemporalOverflow(options);
     const { year, month, day } = this.helper.calendarToIsoDate({ ...fields, day: 1 }, overflow, cache);
@@ -1905,7 +1902,6 @@ const nonIsoGeneralImpl = {
     // For lunisolar calendars, either `monthCode` or `year` must be provided
     // because `month` is ambiguous without a year or a code.
     const fieldNames = this.fields(['day', 'month', 'monthCode', 'year']);
-    ES.Call(ArrayPrototypeSort, fieldNames, []);
     fields = ES.PrepareTemporalFields(fields, fieldNames, []);
     const overflow = ES.ToTemporalOverflow(options);
     const { year, month, day } = this.helper.monthDayFromFields(fields, overflow, cache);

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -405,8 +405,12 @@ export class Duration {
   toString(options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
-    if (precision === 'minute') throw new RangeError('smallestUnit must not be "minute"');
+    const digits = ES.ToFractionalSecondDigits(options);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
+    if (smallestUnit === 'hour' || smallestUnit === 'minute') {
+      throw new RangeError('smallestUnit must be a time unit other than "hours" or "minutes"');
+    }
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     return ES.TemporalDurationToString(this, precision, { unit, increment, roundingMode });
   }

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -407,7 +407,7 @@ export class Duration {
     if (smallestUnit === 'hour' || smallestUnit === 'minute') {
       throw new RangeError('smallestUnit must be a time unit other than "hours" or "minutes"');
     }
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     return ES.TemporalDurationToString(this, precision, { unit, increment, roundingMode });
   }
   toJSON() {

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -18,7 +18,6 @@ import {
   SetSlot
 } from './slots.mjs';
 
-const MathFloor = Math.floor;
 const ObjectCreate = Object.create;
 
 export class Duration {
@@ -265,14 +264,9 @@ export class Duration {
       microsecond: 1000,
       nanosecond: 1000
     };
-    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
     const maximum = maximumIncrements[smallestUnit];
-    if (maximum == undefined) {
-      roundingIncrement = MathFloor(roundingIncrement);
-    } else {
-      roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false);
-    }
-
+    if (maximum !== undefined) ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false);
     let relativeTo = ES.ToRelativeTemporalObject(roundTo);
 
     ({ years, months, weeks, days } = ES.UnbalanceDurationRelative(

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -234,14 +234,19 @@ export class Duration {
     } else {
       roundTo = ES.GetOptionsObject(roundTo);
     }
+
+    let largestUnit = ES.GetTemporalUnit(roundTo, 'largestUnit', 'datetime', undefined, ['auto']);
+    let relativeTo = ES.ToRelativeTemporalObject(roundTo);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
     let smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'datetime', undefined);
+
     let smallestUnitPresent = true;
     if (!smallestUnit) {
       smallestUnitPresent = false;
       smallestUnit = 'nanosecond';
     }
     defaultLargestUnit = ES.LargerOfTwoTemporalUnits(defaultLargestUnit, smallestUnit);
-    let largestUnit = ES.GetTemporalUnit(roundTo, 'largestUnit', 'datetime', undefined, ['auto']);
     let largestUnitPresent = true;
     if (!largestUnit) {
       largestUnitPresent = false;
@@ -254,7 +259,6 @@ export class Duration {
     if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
       throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
     }
-    const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
 
     const maximumIncrements = {
       hour: 24,
@@ -264,10 +268,8 @@ export class Duration {
       microsecond: 1000,
       nanosecond: 1000
     };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
     const maximum = maximumIncrements[smallestUnit];
     if (maximum !== undefined) ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false);
-    let relativeTo = ES.ToRelativeTemporalObject(roundTo);
 
     ({ years, months, weeks, days } = ES.UnbalanceDurationRelative(
       years,
@@ -400,12 +402,12 @@ export class Duration {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
     const digits = ES.ToFractionalSecondDigits(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour' || smallestUnit === 'minute') {
       throw new RangeError('smallestUnit must be a time unit other than "hours" or "minutes"');
     }
     const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     return ES.TemporalDurationToString(this, precision, { unit, increment, roundingMode });
   }
   toJSON() {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -798,8 +798,7 @@ export const ES = ObjectAssign({}, ES2022, {
     return MathTrunc(increment);
   },
   ValidateTemporalRoundingIncrement: (increment, dividend, inclusive) => {
-    let maximum = dividend;
-    if (!inclusive) maximum = dividend > 1 ? dividend - 1 : 1;
+    const maximum = inclusive ? dividend : dividend - 1;
     if (increment > maximum) {
       throw new RangeError(`roundingIncrement must be at least 1 and less than ${maximum}, not ${increment}`);
     }

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -795,7 +795,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (!NumberIsFinite(increment) || increment < 1) {
       throw new RangeError(`roundingIncrement must be at least 1 and finite, not ${increment}`);
     }
-    return increment;
+    return MathTrunc(increment);
   },
   ValidateTemporalRoundingIncrement: (increment, dividend, inclusive) => {
     let maximum = dividend;
@@ -803,11 +803,9 @@ export const ES = ObjectAssign({}, ES2022, {
     if (increment > maximum) {
       throw new RangeError(`roundingIncrement must be at least 1 and less than ${maximum}, not ${increment}`);
     }
-    increment = MathFloor(increment);
     if (dividend % increment !== 0) {
       throw new RangeError(`Rounding increment must divide evenly into ${dividend}`);
     }
-    return increment;
   },
   ToFractionalSecondDigits: (normalizedOptions) => {
     let digitsValue = normalizedOptions.fractionalSecondDigits;
@@ -3579,13 +3577,10 @@ export const ES = ObjectAssign({}, ES2022, {
       microsecond: 1000,
       nanosecond: 1000
     };
-    let roundingIncrement = ES.ToTemporalRoundingIncrement(options);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(options);
     const maximum = MAX_DIFFERENCE_INCREMENTS[smallestUnit];
-    if (maximum === undefined) {
-      roundingIncrement = MathFloor(roundingIncrement);
-    } else {
-      roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false);
-    }
+    if (maximum !== undefined) ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false);
+
     return { largestUnit, roundingIncrement, roundingMode, smallestUnit };
   },
   DifferenceTemporalInstant: (operation, instant, other, options) => {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1034,7 +1034,6 @@ export const ES = ObjectAssign({}, ES2022, {
     }
     return result;
   },
-  // field access in the following operations is intentionally alphabetical
   ToTemporalTimeRecord: (bag, completeness = 'complete') => {
     const fields = ['hour', 'microsecond', 'millisecond', 'minute', 'nanosecond', 'second'];
     const partial = ES.PrepareTemporalFields(bag, fields, 'partial', { emptySourceErrorMessage: 'invalid time-like' });

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2,6 +2,7 @@
 
 const ArrayIncludes = Array.prototype.includes;
 const ArrayPrototypePush = Array.prototype.push;
+const ArrayPrototypeSort = Array.prototype.sort;
 const IntlDateTimeFormat = globalThis.Intl.DateTimeFormat;
 const MathMin = Math.min;
 const MathMax = Math.max;
@@ -1007,6 +1008,7 @@ export const ES = ObjectAssign({}, ES2022, {
   ) => {
     const result = ObjectCreate(null);
     let any = false;
+    ES.Call(ArrayPrototypeSort, fields, []);
     for (let index = 0; index < fields.length; index++) {
       const property = fields[index];
       let value = bag[property];

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -914,14 +914,15 @@ export const ES = ObjectAssign({}, ES2022, {
         'second',
         'year'
       ]);
+      ES.Call(ArrayPrototypePush, fieldNames, ['timeZone', 'offset']);
       const fields = ES.PrepareTemporalFields(relativeTo, fieldNames, []);
       const dateOptions = ObjectCreate(null);
       dateOptions.overflow = 'constrain';
       ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
         ES.InterpretTemporalDateTimeFields(calendar, fields, dateOptions));
-      offset = relativeTo.offset;
+      offset = fields.offset;
       if (offset === undefined) offsetBehaviour = 'wall';
-      timeZone = relativeTo.timeZone;
+      timeZone = fields.timeZone;
     } else {
       let ianaName, z;
       ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar, ianaName, offset, z } =
@@ -944,7 +945,7 @@ export const ES = ObjectAssign({}, ES2022, {
     }
     if (timeZone === undefined) return ES.CreateTemporalDate(year, month, day, calendar);
     timeZone = ES.ToTemporalTimeZone(timeZone);
-    const offsetNs = offsetBehaviour === 'option' ? ES.ParseTimeZoneOffsetString(ES.ToString(offset)) : 0;
+    const offsetNs = offsetBehaviour === 'option' ? ES.ParseTimeZoneOffsetString(offset) : 0;
     const epochNanoseconds = ES.InterpretISODateTimeOffset(
       year,
       month,

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -822,7 +822,7 @@ export const ES = ObjectAssign({}, ES2022, {
     }
     return digitCount;
   },
-  ToSecondsStringPrecision: (smallestUnit, precision) => {
+  ToSecondsStringPrecisionRecord: (smallestUnit, precision) => {
     switch (smallestUnit) {
       case 'minute':
         return { precision: 'minute', unit: 'minute', increment: 1 };

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -79,8 +79,9 @@ export class Instant {
     } else {
       roundTo = ES.GetOptionsObject(roundTo);
     }
-    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
+    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED);
     const maximumIncrements = {
       hour: 24,
       minute: 1440,
@@ -89,7 +90,6 @@ export class Instant {
       microsecond: 86400e6,
       nanosecond: 86400e9
     };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
     ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], true);
     const ns = GetSlot(this, EPOCHNANOSECONDS);
     const roundedNs = ES.RoundInstant(ns, roundingIncrement, smallestUnit, roundingMode);
@@ -105,13 +105,13 @@ export class Instant {
   toString(options = undefined) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
-    let timeZone = options.timeZone;
-    if (timeZone !== undefined) timeZone = ES.ToTemporalTimeZone(timeZone);
     const digits = ES.ToFractionalSecondDigits(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
+    let timeZone = options.timeZone;
+    if (timeZone !== undefined) timeZone = ES.ToTemporalTimeZone(timeZone);
     const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const ns = GetSlot(this, EPOCHNANOSECONDS);
     const roundedNs = ES.RoundInstant(ns, increment, unit, roundingMode);
     const roundedInstant = new Instant(roundedNs);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -111,7 +111,7 @@ export class Instant {
     if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
     let timeZone = options.timeZone;
     if (timeZone !== undefined) timeZone = ES.ToTemporalTimeZone(timeZone);
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     const ns = GetSlot(this, EPOCHNANOSECONDS);
     const roundedNs = ES.RoundInstant(ns, increment, unit, roundingMode);
     const roundedInstant = new Instant(roundedNs);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -89,8 +89,8 @@ export class Instant {
       microsecond: 86400e6,
       nanosecond: 86400e9
     };
-    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
-    roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], true);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], true);
     const ns = GetSlot(this, EPOCHNANOSECONDS);
     const roundedNs = ES.RoundInstant(ns, roundingIncrement, smallestUnit, roundingMode);
     return new Instant(roundedNs);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -107,7 +107,10 @@ export class Instant {
     options = ES.GetOptionsObject(options);
     let timeZone = options.timeZone;
     if (timeZone !== undefined) timeZone = ES.ToTemporalTimeZone(timeZone);
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    const digits = ES.ToFractionalSecondDigits(options);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
+    if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const ns = GetSlot(this, EPOCHNANOSECONDS);
     const roundedNs = ES.RoundInstant(ns, increment, unit, roundingMode);

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -311,7 +311,9 @@ export class PlainDateTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], false);
+    const maximum = maximumIncrements[smallestUnit];
+    const inclusive = maximum === 1;
+    ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, inclusive);
 
     let year = GetSlot(this, ISO_YEAR);
     let month = GetSlot(this, ISO_MONTH);

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -299,8 +299,9 @@ export class PlainDateTime {
     } else {
       roundTo = ES.GetOptionsObject(roundTo);
     }
-    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED, ['day']);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
+    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED, ['day']);
     const maximumIncrements = {
       day: 1,
       hour: 24,
@@ -310,7 +311,6 @@ export class PlainDateTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
     ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], false);
 
     let year = GetSlot(this, ISO_YEAR);
@@ -367,12 +367,12 @@ export class PlainDateTime {
   toString(options = undefined) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
+    const showCalendar = ES.ToCalendarNameOption(options);
     const digits = ES.ToFractionalSecondDigits(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
     const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
-    const showCalendar = ES.ToCalendarNameOption(options);
     return ES.TemporalDateTimeToString(this, precision, showCalendar, { unit, increment, roundingMode });
   }
   toJSON() {

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -367,7 +367,10 @@ export class PlainDateTime {
   toString(options = undefined) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    const digits = ES.ToFractionalSecondDigits(options);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
+    if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const showCalendar = ES.ToCalendarNameOption(options);
     return ES.TemporalDateTimeToString(this, precision, showCalendar, { unit, increment, roundingMode });

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -372,7 +372,7 @@ export class PlainDateTime {
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     return ES.TemporalDateTimeToString(this, precision, showCalendar, { unit, increment, roundingMode });
   }
   toJSON() {

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -310,8 +310,8 @@ export class PlainDateTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
-    roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], false);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], false);
 
     let year = GetSlot(this, ISO_YEAR);
     let month = GetSlot(this, ISO_MONTH);

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -212,7 +212,7 @@ export class PlainTime {
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     return TemporalTimeToString(this, precision, { unit, increment, roundingMode });
   }
   toJSON() {

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -208,7 +208,10 @@ export class PlainTime {
   toString(options = undefined) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    const digits = ES.ToFractionalSecondDigits(options);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
+    if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     return TemporalTimeToString(this, precision, { unit, increment, roundingMode });
   }

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -171,8 +171,8 @@ export class PlainTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
-    roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, MAX_INCREMENTS[smallestUnit], false);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    ES.ValidateTemporalRoundingIncrement(roundingIncrement, MAX_INCREMENTS[smallestUnit], false);
 
     let hour = GetSlot(this, ISO_HOUR);
     let minute = GetSlot(this, ISO_MINUTE);

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -161,8 +161,9 @@ export class PlainTime {
     } else {
       roundTo = ES.GetOptionsObject(roundTo);
     }
-    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
+    const smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'time', ES.REQUIRED);
     const MAX_INCREMENTS = {
       hour: 24,
       minute: 60,
@@ -171,7 +172,6 @@ export class PlainTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
     ES.ValidateTemporalRoundingIncrement(roundingIncrement, MAX_INCREMENTS[smallestUnit], false);
 
     let hour = GetSlot(this, ISO_HOUR);
@@ -209,10 +209,10 @@ export class PlainTime {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
     const digits = ES.ToFractionalSecondDigits(options);
+    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
     const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
-    const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     return TemporalTimeToString(this, precision, { unit, increment, roundingMode });
   }
   toJSON() {

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -433,7 +433,7 @@ export class ZonedDateTime {
     const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
     const showTimeZone = ES.ToTimeZoneNameOption(options);
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
+    const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     return ES.TemporalZonedDateTimeToString(this, precision, showCalendar, showTimeZone, showOffset, {
       unit,
       increment,

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -425,7 +425,10 @@ export class ZonedDateTime {
   toString(options = undefined) {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
-    const { precision, unit, increment } = ES.ToSecondsStringPrecision(options);
+    const digits = ES.ToFractionalSecondDigits(options);
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', undefined);
+    if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
+    const { precision, unit, increment } = ES.ToSecondsStringPrecision(smallestUnit, digits);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'trunc');
     const showCalendar = ES.ToCalendarNameOption(options);
     const showTimeZone = ES.ToTimeZoneNameOption(options);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -346,8 +346,8 @@ export class ZonedDateTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    let roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
-    roundingIncrement = ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], false);
+    const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
+    ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], false);
 
     // first, round the underlying DateTime fields
     const dt = dateTime(this);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -348,7 +348,9 @@ export class ZonedDateTime {
       microsecond: 1000,
       nanosecond: 1000
     };
-    ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], false);
+    const maximum = maximumIncrements[smallestUnit];
+    const inclusive = maximum === 1;
+    ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, inclusive);
 
     // first, round the underlying DateTime fields
     const dt = dateTime(this);

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -196,50 +196,48 @@
     <h1>
       ToTemporalRoundingIncrement (
         _normalizedOptions_: an Object,
-      ): either a normal completion containing a Number, or an abrupt completion
+      ): either a normal completion containing a positive integer, or an abrupt completion
     </h1>
     <dl class="header">
       <dt>description</dt>
       <dd>
-        It extracts the value of the property named *"roundingIncrement"* from _normalizedOptions_, makes sure it is a finite Number greater than or equal to 1, and returns that value.
-        It performs no further validation.
+        It extracts the value of the property named *"roundingIncrement"* from _normalizedOptions_, makes sure it represents a finite number greater than or equal to 1, and returns that value truncated to an integer.
       </dd>
     </dl>
     <emu-alg>
       1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
       1. If _increment_ is not finite, throw a *RangeError* exception.
       1. If _increment_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
-      1. Return _increment_.
+      1. Return truncate(ℝ(_increment_)).
     </emu-alg>
   </emu-clause>
 
   <emu-clause id="sec-validatetemporalroundingincrement" type="abstract operation">
     <h1>
       ValidateTemporalRoundingIncrement (
-        _increment_: a Number,
+        _increment_: a positive integer,
         _dividend_: a positive integer,
         _inclusive_: a Boolean,
-      ): either a normal completion containing an integer, or an abrupt completion
+      ): either a normal completion containing ~unused~, or an abrupt completion
     </h1>
     <dl class="header">
       <dt>description</dt>
       <dd>
-        It truncates an _increment_ from ToTemporalRoundingIncrement to an integer and returns the result if it evenly divides _dividend_, otherwise throwing a *RangeError*.
+        It verifies that _increment_ evenly divides _dividend_, otherwise throwing a *RangeError*.
         _dividend_ must be divided into more than one part unless _inclusive_ is *true*.
       </dd>
     </dl>
     <emu-alg>
       1. If _inclusive_ is *true*, then
-        1. Let _maximum_ be 𝔽(_dividend_).
+        1. Let _maximum_ be _dividend_.
       1. Else if _dividend_ is more than 1, then
-        1. Let _maximum_ be 𝔽(_dividend_ - 1).
+        1. Let _maximum_ be _dividend_ - 1.
       1. Else,
-        1. Let _maximum_ be *1*<sub>𝔽</sub>.
+        1. Let _maximum_ be 1.
       1. If _increment_ &gt; _maximum_, throw a *RangeError* exception.
-      1. Set _increment_ to floor(ℝ(_increment_)).
       1. If _dividend_ modulo _increment_ &ne; 0, then
         1. Throw a *RangeError* exception.
-      1. Return _increment_.
+      1. Return ~unused~.
     </emu-alg>
   </emu-clause>
 
@@ -1824,10 +1822,7 @@
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
       1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
       1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_).
-      1. If _maximum_ is *undefined*, then
-        1. Set _roundingIncrement_ to floor(ℝ(_roundingIncrement_)).
-      1. Else,
-        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
+      1. If _maximum_ is not *undefined*, perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
       1. Return the Record {
             [[SmallestUnit]]: _smallestUnit_,
             [[LargestUnit]]: _largestUnit_,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -230,10 +230,9 @@
     <emu-alg>
       1. If _inclusive_ is *true*, then
         1. Let _maximum_ be _dividend_.
-      1. Else if _dividend_ is more than 1, then
-        1. Let _maximum_ be _dividend_ - 1.
       1. Else,
-        1. Let _maximum_ be 1.
+        1. Assert: _dividend_ &gt; 1.
+        1. Let _maximum_ be _dividend_ - 1.
       1. If _increment_ &gt; _maximum_, throw a *RangeError* exception.
       1. If _dividend_ modulo _increment_ &ne; 0, then
         1. Throw a *RangeError* exception.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1653,7 +1653,8 @@
     <emu-alg>
       1. Let _result_ be OrdinaryObjectCreate(*null*).
       1. Let _any_ be *false*.
-      1. For each property name _property_ of _fieldNames_, do
+      1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
+      1. For each property name _property_ of _sortedFieldNames_, do
         1. Let _value_ be ? Get(_fields_, _property_).
         1. If _value_ is not *undefined*, then
           1. Set _any_ to *true*.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -243,15 +243,45 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-tosecondsstringprecision" aoid="ToSecondsStringPrecision">
-    <h1>ToSecondsStringPrecision ( _normalizedOptions_ )</h1>
-    <p>
-      The abstract operation ToSecondsStringPrecision combines the values of the options `smallestUnit` and `fractionalSecondDigits` to yield a precision for printing minutes and seconds to a string, and a rounding unit and increment.
-      The precision may be an integer 0 through 9 signifying a number of digits after the decimal point in the seconds, the string *"minute"* signifying not to print seconds at all, or the string *"auto"* signifying to drop trailing zeroes after the decimal point.
-    </p>
+  <emu-clause id="sec-temporal-tofractionalseconddigits" type="abstract operation">
+    <h1>
+      ToFractionalSecondDigits (
+        _normalizedOptions_: an Object,
+      ): either a normal completion containing either an integer or *"auto"*, or an abrupt completion
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It extracts the value of the property named *"fractionalSecondDigits"* from _normalizedOptions_ and makes sure it is a valid value for the option.</dd>
+    </dl>
     <emu-alg>
-      1. Let _smallestUnit_ be ? GetTemporalUnit(_normalizedOptions_, *"smallestUnit"*, ~time~, *undefined*).
-      1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
+      1. Let _digitsValue_ be ? Get(_normalizedOptions_, *"fractionalSecondDigits"*).
+      1. If _digitsValue_ is *undefined*, return *"auto"*.
+      1. If _digitsValue_ is not a Number, then
+        1. If ? ToString(_digitsValue_) is not *"auto"*, throw a *RangeError* exception.
+        1. Return *"auto"*.
+      1. If _digitsValue_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
+      1. Let _digitCount_ be floor(ℝ(_digitsValue_)).
+      1. If _digitCount_ &lt; 0 or _digitCount_ &gt; 9, throw a *RangeError* exception.
+      1. Return _digitCount_.
+    </emu-alg>
+  </emu-clause>
+
+  <emu-clause id="sec-temporal-tosecondsstringprecision" type="abstract operation">
+    <h1>
+      ToSecondsStringPrecision (
+        _smallestUnit_: one of *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"*, or *undefined*,
+        _fractionalDigitCount_: either *"auto"* or an integer in the inclusive range 0 to 9,
+      ): a Record with fields [[Precision]] (one of *"minute"*, *"auto"*, or an integer in the inclusive range 0 to 9), [[Unit]] (one of *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*), and [[Increment]] (one of 1, 10, or 100)
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>
+        The returned Record represents details for serializing minutes and seconds to a string subject to the specified _smallestUnit_ or (when _smallestUnit_ is *undefined*) _fractionalDigitCount_ digits after the decimal point in the seconds.
+        Its [[Precision]] field is either that count of digits, the string *"auto"* signifying that there should be no insignificant trailing zeroes, or the string *"minute"* signifying that seconds should not be included at all.
+        Its [[Unit]] field is the most precise unit that can contribute to the string, and its [[Increment]] field indicates the rounding increment that should be applied to that unit.
+      </dd>
+    </dl>
+    <emu-alg>
       1. If _smallestUnit_ is *"minute"*, then
         1. Return the Record {
             [[Precision]]: *"minute"*,
@@ -283,18 +313,12 @@
             [[Increment]]: 1
           }.
       1. Assert: _smallestUnit_ is *undefined*.
-      1. Let _fractionalDigitsVal_ be ? Get(_normalizedOptions_, *"fractionalSecondDigits"*).
-      1. If Type(_fractionalDigitsVal_) is not Number, then
-        1. If _fractionalDigitsVal_ is not *undefined*, then
-          1. If ? ToString(_fractionalDigitsVal_) is not *"auto"*, throw a *RangeError* exception.
+      1. If _fractionalDigitCount_ is *"auto"*, then
         1. Return the Record {
             [[Precision]]: *"auto"*,
             [[Unit]]: *"nanosecond"*,
             [[Increment]]: 1
           }.
-      1. If _fractionalDigitsVal_ is *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>, throw a *RangeError* exception.
-      1. Let _fractionalDigitCount_ be truncate(ℝ(_fractionalDigitsVal_)).
-      1. If _fractionalDigitCount_ &lt; 0 or _fractionalDigitCount_ &gt; 9, throw a *RangeError* exception.
       1. If _fractionalDigitCount_ is 0, then
         1. Return the Record {
             [[Precision]]: 0,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -264,9 +264,9 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-tosecondsstringprecision" type="abstract operation">
+  <emu-clause id="sec-temporal-tosecondsstringprecisionrecord" type="abstract operation">
     <h1>
-      ToSecondsStringPrecision (
+      ToSecondsStringPrecisionRecord (
         _smallestUnit_: one of *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, *"nanosecond"*, or *undefined*,
         _fractionalDigitCount_: either *"auto"* or an integer in the inclusive range 0 to 9,
       ): a Record with fields [[Precision]] (one of *"minute"*, *"auto"*, or an integer in the inclusive range 0 to 9), [[Unit]] (one of *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*), and [[Increment]] (one of 1, 10, or 100)

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1810,18 +1810,19 @@
     </dl>
     <emu-alg>
       1. Set _options_ to ? GetOptionsObject(_options_).
-      1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, _unitGroup_, _fallbackSmallestUnit_).
-      1. If _disallowedUnits_ contains _smallestUnit_, throw a *RangeError* exception.
-      1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(_smallestLargestDefaultUnit_, _smallestUnit_).
+      1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalRoundingIncrement reads *"roundingIncrement"* and ToTemporalRoundingMode reads *"roundingMode"*).
       1. Let _largestUnit_ be ? GetTemporalUnit(_options_, *"largestUnit"*, _unitGroup_, *"auto"*).
       1. If _disallowedUnits_ contains _largestUnit_, throw a *RangeError* exception.
-      1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
-      1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
+      1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_).
       1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
       1. If _operation_ is ~since~, then
         1. Set _roundingMode_ to ! NegateTemporalRoundingMode(_roundingMode_).
+      1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, _unitGroup_, _fallbackSmallestUnit_).
+      1. If _disallowedUnits_ contains _smallestUnit_, throw a *RangeError* exception.
+      1. Let _defaultLargestUnit_ be ! LargerOfTwoTemporalUnits(_smallestLargestDefaultUnit_, _smallestUnit_).
+      1. If _largestUnit_ is *"auto"*, set _largestUnit_ to _defaultLargestUnit_.
+      1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
       1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-      1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_options_).
       1. If _maximum_ is not *undefined*, perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
       1. Return the Record {
             [[SmallestUnit]]: _smallestUnit_,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -462,12 +462,14 @@
           1. Return ! CreateTemporalDate(_value_.[[ISOYear]], _value_.[[ISOMonth]], _value_.[[ISODay]], _value_.[[Calendar]]).
         1. Let _calendar_ be ? GetTemporalCalendarWithISODefault(_value_).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
+        1. Append *"timeZone"* to _fieldNames_.
+        1. Append *"offset"* to _fieldNames_.
         1. Let _fields_ be ? PrepareTemporalFields(_value_, _fieldNames_, «»).
         1. Let _dateOptions_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_dateOptions_, *"overflow"*, *"constrain"*).
         1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _dateOptions_).
-        1. Let _offsetString_ be ? Get(_value_, *"offset"*).
-        1. Let _timeZone_ be ? Get(_value_, *"timeZone"*).
+        1. Let _offsetString_ be ! Get(_fields_, *"offset"*).
+        1. Let _timeZone_ be ! Get(_fields_, *"timeZone"*).
         1. If _timeZone_ is not *undefined*, then
           1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
         1. If _offsetString_ is *undefined*, then
@@ -493,7 +495,6 @@
       1. If _timeZone_ is *undefined*, then
         1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       1. If _offsetBehaviour_ is ~option~, then
-        1. Set _offsetString_ to ? ToString(_offsetString_).
         1. If IsTimeZoneOffsetString(_offsetString_) is *false*, throw a *RangeError* exception.
         1. Let _offsetNs_ be ParseTimeZoneOffsetString(_offsetString_).
       1. Else,

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -508,8 +508,10 @@
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
-        1. If _precision_.[[Unit]] is *"minute"*, throw a *RangeError* exception.
+        1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
+        1. If _smallestUnit_ is *"hour"* or *"minute"*, throw a *RangeError* exception.
+        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _result_ be (? RoundDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_)).[[DurationRecord]].
         1. Return ! TemporalDurationToString(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _precision_.[[Precision]]).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -413,13 +413,17 @@
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
         1. Let _smallestUnitPresent_ be *true*.
         1. Let _largestUnitPresent_ be *true*.
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToRelativeTemporalObject reads *"relativeTo"*, ToTemporalRoundingIncrement reads *"roundingIncrement"* and ToTemporalRoundingMode reads *"roundingMode"*).
+        1. Let _largestUnit_ be ? GetTemporalUnit(_roundTo_, *"largestUnit"*, ~datetime~, *undefined*, « *"auto"* »).
+        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_roundTo_).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~datetime~, *undefined*).
         1. If _smallestUnit_ is *undefined*, then
           1. Set _smallestUnitPresent_ to *false*.
           1. Set _smallestUnit_ to *"nanosecond"*.
         1. Let _defaultLargestUnit_ be ! DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
         1. Set _defaultLargestUnit_ to ! LargerOfTwoTemporalUnits(_defaultLargestUnit_, _smallestUnit_).
-        1. Let _largestUnit_ be ? GetTemporalUnit(_roundTo_, *"largestUnit"*, ~datetime~, *undefined*, « *"auto"* »).
         1. If _largestUnit_ is *undefined*, then
           1. Set _largestUnitPresent_ to *false*.
           1. Set _largestUnit_ to _defaultLargestUnit_.
@@ -428,11 +432,8 @@
         1. If _smallestUnitPresent_ is *false* and _largestUnitPresent_ is *false*, then
           1. Throw a *RangeError* exception.
         1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. If _maximum_ is not *undefined*, perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
-        1. Let _relativeTo_ be ? ToRelativeTemporalObject(_roundTo_).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _relativeTo_).
         1. Let _roundResult_ be (? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].
         1. Let _adjustResult_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_).
@@ -505,11 +506,12 @@
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToFractionalSecondDigits reads *"fractionalSecondDigits"* and ToTemporalRoundingMode reads *"roundingMode"*).
         1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"* or *"minute"*, throw a *RangeError* exception.
         1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _result_ be (? RoundDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_)).[[DurationRecord]].
         1. Return ! TemporalDurationToString(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _precision_.[[Precision]]).
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -512,7 +512,7 @@
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"* or *"minute"*, throw a *RangeError* exception.
-        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
+        1. Let _precision_ be ToSecondsStringPrecisionRecord(_smallestUnit_, _digits_).
         1. Let _result_ be (? RoundDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_)).[[DurationRecord]].
         1. Return ! TemporalDurationToString(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _precision_.[[Precision]]).
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -460,6 +460,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_totalOf_, *"unit"*, _paramString_).
         1. Else,
           1. Set _totalOf_ to ? GetOptionsObject(_totalOf_).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToRelativeTemporalObject reads *"relativeTo"*).
         1. Let _relativeTo_ be ? ToRelativeTemporalObject(_totalOf_).
         1. Let _unit_ be ? GetTemporalUnit(_totalOf_, *"unit"*, ~datetime~, ~required~).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _relativeTo_).
@@ -1054,6 +1055,7 @@
         1. If Type(_temporalDurationLike_) is not Object, then
           1. Throw a *TypeError* exception.
         1. Let _result_ be a new partial Duration Record with each field set to *undefined*.
+        1. NOTE: The following steps read properties and perform independent validation in alphabetical order.
         1. Let _days_ be ? Get(_temporalDurationLike_, *"days"*).
         1. If _days_ is not *undefined*, set _result_.[[Days]] to ? ToIntegerIfIntegral(_days_).
         1. Let _hours_ be ? Get(_temporalDurationLike_, *"hours"*).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -431,10 +431,7 @@
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
-        1. If _maximum_ is *undefined*, then
-          1. Set _roundingIncrement_ to floor(ℝ(_roundingIncrement_)).
-        1. Else,
-          1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
+        1. If _maximum_ is not *undefined*, perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _relativeTo_ be ? ToRelativeTemporalObject(_roundTo_).
         1. Let _unbalanceResult_ be ? UnbalanceDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _relativeTo_).
         1. Let _roundResult_ be (? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _relativeTo_)).[[DurationRecord]].

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -329,7 +329,7 @@
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is not *undefined*, then
           1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
-        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
+        1. Let _precision_ be ToSecondsStringPrecisionRecord(_smallestUnit_, _digits_).
         1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Let _roundedInstant_ be ! CreateTemporalInstant(_roundedNs_).
         1. Return ? TemporalInstantToString(_roundedInstant_, _timeZone_, _precision_.[[Precision]]).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -291,7 +291,7 @@
           1. Assert: _smallestUnit_ is *"nanosecond"*.
           1. Let _maximum_ be nsPerDay.
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
-        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *true*).
+        1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *true*).
         1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalInstant(_roundedNs_).
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -275,8 +275,10 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalRoundingIncrement reads *"roundingIncrement"* and ToTemporalRoundingMode reads *"roundingMode"*).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~).
         1. If _smallestUnit_ is *"hour"*, then
           1. Let _maximum_ be HoursPerDay.
         1. Else if _smallestUnit_ is *"minute"*, then
@@ -290,7 +292,6 @@
         1. Else,
           1. Assert: _smallestUnit_ is *"nanosecond"*.
           1. Let _maximum_ be nsPerDay.
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *true*).
         1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalInstant(_roundedNs_).
@@ -320,14 +321,15 @@
         1. Let _instant_ be the *this* value.
         1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToFractionalSecondDigits reads *"fractionalSecondDigits"* and ToTemporalRoundingMode reads *"roundingMode"*).
+        1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
+        1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is not *undefined*, then
           1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
-        1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
-        1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
         1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Let _roundedInstant_ be ! CreateTemporalInstant(_roundedNs_).
         1. Return ? TemporalInstantToString(_roundedInstant_, _timeZone_, _precision_.[[Precision]]).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -323,7 +323,10 @@
         1. Let _timeZone_ be ? Get(_options_, *"timeZone"*).
         1. If _timeZone_ is not *undefined*, then
           1. Set _timeZone_ to ? ToTemporalTimeZone(_timeZone_).
-        1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
+        1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
+        1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
+        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundedNs_ be ! RoundTemporalInstant(_instant_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Let _roundedInstant_ be ! CreateTemporalInstant(_roundedNs_).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1697,8 +1697,7 @@
               1. Let _result_ be ? ISODateFromFields(_fields_, _options_).
             1. Else,
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
-              1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _sortedFieldNames_, « »).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
@@ -1720,8 +1719,7 @@
               1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _options_).
             1. Else,
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"month"*, *"monthCode"*, *"year"* »).
-              1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _sortedFieldNames_, « »).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISODay]] to _result_.[[Day]].
@@ -1744,8 +1742,7 @@
               1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _options_).
             1. Else,
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
-              1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _sortedFieldNames_, « »).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISOYear]] to _result_.[[Year]].

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -521,10 +521,12 @@
         1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
         1. If _smallestUnit_ is *"day"*, then
           1. Let _maximum_ be 1.
+          1. Let _inclusive_ be *true*.
         1. Else,
           1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
           1. Assert: _maximum_ is not *undefined*.
-        1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
+          1. Let _inclusive_ be *false*.
+        1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, _inclusive_).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -560,7 +560,7 @@
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
-        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
+        1. Let _precision_ be ToSecondsStringPrecisionRecord(_smallestUnit_, _digits_).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ? TemporalDateTimeToString(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]], _precision_.[[Precision]], _showCalendar_).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -523,7 +523,7 @@
           1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
           1. Assert: _maximum_ is not *undefined*.
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
-        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
+        1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -553,7 +553,10 @@
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
+        1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
+        1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
+        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -515,14 +515,15 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalRoundingIncrement reads *"roundingIncrement"* and ToTemporalRoundingMode reads *"roundingMode"*).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
         1. If _smallestUnit_ is *"day"*, then
           1. Let _maximum_ be 1.
         1. Else,
           1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
           1. Assert: _maximum_ is not *undefined*.
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
@@ -553,12 +554,13 @@
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToCalendarNameOption reads *"calendarName"*, ToFractionalSecondDigits reads *"fractionalSecondDigits"*, and ToTemporalRoundingMode reads *"roundingMode"*).
+        1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
         1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ? TemporalDateTimeToString(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]], _precision_.[[Precision]], _showCalendar_).
       </emu-alg>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -311,7 +311,7 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Assert: _maximum_ is not *undefined*.
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
-        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
+        1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _result_ be ! RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -306,11 +306,12 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalRoundingIncrement reads *"roundingIncrement"* and ToTemporalRoundingMode reads *"roundingMode"*).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~).
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Assert: _maximum_ is not *undefined*.
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _result_ be ! RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
@@ -405,11 +406,12 @@
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToFractionalSecondDigits reads *"fractionalSecondDigits"* and ToTemporalRoundingMode reads *"roundingMode"*).
         1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
         1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundResult_ be ! RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ! TemporalTimeToString(_roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], _precision_.[[Precision]]).
       </emu-alg>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -405,7 +405,10 @@
         1. Let _temporalTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
+        1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
+        1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
+        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _roundResult_ be ! RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ! TemporalTimeToString(_roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], _precision_.[[Precision]]).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -411,7 +411,7 @@
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
-        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
+        1. Let _precision_ be ToSecondsStringPrecisionRecord(_smallestUnit_, _digits_).
         1. Let _roundResult_ be ! RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ! TemporalTimeToString(_roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], _precision_.[[Precision]]).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -785,7 +785,10 @@
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _precision_ be ? ToSecondsStringPrecision(_options_).
+        1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
+        1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
+        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Let _showTimeZone_ be ? ToTimeZoneNameOption(_options_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -741,7 +741,7 @@
           1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
           1. Assert: _maximum_ is not *undefined*.
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
-        1. Set _roundingIncrement_ to ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
+        1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -796,7 +796,7 @@
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
         1. Let _showTimeZone_ be ? ToTimeZoneNameOption(_options_).
-        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
+        1. Let _precision_ be ToSecondsStringPrecisionRecord(_smallestUnit_, _digits_).
         1. Return ? TemporalZonedDateTimeToString(_zonedDateTime_, _precision_.[[Precision]], _showCalendar_, _showTimeZone_, _showOffset_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -61,9 +61,10 @@
       <emu-alg>
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. If Type(_item_) is Object and _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
-          1. Perform ? ToTemporalOverflow(_options_).
+          1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalDisambiguation reads *"disambiguation"*, ToTemporalOffset reads *"offset"*, and ToTemporalOverflow reads *"overflow"*).
           1. Perform ? ToTemporalDisambiguation(_options_).
           1. Perform ? ToTemporalOffset(_options_, *"reject"*).
+          1. Perform ? ToTemporalOverflow(_options_).
           1. Return ! CreateTemporalZonedDateTime(_item_.[[Nanoseconds]], _item_.[[TimeZone]], _item_.[[Calendar]]).
         1. Return ? ToTemporalZonedDateTime(_item_, _options_).
       </emu-alg>
@@ -584,9 +585,6 @@
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
         1. Append *"offset"* to _fieldNames_.
         1. Let _partialZonedDateTime_ be ? PrepareTemporalFields(_temporalZonedDateTimeLike_, _fieldNames_, ~partial~).
-        1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
-        1. Let _offset_ be ? ToTemporalOffset(_options_, *"prefer"*).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Append *"timeZone"* to _fieldNames_.
         1. Let _fields_ be ? PrepareTemporalFields(_zonedDateTime_, _fieldNames_, « *"timeZone"*, *"offset"* »).
@@ -594,6 +592,10 @@
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « *"timeZone"*, *"offset"* »).
         1. Let _offsetString_ be ! Get(_fields_, *"offset"*).
         1. Assert: Type(_offsetString_) is String.
+        1. Set _options_ to ? GetOptionsObject(_options_).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalDisambiguation reads *"disambiguation"*, ToTemporalOffset reads *"offset"*, and InterpretTemporalDateTimeFields reads *"overflow"*).
+        1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
+        1. Let _offset_ be ? ToTemporalOffset(_options_, *"prefer"*).
         1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. If IsTimeZoneOffsetString(_offsetString_) is *false*, throw a *RangeError* exception.
         1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_offsetString_).
@@ -733,14 +735,15 @@
           1. Perform ! CreateDataPropertyOrThrow(_roundTo_, *"smallestUnit"*, _paramString_).
         1. Else,
           1. Set _roundTo_ to ? GetOptionsObject(_roundTo_).
-        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalRoundingIncrement reads *"roundingIncrement"* and ToTemporalRoundingMode reads *"roundingMode"*).
+        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
+        1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
         1. If _smallestUnit_ is *"day"*, then
           1. Let _maximum_ be 1.
         1. Else,
           1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
           1. Assert: _maximum_ is not *undefined*.
-        1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
@@ -785,14 +788,15 @@
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Set _options_ to ? GetOptionsObject(_options_).
+        1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToCalendarNameOption reads *"calendarName"*, ToFractionalSecondDigits reads *"fractionalSecondDigits"*, ToShowOffsetOption reads *"offset"*, and ToTemporalRoundingMode reads *"roundingMode"*).
+        1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Let _digits_ be ? ToFractionalSecondDigits(_options_).
+        1. Let _showOffset_ be ? ToShowOffsetOption(_options_).
+        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
-        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
-        1. Let _roundingMode_ be ? ToTemporalRoundingMode(_options_, *"trunc"*).
-        1. Let _showCalendar_ be ? ToCalendarNameOption(_options_).
         1. Let _showTimeZone_ be ? ToTimeZoneNameOption(_options_).
-        1. Let _showOffset_ be ? ToShowOffsetOption(_options_).
+        1. Let _precision_ be ToSecondsStringPrecision(_smallestUnit_, _digits_).
         1. Return ? TemporalZonedDateTimeToString(_zonedDateTime_, _precision_.[[Precision]], _showCalendar_, _showTimeZone_, _showOffset_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
       </emu-alg>
     </emu-clause>
@@ -1132,9 +1136,11 @@
           1. Assert: _offsetString_ is a String or *undefined*.
           1. If _offsetString_ is *undefined*, then
             1. Set _offsetBehaviour_ to ~wall~.
+          1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalDisambiguation reads *"disambiguation"*, ToTemporalOffset reads *"offset"*, and InterpretTemporalDateTimeFields reads *"overflow"*).
+          1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
+          1. Let _offsetOption_ be ? ToTemporalOffset(_options_, *"reject"*).
           1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Else,
-          1. Perform ? ToTemporalOverflow(_options_).
           1. Let _string_ be ? ToString(_item_).
           1. Let _result_ be ? ParseTemporalZonedDateTimeString(_string_).
           1. Let _timeZoneName_ be _result_.[[TimeZone]].[[Name]].
@@ -1150,12 +1156,13 @@
           1. Let _timeZone_ be ! CreateTemporalTimeZone(_timeZoneName_).
           1. Let _calendar_ be ? ToTemporalCalendarWithISODefault(_result_.[[Calendar]]).
           1. Set _matchBehaviour_ to ~match minutes~.
+          1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
+          1. Let _offsetOption_ be ? ToTemporalOffset(_options_, *"reject"*).
+          1. Perform ? ToTemporalOverflow(_options_).
         1. Let _offsetNanoseconds_ be 0.
         1. If _offsetBehaviour_ is ~option~, then
           1. If IsTimeZoneOffsetString(_offsetString_) is *false*, throw a *RangeError* exception.
           1. Set _offsetNanoseconds_ to ParseTimeZoneOffsetString(_offsetString_).
-        1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
-        1. Let _offsetOption_ be ? ToTemporalOffset(_options_, *"reject"*).
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offsetOption_, _matchBehaviour_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -741,10 +741,12 @@
         1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~time~, ~required~, « *"day"* »).
         1. If _smallestUnit_ is *"day"*, then
           1. Let _maximum_ be 1.
+          1. Let _inclusive_ be *true*.
         1. Else,
           1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
           1. Assert: _maximum_ is not *undefined*.
-        1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
+          1. Let _inclusive_ be *false*.
+        1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, _inclusive_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].


### PR DESCRIPTION
Spec algorithms should do one of two things to an object that is passed in from user code, depending on the situation:

- Perform a Get on each of a list of predefined property keys in alphabetical order, and read them into a Record. The alphabetical order should be enforced rather than implicit by table order. This action is appropriate when the list of property keys is known beforehand (although it may include extra calendar fields, so not necessarily known at spec-writing time) and/or when some of the properties are allowed to be absent from the object. An example of this is [ToTemporalTimeRecord](https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimerecord).
- Use CopyDataProperties to access each property on an object in iteration order and copy it onto a null-prototype object, whose properties can subsequently be unobservably read as many times as necessary. This action is appropriate in cases like [DefaultMergeCalendarFields](https://tc39.es/proposal-temporal/#sec-temporal-defaultmergecalendarfields) when a previously-known list of property keys is not possible.

This implements the above change in the spec text and in the reference code. No documentation change is necessary.

The first three commits on this branch are taken from #2435. This branch should be rebased when those changes are merged.

I recommend reviewing this commit by commit. Each commit contains the spec text change, and the corresponding change in the reference code. (Sorry it's so huge.)

Test262 tests to follow.

Closes: #2254 
