### PR TITLE
Prevent auto-link of "safe" in "DST-safe"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -13,7 +13,7 @@ markEffects: true
   <p>The venerable ECMAScript Date object has a number of challenges, including lack of immutability, lack of support for time zones, lack of support for use cases that require dates only or times only, a confusing and non-ergonomic API, and many other challenges.</p>
   <p>The Temporal set of types addresses these challenges with a built-in date and time API for ECMAScript that includes:</p>
   <ul>
-    <li>First-class support for all time zones, including DST-safe arithmetic</li>
+    <li>First-class support for all time zones, including DST-<emu-not-ref>safe</emu-not-ref> arithmetic</li>
     <li>Strongly-typed objects for dates, times, date/<emu-not-ref>time values</emu-not-ref>, year/month values, month/year values, "zoned" date/<emu-not-ref>time values</emu-not-ref>, and durations</li>
     <li>Immutability for all Temporal objects</li>
     <li>String serialization and interoperability via standardized formats</li>


### PR DESCRIPTION
Thanks to @bakkot for teaching me about [`<emu-not-ref>`](https://tc39.es/ecmarkup/#emu-not-ref) !