### PR TITLE
Editorial: Simplify date/time range validation

### DIFF
--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -62,8 +62,10 @@ Together, `isoYear`, `isoMonth`, and `isoDay` must represent a valid date in tha
 > **NOTE**: Although Temporal does not deal with leap seconds, dates coming from other software may have a `second` value of 60.
 > This value will cause the constructor will throw, so if you have to interoperate with times that may contain leap seconds, use `Temporal.PlainDateTime.from()` instead.
 
-The range of allowed values for this type is exactly enough that calling `timeZone.getPlainDateTimeFor(instant)` will succeed when `timeZone` is any built-in `Temporal.TimeZone` and `instant` is any valid `Temporal.Instant`.
-If the parameters passed in to this constructor form a date outside of this range, then this function will throw a `RangeError`.
+The range of allowed values for this type is wider (by one nanosecond smaller than one day) on each end than the range of `Temporal.Instant`.
+Because the magnitude of built-in time zones' UTC offset will always be less than 24 hours, this extra range ensures that a valid `Temporal.Instant` can always be converted to a valid `Temporal.PlainDateTime` using any built-in time zone.
+Note that the reverse conversion is not guaranteed to succeed; a valid `Temporal.PlainDateTime` at the edge of its range may, for some built-in time zones, be out of range of `Temporal.Instant`.
+If the parameters passed in to this constructor are out of range, then this function will throw a `RangeError`.
 
 Usually `calendar` will be a string containing the identifier of a built-in calendar, such as `'islamic'` or `'gregory'`.
 Use an object if you need to supply [custom calendar behaviour](./calendar.md#custom-calendars).

--- a/polyfill/lib/timezone.mjs
+++ b/polyfill/lib/timezone.mjs
@@ -96,10 +96,10 @@ export class TimeZone {
         GetSlot(dateTime, ISO_SECOND),
         GetSlot(dateTime, ISO_MILLISECOND),
         GetSlot(dateTime, ISO_MICROSECOND),
-        GetSlot(dateTime, ISO_NANOSECOND)
+        GetSlot(dateTime, ISO_NANOSECOND),
+        offsetMinutes * 60e9
       );
-      if (epochNs === null) throw new RangeError('DateTime outside of supported range');
-      return [new Instant(epochNs.minus(offsetMinutes * 60e9))];
+      return [new Instant(epochNs)];
     }
 
     const possibleEpochNs = ES.GetNamedTimeZoneEpochNanoseconds(

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1452,7 +1452,7 @@
     <h1>
       ParseTemporalInstantString (
         _isoString_: a String,
-      )
+      ): either a normal completion containing a Record, or a throw completion
     </h1>
     <dl class="header">
       <dt>description</dt>
@@ -1461,21 +1461,19 @@
     <emu-alg>
       1. If ParseText(StringToCodePoints(_isoString_), |TemporalInstantString|) is a List of errors, throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
-      1. Let _offsetString_ be _result_.[[TimeZone]].[[OffsetString]].
-      1. If _result_.[[TimeZone]].[[Z]] is *true*, then
-        1. Set _offsetString_ to *"+00:00"*.
-      1. Assert: _offsetString_ is not *undefined*.
+      1. Assert: Either _result_.[[TimeZone]].[[OffsetString]] is a String or _result_.[[TimeZone]].[[Z]] is *true*, but not both.
       1. Return the Record {
-        [[Year]]: _result_.[[Year]],
-        [[Month]]: _result_.[[Month]],
-        [[Day]]: _result_.[[Day]],
-        [[Hour]]: _result_.[[Hour]],
-        [[Minute]]: _result_.[[Minute]],
-        [[Second]]: _result_.[[Second]],
-        [[Millisecond]]: _result_.[[Millisecond]],
-        [[Microsecond]]: _result_.[[Microsecond]],
-        [[Nanosecond]]: _result_.[[Nanosecond]],
-        [[TimeZoneOffsetString]]: _offsetString_
+          [[Year]]: _result_.[[Year]],
+          [[Month]]: _result_.[[Month]],
+          [[Day]]: _result_.[[Day]],
+          [[Hour]]: _result_.[[Hour]],
+          [[Minute]]: _result_.[[Minute]],
+          [[Second]]: _result_.[[Second]],
+          [[Millisecond]]: _result_.[[Millisecond]],
+          [[Microsecond]]: _result_.[[Microsecond]],
+          [[Nanosecond]]: _result_.[[Nanosecond]],
+          [[OffsetString]]: _result_.[[TimeZone]].[[OffsetString]],
+          [[Z]]: _result_.[[TimeZone]].[[Z]]
         }.
     </emu-alg>
   </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -32,7 +32,7 @@
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. Let _epochNanoseconds_ be ? ToBigInt(_epochNanoseconds_).
-        1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ? CreateTemporalInstant(_epochNanoseconds_, NewTarget).
       </emu-alg>
     </emu-clause>
@@ -70,7 +70,7 @@
         1. Set _epochSeconds_ to ? ToNumber(_epochSeconds_).
         1. Set _epochSeconds_ to ? NumberToBigInt(_epochSeconds_).
         1. Let _epochNanoseconds_ be _epochSeconds_ &times; ℤ(10<sup>9</sup>).
-        1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
     </emu-clause>
@@ -84,7 +84,7 @@
         1. Set _epochMilliseconds_ to ? ToNumber(_epochMilliseconds_).
         1. Set _epochMilliseconds_ to ? NumberToBigInt(_epochMilliseconds_).
         1. Let _epochNanoseconds_ be _epochMilliseconds_ &times; ℤ(10<sup>6</sup>).
-        1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
     </emu-clause>
@@ -97,7 +97,7 @@
       <emu-alg>
         1. Set _epochMicroseconds_ to ? ToBigInt(_epochMicroseconds_).
         1. Let _epochNanoseconds_ be _epochMicroseconds_ &times; *1000*<sub>ℤ</sub>.
-        1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
     </emu-clause>
@@ -109,7 +109,7 @@
       </p>
       <emu-alg>
         1. Set _epochNanoseconds_ to ? ToBigInt(_epochNanoseconds_).
-        1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
     </emu-clause>
@@ -583,7 +583,7 @@
             ℤ(_seconds_) &times; ℤ(10<sup>9</sup>) +
             ℤ(_minutes_) &times; *60*<sub>ℤ</sub> &times; ℤ(10<sup>9</sup>) +
             ℤ(_hours_) &times; *3600*<sub>ℤ</sub> &times; ℤ(10<sup>9</sup>).
-        1. If ! IsValidEpochNanoseconds(_result_) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(_result_) is *false*, throw a *RangeError* exception.
         1. Return _result_.
       </emu-alg>
     </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -521,24 +521,11 @@
           1. NOTE: This use of ToPrimitive allows Instant-like objects to be converted.
           1. Set _item_ to ? ToPrimitive(_item_, ~string~).
         1. If _item_ is not a String, throw a *TypeError* exception.
-        1. Let _epochNanoseconds_ be ? ParseTemporalInstant(_item_).
+        1. Let _parsed_ be ? ParseTemporalInstantString(_item_).
+        1. If _parsed_.[[Z]] is *true*, let _offsetNanoseconds_ be 0; otherwise, let _offsetNanoseconds_ be ! ParseDateTimeUTCOffset(_parsed_.[[OffsetString]]).
+        1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_parsed_.[[Year]], _parsed_.[[Month]], _parsed_.[[Day]], _parsed_.[[Hour]], _parsed_.[[Minute]], _parsed_.[[Second]], _parsed_.[[Millisecond]], _parsed_.[[Microsecond]], _parsed_.[[Nanosecond]], _offsetNanoseconds_).
+        1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-parsetemporalinstant" aoid="ParseTemporalInstant">
-      <h1>ParseTemporalInstant ( _isoString_ )</h1>
-      <emu-alg>
-        1. Assert: Type(_isoString_) is String.
-        1. Let _result_ be ? ParseTemporalInstantString(_isoString_).
-        1. Let _offsetString_ be _result_.[[TimeZoneOffsetString]].
-        1. Assert: _offsetString_ is not *undefined*.
-        1. Let _utc_ be GetUTCEpochNanoseconds(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
-        1. Let _offsetNanoseconds_ be ? ParseDateTimeUTCOffset(_offsetString_).
-        1. Let _result_ be _utc_ - ℤ(_offsetNanoseconds_).
-        1. If ! IsValidEpochNanoseconds(_result_) is *false*, then
-          1. Throw a *RangeError* exception.
-        1. Return _result_.
       </emu-alg>
     </emu-clause>
 

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -188,6 +188,40 @@
 
     <p>[...]</p>
 
+    <emu-clause id="sec-temporal-getutcepochnanoseconds" type="abstract operation">
+      <h1>
+        GetUTCEpochNanoseconds (
+          _year_: an integer,
+          _month_: an integer in the inclusive interval from 1 to 12,
+          _day_: an integer in the inclusive interval from 1 to 31,
+          _hour_: an integer in the inclusive interval from 0 to 23,
+          _minute_: an integer in the inclusive interval from 0 to 59,
+          _second_: an integer in the inclusive interval from 0 to 59,
+          _millisecond_: an integer in the inclusive interval from 0 to 999,
+          _microsecond_: an integer in the inclusive interval from 0 to 999,
+          _nanosecond_: an integer in the inclusive interval from 0 to 999,
+          <ins>optional _offsetNanoseconds_: an integer in the interval from -nsPerDay (exclusive) to nsPerDay (exclusive),</ins>
+        ): a BigInt
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          The returned value represents a number of nanoseconds since the epoch that corresponds to the given ISO 8601 calendar date and wall-clock time in UTC.
+          <ins>If a UTC offset is provided, the returned value will be adjusted by that offset.</ins>
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _date_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
+        1. Let _time_ be MakeTime(𝔽(_hour_), 𝔽(_minute_), 𝔽(_second_), 𝔽(_millisecond_)).
+        1. Let _ms_ be MakeDate(_date_, _time_).
+        1. Assert: _ms_ is an integral Number.
+        1. <del>Return ℤ(ℝ(_ms_) × 10<sup>6</sup> + _microsecond_ × 10<sup>3</sup> + _nanosecond_).</del>
+        1. <ins>Let _epochNanoseconds_ be ℝ(_ms_) × 10<sup>6</sup> + _microsecond_ × 10<sup>3</sup> + _nanosecond_.</ins>
+        1. <ins>If _offsetNanoseconds_ is present and _offsetNanoseconds_ ≠ 0, set _epochNanoseconds_ to _epochNanoseconds_ - _offsetNanoseconds_.</ins>
+        1. <ins>Return ℤ(_epochNanoseconds_).</ins>
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-time-zone-identifiers">
       <h1>Time Zone Identifiers</h1>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -190,7 +190,7 @@
           1. Let _possibleEpochNanoseconds_ be GetNamedTimeZoneEpochNanoseconds(_timeZone_.[[Identifier]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
         1. Let _possibleInstants_ be a new empty List.
         1. For each value _epochNanoseconds_ in _possibleEpochNanoseconds_, do
-          1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
+          1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
           1. Let _instant_ be ! CreateTemporalInstant(_epochNanoseconds_).
           1. Append _instant_ to _possibleInstants_.
         1. Return CreateArrayFromList(_possibleInstants_).
@@ -757,10 +757,10 @@
           1. Throw a *RangeError* exception.
         1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
         1. Let _dayBeforeNs_ be _epochNanoseconds_ - ℤ(nsPerDay).
-        1. If ! IsValidEpochNanoseconds(_dayBeforeNs_) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(_dayBeforeNs_) is *false*, throw a *RangeError* exception.
         1. Let _dayBefore_ be ! CreateTemporalInstant(_dayBeforeNs_).
         1. Let _dayAfterNs_ be _epochNanoseconds_ + ℤ(nsPerDay).
-        1. If ! IsValidEpochNanoseconds(_dayAfterNs_) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(_dayAfterNs_) is *false*, throw a *RangeError* exception.
         1. Let _dayAfter_ be ! CreateTemporalInstant(_dayAfterNs_).
         1. Let _offsetBefore_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayBefore_).
         1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZone_, _dayAfter_).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -184,8 +184,8 @@
         1. Perform ? RequireInternalSlot(_timeZone_, [[InitializedTemporalTimeZone]]).
         1. Set _dateTime_ to ? ToTemporalDateTime(_dateTime_).
         1. If _timeZone_.[[OffsetMinutes]] is not ~empty~, then
-          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
-          1. Let _possibleEpochNanoseconds_ be « _epochNanoseconds_ - ℤ(_timeZone_.[[OffsetMinutes]] × (60 × 10<sup>9</sup>)) ».
+          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _timeZone_.[[OffsetMinutes]] × (60 × 10<sup>9</sup>)).
+          1. Let _possibleEpochNanoseconds_ be « _epochNanoseconds_ ».
         1. Else,
           1. Let _possibleEpochNanoseconds_ be GetNamedTimeZoneEpochNanoseconds(_timeZone_.[[Identifier]], _dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]]).
         1. Let _possibleInstants_ be a new empty List.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1121,9 +1121,8 @@
           1. Let _instant_ be ? GetInstantFor(_timeZone_, _dateTime_, _disambiguation_).
           1. Return _instant_.[[Nanoseconds]].
         1. If _offsetBehaviour_ is ~exact~ or _offsetOption_ is *"use"*, then
-          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
-          1. Set _epochNanoseconds_ to _epochNanoseconds_ - ℤ(_offsetNanoseconds_).
-          1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
+          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _offsetNanoseconds_).
+          1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
           1. Return _epochNanoseconds_.
         1. Assert: _offsetBehaviour_ is ~option~.
         1. Assert: _offsetOption_ is *"prefer"* or *"reject"*.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -34,7 +34,7 @@
         1. If NewTarget is *undefined*, then
           1. Throw a *TypeError* exception.
         1. Set _epochNanoseconds_ to ? ToBigInt(_epochNanoseconds_).
-        1. If ! IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Let _timeZone_ be ? ToTemporalTimeZoneSlotValue(_timeZoneLike_).
         1. Let _calendar_ be ? ToTemporalCalendarSlotValue(_calendarLike_, *"iso8601"*).
         1. Return ? CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_, NewTarget).
@@ -1371,7 +1371,7 @@
         1. Let _startInstant_ be ! CreateTemporalInstant(ℤ(_startNs_)).
         1. Let _startDateTime_ be ? GetPlainDateTimeFor(_zonedRelativeTo_.[[TimeZone]], _startInstant_, _zonedRelativeTo_.[[Calendar]]).
         1. Let _endNs_ be _startNs_ + _nanoseconds_.
-        1. If ! IsValidEpochNanoseconds(ℤ(_endNs_)) is *false*, throw a *RangeError* exception.
+        1. If IsValidEpochNanoseconds(ℤ(_endNs_)) is *false*, throw a *RangeError* exception.
         1. Let _endInstant_ be ! CreateTemporalInstant(ℤ(_endNs_)).
         1. Let _endDateTime_ be ? GetPlainDateTimeFor(_zonedRelativeTo_.[[TimeZone]], _endInstant_, _zonedRelativeTo_.[[Calendar]]).
         1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _relativeTo_.[[Calendar]], *"day"*, OrdinaryObjectCreate(*null*)).


### PR DESCRIPTION
This PR refactors several operations related to range validation of Temporal.PlainDateTime and Temporal.Instant.

commit 1: remove the `!` from existing calls to IsValidEpochNanoseconds which is infallible. 

commit 2:
* Makes polyfill GetUTCEpochNanoseconds infallible, like in the spec, using @ptomato's `year % 400` trick to avoid overflows.
* Simplifies the polyfill's GetNamedTimeZoneOffsetNanoseconds by using the now-infallible GetUTCEpochNanoseconds.
* Adds optional `_offsetNanoseconds_` parameter to GetUTCEpochNanoseconds, and uses it in call sites of GetUTCEpochNanoseconds where an offset was previously applied to its result.
* Simplifies the polyfill's GetNamedTimeZoneOffsetNanoseconds by using the now-infallible GetUTCEpochNanoseconds.
* Simplifies the polyfill's PlainDateTime range validation in RejectDateTimeRange.
* Clarifies the PlainDateTime docs about that type's valid range.
* Removes non-parsing logic from ParseTemporalInstantString, aligning Instant parsing with the parsing pattern used in other Temporal types where parsing AOs contain only parsing without interpretation.
* Inlines the single-caller ParseTemporalInstant into ToTemporalInstant, matching the pattern used by ToTemporalYearMonth, ToTemporalTime, etc.
* Marks ParseDateTimeUTCOffset as infallible after parsing instant strings, because ParseTemporalInstantString guarantees that the offset is valid. Fixes #2637.
* Aligns polyfill more closely to spec for Instant parsing.
