### PR TITLE
Polyfill: Support Node 20 and work around ICU 73.1 bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: use node.js v19.x
+      - name: use node.js v20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 19.x
+          node-version: 20.x
       - run: npm ci
       - run: npm run build
       - uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: use node.js v19.x
+      - name: use node.js v20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 19.x
+          node-version: 20.x
       - run: npm ci
       - run: npm run lint
       - run: npm run build:spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: use node.js v19.x
+      - name: use node.js v20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 19.x
+          node-version: 20.x
       - run: npm ci
       - run: npm run test-demitasse
         env:
@@ -23,10 +23,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: use node.js v19.x
+      - name: use node.js v20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 19.x
+          node-version: 20.x
       - run: npm ci
       - run: npm run codecov:test262
         env:
@@ -35,20 +35,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: use node.js v19.x
+      - name: use node.js v20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 19.x
+          node-version: 20.x
       - run: npm ci
       - run: npm run test-cookbook
   test-validstrings:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: use node.js v19.x
+      - name: use node.js v20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 19.x
+          node-version: 20.x
       - run: npm ci
       - run: |
           cd polyfill


### PR DESCRIPTION
This PR adds support for running tests in Node 20 and adds a workaround for an [ICU 73.1 regression](https://unicode-org.atlassian.net/browse/ICU-22412) in the iso8601 calendar that breaks some tests in Node 20.

The fix was to stop using Intl.DateTimeFormat for Gregorian-based calendars like `roc` and `japanese`. As a side effect, a few tests that previously failed now work correctly, and tests run a little faster. 

This PR depends on https://github.com/tc39/test262/pull/3848, so don't please don't merge this PR until I have a chance to rebase this PR's submodule to the latest test262 after the test262 PR is merged. 