### PR TITLE
Polyfill: fix codecov/Test262 issues in ISO parser & align it closer to spec

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -437,23 +437,11 @@ export function ParseISODateTime(isoString) {
   if (match[13]) {
     offset = undefined;
     z = true;
-  } else if (match[14] && match[15]) {
-    const offsetSign = match[14] === '-' || match[14] === '\u2212' ? '-' : '+';
-    const offsetHours = match[15] || '00';
-    const offsetMinutes = match[16] || '00';
-    const offsetSeconds = match[17] || '00';
-    let offsetFraction = match[18] || '0';
-    offset = `${offsetSign}${offsetHours}:${offsetMinutes}`;
-    if (+offsetFraction) {
-      while (offsetFraction.endsWith('0')) offsetFraction = offsetFraction.slice(0, -1);
-      offset += `:${offsetSeconds}.${offsetFraction}`;
-    } else if (+offsetSeconds) {
-      offset += `:${offsetSeconds}`;
-    }
-    if (offset === '-00:00') offset = '+00:00';
+  } else if (match[14]) {
+    offset = match[14];
   }
-  const tzName = match[19];
-  const calendar = processAnnotations(match[20]);
+  const tzName = match[15];
+  const calendar = processAnnotations(match[16]);
   RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
   return {
     year,
@@ -505,7 +493,7 @@ export function ParseTemporalTimeString(isoString) {
     millisecond = ToIntegerOrInfinity(fraction.slice(0, 3));
     microsecond = ToIntegerOrInfinity(fraction.slice(3, 6));
     nanosecond = ToIntegerOrInfinity(fraction.slice(6, 9));
-    processAnnotations(match[14]); // ignore found calendar
+    processAnnotations(match[10]); // ignore found calendar
     if (match[8]) throw new RangeError('Z designator not supported for PlainTime');
   } else {
     let z, hasTime;
@@ -2624,7 +2612,7 @@ export function IsOffsetTimeZoneIdentifier(string) {
 }
 
 export function ParseDateTimeUTCOffset(string) {
-  const match = OFFSET.exec(string);
+  const match = OFFSET_WITH_PARTS.exec(string);
   if (!match) {
     throw new RangeError(`invalid time zone offset: ${string}`);
   }
@@ -5632,6 +5620,7 @@ export function ASCIILowercase(str) {
 }
 
 const OFFSET = new RegExp(`^${PARSE.offset.source}$`);
+const OFFSET_WITH_PARTS = new RegExp(`^${PARSE.offsetWithParts.source}$`);
 
 function bisect(getState, left, right, lstate = getState(left), rstate = getState(right)) {
   left = bigInt(left);

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -22,7 +22,9 @@ export const datesplit = new RegExp(
   `(${yearpart.source})(?:-(${monthpart.source})-(${daypart.source})|(${monthpart.source})(${daypart.source}))`
 );
 const timesplit = /(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?|(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?/;
-export const offset = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5][0-9])(?:[.,](\d{1,9}))?)?)?/;
+export const offsetWithParts = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5][0-9])(?:[.,](\d{1,9}))?)?)?/;
+export const offset =
+  /((?:[+\u2212-])(?:[01][0-9]|2[0-3])(?::?(?:[0-5][0-9])(?::?(?:[0-5][0-9])(?:[.,](?:\d{1,9}))?)?)?)/;
 const offsetpart = new RegExp(`([zZ])|${offset.source}?`);
 export const offsetIdentifier = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])?)?/;
 export const annotation = /\[(!)?([a-z_][a-z0-9_-]*)=([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\]/g;


### PR DESCRIPTION
To make it easier to find Test262 gaps, this PR removes unreachable code in ISO parsing in the polyfill that codecov complained about. 

It also removes offset normalization code from ParseISODateTime, to better mach the spec that only normalizes downstream from ISO string parsing. Doing this exposed a test bug that's fixed in the second commit of https://github.com/tc39/test262/pull/3877. For good measure, this PR pulls in the entirety of https://github.com/tc39/test262/pull/3877.

Note that this PR shouldn't be merged until the corresponding Test262 PR is merged.