### PR TITLE
chore: Override ESLint quote config for Test262

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.js]
 max_line_length = 120
+
+[polyfill/test262/]
+quote_type = double

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -92,3 +92,13 @@ overrides:
       - polyfill/test/validStrings.mjs
     rules:
       no-console: off
+  - files:
+      - polyfill/test262/**
+    rules:
+      quotes:
+        - error
+        - double
+        - avoidEscape: true
+      prettier/prettier:
+        - error
+        - singleQuote: false

--- a/package.json
+++ b/package.json
@@ -50,6 +50,14 @@
     "semi": true,
     "singleQuote": true,
     "bracketSpacing": true,
-    "arrowParens": "always"
+    "arrowParens": "always",
+    "overrides": [
+      {
+        "files": "polyfill/test262/**",
+        "options": {
+          "singleQuote": false
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
This PR updates ESLint config to use double-quotes in Test262 tests, unlike polyfill code that uses single quotes. This configuration is helpful if you're using VS Code's auto-format feature so it won't make unexpected quoting updates to Test262 tests.