### PR TITLE
Normative: Reject invalid output from custom Calendar/TimeZone methods

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1650,7 +1650,7 @@ export const ES = ObjectAssign({}, ES2022, {
       return result;
     }
     if (typeof result !== 'string') {
-      throw new TypeError('calendar era result must be a string');
+      throw new TypeError('calendar era result must be a string or undefined');
     }
     return result;
   },
@@ -1661,10 +1661,10 @@ export const ES = ObjectAssign({}, ES2022, {
       return result;
     }
     if (typeof result !== 'number') {
-      throw new TypeError('calendar eraYear result must be an integer');
+      throw new TypeError('calendar eraYear result must be an integer or undefined');
     }
     if (!IsIntegralNumber(result)) {
-      throw new RangeError('calendar eraYear result must be an integer');
+      throw new RangeError('calendar eraYear result must be an integer or undefined');
     }
     return result;
   },

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1605,78 +1605,164 @@ export const ES = ObjectAssign({}, ES2022, {
   CalendarYear: (calendar, dateLike) => {
     const year = ES.GetMethod(calendar, 'year');
     const result = ES.Call(year, calendar, [dateLike]);
-    return ES.ToIntegerWithTruncation(result);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar year result must be an integer');
+    }
+    if (!IsIntegralNumber(result)) {
+      throw new RangeError('calendar year result must be an integer');
+    }
+    return result;
   },
   CalendarMonth: (calendar, dateLike) => {
     const month = ES.GetMethod(calendar, 'month');
     const result = ES.Call(month, calendar, [dateLike]);
-    return ES.ToPositiveIntegerWithTruncation(result);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar month result must be a positive integer');
+    }
+    if (!IsIntegralNumber(result) || result <= 0) {
+      throw new RangeError('calendar month result must be a positive integer');
+    }
+    return result;
   },
   CalendarMonthCode: (calendar, dateLike) => {
     const monthCode = ES.GetMethod(calendar, 'monthCode');
     const result = ES.Call(monthCode, calendar, [dateLike]);
-    if (result === undefined) {
-      throw new RangeError('calendar monthCode result must be a string');
+    if (typeof result !== 'string') {
+      throw new TypeError('calendar monthCode result must be a string');
     }
-    return ES.ToString(result);
+    return result;
   },
   CalendarDay: (calendar, dateLike) => {
     const day = ES.GetMethod(calendar, 'day');
     const result = ES.Call(day, calendar, [dateLike]);
-    return ES.ToPositiveIntegerWithTruncation(result);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar day result must be a positive integer');
+    }
+    if (!IsIntegralNumber(result) || result <= 0) {
+      throw new RangeError('calendar day result must be a positive integer');
+    }
+    return result;
   },
   CalendarEra: (calendar, dateLike) => {
     const era = ES.GetMethod(calendar, 'era');
     let result = ES.Call(era, calendar, [dateLike]);
-    if (result !== undefined) {
-      result = ES.ToString(result);
+    if (result === undefined) {
+      return result;
+    }
+    if (typeof result !== 'string') {
+      throw new TypeError('calendar era result must be a string');
     }
     return result;
   },
   CalendarEraYear: (calendar, dateLike) => {
     const eraYear = ES.GetMethod(calendar, 'eraYear');
     let result = ES.Call(eraYear, calendar, [dateLike]);
-    if (result !== undefined) {
-      result = ES.ToIntegerWithTruncation(result);
+    if (result === undefined) {
+      return result;
+    }
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar eraYear result must be an integer');
+    }
+    if (!IsIntegralNumber(result)) {
+      throw new RangeError('calendar eraYear result must be an integer');
     }
     return result;
   },
   CalendarDayOfWeek: (calendar, dateLike) => {
     const dayOfWeek = ES.GetMethod(calendar, 'dayOfWeek');
-    return ES.ToPositiveIntegerWithTruncation(ES.Call(dayOfWeek, calendar, [dateLike]));
+    const result = ES.Call(dayOfWeek, calendar, [dateLike]);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar dayOfWeek result must be a positive integer');
+    }
+    if (!IsIntegralNumber(result) || result <= 0) {
+      throw new RangeError('calendar dayOfWeek result must be a positive integer');
+    }
+    return result;
   },
   CalendarDayOfYear: (calendar, dateLike) => {
     const dayOfYear = ES.GetMethod(calendar, 'dayOfYear');
-    return ES.ToPositiveIntegerWithTruncation(ES.Call(dayOfYear, calendar, [dateLike]));
+    const result = ES.Call(dayOfYear, calendar, [dateLike]);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar dayOfYear result must be a positive integer');
+    }
+    if (!IsIntegralNumber(result) || result <= 0) {
+      throw new RangeError('calendar dayOfYear result must be a positive integer');
+    }
+    return result;
   },
   CalendarWeekOfYear: (calendar, dateLike) => {
     const weekOfYear = ES.GetMethod(calendar, 'weekOfYear');
-    return ES.ToPositiveIntegerWithTruncation(ES.Call(weekOfYear, calendar, [dateLike]));
+    const result = ES.Call(weekOfYear, calendar, [dateLike]);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar weekOfYear result must be a positive integer');
+    }
+    if (!IsIntegralNumber(result) || result <= 0) {
+      throw new RangeError('calendar weekOfYear result must be a positive integer');
+    }
+    return result;
   },
   CalendarYearOfWeek: (calendar, dateLike) => {
     const yearOfWeek = ES.GetMethod(calendar, 'yearOfWeek');
     const result = ES.Call(yearOfWeek, calendar, [dateLike]);
-    return ES.ToIntegerWithTruncation(result);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar yearOfWeek result must be an integer');
+    }
+    if (!IsIntegralNumber(result)) {
+      throw new RangeError('calendar yearOfWeek result must be an integer');
+    }
+    return result;
   },
   CalendarDaysInWeek: (calendar, dateLike) => {
     const daysInWeek = ES.GetMethod(calendar, 'daysInWeek');
-    return ES.ToPositiveIntegerWithTruncation(ES.Call(daysInWeek, calendar, [dateLike]));
+    const result = ES.Call(daysInWeek, calendar, [dateLike]);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar daysInWeek result must be a positive integer');
+    }
+    if (!IsIntegralNumber(result) || result <= 0) {
+      throw new RangeError('calendar daysInWeek result must be a positive integer');
+    }
+    return result;
   },
   CalendarDaysInMonth: (calendar, dateLike) => {
     const daysInMonth = ES.GetMethod(calendar, 'daysInMonth');
-    return ES.ToPositiveIntegerWithTruncation(ES.Call(daysInMonth, calendar, [dateLike]));
+    const result = ES.Call(daysInMonth, calendar, [dateLike]);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar daysInMonth result must be a positive integer');
+    }
+    if (!IsIntegralNumber(result) || result <= 0) {
+      throw new RangeError('calendar daysInMonth result must be a positive integer');
+    }
+    return result;
   },
   CalendarDaysInYear: (calendar, dateLike) => {
     const daysInYear = ES.GetMethod(calendar, 'daysInYear');
-    return ES.ToPositiveIntegerWithTruncation(ES.Call(daysInYear, calendar, [dateLike]));
+    const result = ES.Call(daysInYear, calendar, [dateLike]);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar daysInYear result must be a positive integer');
+    }
+    if (!IsIntegralNumber(result) || result <= 0) {
+      throw new RangeError('calendar daysInYear result must be a positive integer');
+    }
+    return result;
   },
   CalendarMonthsInYear: (calendar, dateLike) => {
     const monthsInYear = ES.GetMethod(calendar, 'monthsInYear');
-    return ES.ToPositiveIntegerWithTruncation(ES.Call(monthsInYear, calendar, [dateLike]));
+    const result = ES.Call(monthsInYear, calendar, [dateLike]);
+    if (typeof result !== 'number') {
+      throw new TypeError('calendar monthsInYear result must be a positive integer');
+    }
+    if (!IsIntegralNumber(result) || result <= 0) {
+      throw new RangeError('calendar monthsInYear result must be a positive integer');
+    }
+    return result;
   },
   CalendarInLeapYear: (calendar, dateLike) => {
     const inLeapYear = ES.GetMethod(calendar, 'inLeapYear');
-    return !!ES.Call(inLeapYear, calendar, [dateLike]);
+    const result = ES.Call(inLeapYear, calendar, [dateLike]);
+    if (typeof result !== 'boolean') {
+      throw new TypeError('calendar inLeapYear result must be a boolean');
+    }
+    return result;
   },
 
   ToTemporalCalendar: (calendarLike) => {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1619,7 +1619,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (typeof result !== 'number') {
       throw new TypeError('calendar month result must be a positive integer');
     }
-    if (!IsIntegralNumber(result) || result <= 0) {
+    if (!IsIntegralNumber(result) || result < 1) {
       throw new RangeError('calendar month result must be a positive integer');
     }
     return result;
@@ -1638,7 +1638,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (typeof result !== 'number') {
       throw new TypeError('calendar day result must be a positive integer');
     }
-    if (!IsIntegralNumber(result) || result <= 0) {
+    if (!IsIntegralNumber(result) || result < 1) {
       throw new RangeError('calendar day result must be a positive integer');
     }
     return result;
@@ -1674,7 +1674,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (typeof result !== 'number') {
       throw new TypeError('calendar dayOfWeek result must be a positive integer');
     }
-    if (!IsIntegralNumber(result) || result <= 0) {
+    if (!IsIntegralNumber(result) || result < 1) {
       throw new RangeError('calendar dayOfWeek result must be a positive integer');
     }
     return result;
@@ -1685,7 +1685,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (typeof result !== 'number') {
       throw new TypeError('calendar dayOfYear result must be a positive integer');
     }
-    if (!IsIntegralNumber(result) || result <= 0) {
+    if (!IsIntegralNumber(result) || result < 1) {
       throw new RangeError('calendar dayOfYear result must be a positive integer');
     }
     return result;
@@ -1696,7 +1696,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (typeof result !== 'number') {
       throw new TypeError('calendar weekOfYear result must be a positive integer');
     }
-    if (!IsIntegralNumber(result) || result <= 0) {
+    if (!IsIntegralNumber(result) || result < 1) {
       throw new RangeError('calendar weekOfYear result must be a positive integer');
     }
     return result;
@@ -1718,7 +1718,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (typeof result !== 'number') {
       throw new TypeError('calendar daysInWeek result must be a positive integer');
     }
-    if (!IsIntegralNumber(result) || result <= 0) {
+    if (!IsIntegralNumber(result) || result < 1) {
       throw new RangeError('calendar daysInWeek result must be a positive integer');
     }
     return result;
@@ -1729,7 +1729,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (typeof result !== 'number') {
       throw new TypeError('calendar daysInMonth result must be a positive integer');
     }
-    if (!IsIntegralNumber(result) || result <= 0) {
+    if (!IsIntegralNumber(result) || result < 1) {
       throw new RangeError('calendar daysInMonth result must be a positive integer');
     }
     return result;
@@ -1740,7 +1740,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (typeof result !== 'number') {
       throw new TypeError('calendar daysInYear result must be a positive integer');
     }
-    if (!IsIntegralNumber(result) || result <= 0) {
+    if (!IsIntegralNumber(result) || result < 1) {
       throw new RangeError('calendar daysInYear result must be a positive integer');
     }
     return result;
@@ -1751,7 +1751,7 @@ export const ES = ObjectAssign({}, ES2022, {
     if (typeof result !== 'number') {
       throw new TypeError('calendar monthsInYear result must be a positive integer');
     }
-    if (!IsIntegralNumber(result) || result <= 0) {
+    if (!IsIntegralNumber(result) || result < 1) {
       throw new RangeError('calendar monthsInYear result must be a positive integer');
     }
     return result;

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -227,7 +227,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"month"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -265,7 +265,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"day"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -285,7 +285,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfWeek"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -305,7 +305,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -325,7 +325,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"weekOfYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -364,7 +364,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"daysInWeek"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -384,7 +384,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"daysInMonth"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -404,7 +404,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"daysInYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -424,7 +424,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"monthsInYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
+        1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -206,9 +206,10 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"year"*, « _dateLike_ »).
-        1. Return ? ToIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarmonth" type="abstract operation">
@@ -224,9 +225,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"month"*, « _dateLike_ »).
-        1. Return ? ToPositiveIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarmonthcode" type="abstract operation">
@@ -242,8 +245,8 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"monthCode"*, « _dateLike_ »).
-        1. If _result_ is *undefined*, throw a *RangeError* exception.
-        1. Return ? ToString(_result_).
+        1. If Type(_result_) is not String, throw a *TypeError* exception.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 
@@ -260,9 +263,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"day"*, « _dateLike_ »).
-        1. Return ? ToPositiveIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardayofweek" type="abstract operation">
@@ -278,9 +283,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfWeek"*, « _dateLike_ »).
-        1. Return ? ToPositiveIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardayofyear" type="abstract operation">
@@ -296,9 +303,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfYear"*, « _dateLike_ »).
-        1. Return ? ToPositiveIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarweekofyear" type="abstract operation">
@@ -314,9 +323,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"weekOfYear"*, « _dateLike_ »).
-        1. Return ? ToPositiveIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendaryearofweek" type="abstract operation">
@@ -332,9 +343,10 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"yearOfWeek"*, « _dateLike_ »).
-        1. Return ? ToIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardaysinweek" type="abstract operation">
@@ -350,9 +362,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"daysInWeek"*, « _dateLike_ »).
-        1. Return ? ToPositiveIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardaysinmonth" type="abstract operation">
@@ -368,9 +382,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"daysInMonth"*, « _dateLike_ »).
-        1. Return ? ToPositiveIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardaysinyear" type="abstract operation">
@@ -386,9 +402,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"daysInYear"*, « _dateLike_ »).
-        1. Return ? ToPositiveIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarmonthsinyear" type="abstract operation">
@@ -404,9 +422,11 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"monthsInYear"*, « _dateLike_ »).
-        1. Return ? ToPositiveIntegerWithTruncation(_result_).
+        1. If Type(_result_) is not Number, throw a *TypeError* exception.
+        1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. Return ℝ(_result_).
       </emu-alg>
-      <emu-note>ToPositiveIntegerWithTruncation(*undefined*) will throw a *RangeError*.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarinleapyear" type="abstract operation">
@@ -422,7 +442,8 @@
       </dl>
       <emu-alg>
         1. Let _result_ be ? Invoke(_calendar_, *"inLeapYear"*, « _dateLike_ »).
-        1. Return ToBoolean(_result_).
+        1. If Type(_result_) is not Boolean, throw a *TypeError* exception.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -227,7 +227,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"month"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -265,7 +265,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"day"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -285,7 +285,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfWeek"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -305,7 +305,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -325,7 +325,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"weekOfYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -364,7 +364,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"daysInWeek"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -384,7 +384,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"daysInMonth"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -404,7 +404,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"daysInYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>
@@ -424,7 +424,7 @@
         1. Let _result_ be ? Invoke(_calendar_, *"monthsInYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
-        1. If _result_ &le; 0, throw a *RangeError* exception.
+        1. If _result_ &lt; 1<sub>𝔽</sub>, throw a *RangeError* exception.
         1. Return ℝ(_result_).
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1364,7 +1364,7 @@
             CalendarEra (
               _calendar_: an Object,
               _dateLike_: a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth,
-            ): either a normal completion containing a String, or an abrupt completion
+            ): either a normal completion containing either a String or *undefined*, or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1359,29 +1359,44 @@
       <emu-clause id="sup-temporal-calendar-abstract-ops">
         <h1>Abstract Operations for Temporal.Calendar Objects</h1>
 
-        <emu-clause id="sec-temporal-calendarera" aoid="CalendarEra">
-          <h1>CalendarEra ( _calendar_, _dateLike_ )</h1>
-          <p>
-            The abstract operation CalendarEra calls the given _calendar_'s `era()` method and validates the result.
-          </p>
+        <emu-clause id="sec-temporal-calendarera" type="abstract operation">
+          <h1>
+            CalendarEra (
+              _calendar_: an Object,
+              _dateLike_: a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth,
+            ): either a normal completion containing a String, or an abrupt completion
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It calls the given _calendar_'s `era()` method and validates the result.</dd>
+          </dl>
           <emu-alg>
             1. Assert: Type(_calendar_) is Object.
             1. Let _result_ be ? Invoke(_calendar_, *"era"*, « _dateLike_ »).
-            1. If _result_ is not *undefined*, set _result_ to ? ToString(_result_).
+            1. If _result_ is *undefined*, return _result_.
+            1. If Type(_result_) is not String, throw a *TypeError* exception.
             1. Return _result_.
           </emu-alg>
         </emu-clause>
 
-        <emu-clause id="sec-temporal-calendarerayear" aoid="CalendarEraYear">
-          <h1>CalendarEraYear ( _calendar_, _dateLike_ )</h1>
-          <p>
-            The abstract operation CalendarEraYear calls the given _calendar_'s `eraYear()` method and validates the result.
-          </p>
+        <emu-clause id="sec-temporal-calendarerayear" type="abstract operation">
+          <h1>
+            CalendarEraYear (
+              _calendar_: an Object,
+              _dateLike_: a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainYearMonth,
+            ): either a normal completion containing either an integer or *undefined*, or an abrupt completion
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It calls the given _calendar_'s `eraYear()` method and validates the result.</dd>
+          </dl>
           <emu-alg>
             1. Assert: Type(_calendar_) is Object.
             1. Let _result_ be ? Invoke(_calendar_, *"eraYear"*, « _dateLike_ »).
-            1. If _result_ is not *undefined*, set _result_ to ? ToIntegerWithTruncation(_result_).
-            1. Return _result_.
+            1. If _result_ is *undefined*, return _result_.
+            1. If Type(_result_) is not Number, throw a *TypeError* exception.
+            1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
+            1. Return ℝ(_result_).
           </emu-alg>
         </emu-clause>
 


### PR DESCRIPTION
Fixes #2443

It looked to me like the TimeZone operations already behaved appropriately[^1], but please verify in review (along with confirmation that I have preserved the distinction between fields that must be positive vs. those that can be zero or negative).

test262 pull request: https://github.com/tc39/test262/pull/3761

[^1]: [GetOffsetNanosecondsFor](https://tc39.es/proposal-temporal/#sec-temporal-getoffsetnanosecondsfor) requires `getOffsetNanosecondsFor` to return an integral Number with absolute value no greater than [nsPerDay](https://tc39.es/proposal-temporal/#eqn-nsPerDay), and [GetPossibleInstantsFor](https://tc39.es/proposal-temporal/#sec-temporal-getpossibleinstantsfor) requires `getPossibleInstantsFor` to return an iterable of Temporal Instant instances.