### PR TITLE
Editorial: Remove redundant redefinition of "ASCII-case-insensitive"

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -40,9 +40,6 @@
       <p>
         Once IsAvailableTimeZoneName(_timeZone_) has returned *true*, for the lifetime of the surrounding agent, IsAvailableTimeZoneName(_variant_) must return *true* if _variant_ is an ASCII-case-insensitive match for either _timeZone_ or CanonicalizeTimeZoneName(_timeZone_).
       </p>
-      <p>
-        For the purposes of this section, a String value _A_ is an ASCII-case-insensitive match for String value _B_ if the String value derived from _A_ by replacing each occurrence of a lowercase ASCII letter code unit (0x0061 through 0x007A, inclusive) with the corresponding uppercase ASCII letter code unit (0x0041 through 0x005A, inclusive) while preserving all other code units is exactly the same sequence of code units as the String value that is derived from _B_ in the same way.
-      </p>
 
       <emu-alg>
         1. Let _timeZones_ be AvailableTimeZones().


### PR DESCRIPTION
The definition is already being added to ECMA-262 by https://tc39.es/proposal-temporal/#sec-ecmascript-language-types-string-type .