### PR TITLE
Editorial: Simpler time zone parsing in ToTemporalTimeZoneSlotValue

### DIFF
--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -1,5 +1,5 @@
 const tzComponent = /\.[-A-Za-z_]|\.\.[-A-Za-z._]{1,12}|\.[-A-Za-z_][-A-Za-z._]{0,12}|[A-Za-z_][-A-Za-z._]{0,13}/;
-const offsetNoCapture = /(?:[+\u2212-][0-2][0-9](?::?[0-5][0-9](?::?[0-5][0-9](?:[.,]\d{1,9})?)?)?)/;
+const offsetIdentifierNoCapture = /(?:[+\u2212-][0-2][0-9](?::?[0-5][0-9])?)/;
 export const timeZoneID = new RegExp(
   '(?:' +
     [
@@ -10,7 +10,7 @@ export const timeZoneID = new RegExp(
       'CST6CDT',
       'MST7MDT',
       'PST8PDT',
-      offsetNoCapture.source
+      offsetIdentifierNoCapture.source
     ].join('|') +
     ')'
 );

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -206,7 +206,7 @@ export class ZonedDateTime {
 
     let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
       ES.InterpretTemporalDateTimeFields(calendar, fields, options);
-    const offsetNs = ES.ParseDateTimeUTCOffset(fields.offset).offsetNanoseconds;
+    const offsetNs = ES.ParseDateTimeUTCOffset(fields.offset);
     const timeZone = GetSlot(this, TIME_ZONE);
     const epochNanoseconds = ES.InterpretISODateTimeOffset(
       year,

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -203,7 +203,7 @@ const timeDesignator = character('Tt');
 const weeksDesignator = character('Ww');
 const yearsDesignator = character('Yy');
 const utcDesignator = withCode(character('Zz'), (data) => {
-  data.z = 'Z';
+  data.z = true;
 });
 const annotationCriticalFlag = character('!');
 const fraction = seq(decimalSeparator, between(1, 9, digit()));
@@ -426,7 +426,7 @@ const goals = {
 const dateItems = ['year', 'month', 'day'];
 const timeItems = ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'];
 const comparisonItems = {
-  Instant: [...dateItems, ...timeItems, 'offset'],
+  Instant: [...dateItems, ...timeItems, 'offset', 'z'],
   Date: [...dateItems, 'calendar'],
   DateTime: [...dateItems, ...timeItems, 'calendar'],
   Duration: [
@@ -443,9 +443,9 @@ const comparisonItems = {
   ],
   MonthDay: ['month', 'day', 'calendar'],
   Time: [...timeItems],
-  TimeZone: ['offset', 'tzAnnotation'],
+  TimeZone: ['offset', 'tzAnnotation', 'z'],
   YearMonth: ['year', 'month', 'calendar'],
-  ZonedDateTime: [...dateItems, ...timeItems, 'offset', 'tzAnnotation', 'calendar']
+  ZonedDateTime: [...dateItems, ...timeItems, 'offset', 'z', 'tzAnnotation', 'calendar']
 };
 const plainModes = ['Date', 'DateTime', 'MonthDay', 'Time', 'YearMonth'];
 
@@ -462,7 +462,7 @@ function fuzzMode(mode) {
       const parsed = parsingMethod(fuzzed);
       for (let prop of comparisonItems[mode]) {
         let expected = generatedData[prop];
-        if (!['tzAnnotation', 'offset', 'calendar'].includes(prop)) expected ??= 0;
+        if (!['tzAnnotation', 'offset', 'calendar'].includes(prop)) expected ??= prop === 'z' ? false : 0;
         if (prop === 'offset') {
           const parsedResult = parsed[prop] === undefined ? undefined : ES.ParseDateTimeUTCOffset(parsed[prop]);
           assert.equal(parsedResult, expected, prop);

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1745,10 +1745,10 @@
         It parses the argument as either a time zone identifier or an ISO 8601 string.
         The returned Record's fields are set as follows:
         <ul>
-          <li>If _timeZoneString_ is either a named time zone identifier or offset time zone identifier, then [[Name]] is _timeZoneString_, while [[Z]] is *false* and [[OffsetString]] is *undefined*.</li>
-          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string with a time zone annotation containing either a named time zone identifier or offset time zone identifier, then [[Name]] is the time zone identifier contained in the annotation, while [[Z]] is *false* and [[OffsetString]] is *undefined*.</li>
-          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a *Z* offset designator, then [[Z]] is *true*, while [[Name]] and [[OffsetString]] are *undefined*.</li>
-          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a numeric UTC offset, then [[OffsetString]] is _timeZoneString_, while [[Z]] is *false* and [[Name]] is *undefined*.</li>
+          <li>If _timeZoneString_ is either a named time zone identifier or offset time zone identifier, then [[Name]] is _timeZoneString_ and [[OffsetString]] is *undefined*.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string with a time zone annotation containing either a named time zone identifier or offset time zone identifier, then [[Name]] is the time zone identifier contained in the annotation and [[OffsetString]] is *undefined*.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a *Z* offset designator, then [[Name]] is *"UTC"* and [[OffsetString]] is *undefined*.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a numeric UTC offset, then [[OffsetString]] is _timeZoneString_ and [[Name]] is *undefined*.</li>
           <li>Otherwise, a *RangeError* is thrown.</li>
         </ul>
       </dd>
@@ -1756,11 +1756,16 @@
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_timeZoneString_), |TimeZoneIdentifier|).
       1. If _parseResult_ is a Parse Node, then
-        1. Return the Record { [[Z]]: *false*, [[OffsetString]]: *undefined*, [[Name]]: _timeZoneString_ }.
+        1. Return the Record { [[OffsetString]]: *undefined*, [[Name]]: _timeZoneString_ }.
       1. Let _result_ be ? ParseISODateTime(_timeZoneString_).
       1. Let _timeZoneResult_ be _result_.[[TimeZone]].
-      1. If _timeZoneResult_.[[Z]] is *false*, _timeZoneResult_.[[OffsetString]] is *undefined*, and _timeZoneResult_.[[Name]] is *undefined*, throw a *RangeError* exception.
-      1. Return _timeZoneResult_.
+      1. If _timeZoneResult_.[[Name]] is not *undefined*, then
+        1. Return the Record { [[OffsetString]]: *undefined*, [[Name]]: _timeZoneResult_.[[Name]] }.
+      1. If _timeZoneResult_.[[Z]] is *true*, then
+        1. Return the Record { [[OffsetString]]: *undefined*, [[Name]]: *"UTC"* }.
+      1. If _timeZoneResult_.[[OffsetString]] is not *undefined*, then
+        1. Return the Record { [[OffsetString]]: _timeZoneResult_.[[OffsetString]], [[Name]]: *undefined* }.
+      1. Throw a *RangeError* exception.
     </emu-alg>
   </emu-clause>
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -626,7 +626,7 @@
       1. If _timeZone_ is *undefined*, then
         1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_).
       1. If _offsetBehaviour_ is ~option~, then
-        1. Let _offsetNs_ be ? ParseDateTimeUTCOffset(_offsetString_).[[OffsetNanoseconds]].
+        1. Let _offsetNs_ be ? ParseDateTimeUTCOffset(_offsetString_).
       1. Else,
         1. Let _offsetNs_ be 0.
       1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNs_, _timeZone_, *"compatible"*, *"reject"*, _matchBehaviour_).

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1745,10 +1745,12 @@
         It parses the argument as either a time zone identifier or an ISO 8601 string.
         The returned Record's fields are set as follows:
         <ul>
-          <li>If _timeZoneString_ is either a named time zone identifier or offset time zone identifier, then [[Name]] is _timeZoneString_ and [[OffsetString]] is *undefined*.</li>
-          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string with a time zone annotation containing either a named time zone identifier or offset time zone identifier, then [[Name]] is the time zone identifier contained in the annotation and [[OffsetString]] is *undefined*.</li>
-          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a *Z* offset designator, then [[Name]] is *"UTC"* and [[OffsetString]] is *undefined*.</li>
-          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a numeric UTC offset, then [[OffsetString]] is _timeZoneString_ and [[Name]] is *undefined*.</li>
+          <li>If _timeZoneString_ is a named time zone identifier, then [[Name]] is _timeZoneString_ and [[OffsetMinutes]] is ~empty~.</li>
+          <li>Otherwise, if _timeZoneString_ is an offset time zone identifier, then [[OffsetMinutes]] is a signed integer and [[Name]] is ~empty~.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string with a time zone annotation containing a named time zone identifier, then [[Name]] is the time zone identifier contained in the annotation and [[OffsetMinutes]] is ~empty~.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string with a time zone annotation containing an offset time zone identifier, then [[OffsetMinutes]] is a signed integer and [[Name]] is ~empty~.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a *Z* offset designator, then [[Name]] is *"UTC"* and [[OffsetMinutes]] is ~empty~.</li>
+          <li>Otherwise, if _timeZoneString_ is an ISO 8601 string using a numeric UTC offset, then [[OffsetMinutes]] is a signed integer and [[Name]] is ~empty~.</li>
           <li>Otherwise, a *RangeError* is thrown.</li>
         </ul>
       </dd>
@@ -1756,15 +1758,15 @@
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_timeZoneString_), |TimeZoneIdentifier|).
       1. If _parseResult_ is a Parse Node, then
-        1. Return the Record { [[OffsetString]]: *undefined*, [[Name]]: _timeZoneString_ }.
+        1. Return ! ParseTimeZoneIdentifier(_timeZoneString_).
       1. Let _result_ be ? ParseISODateTime(_timeZoneString_).
       1. Let _timeZoneResult_ be _result_.[[TimeZone]].
       1. If _timeZoneResult_.[[Name]] is not *undefined*, then
-        1. Return the Record { [[OffsetString]]: *undefined*, [[Name]]: _timeZoneResult_.[[Name]] }.
+        1. Return ! ParseTimeZoneIdentifier(_timeZoneResult_.[[Name]]).
       1. If _timeZoneResult_.[[Z]] is *true*, then
-        1. Return the Record { [[OffsetString]]: *undefined*, [[Name]]: *"UTC"* }.
+        1. Return ! ParseTimeZoneIdentifier(*"UTC"*).
       1. If _timeZoneResult_.[[OffsetString]] is not *undefined*, then
-        1. Return the Record { [[OffsetString]]: _timeZoneResult_.[[OffsetString]], [[Name]]: *undefined* }.
+        1. Return ? ParseTimeZoneIdentifier(_timeZoneResult_.[[OffsetString]]).
       1. Throw a *RangeError* exception.
     </emu-alg>
   </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -534,7 +534,7 @@
         1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
         1. Assert: _offsetString_ is not *undefined*.
         1. Let _utc_ be GetUTCEpochNanoseconds(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
-        1. Let _offsetNanoseconds_ be ? ParseDateTimeUTCOffset(_offsetString_).[[OffsetNanoseconds]].
+        1. Let _offsetNanoseconds_ be ? ParseDateTimeUTCOffset(_offsetString_).
         1. Let _result_ be _utc_ - ℤ(_offsetNanoseconds_).
         1. If ! IsValidEpochNanoseconds(_result_) is *false*, then
           1. Throw a *RangeError* exception.

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -498,7 +498,6 @@
         <dd>
           <del>The return value is the UTC offset, as a number of nanoseconds, that corresponds to the String _offsetString_.</del>
           <ins>[[OffsetNanoseconds]] is the UTC offset, as a number of nanoseconds, that corresponds to _offsetString_.</ins>
-          <ins>[[HasSubMinutePrecision]] is *true* if _offsetString_ includes seconds or sub-second units, and *false* otherwise.</ins>
           <ins>If _offsetString_ is invalid, a *RangeError* is thrown.</ins>
         </dd>
       </dl>
@@ -506,7 +505,6 @@
         1. Let _parseResult_ be ParseText(StringToCodePoints(_offsetString_), <del>|UTCOffset|</del><ins>|UTCOffsetSubMinutePrecision|</ins>).
         1. <del>Assert: _parseResult_ is not a List of errors.</del>
         1. <ins>If _parseResult_ is a List of errors, throw a *RangeError* exception.</ins>
-        1. <ins>Let _hasSubMinutePrecision_ be *false*.</ins>
         1. Assert: _parseResult_ contains a |TemporalSign| Parse Node.
         1. Let _parsedSign_ be the source text matched by the |TemporalSign| Parse Node contained within _parseResult_.
         1. If _parsedSign_ is the single code point U+002D (HYPHEN-MINUS) or U+2212 (MINUS SIGN), then
@@ -526,7 +524,6 @@
           1. Let _seconds_ be 0.
           1. <ins>Let _nanoseconds_ be 0.</ins>
         1. Else,
-          1. <ins>Set _hasSubMinutePrecision_ to *true*.</ins>
           1. Let _parsedSeconds_ be the source text matched by the second |MinuteSecond| Parse Node contained within _parseResult_.
           1. Let _seconds_ be ℝ(StringToNumber(CodePointsToString(_parsedSeconds_))).
           1. <ins>If _parseResult_ contains a |TemporalDecimalFraction| Parse Node, then</ins>
@@ -543,7 +540,7 @@
           1. <del>Let _nanoseconds_ be ℝ(StringToNumber(_nanosecondsString_)).</del>
         1. <del>Return _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).</del>
         1. <ins>Let _offsetNanoseconds_ be _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).</ins>
-        1. <ins>Return the Record { [[OffsetNanoseconds]]: _offsetNanoseconds_, [[HasSubMinutePrecision]]: _hasSubMinutePrecision_ }.</ins>
+        1. <ins>Return the Record { [[OffsetNanoseconds]]: _offsetNanoseconds_ }.</ins>
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -482,22 +482,21 @@
       <del class="block">
       <h1>
         ParseTimeZoneOffsetString (
-          _offsetString_: a String
-        ): either a normal completion containing a Record, or a throw completion
+          _offsetString_: a String,
+        ): an integer
       </h1>
       </del>
       <ins class="block">
       <h1>
         ParseDateTimeUTCOffset (
           _offsetString_: a String
-        ): either a normal completion containing a Record, or a throw completion
+        ): either a normal completion containing an integer, or a throw completion
       </h1>
       </ins>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          <del>The return value is the UTC offset, as a number of nanoseconds, that corresponds to the String _offsetString_.</del>
-          <ins>[[OffsetNanoseconds]] is the UTC offset, as a number of nanoseconds, that corresponds to _offsetString_.</ins>
+          The return value is the UTC offset, as a number of nanoseconds, that corresponds to the String _offsetString_.
           <ins>If _offsetString_ is invalid, a *RangeError* is thrown.</ins>
         </dd>
       </dl>
@@ -522,25 +521,17 @@
           1. Let _minutes_ be ℝ(StringToNumber(CodePointsToString(_parsedMinutes_))).
         1. If _parseResult_ does not contain two |MinuteSecond| Parse Nodes, then
           1. Let _seconds_ be 0.
-          1. <ins>Let _nanoseconds_ be 0.</ins>
         1. Else,
           1. Let _parsedSeconds_ be the source text matched by the second |MinuteSecond| Parse Node contained within _parseResult_.
           1. Let _seconds_ be ℝ(StringToNumber(CodePointsToString(_parsedSeconds_))).
-          1. <ins>If _parseResult_ contains a |TemporalDecimalFraction| Parse Node, then</ins>
-            1. <ins>Let _parsedFraction_ be the source text matched by the |TemporalDecimalFraction| Parse Node contained within _parseResult_.</ins>
-            1. <ins>Let _fraction_ be the string-concatenation of CodePointsToString(_parsedFraction_) and *"000000000"*.</ins>
-            1. <ins>Let _nanosecondsString_ be the substring of _fraction_ from 1 to 10.</ins>
-            1. <ins>Let _nanoseconds_ be ℝ(StringToNumber(_nanosecondsString_)).</ins>
-        1. <del>If _parseResult_ does not contain a |TemporalDecimalFraction| Parse Node, then</del>
-          1. <del>Let _nanoseconds_ be 0.</del>
-        1. <del>Else,</del>
-          1. <del>Let _parsedFraction_ be the source text matched by the |TemporalDecimalFraction| Parse Node contained within _parseResult_.</del>
-          1. <del>Let _fraction_ be the string-concatenation of CodePointsToString(_parsedFraction_) and *"000000000"*.</del>
-          1. <del>Let _nanosecondsString_ be the substring of _fraction_ from 1 to 10.</del>
-          1. <del>Let _nanoseconds_ be ℝ(StringToNumber(_nanosecondsString_)).</del>
-        1. <del>Return _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).</del>
-        1. <ins>Let _offsetNanoseconds_ be _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).</ins>
-        1. <ins>Return the Record { [[OffsetNanoseconds]]: _offsetNanoseconds_ }.</ins>
+        1. If _parseResult_ does not contain a |TemporalDecimalFraction| Parse Node, then
+          1. Let _nanoseconds_ be 0.
+        1. Else,
+          1. Let _parsedFraction_ be the source text matched by the |TemporalDecimalFraction| Parse Node contained within _parseResult_.
+          1. Let _fraction_ be the string-concatenation of CodePointsToString(_parsedFraction_) and *"000000000"*.
+          1. Let _nanosecondsString_ be the substring of _fraction_ from 1 to 10.
+          1. Let _nanoseconds_ be ℝ(StringToNumber(_nanosecondsString_)).
+        1. Return _sign_ × (((_hours_ × 60 + _minutes_) × 60 + _seconds_) × 10<sup>9</sup> + _nanoseconds_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -598,7 +598,6 @@
           1. Let _timeZoneIdentifierRecord_ be GetAvailableNamedTimeZoneIdentifier(_name_).
           1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
           1. Return _timeZoneIdentifierRecord_.[[Identifier]].
-        1. If _parseResult_.[[Z]] is *true*, return *"UTC"*.
         1. Let _offsetParseResult_ be ? ParseTimeZoneIdentifier(_parseResult_.[[OffsetString]]).
         1. Return FormatOffsetTimeZoneIdentifier(_offsetParseResult_.[[OffsetMinutes]]).
       </emu-alg>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -591,15 +591,12 @@
           1. Return _temporalTimeZoneLike_.
         1. If _temporalTimeZoneLike_ is not a String, throw a *TypeError* exception.
         1. Let _parseResult_ be ? ParseTemporalTimeZoneString(_temporalTimeZoneLike_).
-        1. If _parseResult_.[[Name]] is not *undefined*, then
-          1. Let _name_ be _parseResult_.[[Name]].
-          1. Let _offsetMinutes_ be ? ParseTimeZoneIdentifier(_name_).[[OffsetMinutes]].
-          1. If _offsetMinutes_ is not ~empty~, return FormatOffsetTimeZoneIdentifier(_offsetMinutes_).
-          1. Let _timeZoneIdentifierRecord_ be GetAvailableNamedTimeZoneIdentifier(_name_).
-          1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
-          1. Return _timeZoneIdentifierRecord_.[[Identifier]].
-        1. Let _offsetParseResult_ be ? ParseTimeZoneIdentifier(_parseResult_.[[OffsetString]]).
-        1. Return FormatOffsetTimeZoneIdentifier(_offsetParseResult_.[[OffsetMinutes]]).
+        1. Let _offsetMinutes_ be _parseResult_.[[OffsetMinutes]].
+        1. If _offsetMinutes_ is not ~empty~, return FormatOffsetTimeZoneIdentifier(_offsetMinutes_).
+        1. Let _name_ be _parseResult_.[[Name]].
+        1. Let _timeZoneIdentifierRecord_ be GetAvailableNamedTimeZoneIdentifier(_name_).
+        1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
+        1. Return _timeZoneIdentifierRecord_.[[Identifier]].
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -599,8 +599,7 @@
           1. If _timeZoneIdentifierRecord_ is ~empty~, throw a *RangeError* exception.
           1. Return _timeZoneIdentifierRecord_.[[Identifier]].
         1. If _parseResult_.[[Z]] is *true*, return *"UTC"*.
-        1. Let _offsetParseResult_ be ! ParseDateTimeUTCOffset(_parseResult_.[[OffsetString]]).
-        1. If _offsetParseResult_.[[HasSubMinutePrecision]] is *true*, throw a *RangeError* exception.
+        1. Let _offsetParseResult_ be ? ParseTimeZoneIdentifier(_parseResult_.[[OffsetString]]).
         1. Return FormatOffsetTimeZoneIdentifier(_offsetParseResult_.[[OffsetMinutes]]).
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -598,7 +598,7 @@
         1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _options_).
         1. Let _offsetString_ be ! Get(_fields_, *"offset"*).
         1. Assert: Type(_offsetString_) is String.
-        1. Let _offsetNanoseconds_ be ? ParseDateTimeUTCOffset(_offsetString_).[[OffsetNanoseconds]].
+        1. Let _offsetNanoseconds_ be ? ParseDateTimeUTCOffset(_offsetString_).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offset_, ~match exactly~).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
@@ -1189,7 +1189,7 @@
           1. Perform ? ToTemporalOverflow(_options_).
         1. Let _offsetNanoseconds_ be 0.
         1. If _offsetBehaviour_ is ~option~, then
-          1. Set _offsetNanoseconds_ to ? ParseDateTimeUTCOffset(_offsetString_).[[OffsetNanoseconds]].
+          1. Set _offsetNanoseconds_ to ? ParseDateTimeUTCOffset(_offsetString_).
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offsetOption_, _matchBehaviour_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>


### PR DESCRIPTION
When directly calling `ParseTimeZoneIdentifier` in `ParseTemporalTimeZoneString`, the time zone parsing in `ToTemporalTimeZoneSlotValue` can be simplified.

Also fixes #2639.

And fixes an incorrect `? ParseTimeZoneIdentifier` call in `ToTemporalTimeZoneSlotValue`, which is actually infallible and therefore should have been `! ParseTimeZoneIdentifier`.

And fixes an incorrect `offsetParseResult.[[OffsetMinutes]]` access in `ToTemporalTimeZoneSlotValue`, which should have been `offsetParseResult.[[OffsetNanoseconds]] / (60 * 10^9)`.