### PR TITLE
Normative: don't coerce non-string primitives to strings, esp. time zones, offsets, and calendars

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -41,20 +41,14 @@ const impl = {};
 
 export class Calendar {
   constructor(id) {
-    // Note: if the argument is not passed, IsBuiltinCalendar("undefined") will fail. This check
-    //       exists only to improve the error message.
-    if (arguments.length < 1) {
-      throw new RangeError('missing argument: id is required');
-    }
-
-    id = ES.ToString(id);
-    if (!ES.IsBuiltinCalendar(id)) throw new RangeError(`invalid calendar identifier ${id}`);
+    const stringId = ES.RequireString(id);
+    if (!ES.IsBuiltinCalendar(stringId)) throw new RangeError(`invalid calendar identifier ${stringId}`);
     CreateSlots(this);
-    SetSlot(this, CALENDAR_ID, ES.ASCIILowercase(id));
+    SetSlot(this, CALENDAR_ID, ES.ASCIILowercase(stringId));
 
     if (typeof __debug__ !== 'undefined' && __debug__) {
       Object.defineProperty(this, '_repr_', {
-        value: `${this[Symbol.toStringTag]} <${id}>`,
+        value: `${this[Symbol.toStringTag]} <${stringId}>`,
         writable: false,
         enumerable: false,
         configurable: false

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -21,12 +21,7 @@ import {
 
 export class TimeZone {
   constructor(identifier) {
-    // Note: if the argument is not passed, GetCanonicalTimeZoneIdentifier(undefined) will throw.
-    //       This check exists only to improve the error message.
-    if (arguments.length < 1) {
-      throw new RangeError('missing argument: identifier is required');
-    }
-    let stringIdentifier = ES.ToString(identifier);
+    let stringIdentifier = ES.RequireString(identifier);
     const parseResult = ES.ParseTimeZoneIdentifier(identifier);
     if (parseResult.offsetNanoseconds !== undefined) {
       stringIdentifier = ES.FormatOffsetTimeZoneIdentifier(parseResult.offsetNanoseconds);

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -567,16 +567,21 @@
     </emu-table>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-torelativetemporalobject" aoid="ToRelativeTemporalObject">
-    <h1>ToRelativeTemporalObject ( _options_ )</h1>
-    <p>
-      The abstract operation ToRelativeTemporalObject examines the value of the `relativeTo` property of its _options_ argument.
-      If this is not present, it returns *undefined*.
-      Otherwise, it attempts to return a Temporal.ZonedDateTime instance or Temporal.PlainDate instance, in order of preference, by converting the value.
-      If neither of those are possible, the operation throws a *RangeError*.
-    </p>
+  <emu-clause id="sec-temporal-torelativetemporalobject" type="abstract operation">
+    <h1>ToRelativeTemporalObject (
+      _options_: an Object
+    ): either a normal completion containing either a Temporal.ZonedDateTime object or a Temporal.PlainDate object, or a throw completion</h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>
+        It examines the value of the `relativeTo` property of its _options_ argument.
+        If the value is *undefined*, it returns *undefined*.
+        If the value is not a String or an Object, it throws a *TypeError*.
+        Otherwise, it attempts to return a Temporal.ZonedDateTime instance or Temporal.PlainDate instance, in order of preference, by converting the value.
+        If neither of those are possible, it throws a *RangeError*.
+      </dd>
+    </dl>
     <emu-alg>
-      1. Assert: Type(_options_) is Object.
       1. Let _value_ be ? Get(_options_, *"relativeTo"*).
       1. If _value_ is *undefined*, return *undefined*.
       1. Let _offsetBehaviour_ be ~option~.
@@ -601,8 +606,8 @@
         1. If _offsetString_ is *undefined*, then
           1. Set _offsetBehaviour_ to ~wall~.
       1. Else,
-        1. Let _string_ be ? ToString(_value_).
-        1. Let _result_ be ? ParseTemporalRelativeToString(_string_).
+        1. If _value_ is not a String, throw a *TypeError* exception.
+        1. Let _result_ be ? ParseTemporalRelativeToString(_value_).
         1. Let _offsetString_ be _result_.[[TimeZone]].[[OffsetString]].
         1. Let _timeZoneName_ be _result_.[[TimeZone]].[[Name]].
         1. If _timeZoneName_ is *undefined*, then
@@ -1869,8 +1874,10 @@
                 1. Set _value_ to ? ToPositiveIntegerWithTruncation(_value_).
                 1. Set _value_ to 𝔽(_value_).
               1. Else,
-                1. Assert: _Conversion_ is ~ToString~.
-                1. Set _value_ to ? ToString(_value_).
+                1. Assert: _Conversion_ is ~ToPrimitiveAndRequireString~.
+                1. NOTE: Non-primitive values are supported here for consistency with other fields, but such values must coerce to Strings.
+                1. Set _value_ to ? ToPrimitive(_value_, ~string~).
+                1. If _value_ is not a String, throw a *TypeError* exception.
             1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
           1. Else if _requiredFields_ is a List, then
             1. If _requiredFields_ contains _property_, then
@@ -1908,7 +1915,7 @@
           </tr>
           <tr>
             <td>*"monthCode"*</td>
-            <td>~ToString~</td>
+            <td>~ToPrimitiveAndRequireString~</td>
             <td>*undefined*</td>
           </tr>
           <tr>
@@ -1948,12 +1955,12 @@
           </tr>
           <tr>
             <td>*"offset"*</td>
-            <td>~ToString~</td>
+            <td>~ToPrimitiveAndRequireString~</td>
             <td>*undefined*</td>
           </tr>
           <tr>
             <td>*"era"*</td>
-            <td>~ToString~</td>
+            <td>~ToPrimitiveAndRequireString~</td>
             <td>*undefined*</td>
           </tr>
           <tr>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -525,8 +525,8 @@
             1. Return _temporalCalendarLike_.[[Calendar]].
           1. If ? ObjectImplementsTemporalCalendarProtocol(_temporalCalendarLike_) is *false*, throw a *TypeError* exception.
           1. Return _temporalCalendarLike_.
-        1. Let _identifier_ be ? ToString(_temporalCalendarLike_).
-        1. Set _identifier_ to ? ParseTemporalCalendarString(_identifier_).
+        1. If _temporalCalendarLike_ is not a String, throw a *TypeError* exception.
+        1. Let _identifier_ be ? ParseTemporalCalendarString(_temporalCalendarLike_).
         1. If IsBuiltinCalendar(_identifier_) is *false*, throw a *RangeError* exception.
         1. Return the ASCII-lowercase of _identifier_.
       </emu-alg>
@@ -1020,7 +1020,7 @@
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Set _id_ to ? ToString(_id_).
+        1. If _id_ is not a String, throw a *TypeError* exception.
         1. If IsBuiltinCalendar(_id_) is *false*, then
           1. Throw a *RangeError* exception.
         1. Return ? CreateTemporalCalendar(_id_, NewTarget).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -912,8 +912,8 @@
       </dl>
       <emu-alg>
         1. If Type(_temporalDurationLike_) is not Object, then
-          1. Let _string_ be ? ToString(_temporalDurationLike_).
-          1. Return ? ParseTemporalDurationString(_string_).
+          1. If _temporalDurationLike_ is not a String, throw a *TypeError* exception.
+          1. Return ? ParseTemporalDurationString(_temporalDurationLike_).
         1. If _temporalDurationLike_ has an [[InitializedTemporalDuration]] internal slot, then
           1. Return ! CreateDurationRecord(_temporalDurationLike_.[[Years]], _temporalDurationLike_.[[Months]], _temporalDurationLike_.[[Weeks]], _temporalDurationLike_.[[Days]], _temporalDurationLike_.[[Hours]], _temporalDurationLike_.[[Minutes]], _temporalDurationLike_.[[Seconds]], _temporalDurationLike_.[[Milliseconds]], _temporalDurationLike_.[[Microseconds]], _temporalDurationLike_.[[Nanoseconds]]).
         1. Let _result_ be a new Duration Record with each field set to 0.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -518,8 +518,10 @@
             1. Return _item_.
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Return ! CreateTemporalInstant(_item_.[[Nanoseconds]]).
-        1. Let _string_ be ? ToString(_item_).
-        1. Let _epochNanoseconds_ be ? ParseTemporalInstant(_string_).
+          1. NOTE: This use of ToPrimitive allows Instant-like objects to be converted.
+          1. Set _item_ to ? ToPrimitive(_item_, ~string~).
+        1. If _item_ is not a String, throw a *TypeError* exception.
+        1. Let _epochNanoseconds_ be ? ParseTemporalInstant(_item_).
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
     </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -756,8 +756,8 @@
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
           1. Return ? CalendarDateFromFields(_calendar_, _fields_, _options_).
         1. Perform ? ToTemporalOverflow(_options_).
-        1. Let _string_ be ? ToString(_item_).
-        1. Let _result_ be ? ParseTemporalDateString(_string_).
+        1. If _item_ is not a String, throw a *TypeError* exception.
+        1. Let _result_ be ? ParseTemporalDateString(_item_).
         1. Assert: IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
         1. Let _calendar_ be _result_.[[Calendar]].
         1. If _calendar_ is *undefined*, set _calendar_ to *"iso8601"*.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -916,8 +916,8 @@
           1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Else,
           1. Perform ? ToTemporalOverflow(_options_).
-          1. Let _string_ be ? ToString(_item_).
-          1. Let _result_ be ? ParseTemporalDateTimeString(_string_).
+          1. If _item_ is not a String, throw a *TypeError* exception.
+          1. Let _result_ be ? ParseTemporalDateTimeString(_item_).
           1. Assert: IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
           1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
           1. Let _calendar_ be _result_.[[Calendar]].

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -383,8 +383,8 @@
             1. Perform ! CreateDataPropertyOrThrow(_fields_, *"year"*, 𝔽(_referenceISOYear_)).
           1. Return ? CalendarMonthDayFromFields(_calendar_, _fields_, _options_).
         1. Perform ? ToTemporalOverflow(_options_).
-        1. Let _string_ be ? ToString(_item_).
-        1. Let _result_ be ? ParseTemporalMonthDayString(_string_).
+        1. If _item_ is not a String, throw a *TypeError* exception.
+        1. Let _result_ be ? ParseTemporalMonthDayString(_item_).
         1. Let _calendar_ be _result_.[[Calendar]].
         1. If _calendar_ is *undefined*, set _calendar_ to *"iso8601"*.
         1. If IsBuiltinCalendar(_calendar_) is *false*, throw a *RangeError* exception.

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -580,8 +580,8 @@
           1. Let _result_ be ? ToTemporalTimeRecord(_item_).
           1. Set _result_ to ? RegulateTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _overflow_).
         1. Else,
-          1. Let _string_ be ? ToString(_item_).
-          1. Let _result_ be ? ParseTemporalTimeString(_string_).
+          1. If _item_ is not a String, throw a *TypeError* exception.
+          1. Let _result_ be ? ParseTemporalTimeString(_item_).
           1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ! CreateTemporalTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -497,8 +497,8 @@
           1. Let _fields_ be ? PrepareTemporalFields(_item_, _fieldNames_, «»).
           1. Return ? CalendarYearMonthFromFields(_calendar_, _fields_, _options_).
         1. Perform ? ToTemporalOverflow(_options_).
-        1. Let _string_ be ? ToString(_item_).
-        1. Let _result_ be ? ParseTemporalYearMonthString(_string_).
+        1. If _item_ is not a String, throw a *TypeError* exception.
+        1. Let _result_ be ? ParseTemporalYearMonthString(_item_).
         1. Let _calendar_ be _result_.[[Calendar]].
         1. If _calendar_ is *undefined*, set _calendar_ to *"iso8601"*.
         1. If IsBuiltinCalendar(_calendar_) is *false*, throw a *RangeError* exception.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -31,7 +31,7 @@
       <emu-alg>
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
-        1. Set _identifier_ to ? ToString(_identifier_).
+        1. If _identifier_ is not a String, throw a *TypeError* exception.
         1. Let _parseResult_ be ? ParseTimeZoneIdentifier(_identifier_).
         1. If _parseResult_.[[OffsetNanoseconds]] is not ~empty~, then
           1. Set _identifier_ to FormatOffsetTimeZoneIdentifier(_parseResult_.[[OffsetNanoseconds]], ~separated~).
@@ -564,8 +564,8 @@
             1. Return _temporalTimeZoneLike_.[[TimeZone]].
           1. If ? ObjectImplementsTemporalTimeZoneProtocol(_temporalTimeZoneLike_) is *false*, throw a *TypeError* exception.
           1. Return _temporalTimeZoneLike_.
-        1. Let _identifier_ be ? ToString(_temporalTimeZoneLike_).
-        1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_identifier_).
+        1. If _temporalTimeZoneLike_ is not a String, throw a *TypeError* exception.
+        1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_temporalTimeZoneLike_).
         1. If _parseResult_.[[Name]] is not *undefined*, then
           1. Let _name_ be _parseResult_.[[Name]].
           1. Let _offsetNanoseconds_ be ? ParseTimeZoneIdentifier(_name_).[[OffsetNanoseconds]].

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1168,8 +1168,8 @@
           1. Let _offsetOption_ be ? ToTemporalOffset(_options_, *"reject"*).
           1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Else,
-          1. Let _string_ be ? ToString(_item_).
-          1. Let _result_ be ? ParseTemporalZonedDateTimeString(_string_).
+          1. If _item_ is not a String, throw a *TypeError* exception.
+          1. Let _result_ be ? ParseTemporalZonedDateTimeString(_item_).
           1. Let _timeZoneName_ be _result_.[[TimeZone]].[[Name]].
           1. Assert: _timeZoneName_ is not *undefined*.
           1. Let _timeZone_ be ? ToTemporalTimeZoneSlotValue(_timeZoneName_).


### PR DESCRIPTION
This normative PR removes string coercion that is currently used in Temporal methods where inputs are expected to be strings. This change is an implementer-recommended fix to the problem that numbers can sometimes be coerced into syntactically valid Temporal string inputs, especially dates and time zone offsets.

Although coercing numbers to strings sometimes works, this behavior is brittle and unpredictable. For example, `-1000` is a valid time zone offset when coerced to a string, but neither `1000` nor `-900` can be coerced into valid offsets. 

Calendars are also affected because while a number cannot be a calendar identifier, an ISO string can be passed in place of a calendar ID. This means that a number like 20200101 (if coerced to a string) is a valid ISO string representing the date 2020-01-01 that has a default calendar of `iso8601`.

Here's a few examples of confusing and inconsistent code that this PR prevents by throwing `TypeError`s in all the cases below:

```js
zdt = Temporal.ZonedDateTime.from('2023-05-17T00:00-07:00[America/Los_Angeles]')
zdt.with({ offset: -10 })
// => no error

zdt.with({ offset: -7 })
// RangeError: invalid time zone offset: -7

zdt.with({ offset: -10.5 })
// => RangeError: invalid time zone offset: -10.5

Temporal.TimeZone.from(-10).id
// => "-10:00"

Temporal.TimeZone.from(-10.5).id
// => RangeError: invalid time zone offset: -10.5

Temporal.Calendar.from(20200101)
// => iso8601

Temporal.PlainDate.from(20200101)
// => 2020-01-01

Temporal.PlainDate.from(-20200101)
// => RangeError: invalid ISO 8601 string: -20200101
```

This PR throws a TypeError in response to non-String primitive inputs in:
* Parameters that accept an ISO string (or a subset of an ISO string) in methods like `from`, `with`, or `add`
* The `relativeTo` option accepted in `Temporal.Duration` methods like `compare` or `add`, because `relativeTo` can also be an ISO string.
* `offset`, `era`, and `monthCode` properties in property bags that are accepted in place of an ISO string in the methods and `relativeTo` option noted above.

If the input in the places above is an object and not a primitive, this PR changes `ToString` to `ToPrimitive(_value_, ~string~)` and if the resulting primitive is not a String, then it will throw a TypeError.

The `Temporal.TimeZone` and `Temporal.Calendar` constructors now throw a TypeError for all non-String inputs, including objects.

Other than `relativeTo`, options behavior is unchanged in this PR so that we can maintain consistency with 402's precedent to coerce options to the expected type before interpreting them.

For cases where an exception was already thrown in current spec text (for example, no non-String primitive value can be cast to a valid `monthCode`) this PR changes RangeError to TypeError when a non-String value is provided.

Test changes are at https://github.com/tc39/test262/pull/3847.
