### PR TITLE
Normative: Fixed DifferenceInstant

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -604,8 +604,12 @@
         <dd>It computes the difference between two exact times _ns1_ and _ns2_ expressed in nanoseconds since the epoch, and rounds the result according to the parameters _roundingIncrement_, _smallestUnit_, _largestUnit_, and _roundingMode_.</dd>
       </dl>
       <emu-alg>
-        1. Assert: The following step cannot fail due to overflow in the Number domain because abs(ℝ(_ns2_) - ℝ(_ns1_)) &le; 2 &times; nsMaxInstant.
-        1. Let _roundResult_ be ! RoundDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, ℝ(_ns2_) - ℝ(_ns1_), _roundingIncrement_, _smallestUnit_, _roundingMode_).[[DurationRecord]].
+        1. Let _difference_ be ℝ(_ns2_) - ℝ(_ns1_).
+        1. Let _nanoseconds_ be remainder(_difference_, 1000).
+        1. Let _microseconds_ be remainder(truncate(_difference_ / 1000), 1000).
+        1. Let _milliseconds_ be remainder(truncate(_difference_ / 10<sup>6</sup>), 1000).
+        1. Let _seconds_ be truncate(_difference_ / 10<sup>9</sup>).
+        1. Let _roundResult_ be ! RoundDuration(0, 0, 0, 0, 0, 0, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _roundingIncrement_, _smallestUnit_, _largestUnit_, _roundingMode_).
         1. Assert: _roundResult_.[[Days]] is 0.
         1. Return ! BalanceDuration(0, _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
       </emu-alg>


### PR DESCRIPTION
Made changes to DifferenceInstant operation to prevent loss of precision.
The approach is to convert the nanoseconds into seconds, milliseconds ≤ 999, microseconds ≤ 999, and
nanoseconds ≤ 999 before passing those values to `RoundDuration`. 

Fixes: #2419 