### PR TITLE
Editorial: Remove qualifiers before "epoch"

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -917,7 +917,7 @@
         1. Set _month_ to ? ISOResolveMonth(_fields_).
         1. Let _day_ be ! Get(_fields_, *"day"*).
         1. Assert: Type(_day_) is Number.
-        1. Let _referenceISOYear_ be 1972 (the first leap year after the Unix epoch).
+        1. Let _referenceISOYear_ be 1972 (the first leap year after the epoch).
         1. If _monthCode_ is *undefined*, then
           1. Assert: Type(_year_) is Number.
           1. Let _result_ be ? RegulateISODate(ℝ(_year_), _month_, ℝ(_day_), _overflow_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -444,7 +444,7 @@
               [[Nanoseconds]]
             </td>
             <td>
-              A BigInt value representing the number of nanoseconds since the Unix epoch.
+              A BigInt value representing the number of nanoseconds since the epoch.
             </td>
           </tr>
         </tbody>
@@ -477,7 +477,7 @@
     <emu-clause id="sec-temporal-isvalidepochnanoseconds" aoid="IsValidEpochNanoseconds">
       <h1>IsValidEpochNanoseconds ( _epochNanoseconds_ )</h1>
       <p>
-        The abstract operation IsValidEpochNanoseconds returns *true* if its argument _epochNanoseconds_ is within the allowed range of nanoseconds since the Unix epoch for a Temporal.Instant and Temporal.ZonedDateTime, and *false* otherwise.
+        The abstract operation IsValidEpochNanoseconds returns *true* if its argument _epochNanoseconds_ is within the allowed range of nanoseconds since the epoch for a Temporal.Instant and Temporal.ZonedDateTime, and *false* otherwise.
       </p>
       <emu-alg>
         1. Assert: Type(_epochNanoseconds_) is BigInt.
@@ -574,7 +574,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It adds a duration in various time units to a number of nanoseconds since the Unix epoch, and returns the result as a BigInt value.</dd>
+        <dd>It adds a duration in various time units to a number of nanoseconds since the epoch, and returns the result as a BigInt value.</dd>
       </dl>
       <emu-alg>
         1. Let _result_ be _epochNanoseconds_ + ℤ(_nanoseconds_) +

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -39,7 +39,7 @@
         1. Let _ref_ be ? ToIntegerWithTruncation(_referenceISOYear_).
         1. Return ? CreateTemporalMonthDay(_m_, _d_, _calendar_, _ref_, NewTarget).
       </emu-alg>
-      <emu-note>1972 is the first leap year after the Unix epoch.</emu-note>
+      <emu-note>1972 is the first leap year after the epoch.</emu-note>
     </emu-clause>
   </emu-clause>
 
@@ -361,7 +361,7 @@
         1. If _options_ is not present, set _options_ to *undefined*.
         1. Assert: Type(_options_) is Object or Undefined.
         1. If _options_ is not *undefined*, set _options_ to ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
-        1. Let _referenceISOYear_ be 1972 (the first leap year after the Unix epoch).
+        1. Let _referenceISOYear_ be 1972 (the first leap year after the epoch).
         1. If Type(_item_) is Object, then
           1. If _item_ has an [[InitializedTemporalMonthDay]] internal slot, then
             1. Return _item_.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -394,7 +394,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns the components of a date corresponding to the given number of nanoseconds since the Unix epoch in UTC.</dd>
+        <dd>It returns the components of a date in UTC corresponding to the given number of nanoseconds since the epoch.</dd>
       </dl>
       <emu-alg>
         1. Assert: ! IsValidEpochNanoseconds(ℤ(_epochNanoseconds_)) is *true*.
@@ -434,7 +434,7 @@
       <dl class="header">
       </dl>
       <p>
-        The returned value _t_ represents the number of nanoseconds since the Unix epoch in UTC that corresponds to the first time zone transition after _epochNanoseconds_ in the IANA time zone identified by _timeZoneIdentifier_.
+        The returned value _t_ represents the number of nanoseconds since the epoch that corresponds to the first time zone transition after _epochNanoseconds_ in the IANA time zone identified by _timeZoneIdentifier_.
         The operation returns *null* if no such transition exists for which _t_ &le; ℤ(nsMaxInstant).
       </p>
       <p>
@@ -463,7 +463,7 @@
       <dl class="header">
       </dl>
       <p>
-        The returned value _t_ represents the number of nanoseconds since the Unix epoch in UTC that corresponds to the last time zone transition before _epochNanoseconds_ in the IANA time zone identified by _timeZoneIdentifier_.
+        The returned value _t_ represents the number of nanoseconds since the epoch that corresponds to the last time zone transition before _epochNanoseconds_ in the IANA time zone identified by _timeZoneIdentifier_.
         The operation returns *null* if no such transition exists for which _t_ &ge; ℤ(nsMinInstant).
       </p>
       <p>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1054,7 +1054,7 @@
               [[Nanoseconds]]
             </td>
             <td>
-              A BigInt value representing the number of nanoseconds since the Unix epoch.
+              A BigInt value representing the number of nanoseconds since the epoch.
             </td>
           </tr>
           <tr>
@@ -1295,7 +1295,7 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It adds a duration in various units to a number of nanoseconds _epochNanoseconds_ since the Unix epoch, subject to the rules of _timeZone_ and _calendar_, and returns the result as a BigInt value.
+          It adds a duration in various units to a number of nanoseconds _epochNanoseconds_ since the epoch, subject to the rules of _timeZone_ and _calendar_, and returns the result as a BigInt value.
           As specified in <a href="https://tools.ietf.org/html/rfc5545">RFC 5545</a>, the date portion of the duration is added in calendar days, and the time portion is added in exact time.
         </dd>
       </dl>
@@ -1329,7 +1329,7 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It computes the difference between two exact times expressed in nanoseconds since the Unix epoch, and balances the result so that there is no non-zero unit larger than _largestUnit_ in the result, taking calendar reckoning and time zone offset changes into account.
+          It computes the difference between two exact times expressed in nanoseconds since the epoch, and balances the result so that there is no non-zero unit larger than _largestUnit_ in the result, taking calendar reckoning and time zone offset changes into account.
         </dd>
       </dl>
       <emu-alg>


### PR DESCRIPTION
The term already links to a precise definition in ECMA-262: https://tc39.es/ecma262/multipage/numbers-and-dates.html#epoch