### PR TITLE
Normative: Prevent mergeFields from reordering properties

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -115,9 +115,9 @@ export class Calendar {
     const additionalFieldsCopy = ObjectCreate(null);
     ES.CopyDataProperties(additionalFieldsCopy, additionalFields, [], [undefined]);
     const additionalKeys = ObjectKeys(additionalFieldsCopy);
-    const ignoredKeys = impl[GetSlot(this, CALENDAR_ID)].fieldKeysToIgnore(additionalKeys);
+    const overriddenKeys = impl[GetSlot(this, CALENDAR_ID)].fieldKeysToIgnore(additionalKeys);
     const merged = ObjectCreate(null);
-    ES.CopyDataProperties(merged, fieldsCopy, ignoredKeys, [undefined]);
+    ES.CopyDataProperties(merged, fieldsCopy, overriddenKeys, [undefined]);
     ES.CopyDataProperties(merged, additionalFieldsCopy, []);
     return merged;
   }

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1394,7 +1394,15 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _overriddenKeys_ be ISOFieldKeysToIgnore(_additionalKeys_).
         1. Let _merged_ be OrdinaryObjectCreate(*null*).
-        1. Perform ! CopyDataProperties(_merged_, _fieldsCopy_, _overriddenKeys_, « *undefined* »).
+        1. NOTE: The following steps ensure that property iteration order of _merged_ matches that of _fields_ as modified by omitting overridden properties and appending non-overlapping properties from _additionalFields_ in iteration order.
+        1. Let _fieldsKeys_ be ! _fieldsCopy_.[[OwnPropertyKeys]]().
+        1. For each element _key_ of _fieldsKeys_, do
+          1. Let _propValue_ be *undefined*.
+          1. If _overriddenKeys_ contains _key_, then
+            1. Set _propValue_ to ! Get(_additionalFieldsCopy_, _key_).
+          1. Else,
+            1. Set _propValue_ to ! Get(_fieldsCopy_, _key_).
+          1. If _propValue_ is not *undefined*, perform ! CreateDataPropertyOrThrow(_merged_, _key_, _propValue_).
         1. Perform ! CopyDataProperties(_merged_, _additionalFieldsCopy_, « »).
         1. Return _merged_.
       </emu-alg>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1389,7 +1389,7 @@
         1. Set _additionalFields_ to ? ToObject(_additionalFields_).
         1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(*null*).
         1. Perform ? CopyDataProperties(_additionalFieldsCopy_, _additionalFields_, « », « *undefined* »).
-        1. NOTE: Every property of _fieldsCopy_ and _additionalFieldsCopy_ is an enumerable data property with non-*undefined* value, but some property keys may be Symbols.
+        1. NOTE: Every property of _fieldsCopy_ and _additionalFieldsCopy_ is an enumerable data property with a non-*undefined* value, but some property keys may be Symbols.
         1. Let _additionalKeys_ be ! _additionalFieldsCopy_.[[OwnPropertyKeys]]().
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. Let _overriddenKeys_ be ISOFieldKeysToIgnore(_additionalKeys_).

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1389,12 +1389,12 @@
         1. Set _additionalFields_ to ? ToObject(_additionalFields_).
         1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(*null*).
         1. Perform ? CopyDataProperties(_additionalFieldsCopy_, _additionalFields_, « », « *undefined* »).
-        1. NOTE: Every property of _additionalFieldsCopy_ is a data property with non-*undefined* value, but some property keys may be Symbols.
+        1. NOTE: Every property of _fieldsCopy_ and _additionalFieldsCopy_ is an enumerable data property with non-*undefined* value, but some property keys may be Symbols.
         1. Let _additionalKeys_ be ! _additionalFieldsCopy_.[[OwnPropertyKeys]]().
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
-        1. Let _ignoredKeys_ be ISOFieldKeysToIgnore(_additionalKeys_).
+        1. Let _overriddenKeys_ be ISOFieldKeysToIgnore(_additionalKeys_).
         1. Let _merged_ be OrdinaryObjectCreate(*null*).
-        1. Perform ! CopyDataProperties(_merged_, _fieldsCopy_, _ignoredKeys_, « *undefined* »).
+        1. Perform ! CopyDataProperties(_merged_, _fieldsCopy_, _overriddenKeys_, « *undefined* »).
         1. Perform ! CopyDataProperties(_merged_, _additionalFieldsCopy_, « »).
         1. Return _merged_.
       </emu-alg>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2275,7 +2275,15 @@
             1. Else,
               1. Let _overriddenKeys_ be CalendarFieldKeysToIgnore(_calendar_, _additionalKeys_).
             1. Let _merged_ be OrdinaryObjectCreate(*null*).
-            1. Perform ! CopyDataProperties(_merged_, _fieldsCopy_, _overriddenKeys_, « *undefined* »).
+            1. NOTE: The following steps ensure that property iteration order of _merged_ matches that of _fields_ as modified by omitting overridden properties and appending non-overlapping properties from _additionalFields_ in iteration order.
+            1. Let _fieldsKeys_ be ! _fieldsCopy_.[[OwnPropertyKeys]]().
+            1. For each element _key_ of _fieldsKeys_, do
+              1. Let _propValue_ be *undefined*.
+              1. If _overriddenKeys_ contains _key_, then
+                1. Set _propValue_ to ! Get(_additionalFieldsCopy_, _key_).
+              1. Else,
+                1. Set _propValue_ to ! Get(_fieldsCopy_, _key_).
+              1. If _propValue_ is not *undefined*, perform ! CreateDataPropertyOrThrow(_merged_, _key_, _propValue_).
             1. Perform ! CopyDataProperties(_merged_, _additionalFieldsCopy_, « »).
             1. Return _merged_.
           </emu-alg>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2268,7 +2268,7 @@
             1. Set _additionalFields_ to ? ToObject(_additionalFields_).
             1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(*null*).
             1. Perform ? CopyDataProperties(_additionalFieldsCopy_, _additionalFields_, « », « *undefined* »).
-            1. NOTE: Every property of _additionalFieldsCopy_ is a data property with non-*undefined* value, but some property keys may be Symbols.
+            1. NOTE: Every property of _fieldsCopy_ and _additionalFieldsCopy_ is an enumerable data property with non-*undefined* value, but some property keys may be Symbols.
             1. Let _additionalKeys_ be ! _additionalFieldsCopy_.[[OwnPropertyKeys]]().
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _overriddenKeys_ be ISOFieldKeysToIgnore(_additionalKeys_).


### PR DESCRIPTION
Fixes #2504

test262 PR: https://github.com/tc39/test262/pull/3789