### PR TITLE
Editorial: Various changes

### DIFF
--- a/docs/balancing.md
+++ b/docs/balancing.md
@@ -56,7 +56,7 @@ d.round({ largestUnit: 'hour' }); // => PT1H21M30S (fully balanced)
 ## Balancing Relative to a Reference Point
 
 Balancing that includes days, weeks, months, and years is more complicated because those units can be different lengths.
-In the default ISO calendar, a year can be 365 or 366 days, and a month can be 28, 29, 30, or 31 days.
+In the default ISO 8601 calendar, a year can be 365 or 366 days, and a month can be 28, 29, 30, or 31 days.
 In other calendars, years aren't always 12 months long and weeks aren't always 7 days.
 Finally, in time zones that use Daylight Saving Time (DST) days are not always 24 hours long.
 

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -48,7 +48,7 @@ The following "invariants" (statements that are always true) hold for all built-
 
 Here are best practices for writing code that will work regardless of the calendar used:
 
-- Validate or coerce the calendar of all external input. If your code receives a Temporal object from an external source, you should check that its calendar is what you expect, and if you are not prepared to handle other calendars, convert it to the ISO calendar using `withCalendar('iso8601')`. Otherwise, you may end up with unexpected behavior in your app or introduce security or performance issues by introducing an unexpected calendar.
+- Validate or coerce the calendar of all external input. If your code receives a Temporal object from an external source, you should check that its calendar is what you expect, and if you are not prepared to handle other calendars, convert it to the ISO 8601 calendar using `withCalendar('iso8601')`. Otherwise, you may end up with unexpected behavior in your app or introduce security or performance issues by introducing an unexpected calendar.
 - Use `compare` methods (e.g. `Temporal.PlainDate.compare(date1, '2000-01-01')`) instead of manually comparing individual properties (e.g. `date.year > 2000`) whose meaning may vary across calendars.
 - Never compare field values in different calendars. A `month` or `year` in one calendar is unrelated to the same property values in another calendar. If dates in different calendars must be compared, use `compare`.
 - When comparing dates for equality that might be in different calendars, convert them both to the same calendar using `withCalendar`. The same ISO date in different calendars will return `false` from the `equals` method and will return a non-zero value from `compare` because the calendars are not equal.
@@ -260,7 +260,7 @@ They provide a way to construct other Temporal objects from values in the calend
 None of the above methods need to be called directly except in specialized code.
 They are called indirectly when using `Temporal.PlainDate.from()`, `Temporal.PlainDateTime.from()`, `Temporal.PlainYearMonth.from()`, and `Temporal.PlainMonthDay.from()`.
 
-A custom implementation of these methods would convert the calendar-space arguments to the ISO calendar, and return an object created using `new Temporal.PlainDate(...isoArgs)`, with `PlainYearMonth` and `PlainMonthDay` substituted for `PlainDate` as appropriate.
+A custom implementation of these methods would convert the calendar-space arguments to the ISO 8601 calendar, and return an object created using `new Temporal.PlainDate(...isoArgs)`, with `PlainYearMonth` and `PlainMonthDay` substituted for `PlainDate` as appropriate.
 
 For example:
 
@@ -304,7 +304,7 @@ If `date` is not a `Temporal.PlainDate` object, or `duration` not a `Temporal.Du
 This method does not need to be called directly except in specialized code.
 It is called indirectly when using `add()` and `subtract()` of `Temporal.PlainDateTime`, `Temporal.PlainDate`, and `Temporal.PlainYearMonth`.
 
-A custom implementation of this method would perform the calendar-specific addition, convert the result to the ISO calendar, and return an object created using `new Temporal.PlainDate(...isoArgs)`.
+A custom implementation of this method would perform the calendar-specific addition, convert the result to the ISO 8601 calendar, and return an object created using `new Temporal.PlainDate(...isoArgs)`.
 
 For example:
 
@@ -391,7 +391,7 @@ Usage example:
 
 <!-- prettier-ignore-start -->
 ```js
-// In the ISO calendar, this method just makes a copy of the input array
+// In the ISO 8601 calendar, this method just makes a copy of the input array
 Temporal.Calendar.from('iso8601').fields(['monthCode', 'day']);
 // => [ 'monthCode', 'day' ]
 ```

--- a/docs/cookbook/makeExpandedTemporal.mjs
+++ b/docs/cookbook/makeExpandedTemporal.mjs
@@ -53,7 +53,7 @@ const expandedYears = new WeakMap();
 
 class ExpandedPlainDate extends Temporal.PlainDate {
   // The expanded-year versions of the Temporal types are limited to using the
-  // ISO calendar.
+  // ISO 8601 calendar.
   constructor(year, isoMonth, isoDay) {
     year = BigInt(year);
     const isoYear = isLeapYear(year) ? 1972 : 1970;

--- a/docs/duration.md
+++ b/docs/duration.md
@@ -240,7 +240,7 @@ Usage example:
 <!-- prettier-ignore-start -->
 ```javascript
 duration = Temporal.Duration.from({ months: 50, days: 50, hours: 50, minutes: 100 });
-// Perform a balance operation using additional ISO calendar rules:
+// Perform a balance operation using additional ISO 8601 calendar rules:
 let { years, months } = duration;
 years += Math.floor(months / 12);
 months %= 12;

--- a/docs/plainmonthday.md
+++ b/docs/plainmonthday.md
@@ -113,7 +113,7 @@ md = Temporal.PlainMonthDay.from({ month: 13, day: 1, year: 2000 }, { overflow: 
 md = Temporal.PlainMonthDay.from({ month: 1, day: 32, year: 2000 }, { overflow: 'reject' });
 // => throws
 md = Temporal.PlainMonthDay.from({ month: 2, day: 29, year: 2001 }, { overflow: 'reject' });
-// => throws (this year is not a leap year in the ISO calendar)
+// => throws (this year is not a leap year in the ISO 8601 calendar)
 
 // non-ISO calendars
 md = Temporal.PlainMonthDay.from({ monthCode: 'M05L', day: 15, calendar: 'hebrew' });

--- a/docs/plainyearmonth.md
+++ b/docs/plainyearmonth.md
@@ -332,7 +332,7 @@ If `duration` is not a `Temporal.Duration` object, then it will be converted to 
 
 If the result is earlier or later than the range of dates that `Temporal.PlainYearMonth` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
 
-The `overflow` option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous.
+The `overflow` option has no effect in the default ISO 8601 calendar, because a year is always 12 months and therefore not ambiguous.
 It doesn't matter in this case that years and months can be different numbers of days, as the resolution of `Temporal.PlainYearMonth` does not distinguish days.
 However, `overflow` may have an effect in other calendars where years can be different numbers of months.
 
@@ -365,7 +365,7 @@ If `duration` is not a `Temporal.Duration` object, then it will be converted to 
 
 If the result is earlier or later than the range of dates that `Temporal.PlainYearMonth` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then this method will throw a `RangeError` regardless of `overflow`.
 
-The `overflow` option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous.
+The `overflow` option has no effect in the default ISO 8601 calendar, because a year is always 12 months and therefore not ambiguous.
 It doesn't matter in this case that years and months can be different numbers of days, as the resolution of `Temporal.PlainYearMonth` does not distinguish days.
 However, `overflow` may have an effect in other calendars where years can be different numbers of months.
 

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -128,7 +128,7 @@ For more about TZDB, see the [`Temporal.TimeZone` documentation](timezone.md) or
 In order to achieve round-trip persistence for `Temporal` objects using non-ISO calendar systems, a calendar system identifier can be added.
 
 Therefore, we are proposing the following extension:
-_Calendar-specific dates are expressed as their equivalent date in the ISO calendar system, with a suffix signifying the calendar system into which the ISO date should be converted when read by a computer._
+_Calendar-specific dates are expressed as their equivalent date in the ISO 8601 calendar system, with a suffix signifying the calendar system into which the ISO date should be converted when read by a computer._
 
 For example, when parsed, the following string would represent the date **28 Iyar 5780** in the Hebrew calendar:
 

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -95,7 +95,7 @@ For example:
 
 If the string isn't valid, then a `RangeError` will be thrown regardless of the value of `overflow`.
 
-Note that this string format (albeit limited to the ISO calendar system) is also used by `java.time` and some other time-zone-aware libraries.
+Note that this string format (albeit limited to the ISO 8601 calendar system) is also used by `java.time` and some other time-zone-aware libraries.
 For more information on `Temporal`'s extensions to the ISO 8601 / RFC 3339 string format and the progress towards becoming a published standard, see [String Parsing, Serialization, and Formatting](./strings.md).
 
 The time zone ID is always required.

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -197,7 +197,6 @@ export class ZonedDateTime {
     ES.Call(ArrayPrototypePush, fieldNames, ['offset']);
     const partialZonedDateTime = ES.PrepareTemporalFields(temporalZonedDateTimeLike, fieldNames, 'partial');
 
-    const timeZone = GetSlot(this, TIME_ZONE);
     ES.Call(ArrayPrototypePush, fieldNames, ['timeZone']);
     let fields = ES.PrepareTemporalFields(this, fieldNames, ['timeZone', 'offset']);
     fields = ES.CalendarMergeFields(calendar, fields, partialZonedDateTime);
@@ -210,6 +209,7 @@ export class ZonedDateTime {
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
       ES.InterpretTemporalDateTimeFields(calendar, fields, options);
     const offsetNs = ES.ParseTimeZoneOffsetString(fields.offset);
+    const timeZone = GetSlot(this, TIME_ZONE);
     const epochNanoseconds = ES.InterpretISODateTimeOffset(
       year,
       month,
@@ -228,7 +228,7 @@ export class ZonedDateTime {
       /* matchMinute = */ false
     );
 
-    return ES.CreateTemporalZonedDateTime(epochNanoseconds, GetSlot(this, TIME_ZONE), calendar);
+    return ES.CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar);
   }
   withPlainDate(temporalDate) {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1394,22 +1394,21 @@
           <h1>
             CalendarDateToISO (
               _calendar_: a String,
-              _fields_: an ordinary null-prototype Object with one or more own data properties and no accessor properties,
+              _fields_: an ordinary Object for which the value of the [[Prototype]] internal slot is *null* and every property is a data property,
               _overflow_: *"constrain"* or *"reject"*,
             ): either a normal completion containing an ISO Date Record, or an abrupt completion
           </h1>
           <dl class="header">
             <dt>description</dt>
             <dd>
-              It performs implementation-defined processing to convert _fields_, that describes a date in the calendar represented by _calendar_, to the ISO calendar.
-              It performs the overflow correction given by _overflow_ on the date described by _fields_ in order to arrive at a valid month code and day pair in _calendar_.
+              It performs implementation-defined processing to convert _fields_, which describes a date in the calendar represented by _calendar_, to the ISO 8601 calendar, subject to processing specified by _overflow_.
               For *"reject"*, values that do not form a valid date cause an exception to be thrown, as described below.
               For *"constrain"*, values that do not form a valid date are clamped to the correct range.
               It then returns an ISO Date Record with the corresponding ISO date.
             </dd>
           </dl>
           <p>
-            The operation throws a *TypeError* exception if the own data properties present on _fields_ are insufficient to calculate a date in _calendar_.
+            The operation throws a *TypeError* exception if the properties present on _fields_ are insufficient to identify a unique date in _calendar_.
             For example, for a _calendar_ that uses eras, a *TypeError* is thrown if _fields_ does not include any of the following minimum combinations of properties:
           </p>
           <ul>
@@ -1419,7 +1418,7 @@
             <li>*"era"*, *"eraYear"*, *"month"*, *"day"*</li>
           </ul>
           <p>
-            The operation throws a *RangeError* exception if the date described by _fields_ forms a date outside the range allowed by ISODateTimeWithinLimits, or if _overflow_ is *"reject"* and the date described by _fields_ does not exist.
+            The operation throws a *RangeError* exception if the date described by _fields_ is outside the range allowed by ISODateTimeWithinLimits, or if _overflow_ is *"reject"* and the date described by _fields_ does not exist.
           </p>
         </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1435,7 +1435,7 @@
           <dl class="header">
             <dt>description</dt>
             <dd>
-              It performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by _calendar_ and returns the corresponding day, month and year of the result in the ISO calendar values as an ISO Date Record.
+              It performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by _calendar_ and returns the corresponding day, month and year of the result in the ISO 8601 calendar values as an ISO Date Record.
               It may throw a *RangeError* exception if _overflow_ is *"reject"* and the resulting month or day would need to be clamped in order to form a valid date in _calendar_, or if the date resulting from the addition is outside the range allowed by ISODateTimeWithinLimits.
             </dd>
           </dl>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -450,11 +450,6 @@
               1. If _v_ is 0 and <del>_dateTimeFormat_.[[HourCycle]]</del><ins>_pattern_.[[hourCycle]]</ins> is *"h12"*, let _v_ be 12.
             1. If _p_ is *"hour"* and <del>_dateTimeFormat_.[[HourCycle]]</del><ins>_pattern_.[[hourCycle]]</ins> is *"h24"*, then
               1. If _v_ is 0, let _v_ be 24.
-            1. <ins>If _p_ is *"timeZoneName"*, then</ins>
-              1. <ins>If _tm_ has a [[timeZoneName]] field, then</ins>
-                1. <ins>Set _v_ to _tm_.[[timeZoneName]].</ins>
-              1. <ins>Else,</ins>
-                1. <ins>Set _v_ to _dateTimeFormat_.[[TimeZone]].</ins>
             1. If _f_ is *"numeric"*, then
               1. Let _fv_ be FormatNumeric(_nf_, _v_).
             1. Else if _f_ is *"2-digit"*, then

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -833,7 +833,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>The return value is *true* if the combination of a date in the ISO calendar with a wall-clock time, given by the arguments, is within the representable range of `Temporal.PlainDateTime`, and *false* otherwise.</dd>
+        <dd>The return value is *true* if the combination of a date in the ISO 8601 calendar with a wall-clock time, given by the arguments, is within the representable range of `Temporal.PlainDateTime`, and *false* otherwise.</dd>
       </dl>
       <emu-note>
         <p>
@@ -855,7 +855,7 @@
     <emu-clause id="sec-temporal-interprettemporaldatetimefields" aoid="InterpretTemporalDateTimeFields">
       <h1>InterpretTemporalDateTimeFields ( _calendar_, _fields_, _options_ )</h1>
       <p>
-        The abstract operation InterpretTemporalDateTimeFields interprets the date/time fields in the object _fields_ using the given _calendar_, and returns a Record with the fields according to the ISO calendar.
+        The abstract operation InterpretTemporalDateTimeFields interprets the date/time fields in the object _fields_ using the given _calendar_, and returns a Record with the fields according to the ISO 8601 calendar.
       </p>
       <emu-alg>
         1. Let _timeResult_ be ? ToTemporalTimeRecord(_fields_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -585,7 +585,6 @@
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"month"*, *"monthCode"*, *"nanosecond"*, *"second"*, *"year"* »).
         1. Append *"offset"* to _fieldNames_.
         1. Let _partialZonedDateTime_ be ? PrepareTemporalFields(_temporalZonedDateTimeLike_, _fieldNames_, ~partial~).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Append *"timeZone"* to _fieldNames_.
         1. Let _fields_ be ? PrepareTemporalFields(_zonedDateTime_, _fieldNames_, « *"timeZone"*, *"offset"* »).
         1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialZonedDateTime_).
@@ -599,6 +598,7 @@
         1. Assert: Type(_offsetString_) is String.
         1. If IsTimeZoneOffsetString(_offsetString_) is *false*, throw a *RangeError* exception.
         1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_offsetString_).
+        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_, ~match exactly~).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>


### PR DESCRIPTION
- Refer to "ISO 8601 calendar" instead of "ISO calendar"
- Remove some dead code that became dead when 'rebasing' the proposal on a newer commit of ECMA-402 that already included this code
- Minor language and readability tweaks