### PR TITLE
Editorial: Replace FractionalPart by its definition and develop the d…

### DIFF
--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -206,8 +206,7 @@ const utcDesignator = withCode(character('Zz'), (data) => {
   data.z = 'Z';
 });
 const annotationCriticalFlag = character('!');
-const timeFractionalPart = between(1, 9, digit());
-const fraction = seq(decimalSeparator, timeFractionalPart);
+const fraction = seq(decimalSeparator, between(1, 9, digit()));
 
 const dateFourDigitYear = repeat(4, digit());
 
@@ -339,13 +338,14 @@ const annotatedMonthDay = withSyntaxConstraints(
   }
 );
 
-const durationFractionalPart = withCode(between(1, 9, digit()), (data, result) => {
+const durationFraction = withCode(fraction, (data, result) => {
+  result = result.slice(1);
   const fraction = result.padEnd(9, '0');
   data.milliseconds = +fraction.slice(0, 3) * data.factor;
   data.microseconds = +fraction.slice(3, 6) * data.factor;
   data.nanoseconds = +fraction.slice(6, 9) * data.factor;
 });
-const durationFraction = seq(decimalSeparator, durationFractionalPart);
+
 const digitsNotInfinite = withSyntaxConstraints(oneOrMore(digit()), (result) => {
   if (!Number.isFinite(+result)) throw new SyntaxError('try again on infinity');
 });

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -988,11 +988,17 @@
           MinuteSecond
           `60`
 
-      FractionalPart :
-          DecimalDigit DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit? DecimalDigit?
-
       Fraction :
-          DecimalSeparator FractionalPart
+          > Readability note: This production matches a decimal separator followed by 1 to 9 digits
+          DecimalSeparator DecimalDigit
+          DecimalSeparator DecimalDigit DecimalDigit
+          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit
+          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
 
       TimeFraction :
           Fraction


### PR DESCRIPTION
…efinition

After changes such as #1957, the FractionalPart production became redundant, and it was a suggestion left over from that change to remove it.

Closes: #1985