### PR TITLE
Editorial: Introduce SystemUTCEpochMilliseconds to confine GetGlobalObject()

### DIFF
--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -218,18 +218,13 @@
       <h1><a href="https://tc39.es/ecma262/#sec-date">Date ( ..._values_ )</a></h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If NewTarget is *undefined*, then
+        1. <del>If NewTarget is *undefined*, then</del>
           1. <del>Let _now_ be the time value (UTC) identifying the current time.</del>
-          1. <ins>Let _global_ be GetGlobalObject().</ins>
-          1. <ins>Let _nowNs_ be HostSystemUTCEpochNanoseconds(_global_).</ins>
-          1. <ins>Let _now_ be 𝔽(floor(_nowNs_ / 10<sup>6</sup>)).</ins>
-          1. Return ToDateString(_now_).
+          1. <del>Return ToDateString(_now_).</del>
+        1. <ins>If NewTarget is *undefined*, return ToDateString(SystemUTCEpochMilliseconds()).</ins>
         1. Let _numberOfArgs_ be the number of elements in _values_.
         1. If _numberOfArgs_ = 0, then
-          1. <del>Let _dv_ be the time value (UTC) identifying the current time.</del>
-          1. <ins>Let _global_ be GetGlobalObject().</ins>
-          1. <ins>Let _nowNs_ be HostSystemUTCEpochNanoseconds(_global_).</ins>
-          1. <ins>Let _dv_ be 𝔽(floor(_nowNs_ / 10<sup>6</sup>)).</ins>
+          1. Let _dv_ be <del>the time value (UTC) identifying the current time</del> <ins>SystemUTCEpochMilliseconds()</ins>.
         1. Else if _numberOfArgs_ = 1, then
           1. Let _value_ be _values_[0].
           1. If _value_ is an Object and _value_ has a [[DateValue]] internal slot, then
@@ -276,9 +271,7 @@
       <ins class="block">
         <p>This function performs the following steps when called:</p>
         <emu-alg>
-          1. Let _global_ be GetGlobalObject().
-          1. Let _nowNs_ be HostSystemUTCEpochNanoseconds(_global_).
-          1. Return 𝔽(floor(_nowNs_ / 10<sup>6</sup>)).
+          1. Return SystemUTCEpochMilliseconds().
         </emu-alg>
       </ins>
     </emu-clause>

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -220,11 +220,21 @@
       <p>ECMAScript hosts that are not web browsers must use the default implementation of HostSystemUTCEpochNanoseconds.</p>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-systemutcepochmilliseconds" aoid="SystemUTCEpochMilliseconds">
+      <h1>SystemUTCEpochMilliseconds ( )</h1>
+      <emu-alg>
+        1. Let _global_ be GetGlobalObject().
+        1. Let _nowNs_ be HostSystemUTCEpochNanoseconds(_global_).
+        1. Return 𝔽(floor(_nowNs_ / 10<sup>6</sup>)).
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-systemutcepochnanoseconds" aoid="SystemUTCEpochNanoseconds">
       <h1>SystemUTCEpochNanoseconds ( )</h1>
       <emu-alg>
         1. Let _global_ be GetGlobalObject().
-        1. Return ℤ(HostSystemUTCEpochNanoseconds(_global_)).
+        1. Let _nowNs_ be HostSystemUTCEpochNanoseconds(_global_).
+        1. Return ℤ(_nowNs_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
As suggested at https://github.com/tc39/proposal-temporal/pull/2573#discussion_r1225751385 .