### PR TITLE
Publish minutes backlog, part 1

### DIFF
--- a/meetings/agenda-minutes-2022-02-03.md
+++ b/meetings/agenda-minutes-2022-02-03.md
@@ -1,0 +1,99 @@
+# February 3, 2022
+
+## Attendees
+- Jesse Alama (JMN)
+- Shane Carr (SFC)
+- Justin Grant (JGT)
+- Philip Chimento (PFC)
+- Philipp Dunkel (PDL)
+
+## Agenda
+
+### IETF status
+Invite USA to attend the next meeting to talk about this.
+There is supposed to be a SEDATE meeting this month, but it has yet to be scheduled.
+
+### ECMA-402 status
+#### What to present at ECMA-402 monthly, 2022-02-10
+- PFC: What would this audience like to know?
+- SFC: [#2005](https://github.com/tc39/proposal-temporal/issues/2005) was one example of an issue we should discuss. Two things; give an overview of the 402 annex changes. Slides not necessary but wouldn't hurt, making sure everyone in TG2 is aware of the changes. Second, overview of all the open issues that concern TG2. #2005 is one, there may be more.
+- JGT: [#1899](https://github.com/tc39/proposal-temporal/issues/1899) is another one.
+
+#### Specifying calendar operations ([#1899](https://github.com/tc39/proposal-temporal/issues/1899))
+JGT to review latest commits to [#1928](https://github.com/tc39/proposal-temporal/pull/1928)
+
+#### In `.toLocaleString()` options, property-bag form of `calendar` and `timeZone` will throw ([#2005](https://github.com/tc39/proposal-temporal/issues/2005))
+To discuss at next week’s 402 meeting.
+- PFC: It looks like we have a clear idea of what we want.
+- JGT: Including the property bag form of calendars and time zones?
+- SFC: I think so.
+- JGT: An overview of all the places in Temporal where we expect TG2 to care seems like it should go in the slides.
+
+#### Clarify if / how Intl.DateTimePattern should format the time zone ([#2013](https://github.com/tc39/proposal-temporal/issues/))
+
+### -0 in Temporal.Duration ([#1715](https://github.com/tc39/proposal-temporal/issues/1715))
+- PFC: This issue is relevant again if we are storing Number values in Duration internal slots. We left off last time with the current situation being inconsistent, and would need to be resolved either consistently with -0 or without -0.
+- RGN left a comment via Matrix that he thinks Duration should not have a concept of -0.
+- JGT: Durations aren't conceptually IEEE floating point numbers, so I don't think -0 is appropriate here.
+- SFC: In IEEE you always get the same number if you add -0. But if you add +0 to -0 it changes the sign.
+- JGT: Weird.
+- SFC: We already throw an exception if numbers in Duration fields have opposite signs. It seems consistent if `Duration.negated()` flips the signs of all the fields including the zeroes.
+- PDL: I'm worried about mathematical implications. It's actually not that easy to get a -0 in JS in the normal course of things, but this would make it easier. I'd worry that we'd be "squirting" -0s all over the place into other contexts where they otherwise would be rare, causing side effects in other code. I'd also propose not throwing on -0 values in input, instead normalizing them to the sign of the other values.
+- JGT: I think what you described matches the intuition of most people. I have worked with JS for 20 years and I didn't even know about -0 until I started working with Temporal.
+- SFC: The semantics of -0 make it behave like 0, mostly. It's quite tricky to tell them apart.
+- PFC: Distinguishing -0 in Temporal.Duration would introduce more opportunities where -0 and 0 didn't behave the same. For example, if you had a Duration with all -0 fields and another one with all 0 fields, you would not be able to create another Duration with fields taken from both of those.
+- PDL: Right, we'd be introducing another opportunity to test whether something is a -0. I think exposing -0 where it's semantically irrelevant is a bad thing.
+- SFC: We could follow the IEEE semantics of 0 + -0 equalling 0.
+- JGT: Turning the question around, what is the advantage to developers of distinguishing -0 in Duration?
+- PFC: I don't see one.
+- SFC: If you're working in negative numbers and you perform some kind of rounding operation and you end up with zero, you retain the sign, so that when you format it the sign is printed.
+- PDL: Would that be relevant in the context of Temporal?
+- SFC: If you format it, you would get -0 hours. So, for example, printing and subtracting one hour you'd get -5, -4, -3, -2, -1, -0 hours.
+- JGT: My problem with that is that "normal humans" don't have a concept of -0.
+- SFC: I think we do agree on that. But say you have the string `-PT0S` you couldn't round-trip it.
+- JGT: You can't roundtrip `PT0H` either, it comes back as `PT0S`.
+- PFC: Similarly the plenary also decided that -000000 isn't a valid year.
+- JMN: Is that also related to there not being a year 0?
+- PFC: There is no Gregorian year 0 but there is an ISO year 0.
+- SFC: Have we checked with the records & tuples champions about whether -0 is distinguished?
+- PDL: Will check.
+- JGT: To summarize, I don't think anyone has come up with a use case for distinguishing -0 that is worth the extra complexity.
+- SFC: I think formatting -0 is worth it.
+- PDL: I have an answer from records & tuples - they use SameValueZero semantics, so they don't distinguish -0.
+- SFC: I'm surprised, that means records & tuples don't have bitwise equality.
+- PFC: Another option if we wanted to preserve formatting -0, would be to allow the internal slot to store -0, and take it into account in formatting, but have all the getters normalize -0 to 0. That way we'd avoid leaking -0 into other contexts.
+- SFC: That would be the weirdest outcome for me. Two questions, 1) If we have a -0 Duration do we automatically turn it into a 0 Duration? 2) If we have a nonzero negative duration, are the 0 fields negative or positive? The more I worked in specs in JS the more I've become amenable to the concept of -0.
+- PDL: 1) Yes 2) Positive. Interesting, the more I see -0 in the real world the more I think it was a mistake to ever introduce it.
+- JGT: I agree.
+- PDL: I see numbers as an axis, with 0 in the middle between negative and positive, not split.
+- SFC: The intuition of IEEE numbers is that the number line is closed at one end, at 0, and the sign is a separate bit.
+Conclusion: no consensus yet, we'll discuss this again next time.
+
+### Should dates whose year part is “-000000” be rejected as grammatically invalid or domain invalid? (PR [#2027](https://github.com/tc39/proposal-temporal/pull/2027))
+- JMN: I wanted to check the intuition being discussed in this PR. Anyone have comments about this?
+- PFC: I thought writing it explicitly with throwing an exception would be clearer to read, but that brings other problems that I didn't see before. This doesn't change any semantics, though.
+
+### DST problem with Duration.compare (issue [#1791](https://github.com/tc39/proposal-temporal/issues/1791), PR [#2026](https://github.com/tc39/proposal-temporal/pull/2026))
+- JMN: I'm not confident that this fix is the correct one. I'd like to find more cases that are either fixed or broken by this issue.
+- JGT: The way the algorithm works is that you add the dates, account for the offsets, and then add the times.
+- JMN: I'll keep looking for a counterexample.
+- SFC: What is the consequence of throwing out the hours and lower in determining the shift?
+- JMN: I'm trying to figure that out.
+- SFC: I reviewed this in more detail and I think the proposed solution looks correct to me. The reason it makes sense is that in the next step we collapse all the fields down to days.
+
+### Round-trip violation ([#1971](https://github.com/tc39/proposal-temporal/issues/1971))
+Loss of information (reference day, if available, gets dropped & replaced by hardcoded value 1) makes this impossible?
+- JMN: Is this a round trip violation?
+- JGT: This issue is purely about the behaviour of `calendarName: 'always'`, right? I like SFC's suggestion of always showing the full date.
+- JMN: However, the reference day gets dropped. Does that make it non-roundtrippable? `Temporal.PlainYearMonth.from("2019-10-31").toString({ calendarName: "always" })` gives `"2019-10-01[u-ca=iso8601]"`.
+- JGT: My understanding is this matches what we intentionally decided.
+- PFC: That matches my understanding as well. Unless you use the 4-argument form of the constructor, which is a low-level API intended to be used only by calendar implementations, you don't get to choose the reference day, only the calendar does.
+
+### What's the behavior of date arithmetic around epagomenal days? ([#1994](https://github.com/tc39/proposal-temporal/issues/1994))
+- JGT: This was a concern brought up by MG about e.g. the extra month at the end of the Ethiopian calendar, if you add a month to the last regular month, should it go to the extra month or back to month 1? MG's thought was that we should get information from users of that calendar.
+- PFC: I'll put this in my presentation for TG2 next week.
+- SFC: This is something that I hope USA's calendar spec will address.
+- JGT: Certainly if there was a judgment call I'd be nervous about deviating any one calendar's behavior without clear evidence from the local calendar users, because that would make it harder to write calendar-neutral code.
+- SFC: I don't know if we'll get much from discussing it next week, it requires research.
+- JGT: Would be good to figure out who owns doing that research.
+- SFC: Good question. MG owns the calendar arithmetic in ICU4X, USA owns the spec that we're supposed to be writing.

--- a/meetings/agenda-minutes-2022-02-17.md
+++ b/meetings/agenda-minutes-2022-02-17.md
@@ -1,0 +1,83 @@
+# February 17, 2022
+
+## Attendees
+- Shane F. Carr (SFC)
+- Justin Grant (JGT)
+- Richard Gibson (RGN)
+- Philipp Dunkel (PDL)
+- Philip Chimento (PFC)
+
+## Agenda
+
+### IETF status
+- SFC: USA shared an update. He believes there are no more open questions on the draft so he plans to ask for adoption on the next IETF meeting.
+- JGT: I thought there was one open issue on the mailing list about interpretation of timestamps.
+- We'll discuss this with USA on Matrix.
+
+### ECMA-402 status - discuss any open issues after last week’s ECMA 402 meeting
+Did the presentation achieve what we wanted?
+- SFC: I think it did. The goal was transparency and we achieved that.
+- PFC: We discussed passing calendar and time zone objects into the options parameter of DateTimeFormat, anything else while I was out of the meeting?
+- SFC: Mainly that. We got an explicit signal to go ahead with the plan that we had formulated on that issue, that it's OK to do things in 402 that are strongly dependent on Temporal.
+- JGT: The calendar standardization pull request is close, but it would be great to be able to merge it.
+- PFC to follow up about that pull request.
+
+### Is 12-07 standardized in ISO 8601, and if not should we use a standard format instead? ([#2049](https://github.com/tc39/proposal-temporal/issues/2049))
+- PFC: I know the 2-dashes format was in previous editions of ISO 8601, not in current ones, and it's still in the grammar in RFC 3339
+- RGN: I did some digging. The semantics were of an "implied" year, where it would be clear from context.
+- PDL: I thought that both the dash and the X syntax referred to missing data. That is, there is a year but we don't know what it is. That's different from PlainMonthDay, where the year is intentionally not there. I wonder if the Xs or the dashes would be the right semantic format.
+- RGN: I think the Xs definitely not. They mean unspecified, rather than a collection that may mean multiple values. There is a specified syntax for month-day in HTML, which supports either 0 or 2 leading dashes, which doesn't provide clarity here, but confirms that either seem reasonable.
+- PFC: After reading RGN's comment on GitHub I think it's OK to use the current format, since PlainMonthDay was added originally to match the corresponding HTML input type.
+- SFC: My interpretation is that the Xs mean missing information, that is supposed to be there but is unknown. So I don't think PlainMonthDay is what the X is intended for.
+- RGN: Agreed. Given that, it looks like the two good choices are `MM-DD` and `--MM-DD` and the choice is arbitrary since HTML will accept either.
+- PDL: If you look at what a PlainDate looks like, you get `YYYY-MM-DD`, so if you replace `YYYY` with `-` you get `--MM-DD`. To my mind that's also an indication that the year is missing rather than unspecified, so I have a preference for not using `--MM-DD`.
+- PFC: Would anyone object to the status quo, accepting both `--MM-DD` and `MM-DD`, and emitting `MM-DD`?
+- PDL: That's what I'm proposing.
+- JGT: The reason I opened this issue is that we got pushback on appearing to choose an unstandardized format. If this format is standardized, even if not in ISO 8601, that seems fine. The argument about interoperation with HTML seems most compelling to me.
+- PFC: Agreed.
+- JGT: Does anyone foresee any problems with that?
+- SFC: We could ask USA whether this format would be in scope of the IETF draft.
+- PFC: My recollection was that the chairs of that working group asked to limit the scope of that draft. We dropped things for that reason.
+- SFC: True, but that was mainly about the scope of replacing RFC 3339. I don't think that adding MM-DD would necessarily be out of scope. I think if we were to make a small addendum before going for ratification, maybe it would meet resistance but I don't think it would be out of scope.
+- JGT to follow up with USA about this.
+- SFC: Why prefer the format without the dashes?
+- PFC: I prefer it because it's less surprising when people see it in the output of toString.
+- PDL: I see it as a dash for the year and a second dash for the separator, implying that the year is missing.
+- SFC: The two dashes are less ambiguous to my mind, but I don't have a strong preference.
+- PDL: I think the ambiguity is already eliminated because we always have components in descending order: Y-M-D, M-D. We never have D-M. Also other formats are likelier to have / or . as separators, so the - already sets it off.
+- SFC: I have a slight preference for `--` in the output, but the thing that sways me is that we haven't had those dashes the whole time we've been at Stage 3, and there hasn't been an issue. So it's working and I don't see a compelling reason to change.
+- JGT: Agreed.
+- Conclusion:
+  - keep the status quo
+  - update the documentation to point to the HTML format if necessary
+  - and investigate adding this format to the IETF draft, but do the above regardless.
+### -0 in Temporal.Duration ([#1715](https://github.com/tc39/proposal-temporal/issues/1715))
+Any new thoughts?
+- JGT: What's the status quo?
+- PFC: -0 is not supported in Temporal.Duration, except there are some places in the spec where it is accidentally inconsistent and you can get -0.
+- JGT: Does anybody think we should support -0?
+- SFC: I think we should, but I was the only one. I think this is something we could look to TC39 for guidance about.
+- JGT: My point of view is that Durations are not IEEE floating point numbers, so there is no reason to have -0.
+- PFC: I agree, BigInt does not have -0. Duration is still a bit ambiguous. On one hand it is a collection of numbers that overflow to infinity, but on the other hand they are integers so are not floating point numbers.
+- SFC: My point from last week is that -0 has meaning, it's a negative Duration that has no magnitude.
+- PFC: My understanding of -0 in IEEE floats is so that when they underflow to 0 they preserve the sign. I don't think we have that use case in Duration.
+- JGT: I always assumed they just exposed the sign bit because it was easier.
+- SFC: In NumberFormat we preserve the sign when rounding down, so that is akin to the underflow use case. It seems useful to preserve the sign as well when rounding down in DurationFormat.
+- JGT: If we do have -0, then yes I agree it should work like -0 in other contexts. For me the higher order bit is, does it help or hurt in the contexts where people would use Duration. I think it's a net harm, and I think there's a reason that more recent numeric types like BigInt eschew it.
+- SFC: BigInt not having it is certainly a precedent we could cite.
+- RGN: https://github.com/tc39/proposal-bigint/issues/29 is the original issue from BigInt where it was decided (without much discussion) to not have -0.
+- SFC: In Duration, all of the values are integer Numbers?
+- PFC: Indeed, they cannot have a fractional part, they can be infinity, and they can't be NaN. (note afterwards: I was mistaken, valid Duration objects cannot have fields that are infinity; Duration arithmetic overflows to infinity the same way Number does, but then the operation throws)
+- SFC: If we are already disallowing some legal Number values then it's not such a stretch to disallow -0.
+- JGT: I see it as defining which collection Number values are a valid Duration object. Is this discussion on BigInt the precedent that we need?
+- SFC: I would like to explicitly call it out to the plenary.
+- PFC: That will happen in any case, because we'll need to present a normative change to fix the inconsistencies in the spec where you can accidentally get -0 out in the status quo. We can point it out at that point.
+- JGT: Works for me.
+- SFC: I'd like to make sure we explicitly call it out in the slide, we should be very explicit about it and not brush it under the rug, since it was an implicit decision before.
+
+### New community polyfill!
+https://github.com/fullcalendar/temporal/tree/main/packages/temporal-polyfill
+- JGT: I've used Adam Shaw's work in my startup and it's good stuff. It doesn't seem to be 100% spec compliant and I wonder if TC39 has any guidelines on that.
+- PFC: He does say that he optimizes for bundle size at the expense of spec compliance?
+- JGT: It wasn't clear whether that meant, "not work on pre-BigInt browsers" or "be OK with gaps in spec compliance".
+- PFC: If they add test262 tests, we'll have more information.

--- a/meetings/agenda-minutes-2022-03-03.md
+++ b/meetings/agenda-minutes-2022-03-03.md
@@ -1,0 +1,74 @@
+# March 3, 2022
+
+## Attendees
+- Justin Grant (JGT)
+- Philip Chimento (PFC)
+- Richard Gibson (RGN)
+- Shane F. Carr (SFC)
+- Ujjwal Sharma (USA)
+
+## Agenda
+
+### Planning for Stage 4
+#### Prerequisites
+- Iron out any remaining normative changes
+- Implementations: two
+- Test262
+- Standardization of ISO 8601 extensions
+
+#### Relevant schedules
+- Plenaries in March, June, July, September, November
+- ICU releases: freeze mid-August, ship September
+- ICU4X releases every quarter, but Mozilla has it integrated and can pull in changes anytime
+- IETF meetings in March, July, November
+
+#### Discussion
+- PFC: I'm investigating creating a timetable for going to Stage 4. Test262 is going well. I would expect to be presenting normative changes in March and June, and maybe in July depending on what implementations dig up in the meantime. Firefox has a full but rough implementation of Temporal, which is paused until we solve the normative issues. JSC has a partial implementation of Temporal.
+- SFC: V8 has a large patch stack by FYT that is gradually being reviewed and landed. I'm not sure if the Firefox implementation includes the "interesting parts" yet of calendar calculations and formatting.
+- RGN: Implementations reaching what Shane called the "interesting parts" would probably surface more bugs. If we have a tight feedback loop, it seems like it could be reasonable to move implementations along quickly.
+- SFC: When we implement ECMA-402 proposals, we often have to fix bugs in ICU so we are somewhat tied to the ICU release cycle. We can have a bug open, and close it when ICU releases. This affects V8 and JSC. Mozilla hasn't decided yet whether to use ICU or ICU4X for Temporal. ICU4X has a stable API.
+- USA: Does ICU4X have the constraint of not making breaking changes?
+- SFC: It's not at 1.0 yet.
+More on this in following weeks.
+
+### IETF status
+- Interim in December
+- SEDATE in IETF 113 (21 March, Vienna)
+```js
+Temporal.ZonedDateTime
+  .from('2022-03-21T13:00[Europe/Vienna]')
+  .withTimeZone('America/Los_Angeles')
+// => 2022-03-21T05:00:00-07:00[America/Los_Angeles]
+```
+
+#### ISO Liaison (ongoing, will ask for updates)
+- USA: Pinged the chairs about this, waiting for an answer.
+
+#### Offset and timezone: an error ([link](https://mailarchive.ietf.org/arch/msg/sedate/8AsY1vpqjwRK2-o77uBOvst8j2g/))
+- JGT: My understanding is that there's not consensus on this? If the answer is "you can put a time zone or an offset but not both" that's really bad for us. If the answer is "the offset overrides the time zone" that's less bad. The best outcome is that it's up to the implementation to decide. Is that accurate?
+- USA: I think the disagreement comes down to some people in IETF thinking about different environments where you don't have the options bag that we have in Temporal. Maybe we can specify a behaviour for what to do in that case, where the programmer has no control.
+- JGT: The consensus on the IETF side should be that we can preserve the current behaviour of Temporal.
+- USA: We can discuss this at the upcoming SEDATE in IETF 113.
+
+SFC and JGT might attend if the time is not in the middle of the night. 
+
+#### Floating and future times
+- USA: Conclusion was reached that we don't need to be blocked on floating times.
+- JGT: What was it again?
+- USA: Date-time with a time zone and no offset. The calendar people want this, and we accept it in Temporal, but we don't emit it.
+- JGT: What's the chance that a different format would be standardized eventually?
+- USA: I'm fairly confident that this is a de-facto standard anyway and that either this format gets standardized, or nothing does.
+
+#### The question re:"optional extra" ([link](https://mailarchive.ietf.org/arch/msg/sedate/c4LcppU5dXXqenyUef615tFxW2k/))
+- USA: JGT replied to this thread with a position that I think everyone shares: not breaking compatibility with the Java syntax, but it's OK to namespace other things. This is still a discussion we need to settle but I'm confident we can do it this month.
+
+#### Editorial issues like the calendar system
+- USA: There are a few minor to-do items and a few PRs from my co-editor that I'm reviewing. I expect those will be done by the time of IETF 113.
+- USA: I'm hoping that if the ISO liaison happens, we can go for publication in the IETF 113 meeting this month. If changes get added during the meeting, we can publish in between meetings with enough notice.
+
+### ECMA 402 spec update ([#1928](https://github.com/tc39/proposal-temporal/issues/1928))
+- USA: I saw the last change requests, hoping to get another patch in during the next week.
+- JGT: Would love to wrap this up, it's close to the finish line.
+
+### Big backlog of GitHub issues?
+Some can be simply closed. Ecma-402 is the right location for some issues. Some are just waiting on execution. Some educational material. Plan to do a sweep through the backlog in 2 weeks. Prioritize “spec-text” issues? (currently 36 open issues)

--- a/meetings/agenda-minutes-2022-03-17.md
+++ b/meetings/agenda-minutes-2022-03-17.md
@@ -1,0 +1,85 @@
+# March 17, 2022
+
+## Attendees
+- Shane F. Carr (SFC)
+- Ujjwal Sharma (USA)
+- Philip Chimento (PFC)
+- Justin Grant (JGT)
+- Richard Gibson (RGN)
+
+## Agenda
+
+### IETF status
+- USA: Our session is the first one in the afternoon on Monday (2022-03-21T12:00Z). Open threads have been closed off and I hope we can reach some tentative consensus in this meeting and close all discussion items for good. Open question is about the liaison, I can ask about this more emphatically on the mailing list.
+- JGT: I have seen a resolution to the brackets issue, but not the "how to deal with conflicts" issue. That one hasn't been active in a while.
+- USA: I can DM Bron Gondwana about this. But Temporal is in a special position about this issue, because we can give the choice to the developer, which some of these other applications can't.
+- JGT: Agreed, as long as we can give the choice, the default doesn't matter that much. Would we change our default for `ZonedDateTime.from()` if the default in IETF was that the offset always wins?
+- RGN: There's no point in doing this until the draft is settled.
+- USA: Offset-wins is the only default that makes sense to put in the standard.
+- RGN: I disagree. The case has been made for future dates to trust the annotation over the offset when conflicts occur.
+- USA: I think the IETF will probably push for offset-wins and it's OK for us to follow that default if it's the case.
+- JGT: Do we need to have some explicit escape hatch in the draft that allows us to give the choice to the developer?
+- USA: I don't think so. It applies to non-interactive interpretation of a timestamp, Temporal is an interactive environment.
+
+**Consensus:** We are OK with the default behaviour in the draft being either offset-wins or conflicts-not-allowed, and will change the default behaviour of `ZonedDateTime.from()` (if no option is specified) accordingly.
+
+### ECMA 402 spec update ([#1928](https://github.com/tc39/proposal-temporal/issues/1928))
+- USA: Will fix the linter issue expediently and open an issue in ecmarkup.
+
+### Return value of `Duration.prototype.total()` when the result is not representable as a Number ([#2079](https://github.com/tc39/proposal-temporal/issues/2079))
+- PFC: This was not correctly specified so it led to an assertion failure in the spec. The polyfill has a behaviour already.
+- SFC: Could `total()` return BigInt?
+- JGT: It can return non-integer values.
+- JGT: Why would we not have bounds on the Duration fields so that this situation wouldn't occur?
+- SFC: I think it's better for any throwing behaviour to happen in constructors. Throwing in `total()` here could be considered a data-driven exception. I'd rather downsample to a representable Number.
+- RGN: I've proposed in the past that the limit for a Duration be the difference between the earliest and latest possible Instant. That would fix this problem, even if there were precision loss.
+- JGT: Agree.
+- PFC: I disagree that an edge case like this would justify making a fundamental change to how Duration works. I think we should pick one of the options for this weird unlikely case and move on.
+- SFC: I think `Infinity` is the best option here. It avoids the data-driven exception. It would be weird for Number overflow to throw an exception.
+- JGT: Why is it a fundamental change to have a limit?
+- PFC: It changes the semantics of Duration, implementers have mostly implemented it already, they'd have to check the arbitrary limit everywhere.
+- JGT: Presumably checking at construction would only happen in one place. Why not make this case impossible by limiting every field to the equivalent of `Number.MAX_VALUE` in nanoseconds? Otherwise conscientious developers have to check the return value.
+- SFC: Conscientious developers have to check the return value anyway, for loss of precision.
+- RGN: What cases would require checking for `Infinity`, if we were to return `Infinity` in this situation?
+- JGT: For display.
+- RGN: Such things occurring in display are annoying, but really only if the input was reasonable. The input wouldn't be reasonable in this case. Displaying `Infinity` is better than `NaN` because `Infinity` has a meaning in informal discourse.
+- SFC: If we were not at Stage 3, I'd be more interested in going back and adding limits, but as it is I think we should just fix this case. I'm in favour of `Infinity`.
+
+**Consensus:** Return `Infinity` in this situation.
+
+### Canonical representation for 0000~0999 years in ISO8601 ([#2082](https://github.com/tc39/proposal-temporal/issues/2082))
+- JGT: I would prefer to match the Date behaviour because (???)
+- SFC: Does legacy Date parse both of the options?
+- JGT: Yes, but other systems don't.
+- SFC: Those other systems are broken anyway, then.
+- PFC: Agreed.
+- JGT: My main concern is if people already have code that works with legacy Date, and we have a somewhat arbitrary choice, it's better to match Date.
+- SFC: What does ISO say about this?
+- PFC: Years before 1582 are not allowed except by mutual agreement of the communicating parties, so it doesn't come up.
+- JGT: Would anyone object to changing this?
+- PFC: I wouldn't object. But I don't find any of the reasons convincing. Other systems not parsing it would still be broken for years < 0. On the other hand, I don't find PDL's argument for the boundary being at 1000 very convincing either. I guess there could be some weirdness when people port their code from legacy Date to Temporal.
+- JGT: I think it's unavoidable that there are some differences, like nanosecond precision, but having this discrepancy in years seems like an own goal.
+- SFC: Agreed. The last comment on the thread from Livia Medeiros mentions RFC 3339. Does RFC 3339 not accept extended years?
+- JGT: No.
+- SFC: It seems undesirable to shrink the space of interoperable dates by 1000 years, then.
+
+**Consensus:** we'll make the proposed change to output 0000-0999 as 4-digit years.
+
+- RGN: Not every engine accepts excess precision in Date.parse, in fact most don't.
+- JGT: Can we change Date.parse to handle this in a consistent way?
+- SFC: RGN proposed some improvements to Date.parse some time ago, but it was shot down.
+- JGT: This seems like a bad compatibility issue.
+- RGN: There's still time to put this on the agenda for the plenary.
+- PFC: I propose to mention it alongside this PR in my presentation, but not make a rushed proposal.
+- RGN: Actually, I typoed. Engines do all accept nanoseconds precision in Date.parse. They treat it slightly differently though.
+- JGT: Let's not bring this up in the plenary, then.
+
+### `MIN_VALUE` and `MAX_VALUE` ([#2092](https://github.com/tc39/proposal-temporal/issues/2092))
+- PFC: My opinion is this belongs in Temporal V2
+- SFC: If we do this, I'd want to do it as in JGT's comment in the issue.
+- JGT: I don't think this meets the bar for a Stage 3 change.
+
+**Consensus:** Save this for a follow-on proposal.
+
+### Bug tracker sweep!
+Postponed to next time.

--- a/meetings/agenda-minutes-2022-04-28.md
+++ b/meetings/agenda-minutes-2022-04-28.md
@@ -1,0 +1,33 @@
+# April 28, 2022
+
+## Attendees
+- Richard Gibson (RGN)
+- Ujjwal Sharma (USA)
+- Philip Chimento (PFC)
+- Frank Yung-Fong Tang (FYT)
+- Philipp Dunkel (PDL)
+
+## Agenda
+
+### Non-ISO calendars in implementations without 402 ([#2160](https://github.com/tc39/proposal-temporal/issues/2160))
+- RGN: It's surprising that a 262 implementation would be prohibited from adding calendars that would be valid if it included 402. E.g., `"gregory"`, `"islamicc"`.
+- PFC: I agree in theory, but I've been assuming that we should not add more implementation-defined behaviour if we can help it.
+- RGN: I don't feel strongly about it, it's possible to change later, but it should be intentional. It might matter for XS.
+- USA: Is there a reason for XS to implement anything other than `"iso8601"`?
+- RGN: Unclear.
+- USA: Espruino might have a valid use case.
+- RGN to make a pull request.
+
+### Need to be more specific about "according to ISO-8601" in ToISOWeekOfYear ([#1641](https://github.com/tc39/proposal-temporal/issues/1641))
+- FYT: We need to tie this to a published algorithm. I referenced Wikipedia's description but my patch to v8 got rejected.
+- PDL: It's specified as the first week in January that contains a Thursday. What is the reviewer looking for?
+- FYT: An algorithm, instead of a description.
+- PFC: I can prioritize this more if it's blocking landing your patch in v8.
+
+### ECMA-402 refactors ([#1928](https://github.com/tc39/proposal-temporal/pull/1928))
+- PFC: Slightly related to the previous issue, but probably doesn't solve it completely.
+- USA: What's missing on this?
+- PFC: Only the ecmarkup failures.
+
+### Bug tracker sweep!
+We started discussing the list of issues labeled "spec-text", starting from the most recent.

--- a/meetings/agenda-minutes-2022-05-11.md
+++ b/meetings/agenda-minutes-2022-05-11.md
@@ -1,0 +1,108 @@
+# May 11, 2022
+
+## Attendees
+- Justin Grant (JGT)
+- Richard Gibson (RGN)
+- Philip Chimento (PFC)
+- Shane F. Carr (SFC)
+- Aditi Singh (ADT)
+- Philipp Dunkel (PDL)
+- Philip Chimento (PFC)
+
+## Agenda
+
+### Recursive calendar/timeZone property bag edge case ([#2104](https://github.com/tc39/proposal-temporal/issues/2104))
+Recommendation from JGT and PFC: do nothing, close issue
+- PFC: The code example in my comment from March 18 is a bit of a red herring because it uses `toString()`.
+- SFC / JGT explain the issue.
+- RGN: I think this is worth fixing.
+
+Come back to this next time.
+
+### Calendar annotation in Instant string ([#2143](https://github.com/tc39/proposal-temporal/issues/2143))
+- JGT: I feel strongly that this should be supported.
+- SFC: Do we currently ignore time zones in this function?
+- JGT: No.
+- SFC: Then that's inconsistent.
+- PFC: It's not clear-cut because Instant uses the time zone offset.
+- SFC: What does it do if the offset disagrees with the IANA annotation?
+- JGT: It ignores it.
+- PDL: I agree, this is a spec bug.
+- SFC: We should either ignore both IANA and calendar, or reject both IANA and calendar.
+- RGN: Does "fixing it" mean that anything syntactically valid is accepted and ignored?
+- PDL: Yes.
+
+**Consensus:** This is a spec bug and should be fixed. 
+
+### Special-case -00:00 offset ([#2113](https://github.com/tc39/proposal-temporal/issues/2113))
+- PFC: I'm skeptical of this because it conflicts with ISO 8601 and I wonder how many applications actually treat -00:00 as what RFC 3339 says.
+- PDL: What is the practical difference? It seems to me there may not be any. We can parse this into an Instant either way.
+- JGT: The main question is when you are parsing a PlainDateTime from an ISO string with UTC offset -00:00. According to RFC 3339 we wouldn't know what the local datetime is.
+- PDL: That's why we called it PlainDateTime rather than LocalDateTime.
+- JGT: I don't have a strong opinion. It makes us less compatible with RFC 3339 but I'm not sure how often -00:00 is used.
+- PDL: Agree, and I'm not sure there actually is an implication for us.
+- JGT: Another case where it might be different is using `offset: "reject"` in `ZonedDateTime.from()`.
+- SFC: Can you get that behaviour with Z?
+- JGT: Yes. My proposal if we do want to change anything is to treat -00:00 like Z.
+- SFC: The text from RFC 3339 mentions that -00:00 differs from Z and +00:00, but you're proposing to treat +00:00 different from Z and -00:00.
+- JGT: We do treat Z differently because in practice many apps and environments (like Java) use Z to represent what RFC 3339 says -00:00 represents.
+- SFC: If we can fix this in USA's RFC I think that'd be the best place to solve it. Specify Z to mean what Java uses it to mean, and keep -00:00 and +00:00 meaning the same thing.
+
+**Consensus:** Not change this in Temporal, but see whether it's possible to standardize the Temporal behaviour in IETF.
+
+- JGT: If the IETF draft ends up saying that -00:00 has this special meaning for legacy reasons, would we change it?
+- PDL: I would say no because we are primarily parsing ISO 8601 strings.
+- SFC: I'm slightly in favour of retaining -0 for future-proofing but I don't feel strongly.
+
+### Instant.toString with UTC time zone ([#2057](https://github.com/tc39/proposal-temporal/issues/2057))
+- SFC: This is kind of like the last issue. If we see a Z, is it considered an offset time zone or an IANA time zone?
+- JGT: It's considered an offset in every case except when we are trying to get a local time.
+- SFC: Note the behavior:
+```js
+Temporal.TimeZone.from("2022-02-28T03:06:00Z").toString()
+  // => 'UTC'
+Temporal.TimeZone.from("2022-02-28T03:06:00+00:00").toString()
+  // => '+00:00'
+Temporal.TimeZone.from("2022-02-28T03:06:00[UTC]").toString()
+  // => 'UTC'
+instant.toString({ timeZone: "America/Chicago" })
+  // => '2022-02-27T21:06:00-06:00'
+instant.toString({ timeZone: "UTC" })
+  // => '2022-02-28T03:06:00+00:00'
+Temporal.Instant.from('2022-02-27T21:06:00-06:00').toString()
+  // => '2022-02-28T03:06:00Z'
+```
+- SFC: We consistently output "Z" on no-argument Instant.prototype.toString, even if the string contained a non-Z time zone, and we consistently output an offset when toString has an argument. I like that consistency.
+- PDL: I think this is behaviour that we already talked about. We chose the current behaviour because it was flexible.
+- JGT: What do you expect would be the output of `{ timeZone: "UTC" }`?
+- PDL: `+00:00[UTC]`
+- RGN: Instant.toString never outputs brackets.
+- PDL: Still, `+00:00`. Having the option leaves the developer the choice of which one to get.
+- RGN: I agree because there are a number of aliases to UTC.
+- JGT: The aliases to UTC are all canonicalized to UTC.
+- RGN: Even `Etc/Zulu` and `Etc/Universal`?
+- PFC: I think they are only canonicalized in ECMA-402.
+
+**Consensus:** Keep the current behaviour.
+
+### Follow up to options bags in Duration.round ([#1876](https://github.com/tc39/proposal-temporal/issues/))
+- JGT: The idea here was that you only get one "bite at the optional apple". JHD is saying that because either the string or the property bag is required, if you use the property bag, the option that the string represents should be required.
+- PFC: This doesn't make sense to me because JHD was the one who objected to options bags with required properties in the first place.
+
+We'll come back to this. JGT will try to read up on it.
+
+### Access of era and eraYear fields ([#1789](https://github.com/tc39/proposal-temporal/issues/1789))
+- SFC: How about specifying that the fields must be accessed in alphabetical order and only the ones you need? This is related to [#2169](https://github.com/tc39/proposal-temporal/issues/2169). There are going to be other fields than era and eraYear.
+- JGT: This is only about ECMA-402 text?
+- PFC: I think so. How about I take an action to come up with some language that admits other calendar-specific fields.
+
+### Break from ToIntegerOrInfinity precedent ([#2112](https://github.com/tc39/proposal-temporal/issues/2112))
+- RGN: This was very surprising to me and seems like a bug factory. I think we should throw a TypeError in these cases.
+- JGT: Would you still want to accept "6" as a string?
+- RGN: Yes.
+- JGT: So we'd essentially have to have our own version of ToIntegerOrInfinity.
+- RGN: Temporal already does have ToIntegerWithoutRounding.
+- JGT: So you're suggesting we change ToIntegerWithoutRounding to reject `NaN`?
+- RGN: I don't have a particular solution in mind.
+- PFC: Are you also concerned about e.g. ToIntegerOrInfinity in the PlainDate constructor?
+- RGN: Less so, because ToIntegerOrInfinity doesn't treat fractions specially. But e.g. `new Date(2022, "foo")` returns an invalid date, and Temporal should not be _worse_. Anywhere a number is expected, non-numeric input should not be coerced to zero.


### PR DESCRIPTION
This is the minutes backlog from the champions meetings in the first half of 2022.