### PR TITLE
Normative: Treat `daysInMonth` as the count of days in a month

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4735,13 +4735,24 @@ export function AddDurationToOrSubtractDurationFromPlainYearMonth(operation, yea
   const calendar = GetSlot(yearMonth, CALENDAR);
   const fieldNames = CalendarFields(calendar, ['monthCode', 'year']);
   const fields = PrepareTemporalFields(yearMonth, fieldNames, []);
+  const fieldsCopy = ObjectCreate(null);
+  CopyDataProperties(fieldsCopy, fields, []);
+  fields.day = 1;
+  let startDate = CalendarDateFromFields(calendar, fields);
   const sign = DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
-  fields.day = sign < 0 ? CalendarDaysInMonth(calendar, yearMonth) : 1;
-  const startDate = CalendarDateFromFields(calendar, fields);
+  const dateAdd = GetMethod(calendar, 'dateAdd');
   const Duration = GetIntrinsic('%Temporal.Duration%');
+  if (sign < 0) {
+    const oneMonthDuration = new Duration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0);
+    const nextMonth = CalendarDateAdd(calendar, startDate, oneMonthDuration, undefined, dateAdd);
+    const minusDayDuration = new Duration(0, 0, 0, -1, 0, 0, 0, 0, 0, 0);
+    const endOfMonth = CalendarDateAdd(calendar, nextMonth, minusDayDuration, undefined, dateAdd);
+    fieldsCopy.day = CalendarDay(calendar, endOfMonth);
+    startDate = CalendarDateFromFields(calendar, fieldsCopy);
+  }
   const durationToAdd = new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
   const optionsCopy = CopyOptions(options);
-  const addedDate = CalendarDateAdd(calendar, startDate, durationToAdd, options);
+  const addedDate = CalendarDateAdd(calendar, startDate, durationToAdd, options, dateAdd);
   const addedDateFields = PrepareTemporalFields(addedDate, fieldNames, []);
 
   return CalendarYearMonthFromFields(calendar, addedDateFields, optionsCopy);

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -666,16 +666,26 @@
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
+        1. Let _fieldsCopy_ be OrdinaryObjectCreate(*null*).
+        1. Perform ! CopyDataProperties(_fieldsCopy_, _fields_, «»).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, *1*<sub>𝔽</sub>).
+        1. Let _intermediateDate_ be ? CalendarDateFromFields(_calendar_, _fields_).
         1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
         1. If _sign_ &lt; 0, then
-          1. Let _day_ be ? CalendarDaysInMonth(_calendar_, _yearMonth_).
+          1. Let _oneMonthDuration_ be ! CreateTemporalDuration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Let _nextMonth_ be ? CalendarDateAdd(_calendar_, _intermediateDate_, _oneMonthDuration_, *undefined*, _dateAdd_).
+          1. Let _minusDayDuration_ be ! CreateTemporalDuration(0, 0, 0, -1, 0, 0, 0, 0, 0, 0).
+          1. Let _endOfMonth_ be ? CalendarDateAdd(_calendar_, _nextMonth_, _minusDayDuration_, *undefined*, _dateAdd_).
+          1. Let _day_ be ? CalendarDay(_calendar_, _endOfMonth_).
+          1. Perform ! CreateDataPropertyOrThrow(_fieldsCopy_, *"day"*, _day_).
+          1. Let _date_ be ? CalendarDateFromFields(_calendar_, _fieldsCopy_).
         1. Else,
-          1. Let _day_ be 1.
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, 𝔽(_day_)).
-        1. Let _date_ be ? CalendarDateFromFields(_calendar_, _fields_).
+          1. Let _date_ be _intermediateDate_.
         1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _optionsCopy_ be ? CopyOptions(_options_).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _options_).
+        1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _options_, _dateAdd_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).
         1. Return ? CalendarYearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).
       </emu-alg>


### PR DESCRIPTION
Addresses #1315.

Updates Plain Year Month arithmetic to use a version of `.with({ day: 1 }).add({ months: 1 }).subtract({ days: 1}).day` to get the index of the last day of the month. Chose this over the alternative of `.with({ day: 1 }).add({ days: yearMonth.daysInMonth() - 1]}).day` beacuse the `GetMethod(calendar, "dateAdd")` can be reduced to one GetMethod.

Updates polyfill, no changes needed to non-ISO calendars because there are no skipped days in any of the calendars it implements.

Updates to docs pending, will update PR when ready.

Will prepare separate editorial PR to make language of CalendarDateDaysIn{Week,Month,Year} and CalendarDateMonthsInYear more consistent, but current phrasing is correct - nothing needed to address this.