### PR TITLE
Editorial: Align time zone name syntax with IXDTF

### DIFF
--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -1,18 +1,7 @@
-const tzComponent = /\.[-A-Za-z_]|\.\.[-A-Za-z._]{1,12}|\.[-A-Za-z_][-A-Za-z._]{0,12}|[A-Za-z_][-A-Za-z._]{0,13}/;
-const offsetIdentifierNoCapture = /(?:[+\u2212-][0-2][0-9](?::?[0-5][0-9])?)/;
+const offsetIdentifierNoCapture = /(?:[+\u2212-](?:[01][0-9]|2[0-3])(?::?[0-5][0-9])?)/;
+const tzComponent = /[A-Za-z._][A-Za-z._0-9+-]*/;
 export const timeZoneID = new RegExp(
-  '(?:' +
-    [
-      `(?:${tzComponent.source})(?:\\/(?:${tzComponent.source}))*`,
-      'Etc/GMT(?:0|[-+]\\d{1,2})',
-      'GMT[-+]?0',
-      'EST5EDT',
-      'CST6CDT',
-      'MST7MDT',
-      'PST8PDT',
-      offsetIdentifierNoCapture.source
-    ].join('|') +
-    ')'
+  `(?:${offsetIdentifierNoCapture.source}|(?:${tzComponent.source})(?:\\/(?:${tzComponent.source}))*)`
 );
 
 const yearpart = /(?:[+\u2212-]\d{6}|\d{4})/;

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1168,40 +1168,23 @@
           `.`
           `_`
 
-      TZChar[Legacy] :
+      TZChar :
           TZLeadingChar
+          DecimalDigit
           `-`
-          [+Legacy] `+`
-          [+Legacy] DecimalDigit
+          `+`
 
-      TimeZoneIANANameComponent[Legacy] :
-          > Readability note: This production matches 1 to 14 characters.
-          TZLeadingChar but not `.`
-          TZLeadingChar TZChar[?Legacy] but not `..`
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-          TZLeadingChar TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy] TZChar[?Legacy]
-
-      TimeZoneIANANameTail[Legacy] :
-          TimeZoneIANANameComponent[?Legacy]
-          TimeZoneIANANameComponent[?Legacy] `/` TimeZoneIANANameTail[?Legacy]
+      TimeZoneIANANameComponent :
+          TZLeadingChar
+          TimeZoneIANANameComponent TZChar
 
       TimeZoneIANAName :
-          TimeZoneIANANameTail[~Legacy]
-          TimeZoneIANANameTail[+Legacy] [> but only if IsLegacyIANATimeZoneName of |TimeZoneIANANameTail| is *true*]
+          TimeZoneIANANameComponent
+          TimeZoneIANAName `/` TimeZoneIANANameComponent
 
       TimeZoneIdentifier :
-          TimeZoneIANAName
           TimeZoneUTCOffsetName
+          TimeZoneIANAName
 
       TimeZoneAnnotation :
           `[` AnnotationCriticalFlag? TimeZoneIdentifier `]`
@@ -1371,31 +1354,6 @@
           It is a Syntax Error if |DateYear| is *"-000000"* or *"−000000"* (U+2212 MINUS SIGN followed by `000000`).
         </li>
       </ul>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-iso8601grammar-static-semantics-islegacyianatimezonename" type="sdo">
-      <h1>Static Semantics: IsLegacyIANATimeZoneName ( ): a Boolean</h1>
-      <dl class="header">
-      </dl>
-      <emu-note>
-        <p>The IANA Time Zone Database naming guidelines do not allow digits in new named time zone identifiers, but legacy exceptions remain as described at <a href="https://data.iana.org/time-zones/theory.html">Theory and pragmatics of the tz code and data</a>. In addition to specific names mentioned there, this specification also recognizes all time zone identifiers consisting of *"Etc/GMT-"* or *"Etc/GMT+"* followed by an unpadded count of hours less than 24 as syntactically valid, even those that are not currently included in the IANA Time Zone Database (but does not require any such identifier to be an available named time zone identifier).</p>
-      </emu-note>
-      <emu-grammar>
-        TimeZoneIANANameTail[Legacy] :
-            TimeZoneIANANameComponent[?Legacy]
-            TimeZoneIANANameComponent[?Legacy] `/` TimeZoneIANANameTail[?Legacy]
-      </emu-grammar>
-      <emu-alg>
-        1. Let _name_ be the source text matched by |TimeZoneIANANameTail|.
-        1. Let _nameStr_ be CodePointsToString(_name_).
-        1. For each String _legacyName_ of « *"Etc/GMT0"*, *"GMT0"*, *"GMT-0"*, *"GMT+0"*, *"EST5EDT"*, *"CST6CDT"*, *"MST7MDT"*, *"PST8PDT"* », do
-          1. If _nameStr_ is an ASCII-case-insensitive match for _legacyName_, return *true*.
-        1. If the length of _nameStr_ &lt; 9, return *false*.
-        1. If the substring of _nameStr_ from 0 to 8 is not an ASCII-case-insensitive match for *"Etc/GMT-"* or *"Etc/GMT+"*, return *false*.
-        1. Let _hour_ be the substring of _nameStr_ from 8.
-        1. If ParseText(_hour_, |Hour[~Padded]|) is a List of errors, return *false*.
-        1. Return *true*.
-      </emu-alg>
     </emu-clause>
   </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -865,6 +865,7 @@
         1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
         1. If _parseResult_ contains a |TimeZoneIANAName| Parse Node, then
           1. Let _name_ be the source text matched by the |TimeZoneIANAName| Parse Node contained within _parseResult_.
+          1. NOTE: _name_ is syntactically valid, but does not necessarily conform to <a href="https://data.iana.org/time-zones/theory.html#naming">IANA Time Zone Database naming guidelines</a> or correspond with an available named time zone identifier.
           1. Return the Record { [[Name]]: _name_, [[OffsetMinutes]]: ~empty~ }.
         1. Else,
           1. Assert: _parseResult_ contains a |TimeZoneUTCOffsetName| Parse Node.


### PR DESCRIPTION
Fixes #2608

https://www.ietf.org/archive/id/draft-ietf-sedate-datetime-extended-09.html#name-abnf

Note that _semantic_ constraints remain unchanged; a syntactically valid but unknown time zone like "Etc/GMT-23" or "Foo/Bar+1" is still rejected.