### PR TITLE
Editorial: refactor time zone offset handling (prepare for #2607)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@tc39/ecma262-biblio": "=2.1.2577",
         "@typescript-eslint/eslint-plugin": "^5.59.9",
         "@typescript-eslint/parser": "^5.59.9",
-        "ecmarkup": "^17.0.0",
+        "ecmarkup": "^17.0.1",
         "eslint": "^8.42.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.0.tgz",
-      "integrity": "sha512-eQr9Vn9IPIH3rrbYEGPqfAwDJ9pg1zrOSZXc8HQwVMQ9d5tb+BsoPeKw5W1SinL09yZalcbLyqnX7rC393VRdA==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.1.tgz",
+      "integrity": "sha512-UEfqnRBbqyBdy82gpArzDf5fopvP3Rs/ogE0g2kKVlB/TEEcnY2h0w21/sVFddLtVwOzdDLJ6Kql+oBOQLtufw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3566,9 +3566,9 @@
       }
     },
     "ecmarkup": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.0.tgz",
-      "integrity": "sha512-eQr9Vn9IPIH3rrbYEGPqfAwDJ9pg1zrOSZXc8HQwVMQ9d5tb+BsoPeKw5W1SinL09yZalcbLyqnX7rC393VRdA==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.1.tgz",
+      "integrity": "sha512-UEfqnRBbqyBdy82gpArzDf5fopvP3Rs/ogE0g2kKVlB/TEEcnY2h0w21/sVFddLtVwOzdDLJ6Kql+oBOQLtufw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@tc39/ecma262-biblio": "=2.1.2577",
     "@typescript-eslint/eslint-plugin": "^5.59.9",
     "@typescript-eslint/parser": "^5.59.9",
-    "ecmarkup": "^17.0.0",
+    "ecmarkup": "^17.0.1",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -101,7 +101,7 @@ export function DateTimeFormat(locale = undefined, options = undefined) {
     this[TZ_ORIGINAL] = ro.timeZone;
   } else {
     const id = ES.ToString(timeZoneOption);
-    if (ES.IsTimeZoneOffsetString(id)) {
+    if (ES.IsOffsetTimeZoneIdentifier(id)) {
       // Note: https://github.com/tc39/ecma402/issues/683 will remove this
       throw new RangeError('Intl.DateTimeFormat does not currently support offset time zones');
     }

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -24,6 +24,7 @@ export const datesplit = new RegExp(
 const timesplit = /(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?|(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?/;
 export const offset = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5][0-9])(?:[.,](\d{1,9}))?)?)?/;
 const offsetpart = new RegExp(`([zZ])|${offset.source}?`);
+export const offsetIdentifier = offset;
 export const annotation = /\[(!)?([a-z_][a-z0-9_-]*)=([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\]/g;
 
 export const zoneddatetime = new RegExp(

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -206,7 +206,7 @@ export class ZonedDateTime {
 
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
       ES.InterpretTemporalDateTimeFields(calendar, fields, options);
-    const offsetNs = ES.ParseTimeZoneOffsetString(fields.offset);
+    const offsetNs = ES.ParseDateTimeUTCOffset(fields.offset).offsetNanoseconds;
     const timeZone = GetSlot(this, TIME_ZONE);
     const epochNanoseconds = ES.InterpretISODateTimeOffset(
       year,
@@ -472,7 +472,7 @@ export class ZonedDateTime {
     }
 
     const timeZoneIdentifier = ES.ToTemporalTimeZoneIdentifier(GetSlot(this, TIME_ZONE));
-    if (ES.IsTimeZoneOffsetString(timeZoneIdentifier)) {
+    if (ES.IsOffsetTimeZoneIdentifier(timeZoneIdentifier)) {
       // Note: https://github.com/tc39/ecma402/issues/683 will remove this
       throw new RangeError('toLocaleString does not currently support offset time zones');
     } else {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -622,8 +622,7 @@
       1. If _timeZone_ is *undefined*, then
         1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       1. If _offsetBehaviour_ is ~option~, then
-        1. If IsTimeZoneOffsetString(_offsetString_) is *false*, throw a *RangeError* exception.
-        1. Let _offsetNs_ be ParseTimeZoneOffsetString(_offsetString_).
+        1. Let _offsetNs_ be ? ParseDateTimeUTCOffset(_offsetString_).[[OffsetNanoseconds]].
       1. Else,
         1. Let _offsetNs_ be 0.
       1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNs_, _timeZone_, *"compatible"*, *"reject"*, _matchBehaviour_).
@@ -946,6 +945,7 @@
       <li>Alphabetic designators may be in lower or upper case.</li>
       <li>Period or comma may be used as the decimal separator.</li>
       <li>A time zone offset of *"-00:00"* is allowed, and means the same thing as *"+00:00"*.</li>
+      <li>UTC offsets may have seconds and up to 9 sub-second fractional digits.</li>
       <li>
         In a combined representation, combinations of date, time, and time zone offset with Basic (no `-` or `:` separators) and Extended (with `-` or `:` separators) formatting are allowed.
         (The date, time, and time zone offset must each be fully in Basic format or Extended format.)
@@ -1098,14 +1098,25 @@
       TimeFraction :
           Fraction
 
-      TimeZoneUTCOffset :
-          UTCOffset
-          UTCDesignator
-
-      TimeZoneUTCOffsetName[Extended] :
-          Sign Hour[+Padded]
-          Sign Hour[+Padded] TimeSeparator[?Extended] MinuteSecond
+      UTCOffsetWithSubMinuteComponents[Extended] :
           Sign Hour[+Padded] TimeSeparator[?Extended] MinuteSecond TimeSeparator[?Extended] MinuteSecond Fraction?
+
+      UTCOffsetMinutePrecision :
+          Sign Hour[+Padded]
+          Sign Hour[+Padded] TimeSeparator[+Extended] MinuteSecond
+          Sign Hour[+Padded] TimeSeparator[~Extended] MinuteSecond
+
+      UTCOffsetSubMinutePrecision :
+          UTCOffsetMinutePrecision
+          UTCOffsetWithSubMinuteComponents[+Extended]
+          UTCOffsetWithSubMinuteComponents[~Extended]
+
+      DateTimeUTCOffset :
+          UTCDesignator
+          UTCOffsetSubMinutePrecision
+
+      TimeZoneUTCOffsetName :
+          UTCOffsetSubMinutePrecision
 
       TZLeadingChar :
           Alpha
@@ -1145,8 +1156,7 @@
 
       TimeZoneIdentifier :
           TimeZoneIANAName
-          TimeZoneUTCOffsetName[+Extended]
-          TimeZoneUTCOffsetName[~Extended]
+          TimeZoneUTCOffsetName
 
       TimeZoneAnnotation :
           `[` AnnotationCriticalFlag? TimeZoneIdentifier `]`
@@ -1186,21 +1196,21 @@
           TimeHour TimeMinute TimeSecond TimeFraction?
 
       TimeSpecWithOptionalOffsetNotAmbiguous :
-          TimeSpec TimeZoneUTCOffset? but not one of ValidMonthDay or DateSpecYearMonth
+          TimeSpec DateTimeUTCOffset? but not one of ValidMonthDay or DateSpecYearMonth
 
       DateTime :
           Date
-          Date DateTimeSeparator TimeSpec TimeZoneUTCOffset?
+          Date DateTimeSeparator TimeSpec DateTimeUTCOffset?
 
       AnnotatedTime :
-          TimeDesignator TimeSpec TimeZoneUTCOffset? TimeZoneAnnotation? Annotations?
+          TimeDesignator TimeSpec DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
           TimeSpecWithOptionalOffsetNotAmbiguous TimeZoneAnnotation? Annotations?
 
       AnnotatedDateTime:
           DateTime TimeZoneAnnotation? Annotations?
 
       AnnotatedDateTimeTimeRequired :
-          Date DateTimeSeparator TimeSpec TimeZoneUTCOffset? TimeZoneAnnotation? Annotations?
+          Date DateTimeSeparator TimeSpec DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
 
       AnnotatedYearMonth:
           DateSpecYearMonth TimeZoneAnnotation? Annotations?
@@ -1281,7 +1291,7 @@
           Sign? DurationDesignator DurationTime
 
       TemporalInstantString :
-          Date DateTimeSeparator TimeSpec TimeZoneUTCOffset TimeZoneAnnotation? Annotations?
+          Date DateTimeSeparator TimeSpec DateTimeUTCOffset TimeZoneAnnotation? Annotations?
 
       TemporalDateTimeString :
           AnnotatedDateTime
@@ -1408,10 +1418,9 @@
         1. Set _timeZoneResult_.[[Name]] to CodePointsToString(_name_).
       1. If _parseResult_ contains a |UTCDesignator| Parse Node, then
         1. Set _timeZoneResult_.[[Z]] to *true*.
-      1. Else,
-        1. If _parseResult_ contains a |UTCOffset| Parse Node, then
-          1. Let _offset_ be the source text matched by the |UTCOffset| Parse Node contained within _parseResult_.
-          1. Set _timeZoneResult_.[[OffsetString]] to CodePointsToString(_offset_).
+      1. Else if _parseResult_ contains a |UTCOffsetSubMinutePrecision| Parse Node, then
+        1. Let _offset_ be the source text matched by the |UTCOffsetSubMinutePrecision| Parse Node contained within _parseResult_.
+        1. Set _timeZoneResult_.[[OffsetString]] to CodePointsToString(_offset_).
       1. Let _calendar_ be *undefined*.
       1. Let _calendarWasCritical_ be *false*.
       1. For each |Annotation| Parse Node _annotation_ contained within _parseResult_, do
@@ -1682,11 +1691,21 @@
     <h1>
       ParseTemporalTimeZoneString (
         _timeZoneString_: a String,
-      )
+      ): either a normal completion containing a Record containing information about the time zone, or a throw completion
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It parses the argument as either a time zone identifier or an ISO 8601 string and returns a Record representing information about the time zone.</dd>
+      <dd>
+        It parses the argument as either a time zone identifier or an ISO 8601 string.
+        The returned Record's fields are set as follows:
+        <ul>
+          <li>If _timeZoneString_ is either a named time zone identifier or offset time zone identifier, then [[Name]] is _timeZoneString_, while [[Z]] is *false* and [[OffsetString]] is *undefined*.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string with a time zone annotation containing either a named time zone identifier or offset time zone identifier, then [[Name]] is the time zone identifier contained in the annotation, while [[Z]] is *false* and [[OffsetString]] is *undefined*.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a *Z* offset designator, then [[Z]] is *true*, while [[Name]] and [[OffsetString]] are *undefined*.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a numeric UTC offset, then [[OffsetString]] is _timeZoneString_, while [[Z]] is *false* and [[Name]] is *undefined*.</li>
+          <li>Otherwise, a *RangeError* is thrown.</li>
+        </ul>
+      </dd>
     </dl>
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_timeZoneString_), |TimeZoneIdentifier|).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -532,8 +532,7 @@
         1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
         1. Assert: _offsetString_ is not *undefined*.
         1. Let _utc_ be GetUTCEpochNanoseconds(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
-        1. If IsTimeZoneOffsetString(_offsetString_) is *false*, throw a *RangeError* exception.
-        1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_offsetString_).
+        1. Let _offsetNanoseconds_ be ? ParseDateTimeUTCOffset(_offsetString_).[[OffsetNanoseconds]].
         1. Let _result_ be _utc_ - ℤ(_offsetNanoseconds_).
         1. If ! IsValidEpochNanoseconds(_result_) is *false*, then
           1. Throw a *RangeError* exception.
@@ -658,7 +657,7 @@
           1. Let _timeZoneString_ be *"Z"*.
         1. Else,
           1. Let _offsetNs_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-          1. Let _timeZoneString_ be ! FormatISOTimeZoneOffsetString(_offsetNs_).
+          1. Let _timeZoneString_ be FormatDateTimeUTCOffsetRounded(_offsetNs_).
         1. Return the string-concatenation of _dateTimeString_ and _timeZoneString_.
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2542,7 +2542,8 @@
             1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
             1. Let _dateTimeFormat_ be ! OrdinaryCreateFromConstructor(%DateTimeFormat%, %DateTimeFormat.prototype%, « [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]], [[TimeZoneName]], [[HourCycle]], [[Pattern]], [[BoundFormat]] »).
             1. Let _timeZone_ be ? ToTemporalTimeZoneIdentifier(_zonedDateTime_.[[TimeZone]]).
-            1. If IsTimeZoneOffsetString(_timeZone_) is *true*, throw a *RangeError* exception.
+            1. Let _timeZoneParseResult_ be ? ParseTimeZoneIdentifier(_timeZone_).
+            1. If _timeZoneParseResult_.[[OffsetNanoseconds]] is not ~empty~, throw a *RangeError* exception.
             1. Let _timeZoneIdentifierRecord_ be GetAvailableNamedTimeZoneIdentifier(_timeZone_).
             1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
             1. Set _timeZone_ to _timeZoneIdentifierRecord_.[[PrimaryIdentifier]].

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -218,7 +218,7 @@
 
       <p>
         Time zones in ECMAScript are represented by <dfn variants="time zone identifier">time zone identifiers</dfn>, which are Strings composed entirely of code units in the inclusive interval from <del>0x0000 to 0x007F</del><ins>0x0021 to 0x007E</ins>.
-        Time zones supported by an ECMAScript implementation may be <dfn variants="available named time zone">available named time zones</dfn>, represented by the [[Identifier]] field of the Time Zone Identifier Records returned by AvailableNamedTimeZoneIdentifiers, or <dfn variants="offset time zone">offset time zones</dfn>, represented by Strings for which IsTimeZoneOffsetString returns *true*.
+        Time zones supported by an ECMAScript implementation may be <dfn variants="available named time zone">available named time zones</dfn>, represented by the [[Identifier]] field of the Time Zone Identifier Records returned by AvailableNamedTimeZoneIdentifiers, or <dfn variants="offset time zone">offset time zones</dfn>, represented by Strings for which <del>IsTimeZoneOffsetString</del><ins>IsOffsetTimeZoneIdentifier</ins> returns *true*.
         <ins>Time zone identifiers are compared using ASCII-case-insensitive comparisons.</ins>
       </p>
       <p>
@@ -269,6 +269,275 @@
           1. Append _record_ to _result_.
         1. Assert: _result_ contains a Time Zone Identifier Record _r_ such that _r_.[[Identifier]] is *"UTC"* and _r_.[[PrimaryIdentifier]] is *"UTC"*.
         1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-systemtimezoneidentifier" oldids="sec-defaulttimezone" type="implementation-defined abstract operation">
+      <h1>SystemTimeZoneIdentifier ( ): a String</h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It returns a String representing the host environment's current time zone, which is either <del>a String representing a UTC offset for which IsTimeZoneOffsetString returns *true*, or a primary time zone identifier</del><ins>a primary time zone identifier or an offset time zone identifier</ins>.
+        </dd>
+      </dl>
+
+      <emu-alg>
+        1. If the implementation only supports the UTC time zone, return *"UTC"*.
+        1. Let _systemTimeZoneString_ be the String representing the host environment's current time zone, either: a primary time zone identifier; or an offset time zone identifier.
+        1. Return _systemTimeZoneString_.
+      </emu-alg>
+
+      <emu-note>
+        <p>
+          To ensure the level of functionality that implementations commonly provide in the methods of the Date object, it is recommended that SystemTimeZoneIdentifier return an IANA time zone name corresponding to the host environment's time zone setting, if such a thing exists.
+          GetNamedTimeZoneEpochNanoseconds and GetNamedTimeZoneOffsetNanoseconds must reflect the local political rules for standard time and daylight saving time in that time zone, if such rules exist.
+        </p>
+        <p>For example, if the host environment is a browser on a system where the user has chosen US Eastern Time as their time zone, SystemTimeZoneIdentifier returns *"America/New_York"*.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-time-zone-offset-strings">
+      <h1>Time Zone Offset String <del>Format</del><ins>Formats</ins></h1>
+
+      <del class="block">
+      <p>
+        ECMAScript defines a string interchange format for UTC offsets, derived from ISO 8601.
+        The format is described by the following grammar.
+        The usage of Unicode code points in this grammar is listed in <emu-xref href="#table-time-zone-offset-string-code-points"></emu-xref>.
+      </p>
+      </del>
+
+      <ins class="block">
+      <p>
+        ECMAScript defines string interchange formats for UTC offsets, derived from ISO 8601.
+      </p>
+      <p>
+        These formats are described by the ISO String grammar in <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>.
+        The usage of Unicode code points in this grammar is listed in <emu-xref href="#table-time-zone-offset-string-code-points"></emu-xref>.
+      </p>
+      </ins>
+
+      <p>[...]</p>
+
+      <emu-note type="editor">
+        The grammar in this section should be deleted; it is replaced by the ISO 8601 String grammar in <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>.
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-localtime" type="abstract operation">
+      <h1>
+        LocalTime (
+          _t_: a finite time value,
+        ): an integral Number
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It converts _t_ from UTC to local time.
+          The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
+        1. <ins>Let _parseResult_ be ! ParseTimeZoneIdentifier(_systemTimeZoneIdentifier_).</ins>
+        1. If <del>IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*</del><ins>_parseResult_.[[OffsetNanoseconds]] is not ~empty~</ins>, then
+          1. Let _offsetNs_ be <del>ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_)</del><ins>_parseResult_.[[OffsetNanoseconds]]</ins>.
+        1. Else,
+          1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_t_) × 10<sup>6</sup>)).
+        1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
+        1. Return _t_ + 𝔽(_offsetMs_).
+      </emu-alg>
+      <emu-note>
+        <p>If political rules for the local time _t_ are not available within the implementation, the result is _t_ because SystemTimeZoneIdentifier returns *"UTC"* and GetNamedTimeZoneOffsetNanoseconds returns 0.</p>
+      </emu-note>
+      <emu-note>
+        <p>It is required for time zone aware implementations (and recommended for all others) to use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
+      </emu-note>
+      <emu-note>
+        <p>Two different input time values <emu-eqn>_t_<sub>UTC</sub></emu-eqn> are converted to the same local time <emu-eqn>t<sub>local</sub></emu-eqn> at a negative time zone transition when there are repeated times (e.g. the daylight saving time ends or the time zone adjustment is decreased.).</p>
+        <p><emu-eqn>LocalTime(UTC(_t_<sub>local</sub>))</emu-eqn> is not necessarily always equal to <emu-eqn>_t_<sub>local</sub></emu-eqn>. Correspondingly, <emu-eqn>UTC(LocalTime(_t_<sub>UTC</sub>))</emu-eqn> is not necessarily always equal to <emu-eqn>_t_<sub>UTC</sub></emu-eqn>.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-utc-t" type="abstract operation">
+      <h1>
+        UTC (
+          _t_: a Number,
+        ): a time value
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It converts _t_ from local time to a UTC time value.
+          The local political rules for standard time and daylight saving time in effect at _t_ should be used to determine the result in the way specified in this section.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
+        1. <ins>Let _parseResult_ be ! ParseTimeZoneIdentifier(_systemTimeZoneIdentifier_).</ins>
+        1. If <del>IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*</del><ins>_parseResult_.[[OffsetNanoseconds]] is not ~empty~</ins>, then
+          1. Let _offsetNs_ be <del>ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_)</del><ins>_parseResult_.[[OffsetNanoseconds]]</ins>.
+        1. Else,
+          1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_t_)), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(msFromTime(_t_)), 0, 0).
+          1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
+          1. If _possibleInstants_ is not empty, then
+            1. Let _disambiguatedInstant_ be _possibleInstants_[0].
+          1. Else,
+            1. NOTE: _t_ represents a local time skipped at a positive time zone transition (e.g. due to daylight saving time starting or a time zone rule change increasing the UTC offset).
+            1. [declared="tBefore"] Let _possibleInstantsBefore_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_tBefore_)), ℝ(MonthFromTime(_tBefore_)) + 1, ℝ(DateFromTime(_tBefore_)), ℝ(HourFromTime(_tBefore_)), ℝ(MinFromTime(_tBefore_)), ℝ(SecFromTime(_tBefore_)), ℝ(msFromTime(_tBefore_)), 0, 0), where _tBefore_ is the largest integral Number &lt; _t_ for which _possibleInstantsBefore_ is not empty (i.e., _tBefore_ represents the last local time before the transition).
+            1. Let _disambiguatedInstant_ be the last element of _possibleInstantsBefore_.
+          1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, _disambiguatedInstant_).
+        1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
+        1. Return _t_ - 𝔽(_offsetMs_).
+      </emu-alg>
+      <p>
+        Input _t_ is nominally a time value but may be any Number value.
+        The algorithm must not limit _t_ to the time value range, so that inputs corresponding with a boundary of the time value range can be supported regardless of local UTC offset.
+        For example, the maximum time value is 8.64 × 10<sup>15</sup>, corresponding with *"+275760-09-13T00:00:00Z"*.
+        In an environment where the local time zone offset is ahead of UTC by 1 hour at that instant, it is represented by the larger input of 8.64 × 10<sup>15</sup> + 3.6 × 10<sup>6</sup>, corresponding with *"+275760-09-13T01:00:00+01:00"*.
+      </p>
+      <p>If political rules for the local time _t_ are not available within the implementation, the result is _t_ because SystemTimeZoneIdentifier returns *"UTC"* and GetNamedTimeZoneOffsetNanoseconds returns 0.</p>
+      <emu-note>
+        <p>It is required for time zone aware implementations (and recommended for all others) to use the time zone information of the IANA Time Zone Database <a href="https://www.iana.org/time-zones/">https://www.iana.org/time-zones/</a>.</p>
+        <p>
+          1:30 AM on 5 November 2017 in America/New_York is repeated twice (fall backward), but it must be interpreted as 1:30 AM UTC-04 instead of 1:30 AM UTC-05.
+          In UTC(TimeClip(MakeDate(MakeDay(2017, 10, 5), MakeTime(1, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-4 × msPerHour</emu-eqn>.
+        </p>
+        <p>
+          2:30 AM on 12 March 2017 in America/New_York does not exist, but it must be interpreted as 2:30 AM UTC-05 (equivalent to 3:30 AM UTC-04).
+          In UTC(TimeClip(MakeDate(MakeDay(2017, 2, 12), MakeTime(2, 30, 0, 0)))), the value of _offsetMs_ is <emu-eqn>-5 × msPerHour</emu-eqn>.
+        </p>
+      </emu-note>
+      <emu-note>
+        <p><emu-eqn>UTC(LocalTime(_t_<sub>UTC</sub>))</emu-eqn> is not necessarily always equal to <emu-eqn>_t_<sub>UTC</sub></emu-eqn>. Correspondingly, <emu-eqn>LocalTime(UTC(_t_<sub>local</sub>))</emu-eqn> is not necessarily always equal to <emu-eqn>_t_<sub>local</sub></emu-eqn>.</p>
+      </emu-note>
+    </emu-clause>
+
+    <p>[...]</p>
+
+    <emu-clause id="sec-timezoneestring" type="abstract operation">
+      <h1>
+        TimeZoneString (
+          _tv_: an integral Number,
+        ): a String
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
+        1. <ins>Let _parseResult_ be ! ParseTimeZoneIdentifier(_systemTimeZoneIdentifier_).</ins>
+        1. If <del>IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*</del><ins>_parseResult_.[[OffsetNanoseconds]] is not ~empty~</ins>, then
+          1. Let _offsetNs_ be <del>ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_)</del><ins>_parseResult_.[[OffsetNanoseconds]]</ins>.
+        1. Else,
+          1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × 10<sup>6</sup>)).
+        1. <del>Let _offset_ be 𝔽(truncate(_offsetNs_ / 10<sup>6</sup>)).</del>
+        1. <del>If _offset_ is *+0*<sub>𝔽</sub> or _offset_ > *+0*<sub>𝔽</sub>, then</del>
+          1. <del>Let _offsetSign_ be *"+"*.</del>
+          1. <del>Let _absOffset_ be _offset_.</del>
+        1. <del>Else,</del>
+          1. <del>Let _offsetSign_ be *"-"*.</del>
+          1. <del>Let _absOffset_ be -_offset_.</del>
+        1. <del>Let _offsetMin_ be ToZeroPaddedDecimalString(ℝ(MinFromTime(_absOffset_)), 2).</del>
+        1. <del>Let _offsetHour_ be ToZeroPaddedDecimalString(ℝ(HourFromTime(_absOffset_)), 2).</del>
+        1. <ins>Let _offsetString_ be FormatOffsetTimeZoneIdentifier(_offsetNs_, ~legacy~).</ins>
+        1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
+        1. <del>Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.</del>
+        1. <ins>Return the string-concatenation of _offsetString_ and _tzName_.</ins>
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-isoffsettimezoneidentifier" oldids="sec-istimezoneoffsetstring" type="abstract operation">
+      <del class="block">
+      <h1>
+        IsTimeZoneOffsetString (
+          _offsetString_: a String,
+        ): a Boolean
+      </h1>
+      </del>
+      <ins class="block">
+      <h1>
+        IsOffsetTimeZoneIdentifier (
+          _offsetString_: a String,
+        ): a Boolean
+      </h1>
+      </ins>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The return value indicates whether _offsetString_ conforms to the grammar given by <del>|UTCOffset|</del><ins>|TimeZoneUTCOffsetName|</ins>.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _parseResult_ be ParseText(StringToCodePoints(_offsetString_), <del>|UTCOffset|</del><ins>|TimeZoneUTCOffsetName|</ins>).
+        1. If _parseResult_ is a List of errors, return *false*.
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-parsedatetimeutcoffset" oldids="sec-parsetimezoneoffsetstring" type="abstract operation">
+      <del class="block">
+      <h1>
+        ParseTimeZoneOffsetString (
+          _offsetString_: a String
+        ): either a normal completion containing a Record, or a throw completion
+      </h1>
+      </del>
+      <ins class="block">
+      <h1>
+        ParseDateTimeUTCOffset (
+          _offsetString_: a String
+        ): either a normal completion containing a Record, or a throw completion
+      </h1>
+      </ins>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          <del>The return value is the UTC offset, as a number of nanoseconds, that corresponds to the String _offsetString_.</del>
+          <ins>[[OffsetNanoseconds]] is the UTC offset, as a number of nanoseconds, that corresponds to _offsetString_.</ins>
+          <ins>[[HasSubMinutePrecision]] is *true* if _offsetString_ includes seconds or sub-second units, and *false* otherwise.</ins>
+          <ins>If _offsetString_ is invalid, a *RangeError* is thrown.</ins>
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _parseResult_ be ParseText(StringToCodePoints(_offsetString_), <del>|UTCOffset|</del><ins>|UTCOffsetSubMinutePrecision|</ins>).
+        1. <del>Assert: _parseResult_ is not a List of errors.</del>
+        1. <ins>If _parseResult_ is a List of errors, throw a *RangeError* exception.</ins>
+        1. <ins>Let _hasSubMinutePrecision_ be *false*.</ins>
+        1. Assert: _parseResult_ contains a |TemporalSign| Parse Node.
+        1. Let _parsedSign_ be the source text matched by the |TemporalSign| Parse Node contained within _parseResult_.
+        1. If _parsedSign_ is the single code point U+002D (HYPHEN-MINUS) or U+2212 (MINUS SIGN), then
+          1. Let _sign_ be -1.
+        1. Else,
+          1. Let _sign_ be 1.
+        1. NOTE: Applications of StringToNumber below do not lose precision, since each of the parsed values is guaranteed to be a sufficiently short string of decimal digits.
+        1. Assert: _parseResult_ contains an |Hour| Parse Node.
+        1. Let _parsedHours_ be the source text matched by the |Hour| Parse Node contained within _parseResult_.
+        1. Let _hours_ be ℝ(StringToNumber(CodePointsToString(_parsedHours_))).
+        1. If _parseResult_ does not contain a |MinuteSecond| Parse Node, then
+          1. Let _minutes_ be 0.
+        1. Else,
+          1. Let _parsedMinutes_ be the source text matched by the first |MinuteSecond| Parse Node contained within _parseResult_.
+          1. Let _minutes_ be ℝ(StringToNumber(CodePointsToString(_parsedMinutes_))).
+        1. If _parseResult_ does not contain two |MinuteSecond| Parse Nodes, then
+          1. Let _seconds_ be 0.
+          1. <ins>Let _nanoseconds_ be 0.</ins>
+        1. Else,
+          1. <ins>Set _hasSubMinutePrecision_ to *true*.</ins>
+          1. Let _parsedSeconds_ be the source text matched by the second |MinuteSecond| Parse Node contained within _parseResult_.
+          1. Let _seconds_ be ℝ(StringToNumber(CodePointsToString(_parsedSeconds_))).
+          1. <ins>If _parseResult_ contains a |TemporalDecimalFraction| Parse Node, then</ins>
+            1. <ins>Let _parsedFraction_ be the source text matched by the |TemporalDecimalFraction| Parse Node contained within _parseResult_.</ins>
+            1. <ins>Let _fraction_ be the string-concatenation of CodePointsToString(_parsedFraction_) and *"000000000"*.</ins>
+            1. <ins>Let _nanosecondsString_ be the substring of _fraction_ from 1 to 10.</ins>
+            1. <ins>Let _nanoseconds_ be ℝ(StringToNumber(_nanosecondsString_)).</ins>
+        1. <del>If _parseResult_ does not contain a |TemporalDecimalFraction| Parse Node, then</del>
+          1. <del>Let _nanoseconds_ be 0.</del>
+        1. <del>Else,</del>
+          1. <del>Let _parsedFraction_ be the source text matched by the |TemporalDecimalFraction| Parse Node contained within _parseResult_.</del>
+          1. <del>Let _fraction_ be the string-concatenation of CodePointsToString(_parsedFraction_) and *"000000000"*.</del>
+          1. <del>Let _nanosecondsString_ be the substring of _fraction_ from 1 to 10.</del>
+          1. <del>Let _nanoseconds_ be ℝ(StringToNumber(_nanosecondsString_)).</del>
+        1. <del>Return _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).</del>
+        1. <ins>Let _offsetNanoseconds_ be _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).</ins>
+        1. <ins>Return the Record { [[OffsetNanoseconds]]: _offsetNanoseconds_, [[HasSubMinutePrecision]]: _hasSubMinutePrecision_ }.</ins>
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -32,7 +32,10 @@
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. Set _identifier_ to ? ToString(_identifier_).
-        1. If IsTimeZoneOffsetString(_identifier_) is *false*, then
+        1. Let _parseResult_ be ? ParseTimeZoneIdentifier(_identifier_).
+        1. If _parseResult_.[[OffsetNanoseconds]] is not ~empty~, then
+          1. Set _identifier_ to FormatOffsetTimeZoneIdentifier(_parseResult_.[[OffsetNanoseconds]], ~separated~).
+        1. Else,
           1. Let _timeZoneIdentifierRecord_ be GetAvailableNamedTimeZoneIdentifier(_identifier_).
           1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
           1. Set _identifier_ to _timeZoneIdentifierRecord_.[[PrimaryIdentifier]].
@@ -98,7 +101,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return FormatTimeZoneOffsetString(_timeZone_.[[OffsetNanoseconds]]).
+        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return FormatOffsetTimeZoneIdentifier(_timeZone_.[[OffsetNanoseconds]], ~separated~).
         1. Return _timeZone_.[[Identifier]].
       </emu-alg>
     </emu-clause>
@@ -222,7 +225,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return FormatTimeZoneOffsetString(_timeZone_.[[OffsetNanoseconds]]).
+        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return FormatOffsetTimeZoneIdentifier(_timeZone_.[[OffsetNanoseconds]], ~separated~).
         1. Return _timeZone_.[[Identifier]].
       </emu-alg>
     </emu-clause>
@@ -235,7 +238,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return FormatTimeZoneOffsetString(_timeZone_.[[OffsetNanoseconds]]).
+        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return FormatOffsetTimeZoneIdentifier(_timeZone_.[[OffsetNanoseconds]], ~separated~).
         1. Return _timeZone_.[[Identifier]].
       </emu-alg>
     </emu-clause>
@@ -281,7 +284,7 @@
             </td>
             <td>
               An integer for nanoseconds representing the constant offset of this time zone relative to UTC, or ~empty~ if the instance represents a named time zone.
-              If not ~empty~, this value must be greater than &minus;8.64 &times; 10<sup>13</sup> nanoseconds (&minus;24 hours) and smaller than &plus;8.64 &times; 10<sup>13</sup> nanoseconds (&plus;24 hours).
+              If not ~empty~, this value must be in the interval from &minus;8.64 &times; 10<sup>13</sup> (exclusive) to &plus;8.64 &times; 10<sup>13</sup> (exclusive) (i.e., strictly less than 24 hours in magnitude).
             </td>
           </tr>
         </tbody>
@@ -319,10 +322,13 @@
       <emu-alg>
         1. If _newTarget_ is not present, set _newTarget_ to %Temporal.TimeZone%.
         1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.TimeZone.prototype%"*, « [[InitializedTemporalTimeZone]], [[Identifier]], [[OffsetNanoseconds]] »).
-        1. If IsTimeZoneOffsetString(_identifier_) is *true*, then
+        1. Assert: _identifier_ is an available named time zone identifier or an offset time zone identifier.
+        1. Let _parseResult_ be ! ParseTimeZoneIdentifier(_identifier_).
+        1. If _parseResult_.[[OffsetNanoseconds]] is not ~empty~, then
           1. Set _object_.[[Identifier]] to ~empty~.
-          1. Set _object_.[[OffsetNanoseconds]] to ParseTimeZoneOffsetString(_identifier_).
+          1. Set _object_.[[OffsetNanoseconds]] to _parseResult_.[[OffsetNanoseconds]].
         1. Else,
+          1. Assert: _parseResult_.[[Name]] is not ~empty~.
           1. Assert: GetAvailableNamedTimeZoneIdentifier(_identifier_).[[PrimaryIdentifier]] is _identifier_.
           1. Set _object_.[[Identifier]] to _identifier_.
           1. Set _object_.[[OffsetNanoseconds]] to ~empty~.
@@ -336,8 +342,8 @@
           Although the [[Identifier]] internal slot is a String in this specification, implementations may choose to store named time zone identifiers it in any other form (for example as an enumeration or index into a List of identifier strings) as long as the String can be regenerated when needed.
         </p>
         <p>
-          Similar flexibility exists for the storage of the [[OffsetNanoseconds]] internal slot, which can be interchangeably represented as a 6-byte integer or as a String value that may be as long as 19 characters.
-          ParseTimeZoneOffsetString and FormatTimeZoneOffsetString may be used to losslessly convert one representation to the other.
+          Similar flexibility exists for the storage of the [[OffsetNanoseconds]] internal slot, which can be interchangeably represented as a 6-byte signed integer or as a String value that may be as long as 19 characters.
+          ParseTimeZoneIdentifier and FormatOffsetTimeZoneIdentifier may be used to losslessly convert one representation to the other.
           Implementations are free to store either or both representations.
         </p>
       </emu-note>
@@ -464,19 +470,34 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-formattimezoneoffsetstring" aoid="FormatTimeZoneOffsetString">
-      <h1>FormatTimeZoneOffsetString ( _offsetNanoseconds_ )</h1>
+    <emu-clause id="sec-temporal-formatoffsettimezoneidentifier" type="abstract operation">
+      <h1>
+        FormatOffsetTimeZoneIdentifier (
+          _offsetNanoseconds_: an integer,
+          _style_: ~legacy~ or ~separated~,
+        ): a String
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It formats a time zone offset, in nanoseconds, into a UTC offset string.
+          If _style_ is ~legacy~, then the output will be formatted like ±HHMM.
+          If _style_ is ~separated~, then the output will be formatted like ±HH:MM if _offsetNanoseconds_ represents an integer number of minutes, like ±HH:MM:SS if _offsetNanoseconds_ represents an integer number of seconds, and otherwise like ±HH:MM:SS.fff where "fff" is a sequence of at least 1 and at most 9 fractional seconds digits with no trailing zeroes.
+        </dd>
+      </dl>
       <emu-alg>
-        1. Assert: _offsetNanoseconds_ is an integer.
         1. If _offsetNanoseconds_ &ge; 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
         1. Set _offsetNanoseconds_ to abs(_offsetNanoseconds_).
-        1. Let _nanoseconds_ be _offsetNanoseconds_ modulo 10<sup>9</sup>.
-        1. Let _seconds_ be floor(_offsetNanoseconds_ / 10<sup>9</sup>) modulo 60.
-        1. Let _minutes_ be floor(_offsetNanoseconds_ / (6 &times; 10<sup>10</sup>)) modulo 60.
-        1. Let _hours_ be floor(_offsetNanoseconds_ / (3.6 &times; 10<sup>12</sup>)).
+        1. Let _hours_ be floor(_offsetNanoseconds_ / (3.6 × 10<sup>12</sup>)).
         1. Let _h_ be ToZeroPaddedDecimalString(_hours_, 2).
+        1. Let _minutes_ be floor(_offsetNanoseconds_ / (6 × 10<sup>10</sup>)) modulo 60.
         1. Let _m_ be ToZeroPaddedDecimalString(_minutes_, 2).
+        1. If _style_ is ~legacy~, then
+          1. Assert _offsetNanoseconds_ modulo (6 × 10<sup>10</sup>) = 0.
+          1. Return the string-concatenation of _sign_, _h_, and _m_.
+        1. Let _seconds_ be floor(_offsetNanoseconds_ / 10<sup>9</sup>) modulo 60.
         1. Let _s_ be ToZeroPaddedDecimalString(_seconds_, 2).
+        1. Let _nanoseconds_ be _offsetNanoseconds_ modulo 10<sup>9</sup>.
         1. If _nanoseconds_ &ne; 0, then
           1. Let _fraction_ be ToZeroPaddedDecimalString(_nanoseconds_, 9).
           1. Set _fraction_ to the longest possible substring of _fraction_ starting at position 0 and not ending with the code unit 0x0030 (DIGIT ZERO).
@@ -489,21 +510,19 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-formatisotimezoneoffsetstring" aoid="FormatISOTimeZoneOffsetString">
-      <h1>FormatISOTimeZoneOffsetString ( _offsetNanoseconds_ )</h1>
-      <p>
-        The abstract operation FormatISOTimeZoneOffsetString is similar to FormatTimeZoneOffsetString but rounds the offset to the nearest minute boundary, in order to produce a ±HH:MM format offset string for use in ISO 8601 strings.
-      </p>
+    <emu-clause id="sec-temporal-formatdatetimeutcoffsetrounded" type="abstract operation">
+      <h1>
+        FormatDateTimeUTCOffsetRounded (
+          _offsetNanoseconds_: an integer,
+        ) : a String
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It rounds _offsetNanoseconds_ to the nearest minute boundary and formats the rounded value into a ±HH:MM format, to support available named time zones that may have sub-minute offsets.</dd>
+      </dl>
       <emu-alg>
-        1. Assert: _offsetNanoseconds_ is an integer.
-        1. Set _offsetNanoseconds_ to RoundNumberToIncrement(_offsetNanoseconds_, 60 &times; 10<sup>9</sup>, *"halfExpand"*).
-        1. If _offsetNanoseconds_ &ge; 0, let _sign_ be *"+"*; otherwise, let _sign_ be *"-"*.
-        1. Set _offsetNanoseconds_ to abs(_offsetNanoseconds_).
-        1. Let _minutes_ be _offsetNanoseconds_ / (60 &times; 10<sup>9</sup>) modulo 60.
-        1. Let _hours_ be floor(_offsetNanoseconds_ / (3600 &times; 10<sup>9</sup>)).
-        1. Let _h_ be ToZeroPaddedDecimalString(_hours_, 2).
-        1. Let _m_ be ToZeroPaddedDecimalString(_minutes_, 2).
-        1. Return the string-concatenation of _sign_, _h_, the code unit 0x003A (COLON), and _m_.
+        1. Set _offsetNanoseconds_ to RoundNumberToIncrement(_offsetNanoseconds_, 6 × 10<sup>10</sup>, *"halfExpand"*).
+        1. Return FormatOffsetTimeZoneIdentifier(_offsetNanoseconds_, ~separated~).
       </emu-alg>
     </emu-clause>
 
@@ -529,23 +548,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-canonicalizetimezoneoffsetstring" type="abstract operation">
-      <h1>
-        CanonicalizeTimeZoneOffsetString (
-          _offsetString_: a String
-        ): a String
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It converts _offsetString_, which must be a valid time zone offset string, into its canonical form.</dd>
-      </dl>
-      <emu-alg>
-        1. Assert: IsTimeZoneOffsetString(_offsetString_) is *true*.
-        1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_offsetString_).
-        1. Return ! FormatTimeZoneOffsetString(_offsetNanoseconds_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-totemporaltimezoneslotvalue" type="abstract operation">
       <h1>
         ToTemporalTimeZoneSlotValue (
@@ -566,12 +568,15 @@
         1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_identifier_).
         1. If _parseResult_.[[Name]] is not *undefined*, then
           1. Let _name_ be _parseResult_.[[Name]].
-          1. If IsTimeZoneOffsetString(_name_) is *true*, return CanonicalizeTimeZoneOffsetString(_name_).
+          1. Let _offsetNanoseconds_ be ? ParseTimeZoneIdentifier(_name_).[[OffsetNanoseconds]].
+          1. If _offsetNanoseconds_ is not ~empty~, return FormatOffsetTimeZoneIdentifier(_offsetNanoseconds_, ~separated~).
           1. Let _timeZoneIdentifierRecord_ be GetAvailableNamedTimeZoneIdentifier(_name_).
           1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
           1. Return _timeZoneIdentifierRecord_.[[PrimaryIdentifier]].
         1. If _parseResult_.[[Z]] is *true*, return *"UTC"*.
-        1. Return CanonicalizeTimeZoneOffsetString(_parseResult_.[[OffsetString]]).
+        1. Let _offsetParseResult_ be ! ParseDateTimeUTCOffset(_parseResult_.[[OffsetString]]).
+        1. If _offsetParseResult_.[[HasSubMinutePrecision]] is *true*, throw a *RangeError* exception.
+        1. Return FormatOffsetTimeZoneIdentifier(_offsetParseResult_.[[OffsetNanoseconds]], ~separated~).
       </emu-alg>
     </emu-clause>
 
@@ -587,7 +592,7 @@
       </dl>
       <emu-alg>
         1. If _timeZoneSlotValue_ is a String, then
-          1. Assert: Either IsTimeZoneOffsetString(_timeZoneSlotValue_) is *true*, or GetAvailableNamedTimeZoneIdentifier(_timeZoneSlotValue_) is not ~empty~.
+          1. Assert: Either IsOffsetTimeZoneIdentifier(_timeZoneSlotValue_) is *true*, or GetAvailableNamedTimeZoneIdentifier(_timeZoneSlotValue_) is not ~empty~.
           1. Return _timeZoneSlotValue_.
         1. Let _identifier_ be ? Get(_timeZoneSlotValue_, *"id"*).
         1. If _identifier_ is not a String, throw a *TypeError* exception.
@@ -656,7 +661,7 @@
       </dl>
       <emu-alg>
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. Return ! FormatTimeZoneOffsetString(_offsetNanoseconds_).
+        1. Return FormatOffsetTimeZoneIdentifier(_offsetNanoseconds_, ~separated~).
       </emu-alg>
     </emu-clause>
 
@@ -808,6 +813,34 @@
         1. Let _timeZoneTwo_ be ? ToTemporalTimeZoneIdentifier(_two_).
         1. If _timeZoneOne_ is _timeZoneTwo_, return *true*.
         1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-parsetimezoneidentifier" type="abstract operation">
+      <h1>
+        ParseTimeZoneIdentifier (
+          _identifier_: a String,
+        ): either a normal completion containing a Record containing [[Name]] and [[OffsetNanoseconds]] fields, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          If _identifier_ is a named time zone identifier, [[Name]] will be _identifier_ and [[OffsetNanoseconds]] will be ~empty~.
+          If _identifier_ is an offset time zone identifier, [[Name]] will be ~empty~ and [[OffsetNanoseconds]] will be a signed integer.
+          Otherwise, a *RangeError* will be thrown.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _parseResult_ be ParseText(StringToCodePoints(_identifier_), |TimeZoneIdentifier|).
+        1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
+        1. If _parseResult_ contains a |TimeZoneIANAName| Parse Node, then
+          1. Let _name_ be the source text matched by the |TimeZoneIANAName| Parse Node contained within _parseResult_.
+          1. Return the Record { [[Name]]: _name_, [[OffsetNanoseconds]]: ~empty~ }.
+        1. Else,
+          1. Assert: _parseResult_ contains a |TimeZoneUTCOffsetName| Parse Node.
+          1. Let _offsetString_ be the source text matched by the |TimeZoneUTCOffsetName| Parse Node contained within _parseResult_.
+          1. Let _offsetNanoseconds_ be ! ParseDateTimeUTCOffset(_offsetString_).
+          1. Return the Record { [[Name]]: ~empty~, [[OffsetNanoseconds]]: _offsetNanoseconds_ }.
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -598,8 +598,7 @@
         1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Let _offsetString_ be ! Get(_fields_, *"offset"*).
         1. Assert: Type(_offsetString_) is String.
-        1. If IsTimeZoneOffsetString(_offsetString_) is *false*, throw a *RangeError* exception.
-        1. Let _offsetNanoseconds_ be ParseTimeZoneOffsetString(_offsetString_).
+        1. Let _offsetNanoseconds_ be ? ParseDateTimeUTCOffset(_offsetString_).[[OffsetNanoseconds]].
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_, ~match exactly~).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
@@ -1189,8 +1188,7 @@
           1. Perform ? ToTemporalOverflow(_options_).
         1. Let _offsetNanoseconds_ be 0.
         1. If _offsetBehaviour_ is ~option~, then
-          1. If IsTimeZoneOffsetString(_offsetString_) is *false*, throw a *RangeError* exception.
-          1. Set _offsetNanoseconds_ to ParseTimeZoneOffsetString(_offsetString_).
+          1. Set _offsetNanoseconds_ to ? ParseDateTimeUTCOffset(_offsetString_).[[OffsetNanoseconds]].
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offsetOption_, _matchBehaviour_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
@@ -1252,7 +1250,7 @@
           1. Let _offsetString_ be the empty String.
         1. Else,
           1. Let _offsetNs_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-          1. Let _offsetString_ be ! FormatISOTimeZoneOffsetString(_offsetNs_).
+          1. Let _offsetString_ be FormatDateTimeUTCOffsetRounded(_offsetNs_).
         1. If _showTimeZone_ is *"never"*, then
           1. Let _timeZoneString_ be the empty String.
         1. Else,


### PR DESCRIPTION
This PR refactors spec text and polyfill code for time zone offsets, splitting the handling of offsets used as time zone identifiers from offsets used  for ZDT's `offset` property (both parsing and output), and for parsing of Instant and the RFC3339 portion of ZDT strings.

This split will prepare for the normative changes in #2607 and will make the normative PR easier to review. 

Here's more details about what's in this PR: 

* Moves offset string grammar into abstractops.html, remove it from mainadditions.html
* Splits the `|UTCOffset|` production into `|UTCOffsetMinutePrecision|` and `|UTCOffsetSubMinutePrecision|`. 
* Replaces the pattern of calling `IsTimeZoneOffsetString`, throwing if it's `false`, and then calling `ParseTimeZoneOffsetString`. Instead, offset-parsing AOs (like other Temporal parsing AOs) will throw if they're provided with an invalid string, which lets us replace two AO calls and an `If` statement with a single call to a parsing AO.
* Splits `ParseTimeZoneOffsetString` into two new AOs for parsing ISO string offsets and offset time zone identifiers, respectively. Both return Records instead of primtives:
  * `ParseUTCOffsetString` returns { [[OffsetNanoseconds]: an integer, [[HasSubMinutePrecision]]: a Boolean }
  * `ParseTimeZoneIdentifier` returns { [[Name]]: a String or `~empty~`, [[OffsetNanoseconds]]: an integer or `~empty~`}
  * If the input string isn't valid, both new AOs throw a RangeError.
* Renames  `IsTimeZoneOffsetString` to `IsOffsetTimeZoneIdentifier`.
* Updates ecmarkup to a version that supports `<ins>` and `<del>` in structured headers in order to support the renames above.
* Aligns offset parsing in the polyfill more closely to the spec text.
* Adds a note to ISO grammar about how we extend the standard to allow 9 digits for instant string offsets.
