### PR TITLE
Editorial: Add notes about extension points for ECMA-402

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -868,6 +868,10 @@
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
     </ul>
 
+    <emu-note>
+      An ECMAScript implementation that includes the ECMA-402 Internationalization API extends this prototype with additional properties in order to represent calendar data.
+    </emu-note>
+
     <emu-clause id="sec-temporal.calendar.prototype.constructor">
       <h1>Temporal.Calendar.prototype.constructor</h1>
       <p>The initial value of `Temporal.Calendar.prototype.constructor` is %Temporal.Calendar%.</p>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -93,6 +93,10 @@
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
     </ul>
 
+    <emu-note>
+      An ECMAScript implementation that includes the ECMA-402 Internationalization API extends this prototype with additional properties in order to represent calendar data.
+    </emu-note>
+
     <emu-clause id="sec-temporal.plaindate.prototype.constructor">
       <h1>Temporal.PlainDate.prototype.constructor</h1>
       <p>The initial value of `Temporal.PlainDate.prototype.constructor` is %Temporal.PlainDate%.</p>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -96,6 +96,10 @@
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
     </ul>
 
+    <emu-note>
+      An ECMAScript implementation that includes the ECMA-402 Internationalization API extends this prototype with additional properties in order to represent calendar data.
+    </emu-note>
+
     <emu-clause id="sec-temporal.plaindatetime.prototype.constructor">
       <h1>Temporal.PlainDateTime.prototype.constructor</h1>
       <p>The initial value of `Temporal.PlainDateTime.prototype.constructor` is %Temporal.PlainDateTime%.</p>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -80,6 +80,10 @@
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
     </ul>
 
+    <emu-note>
+      An ECMAScript implementation that includes the ECMA-402 Internationalization API extends this prototype with additional properties in order to represent calendar data.
+    </emu-note>
+
     <emu-clause id="sec-temporal.plainmonthday.prototype.constructor">
       <h1>Temporal.PlainMonthDay.prototype.constructor</h1>
       <p>The initial value of `Temporal.PlainMonthDay.prototype.constructor` is %Temporal.PlainMonthDay%.</p>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -91,6 +91,10 @@
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
     </ul>
 
+    <emu-note>
+      An ECMAScript implementation that includes the ECMA-402 Internationalization API extends this prototype with additional properties in order to represent calendar data.
+    </emu-note>
+
     <emu-clause id="sec-temporal.plainyearmonth.prototype.constructor">
       <h1>Temporal.PlainYearMonth.prototype.constructor</h1>
       <p>The initial value of `Temporal.PlainYearMonth.prototype.constructor` is %Temporal.PlainYearMonth%.</p>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -93,6 +93,10 @@
       <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
     </ul>
 
+    <emu-note>
+      An ECMAScript implementation that includes the ECMA-402 Internationalization API extends this prototype with additional properties in order to represent calendar data.
+    </emu-note>
+
     <emu-clause id="sec-temporal.zoneddatetime.prototype.constructor">
       <h1>Temporal.ZonedDateTime.prototype.constructor</h1>
       <p>The initial value of `Temporal.ZonedDateTime.prototype.constructor` is %Temporal.ZonedDateTime%.</p>


### PR DESCRIPTION
As per TC39 plenary, the specification should include informative notes indicating where ECMA-402 extends prototypes with additional properties.

Closes: #2169