### PR TITLE
Editorial: Clarify that DaysInMonth operations return a count of days

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -568,7 +568,7 @@
       <h1>
         ISODaysInMonth (
           _year_: an integer,
-          _month_: an integer between 1 and 12 inclusive,
+          _month_: an integer in the inclusive interval from 1 to 12,
         ): a positive integer
       </h1>
       <dl class="header">

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -564,7 +564,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-isodaysinmonth" aoid="ISODaysInMonth">
+    <emu-clause id="sec-temporal-isodaysinmonth" type="abstract operation">
       <h1>
         ISODaysInMonth (
           _year_: an integer,
@@ -1199,7 +1199,7 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slots, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
-        1. Return 𝔽(! ISODaysInMonth(_temporalDateLike_.[[ISOYear]], _temporalDateLike_.[[ISOMonth]])).
+        1. Return 𝔽(ISODaysInMonth(_temporalDateLike_.[[ISOYear]], _temporalDateLike_.[[ISOMonth]])).
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -565,12 +565,20 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-isodaysinmonth" aoid="ISODaysInMonth">
-      <h1>ISODaysInMonth ( _year_, _month_ )</h1>
+      <h1>
+        ISODaysInMonth (
+          _year_: an integer,
+          _month_: an integer between 1 and 12 inclusive,
+        ): a positive integer
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the number of days in the given year and month in the ISO 8601 calendar.</dd>
+      </dl>
       <emu-alg>
-        1. Assert: _year_ is an integer.
-        1. Assert: _month_ is an integer, _month_ &ge; 1, and _month_ &le; 12.
         1. If _month_ is 1, 3, 5, 7, 8, 10, or 12, return 31.
         1. If _month_ is 4, 6, 9, or 11, return 30.
+        1. Assert: _month_ is 2.
         1. Return 28 + ℝ(InLeapYear(TimeFromYear(𝔽(_year_)))).
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1601,7 +1601,7 @@
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It takes a date-like object _date_ and returns the number of days in the given month in the calendar represented by _calendar_.</dd>
+            <dd>It identifies the month in the specified calendar that contains _date_ and returns the number of days in that month.</dd>
           </dl>
         </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2013,7 +2013,7 @@
             1. If Type(_temporalDateLike_) is not Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slots, then
               1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _daysInMonth_ be ! ISODaysInMonth(_temporalDateLike_.[[ISOYear]], _temporalDateLike_.[[ISOMonth]]).
+              1. Let _daysInMonth_ be ISODaysInMonth(_temporalDateLike_.[[ISOYear]], _temporalDateLike_.[[ISOMonth]]).
             1. Else,
               1. Let _daysInMonth_ be ! CalendarDateDaysInMonth(_calendar_.[[Identifier]], _temporalDateLike_).
             1. Return 𝔽(_daysInMonth_).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -788,8 +788,8 @@
           1. If _mid_.[[Month]] = _end_.[[Month]], then
             1. Assert: _mid_.[[Year]] = _end_.[[Year]].
             1. Let _days_ be _end_.[[Day]] - _mid_.[[Day]].
-          1. Else if _sign_ &lt; 0, let _days_ be -_mid_.[[Day]] - (! ISODaysInMonth(_end_.[[Year]], _end_.[[Month]]) - _end_.[[Day]]).
-          1. Else, let _days_ be _end_.[[Day]] + (! ISODaysInMonth(_mid_.[[Year]], _mid_.[[Month]]) - _mid_.[[Day]]).
+          1. Else if _sign_ &lt; 0, let _days_ be -_mid_.[[Day]] - (ISODaysInMonth(_end_.[[Year]], _end_.[[Month]]) - _end_.[[Day]]).
+          1. Else, let _days_ be _end_.[[Day]] + (ISODaysInMonth(_mid_.[[Year]], _mid_.[[Month]]) - _mid_.[[Day]]).
           1. If _largestUnit_ is *"month"*, then
             1. Set _months_ to _months_ + _years_ &times; 12.
             1. Set _years_ to 0.
@@ -829,7 +829,7 @@
       <emu-alg>
         1. If _overflow_ is *"constrain"*, then
           1. Set _month_ to the result of clamping _month_ between 1 and 12.
-          1. Let _daysInMonth_ be ! ISODaysInMonth(_year_, _month_).
+          1. Let _daysInMonth_ be ISODaysInMonth(_year_, _month_).
           1. Set _day_ to the result of clamping _day_ between 1 and _daysInMonth_.
           1. Return CreateISODateRecord(_year_, _month_, _day_).
         1. Else,
@@ -857,7 +857,7 @@
       <emu-alg>
         1. If _month_ &lt; 1 or _month_ &gt; 12, then
           1. Return *false*.
-        1. Let _daysInMonth_ be ! ISODaysInMonth(_year_, _month_).
+        1. Let _daysInMonth_ be ISODaysInMonth(_year_, _month_).
         1. If _day_ &lt; 1 or _day_ &gt; _daysInMonth_, then
           1. Return *false*.
         1. Return *true*.


### PR DESCRIPTION
...rather than e.g. the number of the last day.

Fixes #1315