### PR TITLE
Run CI tests in Node 19 / ICU 72 / CLDR 42

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,18 +7,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        persist-credentials: false
-    - name: use node.js v15.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 15.x
-    - run: npm ci
-    - run: npm run build
-    - uses: JamesIves/github-pages-deploy-action@3.7.1
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: out
-        CLEAN: true
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: use node.js v19.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 19.x
+      - run: npm ci
+      - run: npm run build
+      - uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: out
+          CLEAN: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,11 +4,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: use node.js v15.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 15.x
-    - run: npm ci
-    - run: npm run lint
-    - run: npm run build:spec
+      - uses: actions/checkout@v3
+      - name: use node.js v19.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 19.x
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build:spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
   test-polyfill:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: use node.js v18.x
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: use node.js v19.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 19.x
       - run: npm ci
       - run: npm run test-demitasse
         env:
@@ -20,13 +20,13 @@ jobs:
   test-test262:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: use node.js v18.x
-        uses: actions/setup-node@v1
+      - name: use node.js v19.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 19.x
       - run: npm ci
       - run: npm run codecov:test262
         env:
@@ -34,21 +34,21 @@ jobs:
   test-cookbook:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: use node.js v18.x
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: use node.js v19.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 19.x
       - run: npm ci
       - run: npm run test-cookbook
   test-validstrings:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: use node.js v18.x
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: use node.js v19.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 19.x
       - run: npm ci
       - run: |
           cd polyfill

--- a/polyfill/ci_codecov_test262.sh
+++ b/polyfill/ci_codecov_test262.sh
@@ -24,6 +24,13 @@ for subdir in $subdirs; do
   node runtest262.mjs "$subdir/**" || failed=1
 done
 node runtest262.mjs "test262/test/staging/Intl402/Temporal/**/*.js" || failed=1
+node runtest262.mjs "test262/test/intl402/**/*[tT]emporal*.js" || failed=1
+# TODO: remove the line above and uncomment the three lines below to run tests for all localilzed
+# date formatting, because the Temporal polyfill replaces the entire DateTimeFormat object.
+# See https://github.com/tc39/proposal-temporal/issues/2471 for more info.
+# node runtest262.mjs "test262/test/intl402/DateTimeFormat/**/*.js" || failed=1
+# node runtest262.mjs "test262/test/intl402/Intl/DateTimeFormat/**/*.js" || [ $? = 66 ] || failed=1
+# node runtest262.mjs "test262/test/built-ins/Date/*/toLocale*String/*.js" || failed=1
 
 c8 report --reporter=text-lcov --temp-directory=$NODE_V8_COVERAGE \
   --exclude=polyfill/runtest262.mjs \

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@babel/preset-env": "^7.16.11",
-    "@js-temporal/temporal-test262-runner": "^0.6.0",
+    "@js-temporal/temporal-test262-runner": "^0.7.0",
     "@pipobscure/demitasse": "^1.0.10",
     "@pipobscure/demitasse-pretty": "^1.0.10",
     "@pipobscure/demitasse-run": "^1.0.10",


### PR DESCRIPTION
Support CI tests in Node 19, and specifically supports running with ICU 72 which contains CLDR 42 which broke a lot of tests. 

This PR is a counterpart to https://github.com/js-temporal/temporal-polyfill/pull/203, but this PR was somewhat easier because there's no TS-specific issues to contend with like there are in the other repo. 

* Update GH actions to latest versions
* Use Node19 on all other actions and tests
* Run Test262 against Node 19 ~~,18, 16, 14~~ _Removed older Node version testing at @ptomato's request; instead, he'll work with Test262 maintainers to avoid downlevel-incompatible tests from getting into Test262._
* ~~Extend expected-failures.txt handling so that some tests can be expected to fail only on some Node versions, but pass on later versions.~~
* Upgrades `@js-temporal/temporal-test262-runner` to include some Temporal-related 402 tests that we weren't running before. (And which failed in Node 19 / CLDR 42) 
* Updates Test262 so those newly-included tests will pass
* Updates the codecov script to run those previously-missed tests