### PR TITLE
Fix handling of overflow returns to BalancePossiblyInfiniteDurationRelative

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3544,17 +3544,11 @@ export function BalancePossiblyInfiniteTimeDurationRelative(
     days = 0;
   }
 
-  ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalancePossiblyInfiniteTimeDuration(
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    nanoseconds,
-    largestUnit
-  ));
-
+  const result = BalancePossiblyInfiniteTimeDuration(0, 0, 0, 0, 0, 0, nanoseconds, largestUnit);
+  if (result === 'positive overflow' || result === 'negative overflow') {
+    return result;
+  }
+  ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = result);
   return { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
 }
 


### PR DESCRIPTION
The [current spec](https://github.com/tc39/proposal-temporal/blob/3f82e8d48d3c062d07a4ae77dc175d65cc3be8ae/spec/duration.html#L1365-L1367) for `BalancePossiblyInfinteTimeDurationRelative` includes early-returning the overflow values, but this is not present in the polyfill code.

This seems to have been introduced in 0547d29dbdf4c5aa9c2dca3c6072513dc52abe36.