### PR TITLE
Editorial: Structured headers, AO for formatting UTC offset with nanoseconds

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1419,7 +1419,7 @@ export function InterpretISODateTimeOffset(
   // the user-provided offset doesn't match any instants for this time
   // zone and date/time.
   if (offsetOpt === 'reject') {
-    const offsetStr = formatOffsetStringNanoseconds(offsetNs);
+    const offsetStr = FormatUTCOffsetNanoseconds(offsetNs);
     const timeZoneString = IsTemporalTimeZone(timeZone) ? GetSlot(timeZone, TIMEZONE_ID) : 'time zone';
     throw new RangeError(`Offset ${offsetStr} is invalid for ${dt} in ${timeZoneString}`);
   }
@@ -2207,12 +2207,10 @@ export function GetOffsetNanosecondsFor(timeZone, instant, getOffsetNanosecondsF
 
 export function GetOffsetStringFor(timeZone, instant) {
   const offsetNs = GetOffsetNanosecondsFor(timeZone, instant);
-  return formatOffsetStringNanoseconds(offsetNs);
+  return FormatUTCOffsetNanoseconds(offsetNs);
 }
 
-// In the spec, the code below only exists as part of GetOffsetStringFor.
-// But in the polyfill, we re-use it to provide clearer error messages.
-function formatOffsetStringNanoseconds(offsetNs) {
+export function FormatUTCOffsetNanoseconds(offsetNs) {
   const sign = offsetNs < 0 ? '-' : '+';
   const absoluteNs = MathAbs(offsetNs);
   const hour = MathFloor(absoluteNs / 3600e9);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -561,6 +561,7 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const dt = dateTime(this);
     const tz = GetSlot(this, TIME_ZONE);
+    const offsetNanoseconds = ES.GetOffsetNanosecondsFor(tz, GetSlot(this, INSTANT));
     return {
       calendar: GetSlot(this, CALENDAR),
       isoDay: GetSlot(dt, ISO_DAY),
@@ -572,7 +573,7 @@ export class ZonedDateTime {
       isoNanosecond: GetSlot(dt, ISO_NANOSECOND),
       isoSecond: GetSlot(dt, ISO_SECOND),
       isoYear: GetSlot(dt, ISO_YEAR),
-      offset: ES.GetOffsetStringFor(tz, GetSlot(this, INSTANT)),
+      offset: ES.FormatUTCOffsetNanoseconds(offsetNanoseconds),
       timeZone: tz
     };
   }

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -530,7 +530,7 @@
           1. Assert: _maximum_ is not *undefined*.
           1. Let _inclusive_ be *false*.
         1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, _inclusive_).
-        1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Let _result_ be RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -566,7 +566,7 @@
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
         1. Let _precision_ be ToSecondsStringPrecisionRecord(_smallestUnit_, _digits_).
-        1. Let _result_ be ! RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Let _result_ be RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ? TemporalDateTimeToString(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]], _precision_.[[Precision]], _showCalendar_).
       </emu-alg>
     </emu-clause>
@@ -833,6 +833,78 @@
   <emu-clause id="sec-temporal-plaindatetime-abstract-ops">
     <h1>Abstract operations</h1>
 
+    <emu-clause id="sec-temporal-iso-date-time-records">
+      <h1>ISO Date-Time Records</h1>
+      <p>
+        An <dfn variants="ISO Date-Time Records">ISO Date-Time Record</dfn> is a Record value used to represent a valid calendar date in the ISO 8601 calendar together with a clock time.
+        For any ISO Date-Time Record _r_, IsValidISODate(_r_.[[Year]], _r_.[[Month]], _r_.[[Day]]) must return *true*, and IsValidTime(_r_.[[Hour]], _r_.[[Minute]], _r_.[[Second]], _r_.[[Millisecond]], _r_.[[Microsecond]], _r_.[[Nanosecond]]) must return *true*.
+        It is not necessary for ISODateTimeWithinLimits(_r_.[[Year]], _r_.[[Month]], _r_.[[Day]], _r_.[[Hour]], _r_.[[Minute]], _r_.[[Second]], _r_.[[Millisecond]], _r_.[[Microsecond]], _r_.[[Nanosecond]]) to return *true*.
+      </p>
+      <p>
+        ISO Date-Time Records have the fields listed in <emu-xref href="#table-temporal-iso-date-time-record-fields"></emu-xref>.
+      </p>
+      <emu-table id="table-temporal-iso-date-time-record-fields" caption="ISO Date-Time Record Fields">
+        <table class="real-table">
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td>[[Year]]</td>
+            <td>an integer</td>
+            <td>
+              The year in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Month]]</td>
+            <td>an integer between 1 and 12, inclusive</td>
+            <td>
+              The number of the month in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Day]]</td>
+            <td>an integer between 1 and 31, inclusive</td>
+            <td>
+              The number of the day of the month in the ISO 8601 calendar.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Hour]]</td>
+            <td>an integer in the inclusive range 0 to 23</td>
+            <td>The number of the hour.</td>
+          </tr>
+          <tr>
+            <td>[[Minute]]</td>
+            <td>an integer in the inclusive range 0 to 59</td>
+            <td>The number of the minute.</td>
+          </tr>
+          <tr>
+            <td>[[Second]]</td>
+            <td>an integer in the inclusive range 0 to 59</td>
+            <td>The number of the second.</td>
+          </tr>
+          <tr>
+            <td>[[Millisecond]]</td>
+            <td>an integer in the inclusive range 0 to 999</td>
+            <td>The number of the millisecond.</td>
+          </tr>
+          <tr>
+            <td>[[Microsecond]]</td>
+            <td>an integer in the inclusive range 0 to 999</td>
+            <td>The number of the microsecond.</td>
+          </tr>
+          <tr>
+            <td>[[Nanosecond]]</td>
+            <td>an integer in the inclusive range 0 to 999</td>
+            <td>The number of the nanosecond.</td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-isodatetimewithinlimits" type="abstract operation">
       <h1>
         ISODateTimeWithinLimits (
@@ -928,10 +1000,25 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-balanceisodatetime" aoid="BalanceISODateTime">
-      <h1>BalanceISODateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
+    <emu-clause id="sec-temporal-balanceisodatetime" type="abstract operation">
+      <h1>
+        BalanceISODateTime (
+          _year_: an integer,
+          _month_: an integer,
+          _day_: an integer,
+          _hour_: an integer,
+          _minute_: an integer,
+          _second_: an integer,
+          _millisecond_: an integer,
+          _microsecond_: an integer,
+          _nanosecond_: an integer,
+        ): an ISO Date-Time Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
+      </dl>
       <emu-alg>
-        1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integers.
         1. Let _balancedTime_ be BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. Let _balancedDate_ be BalanceISODate(_year_, _month_, _day_ + _balancedTime_.[[Days]]).
         1. Return the Record {
@@ -1018,14 +1105,14 @@
       <h1>
         AddDateTime (
           _year_: an integer,
-          _month_: an integer,
-          _day_: an integer,
-          _hour_: an integer,
-          _minute_: an integer,
-          _second_: an integer,
-          _millisecond_: an integer,
-          _microsecond_: an integer,
-          _nanosecond_: an integer,
+          _month_: an integer in the inclusive interval from 1 to 12,
+          _day_: an integer in the inclusive interval from 1 to 31,
+          _hour_: an integer in the inclusive interval from 0 to 23,
+          _minute_: an integer in the inclusive interval from 0 to 59,
+          _second_: an integer in the inclusive interval from 0 to 59,
+          _millisecond_: an integer in the inclusive interval from 0 to 999,
+          _microsecond_: an integer in the inclusive interval from 0 to 999,
+          _nanosecond_: an integer in the inclusive interval from 0 to 999,
           _calendar_: an Object,
           _years_: an integer,
           _months_: an integer,
@@ -1038,7 +1125,7 @@
           _microseconds_: an integer,
           _nanoseconds_: an integer,
           _options_: an Object or *undefined*,
-        )
+        ): either a normal completion containing an ISO Date-Time Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1066,13 +1153,29 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-roundisodatetime" aoid="RoundISODateTime">
-      <h1>RoundISODateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_ [ , _dayLength_ ] )</h1>
-      <p>
-        The abstract operation RoundISODateTime rounds the time part of a combined date and time, carrying over any excess into the date part.
-      </p>
+    <emu-clause id="sec-temporal-roundisodatetime" type="abstract operation">
+      <h1>
+        RoundISODateTime (
+          _year_: an integer,
+          _month_: an integer in the inclusive interval from 1 to 12,
+          _day_: an integer in the inclusive interval from 1 to 31,
+          _hour_: an integer in the inclusive interval from 0 to 23,
+          _minute_: an integer in the inclusive interval from 0 to 59,
+          _second_: an integer in the inclusive interval from 0 to 59,
+          _millisecond_: an integer in the inclusive interval from 0 to 999,
+          _microsecond_: an integer in the inclusive interval from 0 to 999,
+          _nanosecond_: an integer in the inclusive interval from 0 to 999,
+          _increment_: an integer,
+          _unit_: *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
+          _roundingMode_: *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, or *"halfEven"*,
+          optional _dayLength_: an integer,
+        ): an ISO Date-Time Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It rounds the time part of a combined date and time, carrying over any excess into the date part.</dd>
+      </dl>
       <emu-alg>
-        1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integers.
         1. Assert: ISODateTimeWithinLimits(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
         1. If _dayLength_ is not present, set _dayLength_ to nsPerDay.
         1. Let _roundedTime_ be RoundTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_, _dayLength_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -932,7 +932,7 @@
       <h1>BalanceISODateTime ( _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
       <emu-alg>
         1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integers.
-        1. Let _balancedTime_ be ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+        1. Let _balancedTime_ be BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
         1. Let _balancedDate_ be BalanceISODate(_year_, _month_, _day_ + _balancedTime_.[[Days]]).
         1. Return the Record {
             [[Year]]: _balancedDate_.[[Year]],
@@ -1048,7 +1048,7 @@
       </dl>
       <emu-alg>
         1. Assert: ISODateTimeWithinLimits(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
-        1. Let _timeResult_ be ! AddTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+        1. Let _timeResult_ be AddTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Let _datePart_ be ! CreateTemporalDate(_year_, _month_, _day_, _calendar_).
         1. Let _dateDuration_ be ? CreateTemporalDuration(_years_, _months_, _weeks_, _days_ + _timeResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _datePart_, _dateDuration_, _options_).
@@ -1075,7 +1075,7 @@
         1. Assert: _year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integers.
         1. Assert: ISODateTimeWithinLimits(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
         1. If _dayLength_ is not present, set _dayLength_ to nsPerDay.
-        1. Let _roundedTime_ be ! RoundTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_, _dayLength_).
+        1. Let _roundedTime_ be RoundTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_, _dayLength_).
         1. Let _balanceResult_ be BalanceISODate(_year_, _month_, _day_ + _roundedTime_.[[Days]]).
         1. Return the Record {
             [[Year]]: _balanceResult_.[[Year]],

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -299,7 +299,7 @@
         1. Let _maximum_ be ! MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. Assert: _maximum_ is not *undefined*.
         1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
-        1. Let _result_ be ! RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Let _result_ be RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ! CreateTemporalTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>
@@ -397,7 +397,7 @@
         1. Let _smallestUnit_ be ? GetTemporalUnit(_options_, *"smallestUnit"*, ~time~, *undefined*).
         1. If _smallestUnit_ is *"hour"*, throw a *RangeError* exception.
         1. Let _precision_ be ToSecondsStringPrecisionRecord(_smallestUnit_, _digits_).
-        1. Let _roundResult_ be ! RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Let _roundResult_ be RoundTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Return ! TemporalTimeToString(_roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], _precision_.[[Precision]]).
       </emu-alg>
     </emu-clause>
@@ -525,6 +525,61 @@
   <emu-clause id="sec-temporal-plaintime-abstract-ops">
     <h1>Abstract operations</h1>
 
+    <emu-clause id="sec-temporal-time-records">
+      <h1>Time Records</h1>
+      <p>
+        A <dfn variants="Time Records">Time Record</dfn> is a Record value used to represent a valid clock time, together with a number of overflow days such as might occur in BalanceTime.
+        For any Time Record _t_, IsValidTime(_t_.[[Hour]], _t_.[[Minute]], _t_.[[Second]], _t_.[[Millisecond]], _t_.[[Microsecond]], _t_.[[Nanosecond]]) must return *true*.
+      </p>
+      <p>
+        Time Records have the fields listed in <emu-xref href="#table-temporal-time-record-fields"></emu-xref>.
+      </p>
+      <emu-table id="table-temporal-time-record-fields" caption="Time Record Fields">
+        <table class="real-table">
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td>[[Days]]</td>
+            <td>an integer &ge; 0</td>
+            <td>A number of overflow days.</td>
+          </tr>
+          <tr>
+            <td>[[Hour]]</td>
+            <td>an integer in the inclusive range 0 to 23</td>
+            <td>The number of the hour.</td>
+          </tr>
+          <tr>
+            <td>[[Minute]]</td>
+            <td>an integer in the inclusive range 0 to 59</td>
+            <td>The number of the minute.</td>
+          </tr>
+          <tr>
+            <td>[[Second]]</td>
+            <td>an integer in the inclusive range 0 to 59</td>
+            <td>The number of the second.</td>
+          </tr>
+          <tr>
+            <td>[[Millisecond]]</td>
+            <td>an integer in the inclusive range 0 to 999</td>
+            <td>The number of the millisecond.</td>
+          </tr>
+          <tr>
+            <td>[[Microsecond]]</td>
+            <td>an integer in the inclusive range 0 to 999</td>
+            <td>The number of the microsecond.</td>
+          </tr>
+          <tr>
+            <td>[[Nanosecond]]</td>
+            <td>an integer in the inclusive range 0 to 999</td>
+            <td>The number of the nanosecond.</td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-differencetime" type="abstract operation">
       <h1>
         DifferenceTime (
@@ -554,7 +609,7 @@
         1. Let _microseconds_ be _mus2_ - _mus1_.
         1. Let _nanoseconds_ be _ns2_ - _ns1_.
         1. Let _sign_ be ! DurationSign(0, 0, 0, 0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Let _bt_ be ! BalanceTime(_hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
+        1. Let _bt_ be BalanceTime(_hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
         1. Assert: _bt_.[[Days]] is 0.
         1. Return ! CreateTimeDurationRecord(0, _bt_.[[Hour]] &times; _sign_, _bt_.[[Minute]] &times; _sign_, _bt_.[[Second]] &times; _sign_, _bt_.[[Millisecond]] &times; _sign_, _bt_.[[Microsecond]] &times; _sign_, _bt_.[[Nanosecond]] &times; _sign_).
       </emu-alg>
@@ -643,10 +698,22 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-balancetime" aoid="BalanceTime">
-      <h1>BalanceTime ( _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_ )</h1>
+    <emu-clause id="sec-temporal-balancetime" type="abstract operation">
+      <h1>
+        BalanceTime (
+          _hour_: an integer,
+          _minute_: an integer,
+          _second_: an integer,
+          _millisecond_: an integer,
+          _microsecond_: an integer,
+          _nanosecond_: an integer,
+        ): a Time Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
+      </dl>
       <emu-alg>
-        1. Assert: _hour_, _minute_, _second_, _millisecond_, _microsecond_, and _nanosecond_ are integers.
         1. Set _microsecond_ to _microsecond_ + floor(_nanosecond_ / 1000).
         1. Set _nanosecond_ to _nanosecond_ modulo 1000.
         1. Set _millisecond_ to _millisecond_ + floor(_microsecond_ / 1000).
@@ -838,29 +905,58 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-addtime" aoid="AddTime">
-      <h1>AddTime ( _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ )</h1>
+    <emu-clause id="sec-temporal-addtime" type="abstract operation">
+      <h1>
+        AddTime (
+          _hour_: an integer in the inclusive range 0 to 23,
+          _minute_: an integer in the inclusive range 0 to 59,
+          _second_: an integer in the inclusive range 0 to 59,
+          _millisecond_: an integer in the inclusive range 0 to 999,
+          _microsecond_: an integer in the inclusive range 0 to 999,
+          _nanosecond_: an integer in the inclusive range 0 to 999,
+          _hours_: an integer,
+          _minutes_: an integer,
+          _seconds_: an integer,
+          _milliseconds_: an integer,
+          _microseconds_: an integer,
+          _nanoseconds_: an integer,
+        ): a Time Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
+      </dl>
       <emu-alg>
-        1. Assert: _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are integers.
-        1. Assert: IsValidTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
-        1. Let _hour_ be _hour_ + _hours_.
-        1. Let _minute_ be _minute_ + _minutes_.
-        1. Let _second_ be _second_ + _seconds_.
-        1. Let _millisecond_ be _millisecond_ + _milliseconds_.
-        1. Let _microsecond_ be _microsecond_ + _microseconds_.
-        1. Let _nanosecond_ be _nanosecond_ + _nanoseconds_.
-        1. Return ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
+        1. Set _hour_ to _hour_ + _hours_.
+        1. Set _minute_ to _minute_ + _minutes_.
+        1. Set _second_ to _second_ + _seconds_.
+        1. Set _millisecond_ to _millisecond_ + _milliseconds_.
+        1. Set _microsecond_ to _microsecond_ + _microseconds_.
+        1. Set _nanosecond_ to _nanosecond_ + _nanoseconds_.
+        1. Return BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-roundtime" aoid="RoundTime">
-      <h1>RoundTime ( _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_ [ , _dayLengthNs_ ] )</h1>
-      <p>
-        The abstract operation RoundTime rounds a time to the given increment, optionally adjusting for a non-24-hour day.
-      </p>
+    <emu-clause id="sec-temporal-roundtime" type="abstract operation">
+      <h1>
+        RoundTime (
+          _hour_: an integer in the inclusive range 0 to 23,
+          _minute_: an integer in the inclusive range 0 to 59,
+          _second_: an integer in the inclusive range 0 to 59,
+          _millisecond_: an integer in the inclusive range 0 to 999,
+          _microsecond_: an integer in the inclusive range 0 to 999,
+          _nanosecond_: an integer in the inclusive range 0 to 999,
+          _increment_: an integer,
+          _unit_: *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
+          _roundingMode_: *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, or *"halfEven"*,
+          optional _dayLengthNs_: an integer,
+        ): a Time Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It rounds a time to the given increment, optionally adjusting for a non-24-hour day.</dd>
+      </dl>
       <emu-alg>
-        1. Assert: _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, and _increment_ are integers.
-        1. Assert: IsValidTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
         1. Let _fractionalSecond_ be _nanosecond_ &times; 10<sup>-9</sup> + _microsecond_ &times; 10<sup>-6</sup> + _millisecond_ &times; 10<sup>-3</sup> + _second_.
         1. If _unit_ is *"day"*, then
           1. If _dayLengthNs_ is not present, set _dayLengthNs_ to nsPerDay.
@@ -890,17 +986,17 @@
             [[Nanosecond]]: 0
           }.
         1. If _unit_ is *"hour"*, then
-          1. Return ! BalanceTime(_result_, 0, 0, 0, 0, 0).
+          1. Return BalanceTime(_result_, 0, 0, 0, 0, 0).
         1. If _unit_ is *"minute"*, then
-          1. Return ! BalanceTime(_hour_, _result_, 0, 0, 0, 0).
+          1. Return BalanceTime(_hour_, _result_, 0, 0, 0, 0).
         1. If _unit_ is *"second"*, then
-          1. Return ! BalanceTime(_hour_, _minute_, _result_, 0, 0, 0).
+          1. Return BalanceTime(_hour_, _minute_, _result_, 0, 0, 0).
         1. If _unit_ is *"millisecond"*, then
-          1. Return ! BalanceTime(_hour_, _minute_, _second_, _result_, 0, 0).
+          1. Return BalanceTime(_hour_, _minute_, _second_, _result_, 0, 0).
         1. If _unit_ is *"microsecond"*, then
-          1. Return ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _result_, 0).
+          1. Return BalanceTime(_hour_, _minute_, _second_, _millisecond_, _result_, 0).
         1. Assert: _unit_ is *"nanosecond"*.
-        1. Return ! BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _result_).
+        1. Return BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _result_).
       </emu-alg>
     </emu-clause>
     <emu-clause id="sec-temporal-differencetemporalplaintime" type="abstract operation">
@@ -943,7 +1039,7 @@
       <emu-alg>
         1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
-        1. Let _result_ be ! AddTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
+        1. Let _result_ be AddTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
         1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ! CreateTemporalTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -692,7 +692,7 @@
       <emu-alg>
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
         1. Let _result_ be ! GetISOPartsFromEpoch(ℝ(_instant_.[[Nanoseconds]])).
-        1. Set _result_ to ! BalanceISODateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).
+        1. Set _result_ to BalanceISODateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]] + _offsetNanoseconds_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -507,6 +507,32 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-formatutcoffsetnanoseconds" type="abstract operation">
+      <h1>
+        FormatUTCOffsetNanoseconds (
+          _offsetNanoseconds_: an integer,
+        ): a String
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          If the offset represents an integer number of minutes, then the output will be formatted like ±HH:MM.
+          Otherwise, the output will be formatted like ±HH:MM:SS or (if the offset does not evenly divide into seconds) ±HH:MM:SS.fff… where the "fff" part is a sequence of at least 1 and at most 9 fractional seconds digits with no trailing zeroes.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. If _offsetNanoseconds_ &ge; 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
+        1. Let _absoluteNanoseconds_ be abs(_offsetNanoseconds_).
+        1. Let _hour_ be floor(_absoluteNanoseconds_ / (3600 × 10<sup>9</sup>)).
+        1. Let _minute_ be floor(_absoluteNanoseconds_ / (60 × 10<sup>9</sup>)) modulo 60.
+        1. Let _second_ be floor(_absoluteNanoseconds_ / 10<sup>9</sup>) modulo 60.
+        1. Let _subSecondNanoseconds_ be _absoluteNanoseconds_ modulo 10<sup>9</sup>.
+        1. If _second_ = 0 and _subSecondNanoseconds_ = 0, let _precision_ be *"minute"*; otherwise, let _precision_ be *"auto"*.
+        1. Let _timeString_ be FormatTimeString(_hour_, _minute_, _second_, _subSecondNanoseconds_, _precision_).
+        1. Return the string-concatenation of _sign_ and _timeString_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-formatdatetimeutcoffsetrounded" type="abstract operation">
       <h1>
         FormatDateTimeUTCOffsetRounded (
@@ -656,21 +682,11 @@
         <dd>
           This operation is the internal implementation of the `Temporal.TimeZone.prototype.getOffsetStringFor` method.
           If the given _timeZone_ is an Object, it observably calls _timeZone_'s `getOffsetNanosecondsFor` method.
-          If the offset represents an integer number of minutes, then the output will be formatted like ±HH:MM.
-          Otherwise, the output will be formatted like ±HH:MM:SS or (if the offset does not evenly divide into seconds) ±HH:MM:SS.fff… where the "fff" part is a sequence of at least 1 and at most 9 fractional seconds digits with no trailing zeroes.
         </dd>
       </dl>
       <emu-alg>
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
-        1. If _offsetNanoseconds_ &ge; 0, let _sign_ be the code unit 0x002B (PLUS SIGN); otherwise, let _sign_ be the code unit 0x002D (HYPHEN-MINUS).
-        1. Let _absoluteNanoseconds_ be abs(_offsetNanoseconds_).
-        1. Let _hour_ be floor(_absoluteNanoseconds_ / (3600 × 10<sup>9</sup>)).
-        1. Let _minute_ be floor(_absoluteNanoseconds_ / (60 × 10<sup>9</sup>)) modulo 60.
-        1. Let _second_ be floor(_absoluteNanoseconds_ / 10<sup>9</sup>) modulo 60.
-        1. Let _subSecondNanoseconds_ be _absoluteNanoseconds_ modulo 10<sup>9</sup>.
-        1. If _second_ = 0 and _subSecondNanoseconds_ = 0, let _precision_ be *"minute"*; otherwise, let _precision_ be *"auto"*.
-        1. Let _timeString_ be FormatTimeString(_hour_, _minute_, _second_, _subSecondNanoseconds_, _precision_).
-        1. Return the string-concatenation of _sign_ and _timeString_.
+        1. Return FormatUTCOffsetNanoseconds(_offsetNanoseconds_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -971,7 +971,8 @@
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _dateTime_ be ? GetPlainDateTimeFor(_timeZone_, _instant_, _calendar_).
-        1. Let _offset_ be ? GetOffsetStringFor(_timeZone_, _instant_).
+        1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
+        1. Let _offset_ be FormatUTCOffsetNanoseconds(_offsetNanoseconds_).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"calendar"*, _calendar_).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoDay"*, 𝔽(_dateTime_.[[ISODay]])).
         1. Perform ! CreateDataPropertyOrThrow(_fields_, *"isoHour"*, 𝔽(_dateTime_.[[ISOHour]])).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -759,7 +759,7 @@
         1. Let _dayLengthNs_ be ℝ(_endNs_ - _startNs_).
         1. If _dayLengthNs_ &le; 0, then
           1. Throw a *RangeError* exception.
-        1. Let _roundResult_ be ! RoundISODateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dayLengthNs_).
+        1. Let _roundResult_ be RoundISODateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dayLengthNs_).
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZone_, _instant_).
         1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_.[[Year]], _roundResult_.[[Month]], _roundResult_.[[Day]], _roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZone_, *"compatible"*, *"prefer"*, ~match exactly~).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).


### PR DESCRIPTION
I know we just inlined FormatTimeZoneOffsetString into GetOffsetStringFor, but due to rebasing #2519 I'm having to un-inline it — it'll be used in more than one place when we pre-calculate the UTC offset nanoseconds in cases where it was calculated twice.

Also includes some commits adding more structured headers that I had queued up but never submitted.