### PR TITLE
Editorial: Simplify object snapshotting 

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -111,12 +111,8 @@ export class Calendar {
   }
   mergeFields(fields, additionalFields) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
-    fields = ES.ToObject(fields);
-    const fieldsCopy = ObjectCreate(null);
-    ES.CopyDataProperties(fieldsCopy, fields, [], [undefined]);
-    additionalFields = ES.ToObject(additionalFields);
-    const additionalFieldsCopy = ObjectCreate(null);
-    ES.CopyDataProperties(additionalFieldsCopy, additionalFields, [], [undefined]);
+    const fieldsCopy = ES.SnapshotOwnProperties(fields, null, [], [undefined]);
+    const additionalFieldsCopy = ES.SnapshotOwnProperties(additionalFields, null, [], [undefined]);
     const additionalKeys = ReflectOwnKeys(additionalFieldsCopy);
     const overriddenKeys = impl[GetSlot(this, CALENDAR_ID)].fieldKeysToIgnore(additionalKeys);
     const merged = ObjectCreate(null);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3815,7 +3815,7 @@ export function DifferenceISODateTime(
   const date1 = CreateTemporalDate(y1, mon1, d1, calendar);
   const date2 = CreateTemporalDate(y2, mon2, d2, calendar);
   const dateLargestUnit = LargerOfTwoTemporalUnits('day', largestUnit);
-  const untilOptions = CopyOptions(options);
+  const untilOptions = SnapshotOwnProperties(GetOptionsObject(options), null);
   untilOptions.largestUnit = dateLargestUnit;
   const untilResult = CalendarDateUntil(calendar, date1, date2, untilOptions);
   const years = GetSlot(untilResult, YEARS);
@@ -3951,7 +3951,7 @@ export function DifferenceTemporalInstant(operation, instant, other, options) {
   const sign = operation === 'since' ? -1 : 1;
   other = ToTemporalInstant(other);
 
-  const resolvedOptions = CopyOptions(options);
+  const resolvedOptions = SnapshotOwnProperties(GetOptionsObject(options), null);
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'time', [], 'nanosecond', 'second');
 
   const onens = GetSlot(instant, EPOCHNANOSECONDS);
@@ -3986,7 +3986,7 @@ export function DifferenceTemporalPlainDate(operation, plainDate, other, options
   const otherCalendar = GetSlot(other, CALENDAR);
   ThrowIfCalendarsNotEqual(calendar, otherCalendar, 'compute difference between dates');
 
-  const resolvedOptions = CopyOptions(options);
+  const resolvedOptions = SnapshotOwnProperties(GetOptionsObject(options), null);
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'date', [], 'day', 'day');
   resolvedOptions.largestUnit = settings.largestUnit;
 
@@ -4026,7 +4026,7 @@ export function DifferenceTemporalPlainDateTime(operation, plainDateTime, other,
   const otherCalendar = GetSlot(other, CALENDAR);
   ThrowIfCalendarsNotEqual(calendar, otherCalendar, 'compute difference between dates');
 
-  const resolvedOptions = CopyOptions(options);
+  const resolvedOptions = SnapshotOwnProperties(GetOptionsObject(options), null);
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'datetime', [], 'nanosecond', 'day');
 
   let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
@@ -4101,7 +4101,7 @@ export function DifferenceTemporalPlainTime(operation, plainTime, other, options
   const sign = operation === 'since' ? -1 : 1;
   other = ToTemporalTime(other);
 
-  const resolvedOptions = CopyOptions(options);
+  const resolvedOptions = SnapshotOwnProperties(GetOptionsObject(options), null);
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'time', [], 'nanosecond', 'hour');
 
   let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = DifferenceTime(
@@ -4165,7 +4165,7 @@ export function DifferenceTemporalPlainYearMonth(operation, yearMonth, other, op
   const otherCalendar = GetSlot(other, CALENDAR);
   ThrowIfCalendarsNotEqual(calendar, otherCalendar, 'compute difference between months');
 
-  const resolvedOptions = CopyOptions(options);
+  const resolvedOptions = SnapshotOwnProperties(GetOptionsObject(options), null);
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'date', ['week', 'day'], 'month', 'year');
   resolvedOptions.largestUnit = settings.largestUnit;
 
@@ -4209,7 +4209,7 @@ export function DifferenceTemporalZonedDateTime(operation, zonedDateTime, other,
   const otherCalendar = GetSlot(other, CALENDAR);
   ThrowIfCalendarsNotEqual(calendar, otherCalendar, 'compute difference between dates');
 
-  const resolvedOptions = CopyOptions(options);
+  const resolvedOptions = SnapshotOwnProperties(GetOptionsObject(options), null);
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'datetime', [], 'nanosecond', 'hour');
   resolvedOptions.largestUnit = settings.largestUnit;
 
@@ -4744,7 +4744,7 @@ export function AddDurationToOrSubtractDurationFromPlainYearMonth(operation, yea
   const calendar = GetSlot(yearMonth, CALENDAR);
   const fieldNames = CalendarFields(calendar, ['monthCode', 'year']);
   const fields = PrepareTemporalFields(yearMonth, fieldNames, []);
-  const fieldsCopy = CopyOptions(fields);
+  const fieldsCopy = SnapshotOwnProperties(GetOptionsObject(fields), null);
   fields.day = 1;
   let startDate = CalendarDateFromFields(calendar, fields);
   const sign = DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
@@ -4759,7 +4759,7 @@ export function AddDurationToOrSubtractDurationFromPlainYearMonth(operation, yea
     startDate = CalendarDateFromFields(calendar, fieldsCopy);
   }
   const durationToAdd = new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
-  const optionsCopy = CopyOptions(options);
+  const optionsCopy = SnapshotOwnProperties(GetOptionsObject(options), null);
   const addedDate = CalendarDateAdd(calendar, startDate, durationToAdd, options, dateAdd);
   const addedDateFields = PrepareTemporalFields(addedDate, fieldNames, []);
 
@@ -5412,10 +5412,10 @@ export function GetOptionsObject(options) {
   throw new TypeError(`Options parameter must be an object, not ${options === null ? 'null' : `a ${typeof options}`}`);
 }
 
-function CopyOptions(options) {
-  const optionsCopy = ObjectCreate(null);
-  CopyDataProperties(optionsCopy, GetOptionsObject(options), []);
-  return optionsCopy;
+export function SnapshotOwnProperties(source, proto, excludedKeys = [], excludedValues = []) {
+  const copy = ObjectCreate(proto);
+  CopyDataProperties(copy, ToObject(source), excludedKeys, excludedValues);
+  return copy;
 }
 
 export function GetOption(options, property, allowedValues, fallback) {

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -444,12 +444,11 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     options = ES.GetOptionsObject(options);
 
-    const optionsCopy = ObjectCreate(null);
     // This is not quite per specification, but this polyfill's DateTimeFormat
     // already doesn't match the InitializeDateTimeFormat operation, and the
     // access order might change anyway;
     // see https://github.com/tc39/ecma402/issues/747
-    ES.CopyDataProperties(optionsCopy, options, ['timeZone']);
+    const optionsCopy = ES.SnapshotOwnProperties(options, null, ['timeZone']);
 
     if (options.timeZone !== undefined) {
       throw new TypeError('ZonedDateTime toLocaleString does not accept a timeZone option');

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -150,27 +150,6 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-temporal-copyoptions" type="abstract operation">
-    <h1>
-      CopyOptions (
-        _options_: an ECMAScript language value,
-      ): either a normal completion containing an Object, or a throw completion
-    </h1>
-    <dl class="header">
-      <dt>description</dt>
-      <dd>
-        It returns an Object suitable for use with GetOption.
-        Unlike GetOptionsObject, it will never return the same Object as _options_ itself.
-        It always returns a new Object for which the value in its [[Prototype]] internal slot is *null* and every property is a data property.
-      </dd>
-    </dl>
-    <emu-alg>
-      1. Let _optionsCopy_ be OrdinaryObjectCreate(*null*).
-      1. Perform ? CopyDataProperties(_optionsCopy_, ? GetOptionsObject(_options_), &laquo; &raquo;).
-      1. Return _optionsCopy_.
-    </emu-alg>
-  </emu-clause>
-
   <!-- Copied from ECMA-402 GetOption -->
   <emu-clause id="sec-getoption" type="abstract operation">
     <h1>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1505,12 +1505,8 @@
       <emu-alg>
         1. Let _calendar_ be the *this* value.
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-        1. Set _fields_ to ? ToObject(_fields_).
-        1. Let _fieldsCopy_ be OrdinaryObjectCreate(*null*).
-        1. Perform ? CopyDataProperties(_fieldsCopy_, _fields_, « », « *undefined* »).
-        1. Set _additionalFields_ to ? ToObject(_additionalFields_).
-        1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(*null*).
-        1. Perform ? CopyDataProperties(_additionalFieldsCopy_, _additionalFields_, « », « *undefined* »).
+        1. Let _fieldsCopy_ be ? SnapshotOwnProperties(_fields_, *null*, « », « *undefined* »).
+        1. Let _additionalFieldsCopy_ be ? SnapshotOwnProperties(_additionalFields_, *null*, « », « *undefined* »).
         1. NOTE: Every property of _fieldsCopy_ and _additionalFieldsCopy_ is an enumerable data property with a non-*undefined* value, but some property keys may be Symbols.
         1. Let _additionalKeys_ be ! _additionalFieldsCopy_.[[OwnPropertyKeys]]().
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -678,7 +678,7 @@
       <emu-alg>
         1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalInstant(_other_).
-        1. Let _resolvedOptions_ be ? CopyOptions(_options_).
+        1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, &laquo; &raquo;, *"nanosecond"*, *"second"*).
         1. Let _result_ be DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[LargestUnit]], _settings_.[[RoundingMode]]).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2227,12 +2227,8 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-            1. Set _fields_ to ? ToObject(_fields_).
-            1. Let _fieldsCopy_ be OrdinaryObjectCreate(*null*).
-            1. Perform ? CopyDataProperties(_fieldsCopy_, _fields_, « », « *undefined* »).
-            1. Set _additionalFields_ to ? ToObject(_additionalFields_).
-            1. Let _additionalFieldsCopy_ be OrdinaryObjectCreate(*null*).
-            1. Perform ? CopyDataProperties(_additionalFieldsCopy_, _additionalFields_, « », « *undefined* »).
+            1. Let _fieldsCopy_ be ? SnapshotOwnProperties(_fields_, *null*, « », « *undefined* »).
+            1. Let _additionalFieldsCopy_ be ? SnapshotOwnProperties(_additionalFields_, *null*, « », « *undefined* »).
             1. NOTE: Every property of _fieldsCopy_ and _additionalFieldsCopy_ is an enumerable data property with non-*undefined* value, but some property keys may be Symbols.
             1. Let _additionalKeys_ be ! _additionalFieldsCopy_.[[OwnPropertyKeys]]().
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -186,6 +186,32 @@
     </emu-note>
   </emu-clause>
 
+  <ins class="block">
+    <emu-clause id="sec-snapshotownproperties" type="abstract operation">
+      <h1>
+        SnapshotOwnProperties (
+          _source_: an ECMAScript language value,
+          _proto_: an Object or *null*,
+          optional _excludedKeys_: a List of property keys,
+          optional _excludedValues_: a List of ECMAScript language values,
+        ): either a normal completion containing an Object, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It enumerates the own properties of _source_ and copies them into data properties on a new object with the specified prototype, subject to the specified exclusions.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _copy_ be OrdinaryObjectCreate(_proto_).
+        1. If _excludedKeys_ is not present, set _excludedKeys_ to « ».
+        1. If _excludedValues_ is not present, set _excludedValues_ to « ».
+        1. Perform ? CopyDataProperties(_copy_, ? ToObject(_source_), _excludedKeys_, _excludedValues_).
+        1. Return _copy_.
+      </emu-alg>
+    </emu-clause>
+  </ins>
+
   <emu-clause id="sec-temporal-date-constructor">
     <h1><a href="https://tc39.es/ecma262/#sec-date-constructor">The Date Constructor</a></h1>
     <emu-clause id="sec-temporal-date">

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -978,7 +978,7 @@
         1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalDate(_other_).
         1. If ? CalendarEquals(_temporalDate_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
-        1. Let _resolvedOptions_ be ? CopyOptions(_options_).
+        1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~date~, &laquo; &raquo;, *"day"*, *"day"*).
         1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. Let _result_ be ? CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_, _other_, _resolvedOptions_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1139,7 +1139,7 @@
         1. Let _date1_ be ! CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendar_).
         1. Let _date2_ be ! CreateTemporalDate(_y2_, _mon2_, _d2_, _calendar_).
         1. Let _dateLargestUnit_ be ! LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
-        1. Let _untilOptions_ be ? CopyOptions(_options_).
+        1. Let _untilOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _dateLargestUnit_).
         1. Let _dateDifference_ be ? CalendarDateUntil(_calendar_, _date1_, _date2_, _untilOptions_).
         1. Let _balanceResult_ be ? <emu-meta suppress-effects="user-code">BalanceDuration(_dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_)</emu-meta>.
@@ -1163,7 +1163,7 @@
         1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalDateTime(_other_).
         1. If ? CalendarEquals(_dateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
-        1. Let _resolvedOptions_ be ? CopyOptions(_options_).
+        1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~datetime~, &laquo; &raquo;, *"nanosecond"*, *"day"*).
         1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _settings_.[[LargestUnit]], _resolvedOptions_).
         1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -921,7 +921,7 @@
       <emu-alg>
         1. If _operation_ is ~since~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Set _other_ to ? ToTemporalTime(_other_).
-        1. Let _resolvedOptions_ be ? CopyOptions(_options_).
+        1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, &laquo; &raquo;, *"nanosecond"*, *"hour"*).
         1. Let _result_ be ! DifferenceTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]]).
         1. Set _result_ to (! RoundDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]])).[[DurationRecord]].

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -628,7 +628,7 @@
         1. Set _other_ to ? ToTemporalYearMonth(_other_).
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. If ? CalendarEquals(_calendar_, _other_.[[Calendar]]) is *false*, throw a *RangeError* exception.
-        1. Let _resolvedOptions_ be ? CopyOptions(_options_).
+        1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~date~, &laquo; *"week"*, *"day"* &raquo;, *"month"*, *"year"*).
         1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
@@ -682,7 +682,7 @@
         1. Else,
           1. Let _date_ be _intermediateDate_.
         1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
-        1. Let _optionsCopy_ be ? CopyOptions(_options_).
+        1. Let _optionsCopy_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _options_, _dateAdd_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).
         1. Return ? CalendarYearMonthFromFields(_calendar_, _addedDateFields_, _optionsCopy_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -666,8 +666,7 @@
         1. Let _calendar_ be _yearMonth_.[[Calendar]].
         1. Let _fieldNames_ be ? CalendarFields(_calendar_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
-        1. Let _fieldsCopy_ be OrdinaryObjectCreate(*null*).
-        1. Perform ! CopyDataProperties(_fieldsCopy_, _fields_, «»).
+        1. Let _fieldsCopy_ be ! SnapshotOwnProperties(_fields_, *null*).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"day"*, *1*<sub>𝔽</sub>).
         1. Let _intermediateDate_ be ? CalendarDateFromFields(_calendar_, _fields_).
         1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1421,7 +1421,7 @@
         1. Set _other_ to ? ToTemporalZonedDateTime(_other_).
         1. If ? CalendarEquals(_zonedDateTime_.[[Calendar]], _other_.[[Calendar]]) is *false*, then
           1. Throw a *RangeError* exception.
-        1. Let _resolvedOptions_ be ? CopyOptions(_options_).
+        1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~datetime~, &laquo; &raquo;, *"nanosecond"*, *"hour"*).
         1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. If _settings_.[[LargestUnit]] is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then


### PR DESCRIPTION
Introduces SnapshotOwnProperties to precede CopyDataProperties with creating the target object and follow it with returning that object, collapsing many common algorithm subsequences (including all of those using the CopyOptions operation, which is fully subsumed).

Once introduced to ECMA-262, it can also simplify [RestDestructuringAssignmentEvaluation](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-runtime-semantics-restdestructuringassignmentevaluation) and [RestBindingInitialization](https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-destructuring-binding-patterns-runtime-semantics-restbindinginitialization):
```patch
-          1. Let _restObj_ be OrdinaryObjectCreate(%Object.prototype%).
-          1. Perform ? CopyDataProperties(_restObj_, _value_, _excludedNames_).
+          1. Let _restObj_ be ? SnapshotOwnProperties(_value_, %Object.prototype%, _excludedNames_).
```