### PR TITLE
Publish minutes backlog, part 2

### DIFF
--- a/meetings/agenda-minutes-2022-07-07.md
+++ b/meetings/agenda-minutes-2022-07-07.md
@@ -1,0 +1,80 @@
+# July 7, 2022
+
+## Attendees
+- Shane F. Carr (SFC)
+- Philip Chimento (PFC)
+- Richard Gibson (RGN)
+- Justin Grant (JGT)
+
+## Agenda
+### Presentation to July TC39 plenary
+At the moment, there are 16 normative PRs to present, and several more to discuss in this meeting. Agenda deadline is 2022-07-09 (day after tomorrow).
+
+### Changes to ICU ([#2196](https://github.com/tc39/proposal-temporal/issues/2196))
+What part of this work should we be tracking? Is an ICU4C implementation of Temporal impossible without these changes, or just less convenient?
+- SFC: FYT has this under control. ICU4X supports much of what Temporal needs in addition, so we should continue to recommend using it. However, v8 is still on ICU4C. Without these changes it's less convenient but not impossible. Without it, a lot of calendar-specific code has to be in v8.
+
+### Frozen built-in calendars and time zones ([#1808](https://github.com/tc39/proposal-temporal/issues/1808))
+Reminder to take a look at PFC's proposed solution.
+- SFC: I think we should discuss this with plenary.
+- PFC: I would like to have a recommended solution from the champions group first.
+
+### Recursive calendar/timeZone property bag edge case ([#2104](https://github.com/tc39/proposal-temporal/issues/2104))
+Where we left off: Recommendation from JGT and PFC is still to change nothing. RGN to make the case to change it.
+- SFC: I don't have a strong opinion but I can try to form an opinion.
+- RGN: I don't remember the full details but the example presented in the issue I find surprising and bad. We already know what the fix looks like. I don't think the proposal is too mature to fix something like this, and in fact we are now uncovering a number of similarly subtle issues.
+- PFC: I'm coming around to the idea of tacking this on to the presentation in July.
+- JGT: OK.
+
+**Conclusion:** we'll change this.
+
+### Follow up to options bags in Duration.round ([#1876](https://github.com/tc39/proposal-temporal/issues/1876))
+Where we left off: JGT to investigate what is being proposed here.
+- JGT: It's not clear to me whether the change proposed here is what JHD is asking for. I think that he doesn't like the current situation where one or the other is required, but he would not mind the proposed solution.
+- RGN: One or the other of `largestUnit`/`smallestUnit` should be required.
+- JGT: That's how it works now.
+- SFC: I don't understand the objection to the status quo.
+- JGT: I would think that we could add a requirement for `smallestUnit` like in the other round methods.
+- RGN: Agreed, if it's too cumbersome we can relax that in the future without compatibility issues.
+- SFC: Disagree, I think this would hurt the ergonomics of Intl.DurationFormat call sites. Balancing a duration to a particular `largestUnit` is an important operation.
+- RGN: Do you mean that DurationFormat calls this method directly?
+- SFC: No, but DurationFormat doesn't do any balancing or arithmetic, only formats the fields you pass in, so users of DurationFormat rely on this method to get the fields they want.
+- PFC: I agree with SFC, it's going to be a common pattern to call `.round({...}).toLocaleString()`, so adding a bogus `smallestUnit: 'nanoseconds'` if you only want `largestUnit` will hurt the ergonomics.
+- RGN: I think it's a red herring to compare this to DurationFormat.
+- SFC: I'm arguing that in the thread it's mentioned as an edge case, and I don't think that's justified. If we made this change I'd want to go back to DurationFormat and reconsider the principle of not doing arithmetic in DurationFormat.
+- JGT: I wouldn't mind it if resolving this discussion required a change in DurationFormat.
+- SFC: I don't particularly want to change DurationFormat.
+- PFC: I wouldn't want to make a change that makes the API worse. We have an option of closing the issue and doing nothing.
+- JGT: I'm not convinced the change is unequivocally bad. It makes some call sites less ergonomic, but it makes all the `round()` methods more consistent. So it depends on what we value.
+- SFC: Could we remove the string parameter since that's ambiguous between `smallestUnit` and `largestUnit`?
+- PFC: We already made that change at JHD's request.
+- RGN: I think the string change was good.
+- JGT: I think going back to the specific situation that JHD objected to, is a non-starter.
+- RGN: The argument for the current behaviour is that `smallestUnit` is required, except when you are using `largestUnit` to get the additional balancing behaviour; in that case there is an implied default `smallestUnit`.
+- JGT: I agree.
+- RGN: I would think that an implied default `smallestUnit` would be useful in other places as well, although we disallowed that due to the potential for bugs.
+- RGN: I think JHD is objecting to the exception that differentiates Duration.round from other round methods, in that `smallestUnit` is not required under some circumstances.
+- JGT: I think he's OK if it's different, but if the requirements are different then the API signature should be different.
+- RGN: The comment says "an options bag where one of two arbitrary properties are required". The position of this group is that those are not arbitrary.
+- SFC: Can we rename `round()` to `balance()`?
+- JGT: "Balance" doesn't have a colloquial meaning.
+- SFC: It's not too different from having to teach people the difference between a "plain" and a "zoned" date, we have a section in the docs on what duration balancing is.
+- RGN: In that case I'd recommend keeping a `round()` method with `smallestUnit` required, and adding a method that does `largestUnit`, with optional rounding like `since()` and `until()`.
+- JGT: Or a new method that only does `largestUnit`.
+- SFC: You could chain them, `duration.balance('hours').round('seconds')` as an alternative to `duration.round({largestUnit: 'hours', smallestUnit: 'seconds'})`.
+- JGT: If we do add a new method I'd like to bikeshed the name. I don't want to present a placeholder name to plenary.
+- RGN: I think there's a strong case for introducing this method. I'm OK with `round()` being the only mechanism but I'm also OK with a dedicated method.
+- PFC: I would at least find a dedicated `balance()` method not worse than the status quo, but I'd still prefer to just close the issue.
+- RGN: That's also my preference, weakly held.
+- JGT: Agree with RGN. Should we take a few minutes to flesh out what this method would do if we added it?
+- SFC: My preference would be to add another method that is exactly the same as `round()` but the string parameter would map to `largestUnit`. Also, `round()` would require `smallestUnit`, and balance() would require `largestUnit`.
+- RGN: Either that or remove the `largestUnit` behaviour from `round()`.
+- PFC: If we did add a second method, I'd prefer that they did two different things.
+
+We take a moment to examine what this counterfactual method would do if we were to make a change. It would be a new "balance" (name TBD) method that acts the same as Duration.p.round, EXCEPT: the `largestUnit` option is required, and the string parameter corresponds to `largestUnit`. Remove `largestUnit` option from `round()` (throw if it is passed in the options bag?)
+
+- SFC: I wouldn't want to remove `largestUnit` from `round()` just for the sake of it.
+- JGT: There is a consistency argument that `round()` could act like it does in every other type, i.e. `smallestUnit` only.
+- SFC: Every other method that allows rounding, e.g. the other types' `since()`/`until()` methods, has `largestUnit` and `smallestUnit`.
+- PFC: To me that's more of a reason to make no change. `since()`/`until()` include an optional round step.
+- JGT: It doesn't matter if we call that "round" or "balance".

--- a/meetings/agenda-minutes-2022-08-18.md
+++ b/meetings/agenda-minutes-2022-08-18.md
@@ -1,0 +1,73 @@
+# August 18, 2022
+
+## Attendees
+- Ujjwal Sharma (USA)
+- Justin Grant (JGT)
+- Richard Gibson (RGN)
+- Shane F. Carr (SFC)
+- Philip Chimento (PFC)
+
+## Agenda
+
+### IETF SEDATE next steps
+- USA: Thanks JGT for joining the IETF meeting, it was a game changer. We got consensus on the remaining issues. It is roughly equivalent to a Stage 3 in TC39. There are outstanding PRs by both JGT and Carsten Bormann implementing that consensus, and Carsten is going to combine them soon. According to Bron Gondwana, we also need a signal or acknowledgement from the ISO liaison, before submitting this to publication, but we don't have to wait for the next IETF.
+- JGT: When is the next IETF meeting in case we do have to wait?
+- USA: 5th November in London.
+- JGT: Clearly the outcome wasn't what Carsten wanted, but the consensus in the room was strong enough that we got what we wanted.
+- USA: Yes, this is going smoothly. We got approval from the area directors.
+- JGT: Next step is to get those PRs merged that implement the conclusions.
+- Discussion about how this will be implemented in CBOR.
+- SFC: Glad that this is moving forward. In ICU4X we want to start consuming strings, so I think we want to start writing a parser for IXDTF as a Rust crate. What grammar would you recommend using?
+- USA: I would recommend using the grammar in the draft, which is purposely more relaxed on some points than Temporal.
+- PFC: You'll also need to decide which "agreed by communicating parties" extensions from ISO are required for your application, for example extended year format.
+- RGN: What are the differences between the IXDTF grammar and Temporal?
+- USA: Temporal has more restrictive grammar in some cases.
+- PFC: We have a list of differences between ISO 8601 and Temporal at the top of the [grammar section](https://tc39.es/proposal-temporal/#sec-temporal-iso8601grammar).
+- SFC: If anyone is interested in working on this Rust crate, contact me.
+- PFC: Now we come to what needs to change in the proposal:
+  - Recognize critical flags in time zone and calendar annotations
+  - Offset option should still override time zone critical flag in ZonedDateTime.from, precedent has been that the programmer gets the last word
+  - Calendar annotations are already always treated as critical
+  - What to do when annotations with critical flag are passed to a data type that doesn't treat them as relevant, e.g. Instant.from()?
+  - What to do when duplicate calendar annotations are given?
+- JGT: It does seem reasonable that if the sender makes an explicit opt-in decision to add the critical flag, we don't discard that.
+- USA: On the other hand, if you explicitly write Instant.from instead of `ZonedDateTime.from(...).toInstant()`, you are making a choice that says time zone is not relevant.
+- JGT: One reason to ignore is that if we rejected Instants with the critical flag, anybody parsing anything would need to handle the case where there is a conflict, which they've already signalled they don't care about.
+- USA: If we reject on extraneous information, do we also reject on passing a full string into TimeZone.from or Calendar.from? Ignoring extraneous information fits with the precedent.
+- JGT: I'm convinced.
+- USA: For the duplicate calendar annotations, let's file an issue on SEDATE. Happy to reject when that happens and handle it in the future.
+- PFC: Sounds good.
+- SFC: Do what BCP47 does if there are duplicate keywords: first wins.
+- PFC: Also sounds good.
+- JGT: If it was a JS Object, the last would win.
+- RGN: If no one has a good reason for any particular behaviour, then rejecting it with an error allows adoption of reasonable behaviour in the future.
+- SFC: A use case for last wins is that if you want to override the calendar field, you can append it to the string.
+- USA: Does Temporal ever produce a string with a critical flag for output?
+- PFC: I don't see a good reason to at this time. It's not part of our data model and I'm not sure incorporating it should be a Stage 3 question. This could be part of a follow up proposal if there later come to be applications out in the wild that consume this flag.
+- JGT: If we were to implement this, there are both `timeZoneName` and `calendarName` options in `toString()`. If we did want to support this, we could add a `"critical"` value to those options. Maybe a compromise between doing nothing and incorporating it into the data model would be to add this option in `toString()`.
+- USA: I think it should be per-call of `toString()` anyway, not part of the data model, even if it's less ergonomic.
+- JGT: I don't care so much about the ergonomics, but if I'm sending a string to a receiver that requires the critical flag, it's nice to have a way to produce it.
+
+**Conclusions:**
+- Parse critical flags in time zone and calendar annotations
+- Parse syntactically correct but unrecognized annotations, ignore them unless they have a critical flag, in which case reject the string
+- Critical flag in time zone annotation doesn't change behaviour. Default `offset` option in ZonedDateTime.from() is `"reject"`, so the string is already rejected if there is a conflict, and the `offset` option should give the last word.
+- Critical flag in calendar annotation doesn't change behaviour. Calendar annotations are already always treated as critical, i.e. `PlainDate.from('2022-08-18[u-ca=hebrew]')` should never return a date with ISO calendar if the implementation doesn't support the Hebrew calendar.
+- Data types for which time zone or calendar annotations are irrelevant (e.g. Instant), still discard the annotations even if they include a critical flag, so that doesn't change behaviour.
+- Add a value `"critical"` to the `timeZoneName` option in `ZonedDateTime.toString()`, and to the `calendarName` option in PlainDate, PlainDateTime, PlainYearMonth, PlainMonthDay, and ZonedDateTime `toString()`. This option causes the critical flag to be output in the time zone or calendar annotation, respectively.
+- In case of duplicate calendar annotations, we'll tentatively go with first wins, pending the outcome of SEDATE issue [#25](https://github.com/ietf-wg-sedate/draft-ietf-sedate-datetime-extended/issues/25)
+
+### Ross's concerns about precision loss ([#2195](https://github.com/tc39/proposal-temporal/issues/2195))
+- PFC: This is also related to [#2380](https://github.com/tc39/proposal-temporal/issues/2380).
+
+**Conclusion:** Need more time for this, and invite RKG and FYT.
+
+### FYT's specification of ToISOWeekOfYear
+- PFC: How do people feel about this? I'm mostly surprised there is no external reference.
+- SFC: I'm fine with this.
+- RGN: I think it's an indication that the operations we have in Temporal are probably not the correct ones. You could have e.g. a date in January 2022 which is in week 53 of week-year 2021.
+- SFC: CLDR has patterns for this.
+- RGN: It makes me think that the correct operation to have is a composite one that returns both pieces of data. As for the algorithm as long as it's correct that's OK.
+- SFC: In ICU4X we realized you can't just subtract 1 from the year to get the week-year in era-year calendars.
+
+**Conclusion:** Go ahead with Frank's initiative, put week-years more broadly on the agenda next time: add `yearWeek` property or remove `weekOfYear` property

--- a/meetings/agenda-minutes-2022-09-01.md
+++ b/meetings/agenda-minutes-2022-09-01.md
@@ -1,0 +1,36 @@
+# September 1, 2022
+
+## Attendees
+- Philipp Dunkel (PDL)
+- Ujjwal Sharma (USA)
+- Richard Gibson (RGN)
+- Philip Chimento (PFC)
+- Justin Grant (JGT)
+
+## Agenda
+
+### Status: Presentation at September plenary
+To present: [#2377](https://github.com/tc39/proposal-temporal/issues/2377), [#2387](https://github.com/tc39/proposal-temporal/issues/2387), [#2392](https://github.com/tc39/proposal-temporal/issues/2392), [#2394](https://github.com/tc39/proposal-temporal/issues/2394), [#2395](https://github.com/tc39/proposal-temporal/issues/2395), [#2397](https://github.com/tc39/proposal-temporal/issues/2398), [#2398](https://github.com/tc39/proposal-temporal/issues/2320), and an upcoming PR for [#2320](https://github.com/tc39/proposal-temporal/issues/).
+
+### Status: the "big four" issues
+(Frozen builtins [#1808](https://github.com/tc39/proposal-temporal/issues/1808), use Temporal objects in 402 [#2005](https://github.com/tc39/proposal-temporal/issues/2005), remove calendar slot from PlainTime [#1588](https://github.com/tc39/proposal-temporal/issues/1588), Duration precision concerns [#2195](https://github.com/tc39/proposal-temporal/issues/2195).)
+
+Discusson on these issues. It seems like [#1588](https://github.com/tc39/proposal-temporal/issues/1588) could become moot if we adopt the proposal for [#1808](https://github.com/tc39/proposal-temporal/issues/1808). [#2005](https://github.com/tc39/proposal-temporal/issues/2005) doesn't need a lot of discussion, is just a bunch of work, and is gated on resolving conflicting intentions with Intl.Enumeration proposal.
+
+Plan for [#2195](https://github.com/tc39/proposal-temporal/issues/2195) is to write an explainer with solutions considered until now, and invite implementors to a future champions meeting to discuss it.
+
+### Frozen built-in calendars and time zones ([#1808](https://github.com/tc39/proposal-temporal/issues/1808))
+If no comments about the proposed solution, we can get this moving after the plenary.
+
+- PDL: Is this likely to meet resistance from SES?
+- PFC: As far as I know it isn't possible to use these as a covert communication channel.
+- PDL: Worth talking to people in the hallway track in September, otherwise we should go for it.
+- USA: If everything on Temporal is on the global object, doesn't that mean that nothing is shared cross-realm? Each context would have its own instance of everything.
+- RGN: I'd be shocked if anyone were in favour of making it global at a greater scope than realm. There's a Hardened JS meeting on Wednesday, so there'd be an opportunity to ask before the next plenary.
+
+### ECMA-402 concerns ([#1932](https://github.com/tc39/proposal-temporal/issues/1932) and [#2363](https://github.com/tc39/proposal-temporal/issues/2363))
+- USA: FYT has concerns about making DateTimeFormat heavier. I would like to make it possible to initialize DateTimeFormat lazily, for example if you don't format PlainMonthDays, no need to load the formatting patterns for PlainMonthDay.
+- PFC: I don't see any throwing or method calls in that loop, so it seems like it could be lazily initialized.
+- JGT: In the polyfill we lazily initialize these, and use `resolvedOptions()` to avoid observable reading of options.
+- USA: The second issue is about throwing in `formatRange()`. The proposal effectively changes a RangeError to a TypeError, but I think TypeError is the right thing to throw here.
+- PFC: I think FYT is saying the opposite, that it changes TypeError to RangeError. I still think it's a rebase error.

--- a/meetings/agenda-minutes-2022-09-15.md
+++ b/meetings/agenda-minutes-2022-09-15.md
@@ -1,0 +1,71 @@
+# September 15, 2022
+
+## Attendees
+- Shane F. Carr (SFC)
+- Richard Gibson (RGN)
+- Philip Chimento (PFC)
+
+## Agenda
+
+### Status: Presentation at September plenary
+- PFC: Presentation was successful, after handling JHD's objection about preserving the critical flag in the data model.
+
+### Frozen built-in calendars and time zones ([#1808](https://github.com/tc39/proposal-temporal/issues/1808))
+- PFC: We got some comments from Anba on this issue. Anba disagrees with Yusuke and thinks this should be easy enough to optimize without any change, by comparing object shapes. I guess my recommendation would be to proceed with preparing a normative change, and then see whether Anba dislikes it strongly enough.
+- SFC: Remind me how this issue would also solve [#1588](https://github.com/tc39/proposal-temporal/issues/1588)?
+- PFC: The PlainTime.calendar getter returns an ISO 8601 calendar object, and subsequent accesses return the same object. Frank's concern was that you have to reserve space for a pointer to the calendar object in PlainTime's storage, even if you create the calendar lazily. If the ISO 8601 calendar was a frozen singleton, you wouldn't need any space in PlainTime.
+
+### ECMA-402 concerns ([#1932](https://github.com/tc39/proposal-temporal/issues/1932) and [#2363](https://github.com/tc39/proposal-temporal/issues/2363))
+- PFC: I talked to USA about these since the last time we met. He originally thought these would be difficult to solve but I think they are both pretty straightforward, and I think USA agrees now.
+- SFC: We talked about these in the August TG2 meeting. There's a concrete path forward, but someone needs to work on it.
+
+### Annotations on `YYYY-MM` and `MM-DD` ([#2379](https://github.com/tc39/proposal-temporal/issues/2379))
+- SFC: My perspective comes from a few places. I want to figure out how to write an IXDTF parser, and I want to add on Temporal support fairly easily. It concerns me that the grammar is ambiguous, it makes it harder to write a parser. We can already omit things that IXDTF requires, but YearMonth and MonthDay are already a bit of a mess. I'd propose that we only allow `YYYY-MM` and `MM-DD` in those two constructors and not accept annotations on them.
+- RGN: The problem that I feel strongly about is that if a calendar syntax is acceptable for a PlainTime, then it should be applicable for `YYYY-MM` and `MM-DD`. I would also be fine removing it from times.
+- SFC: But if the UTC offset is ambiguous with the day, then that indicates we shouldn't have it on `YYYY-MM`.
+- PFC: We could solve it by not allowing the offset after `YYYY-MM` and only a time zone annotation.
+- SFC: Is an offset allowed after `YYYY-MM-DD`?
+- RGN: I'd prefer not.
+- PFC: Currently it is, and I think ISO 8601 allows it, or at least `YYYY-MM-DDZ`.
+- SFC: If we only allowed offsets after time components, that seems like a good solution too.
+- RGN: I don't think ISO 8601 allows offsets without times, and I'd prefer that we don't. Even if we might have to make an exception for `YYYY-MM-DDZ` for ISO, although I'd prefer not to have that exception.
+- PFC: So if we removed the ability to give a UTC offset without a time component, would that solve the problem?
+- SFC: If we were able to make that change, that would solve my objection to annotations on `YYYY-MM` and `MM-DD`.
+- RGN: We can say that an offset has no meaning without a time component.
+- PFC: But a time zone annotation? If we want to have the same collection of annotations on `YYYY-MM` and `MM-DD` as on `YYYY-MM-DD`, then we'd have to allow a time zone annotation.
+- SFC: I don't think an IANA time zone is strongly linked to a `YYYY-MM-DD`, but it's less poorly linked than a UTC offset to a `YYYY-MM-DD`. You can say "September 15 in the Los Angeles time zone".
+- PFC: This is the ZonedDate that PDL has brought up from time to time.
+- RGN: It's a coherent concept.
+- SFC: What about `Temporal.PlainDate.from('2022-09-15[!UTC]')`?
+- PFC: We covered this when originally discussing annotations. We should do the same thing as e.g. `Temporal.Instant.from('2022-09-15T17:00Z[!u-ca=gregory]')`, that is, drop the annotation.
+- RGN: What do we do with `Temporal.PlainDate.from('2022-09-15[!No_Such_Timezone]')`?
+- PFC: If it's a well-formed string syntactically, we drop the annotation. If it's not well-formed we reject it.
+- SFC: I really don't want any IANA lookup to have to happen during parsing.
+- RGN: In the API surface of Temporal it's never possible to separate parsing from validation.
+- SFC: Right, but I'm talking about internally in Chrome's IXDTF parser.
+- RGN: It's strange that an annotation like `[!No_Such_Timezone]` would be ignored even by a data type that doesn't use it. Maybe not fatally strange, but strange.
+- SFC: I don't find that strange. If we're going to ignore it, we should not do further work to validate it. It seems like a weird middle ground to not use the annotation but do a TZDB lookup to validate it. Note, the TZDB is not constant, so it could parse one day and fail the next.
+- RGN: I can agree with that, it all gets very strange at that point anyway.
+- SFC: So the critical flag doesn't actually change any behaviour for time zones and calendars.
+PFC: Right, it's a text mechanism for what we already have an out-of-band code mechanism for in Temporal: the `offset` option to `ZonedDateTime.from()`. It exists to resolve conflicts between offset and time zone, and was added to other annotations for consistency.
+- SFC: Got it.
+
+### `era` and `eraYear` getters in 262 ([#2169](https://github.com/tc39/proposal-temporal/issues/2169))
+- PFC: Would it be so bad to just include the `era` and `eraYear` getters in 262, since 262 allows supporting a subset of the 402 calendars?
+- SFC: Somewhat relevant is the Chinese calendar which may actually have other fields that are not `era` and `eraYear`, for the cycle and the cycle year which isn't relevant to any other calendar. It's not really transferable. `era` and `eraYear` don't exist on the Chinese calendar or the ISO calendar for that matter. So even if we add them to 262, that doesn't really solve the problem. That would put us in the situation where if Intl wants to specify a new calendar, they have to go to 262 and ask for the field to be added.
+- PFC: I can see the problems with that approach as well.
+- SFC: `era` and `eraYear` are different enough from cycle and cycle year that they really don't merit being stuffed into the same property. If you treated it like eras you'd have to choose an epoch, while cycles are more like weeks in that regard - nobody thinks in terms of week number since the epoch.
+
+### Order of fields in Duration Record Fields table ([#2286](https://github.com/tc39/proposal-temporal/issues/2286))
+- PFC: I don't really understand this issue.
+- RGN: Maybe one of the algorithms depends on ordering?
+- SFC: The issue here is that with Date we read the fields in alphabetical order because we don't want to be in the business of putting custom calendar fields in order of magnitude. With Duration that problem doesn't exist, so we could read them in order of magnitude. So the question is should we really have alphabetical order for Duration? That's my understanding of the issue.
+- RGN: There's a third option that corresponds to PR [#2245](https://github.com/tc39/proposal-temporal/pull/2245). You make a copy in iteration order and then it doesn't matter in which order you read from the copy.
+- PFC: PR [#2245](https://github.com/tc39/proposal-temporal/pull/2245) is still open because I still needs to write tests for it. But I don't think it changes any cases where we say "For each row of Table XX in table order" which is alphabetical. I think it only changes `mergeFields()`.
+- RGN: I propose that we change the tables to be in magnitude order. Alphabetical order there is confusing. But in the algorithms, introduce an explicit sorting to the algorithms that iterate over those tables.
+- SFC: That seems like a good solution.
+- PFC: Would we include custom calendar fields in the sort?
+- RGN: Right.
+- PFC: And then once we have the list of sorted fields, either make a copy or create a Record, in any case do something that makes further reads unobservable.
+- RGN: Right. I'd prefer that we read in source order, but I think there are cases where that's not possible, where you're explicitly looking for information that's not there, or the field is not enumerable. That may not be possible to do consistently one or the other, but I think all cases fit into one of those two approaches.
+- PFC: Right, you could not do `mergeFields()` in alphabetical order and you could not do ToTemporalTimeRecord in source order.

--- a/meetings/agenda-minutes-2022-09-29.md
+++ b/meetings/agenda-minutes-2022-09-29.md
@@ -1,0 +1,63 @@
+# September 29, 2022
+
+## Attendees
+- Daniel Ehrenberg (DE)
+- Philip Chimento (PFC)
+- Richard Gibson (RGN)
+- Philipp Dunkel (PDL)
+
+## Agenda
+
+### Frozen built-in calendars ([#1808](https://github.com/tc39/proposal-temporal/issues/1808))
+Discuss PDL/DE's new proposal for this.
+- DE: I think frozen objects is going to cause problems and I have a counterproposal. Use strings internally for built-in calendars.
+- RGN: On the face, seems fine. Would the calendar getter return the string?
+- DE: The calendar accessors would disappear, to get the calendar you would use `Temporal.Calendar.from(plainDate)`. The optimizations described at the beginning of the thread are awkward for implementors.
+- RGN: I'd like to put aside any discussion of optimizations if we're talking about observable behaviour.
+- DE: Happy to discuss it second, but optimizations are why I'm proposing this.
+- RGN: `Temporal.Calendar.from('gregory')` always returns the same value or a new value?
+- DE: A unique value every time, as in tip of tree. The difference is that if you create a PlainDate via `Temporal.Now.plainDateISO()`, for example, the internal slot will contain a string.
+- RGN: So every time I do `Temporal.Calendar.from(string)` I'll get a new instance which will never compare equal to each other. There is no privileged calendar instance, but there are privileged calendar identifiers. And if I do `Temporal.Calendar.from(plainDate)`, the same behaviour holds? I'll get a new instance regardless of whether that `plainDate` has been used before?
+- DE: Yes. But if you constructed your PlainDate with a custom calendar, you'll get the same instance each time. If it's a built-in calendar, you'll get a new one each time.
+- RGN: A little bit weird, but workable.
+- PDL: Basically if you pass in an object to `Temporal.Calendar.from()`, you get that object. If you pass in a string, you get a new object. This is the status quo. It would be extended to calendar-carrying objects.
+- DE: A variation would be to keep the calendar accessor, but have it return either the string or the object.
+- RGN: Before we discuss variations, I'd like to understand the original proposal. Every [[Calendar]] internal slot contains either a string, or an instance. If it's an instance, it maintains its identity. If it's a string, it doesn't. The string is privileged, I can't come up with my own string.
+- PDL: If we had a getter, I don't think it should have a variable return type.
+- RGN: If I wanted to instantiate a built-in calendar, make some modifications to it, and construct a PlainDate with it, that would work?
+- PDL: Yes, it would maintain its identity.
+- RGN: Privileging strings that identify built-in calendars seems OK.
+- PFC: This would go for time zones as well.
+- PDL: This is why I'm OK not having the accessor. The only reason I can see for the accessor is to determine calendar similarity. Is there a way that avoids constructing calendars that answers the question "do these two objects have the same calendar"?
+- RGN: That would be fulfilled by a getter returning string-or-instance.
+- PDL: Is it too rigid to say that getters shouldn't have multiple return types?
+- RGN: It's an emergent property.
+- PFC: There is a use case for answering the question whether two objects have the same calendar. Taking the Duration difference between two dates, for example, requires them to have the same calendar. Internally we check if the ToString of the [[Calendar]] slot is the same. In userland you could do `Temporal.Calendar.from(...).toString()`.
+- PDL: That requires an allocation.
+- PDL: If we do this I would avoid using the ToString. Internally compare strings if they are both strings, and compare identity if they are objects.
+- DE: That sounds reasonable.
+- PFC: I'm not sure I agree with that. It means if you construct two PlainDates each with `Temporal.Calendar.from('gregory')`, they have distinct instances, and you can't do operations on them.
+- DE: I see how that would break.
+- PFC: Keeping the ToString semantics wouldn't be worse than the status quo.
+- RGN: What would be the problem with having the getter return the contents of the internal slot? What code are you imagining that would be a problem?
+- PDL: Custom calendar as a polyfill until a standard calendar comes along.
+- DE: I'm not convinced by this hazard case.
+- RGN: Where do you think the hazard lies?
+- PDL: Calendar is being standardized in some browser. I test if it's present and if not I inject my polyfill. Now, on running code, the result of your getter changes to an instance, where it would be a string if the browser supported it natively.
+- RGN: If you have polyfilled it correctly, the getter should return a string for your custom calendar. I don't think the interface should be design to minimize the negative consequences of incomplete polyfills.
+- DE: If people have to make such sweeping changes to polyfill custom calendars, then we didn't design our API correctly.
+- PFC: You have to make sweeping changes if you are polyfilling a built-in calendar that's not yet supported in a browser. You don't have to if it's just a custom calendar.
+- RGN: We shouldn't care about ease of polyfilling a built-in calendar.
+- DE: Agreed.
+- RGN: Then are there any other hazards of the getter returning a string-or-instance?
+- PDL: I don't like it, but I don't have one right now. I do think we should then switch to comparing calendars by identity.
+- RGN: That's what I wanted in the first place.
+- PFC: I don't like that for the reason I gave earlier - having two PlainDate instances that don't interoperate with one another. I'd find that confusing for developers learning Temporal.
+- PDL: We should avoid use of Calendar.from in our documentation and cookbook. Don't use Calendar objects if you can use strings.
+- PFC: I agree that using strings is better. But people learning a complicated API will probably end up with these objects anyway, that are 'poisoned' with no obvious way of seeing it. I'm thinking of Stack Overflow questions like "I have two PlainDates which are both `2022-09-29[u-ca=gregory]`, why do they throw 'can't compare dates with gregory and gregory calendars' when I do `until()` on them?"
+- RGN: The obvious way to tell is `a.calendar === b.calendar`.
+- DE: I don't think that's obvious. Let's treat this change of comparison semantics as orthogonal to the proposal of using strings for built-in calendars internally. We should open a different issue for changing the semantics.
+
+**Conclusions:**
+- DE to write the proposal on issue [#1808](https://github.com/tc39/proposal-temporal/issues/1808), with a calendar accessor that returns string-or-instance, keeping calendar equality semantics the same.
+- If we want to change calendar equality semantics, discuss on a new issue.

--- a/meetings/agenda-minutes-2022-10-13.md
+++ b/meetings/agenda-minutes-2022-10-13.md
@@ -1,0 +1,110 @@
+# October 13, 2022
+
+## Attendees
+- Justin Grant (JGT)
+- Shane F. Carr (SFC)
+- Richard Gibson (RGN)
+- Philipp Dunkel (PDL)
+- Philip Chimento (PFC)
+
+## Agenda
+
+### Implementations progress
+- PFC: JSC about ⅓ done. Concerns about floating-points in Duration.
+- SFC: My understanding of Firefox is that Anba's PRs are being reviewed and merged. On V8, FYT has been blocked for some time on era codes and month codes and is working out a separate proposal.
+- JGT: Is there something we should discuss about what is blocking FYT?
+- PFC: My understanding is that we should discuss with FYT whether it needs to be part of Temporal but no action is needed right now from us to unblock.
+- JGT: Can I read about it somewhere?
+- PFC: [Intl Era and Month Codes proposal](https://github.com/FrankYFTang/proposal-intl-era-monthcode).
+- PDL: Is this blocking only V8 or all the implementations?
+- SFC: My understanding is that FYT is close to shipping iso8601-only Temporal, but the month and era codes are blocking non-iso8601 implementations.
+- PDL: Should we make a call on where this goes, in order to support FYT? I'm worried about delaying by starting this as a separate proposal.
+- PFC: I think we can achieve that call by starting a discussion on the proposal repo.
+- JGT: How is this proposal different from any other data-driven stuff such as time zone data?
+- SFC: I agree that this might not belong in ECMAScript, rather in Unicode. But you can't implement it in ECMAScript without knowing what codes to use for eras and months.
+- JGT: So FYT's concern is that the data for these things do not exist upstream in the source data for Unicode.
+- SFC: That's my concern. Temporal requires that era codes exist, but they don't exist.
+- JGT: So the work item here is to work with CLDR to ensure that they exist.
+- SFC: That, and also determine to what extent the era and month code behaviours need to be specified in ECMAScript. Do we rely 100% on what CLDR supplies or lay down some ground rules?
+- JGT: For the second question, that seems fine to include in ECMA-402 or Temporal. If we did that, does it unblock FYT?
+- PFC: We would best ask FYT on an issue thread.
+- JGT: Are there any objections in this group to doing that?
+- No.
+- JGT: Can we solve this with a PR to Temporal?
+- SFC: I was hoping USA would drive that process. This has been something we need to do for a long time, and it's more of a resourcing problem than a difficult technical problem.
+- JGT: Would it involve working with the CLDR folks? Is the data already there?
+- SFC: The data's not there yet. FYT has a good proposal for how the era codes should behave, but someone needs to work on getting it upstream.
+- JGT: For the ground rules, do you think it's more appropriate to have in ECMA-262 or Temporal?
+- SFC: I'll leave it to this group.
+- JGT: What are the next steps?
+- SFC: Find an owner.
+- JGT: I can put the PR into 402, since FYT has already specified it in the proposal. But I don't have time to work upstream with CLDR.
+- SFC: We need an owner for the whole task. If no one steps up FYT can do it but that's not preferable.
+- Action: PFC to check with Igalia's Google Intl contract.
+
+### Status updates
+- PFC: Regarding the IETF standardization work [#1450](https://github.com/tc39/proposal-temporal/issues/1450), no further changes needed. IETF needs to publish the document before we can close the issue.
+- PFC: Regarding [#1876](https://github.com/tc39/proposal-temporal/issues/1876) and [#2169](https://github.com/tc39/proposal-temporal/issues/2169): seems like the champions group is agreed on wanting to close the issue, but it needs to be done in a way that won't cause further problems.
+- PFC: There are several issues that are only waiting on test262 tests in order to be closed. I hoped to have all of those done by today, but didn't succeed. Certainly by next week.
+
+### Week-year support: remove `weekOfYear` or add `weekYear` ([#2405](https://github.com/tc39/proposal-temporal/issues/2405))
+- PFC recommendation: either close, or quickly add `weekYear`
+- PDL: No objections to making YearWeek a thing, but only if the week number remains available as an independent thing. Week numbers are a frequently used concept in communications in Europe. I don't like making it only available together with the year.
+- SFC: I don't understand that objection, do you mean you're not on board with a `yearWeek` getter that returns the year and the week together?
+- PDL: No, that's fine. As long as you can get the number by itself.
+- JGT: The big missing part from year-weeks was string parsing, correct?
+- PDL: The follow-on proposal would also introduce Temporal.YearWeek. Parsing it is the easy bit, it's what object you put the data into.
+- JGT: If we do string parsing of `YYYY-WWW-D`
+- RGN: This is confusing a few things. The issue was raised because there's no getter to get the week-year, which makes `weekOfYear` useless and potentially harmful. If I say `W01-5` you don't know whether it's December or January.
+- PFC: I disagree that it's useless, but it's got a potential for bugs if you are in a context where you need the year number.
+- PDL: `W01-5` is January because day 5 is Friday.
+- JGT: RGN, is your concern that we can go one way from date to week but not in reverse? It's a straightforward calculation but not obvious.
+RGN: If you pull the week number off a PlainDate, then you need to know the week-year.
+- PDL: It's the same as pulling off the month number or month code, you don't always need to know the year.
+- PFC: Could we agree on having a getter despite disagreement on whether week numbers are useless by themselves?
+- PDL: OK with me.
+- RGN: That's one issue. The parsing of `YYYY-WWW-D` is the other issue.
+- PDL: That we can support, because we can put it in a PlainDate. `YYYY-WWW` is problematic because we don't have PlainYearWeek.
+- PFC: I would recommend not supporting the string parsing for now. The getter or combined getter still makes perfect sense without it.
+- PDL, JGT agreed
+- JGT: What should we call the getter?
+- RGN: "Week calendar year" is the ISO 8601 term.
+- PDL: I would prefer a separate getter rather than a combined getter with half-baked object return, so that we don't preclude Temporal.PlainYearWeek in the future, which _should_ be the return of that combined getter.
+- RGN, PFC agreed
+- RGN: Also getters returning non-primitives is problematic in itself.
+- RGN: I confirmed the ISO term, `weekCalendarYear` would be a possible getter name.
+- PDL: I'd rather call it `weekYear`. "Calendar" already has a meaning in Temporal.
+- JGT: It's a bit weird to have `weekOfYear` and `weekYear`.
+- PDL: `yearOfWeek` and `weekOfYear`?
+- JGT: Makes sense to me. It's something you can skip over; if you don't know what it is, you probably don't need it.
+- PFC: Does anyone have a source for the calculation so that we don't go through the whole same process as we did with the ISOWeekOfYear calculation?
+- RGN: It's already embedded in ISOWeekOfYear. Just requires a bit of rearranging so that both getters refer to the operation.
+
+### Unforeseen problems with plain-object calendars and time zones ([#2354](https://github.com/tc39/proposal-temporal/issues/2354))
+Summary: E.g. `new Temporal.ZonedDateTime(0n, calendar, timeZone)` is silently wrong. One solution is to remove plain-object implementations of the protocol; one solution is to do nothing since constructors are low-level; one solution is to require certain methods be present on plain-object calendar or time zone.
+- JGT: I like the last one. Plain objects are a weird and infrequently used way to do it, so it seems reasonable to require some methods to exist. That may be useful even outside of this constructor.
+- PDL: To understand, the question is that we don't check these objects? What happens with `Temporal.TimeZone.from({})`?
+- PFC: Currently, it returns the same `{}`.
+- PDL: We should require certain methods.
+- JGT: Reading the docs:
+> The object must have at least `getOffsetNanosecondsFor()`, `getPossibleInstantsFor()`, and `toString()` methods. 
+> For calendars: The object must implement all of the Temporal.Calendar properties and methods except for `id`, `fields()`, `mergeFields()`, and `toJSON()`.
+- PFC: I think the previous thought was to call as few user-visible operations as possible, but this seems like it's worth deviating from that.
+- PDL: What's the user visible operation?
+- PFC: HasProperty for each required method.
+- PDL: You can only observe that with a Proxy.
+- PFC: Maybe also GetProperty to determine if the value is callable.
+- PDL: I don't think we need to do that. I don't think it's that important to care about the Proxy case.
+- RGN: There's enough for the committee to care about there, though.
+- PDL: I'm very surprised that ToTemporalTimeZone and ToTemporalCalendar don't already throw in this case.
+- PFC: I always considered plain-object time zones and calendars weird, and something that I don't care about - only needing to be there for precedent.
+- PFC: Another solution that just occurred to me is to check the [[TemporalTimeZone]] internal slot in ToTemporalCalendar, and vice versa, which covers the bug for strings and Temporal instances, but not for weird plain objects.
+- JGT: I like that.
+- RGN: I think we should just not rely on argument ordering here and instead use a bag with named arguments.
+- JGT: Why not do the easy, fast, unobservable thing here?
+- RGN: That doesn't have any precedent in the language. It feels like a hack. If getting all the properties, it'd be better to collect them into an internal bag.
+- PFC: I investigated that in [#1294](https://github.com/tc39/proposal-temporal/issues/1294) and it has very strange consequences.
+- RGN: I'm not surprised.
+- PDL: I can also get on board with not fixing the bug.
+- RGN: If it's a fix worth doing, then I think named arguments would be the way to go.
+- PFC: I think we have our temperature check, I'll summarize it on the issue.

--- a/meetings/agenda-minutes-2022-10-27.md
+++ b/meetings/agenda-minutes-2022-10-27.md
@@ -1,0 +1,115 @@
+# October 27, 2022
+
+## Attendees
+- Philip Chimento (PFC)
+- Justin Grant (JGT)
+- Richard Gibson (RGN)
+- Shane F. Carr (SFC)
+
+## Agenda
+
+### Status updates / Implementations progress
+No updates.
+- PFC: Following up from last time on the task of getting era and month codes into CLDR, we'll discuss offline.
+
+### Status of open normative issues
+Short overview of issues in progress that don't have anything specific to discuss.
+
+### Recursive calendar/timeZone property bag edge case ([#2104](https://github.com/tc39/proposal-temporal/issues/2104))
+Where we left off: Fix proposed, but the fix brings new inconsistencies. So either we need another fix or stick with the status quo after all.
+- PFC: I would be OK with closing this issue. The behaviour is a bit weird but it arises from a consistent rule set.
+- RGN: I feel like it is a wart, but not a fatal one. I liked the proposed fix. What was the inconsistency?
+- PFC: The fix makes property bags that are valid for PlainDate.from, not work in Calendar.from.
+- JGT: I don't remember what the disagreement was.
+- RGN: It was about having no deep processing in Calendar.from. JGT presented some use cases but I wasn't thrilled with them.
+- JGT: RGN, are you proposing that we no longer use full ISO strings to stand in for a calendar or a time zone? So you would have to construct another Temporal object with the ISO string?
+- RGN: Correct. Recognizing the distinction between the name of a calendar and an actual calendar object.
+- RGN: This probably would be affected if we went with the related proposal to pass built-in calendars as strings rather than instances ([#1808](https://github.com/tc39/proposal-temporal/issues/)). So I think this ticket should be a dependency of the other one.
+
+### Break from ToIntegerOrInfinity precedent ([#2112](https://github.com/tc39/proposal-temporal/issues/2112))
+Where we left off: No conclusion yet. PFC informally polled delegates and it seems this change would not be contentious. Need to discuss what exactly the changes would be.
+- PFC: I'm fine to go with what we have in that table. I compared it with Web IDL.
+- RGN: I don't care much, but I have a very small preference to go with undefined throwing. E.g., my intuition is that the behaviour should match what would happen if you converted all the arguments to numbers manually. The convention that absent should equal present-but-undefined is there, but not so strong that it couldn't be overridden in this case.
+- PFC: You could also make the distinction between trailing undefined and non-trailing undefined.
+- JGT: My intuition is that no proposal that treats absent differently from present-but-undefined will pass plenary.
+- RGN: That's reasonable. We can go with the table as the plan of record. Does it agree or disagree with Web IDL?
+- PFC: Disagree; Web IDL throws TypeError when converting undefined to 0.
+- RGN: There might not be an actual divergence, if interfaces "shield" ConvertToInt from undefined by substituting a default argument for undefined. I'm in favour of going with what's in the table either way, though.
+
+**Conclusion:** Proceed with the semantics in the table.
+
+- RGN: I found an example of a Web IDL interface with an optional unsigned long long parameter, where passing 'undefined' works: `document.createNodeIterator()`. Aligning with Web IDL would mean that undefined is never explicitly converted to an integer, but undefined in the place of an optional parameter gets the default value.
+- RGN: Confirmed, [ES overloads](https://webidl.spec.whatwg.org/#es-overloads) specifies conversion of explicit undefined arguments for optional parameters to the relevant default value. And there it includes similar language for dictionaries.
+- PFC: So `new PlainDate(undefined, 10, 27)` would be an error.
+
+**Conclusion:** Amend the table to do this.
+
+### Allowing more than 9 digits in fractional part strings ([#1712](https://github.com/tc39/proposal-temporal/issues/1712))
+- PFC recommendation: save for a future addition to Temporal
+- RGN: As long as we reject it with an error, it's viable as a future possibility.
+- SFC: There's not a lot of precision that would be gained here. For seconds, there's at most nine digits. For minutes, we only gain one such digit. For hours, you only get at most 11 digits before you get into fractional nanoseconds. Based on my discussions with FYT, anytime you do arithmetic on strings it gets complicated from an implementation standpoint. I think limiting it to 9 digits is fine and would prefer to keep it the way it is.
+- RGN: Aren't there already inexact values possible?
+- PFC: `"PT0.00001H"`
+- SFC: That will give you an exact number of nanoseconds.
+- RGN: Is that the case for any fractional string?
+- SFC: A minute is 60 billion nanoseconds, so every 9-digit fraction is exact.
+- RGN: As long as the behaviour is reject with error, it's an acceptable quirk that we can revisit if the need arises.
+
+**Conclusion:** Move issue to Temporal V2.
+
+### Non-IANA time zones in non-Intl implementations ([#1996](https://github.com/tc39/proposal-temporal/issues/1996) and [#2209](https://github.com/tc39/proposal-temporal/issues/2209))
+Where we left off: These two alternatives seem mutually exclusive. Recently unblocked now that ECMA-262 uses DefaultTimeZone, so let's make a decision.
+- RGN: We do already have a resolution for this, I think. ECMA-402 issue [#683](https://github.com/tc39/ecma402/issues/683) hasn't been implemented yet, but my goal for it is that ECMA-402 will not need to override DefaultTimeZone. ECMA-402 "does not prohibit behaviour that is otherwise permissible in 262". If 262 allows for a DefaultTimeZone of something that is not IANA, (which is currently the case with numeric offsets), then 402 should as well.
+- PFC: 262 currently says IANA time zone strings are "recommended".
+- RGN: We could have a normative change in 262 that removes that ability, in which case whatever the constraint is would apply to 402. Or we could keep it technically wide open and 402 has to deal with that. In either case, 402 has to deal with numeric offset time zones.
+- PFC: A 262-only environment doesn't have to have a TZDB, but a 402 environment does. (is recommended to?) What do you do if you are polyfilling Intl onto an environment without a TZDB? Is it acceptable to make a fictitious `Etc/System` time zone to represent the one time zone that 262 is aware of?
+- RGN: Yes, after [#683](https://github.com/tc39/ecma402/issues/683) is fixed. That would be unrecommended, but acceptable. As long as the implementation agrees with itself, between DefaultTimeZone, NamedTimeZoneGetOffsetNanoseconds, and NamedTimeZoneGetEpochNanoseconds. Concretely for Temporal, I think we should close both [#1996](https://github.com/tc39/proposal-temporal/issues/1996) and [#2209](https://github.com/tc39/proposal-temporal/issues/2209) — 262 discourages but allows arbitrary time zone names, and 402 uses the 262 operations without override. With Temporal, 262 has a reasonable set of time zone operations, that allow coloring outside of the lines, and what we want is for 402 not to override them.
+- PFC: This means a divergence between calendars and time zones, because neither 262 nor 402 allow arbitrary calendar identifiers, but I think that's justified.
+- RGN: Agreed. We avoid introducing the problem in the first place.
+
+**Conclusion:** Close [#2209](https://github.com/tc39/proposal-temporal/issues/2209), leave [#1996](https://github.com/tc39/proposal-temporal/issues/1996) open until the 402 fix is in, although it might become a no-op.
+
+### Check calendar in fast-path conversion to PlainTime ([#2221](https://github.com/tc39/proposal-temporal/issues/2221))
+Where we left off: PFC would prefer to take the proposed PR. JGT and SFC have asked to be present for this discussion
+- JGT: I reviewed this one beforehand. My main proposal was that today we don't have any use cases for time calendars at all and it's not clear we'll ever add them, so we'd be able to solve this one if we planned that time calendars would be added under `timeCalendar` if they were ever added.
+- RGN: The association of calendar with time never seemed sufficiently fleshed out to me anyway.
+- SFC: (via comment) Can we have a sketch of what time calendars would look like if they were introduced via a `timeCalendar` property, and whether that would be web-compatible?
+- JGT: It sounds like the goal is to have a field that people can check, to see if the behaviour is what they expect?
+- PFC: The goal that we decided on before, was that anytime you would otherwise create a PlainTime with a non-ISO calendar, we throw instead.
+- JGT: One proposal is to introduce timeCalendar now. Would we need this property in V1 at all, in order to support it in V2?
+- PFC: I can't speak for PDL but my understanding was that as the biggest proponent of time calendars, he didn't think that `timeCalendar` property would be sufficient.
+
+**Conclusion:** Table this until PDL is present. JGT to outline `timeCalendar` on the issue.
+
+### Unforeseen problems with plain-object calendars and time zones ([#2354](https://github.com/tc39/proposal-temporal/issues/2354))
+Where we left off: we had a temperature check. Seems like most proposed solutions have at least one strong positive and at least one negative preference, unfortunately
+- JGT: I support number 2 and number 4.
+- PFC: Same.
+- JGT: I wouldn't support 3 even regardless of JHD's comment, but that's another indication we shouldn't do it.
+- JGT: I think they are not mutually exclusive and 4 is a good idea anyway. If we know that one of the objects is wrong, why not do something about that?
+- JGT: Would 4 cause `z = Temporal.Now.zonedDateTimeISO(); new Temporal.ZonedDateTime(0n, z, z)` to throw?
+- PFC: No.
+- RGN: I'd think that should throw anyway.
+- JGT: If we did 2, what methods would we check for?
+- PFC: Unclear, I guess we'd check that all required methods of the protocol are present.
+- JGT: I'd really prefer we do number 4, it's a small adjustment that catches the vast majority of the cases. It's unclear anyone will ever use plain object time zones. Temperature check on number 4 only?
+- RGN: It's weird, but I wouldn't object. The language doesn't really put up those kinds of guardrails, where we check for a specific kind of probably unintentional construct. I don't see any negative consequences, it's just odd.
+- JGT: Maybe an analogy is if you pass a number into an API that expects a bigint, it complains. The difference is this is an object instead of a primitive.
+- RGN: Theoretically I can take a calendar instance and slap on time zone methods.
+- JGT: I'm inclined to ignore that use case.
+- RGN: No objection to number 4.
+- PFC: Explicitly support number 4.
+- PFC: Do we want to still consider number 2 in addition?
+- JGT: I don't think so, it's a very marginal case.
+- PFC: I agree, the remaining weirdness is not worth the can of worms that would be opened by deciding what shape checks to do.
+
+**Conclusion:** Implement number 4.
+
+### Optimize built-in calendars ([#1808](https://github.com/tc39/proposal-temporal/issues/))
+- DE commented on the issue.
+- (Some discussion about the SES constraint of having all built-ins be reachable from the global object)
+- JGT: Can you have frozen objects without having a frozen class?
+- RGN: What happens in hardened JS, you have to freeze all of the built-in objects. There are some built-ins that can't be reached by property traversal and we don't want to increase that set.
+- PFC: My understanding of the frozen objects proposal would be that it's fine if we add already-frozen objects, whether or not they are reachable by property traversal.
+- RGN: You have to do things like ensure all of that object's function properties themselves are frozen, but in theory yes.
+- (More discussion of communication channels)


### PR DESCRIPTION
This is the minutes backlog from Temporal champions meetings from June through October 2022.