### PR TITLE
Editorial: Improve alignment between ISO 8601 vs. other-calendar operations

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -741,14 +741,13 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-isodatefromfields" aoid="ISODateFromFields">
-      <h1>ISODateFromFields ( _fields_, _options_ )</h1>
+      <h1>ISODateFromFields ( _fields_, _overflow_ )</h1>
       <p>
         The ISODateFromFields abstract operation implements the calendar-specific logic in the `Temporal.Calendar.prototype.dateFromFields` method for the ISO 8601 calendar.
       </p>
       <emu-alg>
         1. Assert: Type(_fields_) is Object.
-        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », « *"year"*, *"day"* »).
-        1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. Let _year_ be ! Get(_fields_, *"year"*).
         1. Assert: Type(_year_) is Number.
         1. Let _month_ be ? ResolveISOMonth(_fields_).
@@ -759,15 +758,14 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-isoyearmonthfromfields" aoid="ISOYearMonthFromFields">
-      <h1>ISOYearMonthFromFields ( _fields_, _options_ )</h1>
+      <h1>ISOYearMonthFromFields ( _fields_, _overflow_ )</h1>
       <p>
         The ISOYearMonthFromFields abstract operation implements the calendar-specific logic in the `Temporal.Calendar.prototype.yearMonthFromFields` method for the ISO 8601 calendar.
         It returns a Record with three fields ([[Year]], [[Month]], and [[ReferenceISODay]]). All are integers.
       </p>
       <emu-alg>
         1. Assert: Type(_fields_) is Object.
-        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"month"*, *"monthCode"*, *"year"* », « *"year"* »).
-        1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. Let _year_ be ! Get(_fields_, *"year"*).
         1. Assert: Type(_year_) is Number.
         1. Let _month_ be ? ResolveISOMonth(_fields_).
@@ -781,14 +779,13 @@
     </emu-clause>
 
     <emu-clause id="sec-temporal-isomonthdayfromfields" aoid="ISOMonthDayFromFields">
-      <h1>ISOMonthDayFromFields ( _fields_, _options_ )</h1>
+      <h1>ISOMonthDayFromFields ( _fields_, _overflow_ )</h1>
       <p>
         The ISOMonthDayFromFields abstract operation implements the calendar-specific logic in the `Temporal.Calendar.prototype.monthDayFromFields` method for the ISO 8601 calendar.
       </p>
       <emu-alg>
         1. Assert: Type(_fields_) is Object.
-        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
-        1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. Let _month_ be ! Get(_fields_, *"month"*).
         1. Let _monthCode_ be ! Get(_fields_, *"monthCode"*).
         1. Let _year_ be ! Get(_fields_, *"year"*).
@@ -992,7 +989,9 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_fields_) is not Object, throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _result_ be ? ISODateFromFields(_fields_, _options_).
+        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », « *"year"*, *"day"* »).
+        1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Let _result_ be ? ISODateFromFields(_fields_, _overflow_).
         1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       </emu-alg>
     </emu-clause>
@@ -1012,7 +1011,9 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_fields_) is not Object, throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _options_).
+        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"month"*, *"monthCode"*, *"year"* », « *"year"* »).
+        1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _overflow_).
         1. Return ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[ReferenceISODay]]).
       </emu-alg>
     </emu-clause>
@@ -1032,7 +1033,9 @@
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.
         1. If Type(_fields_) is not Object, throw a *TypeError* exception.
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _options_).
+        1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
+        1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _overflow_).
         1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _result_.[[ReferenceISOYear]]).
       </emu-alg>
     </emu-clause>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -107,6 +107,7 @@
         The CalendarFields abstract operation transforms a List of String values _fieldNames_ into another List of String values by calling the `fields` method of the given _calendar_ Object.
       </p>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.fields"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.fields"></emu-xref>.
         1. Let _fieldsArray_ be ? Invoke(_calendar_, *"fields"*, « CreateArrayFromList(_fieldNames_) »).
         1. Return ? IterableToListOfType(_fieldsArray_, « String »).
       </emu-alg>
@@ -118,6 +119,7 @@
         The CalendarMergeFields abstract operation merges the properties of two Objects _fields_ and _additionalFields_ by calling the `mergeFields` method of the given _calendar_ Object.
       </p>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.mergefields"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.mergefields"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"mergeFields"*, « _fields_, _additionalFields_ »).
         1. If Type(_result_) is not Object, throw a *TypeError* exception.
         1. Return _result_.
@@ -144,6 +146,7 @@
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
         1. If _dateAdd_ is not present, set _dateAdd_ to ? GetMethod(_calendar_, *"dateAdd"*).
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.dateadd"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.dateadd"></emu-xref>.
         1. Let _addedDate_ be ? Call(_dateAdd_, _calendar_, « _date_, _duration_, _options_ »).
         1. Perform ? RequireInternalSlot(_addedDate_, [[InitializedTemporalDate]]).
         1. Return _addedDate_.
@@ -169,6 +172,7 @@
       </dl>
       <emu-alg>
         1. If _dateUntil_ is not present, set _dateUntil_ to ? GetMethod(_calendar_, *"dateUntil"*).
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.dateuntil"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.dateuntil"></emu-xref>.
         1. Let _duration_ be ? Call(_dateUntil_, _calendar_, « _one_, _two_, _options_ »).
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Return _duration_.
@@ -187,6 +191,7 @@
         <dd>It calls the given _calendar_'s `year()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.year"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.year"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"year"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -206,6 +211,7 @@
         <dd>It calls the given _calendar_'s `month()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.month"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.month"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"month"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -226,6 +232,7 @@
         <dd>It calls the given _calendar_'s `monthCode()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.monthcode"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.monthcode"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"monthCode"*, « _dateLike_ »).
         1. If Type(_result_) is not String, throw a *TypeError* exception.
         1. Return _result_.
@@ -244,6 +251,7 @@
         <dd>It calls the given _calendar_'s `day()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.day"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.day"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"day"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -264,6 +272,7 @@
         <dd>It calls the given _calendar_'s `dayOfWeek()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.dayofweek"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.dayofweek"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfWeek"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -284,6 +293,7 @@
         <dd>It calls the given _calendar_'s `dayOfYear()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.dayofyear"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.dayofyear"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"dayOfYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -304,6 +314,7 @@
         <dd>It calls the given _calendar_'s `weekOfYear()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.weekofyear"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.weekofyear"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"weekOfYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -324,6 +335,7 @@
         <dd>It calls the given _calendar_'s `yearOfWeek()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.yearofweek"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.yearofweek"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"yearOfWeek"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -343,6 +355,7 @@
         <dd>It calls the given _calendar_'s `daysInWeek()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.daysinweek"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.daysinweek"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"daysInWeek"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -363,6 +376,7 @@
         <dd>It calls the given _calendar_'s `daysInMonth()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.daysinmonth"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.daysinmonth"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"daysInMonth"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -383,6 +397,7 @@
         <dd>It calls the given _calendar_'s `daysInYear()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.daysinyear"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.daysinyear"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"daysInYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -403,6 +418,7 @@
         <dd>It calls the given _calendar_'s `monthsInYear()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.monthsinyear"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.monthsinyear"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"monthsInYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
@@ -423,6 +439,7 @@
         <dd>It calls the given _calendar_'s `inLeapYear()` method and validates the result.</dd>
       </dl>
       <emu-alg>
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.inleapyear"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.inleapyear"></emu-xref>.
         1. Let _result_ be ? Invoke(_calendar_, *"inLeapYear"*, « _dateLike_ »).
         1. If Type(_result_) is not Boolean, throw a *TypeError* exception.
         1. Return _result_.
@@ -491,6 +508,7 @@
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.datefromfields"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.datefromfields"></emu-xref>.
         1. Let _date_ be ? Invoke(_calendar_, *"dateFromFields"*, « _fields_, _options_ »).
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Return _date_.
@@ -511,6 +529,7 @@
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.yearmonthfromfields"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.yearmonthfromfields"></emu-xref>.
         1. Let _yearMonth_ be ? Invoke(_calendar_, *"yearMonthFromFields"*, « _fields_, _options_ »).
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Return _yearMonth_.
@@ -531,6 +550,7 @@
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
+        1. NOTE: If _calendar_ is a built-in object, then the following step will usually invoke <emu-xref href="#sec-temporal.calendar.prototype.monthdayfromfields"></emu-xref> or <emu-xref href="#sup-temporal.calendar.prototype.monthdayfromfields"></emu-xref>.
         1. Let _monthDay_ be ? Invoke(_calendar_, *"monthDayFromFields"*, « _fields_, _options_ »).
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Return _monthDay_.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1716,11 +1716,11 @@
             CalendarDateFields (
               _calendar_: a String,
               _fields_: a List of Strings,
-            )
+            ): a List of Strings
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It takes a list of standard fields in _fields_ that are necessary for a given operation and returns a new list by adding relevant calendar-specific fields for the calendar represented by _calendar_. This is relevant for calendars which accept fields other than the standard set of built-in calendar fields.</dd>
+            <dd>It interprets _fields_ as the names of fields (<emu-xref href="#table-temporal-field-requirements"></emu-xref>) necessary for a given operation and returns a new List by appending the names of additional calendar-specific fields that are relevant for the built-in calendar identified by _calendar_. For example, *"era"* and *"eraYear"* are appended when _calendar_ is *"gregory"* or *"japanese"*.</dd>
           </dl>
         </emu-clause>
 
@@ -2223,7 +2223,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be _fieldNames_.
             1. Else,
-              1. Let _result_ be ! CalendarDateFields(_calendar_.[[Identifier]], _fieldNames_).
+              1. Let _result_ be CalendarDateFields(_calendar_.[[Identifier]], _fieldNames_).
             1. Return CreateArrayFromList(_result_).
           </emu-alg>
         </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1411,24 +1411,22 @@
           <dl class="header">
             <dt>description</dt>
             <dd>
-              It performs implementation-defined processing to convert _fields_, which describes a date in the calendar represented by _calendar_, to the ISO 8601 calendar, subject to processing specified by _overflow_.
+              It performs implementation-defined processing to convert _fields_, which describes a date in the built-in calendar identified by _calendar_, to the ISO 8601 calendar, subject to processing specified by _overflow_.
               For *"reject"*, values that do not form a valid date cause an exception to be thrown, as described below.
               For *"constrain"*, values that do not form a valid date are clamped to the correct range.
               It then returns an ISO Date Record with the corresponding ISO date.
             </dd>
           </dl>
           <p>
-            The operation throws a *TypeError* exception if the properties present on _fields_ are insufficient to identify a unique date in _calendar_.
-            For example, for a _calendar_ that uses eras, a *TypeError* is thrown if _fields_ does not include any of the following minimum combinations of properties:
+            Like ISODateFromFields, the operation throws a *TypeError* exception if the properties of _fields_ are insufficient to identify a unique date in the calendar. For example:
           </p>
           <ul>
-            <li>*"year"*, *"monthCode"*, *"day"*</li>
-            <li>*"year"*, *"month"*, *"day"*</li>
-            <li>*"era"*, *"eraYear"*, *"monthCode"*, *"day"*</li>
-            <li>*"era"*, *"eraYear"*, *"month"*, *"day"*</li>
+            <li>If *"day"* has the usual interpretation in the calendar and the corresponding value is *undefined*.</li>
+            <li>If *"month"* and *"monthCode"* have the usual interpretation in the calendar and either the corresponding values for both are *undefined* or neither value is *undefined* but they do not identify the same month.</li>
+            <li>If the calendar supports the usual partitioning of years into eras with their own year counting (as in the Gregorian or traditional Japanese calendars) as represented by *"year"*, *"era"*, and *"eraYear"* and either the corresponding values for all three are *undefined*, or the value for one but not both of *"era"* and *"eraYear"* is *undefined*, or none of the three values are *undefined* but the values for *"era"* and *"eraYear"* do not together identify the same year as the value for *"year"*.</li>
           </ul>
           <p>
-            The operation throws a *RangeError* exception if the date described by _fields_ is outside the range allowed by ISODateTimeWithinLimits, or if _overflow_ is *"reject"* and the date described by _fields_ does not exist.
+            Like RegulateISODate, the operation throws a *RangeError* exception if the date described by _fields_ is outside the range allowed by ISODateTimeWithinLimits, or if _overflow_ is *"reject"* and the date described by _fields_ does not exist.
           </p>
         </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1805,12 +1805,16 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. If Type(_fields_) is not Object, throw a *TypeError* exception.
             1. Set _options_ to ? GetOptionsObject(_options_).
+            1. Let _relevantFieldNames_ be « *"day"*, *"month"*, *"monthCode"*, *"year"* ».
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _result_ be ? ISODateFromFields(_fields_, _options_).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _relevantFieldNames_, « *"year"*, *"day"* »).
             1. Else,
-              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], _relevantFieldNames_).
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
-              1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+            1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+            1. If _calendar_.[[Identifier]] is *"iso8601"*, then
+              1. Let _result_ be ? ISODateFromFields(_fields_, _overflow_).
+            1. Else,
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
           </emu-alg>
@@ -1827,14 +1831,18 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. If Type(_fields_) is not Object, throw a *TypeError* exception.
             1. Set _options_ to ? GetOptionsObject(_options_).
+            1. Let _relevantFieldNames_ be « *"month"*, *"monthCode"*, *"year"* ».
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _options_).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _relevantFieldNames_, « *"year"* »).
             1. Else,
-              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"month"*, *"monthCode"*, *"year"* »).
+              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], _relevantFieldNames_).
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
-              1. Let _overflow_ be ? ToTemporalOverflow(_options_).
               1. Let _firstDayIndex_ be the 1-based index of the first day of the month described by _fields_ (i.e., 1 unless the month's first day is skipped by this calendar.)
               1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, 𝔽(_firstDayIndex_)).
+            1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+            1. If _calendar_.[[Identifier]] is *"iso8601"*, then
+              1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _overflow_).
+            1. Else,
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISODay]] to _result_.[[Day]].
             1. Return ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[ReferenceISODay]]).
@@ -1852,12 +1860,16 @@
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
             1. If Type(_fields_) is not Object, throw a *TypeError* exception.
             1. Set _options_ to ? GetOptionsObject(_options_).
+            1. Let _relevantFieldNames_ be « *"day"*, *"month"*, *"monthCode"*, *"year"* ».
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _options_).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _relevantFieldNames_, « *"day"* »).
             1. Else,
-              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], _relevantFieldNames_).
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
-              1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+            1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+            1. If _calendar_.[[Identifier]] is *"iso8601"*, then
+              1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _overflow_).
+            1. Else,
               1. Let _result_ be ? CalendarMonthDayToISOReferenceDate(_calendar_.[[Identifier]], _fields_, _overflow_).
             1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _result_.[[ReferenceISOYear]]).
           </emu-alg>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1411,20 +1411,12 @@
           <dl class="header">
             <dt>description</dt>
             <dd>
-              It performs implementation-defined processing to convert _fields_, which describes a date in the built-in calendar identified by _calendar_, to the ISO 8601 calendar, subject to processing specified by _overflow_.
+              It performs implementation-defined processing to convert _fields_, which describes a date or year and month or month and day in the built-in calendar identified by _calendar_, to a representative date in the ISO 8601 calendar, subject to processing specified by _overflow_.
               For *"reject"*, values that do not form a valid date cause an exception to be thrown, as described below.
               For *"constrain"*, values that do not form a valid date are clamped to the correct range.
               It then returns an ISO Date Record with the corresponding ISO date.
             </dd>
           </dl>
-          <p>
-            Like ISODateFromFields, the operation throws a *TypeError* exception if the properties of _fields_ are insufficient to identify a unique date in the calendar. For example:
-          </p>
-          <ul>
-            <li>If *"day"* has the usual interpretation in the calendar and the corresponding value is *undefined*.</li>
-            <li>If *"month"* and *"monthCode"* have the usual interpretation in the calendar and either the corresponding values for both are *undefined* or neither value is *undefined* but they do not identify the same month.</li>
-            <li>If the calendar supports the usual partitioning of years into eras with their own year counting (as in the Gregorian or traditional Japanese calendars) as represented by *"year"*, *"era"*, and *"eraYear"* and either the corresponding values for all three are *undefined*, or the value for one but not both of *"era"* and *"eraYear"* is *undefined*, or none of the three values are *undefined* but the values for *"era"* and *"eraYear"* do not together identify the same year as the value for *"year"*.</li>
-          </ul>
           <p>
             Like RegulateISODate, the operation throws a *RangeError* exception if the date described by _fields_ is outside the range allowed by ISODateTimeWithinLimits, or if _overflow_ is *"reject"* and the date described by _fields_ does not exist.
           </p>
@@ -1789,6 +1781,30 @@
             In a _calendar_ such as *"japanese"* where eras do not start and end at year and/or month boundaries, note that the returned List should contain *"era"* and *"eraYear"* if _keys_ contains *"day"*, *"month"*, or *"monthCode"* (not only if it contains *"era"*, *"eraYear"*, or *"year"*, as in the example above) because it's possible for changing the day or month to cause a conflict with the era.
           </emu-note>
         </emu-clause>
+
+        <emu-clause id="sec-temporal-calendarresolvefields" type="abstract operation">
+          <h1>
+            CalendarResolveFields (
+              _calendar_: a String,
+              _fields_: an Object,
+              _type_: ~date~, ~year-month~, or ~month-day~,
+            ): either a normal completion containing ~unused~ or a throw completion
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>
+              It performs implementation-defined processing to validate that _fields_ (which describes a date in the built-in calendar identified by _calendar_) is sufficiently complete to satisfy _type_ and not internally inconsistent, and merges data that can be represented in multiple forms into standard properties of _fields_ (for example, merging *"month"* and *"monthCode"* into *"month"* and merging *"era"* and *"eraYear"* into *"year"*).
+            </dd>
+          </dl>
+          <p>
+            The operation throws a *TypeError* exception if the properties of _fields_ are internally inconsistent within the calendar or insufficient to identify a unique instance of _type_ in the calendar. For example:
+          </p>
+          <ul>
+            <li>If _type_ is ~date~ or ~month-day~ and *"day"* has the usual interpretation in the calendar and the corresponding value is *undefined*.</li>
+            <li>If *"month"* and *"monthCode"* have the usual interpretation in the calendar and either the corresponding values for both are *undefined* or neither value is *undefined* but they do not identify the same month.</li>
+            <li>If _type_ is ~date~ or ~year-month~ and the calendar supports the usual partitioning of years into eras with their own year counting (as in the Gregorian or traditional Japanese calendars) as represented by *"year"*, *"era"*, and *"eraYear"* and the value for one but not both of *"era"* and *"eraYear"* is *undefined*, or none of the three values are *undefined* but the values for *"era"* and *"eraYear"* do not together identify the same year as the value for *"year"*.</li>
+          </ul>
+        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sup-properties-of-the-temporal-calendar-prototype-object">
@@ -1815,6 +1831,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ? ISODateFromFields(_fields_, _overflow_).
             1. Else,
+              1. Perform ? CalendarResolveFields(_calendar_.[[Identifier]], _fields_, ~date~).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
           </emu-alg>
@@ -1843,6 +1860,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _overflow_).
             1. Else,
+              1. Perform ? CalendarResolveFields(_calendar_.[[Identifier]], _fields_, ~year-month~).
               1. Let _result_ be ? CalendarDateToISO(_calendar_.[[Identifier]], _fields_, _overflow_).
               1. Set _result_.[[ReferenceISODay]] to _result_.[[Day]].
             1. Return ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[ReferenceISODay]]).
@@ -1870,6 +1888,7 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _overflow_).
             1. Else,
+              1. Perform ? CalendarResolveFields(_calendar_.[[Identifier]], _fields_, ~month-day~).
               1. Let _result_ be ? CalendarMonthDayToISOReferenceDate(_calendar_.[[Identifier]], _fields_, _overflow_).
             1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _result_.[[ReferenceISOYear]]).
           </emu-alg>


### PR DESCRIPTION
Extracted from #2500