### PR TITLE
Polyfill: Align ZonedDateTime.p.toPlain{YearMonth,MonthDay} with spec

### DIFF
--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -565,16 +565,18 @@ export class ZonedDateTime {
   }
   toPlainYearMonth() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const dt = dateTime(this);
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
-    const fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    const fields = ES.PrepareTemporalFields(dt, fieldNames, []);
     return ES.CalendarYearMonthFromFields(calendar, fields);
   }
   toPlainMonthDay() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    const dt = dateTime(this);
     const calendar = GetSlot(this, CALENDAR);
     const fieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);
-    const fields = ES.PrepareTemporalFields(this, fieldNames, []);
+    const fields = ES.PrepareTemporalFields(dt, fieldNames, []);
     return ES.CalendarMonthDayFromFields(calendar, fields);
   }
   getISOFields() {


### PR DESCRIPTION
This has been a bug in the polyfill since ZonedDateTime was originally introduced! The spec says to convert the ZonedDateTime to PlainDateTime once here, whereas the polyfill would Get each property in turn.

Tests will follow as part of #2519.