### PR TITLE
Polyfill: Extend transition-finding lookahead

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2830,7 +2830,13 @@ export function GetNamedTimeZoneNextTransition(id, epochNanoseconds) {
   if (epochNanoseconds.lesser(BEFORE_FIRST_DST)) {
     return GetNamedTimeZoneNextTransition(id, BEFORE_FIRST_DST);
   }
-  const uppercap = SystemUTCEpochNanoSeconds().plus(DAY_NANOS.multiply(366));
+  // Optimization: the farthest that we'll look for a next transition is 3 years
+  // after the later of epochNanoseconds or the current time. If there are no
+  // transitions found before then, we'll assume that there will not be any more
+  // transitions after that.
+  const now = SystemUTCEpochNanoSeconds();
+  const base = epochNanoseconds.greater(now) ? epochNanoseconds : now;
+  const uppercap = base.plus(DAY_NANOS.multiply(366 * 3));
   let leftNanos = epochNanoseconds;
   let leftOffsetNs = GetNamedTimeZoneOffsetNanoseconds(id, leftNanos);
   let rightNanos = leftNanos;
@@ -2855,15 +2861,15 @@ export function GetNamedTimeZoneNextTransition(id, epochNanoseconds) {
 }
 
 export function GetNamedTimeZonePreviousTransition(id, epochNanoseconds) {
-  // Optimization: if the instant is more than a year in the future and there
-  // are no transitions between the present day and a year from now, assume
-  // there are none after
+  // Optimization: if the instant is more than 3 years in the future and there
+  // are no transitions between the present day and 3 years from now, assume
+  // there are none after.
   const now = SystemUTCEpochNanoSeconds();
-  const yearLater = now.plus(DAY_NANOS.multiply(366));
-  if (epochNanoseconds.gt(yearLater)) {
-    const prevBeforeNextYear = GetNamedTimeZonePreviousTransition(id, yearLater);
-    if (prevBeforeNextYear === null || prevBeforeNextYear.lt(now)) {
-      return prevBeforeNextYear;
+  const lookahead = now.plus(DAY_NANOS.multiply(366 * 3));
+  if (epochNanoseconds.gt(lookahead)) {
+    const prevBeforeLookahead = GetNamedTimeZonePreviousTransition(id, lookahead);
+    if (prevBeforeLookahead === null || prevBeforeLookahead.lt(now)) {
+      return prevBeforeLookahead;
     }
   }
 


### PR DESCRIPTION
GetNamedTimeZonePreviousTransition currently has an optimization to avoid fruitlessly searching for a transition in far-future years in time zones that don't have any transitions. This optimization ignores cases where a time zone's offset changes are scheduled more than one year in advance.  This PR extends the lookahead period to three years.

Similarly, GetNamedTimeZoneNextTransition has an optimization where it assumes that no time zone has any transitions more than one year in the future, which IMO is a pretty bad bug because all dates in 2025+ report no transitions in any time zone. This PR extends this lookahead to three years later than either the current date or the input instant, whichever is later. This ensures that, for time zones that currently use recurring DST rules, a next transition will always be reported for any future date. (Admittedly, it seems unlikely that current DST rules will still be in place in 100,000 years, but we need to pick something and aligning transitions with what `Date` and `Intl.DateTimeFormat` reports seems like a good idea.)

When testing locally, these changes slow down these functions by 2%-4%, which IMO is an OK tradeoff for more accuracy.

Fixes #2564