### PR TITLE
Normative: Remove duplicates in PrepareTemporalFields

### DIFF
--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -3,10 +3,8 @@ import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, GetSlot } from './slots.mjs';
 
-const ArrayPrototypePush = Array.prototype.push;
+const ArrayPrototypeConcat = Array.prototype.concat;
 const ObjectCreate = Object.create;
-const SetPrototypeAdd = Set.prototype.add;
-const SetPrototypeForEach = Set.prototype.forEach;
 
 export class PlainMonthDay {
   constructor(isoMonth, isoDay, calendar = 'iso8601', referenceISOYear = 1972) {
@@ -84,20 +82,8 @@ export class PlainMonthDay {
     const inputFieldNames = ES.CalendarFields(calendar, ['year']);
     const inputFields = ES.PrepareTemporalFields(item, inputFieldNames, []);
     let mergedFields = ES.CalendarMergeFields(calendar, fields, inputFields);
-
-    // TODO: Use MergeLists abstract operation.
-    const uniqueFieldNames = new Set();
-    for (let index = 0; index < receiverFieldNames.length; index++) {
-      ES.Call(SetPrototypeAdd, uniqueFieldNames, [receiverFieldNames[index]]);
-    }
-    for (let index = 0; index < inputFieldNames.length; index++) {
-      ES.Call(SetPrototypeAdd, uniqueFieldNames, [inputFieldNames[index]]);
-    }
-    const mergedFieldNames = [];
-    ES.Call(SetPrototypeForEach, uniqueFieldNames, [
-      (element) => ES.Call(ArrayPrototypePush, mergedFieldNames, [element])
-    ]);
-    mergedFields = ES.PrepareTemporalFields(mergedFields, mergedFieldNames, []);
+    const concatenatedFieldNames = ES.Call(ArrayPrototypeConcat, receiverFieldNames, inputFieldNames);
+    mergedFields = ES.PrepareTemporalFields(mergedFields, concatenatedFieldNames, [], 'ignore');
     const options = ObjectCreate(null);
     options.overflow = 'reject';
     return ES.CalendarDateFromFields(calendar, mergedFields, options);

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -3,10 +3,8 @@ import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { ISO_YEAR, ISO_MONTH, ISO_DAY, CALENDAR, GetSlot } from './slots.mjs';
 
-const ArrayPrototypePush = Array.prototype.push;
+const ArrayPrototypeConcat = Array.prototype.concat;
 const ObjectCreate = Object.create;
-const SetPrototypeAdd = Set.prototype.add;
-const SetPrototypeForEach = Set.prototype.forEach;
 
 export class PlainYearMonth {
   constructor(isoYear, isoMonth, calendar = 'iso8601', referenceISODay = 1) {
@@ -126,20 +124,8 @@ export class PlainYearMonth {
     const inputFieldNames = ES.CalendarFields(calendar, ['day']);
     const inputFields = ES.PrepareTemporalFields(item, inputFieldNames, []);
     let mergedFields = ES.CalendarMergeFields(calendar, fields, inputFields);
-
-    // TODO: Use MergeLists abstract operation.
-    const uniqueFieldNames = new Set();
-    for (let index = 0; index < receiverFieldNames.length; index++) {
-      ES.Call(SetPrototypeAdd, uniqueFieldNames, [receiverFieldNames[index]]);
-    }
-    for (let index = 0; index < inputFieldNames.length; index++) {
-      ES.Call(SetPrototypeAdd, uniqueFieldNames, [inputFieldNames[index]]);
-    }
-    const mergedFieldNames = [];
-    ES.Call(SetPrototypeForEach, uniqueFieldNames, [
-      (element) => ES.Call(ArrayPrototypePush, mergedFieldNames, [element])
-    ]);
-    mergedFields = ES.PrepareTemporalFields(mergedFields, mergedFieldNames, []);
+    const concatenatedFieldNames = ES.Call(ArrayPrototypeConcat, receiverFieldNames, inputFieldNames);
+    mergedFields = ES.PrepareTemporalFields(mergedFields, concatenatedFieldNames, [], 'ignore');
     const options = ObjectCreate(null);
     options.overflow = 'reject';
     return ES.CalendarDateFromFields(calendar, mergedFields, options);

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1798,6 +1798,7 @@
         _fields_: an Object,
         _fieldNames_: a List of property names,
         _requiredFields_: ~partial~ or a List of property names,
+        optional _duplicateBehaviour_: ~throw~ or ~ignore~,
       ): either a normal completion containing an Object, or an abrupt completion
     </h1>
     <dl class="header">
@@ -1809,31 +1810,39 @@
       </dd>
     </dl>
     <emu-alg>
+      1. If _duplicateBehaviour_ is not present, set _duplicateBehaviour_ to ~throw~.
       1. Let _result_ be OrdinaryObjectCreate(*null*).
       1. Let _any_ be *false*.
       1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
+      1. Let _previousProperty_ be *undefined*.
       1. For each property name _property_ of _sortedFieldNames_, do
-        1. Let _value_ be ? Get(_fields_, _property_).
-        1. If _value_ is not *undefined*, then
-          1. Set _any_ to *true*.
-          1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
-            1. Let _Conversion_ be the Conversion value of the same row.
-            1. If _Conversion_ is ~ToIntegerWithTruncation~, then
-              1. Set _value_ to ? ToIntegerWithTruncation(_value_).
-              1. Set _value_ to 𝔽(_value_).
-            1. Else if _Conversion_ is ~ToPositiveIntegerWithTruncation~, then
-              1. Set _value_ to ? ToPositiveIntegerWithTruncation(_value_).
-              1. Set _value_ to 𝔽(_value_).
-            1. Else,
-              1. Assert: _Conversion_ is ~ToString~.
-              1. Set _value_ to ? ToString(_value_).
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
-        1. Else if _requiredFields_ is a List, then
-          1. If _requiredFields_ contains _property_, then
-            1. Throw a *TypeError* exception.
-          1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
-            1. Set _value_ to the corresponding Default value of the same row.
-          1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+        1. If _property_ is one of *"constructor"* or *"__proto__"*, then
+          1. Throw a *RangeError* exception.
+        1. If _property_ is not equal to _previousProperty_, then
+          1. Let _value_ be ? Get(_fields_, _property_).
+          1. If _value_ is not *undefined*, then
+            1. Set _any_ to *true*.
+            1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
+              1. Let _Conversion_ be the Conversion value of the same row.
+              1. If _Conversion_ is ~ToIntegerWithTruncation~, then
+                1. Set _value_ to ? ToIntegerWithTruncation(_value_).
+                1. Set _value_ to 𝔽(_value_).
+              1. Else if _Conversion_ is ~ToPositiveIntegerWithTruncation~, then
+                1. Set _value_ to ? ToPositiveIntegerWithTruncation(_value_).
+                1. Set _value_ to 𝔽(_value_).
+              1. Else,
+                1. Assert: _Conversion_ is ~ToString~.
+                1. Set _value_ to ? ToString(_value_).
+            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+          1. Else if _requiredFields_ is a List, then
+            1. If _requiredFields_ contains _property_, then
+              1. Throw a *TypeError* exception.
+            1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+              1. Set _value_ to the corresponding Default value of the same row.
+            1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
+        1. Else if _duplicateBehaviour_ is ~throw~, then
+          1. Throw a *RangeError* exception.
+        1. Set _previousProperty_ to _property_.
       1. If _requiredFields_ is ~partial~ and _any_ is *false*, then
         1. Throw a *TypeError* exception.
       1. Return _result_.

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -68,31 +68,6 @@
   </ins>
 
   <ins class="block">
-    <emu-clause id="sec-temporal-mergelists" type="abstract operation">
-      <h1>
-        MergeLists (
-          _a_: a List,
-          _b_: a List,
-        ): a List
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns the list-concatenation of its arguments, with duplicate elements removed.</dd>
-      </dl>
-      <emu-alg>
-        1. Let _merged_ be a new empty List.
-        1. For each element _element_ of _a_, do
-          1. If _merged_ does not contain _element_, then
-            1. Append _element_ to _merged_.
-        1. For each element _element_ of _b_, do
-          1. If _merged_ does not contain _element_, then
-            1. Append _element_ to _merged_.
-        1. Return _merged_.
-      </emu-alg>
-    </emu-clause>
-  </ins>
-
-  <ins class="block">
     <emu-clause id="sec-sortstringlistbycodeunit" type="abstract operation">
       <h1>
         SortStringListByCodeUnit (

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -248,8 +248,8 @@
         1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"year"* »).
         1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
         1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
-        1. Let _mergedFieldNames_ be MergeLists(_receiverFieldNames_, _inputFieldNames_).
-        1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _mergedFieldNames_, «»).
+        1. Let _concatenatedFieldNames_ be the list-concatenation of _receiverFieldNames_ and _inputFieldNames_.
+        1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _concatenatedFieldNames_, «», ~ignore~).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).
         1. Return ? CalendarDateFromFields(_calendar_, _mergedFields_, _options_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -377,8 +377,8 @@
         1. Let _inputFieldNames_ be ? CalendarFields(_calendar_, « *"day"* »).
         1. Let _inputFields_ be ? PrepareTemporalFields(_item_, _inputFieldNames_, «»).
         1. Let _mergedFields_ be ? CalendarMergeFields(_calendar_, _fields_, _inputFields_).
-        1. Let _mergedFieldNames_ be MergeLists(_receiverFieldNames_, _inputFieldNames_).
-        1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _mergedFieldNames_, «»).
+        1. Let _concatenatedFieldNames_ be the list-concatenation of _receiverFieldNames_ and _inputFieldNames_.
+        1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _concatenatedFieldNames_, «», ~ignore~).
         1. Let _options_ be OrdinaryObjectCreate(*null*).
         1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"reject"*).
         1. Return ? CalendarDateFromFields(_calendar_, _mergedFields_, _options_).


### PR DESCRIPTION
Addresses #2532.

In some cases, duplicate property names are possible in PrepareTemporalFields(). Remove duplicates there, which removes the need for MergeLists(), which is replaced by a list-concatenation in the two places where it was used.

Updates PrepareTemporalFields() to remove duplicates, and {PlainYearMonth,PlainMonthDay}.prototype.toPlainDate() to use list-concatenation instead of MergeLists().

Removes MergeLists() as it's not used any more.

Updates polyfill to match the changes.