### PR TITLE
Normative: Limit Duration units to prevent arbitrary-precision integer arithmetic, and prevent loops

### DIFF
--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -937,6 +937,7 @@
         1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _dayBefore_).
         1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _dayAfter_).
         1. Let _nanoseconds_ be _offsetAfter_ - _offsetBefore_.
+        1. If abs(_nanoseconds_) > nsPerDay, throw a *RangeError* exception.
         1. If _disambiguation_ is *"earlier"*, then
           1. Let _norm_ be NormalizeTimeDuration(0, 0, 0, 0, 0, -_nanoseconds_).
           1. Let _earlierTime_ be AddTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _norm_).
@@ -978,6 +979,14 @@
         1. Repeat,
           1. Let _value_ be ? IteratorStepValue(_iteratorRecord_).
           1. If _value_ is ~done~, then
+            1. Let _numResults_ be _list_'s length.
+            1. If _numResults_ &gt; 1, then
+              1. Let _epochNs_ be a new empty List.
+              1. For each value _instant_ in _list_, do
+                1. Append _instant_.[[EpochNanoseconds]] to the end of the List _epochNs_.
+              1. Let _min_ be the least element of the List _epochNs_.
+              1. Let _max_ be the greatest element of the List _epochNs_.
+              1. If abs(ℝ(_max_ - _min_)) &gt; nsPerDay, throw a *RangeError* exception.
             1. Return _list_.
           1. If _value_ is not an Object or _value_ does not have an [[InitializedTemporalInstant]] internal slot, then
             1. Let _completion_ be ThrowCompletion(a newly created *TypeError* object).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1444,23 +1444,22 @@
         1. Else if _days_ &lt; 0 and _timeSign_ &lt; 0, then
           1. Set _days_ to _days_ + 1.
         1. Let _relativeResult_ be ? AddDaysToZonedDateTime(_startInstant_, _startDateTime_, _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _days_).
-        1. If _sign_ is 1, then
-          1. Repeat, while _days_ &gt; 0 and ℝ(_relativeResult_.[[EpochNanoseconds]]) &gt; _endNs_,
-            1. Set _days_ to _days_ - 1.
-            1. Set _relativeResult_ to ? AddDaysToZonedDateTime(_startInstant_, _startDateTime_, _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _days_).
+        1. If _sign_ = 1, and _days_ &gt; 0, and ℝ(_relativeResult_.[[EpochNanoseconds]]) &gt; _endNs_, then
+          1. Set _days_ to _days_ - 1.
+          1. Set _relativeResult_ to ? AddDaysToZonedDateTime(_startInstant_, _startDateTime_, _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _days_).
+          1. If _days_ &gt; 0 and ℝ(_relativeResult_.[[EpochNanoseconds]]) &gt; _endNs_, throw a *RangeError* exception.
         1. Set _norm_ to NormalizedTimeDurationFromEpochNanosecondsDifference(_endNs_, _relativeResult_.[[EpochNanoseconds]]).
-        1. Let _done_ be *false*.
-        1. Let _dayLengthNs_ be ~unset~.
-        1. Repeat, while _done_ is *false*,
-          1. Let _oneDayFarther_ be ? AddDaysToZonedDateTime(_relativeResult_.[[Instant]], _relativeResult_.[[DateTime]], _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _sign_).
-          1. Set _dayLengthNs_ to NormalizedTimeDurationFromEpochNanosecondsDifference(_oneDayFarther_.[[EpochNanoseconds]], _relativeResult_.[[EpochNanoseconds]]).
-          1. Let _oneDayLess_ be ! SubtractNormalizedTimeDuration(_norm_, _dayLengthNs_).
-          1. If NormalizedTimeDurationSign(_oneDayLess_) &times; _sign_ &ge; 0, then
-            1. Set _norm_ to _oneDayLess_.
-            1. Set _relativeResult_ to _oneDayFarther_.
-            1. Set _days_ to _days_ + _sign_.
-          1. Else,
-            1. Set _done_ to *true*.
+        1. Let _oneDayFarther_ be ? AddDaysToZonedDateTime(_relativeResult_.[[Instant]], _relativeResult_.[[DateTime]], _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _sign_).
+        1. Let _dayLengthNs_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_oneDayFarther.[[EpochNanoseconds]], _relativeResult_.[[EpochNanoseconds]]).
+        1. Let _oneDayLess_ be ! SubtractNormalizedTimeDuration(_norm_, _dayLengthNs_).
+        1. If NormalizedTimeDurationSign(_oneDayLess_) &times; _sign_ &ge; 0, then
+          1. Set _norm_ to _oneDayLess_.
+          1. Set _relativeResult_ to _oneDayFarther_.
+          1. Set _days_ to _days_ + _sign_.
+          1. Set _oneDayFarther_ to ? AddDaysToZonedDateTime(_relativeResult_.[[Instant]], _relativeResult_.[[DateTime]], _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _sign_).
+          1. Set _dayLengthNs_ to NormalizedTimeDurationFromEpochNanosecondsDifference(_oneDayFarther.[[EpochNanoseconds]], _relativeResult_.[[EpochNanoseconds]]).
+          1. If NormalizedTimeDurationSign(? SubtractNormalizedTimeDuration(_norm_, _dayLengthNs_)) &times; _sign_ &ge; 0, then
+            1. Throw a *RangeError* exception.
         1. If _days_ &lt; 0 and _sign_ = 1, throw a *RangeError* exception.
         1. If _days_ &gt; 0 and _sign_ = -1, throw a *RangeError* exception.
         1. If NormalizedTimeDurationSign(_norm_) = -1, then


### PR DESCRIPTION
~~This is the integer math refactor that I have mentioned in the last couple of Temporal presentations.~~

~~It is stacked on top of #2519 and #2609; only the last 7 commits belong to this change. The GitHub UI doesn't let me show a comparison with `HEAD~7` but here is a view that includes the editorial commits from #2609 but without the large PR #2519: https://github.com/tc39/proposal-temporal/compare/user-code-calls...duration-normalize-96?expand=1~~

~~Best reviewed commit by commit. There is more information in each individual commit message.~~

~~Test262 tests are in https://github.com/ptomato/test262/commits/duration-normalize but I still need to review them for complete coverage.~~

~~See: #2195, #1700.~~

This is now part 3 of 3 of this change.
Part 1: #2722
Part 2: #2727 
