### PR TITLE
Adjust polyfill CopyDataProperties return type to match spec

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -257,7 +257,7 @@ export const ES = ObjectAssign({}, ES2022, {
     }
 
     if (typeof source === 'undefined' || source === null) {
-      return target;
+      return;
     }
 
     var from = ToObject(source);
@@ -285,8 +285,6 @@ export const ES = ObjectAssign({}, ES2022, {
         if (excluded === false) CreateDataPropertyOrThrow(target, nextKey, propValue);
       }
     });
-
-    return target;
   },
   ToPositiveIntegerWithTruncation,
   ToIntegerWithTruncation,


### PR DESCRIPTION
The spec says that this AO returns `~unused~`, but the polyfill currently returns an object.

See https://github.com/tc39/proposal-temporal/blob/main/spec/mainadditions.html#L160