### PR TITLE
Add polyfill changes for calendar data consistency validation

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -2,6 +2,8 @@
 
 import * as ES from './ecmascript.mjs';
 import { GetIntrinsic, MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass.mjs';
+import ToString from 'es-abstract/2022/ToString.js';
+import ToIntegerOrInfinity from 'es-abstract/2022/ToIntegerOrInfinity.js';
 import {
   CALENDAR_ID,
   ISO_YEAR,
@@ -306,11 +308,10 @@ impl['iso8601'] = {
     if (fields.month !== undefined && fields.year === undefined && fields.monthCode === undefined) {
       throw new TypeError('either year or monthCode required with month');
     }
-    const useYear = fields.monthCode === undefined;
     const referenceISOYear = 1972;
     fields = resolveNonLunisolarMonth(fields);
     let { month, day, year } = fields;
-    ({ month, day } = ES.RegulateISODate(useYear ? year : referenceISOYear, month, day, overflow));
+    ({ month, day } = ES.RegulateISODate(year !== undefined ? year : referenceISOYear, month, day, overflow));
     return ES.CreateTemporalMonthDay(month, day, calendarSlotValue, referenceISOYear);
   },
   fields(fields) {
@@ -1921,10 +1922,21 @@ const helperDangi = ObjectAssign({}, { ...helperChinese, id: 'dangi' });
  * ISO and non-ISO implementations vs. code that was very different.
  */
 const nonIsoGeneralImpl = {
+  CalendarFieldDescriptors(type) {
+    let fieldDescriptors = [];
+    if (type !== 'month-day') {
+      fieldDescriptors = [
+        { property: 'era', conversion: ToString, required: false },
+        { property: 'eraYear', conversion: ToIntegerOrInfinity, required: false }
+      ];
+    }
+    return fieldDescriptors;
+  },
   dateFromFields(fields, options, calendarSlotValue) {
     const cache = new OneObjectCache();
-    const fieldNames = this.fields(['day', 'month', 'monthCode', 'year']);
-    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
+    const fieldNames = ['day', 'month', 'monthCode', 'year'];
+    const extraFieldDescriptors = this.CalendarFieldDescriptors('date');
+    fields = ES.PrepareTemporalFields(fields, fieldNames, [], '', extraFieldDescriptors);
     const overflow = ES.ToTemporalOverflow(options);
     const { year, month, day } = this.helper.calendarToIsoDate(fields, overflow, cache);
     const result = ES.CreateTemporalDate(year, month, day, calendarSlotValue);
@@ -1933,8 +1945,9 @@ const nonIsoGeneralImpl = {
   },
   yearMonthFromFields(fields, options, calendarSlotValue) {
     const cache = new OneObjectCache();
-    const fieldNames = this.fields(['month', 'monthCode', 'year']);
-    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
+    const fieldNames = ['month', 'monthCode', 'year'];
+    const extraFieldDescriptors = this.CalendarFieldDescriptors('year-month');
+    fields = ES.PrepareTemporalFields(fields, fieldNames, [], '', extraFieldDescriptors);
     const overflow = ES.ToTemporalOverflow(options);
     const { year, month, day } = this.helper.calendarToIsoDate({ ...fields, day: 1 }, overflow, cache);
     const result = ES.CreateTemporalYearMonth(year, month, calendarSlotValue, /* referenceISODay = */ day);
@@ -1945,8 +1958,9 @@ const nonIsoGeneralImpl = {
     const cache = new OneObjectCache();
     // For lunisolar calendars, either `monthCode` or `year` must be provided
     // because `month` is ambiguous without a year or a code.
-    const fieldNames = this.fields(['day', 'month', 'monthCode', 'year']);
-    fields = ES.PrepareTemporalFields(fields, fieldNames, []);
+    const fieldNames = ['day', 'month', 'monthCode', 'year'];
+    const extraFieldDescriptors = this.CalendarFieldDescriptors('date');
+    fields = ES.PrepareTemporalFields(fields, fieldNames, [], '', extraFieldDescriptors);
     const overflow = ES.ToTemporalOverflow(options);
     const { year, month, day } = this.helper.monthDayFromFields(fields, overflow, cache);
     // `year` is a reference year where this month/day exists in this calendar

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1799,6 +1799,7 @@
         _fields_: an Object,
         _fieldNames_: a List of property names,
         _requiredFields_: ~partial~ or a List of property names,
+        optional _extraFieldDescriptors_: a List of Calendar Field Descriptor Records
       ): either a normal completion containing an Object, or an abrupt completion
     </h1>
     <dl class="header">
@@ -1807,11 +1808,18 @@
         The returned Object has a null prototype, and an own data property for each element of _fieldNames_ that corresponds with a non-*undefined* property of the same name on _fields_ used as the input for relevant conversion.
         When _requiredFields_ is ~partial~, this operation throws if none of the properties are present with a non-*undefined* value.
         When _requiredFields_ is a List, this operation throws if any of the properties named by it are absent or undefined, and otherwise substitutes a relevant default for any absent or undefined non-required property (ensuring that the returned object has a property for each element of _fieldNames_).
+        When _extraFieldDescriptors_ is present, its contents are treated as an extension of <emu-xref href="#table-temporal-field-requirements"></emu-xref>.
       </dd>
     </dl>
     <emu-alg>
       1. Let _result_ be OrdinaryObjectCreate(*null*).
       1. Let _any_ be *false*.
+      1. If _extraFieldDescriptors_ is present, then
+        1. For each Calendar Field Descriptor Record _desc_ of _extraFieldDescriptors_, do
+          1. Assert: _fieldNames_ does not contain _desc_.[[Property]].
+          1. Append _desc_.[[Property]] to _fieldNames_.
+          1. If _desc_.[[Required]] is *true* and _requiredFields_ is a List, then
+            1. Append _desc_.[[Property]] to _requiredFields_.
       1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
       1. For each property name _property_ of _sortedFieldNames_, do
         1. Let _value_ be ? Get(_fields_, _property_).
@@ -1828,6 +1836,9 @@
             1. Else,
               1. Assert: _Conversion_ is ~ToString~.
               1. Set _value_ to ? ToString(_value_).
+          1. Else if _extraFieldDescriptors_ is present and _extraFieldDescriptors_ contains a Calendar Field Descriptor Record _desc_ such that _desc_.[[Property]] is _property_, then
+            1. Let _converter_ be _desc_.[[Conversion]].
+            1. Set _value_ to ? _converter_(_value_).
           1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. Else if _requiredFields_ is a List, then
           1. If _requiredFields_ contains _property_, then
@@ -1906,16 +1917,6 @@
             <td>*undefined*</td>
           </tr>
           <tr>
-            <td>*"era"*</td>
-            <td>~ToString~</td>
-            <td>*undefined*</td>
-          </tr>
-          <tr>
-            <td>*"eraYear"*</td>
-            <td>~ToIntegerWithTruncation~</td>
-            <td>*undefined*</td>
-          </tr>
-          <tr>
             <td>*"timeZone"*</td>
             <td></td>
             <td>*undefined*</td>
@@ -1923,6 +1924,36 @@
         </tbody>
       </table>
     </emu-table>
+
+    <emu-clause id="sec-temporal-calendar-field-descriptor-record">
+      <h1>Calendar Field Descriptor Record</h1>
+      <p>A <dfn variants="Calendar Field Descriptor Records">Calendar Field Descriptor Record</dfn> is a Record value used to describe a calendar-specific field for use in creating and interacting with instances of Temporal types.</p>
+      <p>Calendar Field Descriptor Records have the fields listed in <emu-xref href="#table-temporal-calendar-field-descriptor-record"></emu-xref>.</p>
+      <emu-table id="table-temporal-calendar-field-descriptor-record" caption="Calendar Field Descriptor Record Fields">
+        <table>
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td>[[Property]]</td>
+            <td>a String</td>
+            <td>The property name associated with the field, analogous to the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>.</td>
+          </tr>
+          <tr>
+            <td>[[Conversion]]</td>
+            <td>an Abstract Closure accepting a single ECMAScript language value and returning either a normal completion containing an ECMAScript language value representing purely static data or a throw completion.</td>
+            <td>The means by which purported values are coerced to a static representation of the correct type (or rejected if that fails), analogous to steps indicated by the Conversion column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>.</td>
+          </tr>
+          <tr>
+            <td>[[Required]]</td>
+            <td>a Boolean</td>
+            <td>Whether PrepareTemporalFields should consider the field as required when not accepting partial data.</td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-temporal-getdifferencesettings" type="abstract operation">

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -841,7 +841,7 @@
         <dd>It validates that the *"month"* and *"monthCode"* properties of the given _fields_ are not inconsistent and merges them into a *"month"* property with an integral Number value, or throws an exception if both are *undefined*.</dd>
       </dl>
       <emu-alg>
-        1. Assert: _fields_ is an ordinary Object that is not directly observable from ECMAScript code and for which the value of the [[Prototype]] internal slot is *null* and every property is a data property whose value is a primitive value.
+        1. Assert: _fields_ is an ordinary Object that is not directly observable from ECMAScript code and for which the value of the [[Prototype]] internal slot is *null* and every property is a data property.
         1. Let _month_ be ! Get(_fields_, *"month"*).
         1. Assert: _month_ is *undefined* or _month_ is a Number.
         1. Let _monthCode_ be ! Get(_fields_, *"monthCode"*).

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -830,21 +830,26 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-resolveisomonth" aoid="ResolveISOMonth">
-      <h1>ResolveISOMonth ( _fields_ )</h1>
-      <p>
-        The abstract operation ResolveISOMonth merges the `month` and `monthCode` properties of the given _fields_ Object into an integer month, and validates that they match.
-        It returns the integer month.
-      </p>
+    <emu-clause id="sec-temporal-resolveisomonth" type="abstract operation">
+      <h1>
+        ISOResolveMonth (
+          _fields_: an Object,
+        ): either a normal completion containing ~unused~ or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It validates that the *"month"* and *"monthCode"* properties of the given _fields_ are not inconsistent and merges them into a *"month"* property with an integral Number value, or throws an exception if both are *undefined*.</dd>
+      </dl>
       <emu-alg>
-        1. Assert: _fields_ is an ordinary object with no more and no less than the own data properties listed in <emu-xref href="#table-temporal-field-requirements"></emu-xref>.
+        1. Assert: _fields_ is an ordinary Object that is not directly observable from ECMAScript code and for which the value of the [[Prototype]] internal slot is *null* and every property is a data property whose value is a primitive value.
         1. Let _month_ be ! Get(_fields_, *"month"*).
         1. Assert: _month_ is *undefined* or _month_ is a Number.
         1. Let _monthCode_ be ! Get(_fields_, *"monthCode"*).
         1. If _monthCode_ is *undefined*, then
           1. If _month_ is *undefined*, throw a *TypeError* exception.
-          1. Return ℝ(_month_).
-        1. Assert: Type(_monthCode_) is String.
+          1. Return ~unused~.
+        1. Assert: _monthCode_ is a String.
+        1. NOTE: The ISO 8601 calendar does not include leap months.
         1. If the length of _monthCode_ is not 3, throw a *RangeError* exception.
         1. If the first code unit of _monthCode_ is not 0x004D (LATIN CAPITAL LETTER M), throw a *RangeError* exception.
         1. Let _monthCodeDigits_ be the substring of _monthCode_ from 1.
@@ -852,7 +857,8 @@
         1. Let _monthCodeNumber_ be ! ToIntegerOrInfinity(_monthCodeDigits_).
         1. Assert: SameValue(_monthCode_, ISOMonthCode(_monthCodeNumber_)) is *true*.
         1. If _month_ is not *undefined* and SameValue(_month_, _monthCodeNumber_) is *false*, throw a *RangeError* exception.
-        1. Return _monthCodeNumber_.
+        1. Perform ! Set(_fields_, *"month"*, 𝔽(_monthCodeNumber_), *false*).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -865,11 +871,10 @@
         1. Assert: Type(_fields_) is Object.
         1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. Let _year_ be ! Get(_fields_, *"year"*).
-        1. Assert: Type(_year_) is Number.
-        1. Let _month_ be ? ResolveISOMonth(_fields_).
+        1. Let _month_ be ! Get(_fields_, *"month"*).
         1. Let _day_ be ! Get(_fields_, *"day"*).
-        1. Assert: Type(_day_) is Number.
-        1. Return ? RegulateISODate(ℝ(_year_), _month_, ℝ(_day_), _overflow_).
+        1. Assert: _year_, _month_, and _day_ are all Numbers.
+        1. Return ? RegulateISODate(ℝ(_year_), ℝ(_month_), ℝ(_day_), _overflow_).
       </emu-alg>
     </emu-clause>
 
@@ -883,9 +888,9 @@
         1. Assert: Type(_fields_) is Object.
         1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. Let _year_ be ! Get(_fields_, *"year"*).
-        1. Assert: Type(_year_) is Number.
-        1. Let _month_ be ? ResolveISOMonth(_fields_).
-        1. Let _result_ be ? RegulateISOYearMonth(ℝ(_year_), _month_, _overflow_).
+        1. Let _month_ be ! Get(_fields_, *"month"*).
+        1. Assert: _year_ and _month_ are Numbers.
+        1. Let _result_ be ? RegulateISOYearMonth(ℝ(_year_), ℝ(_month_), _overflow_).
         1. Return the Record {
             [[Year]]: _result_.[[Year]],
             [[Month]]: _result_.[[Month]],
@@ -903,19 +908,15 @@
         1. Assert: Type(_fields_) is Object.
         1. Assert: _overflow_ is either *"constrain"* or *"reject"*.
         1. Let _month_ be ! Get(_fields_, *"month"*).
-        1. Let _monthCode_ be ! Get(_fields_, *"monthCode"*).
-        1. Let _year_ be ! Get(_fields_, *"year"*).
-        1. If _month_ is not *undefined*, and _monthCode_ and _year_ are both *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Set _month_ to ? ResolveISOMonth(_fields_).
         1. Let _day_ be ! Get(_fields_, *"day"*).
-        1. Assert: Type(_day_) is Number.
+        1. Assert: _month_ and _day_ are Numbers.
+        1. Let _year_ be ! Get(_fields_, *"year"*).
         1. Let _referenceISOYear_ be 1972 (the first leap year after the Unix epoch).
-        1. If _monthCode_ is *undefined*, then
-          1. Assert: Type(_year_) is Number.
-          1. Let _result_ be ? RegulateISODate(ℝ(_year_), _month_, ℝ(_day_), _overflow_).
+        1. If _year_ is *undefined*, then
+          1. Let _result_ be ? RegulateISODate(_referenceISOYear_, ℝ(_month_), ℝ(_day_), _overflow_).
         1. Else,
-          1. Let _result_ be ? RegulateISODate(_referenceISOYear_, _month_, ℝ(_day_), _overflow_).
+          1. Assert: _year_ is a Number.
+          1. Let _result_ be ? RegulateISODate(ℝ(_year_), ℝ(_month_), ℝ(_day_), _overflow_).
         1. Return the Record {
             [[Month]]: _result_.[[Month]],
             [[Day]]: _result_.[[Day]],
@@ -1106,6 +1107,7 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », « *"year"*, *"day"* »).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Perform ? ISOResolveMonth(_fields_).
         1. Let _result_ be ? ISODateFromFields(_fields_, _overflow_).
         1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], *"iso8601"*).
       </emu-alg>
@@ -1128,6 +1130,7 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"month"*, *"monthCode"*, *"year"* », « *"year"* »).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Perform ? ISOResolveMonth(_fields_).
         1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _overflow_).
         1. Return ? CreateTemporalYearMonth(_result_.[[Year]], _result_.[[Month]], *"iso8601"*, _result_.[[ReferenceISODay]]).
       </emu-alg>
@@ -1150,6 +1153,7 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Set _fields_ to ? PrepareTemporalFields(_fields_, « *"day"*, *"month"*, *"monthCode"*, *"year"* », « *"day"* »).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
+        1. Perform ? ISOResolveMonth(_fields_).
         1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _overflow_).
         1. Return ? CreateTemporalMonthDay(_result_.[[Month]], _result_.[[Day]], *"iso8601"*, _result_.[[ReferenceISOYear]]).
       </emu-alg>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1790,6 +1790,7 @@
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
             1. Let _overflow_ be ? ToTemporalOverflow(_options_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
+              1. Perform ? ISOResolveMonth(_fields_).
               1. Let _result_ be ? ISODateFromFields(_fields_, _overflow_).
             1. Else,
               1. Perform ? CalendarResolveFields(_calendar_.[[Identifier]], _fields_, ~date~).
@@ -1819,6 +1820,7 @@
               1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, 𝔽(_firstDayIndex_)).
             1. Let _overflow_ be ? ToTemporalOverflow(_options_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
+              1. Perform ? ISOResolveMonth(_fields_).
               1. Let _result_ be ? ISOYearMonthFromFields(_fields_, _overflow_).
             1. Else,
               1. Perform ? CalendarResolveFields(_calendar_.[[Identifier]], _fields_, ~year-month~).
@@ -1847,6 +1849,7 @@
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
             1. Let _overflow_ be ? ToTemporalOverflow(_options_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
+              1. Perform ? ISOResolveMonth(_fields_).
               1. Let _result_ be ? ISOMonthDayFromFields(_fields_, _overflow_).
             1. Else,
               1. Perform ? CalendarResolveFields(_calendar_.[[Identifier]], _fields_, ~month-day~).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2216,7 +2216,14 @@
             1. Let _result_ be _fieldNames_.
             1. If _calendar_.[[Identifier]] is not *"iso8601"*, then
               1. NOTE: Every built-in calendar preserves all input field names in output.
-              1. Let _extraFieldDescriptors_ be CalendarFieldDescriptors(_calendar_.[[Identifier]], ~date~).
+              1. Let _type_ be *undefined*.
+              1. If _fieldNames_ does not contain *"year"*, then
+                1. Set _type_ to ~month-day~.
+              1. Else if _fieldNames_ does not contain *"day"*, then
+                1. Set _type_ to ~year-month~.
+              1. Else,
+                1. Set _type_ to ~date~.
+              1. Let _extraFieldDescriptors_ be CalendarFieldDescriptors(_calendar_.[[Identifier]], type).
               1. For each Calendar Field Descriptor Record _desc_ of _extraFieldDescriptors_, do
                 1. Append _desc_.[[Property]] to _result_.
             1. Return CreateArrayFromList(_result_).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1657,16 +1657,16 @@
           </emu-note>
         </emu-clause>
 
-        <emu-clause id="sec-temporal-calendardatefields" type="abstract operation">
+        <emu-clause id="sec-temporal-calendarfielddescriptors" type="abstract operation">
           <h1>
-            CalendarDateFields (
+            CalendarFieldDescriptors (
               _calendar_: a String,
-              _fields_: a List of Strings,
-            ): a List of Strings
+              _type_: ~date~, ~year-month~, or ~month-day~,
+            ): a List of Calendar Field Descriptor Records
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It interprets _fields_ as the names of fields (<emu-xref href="#table-temporal-field-requirements"></emu-xref>) necessary for a given operation and returns a new List by appending the names of additional relevant fields specific to the built-in calendar identified by _calendar_. For example, when _calendar_ is *"gregory"* or *"japanese"*, *"era"* and *"eraYear"* are appended if and only if _fields_ contains *"year"*.</dd>
+            <dd>It characterizes calendar-specific fields that are relevant for values of the provided _type_ in the built-in calendar identified by _calendar_. For example, *"era"* (with ToString conversion) and *"eraYear"* (with ToIntegerWithTruncation conversion) are returned when _calendar_ is *"gregory"* or *"japanese"* and _type_ is ~date~ or ~year-month~.</dd>
           </dl>
         </emu-clause>
 
@@ -1786,8 +1786,8 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _relevantFieldNames_, « *"year"*, *"day"* »).
             1. Else,
-              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], _relevantFieldNames_).
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
+              1. Let _calendarRelevantFieldDescriptors_ be CalendarFieldDescriptors(_calendar_.[[Identifier]], ~date~).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _relevantFieldNames_, « », _calendarRelevantFieldDescriptors_).
             1. Let _overflow_ be ? ToTemporalOverflow(_options_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Perform ? ISOResolveMonth(_fields_).
@@ -1814,8 +1814,8 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _relevantFieldNames_, « *"year"* »).
             1. Else,
-              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], _relevantFieldNames_).
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
+              1. Let _calendarRelevantFieldDescriptors_ be CalendarFieldDescriptors(_calendar_.[[Identifier]], ~year-month~).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _relevantFieldNames_, « », _calendarRelevantFieldDescriptors_).
               1. Let _firstDayIndex_ be the 1-based index of the first day of the month described by _fields_ (i.e., 1 unless the month's first day is skipped by this calendar.)
               1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, 𝔽(_firstDayIndex_)).
             1. Let _overflow_ be ? ToTemporalOverflow(_options_).
@@ -1845,8 +1845,8 @@
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Set _fields_ to ? PrepareTemporalFields(_fields_, _relevantFieldNames_, « *"day"* »).
             1. Else,
-              1. Let _fieldNames_ be CalendarDateFields(_calendar_.[[Identifier]], _relevantFieldNames_).
-              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _fieldNames_, « »).
+              1. Let _calendarRelevantFieldDescriptors_ be CalendarFieldDescriptors(_calendar_.[[Identifier]], ~month-day~).
+              1. Set _fields_ to ? PrepareTemporalFields(_fields_, _relevantFieldNames_, « », _calendarRelevantFieldDescriptors_).
             1. Let _overflow_ be ? ToTemporalOverflow(_options_).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
               1. Perform ? ISOResolveMonth(_fields_).
@@ -2213,10 +2213,12 @@
                     1. Let _completion_ be ThrowCompletion(a newly created *RangeError* object).
                     1. Return ? IteratorClose(_iteratorRecord_, _completion_).
                 1. Append _nextValue_ to the end of the List _fieldNames_.
-            1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _result_ be _fieldNames_.
-            1. Else,
-              1. Let _result_ be CalendarDateFields(_calendar_.[[Identifier]], _fieldNames_).
+            1. Let _result_ be _fieldNames_.
+            1. If _calendar_.[[Identifier]] is not *"iso8601"*, then
+              1. NOTE: Every built-in calendar preserves all input field names in output.
+              1. Let _extraFieldDescriptors_ be CalendarFieldDescriptors(_calendar_.[[Identifier]], ~date~).
+              1. For each Calendar Field Descriptor Record _desc_ of _extraFieldDescriptors_, do
+                1. Append _desc_.[[Property]] to _result_.
             1. Return CreateArrayFromList(_result_).
           </emu-alg>
         </emu-clause>


### PR DESCRIPTION
This pull request adds the polyfill changes for #2500 and also adds a minor fix for `Temporal.Calendar.prototype.fields`. 
