### PR TITLE
Normative: Clarifications of calendar-dependent parts of yearMonthFromFields and monthDayFromFields

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1818,12 +1818,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
         month = monthInfo && monthInfo.monthIndex;
         // If this leap month isn't present in this year, constrain to the same
         // day of the previous month.
-        if (
-          month === undefined &&
-          monthCode.endsWith('L') &&
-          !ES.Call(ArrayIncludes, ['M01L', 'M12L', 'M13L'], [monthCode]) &&
-          overflow === 'constrain'
-        ) {
+        if (month === undefined && monthCode.endsWith('L') && monthCode != 'M13L' && overflow === 'constrain') {
           let withoutML = monthCode.slice(1, -1);
           if (withoutML[0] === '0') withoutML = withoutML.slice(1);
           monthInfo = months[withoutML];

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1013,7 +1013,7 @@ const nonIsoHelperBase = {
     if (monthCode === undefined) {
       let { year, era, eraYear } = fields;
       if (year === undefined && (era === undefined || eraYear === undefined)) {
-        throw new TypeError('`monthCode`, `year`, or `era` and `eraYear` is required');
+        throw new TypeError('when `monthCode` is omitted, `year` (or `era` and `eraYear`) and `month` are required');
       }
       // Apply overflow behaviour to year/month/day, to get correct monthCode/day
       ({ monthCode, day } = this.isoToCalendarDate(this.calendarToIsoDate(fields, overflow, cache), cache));

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -767,7 +767,6 @@ const nonIsoHelperBase = {
     // If the initial guess is not in the same month, then then bisect the
     // distance to the target, starting with 8 days per step.
     let increment = 8;
-    let maybeConstrained = false;
     while (sign) {
       isoEstimate = this.addDaysIso(isoEstimate, sign * increment);
       const oldRoundtripEstimate = roundtripEstimate;
@@ -780,11 +779,6 @@ const nonIsoHelperBase = {
           isoEstimate = calculateSameMonthResult(diff.days);
           // Signal the loop condition that there's a match.
           sign = 0;
-          // If the calendar day is larger than the minimal length for this
-          // month, then it might be larger than the actual length of the month.
-          // So we won't cache it as the correct calendar date for this ISO
-          // date.
-          maybeConstrained = date.day > this.minimumMonthLength(date);
         } else if (oldSign && sign !== oldSign) {
           if (increment > 1) {
             // If the estimate overshot the target, try again with a smaller increment
@@ -802,7 +796,6 @@ const nonIsoHelperBase = {
               const order = this.compareCalendarDates(roundtripEstimate, oldRoundtripEstimate);
               // If current value is larger, then back up to the previous value.
               if (order > 0) isoEstimate = this.addDaysIso(isoEstimate, -1);
-              maybeConstrained = true;
               sign = 0;
             }
           }
@@ -819,17 +812,6 @@ const nonIsoHelperBase = {
       (this.hasEra && (date.era === undefined || date.eraYear === undefined))
     ) {
       throw new RangeError('Unexpected missing property');
-    }
-    if (!maybeConstrained) {
-      // Also cache the reverse mapping
-      const keyReverse = JSON.stringify({
-        func: 'isoToCalendarDate',
-        isoYear: isoEstimate.year,
-        isoMonth: isoEstimate.month,
-        isoDay: isoEstimate.day,
-        id: this.id
-      });
-      cache.set(keyReverse, date);
     }
     return isoEstimate;
   },

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1148,10 +1148,9 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
             if (overflow === 'reject') {
               throw new RangeError(`Hebrew monthCode M05L is invalid in year ${year} which is not a leap year`);
             } else {
-              // constrain to last day of previous month (Av)
-              month = 5;
-              day = 30;
-              monthCode = 'M05';
+              // constrain to same day of next month (Adar)
+              month = 6;
+              monthCode = 'M06';
             }
           }
         } else {
@@ -1817,7 +1816,8 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
         if (numberPart[0] === '0') numberPart = numberPart.slice(1);
         let monthInfo = months[numberPart];
         month = monthInfo && monthInfo.monthIndex;
-        // If this leap month isn't present in this year, constrain down to the last day of the previous month.
+        // If this leap month isn't present in this year, constrain to the same
+        // day of the previous month.
         if (
           month === undefined &&
           monthCode.endsWith('L') &&
@@ -1828,7 +1828,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
           if (withoutML[0] === '0') withoutML = withoutML.slice(1);
           monthInfo = months[withoutML];
           if (monthInfo) {
-            ({ daysInMonth: day, monthIndex: month } = monthInfo);
+            month = monthInfo.monthIndex;
             monthCode = buildMonthCode(withoutML);
           }
         }

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1037,12 +1037,18 @@ const nonIsoHelperBase = {
 
     let isoYear, isoMonth, isoDay;
     let closestCalendar, closestIso;
-    // Look backwards starting from the calendar year of 1972-01-01 up to 100
-    // calendar years to find a year that has this month and day. Normal months
-    // and days will match immediately, but for leap days and leap months we may
-    // have to look for a while.
-    const startDateIso = { year: 1972, month: 1, day: 1 };
-    const { year: calendarYear } = this.isoToCalendarDate(startDateIso, cache);
+    // Look backwards starting from one of the calendar years spanning ISO year
+    // 1972, up to 100 calendar years prior, to find a year that has this month
+    // and day. Normal months and days will match immediately, but for leap days
+    // and leap months we may have to look for a while.
+    const startDateIso = { year: 1972, month: 12, day: 31 };
+    const calendarOfStartDateIso = this.isoToCalendarDate(startDateIso, cache);
+    // Note: relies on lexicographical ordering of monthCodes
+    const calendarYear =
+      calendarOfStartDateIso.monthCode > monthCode ||
+      (calendarOfStartDateIso.monthCode === monthCode && calendarOfStartDateIso.day >= day)
+        ? calendarOfStartDateIso.year
+        : calendarOfStartDateIso.year - 1;
     for (let i = 0; i < 100; i++) {
       let testCalendarDate = this.adjustCalendarDate({ day, monthCode, year: calendarYear - i }, cache);
       const isoDate = this.calendarToIsoDate(testCalendarDate, 'constrain', cache);

--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1027,12 +1027,14 @@ const nonIsoHelperBase = {
   // All built-in calendars except Chinese/Dangi and Hebrew use an era
   hasEra: true,
   monthDayFromFields(fields, overflow, cache) {
-    let { year, month, monthCode, day, era, eraYear } = fields;
+    let { monthCode, day } = fields;
     if (monthCode === undefined) {
+      let { year, era, eraYear } = fields;
       if (year === undefined && (era === undefined || eraYear === undefined)) {
         throw new TypeError('`monthCode`, `year`, or `era` and `eraYear` is required');
       }
-      ({ monthCode, year } = this.adjustCalendarDate({ year, month, monthCode, day, era, eraYear }, cache, overflow));
+      // Apply overflow behaviour to year/month/day, to get correct monthCode/day
+      ({ monthCode, day } = this.isoToCalendarDate(this.calendarToIsoDate(fields, overflow, cache), cache));
     }
 
     let isoYear, isoMonth, isoDay;

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1432,6 +1432,45 @@
           </p>
         </emu-clause>
 
+        <emu-clause id="sec-temporal-calendarmonthdaytoisoreferencedate" type="abstract operation">
+          <h1>
+            CalendarMonthDayToISOReferenceDate (
+              _calendar_: a String,
+              _fields_: an ordinary Object for which the value of the [[Prototype]] internal slot is *null* and every property is a data property,
+              _overflow_: *"constrain"* or *"reject"*,
+            ): either a normal completion containing a Record with fields [[ISOMonth]], [[ISODay]], and [[ReferenceISOYear]], or an abrupt completion
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>
+              It performs implementation-defined processing to convert _fields_, which describes a calendar date without a year (i.e., month code and day pair, or equivalent) in the calendar represented by _calendar_, to a reference date in the ISO 8601 calendar, subject to processing specified by _overflow_.
+              For *"reject"*, values that do not form a valid date cause an exception to be thrown, as described below.
+              For *"constrain"*, values that do not form a valid date are clamped to the correct range.
+              It then returns a Record with a reference ISO date that corresponds to that month code and day pair in a reference year as described below.
+            </dd>
+          </dl>
+          <p>
+            The fields of the returned Record form a reference date in the ISO calendar that, when converted to the calendar given by _calendar_, corresponds to the given month code and day pair in an arbitrary but deterministically chosen reference year.
+            The reference date is the latest ISO date corresponding to the calendar date, that is also earlier than or equal to the ISO date December 31, 1972.
+            If that calendar date never occurs on or before the ISO date December 31, 1972, then the reference date is the earliest ISO date corresponding to that calendar date.
+            The reference year is almost always 1972 (the first ISO leap year after the epoch), with rare exceptions for some calendars where some dates (e.g. leap days or days in leap months) didn't occur during the ISO year 1972.
+          </p>
+          <p>
+            The operation throws a *TypeError* exception if the properties present on _fields_ are insufficient to identify a unique month code and day pair in _calendar_.
+            For example, for a _calendar_ that uses eras, a *TypeError* is thrown if _fields_ does not include any of the following minimum combinations of properties:
+          </p>
+          <ul>
+            <li>*"monthCode"*, *"day"*</li>
+            <li>*"year"*, *"month"*, *"day"*</li>
+            <li>*"era"*, *"eraYear"*, *"month"*, *"day"*</li>
+          </ul>
+          <p>
+            The operation throws a *RangeError* exception if _overflow_ is *"reject"* and the date described by _fields_ does not exist, i.e. cannot be resolved to a month code and day pair.
+            For example, when _calendar_ is *"gregory"* and _overflow_ is *"reject"*, _fields_ values of `{ monthCode: "M01", day: "32" }` and `{ "year": 2001, "month": 2, "day": 29 }` would both cause a *RangeError* to be thrown.
+            In the latter case, even though 02-29 is a date in the Gregorian calendar, a month code cannot be determined from the nonexistent date 2001-02-29.
+          </p>
+        </emu-clause>
+
         <emu-clause id="sec-temporal-calendardateaddition" type="implementation-defined abstract operation">
           <h1>
             CalendarDateAddition (
@@ -1821,8 +1860,7 @@
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-              1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
-              1. Set _result_.[[ReferenceISOYear]] to _result_.[[Year]].
+              1. Let _result_ be ? CalendarMonthDayToISOReferenceDate(_calendar_.[[Identifier]], _fields_, _overflow_).
             1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _result_.[[ReferenceISOYear]]).
           </emu-alg>
         </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1796,6 +1796,8 @@
               1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"month"*, *"monthCode"*, *"year"* »).
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
               1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+              1. Let _firstDayIndex_ be the 1-based index of the first day of the month described by _fields_ (i.e., 1 unless the month's first day is skipped by this calendar.)
+              1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, 𝔽(_firstDayIndex_)).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISODay]] to _result_.[[Day]].
             1. Return ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[ReferenceISODay]]).


### PR DESCRIPTION
The process for choosing the reference ISO day and reference ISO year for non-ISO calendars was missing from the descriptions of `yearMonthFromFields` and `monthDayFromFields`, respectively.

`monthDayFromFields` gets a separate operation CalendarMonthDayToISOReferenceDate explaining how to choose the reference year. Update the description of CalendarDateToISO to match the new, more detailed, language added there.

Closes: #2461