### PR TITLE
Normative: Audit of user-visible operations in Temporal

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -17,7 +17,6 @@ import {
   NANOSECONDS,
   CALENDAR,
   INSTANT,
-  TIME_ZONE,
   CreateSlots,
   GetSlot,
   SetSlot
@@ -250,7 +249,7 @@ export class Duration {
     }
 
     let largestUnit = ES.GetTemporalUnit(roundTo, 'largestUnit', 'datetime', undefined, ['auto']);
-    let { plainRelativeTo, zonedRelativeTo } = ES.ToRelativeTemporalObject(roundTo);
+    let { plainRelativeTo, zonedRelativeTo, timeZoneRec } = ES.ToRelativeTemporalObject(roundTo);
     const roundingIncrement = ES.ToTemporalRoundingIncrement(roundTo);
     const roundingMode = ES.ToTemporalRoundingMode(roundTo, 'halfExpand');
     let smallestUnit = ES.GetTemporalUnit(roundTo, 'smallestUnit', 'datetime', undefined);
@@ -319,7 +318,7 @@ export class Duration {
       // if either is needed in one of the operations below, because the
       // conversion is user visible
       precalculatedPlainDateTime = ES.GetPlainDateTimeFor(
-        GetSlot(zonedRelativeTo, TIME_ZONE),
+        timeZoneRec,
         GetSlot(zonedRelativeTo, INSTANT),
         GetSlot(zonedRelativeTo, CALENDAR)
       );
@@ -351,6 +350,7 @@ export class Duration {
         roundingMode,
         plainRelativeTo,
         zonedRelativeTo,
+        timeZoneRec,
         precalculatedPlainDateTime
       ));
     if (zonedRelativeTo) {
@@ -370,6 +370,7 @@ export class Duration {
           smallestUnit,
           roundingMode,
           zonedRelativeTo,
+          timeZoneRec,
           precalculatedPlainDateTime
         ));
       ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceTimeDurationRelative(
@@ -382,6 +383,7 @@ export class Duration {
         nanoseconds,
         largestUnit,
         zonedRelativeTo,
+        timeZoneRec,
         precalculatedPlainDateTime
       ));
     } else {
@@ -428,7 +430,7 @@ export class Duration {
     } else {
       totalOf = ES.GetOptionsObject(totalOf);
     }
-    let { plainRelativeTo, zonedRelativeTo } = ES.ToRelativeTemporalObject(totalOf);
+    let { plainRelativeTo, zonedRelativeTo, timeZoneRec } = ES.ToRelativeTemporalObject(totalOf);
     const unit = ES.GetTemporalUnit(totalOf, 'unit', 'datetime', ES.REQUIRED);
 
     let precalculatedPlainDateTime;
@@ -445,7 +447,7 @@ export class Duration {
       // Convert a ZonedDateTime relativeTo to PlainDate only if needed in one
       // of the operations below, because the conversion is user visible
       precalculatedPlainDateTime = ES.GetPlainDateTimeFor(
-        GetSlot(zonedRelativeTo, TIME_ZONE),
+        timeZoneRec,
         GetSlot(zonedRelativeTo, INSTANT),
         GetSlot(zonedRelativeTo, CALENDAR)
       );
@@ -466,6 +468,7 @@ export class Duration {
     if (zonedRelativeTo) {
       const intermediate = ES.MoveRelativeZonedDateTime(
         zonedRelativeTo,
+        timeZoneRec,
         years,
         months,
         weeks,
@@ -481,7 +484,8 @@ export class Duration {
         microseconds,
         nanoseconds,
         unit,
-        intermediate
+        intermediate,
+        timeZoneRec
       );
     } else {
       balanceResult = ES.BalancePossiblyInfiniteTimeDuration(
@@ -518,6 +522,7 @@ export class Duration {
       'trunc',
       plainRelativeTo,
       zonedRelativeTo,
+      timeZoneRec,
       precalculatedPlainDateTime
     );
     return total;
@@ -655,19 +660,18 @@ export class Duration {
     ) {
       return 0;
     }
-    const { plainRelativeTo, zonedRelativeTo } = ES.ToRelativeTemporalObject(options);
+    const { plainRelativeTo, zonedRelativeTo, timeZoneRec } = ES.ToRelativeTemporalObject(options);
 
     const calendarUnitsPresent = y1 !== 0 || y2 !== 0 || mon1 !== 0 || mon2 !== 0 || w1 !== 0 || w2 !== 0;
 
     if (zonedRelativeTo && (calendarUnitsPresent || d1 != 0 || d2 !== 0)) {
       const instant = GetSlot(zonedRelativeTo, INSTANT);
-      const timeZone = GetSlot(zonedRelativeTo, TIME_ZONE);
       const calendar = GetSlot(zonedRelativeTo, CALENDAR);
-      const precalculatedPlainDateTime = ES.GetPlainDateTimeFor(timeZone, instant, calendar);
+      const precalculatedPlainDateTime = ES.GetPlainDateTimeFor(timeZoneRec, instant, calendar);
 
       const after1 = ES.AddZonedDateTime(
         instant,
-        timeZone,
+        timeZoneRec,
         calendar,
         y1,
         mon1,
@@ -683,7 +687,7 @@ export class Duration {
       );
       const after2 = ES.AddZonedDateTime(
         instant,
-        timeZone,
+        timeZoneRec,
         calendar,
         y2,
         mon2,

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4877,7 +4877,10 @@ export function AddDuration(
     const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
     const calendar = GetSlot(zonedRelativeTo, CALENDAR);
     const startInstant = GetSlot(zonedRelativeTo, INSTANT);
-    const startDateTime = precalculatedPlainDateTime ?? GetPlainDateTimeFor(timeZoneRec, startInstant, calendar);
+    let startDateTime = precalculatedPlainDateTime;
+    if (largestUnit === 'year' || largestUnit === 'month' || largestUnit === 'week' || largestUnit === 'day') {
+      startDateTime ??= GetPlainDateTimeFor(timeZoneRec, startInstant, calendar);
+    }
     const intermediateNs = AddZonedDateTime(
       startInstant,
       timeZoneRec,

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -1,4 +1,5 @@
 import * as ES from './ecmascript.mjs';
+import { TimeZoneMethodRecord } from './methodrecord.mjs';
 import {
   GetSlot,
   ISO_YEAR,
@@ -364,8 +365,9 @@ function extractOverrides(temporalObj, main) {
       nanosecond,
       'iso8601'
     );
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], datetime, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, datetime, 'compatible'),
       formatter: getPropLazy(main, TIME)
     };
   }
@@ -381,8 +383,9 @@ function extractOverrides(temporalObj, main) {
       );
     }
     const datetime = ES.CreateTemporalDateTime(isoYear, isoMonth, referenceISODay, 12, 0, 0, 0, 0, 0, calendar);
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], datetime, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, datetime, 'compatible'),
       formatter: getPropLazy(main, YM)
     };
   }
@@ -398,8 +401,9 @@ function extractOverrides(temporalObj, main) {
       );
     }
     const datetime = ES.CreateTemporalDateTime(referenceISOYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, calendar);
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], datetime, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, datetime, 'compatible'),
       formatter: getPropLazy(main, MD)
     };
   }
@@ -413,8 +417,9 @@ function extractOverrides(temporalObj, main) {
       throw new RangeError(`cannot format PlainDate with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`);
     }
     const datetime = ES.CreateTemporalDateTime(isoYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, main[CAL_ID]);
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], datetime, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, datetime, 'compatible'),
       formatter: getPropLazy(main, DATE)
     };
   }
@@ -426,8 +431,9 @@ function extractOverrides(temporalObj, main) {
         `cannot format PlainDateTime with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`
       );
     }
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], temporalObj, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, temporalObj, 'compatible'),
       formatter: getPropLazy(main, DATETIME)
     };
   }

--- a/polyfill/lib/methodrecord.mjs
+++ b/polyfill/lib/methodrecord.mjs
@@ -63,3 +63,41 @@ export class TimeZoneMethodRecord extends MethodRecord {
     return this.call('getPossibleInstantsFor', [dateTime]);
   }
 }
+
+export class CalendarMethodRecord extends MethodRecord {
+  constructor(calendar, methodNames = []) {
+    super('Calendar', calendar, methodNames);
+  }
+
+  dateAdd(date, duration, options) {
+    return this.call('dateAdd', [date, duration, options]);
+  }
+
+  dateFromFields(fields, options) {
+    return this.call('dateFromFields', [fields, options]);
+  }
+
+  dateUntil(one, two, options) {
+    return this.call('dateUntil', [one, two, options]);
+  }
+
+  day(date) {
+    return this.call('day', [date]);
+  }
+
+  fields(fieldNames) {
+    return this.call('fields', [fieldNames]);
+  }
+
+  mergeFields(fields, additionalFields) {
+    return this.call('mergeFields', [fields, additionalFields]);
+  }
+
+  monthDayFromFields(fields, options) {
+    return this.call('monthDayFromFields', [fields, options]);
+  }
+
+  yearMonthFromFields(fields, options) {
+    return this.call('yearMonthFromFields', [fields, options]);
+  }
+}

--- a/polyfill/lib/methodrecord.mjs
+++ b/polyfill/lib/methodrecord.mjs
@@ -1,0 +1,65 @@
+import GetMethod from 'es-abstract/2022/GetMethod.js';
+
+import { GetIntrinsic } from './intrinsicclass.mjs';
+
+class MethodRecord {
+  constructor(recordType, receiver, methodNames) {
+    this.recordType = recordType;
+    this.receiver = receiver;
+
+    const nMethods = methodNames.length;
+    for (let ix = 0; ix < nMethods; ix++) {
+      this.lookup(methodNames[ix]);
+    }
+  }
+
+  isBuiltIn() {
+    return typeof this.receiver === 'string';
+  }
+
+  hasLookedUp(methodName) {
+    return !!this[`_${methodName}`];
+  }
+
+  lookup(methodName) {
+    if (this.hasLookedUp(methodName)) {
+      throw new Error(`assertion failure: ${methodName} already looked up`);
+    }
+    if (this.isBuiltIn()) {
+      this[`_${methodName}`] = GetIntrinsic(`%Temporal.${this.recordType}.prototype.${methodName}%`);
+    } else {
+      const method = GetMethod(this.receiver, methodName);
+      if (!method) {
+        // GetMethod may return undefined if method is null or undefined
+        throw new TypeError(`${methodName} should be present on ${this.recordType}`);
+      }
+      this[`_${methodName}`] = method;
+    }
+  }
+
+  call(methodName, args) {
+    if (!this.hasLookedUp(methodName)) {
+      throw new Error(`assertion failure: ${methodName} should have been looked up`);
+    }
+    let receiver = this.receiver;
+    if (this.isBuiltIn()) {
+      const cls = GetIntrinsic(`%Temporal.${this.recordType}%`);
+      receiver = new cls(receiver);
+    }
+    return this[`_${methodName}`].apply(receiver, args);
+  }
+}
+
+export class TimeZoneMethodRecord extends MethodRecord {
+  constructor(timeZone, methodNames = []) {
+    super('TimeZone', timeZone, methodNames);
+  }
+
+  getOffsetNanosecondsFor(instant) {
+    return this.call('getOffsetNanosecondsFor', [instant]);
+  }
+
+  getPossibleInstantsFor(dateTime) {
+    return this.call('getPossibleInstantsFor', [dateTime]);
+  }
+}

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -1,5 +1,6 @@
 import * as ES from './ecmascript.mjs';
 import { GetIntrinsic } from './intrinsicclass.mjs';
+import { TimeZoneMethodRecord } from './methodrecord.mjs';
 
 const instant = () => {
   const Instant = GetIntrinsic('%Temporal.Instant%');
@@ -9,12 +10,14 @@ const plainDateTime = (calendarLike, temporalTimeZoneLike = ES.DefaultTimeZone()
   const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
   const calendar = ES.ToTemporalCalendarSlotValue(calendarLike);
   const inst = instant();
-  return ES.GetPlainDateTimeFor(timeZone, inst, calendar);
+  const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getOffsetNanosecondsFor']);
+  return ES.GetPlainDateTimeFor(timeZoneRec, inst, calendar);
 };
 const plainDateTimeISO = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
   const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
   const inst = instant();
-  return ES.GetPlainDateTimeFor(timeZone, inst, 'iso8601');
+  const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getOffsetNanosecondsFor']);
+  return ES.GetPlainDateTimeFor(timeZoneRec, inst, 'iso8601');
 };
 const zonedDateTime = (calendarLike, temporalTimeZoneLike = ES.DefaultTimeZone()) => {
   const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -1,6 +1,7 @@
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { TimeZoneMethodRecord } from './methodrecord.mjs';
 import {
   ISO_YEAR,
   ISO_MONTH,
@@ -243,7 +244,8 @@ export class PlainDate {
       nanosecond,
       calendar
     );
-    const instant = ES.GetInstantFor(timeZone, dt, 'compatible');
+    const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getPossibleInstantsFor']);
+    const instant = ES.GetInstantFor(timeZoneRec, dt, 'compatible');
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
   toPlainYearMonth() {

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -1,7 +1,7 @@
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
-import { TimeZoneMethodRecord } from './methodrecord.mjs';
+import { CalendarMethodRecord, TimeZoneMethodRecord } from './methodrecord.mjs';
 
 import {
   ISO_YEAR,
@@ -77,7 +77,8 @@ export class PlainDateTime {
   }
   get day() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    return ES.CalendarDay(GetSlot(this, CALENDAR), this);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['day']);
+    return ES.CalendarDay(calendarRec, this);
   }
   get hour() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
@@ -155,8 +156,8 @@ export class PlainDateTime {
     ES.RejectTemporalLikeObject(temporalDateTimeLike);
 
     const resolvedOptions = ES.SnapshotOwnProperties(ES.GetOptionsObject(options), null);
-    const calendar = GetSlot(this, CALENDAR);
-    const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['dateFromFields', 'fields', 'mergeFields']);
+    const fieldNames = ES.CalendarFields(calendarRec, ['day', 'month', 'monthCode', 'year']);
     let fields = ES.PrepareTemporalFields(this, fieldNames, []);
     fields.hour = GetSlot(this, ISO_HOUR);
     fields.minute = GetSlot(this, ISO_MINUTE);
@@ -166,10 +167,10 @@ export class PlainDateTime {
     fields.nanosecond = GetSlot(this, ISO_NANOSECOND);
     ES.Call(ArrayPrototypePush, fieldNames, ['hour', 'microsecond', 'millisecond', 'minute', 'nanosecond', 'second']);
     const partialDateTime = ES.PrepareTemporalFields(temporalDateTimeLike, fieldNames, 'partial');
-    fields = ES.CalendarMergeFields(calendar, fields, partialDateTime);
+    fields = ES.CalendarMergeFields(calendarRec, fields, partialDateTime);
     fields = ES.PrepareTemporalFields(fields, fieldNames, []);
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
-      ES.InterpretTemporalDateTimeFields(calendar, fields, resolvedOptions);
+      ES.InterpretTemporalDateTimeFields(calendarRec, fields, resolvedOptions);
 
     return ES.CreateTemporalDateTime(
       year,
@@ -181,7 +182,7 @@ export class PlainDateTime {
       millisecond,
       microsecond,
       nanosecond,
-      calendar
+      calendarRec.receiver
     );
   }
   withPlainTime(temporalTime = undefined) {
@@ -420,17 +421,17 @@ export class PlainDateTime {
   }
   toPlainYearMonth() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const calendar = GetSlot(this, CALENDAR);
-    const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'yearMonthFromFields']);
+    const fieldNames = ES.CalendarFields(calendarRec, ['monthCode', 'year']);
     const fields = ES.PrepareTemporalFields(this, fieldNames, []);
-    return ES.CalendarYearMonthFromFields(calendar, fields);
+    return ES.CalendarYearMonthFromFields(calendarRec, fields);
   }
   toPlainMonthDay() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const calendar = GetSlot(this, CALENDAR);
-    const fieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'monthDayFromFields']);
+    const fieldNames = ES.CalendarFields(calendarRec, ['day', 'monthCode']);
     const fields = ES.PrepareTemporalFields(this, fieldNames, []);
-    return ES.CalendarMonthDayFromFields(calendar, fields);
+    return ES.CalendarMonthDayFromFields(calendarRec, fields);
   }
   toPlainTime() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -1,6 +1,7 @@
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { TimeZoneMethodRecord } from './methodrecord.mjs';
 
 import {
   ISO_YEAR,
@@ -409,7 +410,8 @@ export class PlainDateTime {
     const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
     options = ES.GetOptionsObject(options);
     const disambiguation = ES.ToTemporalDisambiguation(options);
-    const instant = ES.GetInstantFor(timeZone, this, disambiguation);
+    const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getPossibleInstantsFor']);
+    const instant = ES.GetInstantFor(timeZoneRec, this, disambiguation);
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, GetSlot(this, CALENDAR));
   }
   toPlainDate() {

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -3,6 +3,7 @@
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
+import { TimeZoneMethodRecord } from './methodrecord.mjs';
 
 import {
   ISO_YEAR,
@@ -291,7 +292,8 @@ export class PlainTime {
       nanosecond,
       calendar
     );
-    const instant = ES.GetInstantFor(timeZone, dt, 'compatible');
+    const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getPossibleInstantsFor']);
+    const instant = ES.GetInstantFor(timeZoneRec, dt, 'compatible');
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
   getISOFields() {

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -2,6 +2,7 @@
 
 import * as ES from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass.mjs';
+import { TimeZoneMethodRecord } from './methodrecord.mjs';
 import {
   TIMEZONE_ID,
   EPOCHNANOSECONDS,
@@ -64,20 +65,23 @@ export class TimeZone {
   getOffsetStringFor(instant) {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     instant = ES.ToTemporalInstant(instant);
-    return ES.GetOffsetStringFor(this, instant);
+    const timeZoneRec = new TimeZoneMethodRecord(this, ['getOffsetNanosecondsFor']);
+    return ES.GetOffsetStringFor(timeZoneRec, instant);
   }
   getPlainDateTimeFor(instant, calendar = 'iso8601') {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     instant = ES.ToTemporalInstant(instant);
     calendar = ES.ToTemporalCalendarSlotValue(calendar);
-    return ES.GetPlainDateTimeFor(this, instant, calendar);
+    const timeZoneRec = new TimeZoneMethodRecord(this, ['getOffsetNanosecondsFor']);
+    return ES.GetPlainDateTimeFor(timeZoneRec, instant, calendar);
   }
   getInstantFor(dateTime, options = undefined) {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     dateTime = ES.ToTemporalDateTime(dateTime);
     options = ES.GetOptionsObject(options);
     const disambiguation = ES.ToTemporalDisambiguation(options);
-    return ES.GetInstantFor(this, dateTime, disambiguation);
+    const timeZoneRec = new TimeZoneMethodRecord(this, ['getPossibleInstantsFor']);
+    return ES.GetInstantFor(timeZoneRec, dateTime, disambiguation);
   }
   getPossibleInstantsFor(dateTime) {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -570,8 +570,8 @@
   <emu-clause id="sec-temporal-torelativetemporalobject" type="abstract operation">
     <h1>
       ToRelativeTemporalObject (
-        _options_: an Object
-      ): either a normal completion containing a Record with fields [[PlainRelativeTo]] and [[ZonedRelativeTo]], or a throw completion
+        _options_: an Object,
+      ): either a normal completion containing a Record with fields [[PlainRelativeTo]], [[ZonedRelativeTo]], and [[TimeZoneRec]], or a throw completion
     </h1>
     <dl class="header">
       <dt>description</dt>
@@ -583,6 +583,9 @@
         If neither of those are possible, it throws a *RangeError*.
       </dd>
     </dl>
+    <p>
+      If the returned Record's [[ZonedRelativeTo]] field is *undefined*, then the [[TimeZoneRec]] field is also *undefined*, and vice versa.
+    </p>
     <emu-alg>
       1. Let _value_ be ? Get(_options_, *"relativeTo"*).
       1. If _value_ is *undefined*, return the Record { [[ZonedRelativeTo]]: *undefined*, [[PlainRelativeTo]]: *undefined* }.
@@ -590,12 +593,13 @@
       1. Let _matchBehaviour_ be ~match exactly~.
       1. If Type(_value_) is Object, then
         1. If _value_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
-          1. Return the Record { [[PlainRelativeTo]]: *undefined*, [[ZonedRelativeTo]]: _value_ }.
+          1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_value_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
+          1. Return the Record { [[PlainRelativeTo]]: *undefined*, [[ZonedRelativeTo]]: _value_, [[TimeZoneRec]]: _timeZoneRec_ }.
         1. If _value_ has an [[InitializedTemporalDate]] internal slot, then
-          1. Return the Record { [[PlainRelativeTo]]: _value_, [[ZonedRelativeTo]]: *undefined* }.
+          1. Return the Record { [[PlainRelativeTo]]: _value_, [[ZonedRelativeTo]]: *undefined*, [[TimeZoneRec]]: *undefined* }.
         1. If _value_ has an [[InitializedTemporalDateTime]] internal slot, then
           1. Let _plainDate_ be ! CreateTemporalDate(_value_.[[ISOYear]], _value_.[[ISOMonth]], _value_.[[ISODay]], _value_.[[Calendar]]).
-          1. Return the Record { [[PlainRelativeTo]]: _plainDate_, [[ZonedRelativeTo]]: *undefined* }.
+          1. Return the Record { [[PlainRelativeTo]]: _plainDate_, [[ZonedRelativeTo]]: *undefined*, [[TimeZoneRec]]: *undefined* }.
         1. Let _calendar_ be ? GetTemporalCalendarSlotValueWithISODefault(_value_).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
         1. Append *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"nanosecond"*, *"offset"*, *"second"*, and *"timeZone"* to _fieldNames_.
@@ -629,14 +633,15 @@
         1. Set _calendar_ to the ASCII-lowercase of _calendar_.
       1. If _timeZone_ is *undefined*, then
         1. Let _plainDate_ be ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
-        1. Return the Record { [[PlainRelativeTo]]: _plainDate_, [[ZonedRelativeTo]]: *undefined* }.
+        1. Return the Record { [[PlainRelativeTo]]: _plainDate_, [[ZonedRelativeTo]]: *undefined*, [[TimeZoneRec]]: *undefined* }.
       1. If _offsetBehaviour_ is ~option~, then
         1. Let _offsetNs_ be ? ParseDateTimeUTCOffset(_offsetString_).
       1. Else,
         1. Let _offsetNs_ be 0.
-      1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNs_, _timeZone_, *"compatible"*, *"reject"*, _matchBehaviour_).
+      1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
+      1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNs_, _timeZoneRec_, *"compatible"*, *"reject"*, _matchBehaviour_).
       1. Let _zonedRelativeTo_ be ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
-      1. Return the Record { [[PlainRelativeTo]]: *undefined*, [[ZonedRelativeTo]]: _zonedRelativeTo_ }.
+      1. Return the Record { [[PlainRelativeTo]]: *undefined*, [[ZonedRelativeTo]]: _zonedRelativeTo_, [[TimeZoneRec]]: _timeZoneRec_ }.
     </emu-alg>
   </emu-clause>
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -601,12 +601,13 @@
           1. Let _plainDate_ be ! CreateTemporalDate(_value_.[[ISOYear]], _value_.[[ISOMonth]], _value_.[[ISODay]], _value_.[[Calendar]]).
           1. Return the Record { [[PlainRelativeTo]]: _plainDate_, [[ZonedRelativeTo]]: *undefined*, [[TimeZoneRec]]: *undefined* }.
         1. Let _calendar_ be ? GetTemporalCalendarSlotValueWithISODefault(_value_).
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_calendar_, « ~dateFromFields~, ~fields~ »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
         1. Append *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"nanosecond"*, *"offset"*, *"second"*, and *"timeZone"* to _fieldNames_.
         1. Let _fields_ be ? PrepareTemporalFields(_value_, _fieldNames_, «»).
         1. Let _dateOptions_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_dateOptions_, *"overflow"*, *"constrain"*).
-        1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _dateOptions_).
+        1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendarRec_, _fields_, _dateOptions_).
         1. Let _offsetString_ be ! Get(_fields_, *"offset"*).
         1. Let _timeZone_ be ! Get(_fields_, *"timeZone"*).
         1. If _timeZone_ is not *undefined*, then

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -66,6 +66,280 @@
   <emu-clause id="sec-temporal-calendar-abstract-ops">
     <h1>Abstract Operations for Temporal.Calendar Objects</h1>
 
+    <emu-clause id="sec-temporal-calendar-methods-records">
+      <h1>Calendar Methods Records</h1>
+      <p>
+        A <dfn variants="Calendar Methods Records">Calendar Methods Record</dfn> is a Record value used to store a Temporal.Calendar object, or an Object implementing the calendar protocol, along with any methods that have been observably looked up on that object during the current operation.
+        Calendar Methods Records are produced by the abstract operation CreateCalendarMethodsRecord.
+      </p>
+      <p>
+        Calendar Methods Records have the fields listed in <emu-xref href="#table-temporal-calendar-methods-record-fields"></emu-xref>.
+      </p>
+      <emu-table id="table-temporal-calendar-methods-record-fields" caption="Calendar Methods Record Fields">
+        <table class="real-table">
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td>[[Receiver]]</td>
+            <td>a String or Object</td>
+            <td>
+              The calendar object, or a string indicating a built-in time zone.
+            </td>
+          </tr>
+          <tr>
+            <td>[[DateAdd]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The calendar's `dateAdd` method.
+              For a built-in calendar this is always %Temporal.Calendar.prototype.dateAdd%.
+            </td>
+          </tr>
+          <tr>
+            <td>[[DateFromFields]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The calendar's `dateFromFields` method.
+              For a built-in calendar this is always %Temporal.Calendar.prototype.dateFromFields%.
+            </td>
+          </tr>
+          <tr>
+            <td>[[DateUntil]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The calendar's `dateUntil` method.
+              For a built-in calendar this is always %Temporal.Calendar.prototype.dateUntil%.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Day]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The calendar's `day` method.
+              For a built-in calendar this is always %Temporal.Calendar.prototype.day%.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Fields]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The calendar's `fields` method.
+              For a built-in calendar this is always %Temporal.Calendar.prototype.fields%.
+            </td>
+          </tr>
+          <tr>
+            <td>[[MergeFields]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The calendar's `mergeFields` method.
+              For a built-in calendar this is always %Temporal.Calendar.prototype.mergeFields%.
+            </td>
+          </tr>
+          <tr>
+            <td>[[MonthDayFromFields]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The calendar's `monthDayFromFields` method.
+              For a built-in calendar this is always %Temporal.Calendar.prototype.monthDayFromFields%.
+            </td>
+          </tr>
+          <tr>
+            <td>[[YearMonthFromFields]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The calendar's `yearMonthFromFields` method.
+              For a built-in calendar this is always %Temporal.Calendar.prototype.yearMonthFromFields%.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-createcalendarmethodsrecord" type="abstract operation">
+      <h1>
+        CreateCalendarMethodsRecord (
+          _calendar_: a String or Object,
+          _methods_: a List of one of ~dateAdd~, ~dateFromFields~, ~dateUntil~, ~day~, ~fields~, ~mergeFields~, ~monthDayFromFields~, or ~yearMonthFromFields~,
+        ): either a normal completion containing a Calendar Methods Record, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates a Calendar Methods Record from the given _calendar_, looking up the methods given in _methods_.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _record_ be the Calendar Methods Record {
+            [[Receiver]]: _calendar_,
+            [[DateAdd]]: *undefined*,
+            [[DateFromFields]]: *undefined*,
+            [[DateUntil]]: *undefined*,
+            [[Day]]: *undefined*,
+            [[Fields]]: *undefined*,
+            [[MergeFields]]: *undefined*,
+            [[MonthDayFromFields]]: *undefined*,
+            [[YearMonthFromFields]]: *undefined*
+          }.
+        1. For each element _methodName_ in _methods_, do
+          1. Perform ? CalendarMethodsRecordLookup(_record_, _methodName_).
+        1. Return _record_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarmethodsrecordlookup" type="abstract operation">
+      <h1>
+        CalendarMethodsRecordLookup (
+          _calendarRec_: a Calendar Methods Record,
+          _methodName_: one of ~dateAdd~, ~dateFromFields~, ~dateUntil~, ~day~, ~fields~, ~mergeFields~, ~monthDayFromFields~, or ~yearMonthFromFields~,
+        ): either a normal completion containing ~unused~, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It looks up the given method on the given calendar.
+          For a built-in calendar, this lookup is unobservable and results in the intrinsic method.
+          If the calendar is an Object, the lookup is observable and may result in a user-code method.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, _methodName_) is *false*.
+        1. If _methodName_ is ~dateAdd~, then
+          1. If _calendarRec_.[[Receiver]] is a String, then
+            1. Set _calendarRec_.[[DateAdd]] to %Temporal.Calendar.prototype.dateAdd%.
+          1. Else,
+            1. Set _calendarRec_.[[DateAdd]] to ? GetMethod(_calendarRec_.[[Receiver]], *"dateAdd"*).
+            1. If _calendarRec_.[[GetOffsetNanosecondsFor]] is *undefined*, throw a *TypeError* exception.
+        1. Else if _methodName_ is ~dateFromFields~, then
+          1. If _calendarRec_.[[Receiver]] is a String, then
+            1. Set _calendarRec_.[[DateFromFields]] to %Temporal.TimeZone.prototype.dateFromFields%.
+          1. Else,
+            1. Set _calendarRec_.[[DateFromFields]] to ? GetMethod(_calendarRec_.[[Receiver]], *"dateFromFields"*).
+            1. If _calendarRec_.[[DateFromFields]] is *undefined*, throw a *TypeError* exception.
+        1. Else if _methodName_ is ~dateUntil~, then
+          1. If _calendarRec_.[[Receiver]] is a String, then
+            1. Set _calendarRec_.[[DateUntil]] to %Temporal.TimeZone.prototype.dateUntil%.
+          1. Else,
+            1. Set _calendarRec_.[[DateUntil]] to ? GetMethod(_calendarRec_.[[Receiver]], *"dateUntil"*).
+            1. If _calendarRec_.[[DateUntil]] is *undefined*, throw a *TypeError* exception.
+        1. Else if _methodName_ is ~day~, then
+          1. If _calendarRec_.[[Receiver]] is a String, then
+            1. Set _calendarRec_.[[Day]] to %Temporal.TimeZone.prototype.day%.
+          1. Else,
+            1. Set _calendarRec_.[[Day]] to ? GetMethod(_calendarRec_.[[Receiver]], *"day"*).
+            1. If _calendarRec_.[[Day]] is *undefined*, throw a *TypeError* exception.
+        1. Else if _methodName_ is ~fields~, then
+          1. If _calendarRec_.[[Receiver]] is a String, then
+            1. Set _calendarRec_.[[Fields]] to %Temporal.TimeZone.prototype.fields%.
+          1. Else,
+            1. Set _calendarRec_.[[Fields]] to ? GetMethod(_calendarRec_.[[Receiver]], *"fields"*).
+            1. If _calendarRec_.[[Fields]] is *undefined*, throw a *TypeError* exception.
+        1. Else if _methodName_ is ~mergeFields~, then
+          1. If _calendarRec_.[[Receiver]] is a String, then
+            1. Set _calendarRec_.[[MergeFields]] to %Temporal.TimeZone.prototype.mergeFields%.
+          1. Else,
+            1. Set _calendarRec_.[[MergeFields]] to ? GetMethod(_calendarRec_.[[Receiver]], *"mergeFields"*).
+            1. If _calendarRec_.[[MergeFields]] is *undefined*, throw a *TypeError* exception.
+        1. Else if _methodName_ is ~monthDayFromFields~, then
+          1. If _calendarRec_.[[Receiver]] is a String, then
+            1. Set _calendarRec_.[[MonthDayFromFields]] to %Temporal.TimeZone.prototype.monthDayFromFields%.
+          1. Else,
+            1. Set _calendarRec_.[[MonthDayFromFields]] to ? GetMethod(_calendarRec_.[[Receiver]], *"monthDayFromFields"*).
+            1. If _calendarRec_.[[MonthDayFromFields]] is *undefined*, throw a *TypeError* exception.
+        1. Else if _methodName_ is ~yearMonthFromFields~, then
+          1. If _calendarRec_.[[Receiver]] is a String, then
+            1. Set _calendarRec_.[[YearMonthFromFields]] to %Temporal.TimeZone.prototype.yearMonthFromFields%.
+          1. Else,
+            1. Set _calendarRec_.[[YearMonthFromFields]] to ? GetMethod(_calendarRec_.[[Receiver]], *"yearMonthFromFields"*).
+            1. If _calendarRec_.[[YearMonthFromFields]] is *undefined*, throw a *TypeError* exception.
+        1. Return ~unused~.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarmethodsrecordhaslookedup" type="abstract operation">
+      <h1>
+        CalendarMethodsRecordHasLookedUp (
+          _calendarRec_: a Calendar Methods Record,
+          _methodName_: one of ~dateAdd~, ~dateFromFields~, ~dateUntil~, ~day~, ~fields~, ~mergeFields~, ~monthDayFromFields~, or ~yearMonthFromFields~,
+        ): *true* or *false*
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines whether the given Calendar Methods Record has already looked up the given method.</dd>
+      </dl>
+      <emu-alg>
+        1. If _methodName_ is ~dateAdd~, then
+          1. Let _method_ be _calendarRec_.[[DateAdd]].
+        1. Else if _methodName_ is ~dateFromFields~, then
+          1. Let _method_ be _calendarRec_.[[DateFromFields]].
+        1. Else if _methodName_ is ~dateUntil~, then
+          1. Let _method_ be _calendarRec_.[[DateUntil]].
+        1. Else if _methodName_ is ~day~, then
+          1. Let _method_ be _calendarRec_.[[Day]].
+        1. Else if _methodName_ is ~fields~, then
+          1. Let _method_ be _calendarRec_.[[Fields]].
+        1. Else if _methodName_ is ~mergeFields~, then
+          1. Let _method_ be _calendarRec_.[[MergeFields]].
+        1. Else if _methodName_ is ~monthDayFromFields~, then
+          1. Let _method_ be _calendarRec_.[[MonthDayFromFields]].
+        1. Else if _methodName_ is ~yearMonthFromFields~, then
+          1. Let _method_ be _calendarRec_.[[YearMonthFromFields]].
+        1. If _method_ is *undefined*, return *false*.
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarmethodsrecordisbuiltin" type="abstract operation">
+      <h1>
+        CalendarMethodsRecordIsBuiltin (
+          _calendarRec_: a Calendar Methods Record,
+        ): *true* or *false*
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines whether the given Calendar Methods Record represents a built-in calendar (that is never exposed to user code.)</dd>
+      </dl>
+      <emu-alg>
+        1. If _calendarRec_.[[Receiver]] is a String, return *true*.
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarmethodsrecordcall" type="abstract operation">
+      <h1>
+        CalendarMethodsRecordCall (
+          _calendarRec_: a Calendar Methods Record,
+          _methodName_: one of ~dateAdd~, ~dateFromFields~, ~dateUntil~, ~day~, ~fields~, ~mergeFields~, ~monthDayFromFields~, or ~yearMonthFromFields~,
+          _arguments_: a List of ECMAScript language values,
+        ): either a normal completion containing an ECMAScript language value, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It calls the method _methodName_ stored in the Calendar Methods Record, with the stored receiver as the receiver, and the given _arguments_, and returns the result.</dd>
+      </dl>
+      <emu-alg>
+        1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, _methodName_) is *true*.
+        1. Let _receiver_ be _calendarRec_.[[Receiver]].
+        1. If CalendarMethodsRecordIsBuiltin(_calendarRec_) is *true*, then
+          1. Set _receiver_ to ! CreateTemporalTimeZone(_calendarRec_.[[Receiver]]).
+        1. If _methodName_ is ~dateAdd~, then
+          1. Return ? Call(_calendarRec_.[[DateAdd]], _receiver_, _arguments_).
+        1. If _methodName_ is ~dateFromFields~, then
+          1. Return ? Call(_calendarRec_.[[DateFromFields]], _receiver_, _arguments_).
+        1. If _methodName_ is ~dateUntil~, then
+          1. Return ? Call(_calendarRec_.[[DateUntil]], _receiver_, _arguments_).
+        1. If _methodName_ is ~day~, then
+          1. Return ? Call(_calendarRec_.[[Day]], _receiver_, _arguments_).
+        1. If _methodName_ is ~fields~, then
+          1. Return ? Call(_calendarRec_.[[Fields]], _receiver_, _arguments_).
+        1. If _methodName_ is ~mergeFields~, then
+          1. Return ? Call(_calendarRec_.[[MergeFields]], _receiver_, _arguments_).
+        1. If _methodName_ is ~monthDayFromFields~, then
+          1. Return ? Call(_calendarRec_.[[MonthDayFromFields]], _receiver_, _arguments_).
+        1. If _methodName_ is ~yearMonthFromFields~, then
+          1. Return ? Call(_calendarRec_.[[YearMonthFromFields]], _receiver_, _arguments_).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-createtemporalcalendar" type="abstract operation">
       <h1>
         CreateTemporalCalendar (
@@ -89,23 +363,24 @@
     <emu-clause id="sec-temporal-calendarfields" type="abstract operation">
       <h1>
         CalendarFields (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _fieldNames_: a List of Strings,
         ): either a normal completion containing a List of Strings, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It calls the `fields` method of the given _calendar_ with an array representation of _fieldNames_, and returns a List representation of the result.</dd>
+        <dd>It calls the `fields` method of the given calendar with an array representation of _fieldNames_, and returns a List representation of the result.</dd>
       </dl>
       <emu-alg>
-        1. If _calendar_ is a String, then
+        1. If CalendarMethodsRecordIsBuiltin(_calendarRec_) is *true*, then
+          1. NOTE: %Temporal.Calendar.prototype.fields% is not called in this clause in order to avoid an unnecessary observable Array iteration.
           1. Assert: _fieldNames_ contains no String other than *"year"*, *"month"*, *"monthCode"*, or *"day"*.
-          1. If _calendar_ is *"iso8601"*, return _fieldNames_.
-          1. Let _extraFieldDescriptors_ be CalendarFieldDescriptors(_calendar_, _fieldNames_).
+          1. If _calendarRec_.[[Receiver]] is *"iso8601"*, return _fieldNames_.
+          1. Let _extraFieldDescriptors_ be CalendarFieldDescriptors(_calendarRec_.[[Receiver]], _fieldNames_).
           1. For each Calendar Field Descriptor Record _desc_ of _extraFieldDescriptors_, do
             1. Append _desc_.[[Property]] to _fieldNames_.
           1. Return _fieldNames_.
-        1. Let _fieldsArray_ be ? Invoke(_calendar_, *"fields"*, « CreateArrayFromList(_fieldNames_) »).
+        1. Let _fieldsArray_ be ? CalendarMethodsRecordCall(_calendarRec_, ~fields~, « CreateArrayFromList(_fieldNames_) »).
         1. Let _iteratorRecord_ be ? GetIterator(_fieldsArray_, ~sync~).
         1. Return ? IteratorToListOfType(_iteratorRecord_, « String »).
       </emu-alg>
@@ -114,20 +389,18 @@
     <emu-clause id="sec-temporal-calendarmergefields" type="abstract operation">
       <h1>
         CalendarMergeFields (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _fields_: an Object,
           _additionalFields_: an Object,
         ): either a normal completion containing an Object, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It merges the properties of _fields_ and _additionalFields_ by calling the `mergeFields` method of the given _calendar_.</dd>
+        <dd>It merges the properties of _fields_ and _additionalFields_ by calling the `mergeFields` method of the given calendar.</dd>
       </dl>
       <emu-alg>
-        1. If _calendar_ is a String, then
-          1. Set _calendar_ to ! CreateTemporalCalendar(_calendar_).
-          1. Return ? Call(%Temporal.Calendar.prototype.mergeFields%, _calendar_, « _fields_, _additionalFields_ »).
-        1. Let _result_ be ? Invoke(_calendar_, *"mergeFields"*, « _fields_, _additionalFields_ »).
+        1. Let _result_ be ? CalendarMethodsRecordCall(_calendarRec_, ~mergeFields~, « _fields_, _additionalFields_ »).
+        1. If CalendarMethodsRecordIsBuiltin(_calendarRec_) is *true*, return _result_.
         1. If Type(_result_) is not Object, throw a *TypeError* exception.
         1. Return _result_.
       </emu-alg>
@@ -136,27 +409,22 @@
     <emu-clause id="sec-temporal-calendardateadd" type="abstract operation">
       <h1>
         CalendarDateAdd (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _date_: a Temporal.PlainDate,
           _duration_: a Temporal.Duration,
           optional _options_: an Object or *undefined*,
-          optional _dateAdd_: a function object or ~unused~,
         ): either a normal completion containing a Temporal.PlainDate, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It adds _duration_ to _date_ by calling the `dateAdd` method of the given _calendar_, which may be a built-in calendar identifier.
-          If _dateAdd_ is present, the `dateAdd` method will not be observably looked up.
+          It adds _duration_ to _date_ by calling the `dateAdd` method of the given calendar.
         </dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
-        1. If _calendar_ is a String, then
-          1. Set _calendar_ to ! CreateTemporalCalendar(_calendar_).
-          1. Return ? Call(%Temporal.Calendar.prototype.dateAdd%, _calendar_, « _date_, _duration_, _options_ »).
-        1. If _dateAdd_ is not present, set _dateAdd_ to ? GetMethod(_calendar_, *"dateAdd"*).
-        1. Let _addedDate_ be ? Call(_dateAdd_, _calendar_, « _date_, _duration_, _options_ »).
+        1. Let _addedDate_ be ? CalendarMethodsRecordCall(_calendarRec_, ~dateAdd~, « _date_, _duration_, _options_ »).
+        1. If CalendarMethodsRecordIsBuiltin(_calendarRec_) is *true*, return _addedDate_.
         1. Perform ? RequireInternalSlot(_addedDate_, [[InitializedTemporalDate]]).
         1. Return _addedDate_.
       </emu-alg>
@@ -165,26 +433,21 @@
     <emu-clause id="sec-temporal-calendardateuntil" type="abstract operation">
       <h1>
         CalendarDateUntil (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _one_: a Temporal.PlainDate,
           _two_: a Temporal.PlainDate,
           _options_: an Object or *undefined*,
-          optional _dateUntil_: a function object or ~unused~,
         ): either a normal completion containing a Temporal.Duration, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It determines the difference between the dates _one_ and _two_ by calling the `dateUntil` method of the given _calendar_, which may be a built-in calendar identifier.
-          If _dateUntil_ is present, the `dateUntil` method will not be observably looked up.
+          It determines the difference between the dates _one_ and _two_ by calling the `dateUntil` method of the given calendar.
         </dd>
       </dl>
       <emu-alg>
-        1. If _calendar_ is a String, then
-          1. Set _calendar_ to ! CreateTemporalCalendar(_calendar_).
-          1. Return ? Call(%Temporal.Calendar.prototype.dateUntil%, _calendar_, « _one_, _two_, _options_ »).
-        1. If _dateUntil_ is not present, set _dateUntil_ to ? GetMethod(_calendar_, *"dateUntil"*).
-        1. Let _duration_ be ? Call(_dateUntil_, _calendar_, « _one_, _two_, _options_ »).
+        1. Let _duration_ be ? CalendarMethodsRecordCall(_calendarRec_, ~dateUntil~, « _one_, _two_, _options_ »).
+        1. If CalendarMethodsRecordIsBuiltin(_calendarRec_) is *true*, return _duration_.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
         1. Return _duration_.
       </emu-alg>
@@ -259,19 +522,17 @@
     <emu-clause id="sec-temporal-calendarday" type="abstract operation">
       <h1>
         CalendarDay (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _dateLike_: a Temporal.PlainDateTime, Temporal.PlainDate, or Temporal.PlainMonthDay,
         ): either a normal completion containing an integer, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It calls the given _calendar_'s `day()` method and validates the result.</dd>
+        <dd>It calls the given calendar's `day()` method and validates the result.</dd>
       </dl>
       <emu-alg>
-        1. If _calendar_ is a String, then
-          1. Set _calendar_ to ! CreateTemporalCalendar(_calendar_).
-          1. Return ? Call(%Temporal.Calendar.prototype.day%, _calendar_, « _dateLike_ »).
-        1. Let _result_ be ? Invoke(_calendar_, *"day"*, « _dateLike_ »).
+        1. Let _result_ be ? CalendarMethodsRecordCall(_calendarRec_, ~day~, « _dateLike_ »).
+        1. If CalendarMethodsRecordIsBuiltin(_calendarRec_) is *true*, return _result_.
         1. If Type(_result_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_result_) is *false*, throw a *RangeError* exception.
         1. If _result_ &lt; *1*<sub>𝔽</sub>, throw a *RangeError* exception.
@@ -595,26 +856,21 @@
     <emu-clause id="sec-temporal-calendardatefromfields" type="abstract operation">
       <h1>
         CalendarDateFromFields (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _fields_: an Object,
           optional _options_: an Object or *undefined*,
-          optional _dateFromFields_: a function object,
         ): either a normal completion containing a `Temporal.PlainDate` or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It calls the given _calendar_'s `dateFromFields()` method and validates the result.
-          If _dateFromFields_ is present, the `dateFromFields` method will not be observably looked up.
+          It calls the given calendar's `dateFromFields()` method and validates the result.
         </dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
-        1. If _calendar_ is a String, then
-          1. Set _calendar_ to ! CreateTemporalCalendar(_calendar_).
-          1. Return ? Call(%Temporal.Calendar.prototype.dateFromFields%, _calendar_, « _fields_, _options_ »).
-        1. If _dateFromFields_ is not present, set _dateFromFields_ to ? GetMethod(_calendar_, *"dateFromFields"*).
-        1. Let _date_ be ? Call(_calendar_, _dateFromFields_, « _fields_, _options_ »).
+        1. Let _date_ be ? CalendarMethodsRecordCall(_calendarRec_, ~dateFromFields~, « _fields_, _options_ »).
+        1. If CalendarMethodsRecordIsBuiltin(_calendarRec_) is *true*, return _date_.
         1. Perform ? RequireInternalSlot(_date_, [[InitializedTemporalDate]]).
         1. Return _date_.
       </emu-alg>
@@ -623,21 +879,19 @@
     <emu-clause id="sec-temporal-calendaryearmonthfromfields" type="abstract operation">
       <h1>
         CalendarYearMonthFromFields (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _fields_: an Object,
           optional _options_: an Object or *undefined*,
         ): either a normal completion containing a `Temporal.PlainYearMonth` or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It calls the given _calendar_'s `yearMonthFromFields()` method and validates the result.</dd>
+        <dd>It calls the given calendar's `yearMonthFromFields()` method and validates the result.</dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
-        1. If _calendar_ is a String, then
-          1. Set _calendar_ to ! CreateTemporalCalendar(_calendar_).
-          1. Return ? Call(%Temporal.Calendar.prototype.yearMonthFromFields%, _calendar_, « _fields_, _options_ »).
-        1. Let _yearMonth_ be ? Invoke(_calendar_, *"yearMonthFromFields"*, « _fields_, _options_ »).
+        1. Let _yearMonth_ be ? CalendarMethodsRecordCall(_calendarRec_, ~yearMonthFromFields~, « _fields_, _options_ »).
+        1. If CalendarMethodsRecordIsBuiltin(_calendarRec_) is *true*, return _yearMonth_.
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. Return _yearMonth_.
       </emu-alg>
@@ -646,21 +900,19 @@
     <emu-clause id="sec-temporal-calendarmonthdayfromfields" type="abstract operation">
       <h1>
         CalendarMonthDayFromFields (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _fields_: an Object,
           optional _options_: an Object or *undefined*,
         ): either a normal completion containing a `Temporal.PlainMonthDay` or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It calls the given _calendar_'s `monthDayFromFields()` method and validates the result.</dd>
+        <dd>It calls the given calendar's `monthDayFromFields()` method and validates the result.</dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
-        1. If _calendar_ is a String, then
-          1. Set _calendar_ to ! CreateTemporalCalendar(_calendar_).
-          1. Return ? Call(%Temporal.Calendar.prototype.monthDayFromFields%, _calendar_, « _fields_, _options_ »).
-        1. Let _monthDay_ be ? Invoke(_calendar_, *"monthDayFromFields"*, « _fields_, _options_ »).
+        1. Let _monthDay_ be ? CalendarMethodsRecordCall(_calendarRec_, ~monthDayFromFields~, « _fields_, _options_ »).
+        1. If CalendarMethodsRecordIsBuiltin(_calendarRec_) is *true*, return _monthDay_.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. Return _monthDay_.
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -99,15 +99,15 @@
         1. Let _relativeToRecord_ be ? ToRelativeTemporalObject(_options_).
         1. Let _zonedRelativeTo_ be _relativeToRecord_.[[ZonedRelativeTo]].
         1. Let _plainRelativeTo_ be _relativeToRecord_.[[PlainRelativeTo]].
+        1. Let _timeZoneRec_ be _relativeToRecord_.[[TimeZoneRec]].
         1. Let _calendarUnitsPresent_ be *false*.
         1. If _one_.[[Years]] &ne; 0, or _two_.[[Years]] &ne; 0, or _one_.[[Months]] &ne; 0, or _two_.[[Months]] &ne; 0, or _one_.[[Weeks]] &ne; 0, or _two_.[[Weeks]] &ne; 0, set _calendarUnitsPresent_ to *true*.
         1. If _zonedRelativeTo_ is not *undefined*, and either _calendarUnitsPresent_ is *true*, or _one_.[[Days]] &ne; 0, or _two_.[[Days]] &ne; 0, then
-          1. Let _timeZone_ be _zonedRelativeTo_.[[TimeZone]].
           1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
           1. Let _instant_ be ! CreateTemporalInstant(_zonedRelativeTo_.[[Nanoseconds]]).
-          1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
-          1. Let _after1_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], _one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]], _precalculatedPlainDateTime_).
-          1. Let _after2_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], _two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]], _precalculatedPlainDateTime_).
+          1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
+          1. Let _after1_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendar_, _one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], _one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]], _precalculatedPlainDateTime_).
+          1. Let _after2_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendar_, _two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], _two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]], _precalculatedPlainDateTime_).
           1. If _after1_ &gt; _after2_, return *1*<sub>𝔽</sub>.
           1. If _after1_ &lt; _after2_, return *-1*<sub>𝔽</sub>.
           1. Return *+0*<sub>𝔽</sub>.
@@ -433,6 +433,7 @@
         1. Let _relativeToRecord_ be ? ToRelativeTemporalObject(_roundTo_).
         1. Let _zonedRelativeTo_ be _relativeToRecord_.[[ZonedRelativeTo]].
         1. Let _plainRelativeTo_ be _relativeToRecord_.[[PlainRelativeTo]].
+        1. Let _timeZoneRec_ be _relativeToRecord_.[[TimeZoneRec]].
         1. Let _roundingIncrement_ be ? ToTemporalRoundingIncrement(_roundTo_).
         1. Let _roundingMode_ be ? ToTemporalRoundingMode(_roundTo_, *"halfExpand"*).
         1. Let _smallestUnit_ be ? GetTemporalUnit(_roundTo_, *"smallestUnit"*, ~datetime~, *undefined*).
@@ -464,14 +465,14 @@
         1. If _zonedRelativeTo_ is not *undefined* and _plainDateTimeOrRelativeToWillBeUsed_ is *true*, then
           1. NOTE: The above conditions mean that the corresponding `Temporal.PlainDateTime` or `Temporal.PlainDate` for _zonedRelativeTo_ will be used in one of the operations below.
           1. Let _instant_ be ! CreateTemporalInstant(_zonedRelativeTo_.[[Nanoseconds]]).
-          1. Set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_zonedRelativeTo_.[[TimeZone]], _instant_, _zonedRelativeTo_.[[Calendar]]).
+          1. Set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _zonedRelativeTo_.[[Calendar]]).
           1. Set _plainRelativeTo_ to ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _zonedRelativeTo_.[[Calendar]]).
         1. Let _unbalanceResult_ be ? UnbalanceDateDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _plainRelativeTo_).
-        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _plainRelativeTo_, _zonedRelativeTo_, _precalculatedPlainDateTime_).
+        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _plainRelativeTo_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
         1. If _zonedRelativeTo_ is not *undefined*, then
-          1. Set _roundResult_ to ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedRelativeTo_, _precalculatedPlainDateTime_).
-          1. Let _balanceResult_ be ? BalanceTimeDurationRelative(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_, _zonedRelativeTo_, _precalculatedPlainDateTime_).
+          1. Set _roundResult_ to ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
+          1. Let _balanceResult_ be ? BalanceTimeDurationRelative(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Else,
           1. Let _balanceResult_ be ? BalanceTimeDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
         1. Let _result_ be ? BalanceDateDurationRelative(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _balanceResult_.[[Days]], _largestUnit_, _plainRelativeTo_).
@@ -498,24 +499,25 @@
         1. Let _relativeToRecord_ be ? ToRelativeTemporalObject(_totalOf_).
         1. Let _zonedRelativeTo_ be _relativeToRecord_.[[ZonedRelativeTo]].
         1. Let _plainRelativeTo_ be _relativeToRecord_.[[PlainRelativeTo]].
+        1. Let _timeZoneRec_ be _relativeToRecord_.[[TimeZoneRec]].
         1. Let _unit_ be ? GetTemporalUnit(_totalOf_, *"unit"*, ~datetime~, ~required~).
         1. Let _precalculatedPlainDateTime_ be *undefined*.
         1. If _unit_ is *"year"*, or _unit_ is *"month"*, or _unit_ is *"week"*, or _unit_ is *"day"*, or _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, or _duration_.[[Days]] &ne; 0, let _plainDateTimeOrRelativeToWillBeUsed_ be *true*; else let _plainDateTimeOrRelativeToWillBeUsed_ be *false*.
         1. If _zonedRelativeTo_ is not *undefined* and _plainDateTimeOrRelativeToWillBeUsed_ is *true*, then
           1. NOTE: The above conditions mean that the corresponding `Temporal.PlainDateTime` or `Temporal.PlainDate` for _zonedRelativeTo_ will be used in one of the operations below.
           1. Let _instant_ be ! CreateTemporalInstant(_zonedRelativeTo_.[[Nanoseconds]]).
-          1. Set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_zonedRelativeTo_.[[TimeZone]], _instant_, _zonedRelativeTo_.[[Calendar]]).
+          1. Set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _zonedRelativeTo_.[[Calendar]]).
           1. Set _plainRelativeTo_ to ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _zonedRelativeTo_.[[Calendar]]).
         1. Let _unbalanceResult_ be ? UnbalanceDateDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _plainRelativeTo_).
         1. If _zonedRelativeTo_ is not *undefined*, then
-          1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], 0, _precalculatedPlainDateTime_).
-          1. Let _balanceResult_ be ? BalancePossiblyInfiniteTimeDurationRelative(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_, _intermediate_).
+          1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _timeZoneRec_, _unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], 0, _precalculatedPlainDateTime_).
+          1. Let _balanceResult_ be ? BalancePossiblyInfiniteTimeDurationRelative(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_, _intermediate_, _timeZoneRec_).
         1. Else,
           1. Let _balanceResult_ be BalancePossiblyInfiniteTimeDuration(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_).
         1. If _balanceResult_ is ~positive overflow~, return *+∞*<sub>𝔽</sub>.
         1. If _balanceResult_ is ~negative overflow~, return *-∞*<sub>𝔽</sub>.
         1. Assert: _balanceResult_ is a Time Duration Record.
-        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], 1, _unit_, *"trunc"*, _plainRelativeTo_, _zonedRelativeTo_, _precalculatedPlainDateTime_).
+        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], 1, _unit_, *"trunc"*, _plainRelativeTo_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Return 𝔽(_roundRecord_.[[Total]]).
       </emu-alg>
     </emu-clause>
@@ -1304,6 +1306,7 @@
           _nanoseconds_: an integer,
           _largestUnit_: a String,
           _zonedRelativeTo_: a Temporal.ZonedDateTime,
+          _timeZoneRec_: a Time Zone Methods Record,
           _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
         ): either a normal completion containing a Time Duration Record, or an abrupt completion
       </h1>
@@ -1312,7 +1315,7 @@
         <dd>It converts the time units of a duration into a form where lower units are converted into higher units as much as possible, up to _largestUnit_, taking day length of _zonedRelativeTo_ into account. If the Number value for any unit is infinite, it returns abruptly with a *RangeError*.</dd>
       </dl>
       <emu-alg>
-        1. Let _balanceResult_ be ? BalancePossiblyInfiniteTimeDurationRelative(_days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_, _zonedRelativeTo_, _precalculatedPlainDateTime_).
+        1. Let _balanceResult_ be ? BalancePossiblyInfiniteTimeDurationRelative(_days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. If _balanceResult_ is ~positive overflow~ or ~negative overflow~, then
           1. Throw a *RangeError* exception.
         1. Return _balanceResult_.
@@ -1331,6 +1334,7 @@
           _nanoseconds_: an integer,
           _largestUnit_: a String,
           _zonedRelativeTo_: a Temporal.ZonedDateTime,
+          _timeZoneRec_: a Time Zone Methods Record,
           optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
         ): either a normal completion containing either Time Duration Record if there are no infinite values, ~positive overflow~, or ~negative overflow~ in case of infinite values, or an abrupt completion
       </h1>
@@ -1346,15 +1350,15 @@
         1. Let _intermediateNs_ be _zonedRelativeTo_.[[Nanoseconds]].
         1. Let _startInstant_ be ! CreateTemporalInstant(_zonedRelativeTo_.[[Nanoseconds]]).
         1. If _days_ &ne; 0, then
-          1. If _precalculatedPlainDateTime_ is *undefined*, set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_zonedRelativeTo_.[[TimeZone]], _startInstant_, *"iso8601"*).
-          1. Let _intermediateResult_ be ? AddDaysToZonedDateTime(_startInstant_, _precalculatedPlainDateTime_, _zonedRelativeTo_.[[TimeZone]], *"iso8601"*, _days_).
+          1. If _precalculatedPlainDateTime_ is *undefined*, set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, *"iso8601"*).
+          1. Let _intermediateResult_ be ? AddDaysToZonedDateTime(_startInstant_, _precalculatedPlainDateTime_, _timeZoneRec_, *"iso8601"*, _days_).
           1. Set _intermediateNs_ to _intermediateResult_.[[EpochNanoseconds]].
         1. Let _endNs_ be AddInstant(_intermediateNs_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Set _nanoseconds_ to ℝ(_endNs_ - _zonedRelativeTo_.[[Nanoseconds]]).
         1. If _nanoseconds_ = 0, return ! CreateTimeDurationRecord(0, 0, 0, 0, 0, 0, 0).
         1. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-          1. If _precalculatedPlainDateTime_ is *undefined*, set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_zonedRelativeTo_.[[TimeZone]], _startInstant_, *"iso8601"*).
-          1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _zonedRelativeTo_, _precalculatedPlainDateTime_).
+          1. If _precalculatedPlainDateTime_ is *undefined*, set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, *"iso8601"*).
+          1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
           1. Set _days_ to _result_.[[Days]].
           1. Set _largestUnit_ to *"hour"*.
         1. Else,
@@ -1593,6 +1597,7 @@
           _ns2_: an integer,
           _plainRelativeTo_: a Temporal.PlainDate or *undefined*,
           _zonedRelativeTo_: a Temporal.ZonedDateTime or *undefined*,
+          _timeZoneRec_: a Time Zone Methods Record or *undefined*,
           optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
         ): either a normal completion containing a Duration Record, or a throw completion
       </h1>
@@ -1601,6 +1606,7 @@
         <dd>It adds the components of a second duration represented by _y2_ through _ns2_ to those of a first duration represented by _y1_ through _ns1_, and balances the duration relative to the given date _zonedRelativeTo_ or _plainRelativeTo_, to ensure that no mixed signs remain in the result.</dd>
       </dl>
       <emu-alg>
+        1. Assert: If _zonedRelativeTo_ is not *undefined*, _timeZoneRec_ is not *undefined*.
         1. Let _largestUnit1_ be ! DefaultTemporalLargestUnit(_y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_).
         1. Let _largestUnit2_ be ! DefaultTemporalLargestUnit(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_).
         1. Let _largestUnit_ be ! LargerOfTwoTemporalUnits(_largestUnit1_, _largestUnit2_).
@@ -1630,18 +1636,17 @@
           1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Assert: _zonedRelativeTo_ is not *undefined*.
         1. If _precalculatedPlainDateTime_ is not present, let _precalculatedPlainDateTime_ be *undefined*.
-        1. Let _timeZone_ be _zonedRelativeTo_.[[TimeZone]].
         1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
         1. If _precalculatedPlainDateTime_ is *undefined*, then
-          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _zonedRelativeTo_.[[Nanoseconds]], _calendar_).
+          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _zonedRelativeTo_.[[Nanoseconds]], _calendar_).
         1. Else,
           1. Let _startDateTime_ be _precalculatedPlainDateTime_.
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZone_, _calendar_, _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _startDateTime_).
-        1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZone_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendar_, _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _startDateTime_).
+        1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZoneRec_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _result_ be DifferenceInstant(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, _largestUnit_, *"halfExpand"*).
           1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
-        1. Return ? DifferenceZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, _timeZone_, _calendar_, _largestUnit_, OrdinaryObjectCreate(*null*), _startDateTime_).
+        1. Return ? DifferenceZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, _timeZoneRec_, _calendar_, _largestUnit_, OrdinaryObjectCreate(*null*), _startDateTime_).
       </emu-alg>
     </emu-clause>
 
@@ -1694,6 +1699,7 @@
       <h1>
         MoveRelativeZonedDateTime (
           _zonedDateTime_: a Temporal.ZonedDateTime,
+          _timeZoneRec_: a Time Zone Methods Record,
           _years_: an integer,
           _months_: an integer,
           _weeks_: an integer,
@@ -1706,7 +1712,9 @@
         <dd>It adjusts the calendar part of _zonedDateTime_ for use as the "relative-to" parameter of another operation and returns a new `Temporal.ZonedDateTime` instance.</dd>
       </dl>
       <emu-alg>
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
+        1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getOffsetNanosecondsFor~) is *true*.
+        1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getPossibleInstantsFor~) is *true*.
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _zonedDateTime_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
         1. Return ! CreateTemporalZonedDateTime(_intermediateNs_, _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -1729,6 +1737,7 @@
           _roundingMode_: a String,
           optional _plainRelativeTo_: *undefined* or a Temporal.PlainDate,
           optional _zonedRelativeTo_: *undefined* or a Temporal.ZonedDateTime,
+          optional _timeZoneRec_: *undefined* or a Time Zone Methods Record,
           optional _precalculatedPlainDateTime_: *undefined* or a Temporal.PlainDateTime,
         ): either a normal completion containing a Record with fields [[DurationRecord]] (a Duration Record) and [[Total]] (a mathematical value), or a throw completion
       </h1>
@@ -1741,6 +1750,7 @@
         </dd>
       </dl>
       <emu-alg>
+        1. Assert: If _zonedRelativeTo_ is present and not *undefined*, _timeZoneRec_ is not *undefined*.
         1. If _plainRelativeTo_ is not present, set _plainRelativeTo_ to *undefined*.
         1. If _zonedRelativeTo_ is not present, set _zonedRelativeTo_ to *undefined*.
         1. If _precalculatedPlainDateTime_ is not present, set _precalculatedPlainDateTime_ to *undefined*.
@@ -1749,8 +1759,8 @@
         1. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _nanoseconds_ be TotalDurationNanoseconds(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
           1. If _zonedRelativeTo_ is not *undefined*, then
-            1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _years_, _months_, _weeks_, _days_, _precalculatedPlainDateTime_).
-            1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_).
+            1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _timeZoneRec_, _years_, _months_, _weeks_, _days_, _precalculatedPlainDateTime_).
+            1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_, _timeZoneRec_).
             1. Let _fractionalDays_ be _days_ + _result_.[[Days]] + _result_.[[Nanoseconds]] / _result_.[[DayLength]].
           1. Else,
             1. Let _fractionalDays_ be _days_ + _nanoseconds_ / nsPerDay.
@@ -1897,6 +1907,7 @@
           _unit_: a String,
           _roundingMode_: a String,
           _zonedRelativeTo_: a Temporal.ZonedDateTime,
+          _timeZoneRec_: a Time Zone Methods Record,
           _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
         ): either a normal completion containing a Duration Record, or a throw completion
       </h1>
@@ -1916,15 +1927,15 @@
         1. If _timeRemainderNs_ = 0, let _direction_ be 0.
         1. Else if _timeRemainderNs_ &lt; 0, let _direction_ be -1.
         1. Else, let _direction_ be 1.
-        1. Let _dayStart_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _zonedRelativeTo_.[[TimeZone]], _zonedRelativeTo_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
+        1. Let _dayStart_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
         1. Let _dayStartInstant_ be ! CreateTemporalInstant(_dayStart_).
-        1. Let _dayStartDateTime_ be ? GetPlainDateTimeFor(_zonedRelativeTo_.[[TimeZone]], _dayStartInstant_, _zonedRelativeTo_.[[Calendar]]).
-        1. Let _dayEnd_ be ? AddDaysToZonedDateTime(_dayStartInstant_, _dayStartDateTime_, _zonedRelativeTo_.[[TimeZone]], _zonedRelativeTo_.[[Calendar]], _direction_).[[EpochNanoseconds]].
+        1. Let _dayStartDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _dayStartInstant_, _zonedRelativeTo_.[[Calendar]]).
+        1. Let _dayEnd_ be ? AddDaysToZonedDateTime(_dayStartInstant_, _dayStartDateTime_, _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _direction_).[[EpochNanoseconds]].
         1. Let _dayLengthNs_ be ℝ(_dayEnd_ - _dayStart_).
         1. Let _oneDayLess_ be _timeRemainderNs_ - _dayLengthNs_.
         1. If _oneDayLess_ &times; _direction_ &lt; 0, then
           1. Return ! CreateDurationRecord(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, *undefined*, _zonedRelativeTo_, _precalculatedPlainDateTime_).
+        1. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, *undefined*, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Let _adjustedTimeDuration_ be ! RoundDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, _oneDayLess_, _increment_, _unit_, _roundingMode_).
         1. Set _adjustedTimeDuration_ to ? BalanceTimeDuration(0, _adjustedTimeDuration_.[[Hours]], _adjustedTimeDuration_.[[Minutes]], _adjustedTimeDuration_.[[Seconds]], _adjustedTimeDuration_.[[Milliseconds]], _adjustedTimeDuration_.[[Microseconds]], _adjustedTimeDuration_.[[Nanoseconds]], *"hour"*).
         1. Return ! CreateDurationRecord(_adjustedDateDuration_.[[Years]], _adjustedDateDuration_.[[Months]], _adjustedDateDuration_.[[Weeks]], _adjustedDateDuration_.[[Days]], _adjustedTimeDuration_.[[Hours]], _adjustedTimeDuration_.[[Minutes]], _adjustedTimeDuration_.[[Seconds]], _adjustedTimeDuration_.[[Milliseconds]], _adjustedTimeDuration_.[[Microseconds]], _adjustedTimeDuration_.[[Nanoseconds]]).
@@ -2008,7 +2019,7 @@
         1. Set _other_ to ? ToTemporalDurationRecord(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _relativeToRecord_ be ? ToRelativeTemporalObject(_options_).
-        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _sign_ &times; _other_.[[Years]], _sign_ &times; _other_.[[Months]], _sign_ &times; _other_.[[Weeks]], _sign_ &times; _other_.[[Days]], _sign_ &times; _other_.[[Hours]], _sign_ &times; _other_.[[Minutes]], _sign_ &times; _other_.[[Seconds]], _sign_ &times; _other_.[[Milliseconds]], _sign_ &times; _other_.[[Microseconds]], _sign_ &times; _other_.[[Nanoseconds]], _relativeToRecord_.[[PlainRelativeTo]], _relativeToRecord_.[[ZonedRelativeTo]]).
+        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _sign_ &times; _other_.[[Years]], _sign_ &times; _other_.[[Months]], _sign_ &times; _other_.[[Weeks]], _sign_ &times; _other_.[[Days]], _sign_ &times; _other_.[[Hours]], _sign_ &times; _other_.[[Minutes]], _sign_ &times; _other_.[[Seconds]], _sign_ &times; _other_.[[Milliseconds]], _sign_ &times; _other_.[[Microseconds]], _sign_ &times; _other_.[[Nanoseconds]], _relativeToRecord_.[[PlainRelativeTo]], _relativeToRecord_.[[ZonedRelativeTo]], _relativeToRecord_.[[TimeZoneRec]]).
         1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1643,7 +1643,8 @@
           1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Assert: _zonedRelativeTo_ is not *undefined*.
         1. If _precalculatedPlainDateTime_ is not present, let _precalculatedPlainDateTime_ be *undefined*.
-        1. If _precalculatedPlainDateTime_ is *undefined*, then
+        1. If _largestUnit_ is *"year"*, or _largestUnit_ is *"month"*, or _largestUnit_ is *"week"*, or _largestUnit_ is *"day"*, let _startDateTimeNeeded_ be *true*; else let _startDateTimeNeeded_ be *false*.
+        1. If _precalculatedPlainDateTime_ is *undefined* and _startDateTimeNeeded_ is *true*, then
           1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _zonedRelativeTo_.[[Nanoseconds]], _calendarRec_.[[Receiver]]).
         1. Else,
           1. Let _startDateTime_ be _precalculatedPlainDateTime_.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -102,18 +102,23 @@
         1. Let _timeZoneRec_ be _relativeToRecord_.[[TimeZoneRec]].
         1. Let _calendarUnitsPresent_ be *false*.
         1. If _one_.[[Years]] &ne; 0, or _two_.[[Years]] &ne; 0, or _one_.[[Months]] &ne; 0, or _two_.[[Months]] &ne; 0, or _one_.[[Weeks]] &ne; 0, or _two_.[[Weeks]] &ne; 0, set _calendarUnitsPresent_ to *true*.
+        1. Let _calendarRec_ be *undefined*.
+        1. If _zonedRelativeTo_ is not *undefined* or _plainRelativeTo_ is not *undefined*, then
+          1. If _zonedRelativeTo_ is not *undefined*, let _calendar_ be _zonedRelativeTo_.[[Calendar]]; else let _calendar_ be _plainRelativeTo_.[[Calendar]].
+          1. Set _calendarRec_ to ! CreateCalendarMethodsRecord(_calendar_, « »).
+          1. If _calendarUnitsPresent_ is *true*, then
+            1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
         1. If _zonedRelativeTo_ is not *undefined*, and either _calendarUnitsPresent_ is *true*, or _one_.[[Days]] &ne; 0, or _two_.[[Days]] &ne; 0, then
-          1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
           1. Let _instant_ be ! CreateTemporalInstant(_zonedRelativeTo_.[[Nanoseconds]]).
-          1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
-          1. Let _after1_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendar_, _one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], _one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]], _precalculatedPlainDateTime_).
-          1. Let _after2_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendar_, _two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], _two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]], _precalculatedPlainDateTime_).
+          1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
+          1. Let _after1_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], _one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]], _precalculatedPlainDateTime_).
+          1. Let _after2_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], _two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]], _precalculatedPlainDateTime_).
           1. If _after1_ &gt; _after2_, return *1*<sub>𝔽</sub>.
           1. If _after1_ &lt; _after2_, return *-1*<sub>𝔽</sub>.
           1. Return *+0*<sub>𝔽</sub>.
         1. If _calendarUnitsPresent_ is *true*, then
-          1. Let _unbalanceResult1_ be ? UnbalanceDateDurationRelative(_one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], *"day"*, _plainRelativeTo_).
-          1. Let _unbalanceResult2_ be ? UnbalanceDateDurationRelative(_two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], *"day"*, _plainRelativeTo_).
+          1. Let _unbalanceResult1_ be ? UnbalanceDateDurationRelative(_one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], *"day"*, _plainRelativeTo_, _calendarRec_).
+          1. Let _unbalanceResult2_ be ? UnbalanceDateDurationRelative(_two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], *"day"*, _plainRelativeTo_, _calendarRec_).
           1. Let _days1_ be _unbalanceResult1_.[[Days]].
           1. Let _days2_ be _unbalanceResult2_.[[Days]].
         1. Else,
@@ -467,15 +472,35 @@
           1. Let _instant_ be ! CreateTemporalInstant(_zonedRelativeTo_.[[Nanoseconds]]).
           1. Set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _zonedRelativeTo_.[[Calendar]]).
           1. Set _plainRelativeTo_ to ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _zonedRelativeTo_.[[Calendar]]).
-        1. Let _unbalanceResult_ be ? UnbalanceDateDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _plainRelativeTo_).
-        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _plainRelativeTo_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
+        1. Let _calendarRec_ be *undefined*.
+        1. If _zonedRelativeTo_ is not *undefined* or _plainRelativeTo_ is not *undefined*, then
+          1. If _zonedRelativeTo_ is not *undefined*, let _calendar_ be _zonedRelativeTo_.[[Calendar]]; else let _calendar_ be _plainRelativeTo_.[[Calendar]].
+          1. Set _calendarRec_ to ! CreateCalendarMethodsRecord(_calendar_, « »).
+          1. If _largestUnit_ is *"year"*, or _largestUnit_ is *"month"*, or _largestUnit_ is *"week"*, let _largestUnitIsCalendarUnit_ be *true*; else let _largestUnitIsCalendarUnit_ be *false*.
+          1. If _smallestUnit_ is *"year"*, or _smallestUnit_ is *"month"*, or _smallestUnit_ is *"week"*, let _smallestUnitIsCalendarUnit_ be *true*; else let _smallestUnitIsCalendarUnit_ be *false*.
+          1. If _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, or _largestUnitIsCalendarUnit_ is *true*, or _smallestUnitIsCalendarUnit_ is *true*; then
+            1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+          1. Let _dateUntilMayBeCalled_ be *false*.
+          1. If _largestUnit_ is *"year"*, set _dateUntilMayBeCalled_ to *true*.
+          1. If _largestUnit_ is *"month"* and _duration_.[[Years]] &ne; 0, set _dateUntilMayBeCalled_ to *true*.
+          1. If _smallestUnit_ is *"year"*, set _dateUntilMayBeCalled_ to *true*.
+          1. Let _dateUntilMayBeCalledInAdjustDurationEdgeCase_ be *true*.
+          1. If _zonedRelativeTo_ is *undefined*, set _dateUntilMayBeCalledInAdjustDurationEdgeCase_ to *false*.
+          1. If _roundingGranularityIsNoop_ is *true*, set _dateUntilMayBeCalledInAdjustDurationEdgeCase_ to *false*.
+          1. If _smallestUnitIsCalendarUnit_ is *true*, set _dateUntilMayBeCalledInAdjustDurationEdgeCase_ to *false*.
+          1. If _largestUnitIsCalendarUnit_ is *false*, set _dateUntilMayBeCalledInAdjustDurationEdgeCase_ to *false*.
+          1. If _dateUntilMayBeCalledInAdjustDurationEdgeCase_ is *true*, set _dateUntilMayBeCalled_ to *true*.
+          1. If _dateUntilMayBeCalled_ is *true*, then
+            1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateUntil~).
+        1. Let _unbalanceResult_ be ? UnbalanceDateDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _plainRelativeTo_, _calendarRec_).
+        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _plainRelativeTo_, _calendarRec_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
         1. If _zonedRelativeTo_ is not *undefined*, then
-          1. Set _roundResult_ to ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
+          1. Set _roundResult_ to ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _precalculatedPlainDateTime_).
           1. Let _balanceResult_ be ? BalanceTimeDurationRelative(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Else,
           1. Let _balanceResult_ be ? BalanceTimeDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
-        1. Let _result_ be ? BalanceDateDurationRelative(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _balanceResult_.[[Days]], _largestUnit_, _plainRelativeTo_).
+        1. Let _result_ be ? BalanceDateDurationRelative(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _balanceResult_.[[Days]], _largestUnit_, _plainRelativeTo_, _calendarRec_).
         1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -508,16 +533,24 @@
           1. Let _instant_ be ! CreateTemporalInstant(_zonedRelativeTo_.[[Nanoseconds]]).
           1. Set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _zonedRelativeTo_.[[Calendar]]).
           1. Set _plainRelativeTo_ to ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _zonedRelativeTo_.[[Calendar]]).
-        1. Let _unbalanceResult_ be ? UnbalanceDateDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _plainRelativeTo_).
+        1. Let _calendarRec_ be *undefined*.
+        1. If _zonedRelativeTo_ is not *undefined* and _plainRelativeTo_ is not *undefined*, then
+          1. If _zonedRelativeTo_ is not *undefined*, let _calendar_ be _zonedRelativeTo_.[[Calendar]]; else let _calendar_ be _plainRelativeTo_.[[Calendar]].
+          1. Set _calendarRec_ to ! CreateCalendarMethodsRecord(_calendar_, « »).
+          1. If _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, or _unit_ is *"year"*, or _unit_ is *"month"*, or _unit_ is *"week"*, then
+            1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+          1. If _unit_ is *"year"*, or _unit_ is *"month"* and _duration_.[[Years]] &ne; 0, then
+            1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateUntil~).
+        1. Let _unbalanceResult_ be ? UnbalanceDateDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _plainRelativeTo_, _calendarRec_).
         1. If _zonedRelativeTo_ is not *undefined*, then
-          1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _timeZoneRec_, _unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], 0, _precalculatedPlainDateTime_).
+          1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], 0, _precalculatedPlainDateTime_).
           1. Let _balanceResult_ be ? BalancePossiblyInfiniteTimeDurationRelative(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_, _intermediate_, _timeZoneRec_).
         1. Else,
           1. Let _balanceResult_ be BalancePossiblyInfiniteTimeDuration(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_).
         1. If _balanceResult_ is ~positive overflow~, return *+∞*<sub>𝔽</sub>.
         1. If _balanceResult_ is ~negative overflow~, return *-∞*<sub>𝔽</sub>.
         1. Assert: _balanceResult_ is a Time Duration Record.
-        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], 1, _unit_, *"trunc"*, _plainRelativeTo_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
+        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], 1, _unit_, *"trunc"*, _plainRelativeTo_, _calendarRec_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Return 𝔽(_roundRecord_.[[Total]]).
       </emu-alg>
     </emu-clause>
@@ -1381,6 +1414,7 @@
           _days_: an integer,
           _largestUnit_: a String,
           _plainRelativeTo_: *undefined* or a Temporal.PlainDate,
+          _calendarRec_: *undefined* or a Calendar Methods Record,
         )
       </h1>
       <dl class="header">
@@ -1388,6 +1422,7 @@
         <dd>It converts the calendar units of a duration into a form where no unit is larger than _largestUnit_, and returns the result as a Date Duration Record.</dd>
       </dl>
       <emu-alg>
+        1. Assert: If _plainRelativeTo_ is not *undefined*, _calendarRec_ is not *undefined*.
         1. Let _allZero_ be *false*.
         1. If _years_ = 0, and _months_ = 0, and _weeks_ = 0, and _days_ = 0, set _allZero_ to *true*.
         1. If _largestUnit_ is *"year"* or _allZero_ is *true*, then
@@ -1397,25 +1432,17 @@
         1. Let _oneYear_ be ! CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _oneMonth_ be ! CreateTemporalDuration(0, _sign_, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, _sign_, 0, 0, 0, 0, 0, 0, 0).
-        1. If _plainRelativeTo_ is not *undefined*, then
-          1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
-        1. Else,
-          1. Let _calendar_ be *undefined*.
         1. If _largestUnit_ is *"month"*, then
           1. If _years_ = 0, return ! CreateDateDurationRecord(0, _months_, _weeks_, _days_).
-          1. If _calendar_ is *undefined*, then
+          1. If _calendarRec_ is *undefined*, then
             1. Throw a *RangeError* exception.
-          1. If _calendar_ is an Object, then
-            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-            1. Let _dateUntil_ be ? GetMethod(_calendar_, *"dateUntil"*).
-          1. Else,
-            1. Let _dateAdd_ be ~unused~.
-            1. Let _dateUntil_ be ~unused~.
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateUntil~) is *true*.
           1. Repeat, while _years_ &ne; 0,
-            1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendar_, _plainRelativeTo_, _oneYear_, *undefined*, _dateAdd_).
+            1. Let _newRelativeTo_ be ? CalendarDateAdd(_calendarRec_, _plainRelativeTo_, _oneYear_).
             1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
             1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
-            1. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _plainRelativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
+            1. Let _untilResult_ be ? CalendarDateUntil(_calendarRec_, _plainRelativeTo_, _newRelativeTo_, _untilOptions_).
             1. Let _oneYearMonths_ be _untilResult_.[[Months]].
             1. Set _plainRelativeTo_ to _newRelativeTo_.
             1. Set _years_ to _years_ - _sign_.
@@ -1423,42 +1450,36 @@
           1. Return ? CreateDateDurationRecord(0, _months_, _weeks_, _days_).
         1. If _largestUnit_ is *"week"*, then
           1. If _years_ = 0 and _months_ = 0, return ! CreateDateDurationRecord(0, 0, _weeks_, _days_).
-          1. If _calendar_ is *undefined*, then
+          1. If _calendarRec_ is *undefined*, then
             1. Throw a *RangeError* exception.
-          1. If _calendar_ is an Object, then
-            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Else,
-            1. Let _dateAdd_ be ~unused~.
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
           1. Repeat, while _years_ &ne; 0,
-            1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneYear_, _dateAdd_).
+            1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneYear_).
             1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
             1. Set _years_ to _years_ - _sign_.
           1. Repeat, while _months_ &ne; 0,
-            1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneMonth_, _dateAdd_).
+            1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneMonth_).
             1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _days_ to _days_ + _moveResult_.[[Days]].
             1. Set _months_ to _months_ - _sign_.
           1. Return ? CreateDateDurationRecord(0, 0, _weeks_, _days_).
         1. If _years_ = 0, and _months_ = 0, and _weeks_ = 0, return ! CreateDateDurationRecord(0, 0, 0, _days_).
-        1. If _calendar_ is *undefined*, then
+        1. If _calendarRec_ is *undefined*, then
           1. Throw a *RangeError* exception.
-        1. If _calendar_ is an Object, then
-          1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-        1. Else,
-          1. Let _dateAdd_ be ~unused~.
+        1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
         1. Repeat, while _years_ &ne; 0,
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneYear_, _dateAdd_).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneYear_).
           1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
           1. Set _days_ to _days_ + _moveResult_.[[Days]].
           1. Set _years_ to _years_ - _sign_.
         1. Repeat, while _months_ &ne; 0,
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneMonth_, _dateAdd_).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneMonth_).
           1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
           1. Set _days_ to _days_ +_moveResult_.[[Days]].
           1. Set _months_ to _months_ - _sign_.
         1. Repeat, while _weeks_ &ne; 0,
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneWeek_, _dateAdd_).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneWeek_).
           1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
           1. Set _days_ to _days_ + _moveResult_.[[Days]].
           1. Set _weeks_ to _weeks_ - _sign_.
@@ -1475,6 +1496,7 @@
           _days_: an integer,
           _largestUnit_: a String,
           _plainRelativeTo_: *undefined* or a Temporal.PlainDate,
+          _calendarRec_: *undefined* or a Calendar Methods Record,
         )
       </h1>
       <dl class="header">
@@ -1482,6 +1504,7 @@
         <dd>It converts the calendar units of a duration into a form where lower units are converted into higher units as much as possible, up to _largestUnit_, and returns the result as a Date Duration Record.</dd>
       </dl>
       <emu-alg>
+        1. Assert: If _plainRelativeTo_ is not *undefined*, _calendarRec_ is not *undefined*.
         1. Let _allZero_ be *false*.
         1. If _years_ = 0, and _months_ = 0, and _weeks_ = 0, and _days_ = 0, set _allZero_ to *true*.
         1. If _largestUnit_ is not one of *"year"*, *"month"*, or *"week"*, or _allZero_ is *true*, then
@@ -1493,79 +1516,66 @@
         1. Let _oneYear_ be ! CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _oneMonth_ be ! CreateTemporalDuration(0, _sign_, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, _sign_, 0, 0, 0, 0, 0, 0, 0).
-        1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
         1. If _largestUnit_ is *"year"*, then
-          1. If _calendar_ is an Object, then
-            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Else,
-            1. Let _dateAdd_ be ~unused~.
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneYear_, _dateAdd_).
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateUntil~) is *true*.
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneYear_).
           1. Let _newRelativeTo_ be _moveResult_.[[RelativeTo]].
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneYearDays_),
             1. Set _days_ to _days_ - _oneYearDays_.
             1. Set _years_ to _years_ + _sign_.
             1. Set _plainRelativeTo_ to _newRelativeTo_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneYear_, _dateAdd_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneYear_).
             1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneYearDays_ to _moveResult_.[[Days]].
-          1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneMonth_, _dateAdd_).
+          1. Set _moveResult_ to ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneMonth_).
           1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneMonthDays_),
             1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _months_ to _months_ + _sign_.
             1. Set _plainRelativeTo_ to _newRelativeTo_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneMonth_, _dateAdd_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneMonth_).
             1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
-          1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendar_, _plainRelativeTo_, _oneYear_, *undefined*, _dateAdd_).
-          1. If _calendar_ is an Object, then
-            1. Let _dateUntil_ be ? GetMethod(_calendar_, *"dateUntil"*).
-          1. Else,
-            1. Let _dateUntil_ be ~unused~.
+          1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendarRec_, _plainRelativeTo_, _oneYear_).
           1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
-          1. Let _untilResult_ be ? CalendarDateUntil(_calendar_, _plainRelativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
+          1. Let _untilResult_ be ? CalendarDateUntil(_calendarRec_, _plainRelativeTo_, _newRelativeTo_, _untilOptions_).
           1. Let _oneYearMonths_ be _untilResult_.[[Months]].
           1. Repeat, while abs(_months_) &ge; abs(_oneYearMonths_),
             1. Set _months_ to _months_ - _oneYearMonths_.
             1. Set _years_ to _years_ + _sign_.
             1. Set _plainRelativeTo_ to _newRelativeTo_.
-            1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendar_, _plainRelativeTo_, _oneYear_, *undefined*, _dateAdd_).
+            1. Set _newRelativeTo_ to ? CalendarDateAdd(_calendarRec_, _plainRelativeTo_, _oneYear_).
             1. Set _untilOptions_ to OrdinaryObjectCreate(*null*).
             1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"month"*).
-            1. Set _untilResult_ to ? CalendarDateUntil(_calendar_, _plainRelativeTo_, _newRelativeTo_, _untilOptions_, _dateUntil_).
+            1. Set _untilResult_ to ? CalendarDateUntil(_calendarRec_, _plainRelativeTo_, _newRelativeTo_, _untilOptions_).
             1. Set _oneYearMonths_ to _untilResult_.[[Months]].
         1. Else if _largestUnit_ is *"month"*, then
-          1. If _calendar_ is an Object, then
-            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Else,
-            1. Let _dateAdd_ be ~unused~.
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneMonth_, _dateAdd_).
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneMonth_).
           1. Let _newRelativeTo_ be _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneMonthDays_),
             1. Set _days_ to _days_ - _oneMonthDays_.
             1. Set _months_ to _months_ + _sign_.
             1. Set _plainRelativeTo_ to _newRelativeTo_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneMonth_, _dateAdd_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneMonth_).
             1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
         1. Else,
           1. Assert: _largestUnit_ is *"week"*.
-          1. If _calendar_ is an Object, then
-            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Else,
-            1. Let _dateAdd_ be ~unused~.
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneWeek_, _dateAdd_).
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneWeek_).
           1. Let _newRelativeTo_ be _moveResult_.[[RelativeTo]].
           1. Let _oneWeekDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_days_) &ge; abs(_oneWeekDays_),
             1. Set _days_ to _days_ - _oneWeekDays_.
             1. Set _weeks_ to _weeks_ + _sign_.
             1. Set _plainRelativeTo_ to _newRelativeTo_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneWeek_, _dateAdd_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneWeek_).
             1. Set _newRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneWeekDays_ to _moveResult_.[[Days]].
         1. Return ! CreateDateDurationRecord(_years_, _months_, _weeks_, _days_).
@@ -1596,6 +1606,7 @@
           _mus2_: an integer,
           _ns2_: an integer,
           _plainRelativeTo_: a Temporal.PlainDate or *undefined*,
+          _calendarRec_: a Calendar Methods Record or *undefined*,
           _zonedRelativeTo_: a Temporal.ZonedDateTime or *undefined*,
           _timeZoneRec_: a Time Zone Methods Record or *undefined*,
           optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
@@ -1606,6 +1617,7 @@
         <dd>It adds the components of a second duration represented by _y2_ through _ns2_ to those of a first duration represented by _y1_ through _ns1_, and balances the duration relative to the given date _zonedRelativeTo_ or _plainRelativeTo_, to ensure that no mixed signs remain in the result.</dd>
       </dl>
       <emu-alg>
+        1. Assert: If _zonedRelativeTo_ is not *undefined*, _calendarRec_ is not *undefined*.
         1. Assert: If _zonedRelativeTo_ is not *undefined*, _timeZoneRec_ is not *undefined*.
         1. Let _largestUnit1_ be ! DefaultTemporalLargestUnit(_y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_).
         1. Let _largestUnit2_ be ! DefaultTemporalLargestUnit(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_).
@@ -1617,36 +1629,30 @@
           1. Return ! CreateDurationRecord(0, 0, 0, _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. If _plainRelativeTo_ is not *undefined*, then
           1. Assert: _zonedRelativeTo_ is *undefined*.
-          1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
           1. Let _dateDuration1_ be ! CreateTemporalDuration(_y1_, _mon1_, _w1_, _d1_, 0, 0, 0, 0, 0, 0).
           1. Let _dateDuration2_ be ! CreateTemporalDuration(_y2_, _mon2_, _w2_, _d2_, 0, 0, 0, 0, 0, 0).
           1. Let _calendarUnitsPresent_ be *true*.
           1. If _y1_ = 0 and _mon1_ = 0 and _w1_ = 0 and _y2_ = 0 and _mon2_ = 0 and _w2_ = 0, set _calendarUnitsPresent_ to *false*.
-          1. If _calendar_ is an Object and _calendarUnitsPresent_ is *true*, then
-            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Else,
-            1. Let _dateAdd_ be ~unused~.
-          1. Let _intermediate_ be ? AddDate(_calendar_, _plainRelativeTo_, _dateDuration1_, *undefined*, _dateAdd_).
-          1. Let _end_ be ? AddDate(_calendar_, _intermediate_, _dateDuration2_, *undefined*, _dateAdd_).
+          1. Let _intermediate_ be ? AddDate(_calendarRec_, _plainRelativeTo_, _dateDuration1_).
+          1. Let _end_ be ? AddDate(_calendarRec_, _intermediate_, _dateDuration2_).
           1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
           1. Let _differenceOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_differenceOptions_, *"largestUnit"*, _dateLargestUnit_).
-          1. Let _dateDifference_ be ? DifferenceDate(_calendar_, _plainRelativeTo_, _end_, _differenceOptions_).
+          1. Let _dateDifference_ be ? DifferenceDate(_calendarRec_, _plainRelativeTo_, _end_, _differenceOptions_).
           1. Let _result_ be ? BalanceTimeDuration(_dateDifference_.[[Days]], _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
           1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Assert: _zonedRelativeTo_ is not *undefined*.
         1. If _precalculatedPlainDateTime_ is not present, let _precalculatedPlainDateTime_ be *undefined*.
-        1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
         1. If _precalculatedPlainDateTime_ is *undefined*, then
-          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _zonedRelativeTo_.[[Nanoseconds]], _calendar_).
+          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _zonedRelativeTo_.[[Nanoseconds]], _calendarRec_.[[Receiver]]).
         1. Else,
           1. Let _startDateTime_ be _precalculatedPlainDateTime_.
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendar_, _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _startDateTime_).
-        1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZoneRec_, _calendar_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _startDateTime_).
+        1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZoneRec_, _calendarRec_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _result_ be DifferenceInstant(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, _largestUnit_, *"halfExpand"*).
           1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
-        1. Return ? DifferenceZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, _timeZoneRec_, _calendar_, _largestUnit_, OrdinaryObjectCreate(*null*), _startDateTime_).
+        1. Return ? DifferenceZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, _timeZoneRec_, _calendarRec_, _largestUnit_, OrdinaryObjectCreate(*null*), _startDateTime_).
       </emu-alg>
     </emu-clause>
 
@@ -1672,10 +1678,9 @@
     <emu-clause id="sec-temporal-moverelativedate" type="abstract operation">
       <h1>
         MoveRelativeDate (
-          _calendar_: an Object,
+          _calendarRec_: a Calendar Methods Record,
           _relativeTo_: a Temporal.PlainDate,
           _duration_: a Temporal.Duration,
-          _dateAdd_: a function object or *undefined*,
         )
       </h1>
       <dl class="header">
@@ -1686,7 +1691,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _newDate_ be ? AddDate(_calendar_, _relativeTo_, _duration_, *undefined*, _dateAdd_).
+        1. Let _newDate_ be ? AddDate(_calendarRec_, _relativeTo_, _duration_).
         1. Let _days_ be DaysUntil(_relativeTo_, _newDate_).
         1. Return the Record {
             [[RelativeTo]]: _newDate_,
@@ -1699,6 +1704,7 @@
       <h1>
         MoveRelativeZonedDateTime (
           _zonedDateTime_: a Temporal.ZonedDateTime,
+          _calendarRec_: a Calendar Methods Record,
           _timeZoneRec_: a Time Zone Methods Record,
           _years_: an integer,
           _months_: an integer,
@@ -1714,7 +1720,7 @@
       <emu-alg>
         1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getOffsetNanosecondsFor~) is *true*.
         1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getPossibleInstantsFor~) is *true*.
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _zonedDateTime_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
         1. Return ! CreateTemporalZonedDateTime(_intermediateNs_, _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -1736,6 +1742,7 @@
           _unit_: a String,
           _roundingMode_: a String,
           optional _plainRelativeTo_: *undefined* or a Temporal.PlainDate,
+          optional _calendarRec_: *undefined* or a Calendar Methods Record,
           optional _zonedRelativeTo_: *undefined* or a Temporal.ZonedDateTime,
           optional _timeZoneRec_: *undefined* or a Time Zone Methods Record,
           optional _precalculatedPlainDateTime_: *undefined* or a Temporal.PlainDateTime,
@@ -1750,6 +1757,7 @@
         </dd>
       </dl>
       <emu-alg>
+        1. Assert: If either of _plainRelativeTo_ or _zonedRelativeTo_ are present and not *undefined*, _calendarRec_ is not *undefined*.
         1. Assert: If _zonedRelativeTo_ is present and not *undefined*, _timeZoneRec_ is not *undefined*.
         1. If _plainRelativeTo_ is not present, set _plainRelativeTo_ to *undefined*.
         1. If _zonedRelativeTo_ is not present, set _zonedRelativeTo_ to *undefined*.
@@ -1759,7 +1767,7 @@
         1. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _nanoseconds_ be TotalDurationNanoseconds(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
           1. If _zonedRelativeTo_ is not *undefined*, then
-            1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _timeZoneRec_, _years_, _months_, _weeks_, _days_, _precalculatedPlainDateTime_).
+            1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _years_, _months_, _weeks_, _days_, _precalculatedPlainDateTime_).
             1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_, _timeZoneRec_).
             1. Let _fractionalDays_ be _days_ + _result_.[[Days]] + _result_.[[Nanoseconds]] / _result_.[[DayLength]].
           1. Else,
@@ -1771,60 +1779,53 @@
           1. Assert: _fractionalDays_ is not used below.
         1. Let _total_ be ~unset~.
         1. If _unit_ is *"year"*, then
-          1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateUntil~) is *true*.
           1. Let _yearsDuration_ be ! CreateTemporalDuration(_years_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. If _calendar_ is an Object, then
-            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Else,
-            1. Let _dateAdd_ be ~unused~.
-          1. Let _yearsLater_ be ? AddDate(_calendar_, _plainRelativeTo_, _yearsDuration_, *undefined*, _dateAdd_).
+          1. Let _yearsLater_ be ? AddDate(_calendarRec_, _plainRelativeTo_, _yearsDuration_).
           1. Let _yearsMonthsWeeks_ be ! CreateTemporalDuration(_years_, _months_, _weeks_, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _yearsMonthsWeeksLater_ be ? AddDate(_calendar_, _plainRelativeTo_, _yearsMonthsWeeks_, *undefined*, _dateAdd_).
+          1. Let _yearsMonthsWeeksLater_ be ? AddDate(_calendarRec_, _plainRelativeTo_, _yearsMonthsWeeks_).
           1. Let _monthsWeeksInDays_ be DaysUntil(_yearsLater_, _yearsMonthsWeeksLater_).
           1. Set _plainRelativeTo_ to _yearsLater_.
           1. Set _fractionalDays_ to _fractionalDays_ + _monthsWeeksInDays_.
           1. Let _isoResult_ be ! AddISODate(_plainRelativeTo_.[[ISOYear]]. _plainRelativeTo_.[[ISOMonth]], _plainRelativeTo_.[[ISODay]], 0, 0, 0, truncate(_fractionalDays_), *"constrain"*).
-          1. Let _wholeDaysLater_ be ? CreateTemporalDate(_isoResult_.[[Year]], _isoResult_.[[Month]], _isoResult_.[[Day]], _calendar_).
+          1. Let _wholeDaysLater_ be ? CreateTemporalDate(_isoResult_.[[Year]], _isoResult_.[[Month]], _isoResult_.[[Day]], _calendarRec_.[[Receiver]]).
           1. Let _untilOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, *"year"*).
-          1. Let _timePassed_ be ? DifferenceDate(_calendar_, _plainRelativeTo_, _wholeDaysLater_, _untilOptions_).
+          1. Let _timePassed_ be ? DifferenceDate(_calendarRec_, _plainRelativeTo_, _wholeDaysLater_, _untilOptions_).
           1. Let _yearsPassed_ be _timePassed_.[[Years]].
           1. Set _years_ to _years_ + _yearsPassed_.
           1. Let _yearsDuration_ be ! CreateTemporalDuration(_yearsPassed_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _yearsDuration_, _dateAdd_).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _yearsDuration_).
           1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _daysPassed_ be _moveResult_.[[Days]].
           1. Set _fractionalDays_ to _fractionalDays_ - _daysPassed_.
           1. If _fractionalDays_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneYear_ be ! CreateTemporalDuration(_sign_, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneYear_, _dateAdd_).
+          1. Set _moveResult_ to ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneYear_).
           1. Let _oneYearDays_ be _moveResult_.[[Days]].
           1. Let _fractionalYears_ be _years_ + _fractionalDays_ / abs(_oneYearDays_).
           1. Set _years_ to RoundNumberToIncrement(_fractionalYears_, _increment_, _roundingMode_).
           1. Set _total_ to _fractionalYears_.
           1. Set _months_ and _weeks_ to 0.
         1. Else if _unit_ is *"month"*, then
-          1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
           1. Let _yearsMonths_ be ! CreateTemporalDuration(_years_, _months_, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. If _calendar_ is an Object, then
-            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Else,
-            1. Let _dateAdd_ be ~unused~.
-          1. Let _yearsMonthsLater_ be ? AddDate(_calendar_, _plainRelativeTo_, _yearsMonths_, *undefined*, _dateAdd_).
+          1. Let _yearsMonthsLater_ be ? AddDate(_calendarRec_, _plainRelativeTo_, _yearsMonths_).
           1. Let _yearsMonthsWeeks_ be ! CreateTemporalDuration(_years_, _months_, _weeks_, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _yearsMonthsWeeksLater_ be ? AddDate(_calendar_, _plainRelativeTo_, _yearsMonthsWeeks_, *undefined*, _dateAdd_).
+          1. Let _yearsMonthsWeeksLater_ be ? AddDate(_calendarRec_, _plainRelativeTo_, _yearsMonthsWeeks_).
           1. Let _weeksInDays_ be DaysUntil(_yearsMonthsLater_, _yearsMonthsWeeksLater_).
           1. Set _plainRelativeTo_ to _yearsMonthsLater_.
           1. Set _fractionalDays_ to _fractionalDays_ + _weeksInDays_.
           1. If _fractionalDays_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneMonth_ be ! CreateTemporalDuration(0, _sign_, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneMonth_, _dateAdd_).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneMonth_).
           1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneMonthDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_fractionalDays_) &ge; abs(_oneMonthDays_),
             1. Set _months_ to _months_ + _sign_.
             1. Set _fractionalDays_ to _fractionalDays_ - _oneMonthDays_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneMonth_, _dateAdd_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneMonth_).
             1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneMonthDays_ to _moveResult_.[[Days]].
           1. Let _fractionalMonths_ be _months_ + _fractionalDays_ / abs(_oneMonthDays_).
@@ -1832,20 +1833,16 @@
           1. Set _total_ to _fractionalMonths_.
           1. Set _weeks_ to 0.
         1. Else if _unit_ is *"week"*, then
-          1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
+          1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
           1. If _fractionalDays_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
           1. Let _oneWeek_ be ! CreateTemporalDuration(0, 0, _sign_, 0, 0, 0, 0, 0, 0, 0).
-          1. If _calendar_ is an Object, then
-            1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Else,
-            1. Let _dateAdd_ be ~unused~.
-          1. Let _moveResult_ be ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneWeek_, _dateAdd_).
+          1. Let _moveResult_ be ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneWeek_).
           1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
           1. Let _oneWeekDays_ be _moveResult_.[[Days]].
           1. Repeat, while abs(_fractionalDays_) &ge; abs(_oneWeekDays_),
             1. Set _weeks_ to _weeks_ + _sign_.
             1. Set _fractionalDays_ to _fractionalDays_ - _oneWeekDays_.
-            1. Set _moveResult_ to ? MoveRelativeDate(_calendar_, _plainRelativeTo_, _oneWeek_, _dateAdd_).
+            1. Set _moveResult_ to ? MoveRelativeDate(_calendarRec_, _plainRelativeTo_, _oneWeek_).
             1. Set _plainRelativeTo_ to _moveResult_.[[RelativeTo]].
             1. Set _oneWeekDays_ to _moveResult_.[[Days]].
           1. Let _fractionalWeeks_ be _weeks_ + _fractionalDays_ / abs(_oneWeekDays_).
@@ -1907,6 +1904,7 @@
           _unit_: a String,
           _roundingMode_: a String,
           _zonedRelativeTo_: a Temporal.ZonedDateTime,
+          _calendarRec_: a Calendar Methods Record,
           _timeZoneRec_: a Time Zone Methods Record,
           _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
         ): either a normal completion containing a Duration Record, or a throw completion
@@ -1927,7 +1925,7 @@
         1. If _timeRemainderNs_ = 0, let _direction_ be 0.
         1. Else if _timeRemainderNs_ &lt; 0, let _direction_ be -1.
         1. Else, let _direction_ be 1.
-        1. Let _dayStart_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
+        1. Let _dayStart_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
         1. Let _dayStartInstant_ be ! CreateTemporalInstant(_dayStart_).
         1. Let _dayStartDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _dayStartInstant_, _zonedRelativeTo_.[[Calendar]]).
         1. Let _dayEnd_ be ? AddDaysToZonedDateTime(_dayStartInstant_, _dayStartDateTime_, _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _direction_).[[EpochNanoseconds]].
@@ -1935,7 +1933,7 @@
         1. Let _oneDayLess_ be _timeRemainderNs_ - _dayLengthNs_.
         1. If _oneDayLess_ &times; _direction_ &lt; 0, then
           1. Return ! CreateDurationRecord(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, *undefined*, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
+        1. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, *undefined*, _zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Let _adjustedTimeDuration_ be ! RoundDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, _oneDayLess_, _increment_, _unit_, _roundingMode_).
         1. Set _adjustedTimeDuration_ to ? BalanceTimeDuration(0, _adjustedTimeDuration_.[[Hours]], _adjustedTimeDuration_.[[Minutes]], _adjustedTimeDuration_.[[Seconds]], _adjustedTimeDuration_.[[Milliseconds]], _adjustedTimeDuration_.[[Microseconds]], _adjustedTimeDuration_.[[Nanoseconds]], *"hour"*).
         1. Return ! CreateDurationRecord(_adjustedDateDuration_.[[Years]], _adjustedDateDuration_.[[Months]], _adjustedDateDuration_.[[Weeks]], _adjustedDateDuration_.[[Days]], _adjustedTimeDuration_.[[Hours]], _adjustedTimeDuration_.[[Minutes]], _adjustedTimeDuration_.[[Seconds]], _adjustedTimeDuration_.[[Milliseconds]], _adjustedTimeDuration_.[[Microseconds]], _adjustedTimeDuration_.[[Nanoseconds]]).
@@ -2019,7 +2017,18 @@
         1. Set _other_ to ? ToTemporalDurationRecord(_other_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _relativeToRecord_ be ? ToRelativeTemporalObject(_options_).
-        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _sign_ &times; _other_.[[Years]], _sign_ &times; _other_.[[Months]], _sign_ &times; _other_.[[Weeks]], _sign_ &times; _other_.[[Days]], _sign_ &times; _other_.[[Hours]], _sign_ &times; _other_.[[Minutes]], _sign_ &times; _other_.[[Seconds]], _sign_ &times; _other_.[[Milliseconds]], _sign_ &times; _other_.[[Microseconds]], _sign_ &times; _other_.[[Nanoseconds]], _relativeToRecord_.[[PlainRelativeTo]], _relativeToRecord_.[[ZonedRelativeTo]], _relativeToRecord_.[[TimeZoneRec]]).
+        1. Let _plainRelativeTo_ be _relativeToRecord_.[[PlainRelativeTo]].
+        1. Let _zonedRelativeTo_ be _relativeToRecord_.[[ZonedRelativeTo]].
+        1. Let _timeZoneRec_ be _relativeToRecord_.[[TimeZoneRec]].
+        1. Let _calendarRec_ be *undefined*.
+        1. If _zonedRelativeTo_ is not *undefined* and _plainRelativeTo_ is not *undefined*, then
+          1. If _zonedRelativeTo_ is not *undefined*, let _calendar_ be _zonedRelativeTo_.[[Calendar]]; else let _calendar_ be _plainRelativeTo_.[[Calendar]].
+          1. Set _calendarRec_ to ! CreateCalendarMethodsRecord(_calendar_, « »).
+          1. If _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, or _other_.[[Years]] &ne; 0, or _other_.[[Months]] &ne; 0, or _other_.[[Weeks]] &ne; 0, then
+            1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+            1. If _other_.[[Years]] &ne; 0, or _other_.[[Months]] &ne; 0, or _other_.[[Weeks]] &ne; 0, or _other_.[[Days]] &ne; 0, or _other_.[[Hours]] &ne; 0, or _other_.[[Minutes]] &ne; 0, or _other_.[[Seconds]] &ne; 0, or _other_.[[Milliseconds]] &ne; 0, or _other_.[[Microseconds]] &ne; 0, or _other_.[[Nanoseconds]] &ne; 0, then
+              1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateUntil~).
+        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _sign_ &times; _other_.[[Years]], _sign_ &times; _other_.[[Months]], _sign_ &times; _other_.[[Weeks]], _sign_ &times; _other_.[[Days]], _sign_ &times; _other_.[[Hours]], _sign_ &times; _other_.[[Minutes]], _sign_ &times; _other_.[[Seconds]], _sign_ &times; _other_.[[Milliseconds]], _sign_ &times; _other_.[[Microseconds]], _sign_ &times; _other_.[[Nanoseconds]], _plainRelativeTo_, _calendarRec_, _zonedRelativeTo_, _timeZoneRec_).
         1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -642,8 +642,9 @@
         1. Assert: _instant_ has an [[InitializedTemporalInstant]] internal slot.
         1. Let _outputTimeZone_ be _timeZone_.
         1. If _outputTimeZone_ is *undefined*, set _outputTimeZone_ to *"UTC"*.
-        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_outputTimeZone_, _instant_).
-        1. Let _dateTime_ be ! GetPlainDateTimeFor(_outputTimeZone_, _instant_, *"iso8601"*, _offsetNanoseconds_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_outputTimeZone_, « ~getOffsetNanosecondsFor~ »).
+        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_).
+        1. Let _dateTime_ be ! GetPlainDateTimeFor(_timeZoneRec_, _instant_, *"iso8601"*, _offsetNanoseconds_).
         1. Let _dateTimeString_ be ! TemporalDateTimeToString(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], *"iso8601"*, _precision_, *"never"*).
         1. If _timeZone_ is *undefined*, then
           1. Let _timeZoneString_ be *"Z"*.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -858,7 +858,8 @@
       1. Let _calendar_ be ? ToTemporalCalendarIdentifier(_temporalDate_.[[Calendar]]).
       1. If _calendar_ is not _dateTimeFormat_.[[Calendar]] or *"iso8601"*, throw a *RangeError* exception.
       1. Let _plainDateTime_ be ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], 12, 0, 0, 0, 0, 0, _dateTimeFormat_.[[Calendar]]).
-      1. Let _instant_ be ? GetInstantFor(_dateTimeFormat_.[[TimeZone]], _plainDateTime_, *"compatible"*).
+      1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_dateTimeFormat_.[[TimeZone]], « ~getPossibleInstantsFor~ »).
+      1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _plainDateTime_, *"compatible"*).
       1. If _pattern_ is *null*, throw a *TypeError* exception.
       1. Return the Record {
           [[pattern]]: _pattern_.[[pattern]],
@@ -883,7 +884,8 @@
       1. If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then
         1. Throw a *RangeError* exception.
       1. Let _plainDateTime_ be ? CreateTemporalDateTime(_temporalYearMonth_.[[ISOYear]], _temporalYearMonth_.[[ISOMonth]], _temporalYearMonth_.[[ISODay]], 12, 0, 0, 0, 0, 0, _dateTimeFormat_.[[Calendar]]).
-      1. Let _instant_ be ? GetInstantFor(_dateTimeFormat_.[[TimeZone]], _plainDateTime_, *"compatible"*).
+      1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_dateTimeFormat_.[[TimeZone]], « ~getPossibleInstantsFor~ »).
+      1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _plainDateTime_, *"compatible"*).
       1. If _pattern_ is *null*, throw a *TypeError* exception.
       1. Return the Record {
           [[pattern]]: _pattern_.[[pattern]],
@@ -909,7 +911,8 @@
       1. If _calendar_ is not equal to _dateTimeFormat_.[[Calendar]], then
         1. Throw a *RangeError* exception.
       1. Let _plainDateTime_ be ? CreateTemporalDateTime(_temporalMonthDay_.[[ISOYear]], _temporalMonthDay_.[[ISOMonth]], _temporalMonthDay_.[[ISODay]], 12, 0, 0, 0, 0, 0, _dateTimeFormat_.[[Calendar]]).
-      1. Let _instant_ be ? GetInstantFor(_dateTimeFormat_.[[TimeZone]], _plainDateTime_, *"compatible"*).
+      1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_dateTimeFormat_.[[TimeZone]], « ~getPossibleInstantsFor~ »).
+      1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _plainDateTime_, *"compatible"*).
       1. If _pattern_ is *null*, throw a *TypeError* exception.
       1. Return the Record {
           [[pattern]]: _pattern_.[[pattern]],
@@ -932,7 +935,8 @@
       1. Assert: _temporalTime_ has an [[InitializedTemporalTime]] internal slot.
       1. Let _pattern_ be _dateTimeFormat_.[[TemporalPlainTimePattern]].
       1. Let _plainDateTime_ be ? CreateTemporalDateTime(1970, 1, 1, _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], *"iso8601"*).
-      1. Let _instant_ be ? GetInstantFor(_dateTimeFormat_.[[TimeZone]], _plainDateTime_, *"compatible"*).
+      1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_dateTimeFormat_.[[TimeZone]], « ~getPossibleInstantsFor~ »).
+      1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _plainDateTime_, *"compatible"*).
       1. If _pattern_ is *null*, throw a *TypeError* exception.
       1. Return the Record {
           [[pattern]]: _pattern_.[[pattern]],
@@ -957,7 +961,8 @@
       1. Let _calendar_ be ? ToTemporalCalendarIdentifier(_dateTime_.[[Calendar]]).
       1. If _calendar_ is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then
         1. Throw a *RangeError* exception.
-      1. Let _instant_ be ? GetInstantFor(_dateTimeFormat_.[[TimeZone]], _dateTime_, *"compatible"*).
+      1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_dateTimeFormat_.[[TimeZone]], « ~getPossibleInstantsFor~ »).
+      1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _dateTime_, *"compatible"*).
       1. If _pattern_ is *null*, throw a *TypeError* exception.
       1. Return the Record {
           [[pattern]]: _pattern_.[[pattern]],
@@ -2601,10 +2606,10 @@
           <emu-alg>
             1. Let _zonedDateTime_ be the *this* value.
             1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-            1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
             1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
             1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-            1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+            1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+            1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
             1. Return ? CalendarEra(_calendar_, _plainDateTime_).
           </emu-alg>
         </emu-clause>
@@ -2618,10 +2623,10 @@
           <emu-alg>
             1. Let _zonedDateTime_ be the *this* value.
             1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-            1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
             1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
             1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-            1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+            1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+            1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
             1. Return ? CalendarEraYear(_calendar_, _plainDateTime_).
           </emu-alg>
         </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -175,8 +175,8 @@
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Let _calendar_ be _temporalDate_.[[Calendar]].
-        1. Return 𝔽(? CalendarDay(_calendar_, _temporalDate_)).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_temporalDate_.[[Calendar]], « ~day~ »).
+        1. Return 𝔽(? CalendarDay(_calendarRec_, _temporalDate_)).
       </emu-alg>
     </emu-clause>
 
@@ -314,10 +314,10 @@
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Let _calendar_ be _temporalDate_.[[Calendar]].
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_temporalDate_.[[Calendar]], « ~fields~, ~yearMonthFromFields~ »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDate_, _fieldNames_, «»).
-        1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_).
+        1. Return ? CalendarYearMonthFromFields(_calendarRec_, _fields_).
         1. NOTE: The call to CalendarYearMonthFromFields is necessary in order to create a PlainYearMonth object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
       </emu-alg>
     </emu-clause>
@@ -330,10 +330,10 @@
       <emu-alg>
         1. Let _temporalDate_ be the *this* value.
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
-        1. Let _calendar_ be _temporalDate_.[[Calendar]].
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"monthCode"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_temporalDate_.[[Calendar]], « ~fields~, ~monthDayFromFields~ »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"monthCode"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDate_, _fieldNames_, «»).
-        1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_).
+        1. Return ? CalendarMonthDayFromFields(_calendarRec_, _fields_).
         1. NOTE: The call to CalendarMonthDayFromFields is necessary in order to create a PlainMonthDay object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
       </emu-alg>
     </emu-clause>
@@ -377,7 +377,10 @@
         1. Perform ? RequireInternalSlot(_temporalDate_, [[InitializedTemporalDate]]).
         1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Return ? AddDate(_temporalDate_.[[Calendar]], _temporalDate_, _duration_, _options_).
+        1. Let _calendarRec_ be ! CreateCalendarMethodsRecord(_temporalDate_.[[Calendar]], « »).
+        1. If _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+        1. Return ? AddDate(_calendarRec_, _temporalDate_, _duration_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -392,7 +395,10 @@
         1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _negatedDuration_ be ! CreateNegatedTemporalDuration(_duration_).
-        1. Return ? AddDate(_temporalDate_.[[Calendar]], _temporalDate_, _negatedDuration_, _options_).
+        1. Let _calendarRec_ be ! CreateCalendarMethodsRecord(_temporalDate_.[[Calendar]], « »).
+        1. If _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+        1. Return ? AddDate(_calendarRec_, _temporalDate_, _negatedDuration_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -408,13 +414,13 @@
           1. Throw a *TypeError* exception.
         1. Perform ? RejectTemporalLikeObject(_temporalDateLike_).
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
-        1. Let _calendar_ be _temporalDate_.[[Calendar]].
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_temporalDate_.[[Calendar]], « ~dateFromFields~, ~fields~, ~mergeFields~ »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDate_, _fieldNames_, «»).
         1. Let _partialDate_ be ? PrepareTemporalFields(_temporalDateLike_, _fieldNames_, ~partial~).
-        1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialDate_).
+        1. Set _fields_ to ? CalendarMergeFields(_calendarRec_, _fields_, _partialDate_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, «»).
-        1. Return ? CalendarDateFromFields(_calendar_, _fields_, _resolvedOptions_).
+        1. Return ? CalendarDateFromFields(_calendarRec_, _fields_, _resolvedOptions_).
       </emu-alg>
     </emu-clause>
 
@@ -760,9 +766,10 @@
             1. Perform ? ToTemporalOverflow(_options_).
             1. Return ! CreateTemporalDate(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[Calendar]]).
           1. Let _calendar_ be ? GetTemporalCalendarSlotValueWithISODefault(_item_).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+          1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_calendar_, « ~dateFromFields~, ~fields~ »).
+          1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
-          1. Return ? CalendarDateFromFields(_calendar_, _fields_, _options_).
+          1. Return ? CalendarDateFromFields(_calendarRec_, _fields_, _options_).
         1. If _item_ is not a String, throw a *TypeError* exception.
         1. Let _result_ be ? ParseTemporalDateString(_item_).
         1. Assert: IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
@@ -846,7 +853,7 @@
     <emu-clause id="sec-temporal-differencedate" type="abstract operation">
       <h1>
         DifferenceDate (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _one_: a Temporal.PlainDate,
           _two_: a Temporal.PlainDate,
           _options_: an Object,
@@ -869,7 +876,7 @@
         1. If ! Get(_options_, *"largestUnit"*) is *"day"*, then
           1. Let _days_ be DaysUntil(_one_, _two_).
           1. Return ! CreateTemporalDuration(0, 0, 0, _days_, 0, 0, 0, 0, 0, 0).
-        1. Return ? CalendarDateUntil(_calendar_, _one_, _two_, _options_).
+        1. Return ? CalendarDateUntil(_calendarRec_, _one_, _two_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -989,11 +996,10 @@
     <emu-clause id="sec-temporal-adddate" type="abstract operation">
       <h1>
         AddDate (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _plainDate_: a Temporal.PlainDate,
           _duration_: a Temporal.Duration,
           optional _options_: an Object or *undefined*,
-          optional _dateAdd_: a function Object or ~unused~,
         ): either a normal completion containing a Temporal.PlainDate, or an abrupt completion
       </h1>
       <dl class="header">
@@ -1001,20 +1007,16 @@
         <dd>
           It adds _duration_ to _plainDate_.
           Usually this is accomplished by calling the `dateAdd` method of the given _calendar_ as in CalendarDateAdd, but if the duration only contains days, the computation will not cause an observable method call.
-          If _dateAdd_ is present, the `dateAdd` method will not be observably looked up.
         </dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
         1. If _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, then
-          1. If _dateAdd_ is not present, then
-            1. Set _dateAdd_ to ~unused~.
-            1. If _calendar_ is an Object, set _dateAdd_ to ? GetMethod(_calendar_, *"dateAdd"*).
-          1. Return ? CalendarDateAdd(_calendar_, _plainDate_, _duration_, _options_, _dateAdd_).
+          1. Return ? CalendarDateAdd(_calendarRec_, _plainDate_, _duration_, _options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. Let _days_ be ? BalanceTimeDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).[[Days]].
         1. Let _result_ be ? AddISODate(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], 0, 0, 0, _days_, _overflow_).
-        1. Return ! CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
+        1. Return ! CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendarRec_.[[Receiver]]).
       </emu-alg>
     </emu-clause>
 
@@ -1052,10 +1054,15 @@
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~date~, &laquo; &raquo;, *"day"*, *"day"*).
         1. If _temporalDate_.[[ISOYear]] = _other_.[[ISOYear]], and _temporalDate_.[[ISOMonth]] = _other_.[[ISOMonth]], and _temporalDate_.[[ISODay]] = _other_.[[ISODay]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Let _calendarRec_ be ! CreateCalendarMethodsRecord(_temporalDate_.[[Calendar]], « »).
+        1. If _settings_.[[SmallestUnit]] is *"year"*, or _settings_.[[SmallestUnit]] is *"month"*, or _settings_.[[SmallestUnit]] is *"week"*, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+        1. If _settings_.[[LargestUnit]] is *"year"*, or _settings_.[[LargestUnit]] is *"month"*, or _settings_.[[LargestUnit]] is *"week"*, or _settings_.[[SmallestUnit]] is *"year"*, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateUntil~).
         1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
-        1. Let _result_ be ? DifferenceDate(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _resolvedOptions_).
+        1. Let _result_ be ? DifferenceDate(_calendarRec_, _temporalDate_, _other_, _resolvedOptions_).
         1. If _settings_.[[SmallestUnit]] is not *"day"* or _settings_.[[RoundingIncrement]] &ne; 1, then
-          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _temporalDate_).
+          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _temporalDate_, _calendarRec_).
           1. Set _result_ to _roundRecord_.[[DurationRecord]].
         1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], _sign_ &times; _result_.[[Weeks]], _sign_ &times; _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -517,7 +517,8 @@
         1. Else,
           1. Set _temporalTime_ to ? ToTemporalTime(_temporalTime_).
           1. Let _temporalDateTime_ be ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _temporalDate_.[[Calendar]]).
-        1. Let _instant_ be ? GetInstantFor(_timeZone_, _temporalDateTime_, *"compatible"*).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~getPossibleInstantsFor~ »).
+        1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _temporalDateTime_, *"compatible"*).
         1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _temporalDate_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -752,7 +753,8 @@
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Perform ? ToTemporalOverflow(_options_).
             1. Let _instant_ be ! CreateTemporalInstant(_item_.[[Nanoseconds]]).
-            1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_item_.[[TimeZone]], _instant_, _item_.[[Calendar]]).
+            1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_item_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+            1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _item_.[[Calendar]]).
             1. Return ! CreateTemporalDate(_plainDateTime_.[[ISOYear]], _plainDateTime_.[[ISOMonth]], _plainDateTime_.[[ISODay]], _plainDateTime_.[[Calendar]]).
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
             1. Perform ? ToTemporalOverflow(_options_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -178,8 +178,8 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Let _calendar_ be _dateTime_.[[Calendar]].
-        1. Return 𝔽(? CalendarDay(_calendar_, _dateTime_)).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « ~day~ »).
+        1. Return 𝔽(? CalendarDay(_calendarRec_, _dateTime_)).
       </emu-alg>
     </emu-clause>
 
@@ -399,8 +399,8 @@
           1. Throw a *TypeError* exception.
         1. Perform ? RejectTemporalLikeObject(_temporalDateTimeLike_).
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
-        1. Let _calendar_ be _dateTime_.[[Calendar]].
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « ~dateFromFields~, ~fields~, ~mergeFields~ »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_dateTime_, _fieldNames_, «»).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"hour"*, _dateTime_.[[ISOHour]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"minute"*, _dateTime_.[[ISOMinute]]).
@@ -410,12 +410,12 @@
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"nanosecond"*, _dateTime_.[[ISONanosecond]]).
         1. Append *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"nanosecond"*, and *"second"* to _fieldNames_.
         1. Let _partialDateTime_ be ? PrepareTemporalFields(_temporalDateTimeLike_, _fieldNames_, ~partial~).
-        1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialDateTime_).
+        1. Set _fields_ to ? CalendarMergeFields(_calendarRec_, _fields_, _partialDateTime_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, «»).
-        1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _resolvedOptions_).
+        1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendarRec_, _fields_, _resolvedOptions_).
         1. Assert: IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
         1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
-        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
+        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
       </emu-alg>
     </emu-clause>
 
@@ -658,10 +658,10 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Let _calendar_ be _dateTime_.[[Calendar]].
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « ~fields~, ~yearMonthFromFields~ »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_dateTime_, _fieldNames_, «»).
-        1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_).
+        1. Return ? CalendarYearMonthFromFields(_calendarRec_, _fields_).
         1. NOTE: The call to CalendarYearMonthFromFields is necessary in order to create a PlainYearMonth object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
       </emu-alg>
     </emu-clause>
@@ -674,10 +674,10 @@
       <emu-alg>
         1. Let _dateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Let _calendar_ be _dateTime_.[[Calendar]].
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"monthCode"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « ~fields~, ~monthDayFromFields~ »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"monthCode"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_dateTime_, _fieldNames_, «»).
-        1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_).
+        1. Return ? CalendarMonthDayFromFields(_calendarRec_, _fields_).
         1. NOTE: The call to CalendarMonthDayFromFields is necessary in order to create a PlainMonthDay object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
       </emu-alg>
     </emu-clause>
@@ -953,7 +953,7 @@
     <emu-clause id="sec-temporal-interprettemporaldatetimefields" type="abstract operation">
       <h1>
         InterpretTemporalDateTimeFields (
-          _calendar_: a String or Object,
+          _calendarRec_: a Calendar Methods Record,
           _fields_: an Object,
           _options_: an Object,
         ): either a normal completion containing an ISO Date-Time Record, or a throw completion
@@ -964,11 +964,12 @@
       </dl>
       <emu-alg>
         1. Assert: _options_ is an ordinary extensible Object that is not directly observable from ECMAScript code and for which the value of the [[Prototype]] internal slot is *null* and every property is a configurable data property.
+        1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateFromFields~) is *true*.
         1. Let _timeResult_ be ? ToTemporalTimeRecord(_fields_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
         1. NOTE: The following step is guaranteed to complete normally despite the *"overflow"* property existing, because of the assertion in the first step.
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, _overflow_).
-        1. Let _temporalDate_ be ? CalendarDateFromFields(_calendar_, _fields_, _options_).
+        1. Let _temporalDate_ be ? CalendarDateFromFields(_calendarRec_, _fields_, _options_).
         1. Let _timeResult_ be ? RegulateTime(_timeResult_.[[Hour]], _timeResult_.[[Minute]], _timeResult_.[[Second]], _timeResult_.[[Millisecond]], _timeResult_.[[Microsecond]], _timeResult_.[[Nanosecond]], _overflow_).
         1. Return the Record {
           [[Year]]: _temporalDate_.[[ISOYear]],
@@ -1010,10 +1011,11 @@
             1. Perform ? ToTemporalOverflow(_resolvedOptions_).
             1. Return ? CreateTemporalDateTime(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], 0, 0, 0, 0, 0, 0, _item_.[[Calendar]]).
           1. Let _calendar_ be ? GetTemporalCalendarSlotValueWithISODefault(_item_).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+          1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_calendar_, « ~dateFromFields~, ~fields~ »).
+          1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
           1. Append *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"nanosecond"*, and *"second"* to _fieldNames_.
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
-          1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _resolvedOptions_).
+          1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendarRec_, _fields_, _resolvedOptions_).
         1. Else,
           1. If _item_ is not a String, throw a *TypeError* exception.
           1. Let _result_ be ? ParseTemporalDateTimeString(_item_).
@@ -1141,7 +1143,7 @@
           _millisecond_: an integer in the inclusive interval from 0 to 999,
           _microsecond_: an integer in the inclusive interval from 0 to 999,
           _nanosecond_: an integer in the inclusive interval from 0 to 999,
-          _calendar_: an Object,
+          _calendarRec_: a Calendar Methods Record,
           _years_: an integer,
           _months_: an integer,
           _weeks_: an integer,
@@ -1164,9 +1166,9 @@
       <emu-alg>
         1. Assert: ISODateTimeWithinLimits(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
         1. Let _timeResult_ be AddTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Let _datePart_ be ! CreateTemporalDate(_year_, _month_, _day_, _calendar_).
+        1. Let _datePart_ be ! CreateTemporalDate(_year_, _month_, _day_, _calendarRec_.[[Receiver]]).
         1. Let _dateDuration_ be ? CreateTemporalDuration(_years_, _months_, _weeks_, _days_ + _timeResult_.[[Days]], 0, 0, 0, 0, 0, 0).
-        1. Let _addedDate_ be ? AddDate(_calendar_, _datePart_, _dateDuration_, _options_).
+        1. Let _addedDate_ be ? AddDate(_calendarRec_, _datePart_, _dateDuration_, _options_).
         1. Return the Record {
             [[Year]]: _addedDate_.[[ISOYear]],
             [[Month]]: _addedDate_.[[ISOMonth]],
@@ -1243,7 +1245,7 @@
           _ms2_: an integer between 0 and 999 inclusive,
           _mus2_: an integer between 0 and 999 inclusive,
           _ns2_: an integer between 0 and 999 inclusive,
-          _calendar_: an Object,
+          _calendarRec_: a Calendar Methods Record,
           _largestUnit_: a String,
           _options_: an Object,
         ): either a normal completion containing a Duration Record, or a throw completion
@@ -1251,7 +1253,7 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          The returned Duration Record contains the elapsed duration from a first date and time, until a second date and time, according to the reckoning of the given _calendar_.
+          The returned Duration Record contains the elapsed duration from a first date and time, until a second date and time, according to the reckoning of the given calendar.
           The given date and time units are all in the ISO 8601 calendar.
           The _largestUnit_ and _options_ arguments are used in _calendar_'s `dateUntil` method.
         </dd>
@@ -1259,6 +1261,7 @@
       <emu-alg>
         1. Assert: ISODateTimeWithinLimits(_y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_) is *true*.
         1. Assert: ISODateTimeWithinLimits(_y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_) is *true*.
+        1. Assert: If _y1_ &ne; _y2_, and _mon1_ &ne; _mon2_, and _d1_ &ne; _d2_, and LargerOfTwoTemporalUnits(_largestUnit_, *"day"*) is not *"day"*, CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateUntil~) is *true*.
         1. Let _timeDifference_ be ! DifferenceTime(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. Let _timeSign_ be ! DurationSign(0, 0, 0, 0, _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]]).
         1. Let _dateSign_ be ! CompareISODate(_y2_, _mon2_, _d2_, _y1_, _mon1_, _d1_).
@@ -1266,12 +1269,12 @@
         1. If _timeSign_ is -_dateSign_, then
           1. Set _adjustedDate_ to BalanceISODate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]] - _timeSign_).
           1. Set _timeDifference_ to ! BalanceTimeDuration(-_timeSign_, _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
-        1. Let _date1_ be ! CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendar_).
-        1. Let _date2_ be ! CreateTemporalDate(_y2_, _mon2_, _d2_, _calendar_).
+        1. Let _date1_ be ! CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendarRec_.[[Receiver]]).
+        1. Let _date2_ be ! CreateTemporalDate(_y2_, _mon2_, _d2_, _calendarRec_.[[Receiver]]).
         1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
         1. Let _untilOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _dateLargestUnit_).
-        1. Let _dateDifference_ be ? DifferenceDate(_calendar_, _date1_, _date2_, _untilOptions_).
+        1. Let _dateDifference_ be ? DifferenceDate(_calendarRec_, _date1_, _date2_, _untilOptions_).
         1. Let _balanceResult_ be ! BalanceTimeDuration(_dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
         1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
       </emu-alg>
@@ -1295,13 +1298,23 @@
         1. If ? CalendarEquals(_dateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~datetime~, &laquo; &raquo;, *"nanosecond"*, *"day"*).
-        1. If _dateTime_.[[ISOYear]] = _other_.[[ISOYear]], and _dateTime_.[[ISOMonth]] = _other_.[[ISOMonth]], and _dateTime_.[[ISODay]] = _other_.[[ISODay]], and _dateTime_.[[ISOHour]] = _other_.[[ISOHour]], and _dateTime_.[[ISOMinute]] = _other_.[[ISOMinute]], and _dateTime_.[[ISOSecond]] = _other_.[[ISOSecond]], and _dateTime_.[[ISOMillisecond]] = _other_.[[ISOMillisecond]], and _dateTime_.[[ISOMicrosecond]] = _other_.[[ISOMicrosecond]], and _dateTime_.[[ISONanosecond]] = _other_.[[ISONanosecond]], then
+        1. Let _datePartsIdentical_ be *false*.
+        1. If _dateTime_.[[ISOYear]] = _other_.[[ISOYear]], and _dateTime_.[[ISOMonth]] = _other_.[[ISOMonth]], and _dateTime_.[[ISODay]] = _other_.[[ISODay]], then
+          1. Set _datePartsIdentical_ to *true*.
+        1. If _datePartsIdentical_ is *true*, and _dateTime_.[[ISOHour]] = _other_.[[ISOHour]], and _dateTime_.[[ISOMinute]] = _other_.[[ISOMinute]], and _dateTime_.[[ISOSecond]] = _other_.[[ISOSecond]], and _dateTime_.[[ISOMillisecond]] = _other_.[[ISOMillisecond]], and _dateTime_.[[ISOMicrosecond]] = _other_.[[ISOMicrosecond]], and _dateTime_.[[ISONanosecond]] = _other_.[[ISONanosecond]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-        1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _settings_.[[LargestUnit]], _resolvedOptions_).
+        1. Let _calendarRec_ be ! CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « »).
+        1. If _settings_.[[SmallestUnit]] is *"year"*, or _settings_.[[SmallestUnit]] is *"month"*, or _settings_.[[SmallestUnit]] is *"week"*, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+        1. If _settings_.[[LargestUnit]] is *"year"*, or _settings_.[[LargestUnit]] is *"month"*, or _settings_.[[LargestUnit]] is *"week"*, let _largestUnitIsCalendarUnit_ be *true*; else let _largestUnitIsCalendarUnit_ be *false*.
+        1. If _datePartsIdentical_ is *false* and _largestUnitIsCalendarUnit_ is *true*, let _largestUnitRequiresDateUntilLookup_ be *true*; else let _largestUnitRequiresDateUntilLookup_ be *false*.
+        1. If _largestUnitRequiresDateUntilLookup_ is *true*, or _settings_.[[SmallestUnit]] is *"year"*, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateUntil~).
+        1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _calendarRec_, _settings_.[[LargestUnit]], _resolvedOptions_).
         1. If _settings_.[[SmallestUnit]] is *"nanosecond"* and _settings_.[[RoundingIncrement]] is 1, then
           1. Return ! CreateTemporalDuration(_sign_ &times; _diff_.[[Years]], _sign_ &times; _diff_.[[Months]], _sign_ &times; _diff_.[[Weeks]], _sign_ &times; _diff_.[[Days]], _sign_ &times; _diff_.[[Hours]], _sign_ &times; _diff_.[[Minutes]], _sign_ &times; _diff_.[[Seconds]], _sign_ &times; _diff_.[[Milliseconds]], _sign_ &times; _diff_.[[Microseconds]], _sign_ &times; _diff_.[[Nanoseconds]]).
         1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
-        1. Let _roundRecord_ be ? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _relativeTo_).
+        1. Let _roundRecord_ be ? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _relativeTo_, _calendarRec_).
         1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
         1. Let _result_ be ? BalanceTimeDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _settings_.[[LargestUnit]]).
         1. Return ! CreateTemporalDuration(_sign_ &times; _roundResult_.[[Years]], _sign_ &times; _roundResult_.[[Months]], _sign_ &times; _roundResult_.[[Weeks]], _sign_ &times; _result_.[[Days]], _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
@@ -1324,7 +1337,10 @@
         1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _result_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]], _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]], _options_).
+        1. Let _calendarRec_ be ! CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « »).
+        1. If _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+        1. Let _result_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _calendarRec_, _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]], _options_).
         1. Assert: IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
         1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -632,7 +632,8 @@
         1. Let _timeZone_ be ? ToTemporalTimeZoneSlotValue(_temporalTimeZoneLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
-        1. Let _instant_ be ? GetInstantFor(_timeZone_, _dateTime_, _disambiguation_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~getPossibleInstantsFor~ »).
+        1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _dateTime_, _disambiguation_).
         1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -1003,7 +1004,8 @@
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Perform ? ToTemporalOverflow(_resolvedOptions_).
             1. Let _instant_ be ! CreateTemporalInstant(_item_.[[Nanoseconds]]).
-            1. Return ? GetPlainDateTimeFor(_item_.[[TimeZone]], _instant_, _item_.[[Calendar]]).
+            1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_item_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+            1. Return ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _item_.[[Calendar]]).
           1. If _item_ has an [[InitializedTemporalDate]] internal slot, then
             1. Perform ? ToTemporalOverflow(_resolvedOptions_).
             1. Return ? CreateTemporalDateTime(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], 0, 0, 0, 0, 0, 0, _item_.[[Calendar]]).

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -133,8 +133,8 @@
       <emu-alg>
         1. Let _monthDay_ be the *this* value.
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
-        1. Let _calendar_ be _monthDay_.[[Calendar]].
-        1. Return 𝔽(? CalendarDay(_calendar_, _monthDay_)).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_monthDay_.[[Calendar]], « ~day~ »).
+        1. Return 𝔽(? CalendarDay(_calendarRec_, _monthDay_)).
       </emu-alg>
     </emu-clause>
 
@@ -150,13 +150,13 @@
           1. Throw a *TypeError* exception.
         1. Perform ? RejectTemporalLikeObject(_temporalMonthDayLike_).
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
-        1. Let _calendar_ be _monthDay_.[[Calendar]].
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_monthDay_.[[Calendar]], « ~fields~, ~mergeFields~, ~monthDayFromFields~ »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_monthDay_, _fieldNames_, «»).
         1. Let _partialMonthDay_ be ? PrepareTemporalFields(_temporalMonthDayLike_, _fieldNames_, ~partial~).
-        1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialMonthDay_).
+        1. Set _fields_ to ? CalendarMergeFields(_calendarRec_, _fields_, _partialMonthDay_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, «»).
-        1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_, _resolvedOptions_).
+        1. Return ? CalendarMonthDayFromFields(_calendarRec_, _fields_, _resolvedOptions_).
       </emu-alg>
     </emu-clause>
 
@@ -241,17 +241,17 @@
         1. Perform ? RequireInternalSlot(_monthDay_, [[InitializedTemporalMonthDay]]).
         1. If Type(_item_) is not Object, then
           1. Throw a *TypeError* exception.
-        1. Let _calendar_ be _monthDay_.[[Calendar]].
-        1. Let _receiverFieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"monthCode"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_monthDay_.[[Calendar]], « ~dateFromFields~, ~fields~, ~mergeFields~ »).
+        1. Let _receiverFieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"monthCode"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_monthDay_, _receiverFieldNames_, «»).
-        1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"year"* »).
+        1. Let _inputFieldNames_ be ? CalendarFields(_calendarRec_, « *"year"* »).
         1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
-        1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
+        1. Let _mergedFields_ be ? CalendarMergeFields(_calendarRec_, _fields_, _inputFields_).
         1. Let _concatenatedFieldNames_ be the list-concatenation of _receiverFieldNames_ and _inputFieldNames_.
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _concatenatedFieldNames_, «», «», ~ignore~).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).
-        1. Return ? CalendarDateFromFields(_calendar_, _mergedFields_, _options_).
+        1. Return ? CalendarDateFromFields(_calendarRec_, _mergedFields_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -373,9 +373,10 @@
           1. Else,
             1. Let _calendarLike_ be ? Get(_item_, *"calendar"*).
             1. Let _calendar_ be ? ToTemporalCalendarSlotValue(_calendarLike_, *"iso8601"*).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+          1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_calendar_, « ~fields~, ~monthDayFromFields~ »).
+          1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
-          1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_, _options_).
+          1. Return ? CalendarMonthDayFromFields(_calendarRec_, _fields_, _options_).
         1. If _item_ is not a String, throw a *TypeError* exception.
         1. Let _result_ be ? ParseTemporalMonthDayString(_item_).
         1. Let _calendar_ be _result_.[[Calendar]].
@@ -389,7 +390,7 @@
           1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _referenceISOYear_).
         1. Set _result_ to ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], _calendar_, _result_.[[Year]]).
         1. NOTE: The following operation is called without _options_, in order for the calendar to store a canonical value in the [[ISOYear]] internal slot of the result.
-        1. Return ? CalendarMonthDayFromFields(_calendar_, _result_).
+        1. Return ? CalendarMonthDayFromFields(_calendarRec_, _result_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -358,7 +358,8 @@
           1. Throw a *TypeError* exception.
         1. Let _timeZone_ be ? ToTemporalTimeZoneSlotValue(_temporalTimeZoneLike_).
         1. Let _temporalDateTime_ be ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _temporalDate_.[[Calendar]]).
-        1. Let _instant_ be ? GetInstantFor(_timeZone_, _temporalDateTime_, *"compatible"*).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~getPossibleInstantsFor~ »).
+        1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _temporalDateTime_, *"compatible"*).
         1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _temporalDate_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -628,7 +629,8 @@
             1. Return _item_.
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Let _instant_ be ! CreateTemporalInstant(_item_.[[Nanoseconds]]).
-            1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_item_.[[TimeZone]], _instant_, _item_.[[Calendar]]).
+            1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_item_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+            1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _item_.[[Calendar]]).
             1. Return ! CreateTemporalTime(_plainDateTime_.[[ISOHour]], _plainDateTime_.[[ISOMinute]], _plainDateTime_.[[ISOSecond]], _plainDateTime_.[[ISOMillisecond]], _plainDateTime_.[[ISOMicrosecond]], _plainDateTime_.[[ISONanosecond]]).
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
             1. Return ! CreateTemporalTime(_item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]]).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -232,13 +232,13 @@
           1. Throw a *TypeError* exception.
         1. Perform ? RejectTemporalLikeObject(_temporalYearMonthLike_).
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
-        1. Let _calendar_ be _yearMonth_.[[Calendar]].
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"monthCode"*, *"year"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_yearMonth_.[[Calendar]], « ~fields~, ~mergeFields~, ~yearMonthFromFields~ »).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"month"*, *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
         1. Let _partialYearMonth_ be ? PrepareTemporalFields(_temporalYearMonthLike_, _fieldNames_, ~partial~).
-        1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialYearMonth_).
+        1. Set _fields_ to ? CalendarMergeFields(_calendarRec_, _fields_, _partialYearMonth_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, «»).
-        1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_, _resolvedOptions_).
+        1. Return ? CalendarYearMonthFromFields(_calendarRec_, _fields_, _resolvedOptions_).
       </emu-alg>
     </emu-clause>
 
@@ -371,17 +371,17 @@
         1. Perform ? RequireInternalSlot(_yearMonth_, [[InitializedTemporalYearMonth]]).
         1. If Type(_item_) is not Object, then
           1. Throw a *TypeError* exception.
-        1. Let _calendar_ be _yearMonth_.[[Calendar]].
-        1. Let _receiverFieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_yearMonth_.[[Calendar]], « ~dateFromFields~, ~fields~, ~mergeFields~ »).
+        1. Let _receiverFieldNames_ be ? CalendarFields(_calendarRec_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_yearMonth_, _receiverFieldNames_, «»).
-        1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"day"* »).
+        1. Let _inputFieldNames_ be ? CalendarFields(_calendarRec_, « *"day"* »).
         1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
-        1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
+        1. Let _mergedFields_ be ? CalendarMergeFields(_calendarRec_, _fields_, _inputFields_).
         1. Let _concatenatedFieldNames_ be the list-concatenation of _receiverFieldNames_ and _inputFieldNames_.
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _concatenatedFieldNames_, «», «», ~ignore~).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).
-        1. Return ? CalendarDateFromFields(_calendar_, _mergedFields_, _options_).
+        1. Return ? CalendarDateFromFields(_calendarRec_, _mergedFields_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -499,9 +499,10 @@
           1. If _item_ has an [[InitializedTemporalYearMonth]] internal slot, then
             1. Return _item_.
           1. Let _calendar_ be ? GetTemporalCalendarSlotValueWithISODefault(_item_).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"month"*, *"monthCode"*, *"year"* »).
+          1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_calendar_, « ~fields~, ~yearMonthFromFields~ »).
+          1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"month"*, *"monthCode"*, *"year"* »).
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
-          1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_, _options_).
+          1. Return ? CalendarYearMonthFromFields(_calendarRec_, _fields_, _options_).
         1. If _item_ is not a String, throw a *TypeError* exception.
         1. Let _result_ be ? ParseTemporalYearMonthString(_item_).
         1. Let _calendar_ be _result_.[[Calendar]].
@@ -511,7 +512,8 @@
         1. Perform ? ToTemporalOverflow(_options_).
         1. Set _result_ to ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], _calendar_, _result_.[[Day]]).
         1. NOTE: The following operation is called without _options_, in order for the calendar to store a canonical value in the [[ISODay]] internal slot of the result.
-        1. Return ? CalendarYearMonthFromFields(_calendar_, _result_).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_calendar_, « ~yearMonthFromFields~ »).
+        1. Return ? CalendarYearMonthFromFields(_calendarRec_, _result_).
       </emu-alg>
     </emu-clause>
 
@@ -638,17 +640,24 @@
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~date~, &laquo; *"week"*, *"day"* &raquo;, *"month"*, *"year"*).
         1. If _yearMonth_.[[ISOYear]] = _other_.[[ISOYear]] and _yearMonth_.[[ISOMonth]] = _other_.[[ISOMonth]] and _yearMonth_.[[ISODay]] = _other_.[[ISODay]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
+        1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
+        1. Let _calendarRec_ be ! CreateCalendarMethodsRecord(_calendar_, « »).
+        1. If _settings_.[[SmallestUnit]] is not *"month"* or _settings_.[[RoundingIncrement]] &ne; 1, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+        1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateFromFields~).
+        1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateUntil~).
+        1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~fields~).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"monthCode"*, *"year"* »).
         1. Let _thisFields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
         1. Perform ! CreateDataPropertyOrThrow(_thisFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _thisDate_ be ? CalendarDateFromFields(_calendar_, _thisFields_).
+        1. Let _thisDate_ be ? CalendarDateFromFields(_calendarRec_, _thisFields_).
         1. Let _otherFields_ be ? PrepareTemporalFields(_other_, _fieldNames_, «»).
         1. Perform ! CreateDataPropertyOrThrow(_otherFields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _otherDate_ be ? CalendarDateFromFields(_calendar_, _otherFields_).
+        1. Let _otherDate_ be ? CalendarDateFromFields(_calendarRec_, _otherFields_).
         1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
-        1. Let _result_ be ? CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _resolvedOptions_).
+        1. Let _result_ be ? CalendarDateUntil(_calendarRec_, _thisDate_, _otherDate_, _resolvedOptions_).
         1. If _settings_.[[SmallestUnit]] is not *"month"* or _settings_.[[RoundingIncrement]] &ne; 1, then
-          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _thisDate_).
+          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _thisDate_, _calendarRec_).
           1. Set _result_ to _roundRecord_.[[DurationRecord]].
         1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>
@@ -671,30 +680,35 @@
         1. If _operation_ is ~subtract~, then
           1. Set _duration_ to ! CreateNegatedTemporalDuration(_duration_).
         1. Let _balanceResult_ be ? BalanceTimeDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
-        1. Let _calendar_ be _yearMonth_.[[Calendar]].
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
+        1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _calendarRec_ be ! CreateCalendarMethodsRecord(_yearMonth_.[[Calendar]], « »).
+        1. If _sign_ &lt; 0, or _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+        1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateFromFields~).
+        1. If _sign_ &lt; 0, perform ? CalendarMethodsRecordLookup(_calendarRec_, ~day~).
+        1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~fields~).
+        1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~yearMonthFromFields~).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
         1. Let _fieldsCopy_ be ! SnapshotOwnProperties(_fields_, *null*).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, *1*<sub>𝔽</sub>).
-        1. Let _intermediateDate_ be ? CalendarDateFromFields(_calendar_, _fields_).
-        1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
-        1. Let _dateAdd_ be ? GetMethod(_calendar_, *"dateAdd"*).
+        1. Let _intermediateDate_ be ? CalendarDateFromFields(_calendarRec_, _fields_).
         1. If _sign_ &lt; 0, then
           1. Let _oneMonthDuration_ be ! CreateTemporalDuration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0).
-          1. Let _nextMonth_ be ? CalendarDateAdd(_calendar_, _intermediateDate_, _oneMonthDuration_, *undefined*, _dateAdd_).
+          1. Let _nextMonth_ be ? CalendarDateAdd(_calendarRec_, _intermediateDate_, _oneMonthDuration_).
           1. Let _endOfMonthISO_ be ! AddISODate(_nextMonth_.[[ISOYear]], _nextMonth_.[[ISOMonth]], _nextMonth_.[[ISODay]], 0, 0, 0, -1, *"constrain"*).
-          1. Let _endOfMonth_ be ? CreateTemporalDate(_endOfMonthISO_.[[Year]], _endOfMonthISO_.[[Month]], _endOfMonthISO_.[[Day]], _calendar_).
-          1. Let _day_ be ? CalendarDay(_calendar_, _endOfMonth_).
+          1. Let _endOfMonth_ be ? CreateTemporalDate(_endOfMonthISO_.[[Year]], _endOfMonthISO_.[[Month]], _endOfMonthISO_.[[Day]], _calendarRec_.[[Receiver]]).
+          1. Let _day_ be ? CalendarDay(_calendarRec_, _endOfMonth_).
           1. Perform ! CreateDataPropertyOrThrow(_fieldsCopy_, *"day"*, _day_).
-          1. Let _date_ be ? CalendarDateFromFields(_calendar_, _fieldsCopy_).
+          1. Let _date_ be ? CalendarDateFromFields(_calendarRec_, _fieldsCopy_).
         1. Else,
           1. Let _date_ be _intermediateDate_.
         1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _optionsCopy_ be ? SnapshotOwnProperties(_options_, *null*).
-        1. Let _addedDate_ be ? AddDate(_calendar_, _date_, _durationToAdd_, _options_, _dateAdd_).
+        1. Let _addedDate_ be ? AddDate(_calendarRec_, _date_, _durationToAdd_, _options_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).
-        1. Return ? CalendarYearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).
+        1. Return ? CalendarYearMonthFromFields(_calendarRec_, _addedDateFields_, _optionsCopy_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -255,7 +255,8 @@
           1. Let _timeZone_ be ? ToTemporalTimeZoneSlotValue(_temporalTimeZoneLike_).
         1. Let _calendar_ be ? ToTemporalCalendarSlotValue(_calendarLike_).
         1. Let _instant_ be ! SystemInstant().
-        1. Return ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~getOffsetNanosecondsFor~ »).
+        1. Return ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -141,8 +141,9 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~getOffsetNanosecondsFor~ »).
         1. Set _instant_ to ? ToTemporalInstant(_instant_).
-        1. Return ? GetOffsetStringFor(_timeZone_, _instant_).
+        1. Return ? GetOffsetStringFor(_timeZoneRec_, _instant_).
       </emu-alg>
     </emu-clause>
 
@@ -156,7 +157,8 @@
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Set _instant_ to ? ToTemporalInstant(_instant_).
         1. Let _calendar_ be ? ToTemporalCalendarSlotValue(_calendarLike_, *"iso8601"*).
-        1. Return ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~getOffsetNanosecondsFor~ »).
+        1. Return ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -171,7 +173,8 @@
         1. Set _dateTime_ to ? ToTemporalDateTime(_dateTime_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _disambiguation_ be ? ToTemporalDisambiguation(_options_).
-        1. Return ? GetInstantFor(_timeZone_, _dateTime_, _disambiguation_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~getPossibleInstantsFor~ »).
+        1. Return ? GetInstantFor(_timeZoneRec_, _dateTime_, _disambiguation_).
       </emu-alg>
     </emu-clause>
 
@@ -320,6 +323,166 @@
         <li>GetNamedTimeZoneOffsetNanoseconds</li>
       </ul>
     </emu-note>
+
+    <emu-clause id="sec-temporal-time-zone-methods-records">
+      <h1>Time Zone Methods Records</h1>
+      <p>
+        A <dfn variants="Time Zone Methods Records">Time Zone Methods Record</dfn> is a Record value used to store a Temporal.TimeZone object, or an Object implementing the time zone protocol, along with any methods that have been observably looked up on that object during the current operation.
+        Time Zone Methods Records are produced by the abstract operation CreateTimeZoneMethodsRecord.
+      </p>
+      <p>
+        Time Zone Methods Records have the fields listed in <emu-xref href="#table-temporal-time-zone-methods-record-fields"></emu-xref>.
+      </p>
+      <emu-table id="table-temporal-time-zone-methods-record-fields" caption="Time Zone Methods Record Fields">
+        <table class="real-table">
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td>[[Receiver]]</td>
+            <td>a String or Object</td>
+            <td>
+              The time zone object, or a string indicating a built-in time zone.
+            </td>
+          </tr>
+          <tr>
+            <td>[[GetOffsetNanosecondsFor]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The time zone's `getOffsetNanosecondsFor` method.
+              For a built-in time zone this is always %Temporal.TimeZone.prototype.getOffsetNanosecondsFor%.
+            </td>
+          </tr>
+          <tr>
+            <td>[[GetPossibleInstantsFor]]</td>
+            <td>a function object or *undefined*</td>
+            <td>
+              The time zone's `getPossibleInstantsFor` method.
+              For a built-in time zone this is always %Temporal.TimeZone.prototype.getPossibleInstantsFor%.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-createtimezonemethodsrecord" type="abstract operation">
+      <h1>
+        CreateTimeZoneMethodsRecord (
+          _timeZone_: a String or Object,
+          _methods_: a List of either ~getOffsetNanosecondsFor~ or ~getPossibleInstantsFor~,
+        ): either a normal completion containing a Time Zone Methods Record, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates a Time Zone Methods Record from the given _timeZone_, looking up the methods given in _methods_.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _record_ be the Time Zone Methods Record {
+            [[Receiver]]: _timeZone_,
+            [[GetOffsetNanosecondsFor]]: *undefined*,
+            [[GetPossibleInstantsFor]]: *undefined*
+          }.
+        1. For each element _methodName_ in _methods_, do
+          1. Perform ? TimeZoneMethodsRecordLookup(_record_, _methodName_).
+        1. Return _record_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-timezonemethodsrecordlookup" type="abstract operation">
+      <h1>
+        TimeZoneMethodsRecordLookup (
+          _timeZoneRec_: a Time Zone Methods Record,
+          _methodName_: ~getOffsetNanosecondsFor~ or ~getPossibleInstantsFor~,
+        ): either a normal completion containing ~unused~, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It looks up the given method on the given time zone.
+          For a built-in time zone, this lookup is unobservable and results in the intrinsic method.
+          If the time zone is an Object, the lookup is observable and may result in a user-code method.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, _methodName_) is *false*.
+        1. If _methodName_ is ~getOffsetNanosecondsFor~, then
+          1. If _timeZoneRec_.[[Receiver]] is a String, then
+            1. Set _timeZoneRec_.[[GetOffsetNanosecondsFor]] to %Temporal.TimeZone.prototype.getOffsetNanosecondsFor%.
+          1. Else,
+            1. Set _timeZoneRec_.[[GetOffsetNanosecondsFor]] to ? GetMethod(_timeZoneRec_.[[Receiver]], *"getOffsetNanosecondsFor"*).
+            1. If _timeZoneRec_.[[GetOffsetNanosecondsFor]] is *undefined*, throw a *TypeError* exception.
+        1. Else if _methodName_ is ~getPossibleInstantsFor~, then
+          1. If _timeZoneRec_.[[Receiver]] is a String, then
+            1. Set _timeZoneRec_.[[GetPossibleInstantsFor]] to %Temporal.TimeZone.prototype.getPossibleInstantsFor%.
+          1. Else,
+            1. Set _timeZoneRec_.[[GetPossibleInstantsFor]] to ? GetMethod(_timeZoneRec_.[[Receiver]], *"getPossibleInstantsFor"*).
+            1. If _timeZoneRec_.[[GetPossibleInstantsFor]] is *undefined*, throw a *TypeError* exception.
+        1. Return ~unused~.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-timezonemethodsrecordhaslookedup" type="abstract operation">
+      <h1>
+        TimeZoneMethodsRecordHasLookedUp (
+          _timeZoneRec_: a Time Zone Methods Record,
+          _methodName_: ~getOffsetNanosecondsFor~ or ~getPossibleInstantsFor~,
+        ): *true* or *false*
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines whether the given Time Zone Methods Record has already looked up the given method.</dd>
+      </dl>
+      <emu-alg>
+        1. If _methodName_ is ~getOffsetNanosecondsFor~, then
+          1. Let _method_ be _timeZoneRec_.[[GetOffsetNanosecondsFor]].
+        1. Else if _methodName_ is ~getPossibleInstantsFor~, then
+          1. Let _method_ be _timeZoneRec_.[[GetPossibleInstantsFor]].
+        1. If _method_ is *undefined*, return *false*.
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-timezonemethodsrecordisbuiltin" type="abstract operation">
+      <h1>
+        TimeZoneMethodsRecordIsBuiltin (
+          _timeZoneRec_: a Time Zone Methods Record,
+        ): *true* or *false*
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines whether the given Time Zone Methods Record represents a built-in time zone (that is never exposed to user code.)</dd>
+      </dl>
+      <emu-alg>
+        1. If _timeZoneRec_.[[Receiver]] is a String, return *true*.
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-timezonemethodsrecordcall" type="abstract operation">
+      <h1>
+        TimeZoneMethodsRecordCall (
+          _timeZoneRec_: a Time Zone Methods Record,
+          _methodName_: ~getOffsetNanosecondsFor~ or ~getPossibleInstantsFor~,
+          _arguments_: a List of ECMAScript language values,
+        ): either a normal completion containing an ECMAScript language value, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It calls the method _methodName_ stored in the Time Zone Methods Record, with the stored receiver as the receiver, and the given _arguments_, and returns the result.</dd>
+      </dl>
+      <emu-alg>
+        1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, _methodName_) is *true*.
+        1. Let _receiver_ be _timeZoneRec_.[[Receiver]].
+        1. If TimeZoneMethodsRecordIsBuiltin(_timeZoneRec_) is *true*, then
+          1. Set _receiver_ to ! CreateTemporalTimeZone(_timeZoneRec_.[[Receiver]]).
+        1. If _methodName_ is ~getOffsetNanosecondsFor~, then
+          1. Return ? Call(_timeZoneRec_.[[GetOffsetNanosecondsFor]], _receiver_, _arguments_).
+        1. If _methodName_ is ~getPossibleInstantsFor~, then
+          1. Return ? Call(_timeZoneRec_.[[GetPossibleInstantsFor]], _receiver_, _arguments_).
+      </emu-alg>
+    </emu-clause>
 
     <emu-clause id="sec-temporal-createtemporaltimezone" type="abstract operation">
       <h1>
@@ -640,24 +803,19 @@
     <emu-clause id="sec-temporal-getoffsetnanosecondsfor" type="abstract operation">
       <h1>
         GetOffsetNanosecondsFor (
-          _timeZone_: a String or Object,
+          _timeZoneRec_: a Time Zone Methods Record,
           _instant_: a Temporal.Instant,
-          optional _getOffsetNanosecondsFor_: a function object or ~unused~,
         ): either a normal completion containing an integer, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It determines the UTC offset of an _instant_, in nanoseconds, by calling the `getOffsetNanosecondsFor` method of the given _timeZone_.
-          If _getOffsetNanosecondsFor_ is present, the `getOffsetNanosecondsFor` method will not be observably looked up.
+          It determines the UTC offset of an _instant_, in nanoseconds, by calling the `getOffsetNanosecondsFor` method of the given time zone.
         </dd>
       </dl>
       <emu-alg>
-        1. If _timeZone_ is a String, then
-          1. Set _timeZone_ to ! CreateTemporalTimeZone(_timeZone_).
-          1. Return ? Call(%Temporal.TimeZone.prototype.getOffsetNanosecondsFor%, _timeZone_, « _instant_ »).
-        1. If _getOffsetNanosecondsFor_ is not present, set _getOffsetNanosecondsFor_ to ? GetMethod(_timeZone_, *"getOffsetNanosecondsFor"*).
-        1. Let _offsetNanoseconds_ be ? Call(_getOffsetNanosecondsFor_, _timeZone_, « _instant_ »).
+        1. Let _offsetNanoseconds_ be ? TimeZoneMethodsRecordCall(_timeZoneRec_, ~getOffsetNanosecondsFor~, « _instant_ »).
+        1. If TimeZoneMethodsRecordIsBuiltin(_timeZoneRec_), return ℝ(_offsetNanoseconds_).
         1. If Type(_offsetNanoseconds_) is not Number, throw a *TypeError* exception.
         1. If IsIntegralNumber(_offsetNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Set _offsetNanoseconds_ to ℝ(_offsetNanoseconds_).
@@ -669,7 +827,7 @@
     <emu-clause id="sec-temporal-getoffsetstringfor" type="abstract operation">
       <h1>
         GetOffsetStringFor (
-          _timeZone_: a String or Object,
+          _timeZoneRec_: a Time Zone Methods Record,
           _instant_: a Temporal.Instant,
         ): either a normal completion containing a String, or an abrupt completion
       </h1>
@@ -677,11 +835,11 @@
         <dt>description</dt>
         <dd>
           This operation is the internal implementation of the `Temporal.TimeZone.prototype.getOffsetStringFor` method.
-          If the given _timeZone_ is an Object, it observably calls _timeZone_'s `getOffsetNanosecondsFor` method.
+          If the given time zone is not built-in, it observably calls the time zone's `getOffsetNanosecondsFor` method.
         </dd>
       </dl>
       <emu-alg>
-        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
+        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_).
         1. Return FormatUTCOffsetNanoseconds(_offsetNanoseconds_).
       </emu-alg>
     </emu-clause>
@@ -689,7 +847,7 @@
     <emu-clause id="sec-temporal-getplaindatetimefor" type="abstract operation">
       <h1>
         GetPlainDateTimeFor (
-          _timeZone_: a String or Object,
+          _timeZoneRec_: a Time Zone Methods Record,
           _instant_: a Temporal.Instant,
           _calendar_: a String or Object,
           optional _precalculatedOffsetNanoseconds_: an integer,
@@ -699,12 +857,13 @@
         <dt>description</dt>
         <dd>
           This operation is the internal implementation of the `Temporal.TimeZone.prototype.getPlainDateTimeFor` method.
-          If the given _timeZone_ is an Object, it observably calls _timeZone_'s `getOffsetNanosecondsFor` method unless _precalculatedOffsetNanoseconds_ is supplied.
+          If the given time zone is not built-in, it observably calls _timeZone_'s `getOffsetNanosecondsFor` method unless _precalculatedOffsetNanoseconds_ is supplied.
         </dd>
       </dl>
       <emu-alg>
+        1. Assert: If _precalculatedOffsetNanoseconds_ is not present, TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getOffsetNanosecondsFor~) is *true*.
         1. If _precalculatedOffsetNanoseconds_ is present, let _offsetNanoseconds_ be _precalculatedOffsetNanoseconds_.
-        1. Else, let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
+        1. Else, let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_).
         1. Assert: abs(_offsetNanoseconds_) &lt; nsPerDay.
         1. Let _result_ be ! GetISOPartsFromEpoch(ℝ(_instant_.[[Nanoseconds]])).
         1. Set _result_ to BalanceISODateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).
@@ -715,7 +874,7 @@
     <emu-clause id="sec-temporal-getinstantfor" type="abstract operation">
       <h1>
         GetInstantFor (
-          _timeZone_: a String or Object,
+          _timeZoneRec_: a Time Zone Methods Record,
           _dateTime_: a Temporal.PlainDateTime,
           _disambiguation_: *"compatible"*, *"earlier"*, *"later"*, or *"reject"*,
         ): either a normal completion containing a Temporal.Instant, or an abrupt completion
@@ -724,26 +883,41 @@
         <dt>description</dt>
         <dd>
           It is the internal implementation of the `Temporal.TimeZone.prototype.getInstantFor` method.
-          If the given _timeZone_ is an Object, it observably calls _timeZone_'s `getPossibleInstantsFor` method at least once.
-          If that call returns an empty array and _disambiguation_ is not *"reject"*, it observably calls the time zone's `getOffsetNanosecondsFor` method twice, and `getPossibleInstantsFor` an additional time.
+          It calls the _timeZoneRec_'s `getPossibleInstantsFor` method at least once.
+          If that call returns an empty array and _disambiguation_ is not *"reject"*, it calls _timeZoneRec_'s `getOffsetNanosecondsFor` method twice, and `getPossibleInstantsFor` an additional time.
         </dd>
       </dl>
+      <p>
+        _timeZoneRec_ must have looked up at least the `getPossibleInstantsFor` method.
+        `getOffsetNanosecondsFor` will be looked up as needed, since this is one of the few operations that cannot determine in advance whether it will be used.
+      </p>
       <emu-alg>
-        1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
-        1. Return ? DisambiguatePossibleInstants(_possibleInstants_, _timeZone_, _dateTime_, _disambiguation_).
+        1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZoneRec_, _dateTime_).
+        1. If _possibleInstants_ is empty, and _disambiguation_ is not *"reject"*, and TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getOffsetNanosecondsFor~) is *false*, then
+          1. Perform ? TimeZoneMethodsRecordLookup(_timeZoneRec_, ~getOffsetNanosecondsFor~).
+        1. Return ? DisambiguatePossibleInstants(_possibleInstants_, _timeZoneRec_, _dateTime_, _disambiguation_).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-disambiguatepossibleinstants" aoid="DisambiguatePossibleInstants">
-      <h1>DisambiguatePossibleInstants ( _possibleInstants_, _timeZone_, _dateTime_, _disambiguation_ )</h1>
+    <emu-clause id="sec-temporal-disambiguatepossibleinstants" type="abstract operation">
+      <h1>
+        DisambiguatePossibleInstants (
+          _possibleInstants_: a List of Temporal.Instant objects,
+          _timeZoneRec_: a Time Zone Methods Record,
+          _dateTime_: a Temporal.PlainDateTime,
+          _disambiguation_: *"compatible"*, *"earlier"*, *"later"*, or *"reject"*,
+        ): either a normal completion containing a Temporal.Instant, or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It chooses from a List of possible `Temporal.Instant` instances the one indicated by the _disambiguation_ parameter.</dd>
+      </dl>
       <p>
-        The abstract operation DisambiguatePossibleInstants chooses from a List of possible `Temporal.Instant` instances the one indicated by the _disambiguation_ parameter.
-      </p>
-      <p>
-        The _possibleInstants_ List may be empty, in which case it observably calls the time zone's `getOffsetNanosecondsFor` method twice, and `getPossibleInstantsFor` once, if _disambiguation_ is not *"reject"* and the given _timeZone_ is an Object.
+        The _possibleInstants_ List may be empty, in which case it calls the time zone's `getOffsetNanosecondsFor` method twice, and `getPossibleInstantsFor` once, if _disambiguation_ is not *"reject"*.
       </p>
       <emu-alg>
-        1. Assert: _dateTime_ has an [[InitializedTemporalDateTime]] internal slot.
+        1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getPossibleInstantsFor~) is *true*.
+        1. Assert: If _possibleInstants_ is empty, and _disambiguation_ is not *"reject"*, TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getOffsetNanosecondsFor~) is *true*.
         1. Let _n_ be _possibleInstants_'s length.
         1. If _n_ = 1, then
           1. Return _possibleInstants_[0].
@@ -764,23 +938,21 @@
         1. Let _dayAfterNs_ be _epochNanoseconds_ + ℤ(nsPerDay).
         1. If IsValidEpochNanoseconds(_dayAfterNs_) is *false*, throw a *RangeError* exception.
         1. Let _dayAfter_ be ! CreateTemporalInstant(_dayAfterNs_).
-        1. Let _getOffsetNanosecondsFor_ be ~unused~.
-        1. If _timeZone_ is an Object, set _getOffsetNanosecondsFor_ to ? GetMethod(_timeZone_, *"getOffsetNanosecondsFor"*).
-        1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayBefore_, _getOffsetNanosecondsFor_).
-        1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayAfter_, _getOffsetNanosecondsFor_).
+        1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _dayBefore_).
+        1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _dayAfter_).
         1. Let _nanoseconds_ be _offsetAfter_ - _offsetBefore_.
         1. If _disambiguation_ is *"earlier"*, then
           1. Let _earlierTime_ be AddTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], 0, 0, 0, 0, 0, -_nanoseconds_).
           1. Let _earlierDate_ be AddISODate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], 0, 0, 0, _earlierTime_.[[Days]], *"constrain"*).
           1. Let _earlierDateTime_ be ! CreateTemporalDateTime(_earlierDate_.[[Year]], _earlierDate_.[[Month]], _earlierDate_.[[Day]], _earlierTime_.[[Hour]], _earlierTime_.[[Minute]], _earlierTime_.[[Second]], _earlierTime_.[[Millisecond]], _earlierTime_.[[Microsecond]], _earlierTime_.[[Nanosecond]], *"iso8601"*).
-          1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _earlierDateTime_).
+          1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZoneRec_, _earlierDateTime_).
           1. If _possibleInstants_ is empty, throw a *RangeError* exception.
           1. Return _possibleInstants_[0].
         1. Assert: _disambiguation_ is *"compatible"* or *"later"*.
         1. Let _laterTime_ be AddTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], 0, 0, 0, 0, 0, _nanoseconds_).
         1. Let _laterDate_ be AddISODate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], 0, 0, 0, _laterTime_.[[Days]], *"constrain"*).
         1. Let _laterDateTime_ be ! CreateTemporalDateTime(_laterDate_.[[Year]], _laterDate_.[[Month]], _laterDate_.[[Day]], _laterTime_.[[Hour]], _laterTime_.[[Minute]], _laterTime_.[[Second]], _laterTime_.[[Millisecond]], _laterTime_.[[Microsecond]], _laterTime_.[[Nanosecond]], *"iso8601"*).
-        1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZone_, _laterDateTime_).
+        1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZoneRec_, _laterDateTime_).
         1. Set _n_ to _possibleInstants_'s length.
         1. If _n_ = 0, throw a *RangeError* exception.
         1. Return _possibleInstants_[_n_ - 1].
@@ -790,25 +962,19 @@
     <emu-clause id="sec-temporal-getpossibleinstantsfor" type="abstract operation">
       <h1>
         GetPossibleInstantsFor (
-          _timeZone_: a String or Object,
+          _timeZoneRec_: a Time Zone Methods Record,
           _dateTime_: a Temporal.PlainDateTime,
-          optional _getPossibleInstantsFor_: a function object,
         ): either a normal completion containing a List of Temporal.Instant objects, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It determines the possible Temporal.Instant exact times that may correspond to _dateTime_, by calling the `getPossibleInstantsFor` method of the given _timeZone_.
-          If _getPossibleInstantsFor_ is present, the `getPossibleInstantsFor` method will not be observably looked up.
+          It determines the possible Temporal.Instant exact times that may correspond to _dateTime_, by calling the `getPossibleInstantsFor` method of the given time zone.
         </dd>
       </dl>
       <emu-alg>
-        1. If _timeZone_ is a String, then
-          1. Set _timeZone_ to ! CreateTemporalTimeZone(_timeZone_).
-          1. Let _array_ be ? Call(%Temporal.TimeZone.prototype.getPossibleInstantsFor%, _timeZone_, « _dateTime_ »).
-          1. Return ! CreateListFromArrayLike(_array_, « Object »).
-        1. If _getPossibleInstantsFor_ is not present, set _getPossibleInstantsFor_ to ? GetMethod(_timeZone_, *"getPossibleInstantsFor"*).
-        1. Let _possibleInstants_ be ? Call(_timeZone_, *"getPossibleInstantsFor"*, « _dateTime_ »).
+        1. Let _possibleInstants_ be ? TimeZoneMethodsRecordCall(_timeZoneRec_, ~getPossibleInstantsFor~, « _dateTime_ »).
+        1. If TimeZoneMethodsRecordIsBuiltin(_timeZoneRec_), return ! CreateListFromArrayLike(_possibleInstants_, « Object »).
         1. Let _iteratorRecord_ be ? GetIterator(_possibleInstants_, ~sync~).
         1. Let _list_ be a new empty List.
         1. Let _next_ be *true*.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -199,10 +199,10 @@
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_zonedDateTime_.[[Calendar]], « ~day~ »).
         1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
-        1. Return 𝔽(? CalendarDay(_calendar_, _temporalDateTime_)).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
+        1. Return 𝔽(? CalendarDay(_calendarRec_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
 
@@ -586,12 +586,12 @@
           1. Throw a *TypeError* exception.
         1. Perform ? RejectTemporalLikeObject(_temporalZonedDateTimeLike_).
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
-        1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_zonedDateTime_.[[Calendar]], « ~dateFromFields~, ~fields~, ~mergeFields~ »).
         1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_).
-        1. Let _dateTime_ be ! GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_, _offsetNanoseconds_).
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+        1. Let _dateTime_ be ! GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]], _offsetNanoseconds_).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_dateTime_, _fieldNames_, « »).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"hour"*, _dateTime_.[[ISOHour]]).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"minute"*, _dateTime_.[[ISOMinute]]).
@@ -602,17 +602,17 @@
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"offset"*, FormatUTCOffsetNanoseconds(_offsetNanoseconds_)).
         1. Append *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"nanosecond"*, *"offset"*, and *"second"* to _fieldNames_.
         1. Let _partialZonedDateTime_ be ? PrepareTemporalFields(_temporalZonedDateTimeLike_, _fieldNames_, ~partial~).
-        1. Set _fields_ to ? CalendarMergeFields(_calendar_, _fields_, _partialZonedDateTime_).
+        1. Set _fields_ to ? CalendarMergeFields(_calendarRec_, _fields_, _partialZonedDateTime_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « *"offset"* »).
         1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalDisambiguation reads *"disambiguation"*, ToTemporalOffset reads *"offset"*, and InterpretTemporalDateTimeFields reads *"overflow"*).
         1. Let _disambiguation_ be ? ToTemporalDisambiguation(_resolvedOptions_).
         1. Let _offset_ be ? ToTemporalOffset(_resolvedOptions_, *"prefer"*).
-        1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _resolvedOptions_).
+        1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendarRec_, _fields_, _resolvedOptions_).
         1. Let _offsetString_ be ! Get(_fields_, *"offset"*).
         1. Assert: Type(_offsetString_) is String.
         1. Let _newOffsetNanoseconds_ be ? ParseDateTimeUTCOffset(_offsetString_).
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _newOffsetNanoseconds_, _timeZoneRec_, _disambiguation_, _offset_, ~match exactly~).
-        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZoneRec_.[[Receiver]], _calendar_).
+        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZoneRec_.[[Receiver]], _calendarRec_.[[Receiver]]).
       </emu-alg>
     </emu-clause>
 
@@ -941,13 +941,13 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_zonedDateTime_.[[Calendar]], « ~fields~, ~yearMonthFromFields~ »).
         1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDateTime_, _fieldNames_, «»).
-        1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_).
+        1. Return ? CalendarYearMonthFromFields(_calendarRec_, _fields_).
         1. NOTE: The call to CalendarYearMonthFromFields is necessary in order to create a PlainYearMonth object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
       </emu-alg>
     </emu-clause>
@@ -960,13 +960,13 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_zonedDateTime_.[[Calendar]], « ~fields~, ~monthDayFromFields~ »).
         1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
-        1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"monthCode"* »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
+        1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"monthCode"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDateTime_, _fieldNames_, «»).
-        1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_).
+        1. Return ? CalendarMonthDayFromFields(_calendarRec_, _fields_).
         1. NOTE: The call to CalendarMonthDayFromFields is necessary in order to create a PlainMonthDay object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
       </emu-alg>
     </emu-clause>
@@ -1176,7 +1176,8 @@
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Return _item_.
           1. Let _calendar_ be ? GetTemporalCalendarSlotValueWithISODefault(_item_).
-          1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
+          1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_calendar_, « ~dateFromFields~, ~fields~ »).
+          1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
           1. Append *"hour"*, *"microsecond"*, *"millisecond"*, *"minute"*, *"nanosecond"*, *"offset"*, *"second"*, and *"timeZone"* to _fieldNames_.
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, « *"timeZone"* »).
           1. Let _timeZone_ be ! Get(_fields_, *"timeZone"*).
@@ -1188,7 +1189,7 @@
           1. NOTE: The following steps read options and perform independent validation in alphabetical order (ToTemporalDisambiguation reads *"disambiguation"*, ToTemporalOffset reads *"offset"*, and InterpretTemporalDateTimeFields reads *"overflow"*).
           1. Let _disambiguation_ be ? ToTemporalDisambiguation(_resolvedOptions_).
           1. Let _offsetOption_ be ? ToTemporalOffset(_resolvedOptions_, *"reject"*).
-          1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _resolvedOptions_).
+          1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendarRec_, _fields_, _resolvedOptions_).
         1. Else,
           1. If _item_ is not a String, throw a *TypeError* exception.
           1. Let _result_ be ? ParseTemporalZonedDateTimeString(_item_).
@@ -1293,7 +1294,7 @@
         AddZonedDateTime (
           _epochNanoseconds_: a BigInt,
           _timeZoneRec_: a Time Zone Methods Record,
-          _calendar_: an Object,
+          _calendarRec_: a Calendar Methods Record,
           _years_: an integer,
           _months_: an integer,
           _weeks_: an integer,
@@ -1311,7 +1312,7 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It adds a duration in various units to a number of nanoseconds _epochNanoseconds_ since the epoch, subject to the rules of the time zone and _calendar_, and returns the result as a BigInt value.
+          It adds a duration in various units to a number of nanoseconds _epochNanoseconds_ since the epoch, subject to the rules of the time zone and calendar, and returns the result as a BigInt value.
           As specified in <a href="https://tools.ietf.org/html/rfc5545">RFC 5545</a>, the date portion of the duration is added in calendar days, and the time portion is added in exact time.
         </dd>
       </dl>
@@ -1328,15 +1329,16 @@
         1. If _precalculatedPlainDateTime_ is not *undefined*, then
           1. Let _temporalDateTime_ be _precalculatedPlainDateTime_.
         1. Else,
-          1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
+          1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
         1. If _years_ = 0, and _months_ = 0, and _weeks_ = 0, then
           1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-          1. Let _intermediate_ be ? AddDaysToZonedDateTime(_instant_, _temporalDateTime_, _timeZoneRec_, _calendar_, _days_, _overflow_).[[EpochNanoseconds]].
+          1. Let _intermediate_ be ? AddDaysToZonedDateTime(_instant_, _temporalDateTime_, _timeZoneRec_, _calendarRec_.[[Receiver]], _days_, _overflow_).[[EpochNanoseconds]].
           1. Return ? AddInstant(_intermediate_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Let _datePart_ be ! CreateTemporalDate(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _calendar_).
+        1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~dateAdd~) is *true*.
+        1. Let _datePart_ be ! CreateTemporalDate(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _calendarRec_.[[Receiver]]).
         1. Let _dateDuration_ be ! CreateTemporalDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
-        1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _datePart_, _dateDuration_, _options_).
-        1. Let _intermediateDateTime_ be ? CreateTemporalDateTime(_addedDate_.[[ISOYear]], _addedDate_.[[ISOMonth]], _addedDate_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _calendar_).
+        1. Let _addedDate_ be ? CalendarDateAdd(_calendarRec_, _datePart_, _dateDuration_, _options_).
+        1. Let _intermediateDateTime_ be ? CreateTemporalDateTime(_addedDate_.[[ISOYear]], _addedDate_.[[ISOMonth]], _addedDate_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _calendarRec_.[[Receiver]]).
         1. Let _intermediateInstant_ be ? GetInstantFor(_timeZoneRec_, _intermediateDateTime_, *"compatible"*).
         1. Return ? AddInstant(_intermediateInstant_.[[Nanoseconds]], _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
       </emu-alg>
@@ -1388,7 +1390,7 @@
           _ns1_: a BigInt,
           _ns2_: a BigInt,
           _timeZoneRec_: a Time Zone Methods Record,
-          _calendar_: an Object,
+          _calendarRec_: a Calendar Methods Record,
           _largestUnit_: a String,
           _options_: an Object,
           _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
@@ -1406,15 +1408,15 @@
           1. Return ! CreateDurationRecord(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. If _precalculatedPlainDateTime_ is *undefined*, then
           1. Let _startInstant_ be ! CreateTemporalInstant(_ns1_).
-          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, _calendar_).
+          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, _calendarRec_.[[Receiver]]).
         1. Else,
           1. Let _startDateTime_ be _precalculatedPlainDateTime_.
         1. Let _endInstant_ be ! CreateTemporalInstant(_ns2_).
-        1. Let _endDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _endInstant_, _calendar_).
-        1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZoneRec_, _calendar_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], 0, 0, 0, 0, 0, 0, 0, _startDateTime_).
+        1. Let _endDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _endInstant_, _calendarRec_.[[Receiver]]).
+        1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendarRec_, _largestUnit_, _options_).
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZoneRec_, _calendarRec_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], 0, 0, 0, 0, 0, 0, 0, _startDateTime_).
         1. Let _timeRemainderNs_ be _ns2_ - _intermediateNs_.
-        1. Let _intermediate_ be ! CreateTemporalZonedDateTime(_intermediateNs_, _timeZoneRec_.[[Receiver]], _calendar_).
+        1. Let _intermediate_ be ! CreateTemporalZonedDateTime(_intermediateNs_, _timeZoneRec_.[[Receiver]], _calendarRec_.[[Receiver]]).
         1. Let _result_ be ? NanosecondsToDays(ℝ(_timeRemainderNs_), _intermediate_, _timeZoneRec_).
         1. Let _timeDifference_ be ! BalanceTimeDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], *"hour"*).
         1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]]).
@@ -1515,17 +1517,18 @@
         1. If _zonedDateTime_.[[Nanoseconds]] = _other_.[[Nanoseconds]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_zonedDateTime_.[[Calendar]], « ~dateAdd~, ~dateUntil~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _zonedDateTime_.[[Calendar]]).
-        1. Let _plainRelativeTo_ be ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _zonedDateTime_.[[Calendar]]).
+        1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
+        1. Let _plainRelativeTo_ be ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _calendarRec_.[[Receiver]]).
         1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
-        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _timeZoneRec_, _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _resolvedOptions_, _precalculatedPlainDateTime_).
+        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _settings_.[[LargestUnit]], _resolvedOptions_, _precalculatedPlainDateTime_).
         1. If _settings_.[[SmallestUnit]] is *"nanosecond"* and _settings_.[[RoundingIncrement]] is 1, let _roundingGranularityIsNoop_ be *true*; else let _roundingGranularityIsNoop_ be *false*.
         1. If _roundingGranularityIsNoop_ is *true*, then
           1. Return ! CreateTemporalDuration(_sign_ &times; _difference_.[[Years]], _sign_ &times; _difference_.[[Months]], _sign_ &times; _difference_.[[Weeks]], _sign_ &times; _difference_.[[Days]], _sign_ &times; _difference_.[[Hours]], _sign_ &times; _difference_.[[Minutes]], _sign_ &times; _difference_.[[Seconds]], _sign_ &times; _difference_.[[Milliseconds]], _sign_ &times; _difference_.[[Microseconds]], _sign_ &times; _difference_.[[Nanoseconds]]).
-        1. Let _roundRecord_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _plainRelativeTo_, _zonedDateTime_, _timeZoneRec_, _precalculatedPlainDateTime_).
+        1. Let _roundRecord_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _plainRelativeTo_, _calendarRec_, _zonedDateTime_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
-        1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _zonedDateTime_, _timeZoneRec_, _precalculatedPlainDateTime_).
+        1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _zonedDateTime_, _calendarRec_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], _sign_ &times; _result_.[[Weeks]], _sign_ &times; _result_.[[Days]], _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -1547,9 +1550,11 @@
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
-        1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _calendar_, _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]], *undefined*, _options_).
-        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZoneRec_.[[Receiver]], _calendar_).
+        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_zonedDateTime_.[[Calendar]], « »).
+        1. If _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, then
+          1. Perform ? CalendarMethodsRecordLookup(_calendarRec_, ~dateAdd~).
+        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]], *undefined*, _options_).
+        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZoneRec_.[[Receiver]], _calendarRec_.[[Receiver]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -147,10 +147,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarYear(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -164,10 +164,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarMonth(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -181,10 +181,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return ? CalendarMonthCode(_calendar_, _temporalDateTime_).
       </emu-alg>
     </emu-clause>
@@ -198,10 +198,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarDay(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -215,10 +215,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(_temporalDateTime_.[[ISOHour]]).
       </emu-alg>
     </emu-clause>
@@ -232,10 +232,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(_temporalDateTime_.[[ISOMinute]]).
       </emu-alg>
     </emu-clause>
@@ -249,10 +249,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(_temporalDateTime_.[[ISOSecond]]).
       </emu-alg>
     </emu-clause>
@@ -266,10 +266,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(_temporalDateTime_.[[ISOMillisecond]]).
       </emu-alg>
     </emu-clause>
@@ -283,10 +283,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(_temporalDateTime_.[[ISOMicrosecond]]).
       </emu-alg>
     </emu-clause>
@@ -300,10 +300,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(_temporalDateTime_.[[ISONanosecond]]).
       </emu-alg>
     </emu-clause>
@@ -375,10 +375,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarDayOfWeek(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -392,10 +392,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarDayOfYear(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -409,10 +409,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarWeekOfYear(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -426,10 +426,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarYearOfWeek(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -443,17 +443,17 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, *"iso8601"*).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, *"iso8601"*).
         1. Let _year_ be _temporalDateTime_.[[ISOYear]].
         1. Let _month_ be _temporalDateTime_.[[ISOMonth]].
         1. Let _day_ be _temporalDateTime_.[[ISODay]].
         1. Let _today_ be ? CreateTemporalDateTime(_year_, _month_, _day_, 0, 0, 0, 0, 0, 0, *"iso8601"*).
         1. Let _tomorrowFields_ be BalanceISODate(_year_, _month_, _day_ + 1).
         1. Let _tomorrow_ be ? CreateTemporalDateTime(_tomorrowFields_.[[Year]], _tomorrowFields_.[[Month]], _tomorrowFields_.[[Day]], 0, 0, 0, 0, 0, 0, *"iso8601"*).
-        1. Let _todayInstant_ be ? GetInstantFor(_timeZone_, _today_, *"compatible"*).
-        1. Let _tomorrowInstant_ be ? GetInstantFor(_timeZone_, _tomorrow_, *"compatible"*).
+        1. Let _todayInstant_ be ? GetInstantFor(_timeZoneRec_, _today_, *"compatible"*).
+        1. Let _tomorrowInstant_ be ? GetInstantFor(_timeZoneRec_, _tomorrow_, *"compatible"*).
         1. Let _diffNs_ be _tomorrowInstant_.[[Nanoseconds]] - _todayInstant_.[[Nanoseconds]].
         1. Return 𝔽(_diffNs_ / (3.6 &times; 10<sup>12</sup>)).
       </emu-alg>
@@ -468,10 +468,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarDaysInWeek(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -485,10 +485,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarDaysInMonth(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -502,10 +502,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarDaysInYear(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -519,10 +519,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return 𝔽(? CalendarMonthsInYear(_calendar_, _temporalDateTime_)).
       </emu-alg>
     </emu-clause>
@@ -536,10 +536,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return ? CalendarInLeapYear(_calendar_, _temporalDateTime_).
       </emu-alg>
     </emu-clause>
@@ -553,9 +553,9 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Return 𝔽(? GetOffsetNanosecondsFor(_timeZone_, _instant_)).
+        1. Return 𝔽(? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_)).
       </emu-alg>
     </emu-clause>
 
@@ -568,8 +568,9 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Return ? GetOffsetStringFor(_zonedDateTime_.[[TimeZone]], _instant_).
+        1. Return ? GetOffsetStringFor(_timeZoneRec_, _instant_).
       </emu-alg>
     </emu-clause>
 
@@ -586,10 +587,10 @@
         1. Perform ? RejectTemporalLikeObject(_temporalZonedDateTimeLike_).
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. Let _dateTime_ be ! GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_, _offsetNanoseconds_).
+        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_).
+        1. Let _dateTime_ be ! GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_, _offsetNanoseconds_).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"month"*, *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_dateTime_, _fieldNames_, « »).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"hour"*, _dateTime_.[[ISOHour]]).
@@ -610,8 +611,8 @@
         1. Let _offsetString_ be ! Get(_fields_, *"offset"*).
         1. Assert: Type(_offsetString_) is String.
         1. Let _newOffsetNanoseconds_ be ? ParseDateTimeUTCOffset(_offsetString_).
-        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _newOffsetNanoseconds_, _timeZone_, _disambiguation_, _offset_, ~match exactly~).
-        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _newOffsetNanoseconds_, _timeZoneRec_, _disambiguation_, _offset_, ~match exactly~).
+        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZoneRec_.[[Receiver]], _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -627,13 +628,13 @@
           1. Let _plainTime_ be ! CreateTemporalTime(0, 0, 0, 0, 0, 0).
         1. Else,
           1. Let _plainTime_ be ? ToTemporalTime(_plainTimeLike_).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Let _resultPlainDateTime_ be ? CreateTemporalDateTime(_plainDateTime_.[[ISOYear]], _plainDateTime_.[[ISOMonth]], _plainDateTime_.[[ISODay]], _plainTime_.[[ISOHour]], _plainTime_.[[ISOMinute]], _plainTime_.[[ISOSecond]], _plainTime_.[[ISOMillisecond]], _plainTime_.[[ISOMicrosecond]], _plainTime_.[[ISONanosecond]], _calendar_).
-        1. Set _instant_ to ? GetInstantFor(_timeZone_, _resultPlainDateTime_, *"compatible"*).
-        1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _calendar_).
+        1. Set _instant_ to ? GetInstantFor(_timeZoneRec_, _resultPlainDateTime_, *"compatible"*).
+        1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZoneRec_.[[Receiver]], _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -646,13 +647,13 @@
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Let _plainDate_ be ? ToTemporalDate(_plainDateLike_).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _zonedDateTime_.[[Calendar]]).
+        1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _zonedDateTime_.[[Calendar]]).
         1. Let _calendar_ be ? ConsolidateCalendars(_zonedDateTime_.[[Calendar]], _plainDate_.[[Calendar]]).
         1. Let _resultPlainDateTime_ be ? CreateTemporalDateTime(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], _plainDateTime_.[[ISOHour]], _plainDateTime_.[[ISOMinute]], _plainDateTime_.[[ISOSecond]], _plainDateTime_.[[ISOMillisecond]], _plainDateTime_.[[ISOMicrosecond]], _plainDateTime_.[[ISONanosecond]], _calendar_).
-        1. Set _instant_ to ? GetInstantFor(_timeZone_, _resultPlainDateTime_, *"compatible"*).
-        1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _calendar_).
+        1. Set _instant_ to ? GetInstantFor(_timeZoneRec_, _resultPlainDateTime_, *"compatible"*).
+        1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZoneRec_.[[Receiver]], _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -760,21 +761,21 @@
         1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, _inclusive_).
         1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ is 1, then
           1. Return ! CreateTemporalZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. Let _temporalDateTime_ be ! GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_, _offsetNanoseconds_).
+        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_).
+        1. Let _temporalDateTime_ be ! GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_, _offsetNanoseconds_).
         1. Let _dtStart_ be ? CreateTemporalDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], 0, 0, 0, 0, 0, 0, *"iso8601"*).
-        1. Let _instantStart_ be ? GetInstantFor(_timeZone_, _dtStart_, *"compatible"*).
+        1. Let _instantStart_ be ? GetInstantFor(_timeZoneRec_, _dtStart_, *"compatible"*).
         1. Let _startNs_ be _instantStart_.[[Nanoseconds]].
-        1. Let _endNs_ be ? AddDaysToZonedDateTime(_instantStart_, _dtStart_, _timeZone_, _calendar_, 1).[[EpochNanoseconds]].
+        1. Let _endNs_ be ? AddDaysToZonedDateTime(_instantStart_, _dtStart_, _timeZoneRec_, _calendar_, 1).[[EpochNanoseconds]].
         1. Let _dayLengthNs_ be ℝ(_endNs_ - _startNs_).
         1. If _dayLengthNs_ &le; 0, then
           1. Throw a *RangeError* exception.
         1. Let _roundResult_ be RoundISODateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dayLengthNs_).
-        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_.[[Year]], _roundResult_.[[Month]], _roundResult_.[[Day]], _roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZone_, *"compatible"*, *"prefer"*, ~match exactly~).
-        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_.[[Year]], _roundResult_.[[Month]], _roundResult_.[[Day]], _roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZoneRec_, *"compatible"*, *"prefer"*, ~match exactly~).
+        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZoneRec_.[[Receiver]], _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -864,13 +865,13 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Let _startDateTime_ be ? CreateTemporalDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], 0, 0, 0, 0, 0, 0, _calendar_).
-        1. Let _startInstant_ be ? GetInstantFor(_timeZone_, _startDateTime_, *"compatible"*).
-        1. Return ! CreateTemporalZonedDateTime(_startInstant_.[[Nanoseconds]], _timeZone_, _calendar_).
+        1. Let _startInstant_ be ? GetInstantFor(_timeZoneRec_, _startDateTime_, *"compatible"*).
+        1. Return ! CreateTemporalZonedDateTime(_startInstant_.[[Nanoseconds]], _timeZoneRec_,[[Receiver]], _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -894,10 +895,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return ! CreateTemporalDate(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _calendar_).
       </emu-alg>
     </emu-clause>
@@ -910,10 +911,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Return ! CreateTemporalTime(_temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]]).
       </emu-alg>
     </emu-clause>
@@ -926,9 +927,9 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Return ? GetPlainDateTimeFor(_timeZone_, _instant_, _zonedDateTime_.[[Calendar]]).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Return ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _zonedDateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 
@@ -940,10 +941,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDateTime_, _fieldNames_, «»).
         1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_).
@@ -959,10 +960,10 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"day"*, *"monthCode"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_temporalDateTime_, _fieldNames_, «»).
         1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_).
@@ -979,11 +980,11 @@
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Let _fields_ be OrdinaryObjectCreate(%Object.prototype%).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. Let _dateTime_ be ! GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_, _offsetNanoseconds_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~ »).
+        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_).
+        1. Let _dateTime_ be ! GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_, _offsetNanoseconds_).
         1. Let _offset_ be FormatUTCOffsetNanoseconds(_offsetNanoseconds_).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"calendar"*, _calendar_).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoDay"*, 𝔽(_dateTime_.[[ISODay]])).
@@ -996,7 +997,7 @@
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoSecond"*, 𝔽(_dateTime_.[[ISOSecond]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoYear"*, 𝔽(_dateTime_.[[ISOYear]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"offset"*, _offset_).
-        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"timeZone"*, _timeZone_).
+        1. Perform ! CreateDataPropertyOrThrow(_fields_, *"timeZone"*, _timeZoneRec_.[[Receiver]]).
         1. Return _fields_.
       </emu-alg>
     </emu-clause>
@@ -1097,7 +1098,7 @@
           _nanosecond_: an integer,
           _offsetBehaviour_: one of ~option~, ~exact~, or ~wall~,
           _offsetNanoseconds_: an integer,
-          _timeZone_: an Object,
+          _timeZoneRec_: a Time Zone Methods Record,
           _disambiguation_: one of *"earlier"*, *"later"*, *"compatible"*, or *"reject"*,
           _offsetOption_: one of *"ignore"*, *"use"*, *"prefer"*, or *"reject"*,
           _matchBehaviour_: one of ~match exactly~ or ~match minutes~,
@@ -1114,13 +1115,17 @@
             As a special case when parsing ISO 8601 strings which are only required to specify time zone offsets to minutes precision, if _matchBehaviour_ is ~match minutes~, then a value for _offsetNanoseconds_ that is rounded to the nearest minute will be accepted in those cases where _offsetNanoseconds_ is compared against _timeZone_'s offset.
             If _matchBehaviour_ is ~match exactly~, then this does not happen.
           </p>
+          <p>
+            The _timeZoneRec_ will look up `getOffsetNanosecondsFor` as needed, since this is one of the few operations that cannot determine in advance whether it will be used.
+          </p>
         </dd>
       </dl>
       <emu-alg>
         1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.
         1. Let _dateTime_ be ? CreateTemporalDateTime(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, *"iso8601"*).
         1. If _offsetBehaviour_ is ~wall~ or _offsetOption_ is *"ignore"*, then
-          1. Let _instant_ be ? GetInstantFor(_timeZone_, _dateTime_, _disambiguation_).
+          1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getPossibleInstantsFor~) is *true*.
+          1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _dateTime_, _disambiguation_).
           1. Return _instant_.[[Nanoseconds]].
         1. If _offsetBehaviour_ is ~exact~ or _offsetOption_ is *"use"*, then
           1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _offsetNanoseconds_).
@@ -1128,12 +1133,13 @@
           1. Return _epochNanoseconds_.
         1. Assert: _offsetBehaviour_ is ~option~.
         1. Assert: _offsetOption_ is *"prefer"* or *"reject"*.
-        1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZone_, _dateTime_).
+        1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getPossibleInstantsFor~) is *true*.
+        1. Let _possibleInstants_ be ? GetPossibleInstantsFor(_timeZoneRec_, _dateTime_).
         1. If _possibleInstants_ is not empty, then
-          1. Let _getOffsetNanosecondsFor_ be ~unused~.
-          1. If _timeZone_ is an Object, set _getOffsetNanosecondsFor_ to ? GetMethod(_timeZone_, *"getOffsetNanosecondsFor"*).
+          1. If TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getOffsetNanosecondsFor~) is *false*, then
+            1. Perform ? TimeZoneMethodsRecordLookup(_timeZoneRec_, ~getOffsetNanosecondsFor~).
           1. For each element _candidate_ of _possibleInstants_, do
-            1. Let _candidateNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _candidate_, _getOffsetNanosecondsFor_).
+            1. Let _candidateNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _candidate_).
             1. If _candidateNanoseconds_ = _offsetNanoseconds_, then
               1. Return _candidate_.[[Nanoseconds]].
             1. If _matchBehaviour_ is ~match minutes~, then
@@ -1141,7 +1147,9 @@
               1. If _roundedCandidateNanoseconds_ = _offsetNanoseconds_, then
                 1. Return _candidate_.[[Nanoseconds]].
         1. If _offsetOption_ is *"reject"*, throw a *RangeError* exception.
-        1. Let _instant_ be ? DisambiguatePossibleInstants(_possibleInstants_, _timeZone_, _dateTime_, _disambiguation_).
+        1. If TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getOffsetNanosecondsFor~) is *false*, then
+          1. Perform ? TimeZoneMethodsRecordLookup(_timeZoneRec_, ~getOffsetNanosecondsFor~).
+        1. Let _instant_ be ? DisambiguatePossibleInstants(_possibleInstants_, _timeZoneRec_, _dateTime_, _disambiguation_).
         1. Return _instant_.[[Nanoseconds]].
       </emu-alg>
     </emu-clause>
@@ -1203,7 +1211,10 @@
         1. Let _offsetNanoseconds_ be 0.
         1. If _offsetBehaviour_ is ~option~, then
           1. Set _offsetNanoseconds_ to ? ParseDateTimeUTCOffset(_offsetString_).
-        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offsetOption_, _matchBehaviour_).
+        1. Let _timeZoneRec_ be ! CreateTimeZoneMethodsRecord(_timeZone_, « »).
+        1. If _offsetBehaviour_ is not ~exact~, and _offsetOption_ is not *"use"*, then
+          1. Perform ? TimeZoneMethodsRecordLookup(_timeZoneRec_, ~getPossibleInstantsFor~).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNanoseconds_, _timeZoneRec_, _disambiguation_, _offsetOption_, _matchBehaviour_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -1258,8 +1269,9 @@
         1. Let _ns_ be RoundTemporalInstant(_zonedDateTime_.[[Nanoseconds]], _increment_, _unit_, _roundingMode_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _instant_ be ! CreateTemporalInstant(_ns_).
-        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. Let _temporalDateTime_ be ! GetPlainDateTimeFor(_timeZone_, _instant_, *"iso8601"*, _offsetNanoseconds_).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~getOffsetNanosecondsFor~ »).
+        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_).
+        1. Let _temporalDateTime_ be ! GetPlainDateTimeFor(_timeZoneRec_, _instant_, *"iso8601"*, _offsetNanoseconds_).
         1. Let _dateTimeString_ be ! TemporalDateTimeToString(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], *"iso8601"*, _precision_, *"never"*).
         1. If _showOffset_ is *"never"*, then
           1. Let _offsetString_ be the empty String.
@@ -1280,7 +1292,7 @@
       <h1>
         AddZonedDateTime (
           _epochNanoseconds_: a BigInt,
-          _timeZone_: an Object,
+          _timeZoneRec_: a Time Zone Methods Record,
           _calendar_: an Object,
           _years_: an integer,
           _months_: an integer,
@@ -1299,12 +1311,15 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It adds a duration in various units to a number of nanoseconds _epochNanoseconds_ since the epoch, subject to the rules of _timeZone_ and _calendar_, and returns the result as a BigInt value.
+          It adds a duration in various units to a number of nanoseconds _epochNanoseconds_ since the epoch, subject to the rules of the time zone and _calendar_, and returns the result as a BigInt value.
           As specified in <a href="https://tools.ietf.org/html/rfc5545">RFC 5545</a>, the date portion of the duration is added in calendar days, and the time portion is added in exact time.
         </dd>
       </dl>
-      <p>Unless _precalculatedPlainDateTime_ is supplied, the given _timeZone_'s `getOffsetNanosecondsFor` method will be called to convert _epochNanoseconds_ to a wall-clock time.</p>
+      <p>Unless _precalculatedPlainDateTime_ is supplied, the given _timeZone_'s `getOffsetNanosecondsFor` method will be called to convert _epochNanoseconds_ to a wall-clock time, and _timeZoneRec_ must have looked up `getOffsetNanosecondsFor`. `getPossibleInstantsFor` will always be called and must have been looked up.</p>
       <emu-alg>
+        1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getPossibleInstantsFor~) is *true*.
+        1. If _precalculatedPlainDateTime_ is not present, set _precalculatedPlainDateTime_ to *undefined*.
+        1. Assert: If _precalculatedPlainDateTime_ is *undefined*, TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~getOffsetNanosecondsFor~) is *true*.
         1. If _options_ is not present, set _options_ to *undefined*.
         1. Assert: Type(_options_) is Object or Undefined.
         1. If _years_ = 0, _months_ = 0, _weeks_ = 0, and _days_ = 0, then
@@ -1313,16 +1328,16 @@
         1. If _precalculatedPlainDateTime_ is not *undefined*, then
           1. Let _temporalDateTime_ be _precalculatedPlainDateTime_.
         1. Else,
-          1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+          1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. If _years_ = 0, and _months_ = 0, and _weeks_ = 0, then
           1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-          1. Let _intermediate_ be ? AddDaysToZonedDateTime(_instant_, _temporalDateTime_, _timeZone_, _calendar_, _days_, _overflow_).[[EpochNanoseconds]].
+          1. Let _intermediate_ be ? AddDaysToZonedDateTime(_instant_, _temporalDateTime_, _timeZoneRec_, _calendar_, _days_, _overflow_).[[EpochNanoseconds]].
           1. Return ? AddInstant(_intermediate_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Let _datePart_ be ! CreateTemporalDate(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _calendar_).
         1. Let _dateDuration_ be ! CreateTemporalDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _datePart_, _dateDuration_, _options_).
         1. Let _intermediateDateTime_ be ? CreateTemporalDateTime(_addedDate_.[[ISOYear]], _addedDate_.[[ISOMonth]], _addedDate_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _calendar_).
-        1. Let _intermediateInstant_ be ? GetInstantFor(_timeZone_, _intermediateDateTime_, *"compatible"*).
+        1. Let _intermediateInstant_ be ? GetInstantFor(_timeZoneRec_, _intermediateDateTime_, *"compatible"*).
         1. Return ? AddInstant(_intermediateInstant_.[[Nanoseconds]], _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
       </emu-alg>
     </emu-clause>
@@ -1332,7 +1347,7 @@
         AddDaysToZonedDateTime (
           _instant_: a Temporal.Instant,
           _dateTime_: a Temporal.PlainDateTime,
-          _timeZone_: a String or Object,
+          _timeZoneRec_: a Time Zone Methods Record,
           _calendar_: a String or Object,
           _days_: an integer,
           optional _overflow_: *"constrain"* or *"reject"*,
@@ -1348,7 +1363,7 @@
         This operation is similar to AddZonedDateTime, but adds only a number of days instead of a full duration, which allows performing fewer observable operations.
       </p>
       <emu-alg>
-        1. Assert: If _timeZone_ is a String, _dateTime_'s internal slots are the same as those of the Object returned from ! GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
+        1. Assert: If TimeZoneMethodsRecordIsBuiltin(_timeZoneRec_) is *true*, _dateTime_'s internal slots are the same as those of the Object returned from ! GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_).
         1. If _overflow_ is not present, set _overflow_ to *"constrain"*.
         1. If _days_ = 0, then
           1. Return the Record {
@@ -1358,7 +1373,7 @@
             }.
         1. Let _addedDate_ be ? AddISODate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], 0, 0, 0, _days_, _overflow_).
         1. Let _dateTimeResult_ be ? CreateTemporalDateTime(_addedDate_.[[Year]], _addedDate_.[[Month]], _addedDate_.[[Day]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _calendar_).
-        1. Let _instantResult_ be ? GetInstantFor(_timeZone_, _dateTimeResult_, *"compatible"*).
+        1. Let _instantResult_ be ? GetInstantFor(_timeZoneRec_, _dateTimeResult_, *"compatible"*).
         1. Return the Record {
             [[EpochNanoseconds]]: _instantResult_.[[Nanoseconds]],
             [[Instant]]: _instantResult_,
@@ -1372,7 +1387,7 @@
         DifferenceZonedDateTime (
           _ns1_: a BigInt,
           _ns2_: a BigInt,
-          _timeZone_: an Object,
+          _timeZoneRec_: a Time Zone Methods Record,
           _calendar_: an Object,
           _largestUnit_: a String,
           _options_: an Object,
@@ -1385,21 +1400,22 @@
           It computes the difference between two exact times expressed in nanoseconds since the epoch, and balances the result so that there is no non-zero unit larger than _largestUnit_ in the result, taking calendar reckoning and time zone offset changes into account.
         </dd>
       </dl>
+      <p>Unless _ns1_ and _ns2_ are equal, _timeZoneRec_ must have looked up both `getOffsetNanosecondsFor` and `getPossibleInstantsFor`.</p>
       <emu-alg>
         1. If _ns1_ is _ns2_, then
           1. Return ! CreateDurationRecord(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. If _precalculatedPlainDateTime_ is *undefined*, then
           1. Let _startInstant_ be ! CreateTemporalInstant(_ns1_).
-          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _startInstant_, _calendar_).
+          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, _calendar_).
         1. Else,
           1. Let _startDateTime_ be _precalculatedPlainDateTime_.
         1. Let _endInstant_ be ! CreateTemporalInstant(_ns2_).
-        1. Let _endDateTime_ be ? GetPlainDateTimeFor(_timeZone_, _endInstant_, _calendar_).
+        1. Let _endDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _endInstant_, _calendar_).
         1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendar_, _largestUnit_, _options_).
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZone_, _calendar_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], 0, 0, 0, 0, 0, 0, 0, _startDateTime_).
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZoneRec_, _calendar_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], 0, 0, 0, 0, 0, 0, 0, _startDateTime_).
         1. Let _timeRemainderNs_ be _ns2_ - _intermediateNs_.
-        1. Let _intermediate_ be ! CreateTemporalZonedDateTime(_intermediateNs_, _timeZone_, _calendar_).
-        1. Let _result_ be ? NanosecondsToDays(ℝ(_timeRemainderNs_), _intermediate_).
+        1. Let _intermediate_ be ! CreateTemporalZonedDateTime(_intermediateNs_, _timeZoneRec_.[[Receiver]], _calendar_).
+        1. Let _result_ be ? NanosecondsToDays(ℝ(_timeRemainderNs_), _intermediate_, _timeZoneRec_).
         1. Let _timeDifference_ be ! BalanceTimeDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], *"hour"*).
         1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]]).
       </emu-alg>
@@ -1410,6 +1426,7 @@
         NanosecondsToDays (
           _nanoseconds_: an integer,
           _zonedRelativeTo_: a Temporal.ZonedDateTime,
+          _timeZoneRec_: a Time Zone Methods Record,
           optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime,
         ): either a normal completion containing a Record with fields [[Days]] (an integer), [[Nanoseconds]] (an integer), and [[DayLength]] (an integer), or an abrupt completion
       </h1>
@@ -1420,6 +1437,7 @@
           It also returns the length of the last day in nanoseconds, for rounding purposes.
         </dd>
       </dl>
+      <p>Unless _nanoseconds_ = 0, _timeZoneRec_ must have looked up both `getOffsetNanosecondsFor` and `getPossibleInstantsFor`.</p>
       <emu-alg>
         1. If _nanoseconds_ = 0, then
           1. Return the Record { [[Days]]: 0, [[Nanoseconds]]: 0, [[DayLength]]: nsPerDay }.
@@ -1429,8 +1447,8 @@
         1. Let _endNs_ be _startNs_ + _nanoseconds_.
         1. If IsValidEpochNanoseconds(ℤ(_endNs_)) is *false*, throw a *RangeError* exception.
         1. Let _endInstant_ be ! CreateTemporalInstant(ℤ(_endNs_)).
-        1. If _precalculatedPlainDateTime_ is present, let _startDateTime_ be _precalculatedPlainDateTime_; else let _startDateTime_ be ? GetPlainDateTimeFor(_zonedRelativeTo_.[[TimeZone]], _startInstant_, *"iso8601"*).
-        1. Let _endDateTime_ be ? GetPlainDateTimeFor(_zonedRelativeTo_.[[TimeZone]], _endInstant_, *"iso8601"*).
+        1. If _precalculatedPlainDateTime_ is present, let _startDateTime_ be _precalculatedPlainDateTime_; else let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, *"iso8601"*).
+        1. Let _endDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _endInstant_, *"iso8601"*).
         1. Let _date1_ be ! CreateTemporalDate(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], *"iso8601"*).
         1. Let _date2_ be ! CreateTemporalDate(_endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], *"iso8601"*).
         1. Let _days_ be DaysUntil(_date1_, _date2_).
@@ -1439,16 +1457,16 @@
           1. Set _days_ to _days_ - 1.
         1. Else if _days_ &lt; 0 and _timeSign_ &lt; 0, then
           1. Set _days_ to _days_ + 1.
-        1. Let _relativeResult_ be ? AddDaysToZonedDateTime(_startInstant_, _startDateTime_, _zonedRelativeTo_.[[TimeZone]], _zonedRelativeTo_.[[Calendar]], _days_).
+        1. Let _relativeResult_ be ? AddDaysToZonedDateTime(_startInstant_, _startDateTime_, _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _days_).
         1. If _sign_ is 1, then
           1. Repeat, while _days_ &gt; 0 and ℝ(_relativeResult_.[[EpochNanoseconds]]) &gt; _endNs_,
             1. Set _days_ to _days_ - 1.
-            1. Set _relativeResult_ to ? AddDaysToZonedDateTime(_startInstant_, _startDateTime_, _zonedRelativeTo_.[[TimeZone]], _zonedRelativeTo_.[[Calendar]], _days_).
+            1. Set _relativeResult_ to ? AddDaysToZonedDateTime(_startInstant_, _startDateTime_, _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _days_).
         1. Set _nanoseconds_ to _endNs_ - ℝ(_relativeResult_.[[EpochNanoseconds]]).
         1. Let _done_ be *false*.
         1. Let _dayLengthNs_ be ~unset~.
         1. Repeat, while _done_ is *false*,
-          1. Let _oneDayFarther_ be ? AddDaysToZonedDateTime(_relativeResult_.[[Instant]], _relativeResult_.[[DateTime]], _zonedRelativeTo_.[[TimeZone]], _zonedRelativeTo_.[[Calendar]], _sign_).
+          1. Let _oneDayFarther_ be ? AddDaysToZonedDateTime(_relativeResult_.[[Instant]], _relativeResult_.[[DateTime]], _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _sign_).
           1. Set _dayLengthNs_ to ℝ(_oneDayFarther_.[[EpochNanoseconds]] - _relativeResult_.[[EpochNanoseconds]]).
           1. If (_nanoseconds_ - _dayLengthNs_) &times; _sign_ &ge; 0, then
             1. Set _nanoseconds_ to _nanoseconds_ - _dayLengthNs_.
@@ -1496,17 +1514,18 @@
           1. Throw a *RangeError* exception.
         1. If _zonedDateTime_.[[Nanoseconds]] = _other_.[[Nanoseconds]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_zonedDateTime_.[[TimeZone]], _instant_, _zonedDateTime_.[[Calendar]]).
+        1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _zonedDateTime_.[[Calendar]]).
         1. Let _plainRelativeTo_ be ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _zonedDateTime_.[[Calendar]]).
         1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
-        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _resolvedOptions_, _precalculatedPlainDateTime_).
+        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _timeZoneRec_, _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _resolvedOptions_, _precalculatedPlainDateTime_).
         1. If _settings_.[[SmallestUnit]] is *"nanosecond"* and _settings_.[[RoundingIncrement]] is 1, let _roundingGranularityIsNoop_ be *true*; else let _roundingGranularityIsNoop_ be *false*.
         1. If _roundingGranularityIsNoop_ is *true*, then
           1. Return ! CreateTemporalDuration(_sign_ &times; _difference_.[[Years]], _sign_ &times; _difference_.[[Months]], _sign_ &times; _difference_.[[Weeks]], _sign_ &times; _difference_.[[Days]], _sign_ &times; _difference_.[[Hours]], _sign_ &times; _difference_.[[Minutes]], _sign_ &times; _difference_.[[Seconds]], _sign_ &times; _difference_.[[Milliseconds]], _sign_ &times; _difference_.[[Microseconds]], _sign_ &times; _difference_.[[Nanoseconds]]).
-        1. Let _roundRecord_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _plainRelativeTo_, _zonedDateTime_, _precalculatedPlainDateTime_).
+        1. Let _roundRecord_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _plainRelativeTo_, _zonedDateTime_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
-        1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _zonedDateTime_, _precalculatedPlainDateTime_).
+        1. Let _result_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _zonedDateTime_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], _sign_ &times; _result_.[[Weeks]], _sign_ &times; _result_.[[Days]], _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -1527,10 +1546,10 @@
         1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
+        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~getOffsetNanosecondsFor~, ~getPossibleInstantsFor~ »).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
-        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZone_, _calendar_, _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]], *undefined*, _options_).
-        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
+        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _calendar_, _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]], *undefined*, _options_).
+        1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZoneRec_.[[Receiver]], _calendar_).
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This is an audit of the whole proposal for opportunities where we can reduce the number of calls we make into user code.

Very large, recommend reviewing commit by commit.

- [x] I will push a test262 branch with changes in the order-of-operations tests, so that it's easier to see what the effects are on user code calls: https://github.com/tc39/test262/compare/main...ptomato:user-code-calls?expand=1
- [x] Calendar Record commit to follow tomorrow morning. I'm still doing a bunch of search-and-replace on that one.