### PR TITLE
Add lifetime-of-agent note in CanonicalizeTimeZoneName

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -86,7 +86,9 @@
         <dt>redefinition</dt>
         <dd>true</dd>
       </dl>
-
+      <p>
+        <ins>Given the same value of _timeZone_, the result must be the same for the lifetime of the surrounding agent.</ins>
+      </p>
       <emu-alg>
         1. Let _ianaTimeZone_ be the String value of the Zone or Link name of the IANA Time Zone Database that is an ASCII-case-insensitive match of _timeZone_.
         1. If _ianaTimeZone_ is a Link name, let _ianaTimeZone_ be the String value of the corresponding Zone name as specified in the file <code>backward</code> of the IANA Time Zone Database.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -87,10 +87,10 @@
         <dd>true</dd>
       </dl>
       <p>
-        <ins>Given the same value of _timeZone_, the result must be the same for the lifetime of the surrounding agent.</ins>
+        <ins>Given the same value of _timeZone_ or any value that is an ASCII-case-insensitive match for it, the result must be the same for the lifetime of the surrounding agent.</ins>
       </p>
       <emu-alg>
-        1. Let _ianaTimeZone_ be the String value of the Zone or Link name of the IANA Time Zone Database that is an ASCII-case-insensitive match of _timeZone_.
+        1. Let _ianaTimeZone_ be the String value of the Zone or Link name of the IANA Time Zone Database that is an ASCII-case-insensitive match for _timeZone_.
         1. If _ianaTimeZone_ is a Link name, let _ianaTimeZone_ be the String value of the corresponding Zone name as specified in the file <code>backward</code> of the IANA Time Zone Database.
         1. If _ianaTimeZone_ is *"Etc/UTC"* or *"Etc/GMT"*, return *"UTC"*.
         1. Return _ianaTimeZone_.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -15,10 +15,9 @@
       In addition, implementations may support any number of other built-in time zones.
     </p>
     <p>
-      Built-in time zones may be <dfn variants="named time zone">named time zones</dfn>, represented by Strings for which IsAvailableTimeZoneName returns *true*.
-      Caller-supplied names of named time zones can be aliases for <dfn variants="canonical time zone">canonical time zones</dfn>.
-      CanonicalizeTimeZoneName is used to translate aliases into canonical time zone names.
-      They may also be <dfn variants="offset time zone">offset time zones</dfn>, represented by Strings for which IsTimeZoneOffsetString returns *true*.
+      A built-in time zone may be a <dfn variants="named time zones">named time zone</dfn>, represented by a String for which IsAvailableTimeZoneName returns *true*.
+      Some of those Strings are <dfn variants="canonical time zone name">canonical time zone names</dfn> for which CanonicalizeTimeZoneName returns its input unmodified, while each other one is an <em>alias</em> for a canonical time zone name (for example, *"utc"* and *"Utc"* and [if supported by IsAvailableTimeZoneName] *"Etc/UTC"* are aliases for *"UTC"*, and the IANA Time Zone Database defines many other aliases as “Links”).
+      A built-in time zone may also be an <dfn variants="offset time zones">offset time zone</dfn>, represented by a String for which IsTimeZoneOffsetString returns *true*.
     </p>
     <p>
       <emu-xref href="#sec-temporal-timezone-constructor">The `Temporal.TimeZone` constructor</emu-xref>, when called with the name of a built-in time zone as the argument, will return a valid `Temporal.TimeZone` object.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -16,6 +16,8 @@
     </p>
     <p>
       Built-in time zones may be <dfn variants="named time zone">named time zones</dfn>, represented by Strings for which IsAvailableTimeZoneName returns *true*.
+      Caller-supplied names of named time zones can be aliases for <dfn variants="canonical time zone">canonical time zones</dfn>.
+      CanonicalizeTimeZoneName is used to translate aliases into canonical time zone names.
       They may also be <dfn variants="offset time zone">offset time zones</dfn>, represented by Strings for which IsTimeZoneOffsetString returns *true*.
     </p>
     <p>
@@ -26,6 +28,28 @@
       An ECMAScript implementation that includes the ECMA-402 Internationalization API must define built-in named time zones in correspondence with the Zone and Link names of the IANA Time Zone Database (and <strong>only</strong> such names) and use best available current and historical information about their offsets from UTC and their daylight saving time rules in calculations as specified in the ECMA-402 specification.
       Other implementations are encouraged to do the same.
     </p>
+
+    <emu-clause id="sec-time-zone-data-updates">
+      <h1>Handling Updates and Ensuring Consistency of Time Zone Data</h1>
+      <p>
+        The IANA Time Zone Database is frequently updated, averaging 10 annual releases in recent years.
+        An ECMAScript implementation is strongly encouraged to use the most recent version of the IANA Time Zone Database that was available when the implementation was released.
+      </p>
+      <p>
+        It is also acceptable for implementations to update time zone data dynamically, either directly by loading a new version of the IANA Time Zone Database or indirectly by calling an external, dynamically-updated source like an operating system.
+        It is allowed for these updates to happen during the lifetime of the surrounding agent.
+        However, to ensure that ECMAScript programs can depend on a consistent view of time zone data, this specification places the following requirements on ECMAScript implementations that dynamically update time zone data:
+      </p>
+      <ul>
+        <li>
+          After time zone data for a particular canonical named time zone is used during the lifetime of the surrounding agent, equivalent time zone data must be used for the lifetime of the surrounding agent for all subsequent use of the same canonical time zone name.
+          However, implementations are allowed to use different versions of time zone data for different canonical time zone names.
+        </li>
+        <li>
+          Any time zone name string, when evaluated ASCII-case-insensitively, must be canonicalized to the same canonical time zone name for the lifetime of the surrounding agent.
+        </li>
+      </ul>
+    </emu-clause>
 
     <emu-clause id="sec-isavailabletimezonename" type="abstract operation">
       <h1>


### PR DESCRIPTION
The CanonicalizeTimeZoneName AO should be stable across the lifetime of the agent, like other TZ info operations such as [15.4.22 ToLocalTime](https://tc39.es/proposal-temporal/#sec-temporal-tolocaltime).

My understanding was that TZ data that's specific to a single time zone is guaranteed to remain invariant for the lifetime of the surrounding agent. I believe that canonicalization should have been included in this guarantee, but was missed in the spec text. 

Is this a normative change?