### PR TITLE
Editorial: Move ToObject from SnapshotOwnProperties to Calendar.p.mergeFields

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -111,8 +111,8 @@ export class Calendar {
   }
   mergeFields(fields, additionalFields) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
-    const fieldsCopy = ES.SnapshotOwnProperties(fields, null, [], [undefined]);
-    const additionalFieldsCopy = ES.SnapshotOwnProperties(additionalFields, null, [], [undefined]);
+    const fieldsCopy = ES.SnapshotOwnProperties(ES.ToObject(fields), null, [], [undefined]);
+    const additionalFieldsCopy = ES.SnapshotOwnProperties(ES.ToObject(additionalFields), null, [], [undefined]);
     const additionalKeys = ReflectOwnKeys(additionalFieldsCopy);
     const overriddenKeys = impl[GetSlot(this, CALENDAR_ID)].fieldKeysToIgnore(additionalKeys);
     const merged = ObjectCreate(null);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -5424,7 +5424,7 @@ export function GetOptionsObject(options) {
 
 export function SnapshotOwnProperties(source, proto, excludedKeys = [], excludedValues = []) {
   const copy = ObjectCreate(proto);
-  CopyDataProperties(copy, ToObject(source), excludedKeys, excludedValues);
+  CopyDataProperties(copy, source, excludedKeys, excludedValues);
   return copy;
 }
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1505,8 +1505,8 @@
       <emu-alg>
         1. Let _calendar_ be the *this* value.
         1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-        1. Let _fieldsCopy_ be ? SnapshotOwnProperties(_fields_, *null*, « », « *undefined* »).
-        1. Let _additionalFieldsCopy_ be ? SnapshotOwnProperties(_additionalFields_, *null*, « », « *undefined* »).
+        1. Let _fieldsCopy_ be ? SnapshotOwnProperties(? ToObject(_fields_), *null*, « », « *undefined* »).
+        1. Let _additionalFieldsCopy_ be ? SnapshotOwnProperties(? ToObject(_additionalFields_), *null*, « », « *undefined* »).
         1. NOTE: Every property of _fieldsCopy_ and _additionalFieldsCopy_ is an enumerable data property with a non-*undefined* value, but some property keys may be Symbols.
         1. Let _additionalKeys_ be ! _additionalFieldsCopy_.[[OwnPropertyKeys]]().
         1. Assert: _calendar_.[[Identifier]] is *"iso8601"*.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2228,8 +2228,8 @@
           <emu-alg>
             1. Let _calendar_ be the *this* value.
             1. Perform ? RequireInternalSlot(_calendar_, [[InitializedTemporalCalendar]]).
-            1. Let _fieldsCopy_ be ? SnapshotOwnProperties(_fields_, *null*, « », « *undefined* »).
-            1. Let _additionalFieldsCopy_ be ? SnapshotOwnProperties(_additionalFields_, *null*, « », « *undefined* »).
+            1. Let _fieldsCopy_ be ? SnapshotOwnProperties(? ToObject(_fields_), *null*, « », « *undefined* »).
+            1. Let _additionalFieldsCopy_ be ? SnapshotOwnProperties(? ToObject(_additionalFields_), *null*, « », « *undefined* »).
             1. NOTE: Every property of _fieldsCopy_ and _additionalFieldsCopy_ is an enumerable data property with non-*undefined* value, but some property keys may be Symbols.
             1. Let _additionalKeys_ be ! _additionalFieldsCopy_.[[OwnPropertyKeys]]().
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -190,7 +190,7 @@
     <emu-clause id="sec-snapshotownproperties" type="abstract operation">
       <h1>
         SnapshotOwnProperties (
-          _source_: an ECMAScript language value,
+          _source_: an Object,
           _proto_: an Object or *null*,
           optional _excludedKeys_: a List of property keys,
           optional _excludedValues_: a List of ECMAScript language values,
@@ -206,7 +206,7 @@
         1. Let _copy_ be OrdinaryObjectCreate(_proto_).
         1. If _excludedKeys_ is not present, set _excludedKeys_ to « ».
         1. If _excludedValues_ is not present, set _excludedValues_ to « ».
-        1. Perform ? CopyDataProperties(_copy_, ? ToObject(_source_), _excludedKeys_, _excludedValues_).
+        1. Perform ? CopyDataProperties(_copy_, _source_, _excludedKeys_, _excludedValues_).
         1. Return _copy_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Other call sites always provide an Object, so this isolates the inconsistency.