### PR TITLE
Editorial fixes and time zone optimizations

### DIFF
--- a/polyfill/ci_codecov_test262.sh
+++ b/polyfill/ci_codecov_test262.sh
@@ -12,6 +12,8 @@ npm run build262
 export NODE_V8_COVERAGE=coverage/tmp/
 rm -rf $NODE_V8_COVERAGE
 
+export TIMEOUT=30000
+
 # Run the tests in chunks, by subdirectory
 # Works around memory leak with vm.Script and NODE_V8_COVERAGE
 subdirs=$(find test262/test/*/Temporal/* -maxdepth 0 -type d -exec basename "{}" ";" | sort -u)

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -5170,6 +5170,9 @@ export const ES = ObjectAssign({}, ES2022, {
     }
     return quotient;
   },
+  BigIntIfAvailable: (wrapper) => {
+    return typeof BigInt === 'undefined' ? wrapper : wrapper.value;
+  },
 
   ToBigInt: (arg) => {
     if (bigInt.isInstance(arg)) {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2587,6 +2587,9 @@ export const ES = ObjectAssign({}, ES2022, {
     return ES.BalanceISODateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   },
   GetNamedTimeZoneNextTransition: (id, epochNanoseconds) => {
+    if (epochNanoseconds.lesser(BEFORE_FIRST_DST)) {
+      return ES.GetNamedTimeZoneNextTransition(id, BEFORE_FIRST_DST);
+    }
     const uppercap = ES.SystemUTCEpochNanoSeconds().plus(DAY_NANOS.multiply(366));
     let leftNanos = epochNanoseconds;
     let leftOffsetNs = ES.GetNamedTimeZoneOffsetNanoseconds(id, leftNanos);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2769,6 +2769,18 @@ export const ES = ObjectAssign({}, ES2022, {
   BalanceISODate: (year, month, day) => {
     if (!NumberIsFinite(day)) throw new RangeError('infinity is out of range');
     ({ year, month } = ES.BalanceISOYearMonth(year, month));
+
+    // The pattern of leap years in the ISO 8601 calendar repeats every 400
+    // years. So if we have more than 400 years in days, there's no need to
+    // convert days to a year 400 times. We can convert a multiple of 400 all at
+    // once.
+    const daysIn400YearCycle = 400 * 365 + 97;
+    if (MathAbs(day) > daysIn400YearCycle) {
+      const nCycles = MathTrunc(day / daysIn400YearCycle);
+      year += 400 * nCycles;
+      day -= nCycles * daysIn400YearCycle;
+    }
+
     let daysInYear = 0;
     let testYear = month > 2 ? year : year - 1;
     while (((daysInYear = ES.LeapYear(testYear) ? 366 : 365), day < -daysInYear)) {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2626,6 +2626,20 @@ export const ES = ObjectAssign({}, ES2022, {
       }
     }
 
+    // We assume most time zones either have regular DST rules that extend
+    // indefinitely into the future, or they have no DST transitions between now
+    // and next year. Africa/Casablanca and Africa/El_Aaiun are unique cases
+    // that fit neither of these. Their irregular DST transitions are
+    // precomputed until 2087 in the current time zone database, so requesting
+    // the previous transition for an instant far in the future may take an
+    // extremely long time as it loops backward 2 weeks at a time.
+    if (id === 'Africa/Casablanca' || id === 'Africa/El_Aaiun') {
+      const lastPrecomputed = GetSlot(ES.ToTemporalInstant('2088-01-01T00Z'), EPOCHNANOSECONDS);
+      if (lastPrecomputed.lesser(epochNanoseconds)) {
+        return ES.GetNamedTimeZonePreviousTransition(id, lastPrecomputed);
+      }
+    }
+
     let rightNanos = bigInt(epochNanoseconds).minus(1);
     if (rightNanos.lesser(BEFORE_FIRST_DST)) return null;
     let rightOffsetNs = ES.GetNamedTimeZoneOffsetNanoseconds(id, rightNanos);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2597,6 +2597,7 @@ export const ES = ObjectAssign({}, ES2022, {
     let rightOffsetNs = leftOffsetNs;
     while (leftOffsetNs === rightOffsetNs && bigInt(leftNanos).compare(uppercap) === -1) {
       rightNanos = bigInt(leftNanos).plus(DAY_NANOS.multiply(2 * 7));
+      if (rightNanos.greater(NS_MAX)) return null;
       rightOffsetNs = ES.GetNamedTimeZoneOffsetNanoseconds(id, rightNanos);
       if (leftOffsetNs === rightOffsetNs) {
         leftNanos = rightNanos;
@@ -2625,13 +2626,14 @@ export const ES = ObjectAssign({}, ES2022, {
       }
     }
 
-    const lowercap = BEFORE_FIRST_DST; // 1847-01-01T00:00:00Z
     let rightNanos = bigInt(epochNanoseconds).minus(1);
+    if (rightNanos.lesser(BEFORE_FIRST_DST)) return null;
     let rightOffsetNs = ES.GetNamedTimeZoneOffsetNanoseconds(id, rightNanos);
     let leftNanos = rightNanos;
     let leftOffsetNs = rightOffsetNs;
-    while (rightOffsetNs === leftOffsetNs && bigInt(rightNanos).compare(lowercap) === 1) {
+    while (rightOffsetNs === leftOffsetNs && bigInt(rightNanos).compare(BEFORE_FIRST_DST) === 1) {
       leftNanos = bigInt(rightNanos).minus(DAY_NANOS.multiply(2 * 7));
+      if (leftNanos.lesser(BEFORE_FIRST_DST)) return null;
       leftOffsetNs = ES.GetNamedTimeZoneOffsetNanoseconds(id, leftNanos);
       if (rightOffsetNs === leftOffsetNs) {
         rightNanos = leftNanos;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2490,8 +2490,27 @@ export const ES = ObjectAssign({}, ES2022, {
   GetNamedTimeZoneOffsetNanoseconds: (id, epochNanoseconds) => {
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
       ES.GetNamedTimeZoneDateTimeParts(id, epochNanoseconds);
-    const utc = ES.GetUTCEpochNanoseconds(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
-    if (utc === null) throw new RangeError('Date outside of supported range');
+
+    // The pattern of leap years in the ISO 8601 calendar repeats every 400
+    // years. To avoid overflowing at the edges of the range, we reduce the year
+    // to the remainder after dividing by 400, and then add back all the
+    // nanoseconds from the multiples of 400 years at the end.
+    const reducedYear = year % 400;
+    const yearCycles = (year - reducedYear) / 400;
+    const nsIn400YearCycle = bigInt(400 * 365 + 97).multiply(DAY_NANOS);
+
+    const reducedUTC = ES.GetUTCEpochNanoseconds(
+      reducedYear,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond
+    );
+    const utc = reducedUTC.plus(nsIn400YearCycle.multiply(yearCycles));
     return +utc.minus(epochNanoseconds);
   },
   FormatTimeZoneOffsetString: (offsetNanoseconds) => {

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -46,11 +46,11 @@ export class Instant {
   get epochMicroseconds() {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     const value = GetSlot(this, EPOCHNANOSECONDS);
-    return bigIntIfAvailable(ES.BigIntFloorDiv(value, 1e3));
+    return ES.BigIntIfAvailable(ES.BigIntFloorDiv(value, 1e3));
   }
   get epochNanoseconds() {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    return bigIntIfAvailable(GetSlot(this, EPOCHNANOSECONDS));
+    return ES.BigIntIfAvailable(GetSlot(this, EPOCHNANOSECONDS));
   }
 
   add(temporalDurationLike) {
@@ -192,7 +192,3 @@ export class Instant {
 }
 
 MakeIntrinsicClass(Instant, 'Temporal.Instant');
-
-function bigIntIfAvailable(wrapper) {
-  return typeof BigInt === 'undefined' ? wrapper : wrapper.value;
-}

--- a/polyfill/lib/legacydate.mjs
+++ b/polyfill/lib/legacydate.mjs
@@ -1,3 +1,4 @@
+import { ES } from './ecmascript.mjs';
 import { Instant } from './instant.mjs';
 
 import bigInt from 'big-integer';
@@ -5,9 +6,5 @@ import bigInt from 'big-integer';
 export function toTemporalInstant() {
   // Observable access to valueOf is not correct here, but unavoidable
   const epochNanoseconds = bigInt(+this).multiply(1e6);
-  return new Instant(bigIntIfAvailable(epochNanoseconds));
-}
-
-function bigIntIfAvailable(wrapper) {
-  return typeof BigInt === 'undefined' ? wrapper : wrapper.value;
+  return new Instant(ES.BigIntIfAvailable(epochNanoseconds));
 }

--- a/polyfill/lib/legacydate.mjs
+++ b/polyfill/lib/legacydate.mjs
@@ -3,8 +3,9 @@ import { Instant } from './instant.mjs';
 
 import bigInt from 'big-integer';
 
+const DatePrototypeValueOf = Date.prototype.valueOf;
+
 export function toTemporalInstant() {
-  // Observable access to valueOf is not correct here, but unavoidable
-  const epochNanoseconds = bigInt(+this).multiply(1e6);
+  const epochNanoseconds = bigInt(ES.Call(DatePrototypeValueOf, this, [])).multiply(1e6);
   return new Instant(ES.BigIntIfAvailable(epochNanoseconds));
 }

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -107,11 +107,11 @@ export class ZonedDateTime {
   get epochMicroseconds() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const value = GetSlot(this, EPOCHNANOSECONDS);
-    return bigIntIfAvailable(ES.BigIntFloorDiv(value, 1e3));
+    return ES.BigIntIfAvailable(ES.BigIntFloorDiv(value, 1e3));
   }
   get epochNanoseconds() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    return bigIntIfAvailable(GetSlot(this, EPOCHNANOSECONDS));
+    return ES.BigIntIfAvailable(GetSlot(this, EPOCHNANOSECONDS));
   }
   get dayOfWeek() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
@@ -610,10 +610,6 @@ export class ZonedDateTime {
 }
 
 MakeIntrinsicClass(ZonedDateTime, 'Temporal.ZonedDateTime');
-
-function bigIntIfAvailable(wrapper) {
-  return typeof BigInt === 'undefined' ? wrapper : wrapper.value;
-}
 
 function dateTime(zdt) {
   return ES.GetPlainDateTimeFor(GetSlot(zdt, TIME_ZONE), GetSlot(zdt, INSTANT), GetSlot(zdt, CALENDAR));

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -10,7 +10,7 @@
     "test": "node --loader ./test/resolve.source.mjs ./test/all.mjs",
     "test-cookbook": "npm run build && TEST=all npm run test-cookbook-one && TEST=stockExchangeTimeZone npm run test-cookbook-one",
     "test-cookbook-one": "node --loader ./test/resolve.cookbook.mjs ../docs/cookbook/$TEST.mjs",
-    "test262": "npm run build262 && node runtest262.mjs",
+    "test262": "npm run build262 && TIMEOUT=30000 node runtest262.mjs",
     "codecov:test262": "./ci_codecov_test262.sh",
     "build": "rollup -c rollup.config.js --bundleConfigAsCjs",
     "build262": "TEST262=1 rollup -c rollup.config.js --bundleConfigAsCjs",

--- a/polyfill/runtest262.mjs
+++ b/polyfill/runtest262.mjs
@@ -4,7 +4,7 @@ const result = runTest262({
   test262Dir: 'test262',
   polyfillCodeFile: 'script.js',
   expectedFailureFiles: ['test/expected-failures.txt'],
-  timeout: process.env.TIMEOUT,
+  timeoutMsecs: process.env.TIMEOUT,
   testGlobs: process.argv.slice(2)
 });
 

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -1,6 +1,3 @@
-intl402/Temporal/TimeZone/prototype/getNextTransition/transition-at-instant-boundaries.js
-intl402/Temporal/TimeZone/prototype/getPreviousTransition/transition-at-instant-boundaries.js
-
 # Caused by https://bugs.chromium.org/p/chromium/issues/detail?id=1416538
 # Remove these lines after that bug is fixed.
 staging/Intl402/Temporal/old/date-time-format.js

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -4,17 +4,19 @@
 <emu-clause id="sec-temporal-abstract-ops">
   <h1>Abstract operations</h1>
 
-  <!-- Based on ECMA-262 IterableToList -->
-  <emu-clause id="sec-iterabletolistoftype" aoid="IterableToListOfType">
-    <h1>IterableToListOfType ( _items_, _elementTypes_ )</h1>
-    <p>
-      The abstract operation IterableToListOfType takes arguments _items_ and _elementTypes_ (a List of names of ECMAScript Language Types).
-      It is used to create a List value whose elements are provided by the values of the iterable _items_.
-      _elementTypes_ contains the names of ECMAScript Language Types that are allowed for element values of the List that is created.
-      It performs the following steps when called:
-    </p>
+  <!-- Based on ECMA-262 IteratorToList -->
+  <emu-clause id="sec-iteratortolistoftype" type="abstract operation">
+    <h1>
+      IteratorToListOfType (
+        _iteratorRecord_: an Iterator Record,
+        _elementTypes_: a List of names of ECMAScript language types,
+      ): either a normal completion containing a list of ECMAScript language values or a throw completion
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>_elementTypes_ contains the names of ECMAScript language types that are allowed for element values of the returned List.</dd>
+    </dl>
     <emu-alg>
-      1. Let _iteratorRecord_ be ? GetIterator(_items_, ~sync~).
       1. Let _values_ be a new empty List.
       1. Let _next_ be *true*.
       1. Repeat, while _next_ is not *false*,

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -102,7 +102,8 @@
           1. Set _calendar_ to ! CreateTemporalCalendar(_calendar_).
           1. Return ? Call(%Temporal.Calendar.prototype.fields%, _calendar_, « CreateArrayFromList(_fieldNames_) »).
         1. Let _fieldsArray_ be ? Invoke(_calendar_, *"fields"*, « CreateArrayFromList(_fieldNames_) »).
-        1. Return ? IterableToListOfType(_fieldsArray_, « String »).
+        1. Let _iteratorRecord_ be ? GetIterator(_fieldsArray_, ~sync~).
+        1. Return ? IteratorToListOfType(_iteratorRecord_, « String »).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -611,7 +611,7 @@
       </dl>
       <emu-alg>
         1. If _timeZoneSlotValue_ is a String, then
-          1. Assert: IsAvailableTimeZoneName(_timeZoneSlotValue_) is *true*.
+          1. Assert: Either IsTimeZoneOffsetString(_timeZoneSlotValue_) or IsAvailableTimeZoneName(_timeZoneSlotValue_) is *true*.
           1. Return _timeZoneSlotValue_.
         1. Let _identifier_ be ? Get(_timeZoneSlotValue_, *"id"*).
         1. If _identifier_ is not a String, throw a *TypeError* exception.


### PR DESCRIPTION
- Some minor editorial commits to the spec
- Some optimizations to the reference code
- Particularly to GetNamedTimeZoneNextTransition and GetNamedTimeZonePreviousTransition so that we can correctly run some test262 tests that Anba wrote

I recommend reviewing this commit by commit.