### PR TITLE
Polyfill: rename CalendarEqualsOrThrow => ThrowIfCalendarsNotEqual

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2014,13 +2014,13 @@ export function CalendarEquals(one, two) {
   const cal2 = ToTemporalCalendarIdentifier(two);
   return cal1 === cal2;
 }
+
 // This operation is not in the spec, it implements the following:
 // "If ? CalendarEquals(one, two) is false, throw a RangeError exception."
 // This is so that we can build an informative error message without
 // re-getting the .id properties.
-
-export function CalendarEqualsOrThrow(one, two, errorMessageAction) {
-  if (one === two) return true;
+export function ThrowIfCalendarsNotEqual(one, two, errorMessageAction) {
+  if (one === two) return;
   const cal1 = ToTemporalCalendarIdentifier(one);
   const cal2 = ToTemporalCalendarIdentifier(two);
   if (cal1 !== cal2) {
@@ -3985,7 +3985,7 @@ export function DifferenceTemporalPlainDate(operation, plainDate, other, options
   other = ToTemporalDate(other);
   const calendar = GetSlot(plainDate, CALENDAR);
   const otherCalendar = GetSlot(other, CALENDAR);
-  CalendarEqualsOrThrow(calendar, otherCalendar, 'compute difference between dates');
+  ThrowIfCalendarsNotEqual(calendar, otherCalendar, 'compute difference between dates');
 
   const resolvedOptions = ObjectCreate(null);
   CopyDataProperties(resolvedOptions, GetOptionsObject(options), []);
@@ -4022,7 +4022,7 @@ export function DifferenceTemporalPlainDateTime(operation, plainDateTime, other,
   other = ToTemporalDateTime(other);
   const calendar = GetSlot(plainDateTime, CALENDAR);
   const otherCalendar = GetSlot(other, CALENDAR);
-  CalendarEqualsOrThrow(calendar, otherCalendar, 'compute difference between dates');
+  ThrowIfCalendarsNotEqual(calendar, otherCalendar, 'compute difference between dates');
 
   const resolvedOptions = ObjectCreate(null);
   CopyDataProperties(resolvedOptions, GetOptionsObject(options), []);
@@ -4163,7 +4163,7 @@ export function DifferenceTemporalPlainYearMonth(operation, yearMonth, other, op
   other = ToTemporalYearMonth(other);
   const calendar = GetSlot(yearMonth, CALENDAR);
   const otherCalendar = GetSlot(other, CALENDAR);
-  CalendarEqualsOrThrow(calendar, otherCalendar, 'compute difference between months');
+  ThrowIfCalendarsNotEqual(calendar, otherCalendar, 'compute difference between months');
 
   const resolvedOptions = ObjectCreate(null);
   CopyDataProperties(resolvedOptions, GetOptionsObject(options), []);
@@ -4208,7 +4208,7 @@ export function DifferenceTemporalZonedDateTime(operation, zonedDateTime, other,
   other = ToTemporalZonedDateTime(other);
   const calendar = GetSlot(zonedDateTime, CALENDAR);
   const otherCalendar = GetSlot(other, CALENDAR);
-  CalendarEqualsOrThrow(calendar, otherCalendar, 'compute difference between dates');
+  ThrowIfCalendarsNotEqual(calendar, otherCalendar, 'compute difference between dates');
 
   const resolvedOptions = ObjectCreate(null);
   CopyDataProperties(resolvedOptions, GetOptionsObject(options), []);


### PR DESCRIPTION
Currently `CalendarEqualsOrThrow` (which is an AO in the polyfill but not in the spec, per comments in the code), returns `true`, returns `undefined`, or throws. This variation in return values doesn't break anything because the return value is never used by any callers, but to prevent future problems this commit renames it to `ThrowIfCalendarsNotEqual` and always returns `undefined`.