### PR TITLE
Polyfill: Remove throw in ParseTemporalInstant

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -666,7 +666,7 @@ export function ParseTemporalInstant(isoString) {
   let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, offset, z } =
     ParseTemporalInstantString(isoString);
 
-  if (!z && !offset) throw new RangeError('Temporal.Instant requires a time zone offset');
+  // ParseTemporalInstantString ensures that either `z` or `offset` are non-undefined
   const offsetNs = z ? 0 : ParseDateTimeUTCOffset(offset);
   ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = BalanceISODateTime(
     year,


### PR DESCRIPTION
Found by codecov: ParseTemporalInstantString already throws if neither `z` nor `offset` are present, so there's no need to check again after ParseTemporalInstantString returns.