### PR TITLE
Editorial: Remove non-text content from `*` format wrappers

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -69,7 +69,7 @@
       <emu-alg>
         1. Set _epochSeconds_ to ? ToNumber(_epochSeconds_).
         1. Set _epochSeconds_ to ? NumberToBigInt(_epochSeconds_).
-        1. Let _epochNanoseconds_ be _epochSeconds_ &times; *10<sup>9</sup>*<sub>ℤ</sub>.
+        1. Let _epochNanoseconds_ be _epochSeconds_ &times; ℤ(10<sup>9</sup>).
         1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
@@ -83,7 +83,7 @@
       <emu-alg>
         1. Set _epochMilliseconds_ to ? ToNumber(_epochMilliseconds_).
         1. Set _epochMilliseconds_ to ? NumberToBigInt(_epochMilliseconds_).
-        1. Let _epochNanoseconds_ be _epochMilliseconds_ &times; *10<sup>6</sup>*<sub>ℤ</sub>.
+        1. Let _epochNanoseconds_ be _epochMilliseconds_ &times; ℤ(10<sup>6</sup>).
         1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
@@ -579,10 +579,10 @@
       <emu-alg>
         1. Let _result_ be _epochNanoseconds_ + ℤ(_nanoseconds_) +
             ℤ(_microseconds_) &times; *1000*<sub>ℤ</sub> +
-            ℤ(_milliseconds_) &times; *10<sup>6</sup>*<sub>ℤ</sub> +
-            ℤ(_seconds_) &times; *10<sup>9</sup>*<sub>ℤ</sub> +
-            ℤ(_minutes_) &times; *60*<sub>ℤ</sub> &times; *10<sup>9</sup>*<sub>ℤ</sub> +
-            ℤ(_hours_) &times; *3600*<sub>ℤ</sub> &times; *10<sup>9</sup>*<sub>ℤ</sub>.
+            ℤ(_milliseconds_) &times; ℤ(10<sup>6</sup>) +
+            ℤ(_seconds_) &times; ℤ(10<sup>9</sup>) +
+            ℤ(_minutes_) &times; *60*<sub>ℤ</sub> &times; ℤ(10<sup>9</sup>) +
+            ℤ(_hours_) &times; *3600*<sub>ℤ</sub> &times; ℤ(10<sup>9</sup>).
         1. If ! IsValidEpochNanoseconds(_result_) is *false*, throw a *RangeError* exception.
         1. Return _result_.
       </emu-alg>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -951,7 +951,7 @@
         1. Set _x_ to ? ToNumber(_x_).
       1. Set _x_ to TimeClip(_x_).
       1. If _x_ is *NaN*, throw a *RangeError* exception.
-      1. Let _epochNanoseconds_ be ℤ(_x_) &times; *10<sup>6</sup>*<sub>ℤ</sub>.
+      1. Let _epochNanoseconds_ be ℤ(_x_) &times; ℤ(10<sup>6</sup>).
       1. Return the Record {
           [[pattern]]: _pattern_,
           [[rangePatterns]]: _rangePatterns_,


### PR DESCRIPTION
Elements are _technically_ allowed inside ecmarkdown `*` language value format wrappers, but it seems like bad form and slightly confusing (since there is no similar form within the language to express those values). This PR replaces such uses, all of which involve BigInt powers of 10.
```diff
-*10<sup>x</sup>*<sub>ℤ</sub>
+ℤ(10<sup>x</sup>)
```