### PR TITLE
NanosecondsToDays: Change unreachable RangeErrors to assertions.

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2723,10 +2723,13 @@ export const ES = ObjectAssign({}, ES2022, {
       throw new RangeError('Time zone or calendar converted nanoseconds into a number of days with the opposite sign');
     }
     if (!nanoseconds.isZero() && MathSign(nanoseconds.toJSNumber()) != sign) {
+      if (nanoseconds.lt(0) && sign === 1) {
+        throw new Error('assert not reached');
+      }
       throw new RangeError('Time zone or calendar ended up with a remainder of nanoseconds with the opposite sign');
     }
     if (nanoseconds.abs().geq(MathAbs(dayLengthNs))) {
-      throw new RangeError('Time zone or calendar ended up with a remainder of nanoseconds longer than the day length');
+      throw new Error('assert not reached');
     }
     return { days: days.toJSNumber(), nanoseconds, dayLengthNs: MathAbs(dayLengthNs) };
   },

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1367,9 +1367,10 @@
             1. Set _done_ to *true*.
         1. If _days_ &lt; 0 and _sign_ = 1, throw a *RangeError* exception.
         1. If _days_ &gt; 0 and _sign_ = -1, throw a *RangeError* exception.
-        1. If _nanoseconds_ &lt; 0 and _sign_ = 1, throw a *RangeError* exception.
+        1. If _nanoseconds_ &lt; 0, then
+          1. Assert: _sign_ is -1.
         1. If _nanoseconds_ &gt; 0 and _sign_ = -1, throw a *RangeError* exception.
-        1. If abs(_nanoseconds_) &ge; abs(_dayLengthNs_), throw a *RangeError* exception.
+        1. Assert: The inequality abs(_nanoseconds_) &lt; abs(_dayLengthNs_) holds.
         1. Return the Record {
           [[Days]]: _days_,
           [[Nanoseconds]]: _nanoseconds_,


### PR DESCRIPTION
While working on test262 coverage for the varied edge cases of NanosecondsToDays, I realized step 21 and step 23 - respectively, `nanoseconds < 0 and sign = 1` and `abs(nanoseconds) ≥ abs(dayLengthNs)` - are dead code. Step 21 can never be true without step 19 also being true, so the step will never be reached. Step 23 can never be true without either step 21 or 22 being true, and so the step will also never be reached.

I talked to @anba about it, and he helped me immensely by coming up with concrete proofs of both of those assertions, which makes this a non-normative change.

A summary of the proof for step 23 is as follows:

Because all of the assertions can only be reached following step 18.c: `(nanoseconds - dayLengthNs) × sign ≥ 0`, if `sign = 1`, this means `nanoseconds < dayLengthNs`. Step 21 contradicts this: because `nanoseconds ≥ 0`, the only way the assertion can be true is for `nanoseconds ≥ dayLengthNs` to be true, a contradiction. The converse applies similarly with step 22 if `sign = -1`

For step 21, the contradiction with step 19 is a bit trickier; @anba's proof verbatim:

> Step 21 checks `nanoseconds < 0 and sign = 1`. `nanoseconds` is set in steps 16 and 18.c.i:
> Step 18.c.i trivially never sets `nanoseconds` to a negative value, because of the condition in step 18.c.
> Step 16 sets `nanoseconds := endNs - intermediateN`". There are four cases to consider when evaluating step 15:
> Case 1: `days < 0`
>   This case will throw an error in step 19.
> 
> Case 2: `days = 0`
>   Step 14 sets `intermediateNs := startNs`. (Because the fast path in AddZonedDateTime, step 3 is taken.)
>   Step 15.a loop is never entered.
>   Step 16 sets:
>```     nanoseconds' = endNs - intermediateNs
>                  = endNs - startNs                    // cf. step 14
>                  = startNs + nanoseconds - startNs    // cf. step 8
>                  = nanoseconds
> ```
>   `nanoseconds > 0` is true when `sign = 1`, and therefore also `nanoseconds' > 0.`
> 
> Case 3: `days > 0` and `intermediateNs ≤ endNs`
>  Step 16 sets:
>    ```nanoseconds' = endNs - intermediateNs
>    ⇒ nanoseconds' ≥ 0      // because of intermediateNs ≤ endNs
>```
> Case 4: `days = 1 and intermediateNs > endNs`
>   Step 15.a.i sets `days := 0`.
>   When `days = 0`, then step 15.a.ii sets `intermediateNs := startNs`. (Because the fast path in AddZonedDateTime, step 3 is taken.)
>   Step 16 sets:
>```     nanoseconds' = endNs - intermediateNs
>                  = endNs - startNs                    // cf. 15.a.ii
>                  = startNs + nanoseconds - startNs    // cf. step 8
>                  = nanoseconds
>``` 
>   `nanoseconds > 0` is true when `sign = 1`, and therefore also `nanoseconds' > 0`.
> 
> That means `nanoseconds ≥ 0` when evaluating step 21 and therefore the condition can never be fulfilled.

Tests to follow, exercising all RangeErrors added in https://github.com/tc39/proposal-temporal/pull/2387. Many, many thanks to @anba whose much clearer stated proofs rescued my brain from the rabbit hole.