### PR TITLE
Polyfilll: ObjectCreate + CopyDataProperties => CopyOptions

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4735,8 +4735,7 @@ export function AddDurationToOrSubtractDurationFromPlainYearMonth(operation, yea
   const calendar = GetSlot(yearMonth, CALENDAR);
   const fieldNames = CalendarFields(calendar, ['monthCode', 'year']);
   const fields = PrepareTemporalFields(yearMonth, fieldNames, []);
-  const fieldsCopy = ObjectCreate(null);
-  CopyDataProperties(fieldsCopy, fields, []);
+  const fieldsCopy = CopyOptions(fields);
   fields.day = 1;
   let startDate = CalendarDateFromFields(calendar, fields);
   const sign = DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);


### PR DESCRIPTION
Replaces one use of `ObjectCreate` followed by `CopyDataProperties` with `CopyOptions`.

This pattern is used everywhere else in Temporal but was missed in #2484.