### PR TITLE
Polyfill: Change RoundDuration TypeError to an assertion

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -5316,7 +5316,7 @@ export function RoundDuration(
       zonedRelativeTo = relativeTo;
       relativeTo = ToTemporalDate(relativeTo);
     } else if (!IsTemporalDate(relativeTo)) {
-      throw new TypeError('starting point must be PlainDate or ZonedDateTime');
+      throw new Error('assertion failure in RoundDuration: _relativeTo_ must be PlainDate');
     }
     calendar = GetSlot(relativeTo, CALENDAR);
   }


### PR DESCRIPTION
Align RoundDuration checking of `relativeTo` to an assertion, like in the spec. 

There's no need to throw a TypeError in the (should never happen) case when validating `relativeTo`, because upstream callers guarantee that it is one of `undefined`, a ZDT instance, or a PlainDate instance.
