### PR TITLE
Polyfill: align time zone identifier handling with spec

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -228,10 +228,11 @@ export {
 const IntlDateTimeFormatEnUsCache = new Map();
 
 function getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier) {
-  let instance = IntlDateTimeFormatEnUsCache.get(timeZoneIdentifier);
+  const lowercaseIdentifier = ASCIILowercase(timeZoneIdentifier);
+  let instance = IntlDateTimeFormatEnUsCache.get(lowercaseIdentifier);
   if (instance === undefined) {
     instance = new IntlDateTimeFormat('en-us', {
-      timeZone: String(timeZoneIdentifier),
+      timeZone: lowercaseIdentifier,
       hour12: false,
       era: 'short',
       year: 'numeric',
@@ -241,7 +242,7 @@ function getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier) {
       minute: 'numeric',
       second: 'numeric'
     });
-    IntlDateTimeFormatEnUsCache.set(timeZoneIdentifier, instance);
+    IntlDateTimeFormatEnUsCache.set(lowercaseIdentifier, instance);
   }
   return instance;
 }
@@ -358,13 +359,20 @@ export function RejectTemporalLikeObject(item) {
   }
 }
 
-export function ParseTemporalTimeZone(stringIdent) {
-  const { ianaName, offset, z } = ParseTemporalTimeZoneString(stringIdent);
-  if (ianaName) return GetCanonicalTimeZoneIdentifier(ianaName);
-  if (z) return 'UTC';
-  // if !ianaName && !z then offset must be present
-  const offsetNs = ParseTimeZoneOffsetString(offset);
+export function CanonicalizeTimeZoneOffsetString(offsetString) {
+  const offsetNs = ParseTimeZoneOffsetString(offsetString);
   return FormatTimeZoneOffsetString(offsetNs);
+}
+
+export function ParseTemporalTimeZone(stringIdent) {
+  const { tzName, offset, z } = ParseTemporalTimeZoneString(stringIdent);
+  if (tzName) {
+    if (IsTimeZoneOffsetString(tzName)) return CanonicalizeTimeZoneOffsetString(tzName);
+    return GetCanonicalTimeZoneIdentifier(tzName);
+  }
+  if (z) return 'UTC';
+  // if !tzName && !z then offset must be present
+  return CanonicalizeTimeZoneOffsetString(offset);
 }
 
 export function MaybeFormatCalendarAnnotation(calendar, showCalendar) {
@@ -440,7 +448,7 @@ export function ParseISODateTime(isoString) {
     }
     if (offset === '-00:00') offset = '+00:00';
   }
-  const ianaName = match[19];
+  const tzName = match[19];
   const calendar = processAnnotations(match[20]);
   RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   return {
@@ -454,7 +462,7 @@ export function ParseISODateTime(isoString) {
     millisecond,
     microsecond,
     nanosecond,
-    ianaName,
+    tzName,
     offset,
     z,
     calendar
@@ -469,7 +477,7 @@ export function ParseTemporalInstantString(isoString) {
 
 export function ParseTemporalZonedDateTimeString(isoString) {
   const result = ParseISODateTime(isoString);
-  if (!result.ianaName) throw new RangeError('Temporal.ZonedDateTime requires a time zone ID in brackets');
+  if (!result.tzName) throw new RangeError('Temporal.ZonedDateTime requires a time zone ID in brackets');
   return result;
 }
 
@@ -561,11 +569,11 @@ export function ParseTemporalMonthDayString(isoString) {
 
 export function ParseTemporalTimeZoneString(stringIdent) {
   const bareID = new RegExp(`^${PARSE.timeZoneID.source}$`, 'i');
-  if (bareID.test(stringIdent)) return { ianaName: stringIdent };
+  if (bareID.test(stringIdent)) return { tzName: stringIdent };
   try {
     // Try parsing ISO string instead
     const result = ParseISODateTime(stringIdent);
-    if (result.z || result.offset || result.ianaName) {
+    if (result.z || result.offset || result.tzName) {
       return result;
     }
   } catch {
@@ -973,11 +981,11 @@ export function ToRelativeTemporalObject(options) {
     timeZone = fields.timeZone;
     if (timeZone !== undefined) timeZone = ToTemporalTimeZoneSlotValue(timeZone);
   } else {
-    let ianaName, z;
-    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar, ianaName, offset, z } =
+    let tzName, z;
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar, tzName, offset, z } =
       ParseISODateTime(ToString(relativeTo)));
-    if (ianaName) {
-      timeZone = ToTemporalTimeZoneSlotValue(ianaName);
+    if (tzName) {
+      timeZone = ToTemporalTimeZoneSlotValue(tzName);
       if (z) {
         offsetBehaviour = 'exact';
       } else if (!offset) {
@@ -1440,10 +1448,10 @@ export function ToTemporalZonedDateTime(item, options) {
       options
     ));
   } else {
-    let ianaName, z;
-    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, ianaName, offset, z, calendar } =
+    let tzName, z;
+    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, tzName, offset, z, calendar } =
       ParseTemporalZonedDateTimeString(ToString(item)));
-    timeZone = ToTemporalTimeZoneSlotValue(ianaName);
+    timeZone = ToTemporalTimeZoneSlotValue(tzName);
     if (z) {
       offsetBehaviour = 'exact';
     } else if (!offset) {
@@ -2565,11 +2573,11 @@ export function TemporalZonedDateTimeToString(
 }
 
 export function IsTimeZoneOffsetString(string) {
-  return OFFSET.test(String(string));
+  return OFFSET.test(string);
 }
 
 export function ParseTimeZoneOffsetString(string) {
-  const match = OFFSET.exec(String(string));
+  const match = OFFSET.exec(string);
   if (!match) {
     throw new RangeError(`invalid time zone offset: ${string}`);
   }
@@ -2581,12 +2589,14 @@ export function ParseTimeZoneOffsetString(string) {
   return sign * (((hours * 60 + minutes) * 60 + seconds) * 1e9 + nanoseconds);
 }
 
+// In the spec, GetCanonicalTimeZoneIdentifier is infallible and is always
+// preceded by a call to IsAvailableTimeZoneName. However in the polyfill,
+// we don't (yet) have a way to check if a time zone ID is valid without
+// also canonicalizing it. So we combine both operations into one function,
+// which will return the canonical ID if the ID is valid, and will throw
+// if it's not.
 export function GetCanonicalTimeZoneIdentifier(timeZoneIdentifier) {
-  if (IsTimeZoneOffsetString(timeZoneIdentifier)) {
-    const offsetNs = ParseTimeZoneOffsetString(timeZoneIdentifier);
-    return FormatTimeZoneOffsetString(offsetNs);
-  }
-  const formatter = getIntlDateTimeFormatEnUsForTimeZone(String(timeZoneIdentifier));
+  const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier);
   return formatter.resolvedOptions().timeZone;
 }
 

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -20,20 +20,25 @@ import {
 } from './slots.mjs';
 
 export class TimeZone {
-  constructor(timeZoneIdentifier) {
+  constructor(identifier) {
     // Note: if the argument is not passed, GetCanonicalTimeZoneIdentifier(undefined) will throw.
     //       This check exists only to improve the error message.
     if (arguments.length < 1) {
       throw new RangeError('missing argument: identifier is required');
     }
 
-    timeZoneIdentifier = ES.GetCanonicalTimeZoneIdentifier(timeZoneIdentifier);
+    let stringIdentifier = ES.ToString(identifier);
+    if (ES.IsTimeZoneOffsetString(stringIdentifier)) {
+      stringIdentifier = ES.CanonicalizeTimeZoneOffsetString(stringIdentifier);
+    } else {
+      stringIdentifier = ES.GetCanonicalTimeZoneIdentifier(stringIdentifier);
+    }
     CreateSlots(this);
-    SetSlot(this, TIMEZONE_ID, timeZoneIdentifier);
+    SetSlot(this, TIMEZONE_ID, stringIdentifier);
 
     if (typeof __debug__ !== 'undefined' && __debug__) {
       Object.defineProperty(this, '_repr_', {
-        value: `${this[Symbol.toStringTag]} <${timeZoneIdentifier}>`,
+        value: `${this[Symbol.toStringTag]} <${stringIdentifier}>`,
         writable: false,
         enumerable: false,
         configurable: false

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -248,7 +248,7 @@ const temporalSign = withCode(
 );
 const temporalDecimalFraction = fraction;
 function saveOffset(data, result) {
-  data.offset = ES.GetCanonicalTimeZoneIdentifier(result).toString();
+  data.offset = ES.CanonicalizeTimeZoneOffsetString(result);
 }
 const utcOffset = withCode(
   seq(
@@ -270,7 +270,7 @@ const timeZoneUTCOffsetName = seq(
 const timeZoneIANAName = choice(...timezoneNames);
 const timeZoneIdentifier = withCode(
   choice(timeZoneUTCOffsetName, timeZoneIANAName),
-  (data, result) => (data.ianaName = result)
+  (data, result) => (data.tzName = result)
 );
 const timeZoneAnnotation = seq('[', [annotationCriticalFlag], timeZoneIdentifier, ']');
 const aKeyLeadingChar = choice(lcalpha(), character('_'));
@@ -447,9 +447,9 @@ const comparisonItems = {
   ],
   MonthDay: ['month', 'day', 'calendar'],
   Time: [...timeItems],
-  TimeZone: ['offset', 'ianaName'],
+  TimeZone: ['offset', 'tzName'],
   YearMonth: ['year', 'month', 'calendar'],
-  ZonedDateTime: [...dateItems, ...timeItems, 'offset', 'ianaName', 'calendar']
+  ZonedDateTime: [...dateItems, ...timeItems, 'offset', 'tzName', 'calendar']
 };
 const plainModes = ['Date', 'DateTime', 'MonthDay', 'Time', 'YearMonth'];
 
@@ -465,7 +465,7 @@ function fuzzMode(mode) {
       const parsed = ES[`ParseTemporal${mode}String`](fuzzed);
       for (let prop of comparisonItems[mode]) {
         let expected = generatedData[prop];
-        if (prop !== 'ianaName' && prop !== 'offset' && prop !== 'calendar') expected = expected || 0;
+        if (prop !== 'tzName' && prop !== 'offset' && prop !== 'calendar') expected = expected || 0;
         assert.equal(parsed[prop], expected, prop);
       }
       console.log(`${fuzzed} => ok`);


### PR DESCRIPTION
Refactors a few places in the polyfill to more closely match the spec. These changes will be helpful for testing of later normative PRs and proposals.

* Case-insensitive caching of DTF instances
* Add CanonicalizeTimeZoneOffsetString AO
* Refactor ParseTemporalTimeZone
* Move offset canonicalization out of GetCanonicalTimeZoneIdentifier
* Move string coercion earlier before IsTimeZoneOffsetString and ParseTimeZoneOffsetString
* Rename `ianaName` parse field to `tzName` because offset strings can also live in this field.
* Refactor TimeZone constructor