### PR TITLE
Editorial: Avoid faulty assertion in RoundDuration about integer days

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4771,10 +4771,11 @@ export const ES = ObjectAssign({}, ES2022, {
         relativeTo = yearsLater;
         days += monthsWeeksInDays;
 
-        const daysLater = ES.CalendarDateAdd(calendar, relativeTo, { days }, undefined, dateAdd);
+        const wholeDays = new TemporalDuration(0, 0, 0, days);
+        const wholeDaysLater = ES.CalendarDateAdd(calendar, relativeTo, wholeDays, undefined, dateAdd);
         const untilOptions = ObjectCreate(null);
         untilOptions.largestUnit = 'year';
-        const yearsPassed = ES.CalendarDateUntil(calendar, relativeTo, daysLater, untilOptions).years;
+        const yearsPassed = ES.CalendarDateUntil(calendar, relativeTo, wholeDaysLater, untilOptions).years;
         years += yearsPassed;
         const oldRelativeTo = relativeTo;
         relativeTo = ES.CalendarDateAdd(calendar, relativeTo, { years: yearsPassed }, undefined, dateAdd);

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1661,12 +1661,11 @@
           1. Let _monthsWeeksInDays_ be DaysUntil(_yearsLater_, _yearsMonthsWeeksLater_).
           1. Set _relativeTo_ to _yearsLater_.
           1. Let _days_ be _days_ + _monthsWeeksInDays_.
-          1. Assert: _days_ is an integer.
-          1. Let _daysDuration_ be ? CreateTemporalDuration(0, 0, 0, _days_, 0, 0, 0, 0, 0, 0).
-          1. Let _daysLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _daysDuration_, *undefined*, _dateAdd_).
+          1. Let _wholeDaysDuration_ be ? CreateTemporalDuration(0, 0, 0, truncate(_days_), 0, 0, 0, 0, 0, 0).
+          1. Let _wholeDaysLater_ be ? CalendarDateAdd(_calendar_, _relativeTo_, _wholeDaysDuration_, *undefined*, _dateAdd_).
           1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"year"*).
-          1. Let _timePassed_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _daysLater_, _untilOptions_).
+          1. Let _timePassed_ be ? CalendarDateUntil(_calendar_, _relativeTo_, _wholeDaysLater_, _untilOptions_).
           1. Let _yearsPassed_ be _timePassed_.[[Years]].
           1. Set _years_ to _years_ + _yearsPassed_.
           1. Let _oldRelativeTo_ be _relativeTo_.


### PR DESCRIPTION
At this point in the algorithm, we need to find the number of whole years contained within _days_. Contrary to the assertion, and to the requirement of CreateTemporalDuration, _days_ is not an integer. The algorithm is faulty and unimplementable as written.

However, the answer (_yearsPassed_) is still correct if we temporarily discard the fractional part in the call to CreateTemporalDuration.

Rename the variables _daysLater_ and _daysDuration_ to _wholeDaysLater_ and _wholeDaysDuration_, respectively, to emphasize that they potentially represent a different value from _days_.

The bug was not present in the reference code because it calculates slightly differently with floats, instead of reals as in the spec text. Still, rename the variables there as well. While we are here, correct the reference code to pass a Temporal.Duration instance to dateAdd, as specified.

Closes: #2246