### PR TITLE
Editorial: refactor TimeZone [[OffsetNanoseconds]] internal slot to [[OffsetMinutes]]

### DIFF
--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -23,8 +23,8 @@ export class TimeZone {
   constructor(identifier) {
     let stringIdentifier = ES.RequireString(identifier);
     const parseResult = ES.ParseTimeZoneIdentifier(identifier);
-    if (parseResult.offsetNanoseconds !== undefined) {
-      stringIdentifier = ES.FormatOffsetTimeZoneIdentifier(parseResult.offsetNanoseconds);
+    if (parseResult.offsetMinutes !== undefined) {
+      stringIdentifier = ES.FormatOffsetTimeZoneIdentifier(parseResult.offsetMinutes);
     } else {
       const record = ES.GetAvailableNamedTimeZoneIdentifier(stringIdentifier);
       if (!record) throw new RangeError(`Invalid time zone identifier: ${stringIdentifier}`);
@@ -51,8 +51,8 @@ export class TimeZone {
     instant = ES.ToTemporalInstant(instant);
     const id = GetSlot(this, TIMEZONE_ID);
 
-    const offsetNanoseconds = ES.ParseTimeZoneIdentifier(id).offsetNanoseconds;
-    if (offsetNanoseconds !== undefined) return offsetNanoseconds;
+    const offsetMinutes = ES.ParseTimeZoneIdentifier(id).offsetMinutes;
+    if (offsetMinutes !== undefined) return offsetMinutes * 60e9;
 
     return ES.GetNamedTimeZoneOffsetNanoseconds(id, GetSlot(instant, EPOCHNANOSECONDS));
   }
@@ -80,8 +80,8 @@ export class TimeZone {
     const Instant = GetIntrinsic('%Temporal.Instant%');
     const id = GetSlot(this, TIMEZONE_ID);
 
-    const offsetNanoseconds = ES.ParseTimeZoneIdentifier(id).offsetNanoseconds;
-    if (offsetNanoseconds !== undefined) {
+    const offsetMinutes = ES.ParseTimeZoneIdentifier(id).offsetMinutes;
+    if (offsetMinutes !== undefined) {
       const epochNs = ES.GetUTCEpochNanoseconds(
         GetSlot(dateTime, ISO_YEAR),
         GetSlot(dateTime, ISO_MONTH),
@@ -94,7 +94,7 @@ export class TimeZone {
         GetSlot(dateTime, ISO_NANOSECOND)
       );
       if (epochNs === null) throw new RangeError('DateTime outside of supported range');
-      return [new Instant(epochNs.minus(offsetNanoseconds))];
+      return [new Instant(epochNs.minus(offsetMinutes * 60e9))];
     }
 
     const possibleEpochNs = ES.GetNamedTimeZoneEpochNanoseconds(

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -725,9 +725,9 @@
     <dl class="header">
       <dt>description</dt>
       <dd>
-        The output will be formatted like ±HH:MM if _precision_ is *"minute"*.
-        Otherwise, the output will be formatted like ±HH:MM:SS if _precision_ is zero, or if _subSecondNanoseconds_ is zero and _precision is *"auto"*.
-        Otherwise, the output will be formatted like ±HH:MM:SS.fff where "fff" is a sequence of fractional seconds digits, truncated to _precision_ digits or (if _precision_ is *"auto"*) to the last non-zero digit.
+        The output will be formatted like HH:MM if _precision_ is *"minute"*.
+        Otherwise, the output will be formatted like HH:MM:SS if _precision_ is zero, or if _subSecondNanoseconds_ is zero and _precision is *"auto"*.
+        Otherwise, the output will be formatted like HH:MM:SS.fff where "fff" is a sequence of fractional seconds digits, truncated to _precision_ digits or (if _precision_ is *"auto"*) to the last non-zero digit.
       </dd>
     </dl>
     <emu-alg>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2543,7 +2543,7 @@
             1. Let _dateTimeFormat_ be ! OrdinaryCreateFromConstructor(%DateTimeFormat%, %DateTimeFormat.prototype%, « [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]], [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]], [[FractionalSecondDigits]], [[TimeZoneName]], [[HourCycle]], [[Pattern]], [[BoundFormat]] »).
             1. Let _timeZone_ be ? ToTemporalTimeZoneIdentifier(_zonedDateTime_.[[TimeZone]]).
             1. Let _timeZoneParseResult_ be ? ParseTimeZoneIdentifier(_timeZone_).
-            1. If _timeZoneParseResult_.[[OffsetNanoseconds]] is not ~empty~, throw a *RangeError* exception.
+            1. If _timeZoneParseResult_.[[OffsetMinutes]] is not ~empty~, throw a *RangeError* exception.
             1. Let _timeZoneIdentifierRecord_ be GetAvailableNamedTimeZoneIdentifier(_timeZone_).
             1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
             1. Set _timeZone_ to _timeZoneIdentifierRecord_.[[PrimaryIdentifier]].

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -325,8 +325,8 @@
       <emu-alg>
         1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
         1. <ins>Let _parseResult_ be ! ParseTimeZoneIdentifier(_systemTimeZoneIdentifier_).</ins>
-        1. If <del>IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*</del><ins>_parseResult_.[[OffsetNanoseconds]] is not ~empty~</ins>, then
-          1. Let _offsetNs_ be <del>ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_)</del><ins>_parseResult_.[[OffsetNanoseconds]]</ins>.
+        1. If <del>IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*</del><ins>_parseResult_.[[OffsetMinutes]] is not ~empty~</ins>, then
+          1. Let _offsetNs_ be <del>ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_)</del><ins>_parseResult_.[[OffsetMinutes]] × (60 × 10<sup>9</sup>)</ins>.
         1. Else,
           1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_t_) × 10<sup>6</sup>)).
         1. Let _offsetMs_ be truncate(_offsetNs_ / 10<sup>6</sup>).
@@ -360,8 +360,8 @@
       <emu-alg>
         1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
         1. <ins>Let _parseResult_ be ! ParseTimeZoneIdentifier(_systemTimeZoneIdentifier_).</ins>
-        1. If <del>IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*</del><ins>_parseResult_.[[OffsetNanoseconds]] is not ~empty~</ins>, then
-          1. Let _offsetNs_ be <del>ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_)</del><ins>_parseResult_.[[OffsetNanoseconds]]</ins>.
+        1. If <del>IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*</del><ins>_parseResult_.[[OffsetMinutes]] is not ~empty~</ins>, then
+          1. Let _offsetNs_ be <del>ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_)</del><ins>_parseResult_.[[OffsetMinutes]] × (60 × 10<sup>9</sup>)</ins>.
         1. Else,
           1. Let _possibleInstants_ be GetNamedTimeZoneEpochNanoseconds(_systemTimeZoneIdentifier_, ℝ(YearFromTime(_t_)), ℝ(MonthFromTime(_t_)) + 1, ℝ(DateFromTime(_t_)), ℝ(HourFromTime(_t_)), ℝ(MinFromTime(_t_)), ℝ(SecFromTime(_t_)), ℝ(msFromTime(_t_)), 0, 0).
           1. NOTE: The following steps ensure that when _t_ represents local time repeating multiple times at a negative time zone transition (e.g. when the daylight saving time ends or the time zone offset is decreased due to a time zone rule change) or skipped local time at a positive time zone transition (e.g. when the daylight saving time starts or the time zone offset is increased due to a time zone rule change), _t_ is interpreted using the time zone offset before the transition.
@@ -429,11 +429,13 @@
       </dl>
       <emu-alg>
         1. Let _systemTimeZoneIdentifier_ be SystemTimeZoneIdentifier().
-        1. <ins>Let _parseResult_ be ! ParseTimeZoneIdentifier(_systemTimeZoneIdentifier_).</ins>
-        1. If <del>IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*</del><ins>_parseResult_.[[OffsetNanoseconds]] is not ~empty~</ins>, then
-          1. Let _offsetNs_ be <del>ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_)</del><ins>_parseResult_.[[OffsetNanoseconds]]</ins>.
-        1. Else,
+        1. <del>If IsTimeZoneOffsetString(_systemTimeZoneIdentifier_) is *true*, then</del>
+          1. <del>Let _offsetNs_ be ParseTimeZoneOffsetString(_systemTimeZoneIdentifier_).</del>
+        1. <del>Else,</del>
+        1. <ins>Let _offsetMinutes_ be ! ParseTimeZoneIdentifier(_systemTimeZoneIdentifier_).[[OffsetMinutes]].</ins>
+        1. <ins>If _offsetMinutes_ is ~empty~, then</ins>
           1. Let _offsetNs_ be GetNamedTimeZoneOffsetNanoseconds(_systemTimeZoneIdentifier_, ℤ(ℝ(_tv_) × 10<sup>6</sup>)).
+          1. <ins>Set _offsetMinutes_ to truncate(_offsetNs_ / (60 × 10<sup>9</sup>)).</ins>
         1. <del>Let _offset_ be 𝔽(truncate(_offsetNs_ / 10<sup>6</sup>)).</del>
         1. <del>If _offset_ is *+0*<sub>𝔽</sub> or _offset_ > *+0*<sub>𝔽</sub>, then</del>
           1. <del>Let _offsetSign_ be *"+"*.</del>
@@ -443,7 +445,7 @@
           1. <del>Let _absOffset_ be -_offset_.</del>
         1. <del>Let _offsetMin_ be ToZeroPaddedDecimalString(ℝ(MinFromTime(_absOffset_)), 2).</del>
         1. <del>Let _offsetHour_ be ToZeroPaddedDecimalString(ℝ(HourFromTime(_absOffset_)), 2).</del>
-        1. <ins>Let _offsetString_ be FormatOffsetTimeZoneIdentifier(_offsetNs_, ~legacy~).</ins>
+        1. <ins>Let _offsetString_ be FormatOffsetTimeZoneIdentifier(_offsetMinutes_, ~unseparated~).</ins>
         1. Let _tzName_ be an implementation-defined string that is either the empty String or the string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS), an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
         1. <del>Return the string-concatenation of _offsetSign_, _offsetHour_, _offsetMin_, and _tzName_.</del>
         1. <ins>Return the string-concatenation of _offsetString_ and _tzName_.</ins>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -33,8 +33,8 @@
           1. Throw a *TypeError* exception.
         1. If _identifier_ is not a String, throw a *TypeError* exception.
         1. Let _parseResult_ be ? ParseTimeZoneIdentifier(_identifier_).
-        1. If _parseResult_.[[OffsetNanoseconds]] is not ~empty~, then
-          1. Set _identifier_ to FormatOffsetTimeZoneIdentifier(_parseResult_.[[OffsetNanoseconds]], ~separated~).
+        1. If _parseResult_.[[OffsetMinutes]] is not ~empty~, then
+          1. Set _identifier_ to FormatOffsetTimeZoneIdentifier(_parseResult_.[[OffsetMinutes]]).
         1. Else,
           1. Let _timeZoneIdentifierRecord_ be GetAvailableNamedTimeZoneIdentifier(_identifier_).
           1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
@@ -101,7 +101,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return FormatOffsetTimeZoneIdentifier(_timeZone_.[[OffsetNanoseconds]], ~separated~).
+        1. If _timeZone_.[[OffsetMinutes]] is not ~empty~, return FormatOffsetTimeZoneIdentifier(_timeZone_.[[OffsetMinutes]]).
         1. Return _timeZone_.[[Identifier]].
       </emu-alg>
     </emu-clause>
@@ -115,7 +115,7 @@
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Set _instant_ to ? ToTemporalInstant(_instant_).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return 𝔽(_timeZone_.[[OffsetNanoseconds]]).
+        1. If _timeZone_.[[OffsetMinutes]] is not ~empty~, return 𝔽(_timeZone_.[[OffsetMinutes]] × (60 × 10<sup>9</sup>)).
         1. Return 𝔽(GetNamedTimeZoneOffsetNanoseconds(_timeZone_.[[Identifier]], _instant_.[[Nanoseconds]])).
       </emu-alg>
     </emu-clause>
@@ -171,9 +171,9 @@
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Set _dateTime_ to ? ToTemporalDateTime(_dateTime_).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, then
+        1. If _timeZone_.[[OffsetMinutes]] is not ~empty~, then
           1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
-          1. Let _possibleEpochNanoseconds_ be « _epochNanoseconds_ - ℤ(_timeZone_.[[OffsetNanoseconds]]) ».
+          1. Let _possibleEpochNanoseconds_ be « _epochNanoseconds_ - ℤ(_timeZone_.[[OffsetMinutes]] × (60 × 10<sup>9</sup>)) ».
         1. Else,
           1. Let _possibleEpochNanoseconds_ be GetNamedTimeZoneEpochNanoseconds(_timeZone_.[[Identifier]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
         1. Let _possibleInstants_ be a new empty List.
@@ -194,7 +194,7 @@
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Set _startingPoint_ to ? ToTemporalInstant(_startingPoint_).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return *null*.
+        1. If _timeZone_.[[OffsetMinutes]] is not ~empty~, return *null*.
         1. Let _transition_ be GetNamedTimeZoneNextTransition(_timeZone_.[[Identifier]], _startingPoint_.[[Nanoseconds]]).
         1. If _transition_ is *null*, return *null*.
         1. Return ! CreateTemporalInstant(_transition_).
@@ -210,7 +210,7 @@
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Set _startingPoint_ to ? ToTemporalInstant(_startingPoint_).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return *null*.
+        1. If _timeZone_.[[OffsetMinutes]] is not ~empty~, return *null*.
         1. Let _transition_ be GetNamedTimeZonePreviousTransition(_timeZone_.[[Identifier]], _startingPoint_.[[Nanoseconds]]).
         1. If _transition_ is *null*, return *null*.
         1. Return ! CreateTemporalInstant(_transition_).
@@ -225,7 +225,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return FormatOffsetTimeZoneIdentifier(_timeZone_.[[OffsetNanoseconds]], ~separated~).
+        1. If _timeZone_.[[OffsetMinutes]] is not ~empty~, return FormatOffsetTimeZoneIdentifier(_timeZone_.[[OffsetMinutes]]).
         1. Return _timeZone_.[[Identifier]].
       </emu-alg>
     </emu-clause>
@@ -238,7 +238,7 @@
       <emu-alg>
         1. Let _timeZone_ be the *this* value.
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
-        1. If _timeZone_.[[OffsetNanoseconds]] is not ~empty~, return FormatOffsetTimeZoneIdentifier(_timeZone_.[[OffsetNanoseconds]], ~separated~).
+        1. If _timeZone_.[[OffsetMinutes]] is not ~empty~, return FormatOffsetTimeZoneIdentifier(_timeZone_.[[OffsetMinutes]]).
         1. Return _timeZone_.[[Identifier]].
       </emu-alg>
     </emu-clause>
@@ -280,12 +280,11 @@
           </tr>
           <tr>
             <td>
-              [[OffsetNanoseconds]]
+              [[OffsetMinutes]]
             </td>
             <td>
-              An integer for nanoseconds representing the constant offset of this time zone relative to UTC, or ~empty~ if the instance represents a named time zone.
-              If not ~empty~, this value must represent an integer number of minutes (i.e., [[OffsetNanoseconds]] modulo (6 × 10<sup>10</sup>) must always be 0).
-              If not ~empty~, this value must be in the interval from &minus;8.64 &times; 10<sup>13</sup> (exclusive) to &plus;8.64 &times; 10<sup>13</sup> (exclusive) (i.e., strictly less than 24 hours in magnitude).
+              An integer for minutes representing the constant offset of this time zone relative to UTC, or ~empty~ if the instance represents a named time zone.
+              If not ~empty~, this value must be in the interval from -1440 (exclusive) to 1440 (exclusive) (i.e., strictly less than 24 hours in magnitude).
             </td>
           </tr>
         </tbody>
@@ -322,17 +321,17 @@
       </dl>
       <emu-alg>
         1. If _newTarget_ is not present, set _newTarget_ to %Temporal.TimeZone%.
-        1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.TimeZone.prototype%"*, « [[InitializedTemporalTimeZone]], [[Identifier]], [[OffsetNanoseconds]] »).
+        1. Let _object_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%Temporal.TimeZone.prototype%"*, « [[InitializedTemporalTimeZone]], [[Identifier]], [[OffsetMinutes]] »).
         1. Assert: _identifier_ is an available named time zone identifier or an offset time zone identifier.
         1. Let _parseResult_ be ! ParseTimeZoneIdentifier(_identifier_).
-        1. If _parseResult_.[[OffsetNanoseconds]] is not ~empty~, then
+        1. If _parseResult_.[[OffsetMinutes]] is not ~empty~, then
           1. Set _object_.[[Identifier]] to ~empty~.
-          1. Set _object_.[[OffsetNanoseconds]] to _parseResult_.[[OffsetNanoseconds]].
+          1. Set _object_.[[OffsetMinutes]] to _parseResult_.[[OffsetMinutes]].
         1. Else,
           1. Assert: _parseResult_.[[Name]] is not ~empty~.
           1. Assert: GetAvailableNamedTimeZoneIdentifier(_identifier_).[[PrimaryIdentifier]] is _identifier_.
           1. Set _object_.[[Identifier]] to _identifier_.
-          1. Set _object_.[[OffsetNanoseconds]] to ~empty~.
+          1. Set _object_.[[OffsetMinutes]] to ~empty~.
         1. Return _object_.
       </emu-alg>
 
@@ -343,7 +342,7 @@
           Although the [[Identifier]] internal slot is a String in this specification, implementations may choose to store named time zone identifiers it in any other form (for example as an enumeration or index into a List of identifier strings) as long as the String can be regenerated when needed.
         </p>
         <p>
-          Similar flexibility exists for the storage of the [[OffsetNanoseconds]] internal slot, which can be interchangeably represented as a 12-bit signed integer or as a 6-character ±HH:MM String value.
+          Similar flexibility exists for the storage of the [[OffsetMinutes]] internal slot, which can be interchangeably represented as a 12-bit signed integer or as a 6-character ±HH:MM String value.
           ParseTimeZoneIdentifier and FormatOffsetTimeZoneIdentifier may be used to losslessly convert one representation to the other.
           Implementations are free to store either or both representations.
         </p>
@@ -474,27 +473,26 @@
     <emu-clause id="sec-temporal-formatoffsettimezoneidentifier" type="abstract operation">
       <h1>
         FormatOffsetTimeZoneIdentifier (
-          _offsetNanoseconds_: an integer,
-          _style_: ~legacy~ or ~separated~,
+          _offsetMinutes_: an integer,
+          optional _style_: ~separated~ or ~unseparated~,
         ): a String
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
           It formats a time zone offset, in nanoseconds, into a UTC offset string.
-          If _style_ is ~legacy~, then the output will be formatted like ±HHMM.
-          If _style_ is ~separated~, then the output will be formatted like ±HH:MM.
+          If _style_ is ~separated~ or not present, then the output will be formatted like ±HH:MM.
+          If _style_ is ~unseparated~, then the output will be formatted like ±HHMM.
         </dd>
       </dl>
       <emu-alg>
-        1. If _offsetNanoseconds_ &ge; 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
-        1. Let _absoluteMinutes_ be abs(_offsetNanoseconds_ / (6 × 10<sup>10</sup>)).
-        1. Assert: _absoluteMinutes_ is an integer.
+        1. If _offsetMinutes_ &ge; 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
+        1. Let _absoluteMinutes_ be abs(_offsetMinutes_).
         1. Let _intHours_ be floor(_absoluteMinutes_ / 60).
         1. Let _hh_ be ToZeroPaddedDecimalString(_intHours_, 2).
         1. Let _intMinutes_ be _absoluteMinutes_ modulo 60.
         1. Let _mm_ be ToZeroPaddedDecimalString(_intMinutes_, 2).
-        1. If _style_ is ~legacy~, then
+        1. If _style_ is ~unseparated~, then
           1. Return the string-concatenation of _sign_, _hh_, and _mm_.
         1. Return the string-concatenation of _sign_, _hh_, the code unit 0x003A (COLON), and _mm_.
       </emu-alg>
@@ -511,8 +509,10 @@
         <dd>It rounds _offsetNanoseconds_ to the nearest minute boundary and formats the rounded value into a ±HH:MM format, to support available named time zones that may have sub-minute offsets.</dd>
       </dl>
       <emu-alg>
-        1. Set _offsetNanoseconds_ to RoundNumberToIncrement(_offsetNanoseconds_, 6 × 10<sup>10</sup>, *"halfExpand"*).
-        1. Return FormatOffsetTimeZoneIdentifier(_offsetNanoseconds_, ~separated~).
+        1. Set _offsetNanoseconds_ to RoundNumberToIncrement(_offsetNanoseconds_, 60 × 10<sup>9</sup>, *"halfExpand"*).
+        1. Let _offsetMinutes_ be _offsetNanoseconds_ / (60 × 10<sup>9</sup>).
+        1. Assert: _offsetMinutes_ is an integer.
+        1. Return FormatOffsetTimeZoneIdentifier(_offsetMinutes_).
       </emu-alg>
     </emu-clause>
 
@@ -558,15 +558,15 @@
         1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_temporalTimeZoneLike_).
         1. If _parseResult_.[[Name]] is not *undefined*, then
           1. Let _name_ be _parseResult_.[[Name]].
-          1. Let _offsetNanoseconds_ be ? ParseTimeZoneIdentifier(_name_).[[OffsetNanoseconds]].
-          1. If _offsetNanoseconds_ is not ~empty~, return FormatOffsetTimeZoneIdentifier(_offsetNanoseconds_, ~separated~).
+          1. Let _offsetMinutes_ be ? ParseTimeZoneIdentifier(_name_).[[OffsetMinutes]].
+          1. If _offsetMinutes_ is not ~empty~, return FormatOffsetTimeZoneIdentifier(_offsetMinutes_).
           1. Let _timeZoneIdentifierRecord_ be GetAvailableNamedTimeZoneIdentifier(_name_).
           1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
           1. Return _timeZoneIdentifierRecord_.[[PrimaryIdentifier]].
         1. If _parseResult_.[[Z]] is *true*, return *"UTC"*.
         1. Let _offsetParseResult_ be ! ParseDateTimeUTCOffset(_parseResult_.[[OffsetString]]).
         1. If _offsetParseResult_.[[HasSubMinutePrecision]] is *true*, throw a *RangeError* exception.
-        1. Return FormatOffsetTimeZoneIdentifier(_offsetParseResult_.[[OffsetNanoseconds]], ~separated~).
+        1. Return FormatOffsetTimeZoneIdentifier(_offsetParseResult_.[[OffsetMinutes]]).
       </emu-alg>
     </emu-clause>
 
@@ -653,9 +653,9 @@
       </dl>
       <emu-alg>
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. Let _offsetMinutes_ be truncate(_offsetNanoseconds_ / (6 × 10<sup>10</sup>)).
-        1. Let _offsetString_ be FormatOffsetTimeZoneIdentifier(_offsetMinutes_ × (6 × 10<sup>10</sup>), ~separate~).
-        1. Let _subMinuteNanoseconds_ be abs(_offsetNanoseconds_) modulo (6 × 10<sup>10</sup>).
+        1. Let _offsetMinutes_ be truncate(_offsetNanoseconds_ / (60 × 10<sup>9</sup>)).
+        1. Let _offsetString_ be FormatOffsetTimeZoneIdentifier(_offsetMinutes_, ~separate~).
+        1. Let _subMinuteNanoseconds_ be abs(_offsetNanoseconds_) modulo (60 × 10<sup>9</sup>).
         1. If _subMinuteNanoseconds_ = 0, then
           1. Return _offsetString_.
         1. If _offsetMinutes_ = 0 and _offsetNanoseconds_ &lt; 0, set _offsetString_ to *"-00:00"*.
@@ -825,13 +825,13 @@
       <h1>
         ParseTimeZoneIdentifier (
           _identifier_: a String,
-        ): either a normal completion containing a Record containing [[Name]] and [[OffsetNanoseconds]] fields, or a throw completion
+        ): either a normal completion containing a Record containing [[Name]] and [[OffsetMinutes]] fields, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          If _identifier_ is a named time zone identifier, [[Name]] will be _identifier_ and [[OffsetNanoseconds]] will be ~empty~.
-          If _identifier_ is an offset time zone identifier, [[Name]] will be ~empty~ and [[OffsetNanoseconds]] will be a signed integer that is evenly divisible by 6 × 10<sup>10</sup>.
+          If _identifier_ is a named time zone identifier, [[Name]] will be _identifier_ and [[OffsetMinutes]] will be ~empty~.
+          If _identifier_ is an offset time zone identifier, [[Name]] will be ~empty~ and [[OffsetMinutes]] will be a signed integer.
           Otherwise, a *RangeError* will be thrown.
         </dd>
       </dl>
@@ -840,13 +840,14 @@
         1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
         1. If _parseResult_ contains a |TimeZoneIANAName| Parse Node, then
           1. Let _name_ be the source text matched by the |TimeZoneIANAName| Parse Node contained within _parseResult_.
-          1. Return the Record { [[Name]]: _name_, [[OffsetNanoseconds]]: ~empty~ }.
+          1. Return the Record { [[Name]]: _name_, [[OffsetMinutes]]: ~empty~ }.
         1. Else,
           1. Assert: _parseResult_ contains a |TimeZoneUTCOffsetName| Parse Node.
           1. Let _offsetString_ be the source text matched by the |TimeZoneUTCOffsetName| Parse Node contained within _parseResult_.
           1. Let _offsetNanoseconds_ be ! ParseDateTimeUTCOffset(_offsetString_).
-          1. Assert: _offsetNanoseconds_ modulo (6 × 10<sup>10</sup>) = 0.
-          1. Return the Record { [[Name]]: ~empty~, [[OffsetNanoseconds]]: _offsetNanoseconds_ }.
+          1. Let _offsetMinutes_ be _offsetNanoseconds_ / (60 × 10<sup>9</sup>).
+          1. Assert: _offsetMinutes_ is an integer.
+          1. Return the Record { [[Name]]: ~empty~, [[OffsetMinutes]]: _offsetMinutes_ }.
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
_This PR is stacked on #2607. Please review only the last commit. At @ptomato's request, I'm splitting it into a separate editorial PR to simplify review of the other normative PR.  It's marked as a draft until #2607 is approved at the upcoming TC39 meeting._ 

Now that #2607 limits TimeZone's [[OffsetNanoseconds]] internal slot to minute precision, this PR refactors TimeZone to clarify that only minutes are allowed in that slot and related abstract operations. 

Changes:
* Renames TimeZone's [[OffsetNanoseconds]] internal slot to [[OffsetMinutes]]
* Changes ParseTimeZoneIdentifier to return an [[OffsetMinutes]] field instead of an [[OffsetNanoseconds]] field.
* Changes FormatOffsetTimeZoneIdentifier to expect its argument to be an integer number of minutes, not an integer number of nanoseconds that's required to be evenly divisible by 6e10.

The goal of this change is to avoid the complexity and potential confusion from a slot and AOs that deal with "nanoseconds" values that nonetheless are restricted to minutes.
