### PR TITLE
Fix Test262 timeout for debugging

### DIFF
--- a/polyfill/ci_codecov_test262.sh
+++ b/polyfill/ci_codecov_test262.sh
@@ -12,8 +12,6 @@ npm run build262
 export NODE_V8_COVERAGE=coverage/tmp/
 rm -rf $NODE_V8_COVERAGE
 
-export TIMEOUT=30000
-
 # Run the tests in chunks, by subdirectory
 # Works around memory leak with vm.Script and NODE_V8_COVERAGE
 subdirs=$(find test262/test/*/Temporal/* -maxdepth 0 -type d -exec basename "{}" ";" | sort -u)

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -10,7 +10,7 @@
     "test": "node --loader ./test/resolve.source.mjs ./test/all.mjs",
     "test-cookbook": "npm run build && TEST=all npm run test-cookbook-one && TEST=stockExchangeTimeZone npm run test-cookbook-one",
     "test-cookbook-one": "node --loader ./test/resolve.cookbook.mjs ../docs/cookbook/$TEST.mjs",
-    "test262": "npm run build262 && TIMEOUT=30000 node runtest262.mjs",
+    "test262": "npm run build262 && node runtest262.mjs",
     "codecov:test262": "./ci_codecov_test262.sh",
     "build": "rollup -c rollup.config.js --bundleConfigAsCjs",
     "build262": "TEST262=1 rollup -c rollup.config.js --bundleConfigAsCjs",

--- a/polyfill/runtest262.mjs
+++ b/polyfill/runtest262.mjs
@@ -4,7 +4,7 @@ const result = runTest262({
   test262Dir: 'test262',
   polyfillCodeFile: 'script.js',
   expectedFailureFiles: ['test/expected-failures.txt'],
-  timeoutMsecs: process.env.TIMEOUT,
+  timeoutMsecs: process.env.TIMEOUT || 30000,
   testGlobs: process.argv.slice(2)
 });
 


### PR DESCRIPTION
A previous commit extended the timeout for running Test262 tests because a few of our tests now take as long as 10-20 seconds to run. However, this change clobbered any TIMEOUT values that developers add when running `npm run test262`. 

Instead, the right place to extend the timeout is in `runTest262.mjs`, so that developers can revise the TIMEOUT environment variable on the command line, for example:

```sh
TIMEOUT=3600000 npm run test262
```

This is important when running Test262 under a debugger where timeouts need to be much longer than 30 seconds.