### PR TITLE
Editorial: Introduce an SDO for checking legacy time zone names

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -977,9 +977,6 @@
           ASCIISign
           U+2212
 
-      UnpaddedHour :
-          Hour[~Padded]
-
       Hour[Padded] :
           [~Padded] DecimalDigit
           [+Padded] `0` DecimalDigit
@@ -1144,8 +1141,7 @@
 
       TimeZoneIANAName :
           TimeZoneIANANameTail[~Legacy]
-          TimeZoneIANANameTail[+Legacy] [&gt; but only if `etc/gmt` |ASCIISign| |UnpaddedHour| matches the ASCII-lowercase of the sequence of code points matched by (|TimeZoneIANANameTail|)]
-          TimeZoneIANANameTail[+Legacy] [&gt; but only if the sequence of code points matched by |TimeZoneIANANameTail| is an ASCII-case-insensitive match for an element of « *"Etc/GMT0"*, *"GMT0"*, *"GMT-0"*, *"GMT+0"*, *"EST5EDT"*, *"CST6CDT"*, *"MST7MDT"*, *"PST8PDT"* »]
+          TimeZoneIANANameTail[+Legacy] [> but only if IsLegacyIANATimeZoneName of |TimeZoneIANANameTail| is *true*]
 
       TimeZoneIdentifier :
           TimeZoneIANAName
@@ -1309,8 +1305,8 @@
           DateTime TimeZoneAnnotation Annotations?
     </emu-grammar>
 
-    <emu-clause id="sec-temporal-iso8601grammar-early-errors">
-      <h1>Early errors</h1>
+    <emu-clause id="sec-temporal-iso8601grammar-static-semantics-early-errors">
+      <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
         DateYear :
           Sign DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
@@ -1320,6 +1316,31 @@
           It is a Syntax Error if |DateYear| is *"-000000"* or *"−000000"* (U+2212 MINUS SIGN followed by `000000`).
         </li>
       </ul>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-iso8601grammar-static-semantics-islegacyianatimezonename" type="sdo">
+      <h1>Static Semantics: IsLegacyIANATimeZoneName ( ): a Boolean</h1>
+      <dl class="header">
+      </dl>
+      <emu-note>
+        <p>The IANA Time Zone Database naming guidelines do not allow digits in new named time zone identifiers, but legacy exceptions remain as described at <a href="https://data.iana.org/time-zones/theory.html">Theory and pragmatics of the tz code and data</a>. In addition to specific names mentioned there, this specification also recognizes all time zone identifiers consisting of *"Etc/GMT-"* or *"Etc/GMT+"* followed by an unpadded count of hours less than 24 as syntactically valid, even those that are not currently included in the IANA Time Zone Database (but does not require any such identifier to be an available named time zone identifier).</p>
+      </emu-note>
+      <emu-grammar>
+        TimeZoneIANANameTail[Legacy] :
+            TimeZoneIANANameComponent[?Legacy]
+            TimeZoneIANANameComponent[?Legacy] `/` TimeZoneIANANameTail[?Legacy]
+      </emu-grammar>
+      <emu-alg>
+        1. Let _name_ be the source text matched by |TimeZoneIANANameTail|.
+        1. Let _nameStr_ be CodePointsToString(_name_).
+        1. For each String _legacyName_ of « *"Etc/GMT0"*, *"GMT0"*, *"GMT-0"*, *"GMT+0"*, *"EST5EDT"*, *"CST6CDT"*, *"MST7MDT"*, *"PST8PDT"* », do
+          1. If _nameStr_ is an ASCII-case-insensitive match for _legacyName_, return *true*.
+        1. If the length of _nameStr_ &lt; 9, return *false*.
+        1. If the substring of _nameStr_ from 0 to 8 is not an ASCII-case-insensitive match for *"Etc/GMT-"* or *"Etc/GMT+"*, return *false*.
+        1. Let _hour_ be the substring of _nameStr_ from 8.
+        1. If ParseText(_hour_, |Hour[~Padded]|) is a List of errors, return *false*.
+        1. Return *true*.
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
I think I finally found a way to clean up the complexity of [|TimeZoneIANAName|](https://tc39.es/proposal-temporal/#prod-TimeZoneIANAName) needing to support ASCII-case-insensitive matches of legacy time zone names. This PR introduces an IsLegacyIANATimeZoneName syntax-directed operation that checks against both the static list and the Etc/GMT±\<UnpaddedHour> pattern, and also provides an explanatory note.