### PR TITLE
Remove Unix Epoch references from Temporal.Now.instant()

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ Several important concepts are explained elsewhere: [exact time, wall-clock time
 
 ### **Temporal.Now**
 
-- `Temporal.Now.instant()` - get the exact time since [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)
+- `Temporal.Now.instant()` - get the current system exact time
 - `Temporal.Now.timeZone()` - get the current system time zone
 - `Temporal.Now.zonedDateTime(calendar)` - get the current date and wall-clock time in the system time zone and specified calendar
 - `Temporal.Now.zonedDateTimeISO()` - get the current date and wall-clock time in the system time zone and ISO-8601 calendar


### PR DESCRIPTION
Fixes #2418. Related to #2175.

Creating a PR as suggested.