### PR TITLE
Fix accidental grammar change

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1117,7 +1117,7 @@
 
       TZChar[Legacy] :
           TZLeadingChar
-          `_`
+          `-`
           [+Legacy] `+`
           [+Legacy] DecimalDigit
 


### PR DESCRIPTION
|TZLeadingChar| is an ASCII letter, full stop, or underscore, and |TZChar| should extend that to include hyphen-minus but #2600 accidentally preserved `_` rather than `-` in productions of the latter.