### PR TITLE
Polyfill: clarify error message about why `valueOf` throws

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -509,7 +509,7 @@ export class Duration {
     );
   }
   valueOf() {
-    throw new TypeError('use compare() to compare Temporal.Duration');
+    ES.ValueOfThrows('Duration');
   }
   static from(item) {
     if (ES.IsTemporalDuration(item)) {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -5726,6 +5726,23 @@ export function ASCIILowercase(str) {
   ]);
 }
 
+// This function isn't in the spec, but we put it in the polyfill to avoid
+// repeating the same (long) error message in many files.
+export function ValueOfThrows(constructorName) {
+  const compareCode =
+    constructorName === 'PlainMonthDay'
+      ? 'Temporal.PlainDate.compare(obj1.toPlainDate(year), obj2.toPlainDate(year))'
+      : `Temporal.${constructorName}.compare(obj1, obj2)`;
+
+  throw new TypeError(
+    'Do not use built-in arithmetic operators with Temporal objects. ' +
+      `When comparing, use ${compareCode}, not obj1 > obj2. ` +
+      "When coercing to strings, use obj.toString() or String(obj), not +obj nor '' + obj. " +
+      'When concatenating with strings, use str.concat(obj) or `${str}${obj}`, not str + obj. ' +
+      'In React, call obj.toString() before rendering a Temporal object.'
+  );
+}
+
 const OFFSET = new RegExp(`^${PARSE.offset.source}$`);
 const OFFSET_WITH_PARTS = new RegExp(`^${PARSE.offsetWithParts.source}$`);
 

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -126,7 +126,7 @@ export class Instant {
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
-    throw new TypeError('use compare() or equals() to compare Temporal.Instant');
+    ES.ValueOfThrows('Instant');
   }
   toZonedDateTime(item) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -158,7 +158,7 @@ export class PlainDate {
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
-    throw new TypeError('use compare() or equals() to compare Temporal.PlainDate');
+    ES.ValueOfThrows('PlainDate');
   }
   toPlainDateTime(temporalTime = undefined) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -372,7 +372,7 @@ export class PlainDateTime {
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
-    throw new TypeError('use compare() or equals() to compare Temporal.PlainDateTime');
+    ES.ValueOfThrows('PlainDateTime');
   }
 
   toZonedDateTime(temporalTimeZoneLike, options = undefined) {

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -69,7 +69,7 @@ export class PlainMonthDay {
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
-    throw new TypeError('use equals() to compare Temporal.PlainMonthDay');
+    ES.ValueOfThrows('PlainMonthDay');
   }
   toPlainDate(item) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -217,7 +217,7 @@ export class PlainTime {
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
-    throw new TypeError('use compare() or equals() to compare Temporal.PlainTime');
+    ES.ValueOfThrows('PlainTime');
   }
 
   toPlainDateTime(temporalDate) {

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -111,7 +111,7 @@ export class PlainYearMonth {
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
-    throw new TypeError('use compare() or equals() to compare Temporal.PlainYearMonth');
+    ES.ValueOfThrows('PlainYearMonth');
   }
   toPlainDate(item) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -527,7 +527,7 @@ export class ZonedDateTime {
     return ES.TemporalZonedDateTimeToString(this, 'auto');
   }
   valueOf() {
-    throw new TypeError('use compare() or equals() to compare Temporal.ZonedDateTime');
+    ES.ValueOfThrows('ZonedDateTime');
   }
   startOfDay() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');


### PR DESCRIPTION
We've received enough user confusion about `valueOf` throwing (see #1681 for why we throw) that I think it's worth clarifying the error message.