### PR TITLE
Extend long-test timeout to 60s

### DIFF
--- a/polyfill/runtest262.mjs
+++ b/polyfill/runtest262.mjs
@@ -4,7 +4,7 @@ const result = runTest262({
   test262Dir: 'test262',
   polyfillCodeFile: 'script.js',
   expectedFailureFiles: ['test/expected-failures.txt'],
-  timeoutMsecs: process.env.TIMEOUT || 30000,
+  timeoutMsecs: process.env.TIMEOUT || 60000,
   testGlobs: process.argv.slice(2)
 });
 


### PR DESCRIPTION
I've seen occasional Test262 failures at 30 seconds (perhaps related to GitHub capacity limitations?) so let's bump to 60s.

Note that it doesn't happen every time, so I don't think the problem is our code.