### PR TITLE
Normative: Implement IETF change regarding multiple calendar annotations

### DIFF
--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -284,7 +284,12 @@ const calendarName = withCode(choice(...calendarNames), (data, result) => {
   if (!data.calendar) data.calendar = result;
 });
 const calendarAnnotation = seq('[', [annotationCriticalFlag], 'u-ca=', calendarName, ']');
-const annotations = oneOrMore(choice(calendarAnnotation, annotation));
+const annotations = withSyntaxConstraints(oneOrMore(choice(calendarAnnotation, annotation)), (result) => {
+  const numCalendarAnnotations = (result.match(/u-ca=/g) ?? []).length;
+  if (numCalendarAnnotations > 1 && /\[!u-ca=/.test(result)) {
+    throw new SyntaxError('more than one calendar annotation and at least one critical');
+  }
+});
 const timeSpec = seq(
   timeHour,
   choice([':', timeMinute, [':', timeSecond, [timeFraction]]], seq(timeMinute, [timeSecond, [timeFraction]]))

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1436,12 +1436,16 @@
           1. Let _offset_ be the source text matched by the |UTCOffset| Parse Node contained within _parseResult_.
           1. Set _timeZoneResult_.[[OffsetString]] to CodePointsToString(_offset_).
       1. Let _calendar_ be *undefined*.
+      1. Let _calendarWasCritical_ be *false*.
       1. For each |Annotation| Parse Node _annotation_ contained within _parseResult_, do
         1. Let _key_ be the source text matched by the |AnnotationKey| Parse Node contained within _annotation_.
         1. If CodePointsToString(_key_) is *"u-ca"*, then
           1. If _calendar_ is *undefined*, then
             1. Let _value_ be the source text matched by the |AnnotationValue| Parse Node contained within _annotation_.
             1. Let _calendar_ be CodePointsToString(_value_).
+            1. If _annotation_ contains an |AnnotationCriticalFlag| Parse Node, set _calendarWasCritical_ to *true*.
+          1. Else,
+            1. If _annotation_ contains an |AnnotationCriticalFlag| Parse Node, or _calendarWasCritical_ is *true*, throw a *RangeError* exception.
         1. Else,
           1. If _annotation_ contains an |AnnotationCriticalFlag| Parse Node, throw a *RangeError* exception.
       1. Return the Record {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1389,10 +1389,13 @@
         1. If _parseResult_ is not a Parse Node, then
           1. Set _parseResult_ to ParseText(StringToCodePoints(_isoString_), _goal_).
           1. If _parseResult_ is a Parse Node, then
+            1. Let _foundCalendar_ be *undefined*.
             1. For each |Annotation| Parse Node _annotation_ contained within _parseResult_, do
               1. Let _key_ be the source text matched by the |AnnotationKey| Parse Node contained within _annotation_.
               1. Let _value_ be the source text matched by the |AnnotationValue| Parse Node contained within _annotation_.
-              1. If CodePointsToString(_key_) is *"u-ca"* and the ASCII-lowercase of CodePointsToString(_value_) is not *"iso8601"*, throw a *RangeError* exception.
+              1. If CodePointsToString(_key_) is *"u-ca"*, and _foundCalendar_ is *undefined*, then
+                1. Set _foundCalendar_ to CodePointsToString(_value_).
+            1. If _foundCalendar_ is not *undefined* and the ASCII-lowercase of _foundCalendar_ is not *"iso8601"*, throw a *RangeError* exception.
       1. If _parseResult_ is not a Parse Node, throw a *RangeError* exception.
       1. Let each of _year_, _month_, _day_, _hour_, _minute_, _second_, and _fSeconds_ be the source text matched by the respective |DateYear|, |DateMonth|, |DateDay|, |TimeHour|, |TimeMinute|, |TimeSecond|, and |TimeFraction| Parse Node contained within _parseResult_, or an empty sequence of code points if not present.
       1. If the first code point of _year_ is U+2212 (MINUS SIGN), replace the first code point with U+002D (HYPHEN-MINUS).


### PR DESCRIPTION
As per ietf-wg-sedate/draft-ietf-sedate-datetime-extended#38, there's been a change to the IXDTF draft precipitated by IETF review and adopted in the IETF 116 meeting, which affects how we handle an ISO string with multiple calendar annotations. For example,

    2023-04-13[u-ca=iso8601][u-ca=gregory]

This is unchanged: we continue to use the first annotation and disregard any subsequent ones.

What changes is that if there are multiple annotations, we must throw if any of them have the critical flag. These are both rejected:

    2022-07-08T00:14:07Z[!u-ca=chinese][u-ca=japanese]
    2022-07-08T00:14:07Z[u-ca=chinese][!u-ca=japanese]

Previously, both of these would parse successfully, and disregard the Japanese calendar annotation.

While we are touching multiple calendar annotations anyway, implement Anba's suggestion of discarding the second annotation in YYYY-MM and MM-DD strings, in order to allow better optimizability in implementations' ISO 8601 string parsers.

Closes: #2554
Closes: #2538