### PR TITLE
Normative: Upper limit on rounding increments

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -791,10 +791,14 @@ export const ES = ObjectAssign({}, ES2022, {
     let increment = options.roundingIncrement;
     if (increment === undefined) return 1;
     increment = ES.ToNumber(increment);
-    if (!NumberIsFinite(increment) || increment < 1) {
-      throw new RangeError(`roundingIncrement must be at least 1 and finite, not ${increment}`);
+    if (!NumberIsFinite(increment)) {
+      throw new RangeError('roundingIncrement must be finite');
     }
-    return MathTrunc(increment);
+    const integerIncrement = MathTrunc(increment);
+    if (integerIncrement < 1 || integerIncrement > 1e9) {
+      throw new RangeError(`roundingIncrement must be at least 1 and at most 1e9, not ${increment}`);
+    }
+    return integerIncrement;
   },
   ValidateTemporalRoundingIncrement: (increment, dividend, inclusive) => {
     const maximum = inclusive ? dividend : dividend - 1;

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -201,14 +201,15 @@
     <dl class="header">
       <dt>description</dt>
       <dd>
-        It extracts the value of the property named *"roundingIncrement"* from _normalizedOptions_, makes sure it represents a finite number greater than or equal to 1, and returns that value truncated to an integer.
+        It extracts the value of the property named *"roundingIncrement"* from _normalizedOptions_, makes sure it represents a number in the inclusive interval from 1 to 10<sup>9</sup>, and returns that value truncated to an integer.
       </dd>
     </dl>
     <emu-alg>
       1. Let _increment_ be ? GetOption(_normalizedOptions_, *"roundingIncrement"*, *"number"*, *undefined*, *1*<sub>𝔽</sub>).
       1. If _increment_ is not finite, throw a *RangeError* exception.
-      1. If _increment_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
-      1. Return truncate(ℝ(_increment_)).
+      1. Let _integerIncrement_ be truncate(ℝ(_increment_)).
+      1. If _integerIncrement_ &lt; 1 or _integerIncrement_ &gt; 10<sup>9</sup>, throw a *RangeError* exception.
+      1. Return _integerIncrement_.
     </emu-alg>
   </emu-clause>
 


### PR DESCRIPTION
Rounding increments are usually limited. In a few cases (years, months, weeks, and days for Temporal.Durations), they were previously only limited by being required to be finite. This introduces a limit of 1e9 for these previously unlimited cases.

1e9 fits in a 32-bit integer, to make things simpler for implementations, but is clearer to explain in end-user documentation than UINT32_MAX.

Closes: #2458 