### PR TITLE
Duration normalization, part 2 of 3

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -22,6 +22,7 @@ import {
   HasSlot,
   SetSlot
 } from './slots.mjs';
+import { TimeDuration } from './timeduration.mjs';
 
 const ArrayFrom = Array.from;
 const ArrayIncludes = Array.prototype.includes;
@@ -157,16 +158,15 @@ export class Calendar {
     duration = ES.ToTemporalDuration(duration);
     options = ES.GetOptionsObject(options);
     const overflow = ES.ToTemporalOverflow(options);
-    const { days } = ES.BalanceTimeDuration(
-      GetSlot(duration, DAYS),
+    const norm = TimeDuration.normalize(
       GetSlot(duration, HOURS),
       GetSlot(duration, MINUTES),
       GetSlot(duration, SECONDS),
       GetSlot(duration, MILLISECONDS),
       GetSlot(duration, MICROSECONDS),
-      GetSlot(duration, NANOSECONDS),
-      'day'
+      GetSlot(duration, NANOSECONDS)
     );
+    const days = GetSlot(duration, DAYS) + ES.BalanceTimeDuration(norm, 'day').days;
     const id = GetSlot(this, CALENDAR_ID);
     return impl[id].dateAdd(
       date,

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -481,7 +481,6 @@ export class Duration {
       calendarRec
     ));
     // If the unit we're totalling is smaller than `days`, convert days down to that unit.
-    let balanceResult;
     if (zonedRelativeTo) {
       const intermediate = ES.MoveRelativeZonedDateTime(
         zonedRelativeTo,
@@ -493,7 +492,7 @@ export class Duration {
         0,
         precalculatedPlainDateTime
       );
-      balanceResult = ES.BalancePossiblyInfiniteTimeDurationRelative(
+      ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceTimeDurationRelative(
         days,
         hours,
         minutes,
@@ -504,9 +503,9 @@ export class Duration {
         unit,
         intermediate,
         timeZoneRec
-      );
+      ));
     } else {
-      balanceResult = ES.BalancePossiblyInfiniteTimeDuration(
+      ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceTimeDuration(
         days,
         hours,
         minutes,
@@ -515,14 +514,8 @@ export class Duration {
         microseconds,
         nanoseconds,
         unit
-      );
+      ));
     }
-    if (balanceResult === 'positive overflow') {
-      return Infinity;
-    } else if (balanceResult === 'negative overflow') {
-      return -Infinity;
-    }
-    ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = balanceResult);
     // Finally, truncate to the correct unit and calculate remainder
     const { total } = ES.RoundDuration(
       years,

--- a/polyfill/lib/math.mjs
+++ b/polyfill/lib/math.mjs
@@ -4,6 +4,8 @@ const MathSign = Math.sign;
 const MathTrunc = Math.trunc;
 const NumberParseInt = Number.parseInt;
 const NumberPrototypeToPrecision = Number.prototype.toPrecision;
+const StringPrototypePadStart = String.prototype.padStart;
+const StringPrototypeRepeat = String.prototype.repeat;
 const StringPrototypeSlice = String.prototype.slice;
 
 import Call from 'es-abstract/2022/Call.js';
@@ -29,4 +31,25 @@ export function TruncatingDivModByPowerOf10(x, p) {
   const mod = sign * NumberParseInt(Call(StringPrototypeSlice, xStr, [xDigits - p]), 10);
 
   return { div, mod };
+}
+
+// Computes x * 10**p + z with precision loss only at the end, by string
+// manipulation. If the result is a safe integer, then it is exact. x must be
+// an integer. p must be a non-negative integer. z must have the same sign as
+// x and be less than 10**p.
+export function FMAPowerOf10(x, p, z) {
+  if (x === 0) return z;
+
+  const sign = MathSign(x) || MathSign(z);
+  x = MathAbs(x);
+  z = MathAbs(z);
+
+  const xStr = Call(NumberPrototypeToPrecision, x, [MathTrunc(1 + MathLog10(x))]);
+
+  if (z === 0) return sign * NumberParseInt(xStr + Call(StringPrototypeRepeat, '0', [p]), 10);
+
+  const zStr = Call(NumberPrototypeToPrecision, z, [MathTrunc(1 + MathLog10(z))]);
+
+  const resStr = xStr + Call(StringPrototypePadStart, zStr, [p, '0']);
+  return sign * NumberParseInt(resStr, 10);
 }

--- a/polyfill/lib/math.mjs
+++ b/polyfill/lib/math.mjs
@@ -1,0 +1,32 @@
+const MathAbs = Math.abs;
+const MathLog10 = Math.log10;
+const MathSign = Math.sign;
+const MathTrunc = Math.trunc;
+const NumberParseInt = Number.parseInt;
+const NumberPrototypeToPrecision = Number.prototype.toPrecision;
+const StringPrototypeSlice = String.prototype.slice;
+
+import Call from 'es-abstract/2022/Call.js';
+
+// Computes trunc(x / 10**p) and x % 10**p, returning { div, mod }, with
+// precision loss only once in the quotient, by string manipulation. If the
+// quotient and remainder are safe integers, then they are exact. x must be an
+// integer. p must be a non-negative integer. Both div and mod have the sign of
+// x.
+export function TruncatingDivModByPowerOf10(x, p) {
+  if (x === 0) return { div: x, mod: x }; // preserves signed zero
+
+  const sign = MathSign(x);
+  x = MathAbs(x);
+
+  const xDigits = MathTrunc(1 + MathLog10(x));
+  if (p >= xDigits) return { div: sign * 0, mod: sign * x };
+  if (p === 0) return { div: sign * x, mod: sign * 0 };
+
+  // would perform nearest rounding if x was not an integer:
+  const xStr = Call(NumberPrototypeToPrecision, x, [xDigits]);
+  const div = sign * NumberParseInt(Call(StringPrototypeSlice, xStr, [0, xDigits - p]), 10);
+  const mod = sign * NumberParseInt(Call(StringPrototypeSlice, xStr, [xDigits - p]), 10);
+
+  return { div, mod };
+}

--- a/polyfill/lib/timeduration.mjs
+++ b/polyfill/lib/timeduration.mjs
@@ -1,0 +1,148 @@
+import bigInt from 'big-integer';
+
+const MathAbs = Math.abs;
+const MathSign = Math.sign;
+const NumberIsInteger = Number.isInteger;
+const NumberIsSafeInteger = Number.isSafeInteger;
+
+export class TimeDuration {
+  static MAX = bigInt('9007199254740991999999999');
+  static ZERO = new TimeDuration(bigInt.zero);
+
+  constructor(totalNs) {
+    if (typeof totalNs === 'number') throw new Error('assertion failed: big integer required');
+    this.totalNs = bigInt(totalNs);
+    if (this.totalNs.abs().greater(TimeDuration.MAX)) throw new Error('assertion failed: integer too big');
+
+    const { quotient, remainder } = this.totalNs.divmod(1e9);
+    this.sec = quotient.toJSNumber();
+    this.subsec = remainder.toJSNumber();
+    if (!NumberIsSafeInteger(this.sec)) throw new Error('assertion failed: seconds too big');
+    if (MathAbs(this.subsec) > 999_999_999) throw new Error('assertion failed: subseconds too big');
+  }
+
+  static #validateNew(totalNs, operation) {
+    if (totalNs.abs().greater(TimeDuration.MAX)) {
+      throw new RangeError(`${operation} of duration time units cannot exceed ${TimeDuration.MAX} s`);
+    }
+    return new TimeDuration(totalNs);
+  }
+
+  static fromEpochNsDiff(epochNs1, epochNs2) {
+    const diff = bigInt(epochNs1).subtract(epochNs2);
+    // No extra validate step. Should instead fail assertion if too big
+    return new TimeDuration(diff);
+  }
+
+  static normalize(h, min, s, ms, µs, ns) {
+    const totalNs = bigInt(ns)
+      .add(bigInt(µs).multiply(1e3))
+      .add(bigInt(ms).multiply(1e6))
+      .add(bigInt(s).multiply(1e9))
+      .add(bigInt(min).multiply(60e9))
+      .add(bigInt(h).multiply(3600e9));
+    return TimeDuration.#validateNew(totalNs, 'total');
+  }
+
+  abs() {
+    return new TimeDuration(this.totalNs.abs());
+  }
+
+  add(other) {
+    return TimeDuration.#validateNew(this.totalNs.add(other.totalNs), 'sum');
+  }
+
+  add24HourDays(days) {
+    if (!NumberIsInteger(days)) throw new Error('assertion failed: days is an integer');
+    return TimeDuration.#validateNew(this.totalNs.add(bigInt(days).multiply(86400e9)), 'sum');
+  }
+
+  addToEpochNs(epochNs) {
+    return bigInt(epochNs).add(this.totalNs);
+  }
+
+  cmp(other) {
+    return this.totalNs.compare(other.totalNs);
+  }
+
+  divmod(n) {
+    if (n === 0) throw new Error('division by zero');
+    const { quotient, remainder } = this.totalNs.divmod(n);
+    const q = quotient.toJSNumber();
+    const r = new TimeDuration(remainder);
+    return { quotient: q, remainder: r };
+  }
+
+  fdiv(n) {
+    if (n === 0) throw new Error('division by zero');
+    let { quotient, remainder } = this.totalNs.divmod(n);
+
+    // Perform long division to calculate the fractional part of the quotient
+    // remainder / n with more accuracy than 64-bit floating point division
+    const precision = 50;
+    const decimalDigits = [];
+    let digit;
+    const sign = (this.totalNs.geq(0) ? 1 : -1) * MathSign(n);
+    while (!remainder.isZero() && decimalDigits.length < precision) {
+      remainder = remainder.multiply(10);
+      ({ quotient: digit, remainder } = remainder.divmod(n));
+      decimalDigits.push(MathAbs(digit.toJSNumber()));
+    }
+    return sign * Number(quotient.abs().toString() + '.' + decimalDigits.join(''));
+  }
+
+  isZero() {
+    return this.totalNs.isZero();
+  }
+
+  round(increment, mode) {
+    if (increment === 1) return this;
+    let { quotient, remainder } = this.totalNs.divmod(increment);
+    if (remainder.equals(bigInt.zero)) return this;
+    const sign = remainder.lt(bigInt.zero) ? -1 : 1;
+    const tiebreaker = remainder.multiply(2).abs();
+    const tie = tiebreaker.equals(increment);
+    const expandIsNearer = tiebreaker.gt(increment);
+    switch (mode) {
+      case 'ceil':
+        if (sign > 0) quotient = quotient.add(sign);
+        break;
+      case 'floor':
+        if (sign < 0) quotient = quotient.add(sign);
+        break;
+      case 'expand':
+        // always expand if there is a remainder
+        quotient = quotient.add(sign);
+        break;
+      case 'trunc':
+        // no change needed, because divmod is a truncation
+        break;
+      case 'halfCeil':
+        if (expandIsNearer || (tie && sign > 0)) quotient = quotient.add(sign);
+        break;
+      case 'halfFloor':
+        if (expandIsNearer || (tie && sign < 0)) quotient = quotient.add(sign);
+        break;
+      case 'halfExpand':
+        // "half up away from zero"
+        if (expandIsNearer || tie) quotient = quotient.add(sign);
+        break;
+      case 'halfTrunc':
+        if (expandIsNearer) quotient = quotient.add(sign);
+        break;
+      case 'halfEven': {
+        if (expandIsNearer || (tie && quotient.isOdd())) quotient = quotient.add(sign);
+        break;
+      }
+    }
+    return TimeDuration.#validateNew(quotient.multiply(increment), 'rounding');
+  }
+
+  sign() {
+    return this.cmp(new TimeDuration(0n));
+  }
+
+  subtract(other) {
+    return TimeDuration.#validateNew(this.totalNs.subtract(other.totalNs), 'difference');
+  }
+}

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -18,6 +18,7 @@ import {
   TIME_ZONE,
   GetSlot
 } from './slots.mjs';
+import { TimeDuration } from './timeduration.mjs';
 
 import bigInt from 'big-integer';
 
@@ -157,9 +158,8 @@ export class ZonedDateTime {
     );
     const todayNs = GetSlot(ES.GetInstantFor(timeZoneRec, today, 'compatible'), EPOCHNANOSECONDS);
     const tomorrowNs = GetSlot(ES.GetInstantFor(timeZoneRec, tomorrow, 'compatible'), EPOCHNANOSECONDS);
-    const diffNs = tomorrowNs.subtract(todayNs);
-    const { quotient, remainder } = diffNs.divmod(3.6e12);
-    return quotient.toJSNumber() + remainder.toJSNumber() / 3.6e12;
+    const diff = TimeDuration.fromEpochNsDiff(tomorrowNs, todayNs);
+    return diff.fdiv(3.6e12);
   }
   get daysInWeek() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');

--- a/polyfill/test/all.mjs
+++ b/polyfill/test/all.mjs
@@ -17,6 +17,9 @@ import './ecmascript.mjs';
 // Power-of-10 math
 import './math.mjs';
 
+// Internal 96-bit integer implementation, not suitable for test262
+import './timeduration.mjs';
+
 Promise.resolve()
   .then(() => {
     return Demitasse.report(Pretty.reporter);

--- a/polyfill/test/all.mjs
+++ b/polyfill/test/all.mjs
@@ -14,6 +14,9 @@ import './datemath.mjs';
 // tests of internals, not suitable for test262
 import './ecmascript.mjs';
 
+// Power-of-10 math
+import './math.mjs';
+
 Promise.resolve()
   .then(() => {
     return Demitasse.report(Pretty.reporter);

--- a/polyfill/test/math.mjs
+++ b/polyfill/test/math.mjs
@@ -1,0 +1,69 @@
+import Demitasse from '@pipobscure/demitasse';
+const { describe, it, report } = Demitasse;
+
+import Pretty from '@pipobscure/demitasse-pretty';
+const { reporter } = Pretty;
+
+import { strict as assert } from 'assert';
+const { deepEqual } = assert;
+
+import { TruncatingDivModByPowerOf10 as div } from '../lib/math.mjs';
+
+describe('Math', () => {
+  describe('TruncatingDivModByPowerOf10', () => {
+    it('12345/10**0 = 12345, 0', () => deepEqual(div(12345, 0), { div: 12345, mod: 0 }));
+    it('12345/10**1 = 1234, 5', () => deepEqual(div(12345, 1), { div: 1234, mod: 5 }));
+    it('12345/10**2 = 123, 45', () => deepEqual(div(12345, 2), { div: 123, mod: 45 }));
+    it('12345/10**3 = 12, 345', () => deepEqual(div(12345, 3), { div: 12, mod: 345 }));
+    it('12345/10**4 = 1, 2345', () => deepEqual(div(12345, 4), { div: 1, mod: 2345 }));
+    it('12345/10**5 = 0, 12345', () => deepEqual(div(12345, 5), { div: 0, mod: 12345 }));
+    it('12345/10**6 = 0, 12345', () => deepEqual(div(12345, 6), { div: 0, mod: 12345 }));
+
+    it('-12345/10**0 = -12345, -0', () => deepEqual(div(-12345, 0), { div: -12345, mod: -0 }));
+    it('-12345/10**1 = -1234, -5', () => deepEqual(div(-12345, 1), { div: -1234, mod: -5 }));
+    it('-12345/10**2 = -123, -45', () => deepEqual(div(-12345, 2), { div: -123, mod: -45 }));
+    it('-12345/10**3 = -12, -345', () => deepEqual(div(-12345, 3), { div: -12, mod: -345 }));
+    it('-12345/10**4 = -1, -2345', () => deepEqual(div(-12345, 4), { div: -1, mod: -2345 }));
+    it('-12345/10**5 = -0, -12345', () => deepEqual(div(-12345, 5), { div: -0, mod: -12345 }));
+    it('-12345/10**6 = -0, -12345', () => deepEqual(div(-12345, 6), { div: -0, mod: -12345 }));
+
+    it('0/10**27 = 0, 0', () => deepEqual(div(0, 27), { div: 0, mod: 0 }));
+    it('-0/10**27 = -0, -0', () => deepEqual(div(-0, 27), { div: -0, mod: -0 }));
+
+    it('1001/10**3 = 1, 1', () => deepEqual(div(1001, 3), { div: 1, mod: 1 }));
+    it('-1001/10**3 = -1, -1', () => deepEqual(div(-1001, 3), { div: -1, mod: -1 }));
+
+    it('4019125567429664768/10**3 = 4019125567429664, 768', () =>
+      deepEqual(div(4019125567429664768, 3), { div: 4019125567429664, mod: 768 }));
+    it('-4019125567429664768/10**3 = -4019125567429664, -768', () =>
+      deepEqual(div(-4019125567429664768, 3), { div: -4019125567429664, mod: -768 }));
+    it('3294477463410151260160/10**6 = 3294477463410151, 260160', () =>
+      deepEqual(div(3294477463410151260160, 6), { div: 3294477463410151, mod: 260160 }));
+    it('-3294477463410151260160/10**6 = -3294477463410151, -260160', () =>
+      deepEqual(div(-3294477463410151260160, 6), { div: -3294477463410151, mod: -260160 }));
+    it('7770017954545649059889152/10**9 = 7770017954545649, 59889152', () =>
+      deepEqual(div(7770017954545649059889152, 9), { div: 7770017954545649, mod: 59889152 }));
+    it('-7770017954545649059889152/-10**9 = -7770017954545649, -59889152', () =>
+      deepEqual(div(-7770017954545649059889152, 9), { div: -7770017954545649, mod: -59889152 }));
+
+    // Largest/smallest representable float that will result in a safe quotient,
+    // for each of the divisors 10**3, 10**6, 10**9
+    it('9007199254740990976/10**3 = MAX_SAFE_INTEGER-1, 976', () =>
+      deepEqual(div(9007199254740990976, 3), { div: Number.MAX_SAFE_INTEGER - 1, mod: 976 }));
+    it('-9007199254740990976/10**3 = -MAX_SAFE_INTEGER+1, -976', () =>
+      deepEqual(div(-9007199254740990976, 3), { div: -Number.MAX_SAFE_INTEGER + 1, mod: -976 }));
+    it('9007199254740990951424/10**6 = MAX_SAFE_INTEGER-1, 951424', () =>
+      deepEqual(div(9007199254740990951424, 6), { div: Number.MAX_SAFE_INTEGER - 1, mod: 951424 }));
+    it('-9007199254740990951424/10**6 = -MAX_SAFE_INTEGER+1, -951424', () =>
+      deepEqual(div(-9007199254740990951424, 6), { div: -Number.MAX_SAFE_INTEGER + 1, mod: -951424 }));
+    it('9007199254740990926258176/10**9 = MAX_SAFE_INTEGER-1, 926258176', () =>
+      deepEqual(div(9007199254740990926258176, 9), { div: Number.MAX_SAFE_INTEGER - 1, mod: 926258176 }));
+    it('-9007199254740990926258176/10**9 = -MAX_SAFE_INTEGER+1, -926258176', () =>
+      deepEqual(div(-9007199254740990926258176, 9), { div: -Number.MAX_SAFE_INTEGER + 1, mod: -926258176 }));
+  });
+});
+
+import { normalize } from 'path';
+if (normalize(import.meta.url.slice(8)) === normalize(process.argv[1])) {
+  report(reporter).then((failed) => process.exit(failed ? 1 : 0));
+}

--- a/polyfill/test/math.mjs
+++ b/polyfill/test/math.mjs
@@ -5,9 +5,9 @@ import Pretty from '@pipobscure/demitasse-pretty';
 const { reporter } = Pretty;
 
 import { strict as assert } from 'assert';
-const { deepEqual } = assert;
+const { deepEqual, equal } = assert;
 
-import { TruncatingDivModByPowerOf10 as div } from '../lib/math.mjs';
+import { TruncatingDivModByPowerOf10 as div, FMAPowerOf10 as fma } from '../lib/math.mjs';
 
 describe('Math', () => {
   describe('TruncatingDivModByPowerOf10', () => {
@@ -60,6 +60,47 @@ describe('Math', () => {
       deepEqual(div(9007199254740990926258176, 9), { div: Number.MAX_SAFE_INTEGER - 1, mod: 926258176 }));
     it('-9007199254740990926258176/10**9 = -MAX_SAFE_INTEGER+1, -926258176', () =>
       deepEqual(div(-9007199254740990926258176, 9), { div: -Number.MAX_SAFE_INTEGER + 1, mod: -926258176 }));
+  });
+
+  describe('FMAPowerOf10', () => {
+    it('0*10**0+0 = 0', () => equal(fma(0, 0, 0), 0));
+    it('-0*10**0-0 = -0', () => equal(fma(-0, 0, -0), -0));
+    it('1*10**0+0 = 1', () => equal(fma(1, 0, 0), 1));
+    it('-1*10**0+0 = -1', () => equal(fma(-1, 0, 0), -1));
+    it('0*10**50+1234 = 1234', () => equal(fma(0, 50, 1234), 1234));
+    it('-0*10**50-1234 = -1234', () => equal(fma(-0, 50, -1234), -1234));
+    it('1234*10**12+0', () => equal(fma(1234, 12, 0), 1234000000000000));
+    it('-1234*10**12-0', () => equal(fma(-1234, 12, -0), -1234000000000000));
+
+    it('2*10**2+45 = 245', () => equal(fma(2, 2, 45), 245));
+    it('2*10**3+45 = 2045', () => equal(fma(2, 3, 45), 2045));
+    it('2*10**4+45 = 20045', () => equal(fma(2, 4, 45), 20045));
+    it('2*10**5+45 = 200045', () => equal(fma(2, 5, 45), 200045));
+    it('2*10**6+45 = 2000045', () => equal(fma(2, 6, 45), 2000045));
+
+    it('-2*10**2-45 = -245', () => equal(fma(-2, 2, -45), -245));
+    it('-2*10**3-45 = -2045', () => equal(fma(-2, 3, -45), -2045));
+    it('-2*10**4-45 = -20045', () => equal(fma(-2, 4, -45), -20045));
+    it('-2*10**5-45 = -200045', () => equal(fma(-2, 5, -45), -200045));
+    it('-2*10**6-45 = -2000045', () => equal(fma(-2, 6, -45), -2000045));
+
+    it('8692288669465520*10**9+321414345 = 8692288669465520321414345, rounded to 8692288669465520839327744', () =>
+      equal(fma(8692288669465520, 9, 321414345), 8692288669465520839327744));
+    it('-8692288669465520*10**9-321414345 = -8692288669465520321414345, rounded to -8692288669465520839327744', () =>
+      equal(fma(-8692288669465520, 9, -321414345), -8692288669465520839327744));
+
+    it('MAX_SAFE_INTEGER*10**3+999 rounded to 9007199254740992000', () =>
+      equal(fma(Number.MAX_SAFE_INTEGER, 3, 999), 9007199254740992000));
+    it('-MAX_SAFE_INTEGER*10**3-999 rounded to -9007199254740992000', () =>
+      equal(fma(-Number.MAX_SAFE_INTEGER, 3, -999), -9007199254740992000));
+    it('MAX_SAFE_INTEGER*10**6+999999 rounded to 9007199254740992000000', () =>
+      equal(fma(Number.MAX_SAFE_INTEGER, 6, 999999), 9007199254740992000000));
+    it('-MAX_SAFE_INTEGER*10**6-999999 rounded to -9007199254740992000000', () =>
+      equal(fma(-Number.MAX_SAFE_INTEGER, 6, -999999), -9007199254740992000000));
+    it('MAX_SAFE_INTEGER*10**3+999 rounded to 9007199254740992000', () =>
+      equal(fma(Number.MAX_SAFE_INTEGER, 9, 999999999), 9007199254740992000000000));
+    it('-MAX_SAFE_INTEGER*10**3-999 rounded to -9007199254740992000', () =>
+      equal(fma(-Number.MAX_SAFE_INTEGER, 9, -999999999), -9007199254740992000000000));
   });
 });
 

--- a/polyfill/test/timeduration.mjs
+++ b/polyfill/test/timeduration.mjs
@@ -1,0 +1,514 @@
+import Demitasse from '@pipobscure/demitasse';
+const { describe, it, report } = Demitasse;
+
+import Pretty from '@pipobscure/demitasse-pretty';
+const { reporter } = Pretty;
+
+import { strict as assert, AssertionError } from 'assert';
+const { equal, throws } = assert;
+
+import { TimeDuration } from '../lib/timeduration.mjs';
+
+function check(timeDuration, sec, subsec) {
+  equal(timeDuration.sec, sec);
+  equal(timeDuration.subsec, subsec);
+}
+
+function checkBigInt(value, bigint) {
+  if (value && typeof value === 'object') {
+    equal(value.value, bigint); // bigInteger wrapper
+  } else {
+    equal(value, bigint); // real bigint
+  }
+}
+
+function checkFloat(value, float) {
+  if (!Number.isFinite(value) || Math.abs(value - float) > Number.EPSILON) {
+    throw new AssertionError({
+      message: `Expected ${value} to be within ɛ of ${float}`,
+      expected: float,
+      actual: value,
+      operator: 'checkFloat'
+    });
+  }
+}
+
+describe('Normalized time duration', () => {
+  describe('construction', () => {
+    it('basic', () => {
+      check(new TimeDuration(123456789_987654321n), 123456789, 987654321);
+      check(new TimeDuration(-987654321_123456789n), -987654321, -123456789);
+    });
+
+    it('either sign with zero in the other component', () => {
+      check(new TimeDuration(123n), 0, 123);
+      check(new TimeDuration(-123n), 0, -123);
+      check(new TimeDuration(123_000_000_000n), 123, 0);
+      check(new TimeDuration(-123_000_000_000n), -123, 0);
+    });
+  });
+
+  describe('construction impossible', () => {
+    it('out of range', () => {
+      throws(() => new TimeDuration(2n ** 53n * 1_000_000_000n));
+      throws(() => new TimeDuration(-(2n ** 53n * 1_000_000_000n)));
+    });
+
+    it('not an integer', () => {
+      throws(() => new TimeDuration(Math.PI));
+    });
+  });
+
+  describe('fromEpochNsDiff()', () => {
+    it('basic', () => {
+      check(TimeDuration.fromEpochNsDiff(1695930183_043174412n, 1695930174_412168313n), 8, 631006099);
+      check(TimeDuration.fromEpochNsDiff(1695930174_412168313n, 1695930183_043174412n), -8, -631006099);
+    });
+
+    it('pre-epoch', () => {
+      check(TimeDuration.fromEpochNsDiff(-80000_987_654_321n, -86400_123_456_789n), 6399, 135802468);
+      check(TimeDuration.fromEpochNsDiff(-86400_123_456_789n, -80000_987_654_321n), -6399, -135802468);
+    });
+
+    it('cross-epoch', () => {
+      check(TimeDuration.fromEpochNsDiff(1_000_001_000n, -2_000_002_000n), 3, 3000);
+      check(TimeDuration.fromEpochNsDiff(-2_000_002_000n, 1_000_001_000n), -3, -3000);
+    });
+
+    it('maximum epoch difference', () => {
+      const max = 86400_0000_0000_000_000_000n;
+      check(TimeDuration.fromEpochNsDiff(max, -max), 172800_0000_0000, 0);
+      check(TimeDuration.fromEpochNsDiff(-max, max), -172800_0000_0000, 0);
+    });
+  });
+
+  describe('normalize()', () => {
+    it('basic', () => {
+      check(TimeDuration.normalize(1, 1, 1, 1, 1, 1), 3661, 1001001);
+      check(TimeDuration.normalize(-1, -1, -1, -1, -1, -1), -3661, -1001001);
+    });
+
+    it('overflow from one unit to another', () => {
+      check(TimeDuration.normalize(1, 61, 61, 998, 1000, 1000), 7321, 999001000);
+      check(TimeDuration.normalize(-1, -61, -61, -998, -1000, -1000), -7321, -999001000);
+    });
+
+    it('overflow from subseconds to seconds', () => {
+      check(TimeDuration.normalize(0, 0, 1, 1000, 0, 0), 2, 0);
+      check(TimeDuration.normalize(0, 0, -1, -1000, 0, 0), -2, 0);
+    });
+
+    it('multiple overflows from subseconds to seconds', () => {
+      check(TimeDuration.normalize(0, 0, 0, 1234567890, 1234567890, 1234567890), 1235803, 692457890);
+      check(TimeDuration.normalize(0, 0, 0, -1234567890, -1234567890, -1234567890), -1235803, -692457890);
+    });
+
+    it('fails on overflow', () => {
+      throws(() => TimeDuration.normalize(2501999792984, 0, 0, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.normalize(-2501999792984, 0, 0, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.normalize(0, 150119987579017, 0, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.normalize(0, -150119987579017, 0, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.normalize(0, 0, 2 ** 53, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.normalize(0, 0, -(2 ** 53), 0, 0, 0), RangeError);
+      throws(() => TimeDuration.normalize(0, 0, Number.MAX_SAFE_INTEGER, 1000, 0, 0), RangeError);
+      throws(() => TimeDuration.normalize(0, 0, -Number.MAX_SAFE_INTEGER, -1000, 0, 0), RangeError);
+      throws(() => TimeDuration.normalize(0, 0, Number.MAX_SAFE_INTEGER, 0, 1000000, 0), RangeError);
+      throws(() => TimeDuration.normalize(0, 0, -Number.MAX_SAFE_INTEGER, 0, -1000000, 0), RangeError);
+      throws(() => TimeDuration.normalize(0, 0, Number.MAX_SAFE_INTEGER, 0, 0, 1000000000), RangeError);
+      throws(() => TimeDuration.normalize(0, 0, -Number.MAX_SAFE_INTEGER, 0, 0, -1000000000), RangeError);
+    });
+  });
+
+  describe('abs()', () => {
+    it('positive', () => {
+      const d = new TimeDuration(123_456_654_321n);
+      check(d.abs(), 123, 456_654_321);
+    });
+
+    it('negative', () => {
+      const d = new TimeDuration(-123_456_654_321n);
+      check(d.abs(), 123, 456_654_321);
+    });
+
+    it('zero', () => {
+      const d = new TimeDuration(0n);
+      check(d.abs(), 0, 0);
+    });
+  });
+
+  describe('add()', () => {
+    it('basic', () => {
+      const d1 = new TimeDuration(123_456_654_321_123_456n);
+      const d2 = new TimeDuration(654_321_123_456_654_321n);
+      check(d1.add(d2), 777_777_777, 777_777_777);
+    });
+
+    it('negative', () => {
+      const d1 = new TimeDuration(-123_456_654_321_123_456n);
+      const d2 = new TimeDuration(-654_321_123_456_654_321n);
+      check(d1.add(d2), -777_777_777, -777_777_777);
+    });
+
+    it('signs differ', () => {
+      const d1 = new TimeDuration(333_333_333_333_333_333n);
+      const d2 = new TimeDuration(-222_222_222_222_222_222n);
+      check(d1.add(d2), 111_111_111, 111_111_111);
+
+      const d3 = new TimeDuration(-333_333_333_333_333_333n);
+      const d4 = new TimeDuration(222_222_222_222_222_222n);
+      check(d3.add(d4), -111_111_111, -111_111_111);
+    });
+
+    it('cross zero', () => {
+      const d1 = new TimeDuration(222_222_222_222_222_222n);
+      const d2 = new TimeDuration(-333_333_333_333_333_333n);
+      check(d1.add(d2), -111_111_111, -111_111_111);
+    });
+
+    it('overflow from subseconds to seconds', () => {
+      const d1 = new TimeDuration(999_999_999n);
+      const d2 = new TimeDuration(2n);
+      check(d1.add(d2), 1, 1);
+    });
+
+    it('fails on overflow', () => {
+      const d1 = new TimeDuration(2n ** 52n * 1_000_000_000n);
+      throws(() => d1.add(d1), RangeError);
+    });
+  });
+
+  describe('add24HourDays()', () => {
+    it('basic', () => {
+      const d = new TimeDuration(111_111_111_111_111_111n);
+      check(d.add24HourDays(10), 111_975_111, 111_111_111);
+    });
+
+    it('negative', () => {
+      const d = new TimeDuration(-111_111_111_111_111_111n);
+      check(d.add24HourDays(-10), -111_975_111, -111_111_111);
+    });
+
+    it('signs differ', () => {
+      const d1 = new TimeDuration(864000_000_000_000n);
+      check(d1.add24HourDays(-5), 432000, 0);
+
+      const d2 = new TimeDuration(-864000_000_000_000n);
+      check(d2.add24HourDays(5), -432000, 0);
+    });
+
+    it('cross zero', () => {
+      const d1 = new TimeDuration(86400_000_000_000n);
+      check(d1.add24HourDays(-2), -86400, 0);
+
+      const d2 = new TimeDuration(-86400_000_000_000n);
+      check(d2.add24HourDays(3), 172800, 0);
+    });
+
+    it('overflow from subseconds to seconds', () => {
+      const d1 = new TimeDuration(-86400_333_333_333n);
+      check(d1.add24HourDays(2), 86399, 666_666_667);
+
+      const d2 = new TimeDuration(86400_333_333_333n);
+      check(d2.add24HourDays(-2), -86399, -666_666_667);
+    });
+
+    it('does not accept non-integers', () => {
+      const d = new TimeDuration(0n);
+      throws(() => d.add24HourDays(1.5), Error);
+    });
+
+    it('fails on overflow', () => {
+      const d = new TimeDuration(0n);
+      throws(() => d.add24HourDays(104249991375), RangeError);
+      throws(() => d.add24HourDays(-104249991375), RangeError);
+    });
+  });
+
+  describe('addToEpochNs()', () => {
+    it('basic', () => {
+      const d = new TimeDuration(123_456_654_321_123_456n);
+      checkBigInt(d.addToEpochNs(654_321_123_456_654_321n), 777_777_777_777_777_777n);
+    });
+
+    it('negative', () => {
+      const d = new TimeDuration(-123_456_654_321_123_456n);
+      checkBigInt(d.addToEpochNs(-654_321_123_456_654_321n), -777_777_777_777_777_777n);
+    });
+
+    it('signs differ', () => {
+      const d1 = new TimeDuration(333_333_333_333_333_333n);
+      checkBigInt(d1.addToEpochNs(-222_222_222_222_222_222n), 111_111_111_111_111_111n);
+
+      const d2 = new TimeDuration(-333_333_333_333_333_333n);
+      checkBigInt(d2.addToEpochNs(222_222_222_222_222_222n), -111_111_111_111_111_111n);
+    });
+
+    it('cross zero', () => {
+      const d = new TimeDuration(222_222_222_222_222_222n);
+      checkBigInt(d.addToEpochNs(-333_333_333_333_333_333n), -111_111_111_111_111_111n);
+    });
+
+    it('does not fail on overflow, epochNs overflow is checked elsewhere', () => {
+      const d = new TimeDuration(86400_0000_0000_000_000_000n);
+      checkBigInt(d.addToEpochNs(86400_0000_0000_000_000_000n), 172800_0000_0000_000_000_000n);
+    });
+  });
+
+  describe('cmp()', () => {
+    it('equal', () => {
+      const d1 = new TimeDuration(123_000_000_456n);
+      const d2 = new TimeDuration(123_000_000_456n);
+      equal(d1.cmp(d2), 0);
+      equal(d2.cmp(d1), 0);
+    });
+
+    it('unequal', () => {
+      const smaller = new TimeDuration(123_000_000_456n);
+      const larger = new TimeDuration(654_000_000_321n);
+      equal(smaller.cmp(larger), -1);
+      equal(larger.cmp(smaller), 1);
+    });
+
+    it('cross sign', () => {
+      const neg = new TimeDuration(-654_000_000_321n);
+      const pos = new TimeDuration(123_000_000_456n);
+      equal(neg.cmp(pos), -1);
+      equal(pos.cmp(neg), 1);
+    });
+  });
+
+  describe('divmod()', () => {
+    it('divide by 1', () => {
+      const d = new TimeDuration(1_234_567_890_987n);
+      const { quotient, remainder } = d.divmod(1);
+      equal(quotient, 1234567890987);
+      check(remainder, 0, 0);
+    });
+
+    it('divide by self', () => {
+      const d = new TimeDuration(1_234_567_890n);
+      const { quotient, remainder } = d.divmod(1_234_567_890);
+      equal(quotient, 1);
+      check(remainder, 0, 0);
+    });
+
+    it('no remainder', () => {
+      const d = new TimeDuration(1_234_000_000n);
+      const { quotient, remainder } = d.divmod(1e6);
+      equal(quotient, 1234);
+      check(remainder, 0, 0);
+    });
+
+    it('divide by -1', () => {
+      const d = new TimeDuration(1_234_567_890_987n);
+      const { quotient, remainder } = d.divmod(-1);
+      equal(quotient, -1_234_567_890_987);
+      check(remainder, 0, 0);
+    });
+
+    it('zero seconds remainder has sign of dividend', () => {
+      const d1 = new TimeDuration(1_234_567_890n);
+      let { quotient, remainder } = d1.divmod(-1e6);
+      equal(quotient, -1234);
+      check(remainder, 0, 567890);
+      const d2 = new TimeDuration(-1_234_567_890n);
+      ({ quotient, remainder } = d2.divmod(1e6));
+      equal(quotient, -1234);
+      check(remainder, 0, -567890);
+    });
+
+    it('nonzero seconds remainder has sign of dividend', () => {
+      const d1 = new TimeDuration(10_234_567_890n);
+      let { quotient, remainder } = d1.divmod(-9e9);
+      equal(quotient, -1);
+      check(remainder, 1, 234567890);
+      const d2 = new TimeDuration(-10_234_567_890n);
+      ({ quotient, remainder } = d2.divmod(9e9));
+      equal(quotient, -1);
+      check(remainder, -1, -234567890);
+    });
+
+    it('negative with zero seconds remainder', () => {
+      const d = new TimeDuration(-1_234_567_890n);
+      const { quotient, remainder } = d.divmod(-1e6);
+      equal(quotient, 1234);
+      check(remainder, 0, -567890);
+    });
+
+    it('negative with nonzero seconds remainder', () => {
+      const d = new TimeDuration(-10_234_567_890n);
+      const { quotient, remainder } = d.divmod(-9e9);
+      equal(quotient, 1);
+      check(remainder, -1, -234567890);
+    });
+
+    it('quotient larger than seconds', () => {
+      const d = TimeDuration.normalize(25 + 5 * 24, 0, 86401, 333, 666, 999);
+      const { quotient, remainder } = d.divmod(86400e9);
+      equal(quotient, 7);
+      check(remainder, 3601, 333666999);
+    });
+
+    it('quotient smaller than seconds', () => {
+      const d = new TimeDuration(90061_333666999n);
+      const result1 = d.divmod(1000);
+      equal(result1.quotient, 90061333666);
+      check(result1.remainder, 0, 999);
+
+      const result2 = d.divmod(10);
+      equal(result2.quotient, 9006133366699);
+      check(result2.remainder, 0, 9);
+
+      const result3 = d.divmod(3);
+      equal(result3.quotient, 30020444555666);
+      check(result3.remainder, 0, 1);
+    });
+
+    it('divide by 0', () => {
+      const d = new TimeDuration(90061_333666999n);
+      throws(() => d.divmod(0), Error);
+    });
+  });
+
+  describe('fdiv()', () => {
+    it('divide by 1', () => {
+      const d = new TimeDuration(1_234_567_890_987n);
+      equal(d.fdiv(1), 1_234_567_890_987);
+    });
+
+    it('no remainder', () => {
+      const d = new TimeDuration(1_234_000_000n);
+      equal(d.fdiv(1e6), 1234);
+    });
+
+    it('divide by -1', () => {
+      const d = new TimeDuration(1_234_567_890_987n);
+      equal(d.fdiv(-1), -1_234_567_890_987);
+    });
+
+    it('opposite sign', () => {
+      const d1 = new TimeDuration(1_234_567_890n);
+      checkFloat(d1.fdiv(-1e6), -1234.56789);
+      const d2 = new TimeDuration(-1_234_567_890n);
+      checkFloat(d2.fdiv(1e6), -1234.56789);
+      const d3 = new TimeDuration(-432n);
+      checkFloat(d3.fdiv(864), -0.5);
+    });
+
+    it('negative', () => {
+      const d = new TimeDuration(-1_234_567_890n);
+      checkFloat(d.fdiv(-1e6), 1234.56789);
+    });
+
+    it('quotient larger than seconds', () => {
+      const d = TimeDuration.normalize(25 + 5 * 24, 0, 86401, 333, 666, 999);
+      checkFloat(d.fdiv(86400e9), 7.041682102627303);
+    });
+
+    it('quotient smaller than seconds', () => {
+      const d = new TimeDuration(90061_333666999n);
+      checkFloat(d.fdiv(1000), 90061333666.999);
+      checkFloat(d.fdiv(10), 9006133366699.9);
+      // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+      checkFloat(d.fdiv(3), 30020444555666.333);
+    });
+
+    it('divide by 0', () => {
+      const d = new TimeDuration(90061_333666999n);
+      throws(() => d.fdiv(0), Error);
+    });
+
+    it('large number', () => {
+      const d = new TimeDuration(2939649_187497660n);
+      checkFloat(d.fdiv(3600e9), 816.56921874935);
+    });
+  });
+
+  it('isZero()', () => {
+    assert(new TimeDuration(0n).isZero());
+    assert(!new TimeDuration(1_000_000_000n).isZero());
+    assert(!new TimeDuration(-1n).isZero());
+    assert(!new TimeDuration(1_000_000_001n).isZero());
+  });
+
+  describe('round()', () => {
+    it('basic', () => {
+      const d = new TimeDuration(1_234_567_890n);
+      check(d.round(1000, 'halfExpand'), 1, 234568000);
+    });
+
+    it('increment 1', () => {
+      const d = new TimeDuration(1_234_567_890n);
+      check(d.round(1, 'ceil'), 1, 234567890);
+    });
+
+    it('rounds up from subseconds to seconds', () => {
+      const d = new TimeDuration(1_999_999_999n);
+      check(d.round(1e9, 'halfExpand'), 2, 0);
+    });
+
+    describe('Rounding modes', () => {
+      const increment = 100;
+      const testValues = [-150, -100, -80, -50, -30, 0, 30, 50, 80, 100, 150];
+      const expectations = {
+        ceil: [-100, -100, 0, 0, 0, 0, 100, 100, 100, 100, 200],
+        floor: [-200, -100, -100, -100, -100, 0, 0, 0, 0, 100, 100],
+        trunc: [-100, -100, 0, 0, 0, 0, 0, 0, 0, 100, 100],
+        expand: [-200, -100, -100, -100, -100, 0, 100, 100, 100, 100, 200],
+        halfCeil: [-100, -100, -100, 0, 0, 0, 0, 100, 100, 100, 200],
+        halfFloor: [-200, -100, -100, -100, 0, 0, 0, 0, 100, 100, 100],
+        halfTrunc: [-100, -100, -100, 0, 0, 0, 0, 0, 100, 100, 100],
+        halfExpand: [-200, -100, -100, -100, 0, 0, 0, 100, 100, 100, 200],
+        halfEven: [-200, -100, -100, 0, 0, 0, 0, 0, 100, 100, 200]
+      };
+      for (const roundingMode of Object.keys(expectations)) {
+        describe(roundingMode, () => {
+          testValues.forEach((value, ix) => {
+            const expected = expectations[roundingMode][ix];
+
+            it(`rounds ${value} ns to ${expected} ns`, () => {
+              const d = new TimeDuration(BigInt(value));
+              const result = d.round(increment, roundingMode);
+              check(result, 0, expected);
+            });
+
+            it(`rounds ${value} s to ${expected} s`, () => {
+              const d = new TimeDuration(BigInt(value * 1e9));
+              const result = d.round(increment * 1e9, roundingMode);
+              check(result, expected, 0);
+            });
+          });
+        });
+      }
+    });
+  });
+
+  it('sign()', () => {
+    equal(new TimeDuration(0n).sign(), 0);
+    equal(new TimeDuration(-1n).sign(), -1);
+    equal(new TimeDuration(-1_000_000_000n).sign(), -1);
+    equal(new TimeDuration(1n).sign(), 1);
+    equal(new TimeDuration(1_000_000_000n).sign(), 1);
+  });
+
+  describe('subtract', () => {
+    it('basic', () => {
+      const d1 = new TimeDuration(321_987654321n);
+      const d2 = new TimeDuration(123_123456789n);
+      check(d1.subtract(d2), 198, 864197532);
+      check(d2.subtract(d1), -198, -864197532);
+    });
+
+    it('signs differ in result', () => {
+      const d1 = new TimeDuration(3661_001001001n);
+      const d2 = new TimeDuration(86400_000_000_000n);
+      check(d1.subtract(d2), -82738, -998998999);
+      check(d2.subtract(d1), 82738, 998998999);
+    });
+  });
+});
+
+import { normalize } from 'path';
+if (normalize(import.meta.url.slice(8)) === normalize(process.argv[1])) {
+  report(reporter).then((failed) => process.exit(failed ? 1 : 0));
+}

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -364,22 +364,26 @@ const durationHoursFraction = withCode(fraction, (data, result) => {
 const digitsNotInfinite = withSyntaxConstraints(oneOrMore(digit()), (result) => {
   if (!Number.isFinite(+result)) throw new SyntaxError('try again on infinity');
 });
+const timeDurationDigits = (factor) =>
+  withSyntaxConstraints(between(1, 16, digit()), (result) => {
+    if (!Number.isSafeInteger(+result * factor)) throw new SyntaxError('try again on unsafe integer');
+  });
 const durationSeconds = seq(
-  withCode(digitsNotInfinite, (data, result) => (data.seconds = +result * data.factor)),
+  withCode(timeDurationDigits(1), (data, result) => (data.seconds = +result * data.factor)),
   [durationSecondsFraction],
   secondsDesignator
 );
 const durationMinutes = seq(
-  withCode(digitsNotInfinite, (data, result) => (data.minutes = +result * data.factor)),
+  withCode(timeDurationDigits(60), (data, result) => (data.minutes = +result * data.factor)),
   choice(seq(minutesDesignator, [durationSeconds]), seq(durationMinutesFraction, minutesDesignator))
 );
 const durationHours = seq(
-  withCode(digitsNotInfinite, (data, result) => (data.hours = +result * data.factor)),
+  withCode(timeDurationDigits(3600), (data, result) => (data.hours = +result * data.factor)),
   choice(seq(hoursDesignator, [choice(durationMinutes, durationSeconds)]), seq(durationHoursFraction, hoursDesignator))
 );
 const durationTime = seq(timeDesignator, choice(durationHours, durationMinutes, durationSeconds));
 const durationDays = seq(
-  withCode(digitsNotInfinite, (data, result) => (data.days = +result * data.factor)),
+  withCode(timeDurationDigits(86400), (data, result) => (data.days = +result * data.factor)),
   daysDesignator
 );
 const durationWeeks = seq(

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -361,8 +361,8 @@ const durationHoursFraction = withCode(fraction, (data, result) => {
   data.nanoseconds = Math.trunc(ns % 1e3) * data.factor;
 });
 
-const digitsNotInfinite = withSyntaxConstraints(oneOrMore(digit()), (result) => {
-  if (!Number.isFinite(+result)) throw new SyntaxError('try again on infinity');
+const uint32Digits = withSyntaxConstraints(between(1, 10, digit()), (result) => {
+  if (+result >= 2 ** 32) throw new SyntaxError('try again for an uint32');
 });
 const timeDurationDigits = (factor) =>
   withSyntaxConstraints(between(1, 16, digit()), (result) => {
@@ -387,17 +387,17 @@ const durationDays = seq(
   daysDesignator
 );
 const durationWeeks = seq(
-  withCode(digitsNotInfinite, (data, result) => (data.weeks = +result * data.factor)),
+  withCode(uint32Digits, (data, result) => (data.weeks = +result * data.factor)),
   weeksDesignator,
   [durationDays]
 );
 const durationMonths = seq(
-  withCode(digitsNotInfinite, (data, result) => (data.months = +result * data.factor)),
+  withCode(uint32Digits, (data, result) => (data.months = +result * data.factor)),
   monthsDesignator,
   [choice(durationWeeks, durationDays)]
 );
 const durationYears = seq(
-  withCode(digitsNotInfinite, (data, result) => (data.years = +result * data.factor)),
+  withCode(uint32Digits, (data, result) => (data.years = +result * data.factor)),
   yearsDesignator,
   [choice(durationMonths, durationWeeks, durationDays)]
 );

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1751,7 +1751,18 @@
         1. Let _factor_ be -1.
       1. Else,
         1. Let _factor_ be 1.
-      1. Return ! CreateDurationRecord(_yearsMV_ &times; _factor_, _monthsMV_ &times; _factor_, _weeksMV_ &times; _factor_, _daysMV_ &times; _factor_, _hoursMV_ &times; _factor_, floor(_minutesMV_) &times; _factor_, floor(_secondsMV_) &times; _factor_, floor(_millisecondsMV_) &times; _factor_, floor(_microsecondsMV_) &times; _factor_, floor(_nanosecondsMV_) &times; _factor_).
+      1. Set _yearsMV_ to _yearsMV_ &times; _factor_.
+      1. Set _monthsMV_ to _monthsMV_ &times; _factor_.
+      1. Set _weeksMV_ to _weeksMV_ &times; _factor_.
+      1. Set _daysMV_ to _daysMV_ &times; _factor_.
+      1. Set _hoursMV_ to _hoursMV_ &times; _factor_.
+      1. Set _minutesMV_ to floor(_minutesMV_) &times; _factor_.
+      1. Set _secondsMV_ to floor(_secondsMV_) &times; _factor_.
+      1. Set _millisecondsMV_ to floor(_millisecondsMV_) &times; _factor_.
+      1. Set _microsecondsMV_ to floor(_microsecondsMV_) &times; _factor_.
+      1. Set _nanosecondsMV_ to floor(_nanosecondsMV_) &times; _factor_.
+      1. If IsValidDuration(_yearsMV_, _monthsMV_, _weeksMV_, _daysMV_, _hoursMV_, _minutesMV_, _secondsMV_, _millisecondsMV_, _microsecondsMV_, _nanosecondsMV_) is *false*, throw a *RangeError* exception.
+      1. Return CreateDurationRecord(_yearsMV_, _monthsMV_, _weeksMV_, _daysMV_, _hoursMV_, _minutesMV_, _secondsMV_, _millisecondsMV_, _microsecondsMV_, _nanosecondsMV_).
     </emu-alg>
   </emu-clause>
 

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1448,8 +1448,9 @@
         1. Set _duration_ to ? ToTemporalDuration(_duration_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Let _balanceResult_ be ? BalanceTimeDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
-        1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_).
+        1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Let _balanceResult_ be BalanceTimeDuration(_norm_, *"day"*).
+        1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]] + _balanceResult_.[[Days]], _overflow_).
         1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], *"iso8601"*).
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1203,6 +1203,9 @@
           1. If 𝔽(_v_) is not finite, return *false*.
           1. If _v_ &lt; 0 and _sign_ &gt; 0, return *false*.
           1. If _v_ &gt; 0 and _sign_ &lt; 0, return *false*.
+        1. If abs(_years_) &ge; 2<sup>32</sup>, return *false*.
+        1. If abs(_months_) &ge; 2<sup>32</sup>, return *false*.
+        1. If abs(_weeks_) &ge; 2<sup>32</sup>, return *false*.
         1. Let _normalizedSeconds_ be _days_ &times; 86,400 + _hours_ &times; 3600 + _minutes_ &times; 60 + _seconds_ + _milliseconds_ &times; 10<sup>-3</sup> + _microseconds_ &times; 10<sup>-6</sup> + _nanoseconds_ &times; 10<sup>-9</sup>.
         1. NOTE: The above step cannot be implemented directly using floating-point arithmetic. Multiplying by 10<sup>-3</sup>, 10<sup>-6</sup>, and 10<sup>-9</sup> respectively may be imprecise when _milliseconds_, _microseconds_, or _nanoseconds_ is an unsafe integer. This multiplication can be implemented in C++ with an implementation of `std::remquo()` with sufficient bits in the quotient. String manipulation will also give an exact result, since the multiplication is by a power of 10.
         1. If abs(_normalizedSeconds_) &ge; 2<sup>53</sup>, return *false*.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -513,12 +513,9 @@
         1. Let _unbalanceResult_ be ? UnbalanceDateDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _plainRelativeTo_, _calendarRec_).
         1. If _zonedRelativeTo_ is not *undefined*, then
           1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], 0, _precalculatedPlainDateTime_).
-          1. Let _balanceResult_ be ? BalancePossiblyInfiniteTimeDurationRelative(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_, _intermediate_, _timeZoneRec_).
+          1. Let _balanceResult_ be ? BalanceTimeDurationRelative(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_, _intermediate_, _timeZoneRec_).
         1. Else,
-          1. Let _balanceResult_ be BalancePossiblyInfiniteTimeDuration(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_).
-        1. If _balanceResult_ is ~positive-overflow~, return *+∞*<sub>𝔽</sub>.
-        1. If _balanceResult_ is ~negative-overflow~, return *-∞*<sub>𝔽</sub>.
-        1. Assert: _balanceResult_ is a Time Duration Record.
+          1. Let _balanceResult_ be ! BalanceTimeDuration(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_).
         1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], 1, _unit_, *"trunc"*, _plainRelativeTo_, _calendarRec_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Return 𝔽(_roundRecord_.[[Total]]).
       </emu-alg>
@@ -1038,6 +1035,9 @@
           1. If 𝔽(_v_) is not finite, return *false*.
           1. If _v_ &lt; 0 and _sign_ &gt; 0, return *false*.
           1. If _v_ &gt; 0 and _sign_ &lt; 0, return *false*.
+        1. Let _normalizedSeconds_ be _days_ &times; 86,400 + _hours_ &times; 3600 + _minutes_ &times; 60 + _seconds_ + _milliseconds_ &times; 10<sup>-3</sup> + _microseconds_ &times; 10<sup>-6</sup> + _nanoseconds_ &times; 10<sup>-9</sup>.
+        1. NOTE: The above step cannot be implemented directly using floating-point arithmetic. Multiplying by 10<sup>-3</sup>, 10<sup>-6</sup>, and 10<sup>-9</sup> respectively may be imprecise when _milliseconds_, _microseconds_, or _nanoseconds_ is an unsafe integer. This multiplication can be implemented in C++ with an implementation of `std::remquo()` with sufficient bits in the quotient. String manipulation will also give an exact result, since the multiplication is by a power of 10.
+        1. If abs(_normalizedSeconds_) &ge; 2<sup>53</sup>, return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>
@@ -1211,32 +1211,6 @@
         <dd>It converts the time units of a duration into a form where lower units are converted into higher units as much as possible, up to _largestUnit_. If the Number value for any unit is infinite, it returns abruptly with a *RangeError*.</dd>
       </dl>
       <emu-alg>
-        1. Let _balanceResult_ be BalancePossiblyInfiniteTimeDuration(_days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_).
-        1. If _balanceResult_ is ~positive-overflow~ or ~negative-overflow~, then
-          1. Throw a *RangeError* exception.
-        1. Else,
-          1. Return _balanceResult_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-balancepossiblyinfinitetimeduration" type="abstract operation">
-      <h1>
-        BalancePossiblyInfiniteTimeDuration (
-          _days_: an integer,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
-          _largestUnit_: a String,
-          ): a Time Duration Record if there are no infinite values, or either ~positive-overflow~ or ~negative-overflow~ in case of infinite values
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It converts the time units of a duration into a form where lower units are converted into higher units as much as possible, up to _largestUnit_. If the Number value for any unit is infinite, it returns a special value indicating the direction of overflow.</dd>
-      </dl>
-      <emu-alg>
         1. Set _hours_ to _hours_ + _days_ &times; 24.
         1. Set _nanoseconds_ to TotalDurationNanoseconds(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
         1. Set _days_, _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ to 0.
@@ -1292,13 +1266,8 @@
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
         1. Else,
           1. Assert: _largestUnit_ is *"nanosecond"*.
-        1. For each value _v_ of « _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ », do
-          1. If 𝔽(_v_) is not finite, then
-            1. If _sign_ = 1, then
-              1. Return ~positive-overflow~.
-            1. Else if _sign_ = -1, then
-              1. Return ~negative-overflow~.
-        1. Return ! CreateTimeDurationRecord(_days_ &times; _sign_, _hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
+        1. NOTE: When _largestUnit_ is *"millisecond"*, *"microsecond"*, or *"nanosecond"*, _milliseconds_, _microseconds_, or _nanoseconds_ may be an unsafe integer. In this case, care must be taken when implementing the calculation using floating point arithmetic. It can be implemented in C++ using `std::fma()`. String manipulation will also give an exact result, since the multiplication is by a power of 10.
+        1. Return ? CreateTimeDurationRecord(_days_ &times; _sign_, _hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
       </emu-alg>
     </emu-clause>
 
@@ -1315,40 +1284,12 @@
           _largestUnit_: a String,
           _zonedRelativeTo_: a Temporal.ZonedDateTime,
           _timeZoneRec_: a Time Zone Methods Record,
-          _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
+          optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
         ): either a normal completion containing a Time Duration Record, or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>It converts the time units of a duration into a form where lower units are converted into higher units as much as possible, up to _largestUnit_, taking day length of _zonedRelativeTo_ into account. If the Number value for any unit is infinite, it returns abruptly with a *RangeError*.</dd>
-      </dl>
-      <emu-alg>
-        1. Let _balanceResult_ be ? BalancePossiblyInfiniteTimeDurationRelative(_days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
-        1. If _balanceResult_ is ~positive-overflow~ or ~negative-overflow~, then
-          1. Throw a *RangeError* exception.
-        1. Return _balanceResult_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-balancepossiblyinfinitetimedurationrelative" type="abstract operation">
-      <h1>
-        BalancePossiblyInfiniteTimeDurationRelative (
-          _days_: an integer,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
-          _largestUnit_: a String,
-          _zonedRelativeTo_: a Temporal.ZonedDateTime,
-          _timeZoneRec_: a Time Zone Methods Record,
-          optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
-        ): either a normal completion containing either Time Duration Record if there are no infinite values, ~positive-overflow~, or ~negative-overflow~ in case of infinite values, or an abrupt completion
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It converts the time units of a duration into a form where lower units are converted into higher units as much as possible, up to _largestUnit_, taking day length of _zonedRelativeTo_ into account. If the Number value for any unit is infinite, it returns a special value indicating the direction of overflow.</dd>
       </dl>
       <p>
         This operation observably calls time zone and calendar methods.
@@ -1371,11 +1312,7 @@
           1. Set _largestUnit_ to *"hour"*.
         1. Else,
           1. Set _days_ to 0.
-        1. If 𝔽(_days_) is not finite, then
-          1. If _days_ &gt; 0, return ~positive-overflow~.
-          1. Else, return ~negative-overflow~.
-        1. Let _balanceResult_ be BalancePossiblyInfiniteTimeDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], _largestUnit_).
-        1. If _balanceResult_ is ~positive-overflow~ or ~negative-overflow~, return _balanceResult_.
+        1. Let _balanceResult_ be ? BalanceTimeDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], _largestUnit_).
         1. Return ! CreateTimeDurationRecord(_days_, _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -106,8 +106,10 @@
         1. If _zonedRelativeTo_ is not *undefined*, and either _calendarUnitsPresent_ is *true*, or _one_.[[Days]] &ne; 0, or _two_.[[Days]] &ne; 0, then
           1. Let _instant_ be ! CreateTemporalInstant(_zonedRelativeTo_.[[Nanoseconds]]).
           1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
-          1. Let _after1_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], _one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]], _precalculatedPlainDateTime_).
-          1. Let _after2_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], _two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]], _precalculatedPlainDateTime_).
+          1. Let _norm1_ be NormalizeTimeDuration(_one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]]).
+          1. Let _norm2_ be NormalizeTimeDuration(_two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]]).
+          1. Let _after1_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _one_.[[Years]], _one_.[[Months]], _one_.[[Weeks]], _one_.[[Days]], _norm1_, _precalculatedPlainDateTime_).
+          1. Let _after2_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _two_.[[Years]], _two_.[[Months]], _two_.[[Weeks]], _two_.[[Days]], _norm2_, _precalculatedPlainDateTime_).
           1. If _after1_ &gt; _after2_, return *1*<sub>𝔽</sub>.
           1. If _after1_ &lt; _after2_, return *-1*<sub>𝔽</sub>.
           1. Return *+0*<sub>𝔽</sub>.
@@ -119,13 +121,11 @@
         1. Else,
           1. Let _days1_ be _one_.[[Days]].
           1. Let _days2_ be _two_.[[Days]].
-        1. Let _hours1_ be _one_.[[Hours]] + _days1_ &times; 24.
-        1. Let _hours2_ be _two_.[[Hours]] + _days2_ &times; 24.
-        1. Let _ns1_ be TotalDurationNanoseconds(_hours1_, _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]]).
-        1. Let _ns2_ be TotalDurationNanoseconds(_hours2_, _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]]).
-        1. If _ns1_ &gt; _ns2_, return *1*<sub>𝔽</sub>.
-        1. If _ns1_ &lt; _ns2_, return *-1*<sub>𝔽</sub>.
-        1. Return *+0*<sub>𝔽</sub>.
+        1. Let _norm1_ be NormalizeTimeDuration(_one_.[[Hours]], _one_.[[Minutes]], _one_.[[Seconds]], _one_.[[Milliseconds]], _one_.[[Microseconds]], _one_.[[Nanoseconds]]).
+        1. Set _norm1_ to ? Add24HourDaysToNormalizedTimeDuration(_norm1_, _days1_).
+        1. Let _norm2_ be NormalizeTimeDuration(_two_.[[Hours]], _two_.[[Minutes]], _two_.[[Seconds]], _two_.[[Milliseconds]], _two_.[[Microseconds]], _two_.[[Nanoseconds]]).
+        1. Set _norm2_ to ? Add24HourDaysToNormalizedTimeDuration(_norm2_, _days2_).
+        1. Return 𝔽(CompareNormalizedTimeDuration(_norm1_, _norm2_)).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -469,13 +469,15 @@
           1. Set _plainRelativeTo_ to ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _zonedRelativeTo_.[[Calendar]]).
         1. Let _calendarRec_ be ? CreateCalendarMethodsRecordFromRelativeTo(_plainRelativeTo_, _zonedRelativeTo_, « ~date-add~, ~date-until~ »).
         1. Let _unbalanceResult_ be ? UnbalanceDateDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _largestUnit_, _plainRelativeTo_, _calendarRec_).
-        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _plainRelativeTo_, _calendarRec_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
-        1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
+        1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _unbalanceResult_.[[Days]], _norm_, _roundingIncrement_, _smallestUnit_, _roundingMode_, _plainRelativeTo_, _calendarRec_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
+        1. Let _roundResult_ be _roundRecord_.[[NormalizedDuration]].
         1. If _zonedRelativeTo_ is not *undefined*, then
-          1. Set _roundResult_ to ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _precalculatedPlainDateTime_).
-          1. Let _balanceResult_ be ? BalanceTimeDurationRelative(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
+          1. Set _roundResult_ to ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[NormalizedTime]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _precalculatedPlainDateTime_).
+          1. Let _balanceResult_ be ? BalanceTimeDurationRelative(_roundResult_.[[Days]], _roundResult_.[[NormalizedTime]], _largestUnit_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Else,
-          1. Let _balanceResult_ be ? BalanceTimeDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
+          1. Let _normWithDays_ be ? Add24HourDaysToNormalizedTimeDuration(_roundResult_.[[NormalizedTime]], _roundResult_.[[Days]]).
+          1. Let _balanceResult_ be BalanceTimeDuration(_normWithDays_, _largestUnit_).
         1. Let _result_ be ? BalanceDateDurationRelative(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _balanceResult_.[[Days]], _largestUnit_, _smallestUnit_, _plainRelativeTo_, _calendarRec_).
         1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
       </emu-alg>
@@ -511,12 +513,33 @@
           1. Set _plainRelativeTo_ to ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _zonedRelativeTo_.[[Calendar]]).
         1. Let _calendarRec_ be ? CreateCalendarMethodsRecordFromRelativeTo(_plainRelativeTo_, _zonedRelativeTo_, « ~date-add~, ~date-until~ »).
         1. Let _unbalanceResult_ be ? UnbalanceDateDurationRelative(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _unit_, _plainRelativeTo_, _calendarRec_).
+        1. Let _days_ be _unbalanceResult_.[[Days]].
         1. If _zonedRelativeTo_ is not *undefined*, then
           1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], 0, _precalculatedPlainDateTime_).
-          1. Let _balanceResult_ be ? BalanceTimeDurationRelative(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_, _intermediate_, _timeZoneRec_).
+          1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+          1. Let _startNs_ be _intermediate_.[[Nanoseconds]].
+          1. Let _startInstant_ be ! CreateTemporalInstant(_startNs_).
+          1. Let _startDateTime_ be *undefined*.
+          1. If _days_ &ne; 0, then
+            1. Set _startDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, *"iso8601"*).
+            1. Let _addResult_ be ? AddDaysToZonedDateTime(_startInstant_, _startDateTime_, _timeZoneRec_, *"iso8601"*, _days_).
+            1. Let _intermediateNs_ be _addResult_.[[EpochNanoseconds]].
+          1. Else,
+            1. Let _intermediateNs_ be _startNs_.
+          1. Let _endNs_ be ? AddInstant(_intermediateNs_, _norm_).
+          1. Set _norm_ to NormalizedTimeDurationFromEpochNanosecondsDifference(_endNs_, _startNs_).
+          1. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
+            1. If NormalizedTimeDurationIsZero(_norm_) is *false* and _startDateTime_ is *undefined*, set _startDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, *"iso8601"*).
+            1. Let _result_ be ? NormalizedTimeDurationToDays(_norm_, _intermediate_, _timeZoneRec_, _startDateTime_).
+            1. Set _norm_ to _result_.[[Remainder]].
+            1. Set _days_ to _result_.[[Days]].
+          1. Else,
+            1. Set _days_ to 0.
         1. Else,
-          1. Let _balanceResult_ be ! BalanceTimeDuration(_unbalanceResult_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _unit_).
-        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]], 1, _unit_, *"trunc"*, _plainRelativeTo_, _calendarRec_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
+          1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+          1. Set _norm_ to ? Add24HourDaysToNormalizedTimeDuration(_norm_, _days_).
+          1. Set _days_ to 0.
+        1. Let _roundRecord_ be ? RoundDuration(_unbalanceResult_.[[Years]], _unbalanceResult_.[[Months]], _unbalanceResult_.[[Weeks]], _days_, _norm_, 1, _unit_, *"trunc"*, _plainRelativeTo_, _calendarRec_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
         1. Return 𝔽(_roundRecord_.[[Total]]).
       </emu-alg>
     </emu-clause>
@@ -537,14 +560,16 @@
         1. If _smallestUnit_ is *"hour"* or *"minute"*, throw a *RangeError* exception.
         1. Let _precision_ be ToSecondsStringPrecisionRecord(_smallestUnit_, _digits_).
         1. If _precision_.[[Unit]] is not *"nanosecond"* or _precision_.[[Increment]] &ne; 1, then
+          1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
           1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
-          1. Let _roundRecord_ be ? RoundDuration(0, 0, 0, 0, 0, 0, _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
-          1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
-          1. Let _balanceResult_ be ? BalanceTimeDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
-          1. Let _result_ be ! CreateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
+          1. Let _roundRecord_ be ? RoundDuration(0, 0, 0, 0, _norm_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+          1. Set _norm_ to _roundRecord_.[[NormalizedDuration]].[[NormalizedTime]].
+          1. Let _result_ be BalanceTimeDuration(_norm_, LargerOfTwoTemporalUnits(_largestUnit_, *"second"*)).
+          1. Set _result_ to CreateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]] + _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Else,
           1. Let _result_ be _duration_.
-        1. Return ! TemporalDurationToString(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _precision_.[[Precision]]).
+        1. Let _normSeconds_ be NormalizeTimeDuration(0, 0, _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Return ! TemporalDurationToString(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _normSeconds_, _precision_.[[Precision]]).
       </emu-alg>
     </emu-clause>
 
@@ -556,7 +581,8 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return ! TemporalDurationToString(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"auto"*).
+        1. Let _normSeconds_ be NormalizeTimeDuration(0, 0, _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Return ! TemporalDurationToString(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _normSeconds_, *"auto"*).
       </emu-alg>
     </emu-clause>
 
@@ -572,7 +598,8 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return ! TemporalDurationToString(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"auto"*).
+        1. Let _normSeconds_ be NormalizeTimeDuration(0, 0, _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Return ! TemporalDurationToString(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _normSeconds_, *"auto"*).
       </emu-alg>
     </emu-clause>
 
@@ -841,6 +868,93 @@
       </p>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-normalized-time-duration-records">
+      <h1>Normalized Time Duration Records</h1>
+      <p>
+        A <dfn variants="Normalized Time Duration Records">Normalized Time Duration Record</dfn> is a Record value used to represent the portion of a Temporal.Duration object that deals with time units, but as a combined value.
+        Normalized Time Duration Records are produced by the abstract operation NormalizeTimeDuration, among others.
+      </p>
+      <p>
+        Normalized Time Duration Records have the fields listed in <emu-xref href="#table-temporal-normalized-time-duration-record-fields"></emu-xref>.
+      </p>
+      <emu-table id="table-temporal-normalized-time-duration-record-fields" caption="Normalized Time Duration Record Fields">
+        <table class="real-table">
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td>[[TotalNanoseconds]]</td>
+            <td>
+              an integer in the inclusive interval from -maxTimeDuration to maxTimeDuration, where
+              <emu-eqn id="eqn-maxTimeDuration" aoid="maxTimeDuration">
+                maxTimeDuration = 2<sup>53</sup> &times; 10<sup>9</sup> - 1 = 9,007,199,254,740,991,999,999,999
+              </emu-eqn>
+            </td>
+            <td>
+              The number of nanoseconds in the duration.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-normalized-duration-records">
+      <h1>Normalized Duration Records</h1>
+      <p>
+        A <dfn variants="Normalized Duration Records">Normalized Duration Record</dfn> is a Record value used to represent the combination of a Date Duration Record with a Normalized Time Duration Record.
+        Such Records are used by operations that deal with both date and time portions of durations, such as RoundDuration.
+      </p>
+      <p>
+        Normalized Duration Records have the fields listed in <emu-xref href="#table-temporal-normalized-duration-record-fields"></emu-xref>.
+      </p>
+      <emu-table id="table-temporal-normalized-duration-record-fields" caption="Normalized Duration Record Fields">
+        <table class="real-table">
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td>[[Years]]</td>
+            <td>a float64-representable integer</td>
+            <td>
+              The number of years in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Months]]</td>
+            <td>a float64-representable integer</td>
+            <td>
+              The number of months in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Weeks]]</td>
+            <td>a float64-representable integer</td>
+            <td>
+              The number of weeks in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>[[Days]]</td>
+            <td>a float64-representable integer</td>
+            <td>
+              The number of days in the duration.
+            </td>
+          </tr>
+          <tr>
+            <td>[[NormalizedTime]]</td>
+            <td>a Normalized Time Duration Record</td>
+            <td>
+              The time portion of the duration.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-createdurationrecord" type="abstract operation">
       <h1>
         CreateDurationRecord (
@@ -854,14 +968,14 @@
           _milliseconds_: an integer,
           _microseconds_: an integer,
           _nanoseconds_: an integer,
-        ): either a normal completion containing a Duration Record, or a throw completion
+        ): a Duration Record
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd></dd>
       </dl>
       <emu-alg>
-        1. If ! IsValidDuration(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_) is *false*, throw a *RangeError* exception.
+        1. Assert: ! IsValidDuration(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_) is *true*.
         1. Return the Record {
             [[Years]]: ℝ(𝔽(_years_)),
             [[Months]]: ℝ(𝔽(_months_)),
@@ -931,6 +1045,60 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-createnormalizeddurationrecord" type="abstract operation">
+      <h1>
+        CreateNormalizedDurationRecord (
+          _years_: an integer,
+          _months_: an integer,
+          _weeks_: an integer,
+          _days_: an integer,
+          _norm_: a Normalized Time Duration Record,
+        ): either a normal completion containing a Normalized Duration Record, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
+      </dl>
+      <emu-alg>
+        1. Let _dateDurationRecord_ be ? CreateDateDurationRecord(_years_, _months_, _weeks_, _days_).
+        1. Let _dateSign_ be DurationSign(_dateDurationRecord_.[[Years]], _dateDurationRecord_.[[Months]], _dateDurationRecord_.[[Weeks]], _dateDurationRecord_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _timeSign_ be NormalizedTimeDurationSign(_norm_).
+        1. If _dateSign_ &ne; 0 and _timeSign_ &ne; 0 and _dateSign_ &ne; _timeSign_, throw a *RangeError* exception.
+        1. Return the Record {
+            [[Years]]: _dateDurationRecord_.[[Years]],
+            [[Months]]: _dateDurationRecord_.[[Months]],
+            [[Weeks]]: _dateDurationRecord_.[[Weeks]],
+            [[Days]]: _dateDurationRecord_.[[Days]],
+            [[NormalizedTime]]: _norm_
+          }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-combinedateandnormalizedtimeduration" type="abstract operation">
+      <h1>
+        CombineDateAndNormalizedTimeDuration (
+          _dateDurationRecord_: a Date Duration Record,
+          _norm_: a Normalized Time Duration Record,
+        ): either a normal completion containing a Normalized Duration Record, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
+      </dl>
+      <emu-alg>
+        1. Let _dateSign_ be DurationSign(_dateDurationRecord_.[[Years]], _dateDurationRecord_.[[Months]], _dateDurationRecord_.[[Weeks]], _dateDurationRecord_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _timeSign_ be NormalizedTimeDurationSign(_norm_).
+        1. If _dateSign_ &ne; 0 and _timeSign_ &ne; 0 and _dateSign_ &ne; _timeSign_, throw a *RangeError* exception.
+        1. Return the Record {
+            [[Years]]: _dateDurationRecord_.[[Years]],
+            [[Months]]: _dateDurationRecord_.[[Months]],
+            [[Weeks]]: _dateDurationRecord_.[[Weeks]],
+            [[Days]]: _dateDurationRecord_.[[Days]],
+            [[NormalizedTime]]: _norm_
+          }.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-totemporalduration" type="abstract operation">
       <h1>
         ToTemporalDuration (
@@ -964,7 +1132,7 @@
           1. If _temporalDurationLike_ is not a String, throw a *TypeError* exception.
           1. Return ? ParseTemporalDurationString(_temporalDurationLike_).
         1. If _temporalDurationLike_ has an [[InitializedTemporalDuration]] internal slot, then
-          1. Return ! CreateDurationRecord(_temporalDurationLike_.[[Years]], _temporalDurationLike_.[[Months]], _temporalDurationLike_.[[Weeks]], _temporalDurationLike_.[[Days]], _temporalDurationLike_.[[Hours]], _temporalDurationLike_.[[Minutes]], _temporalDurationLike_.[[Seconds]], _temporalDurationLike_.[[Milliseconds]], _temporalDurationLike_.[[Microseconds]], _temporalDurationLike_.[[Nanoseconds]]).
+          1. Return CreateDurationRecord(_temporalDurationLike_.[[Years]], _temporalDurationLike_.[[Months]], _temporalDurationLike_.[[Weeks]], _temporalDurationLike_.[[Days]], _temporalDurationLike_.[[Hours]], _temporalDurationLike_.[[Minutes]], _temporalDurationLike_.[[Seconds]], _temporalDurationLike_.[[Milliseconds]], _temporalDurationLike_.[[Microseconds]], _temporalDurationLike_.[[Nanoseconds]]).
         1. Let _result_ be a new Duration Record with each field set to 0.
         1. Let _partial_ be ? ToTemporalPartialDurationRecord(_temporalDurationLike_).
         1. If _partial_.[[Years]] is not *undefined*, set _result_.[[Years]] to _partial_.[[Years]].
@@ -1167,21 +1335,23 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-totaldurationnanoseconds" type="abstract operation">
+    <emu-clause id="sec-temporal-normalizetimeduration" type="abstract operation">
       <h1>
-        TotalDurationNanoseconds (
+        NormalizeTimeDuration (
           _hours_: an integer,
           _minutes_: an integer,
           _seconds_: an integer,
           _milliseconds_: an integer,
           _microseconds_: an integer,
           _nanoseconds_: an integer,
-        ): an integer
+        ): a Normalized Time Duration Record
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It computes an integer number of nanoseconds from the given units.
+          From the given units, it computes a normalized time duration consisting of whole seconds, and subseconds expressed in nanoseconds.
+          The normalized time duration can be stored losslessly in two 64-bit floating point numbers.
+          Alternatively, _normalizedSeconds_ &times; 10<sup>9</sup> + _subseconds_ can be stored as a 96-bit integer.
         </dd>
       </dl>
       <emu-alg>
@@ -1189,33 +1359,268 @@
         1. Set _seconds_ to _seconds_ + _minutes_ &times; 60.
         1. Set _milliseconds_ to _milliseconds_ + _seconds_ &times; 1000.
         1. Set _microseconds_ to _microseconds_ + _milliseconds_ &times; 1000.
-        1. Return _nanoseconds_ + _microseconds_ &times; 1000.
+        1. Set _nanoseconds_ to _nanoseconds_ + _microseconds_ &times; 1000.
+        1. Assert: abs(_nanoseconds_) &le; maxTimeDuration.
+        1. Return the Record { [[TotalNanoseconds]]: _nanoseconds_ }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-normalizedtimedurationabs" type="abstract operation">
+      <h1>
+        NormalizedTimeDurationAbs (
+          _d_: a Normalized Time Duration Record,
+        ): a Normalized Time Duration Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a new normalized time duration that is the absolute value of _d_.</dd>
+      </dl>
+      <emu-alg>
+        1. Return the Record { [[TotalNanoseconds]]: abs(_d_.[[TotalNanoseconds]]) }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-addnormalizedtimeduration" type="abstract operation">
+      <h1>
+        AddNormalizedTimeDuration (
+          _one_: a Normalized Time Duration Record,
+          _two_: a Normalized Time Duration Record,
+        ): either a normal completion containing a Normalized Time Duration Record, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a normalized time duration that is the sum of _one_ and _two_, throwing an exception if the result is greater than the maximum normalized time duration.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _result_ be _one_.[[TotalNanoseconds]] + _two_.[[TotalNanoseconds]].
+        1. If abs(_result_) &gt; maxTimeDuration, throw a *RangeError* exception.
+        1. Return the Record { [[TotalNanoseconds]]: _result_ }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-add24hourdaystonormalizedtimeduration" type="abstract operation">
+      <h1>
+        Add24HourDaysToNormalizedTimeDuration (
+          _d_: a Normalized Time Duration Record,
+          _days_: an integer,
+        ): either a normal completion containing a Normalized Time Duration Record, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It returns a normalized time duration that is the sum of _d_ and the number of 24-hour days indicated by _days_, throwing an exception if the result is greater than the maximum normalized time duration.
+          This operation should not be used when adding days relative to a Temporal.ZonedDateTime, since the days may not be 24 hours long.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Let _result_ be _d_.[[TotalNanoseconds]] + _days_ &times; nsPerDay.
+        1. If abs(_result_) &gt; maxTimeDuration, throw a *RangeError* exception.
+        1. Return the Record { [[TotalNanoseconds]]: _result_ }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-addnormalizedtimedurationtoepochnanoseconds" type="abstract operation">
+      <h1>
+        AddNormalizedTimeDurationToEpochNanoseconds (
+          _d_: a Normalized Time Duration Record,
+          _epochNs_: a BigInt,
+        ): a BigInt
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It adds a normalized time duration _d_ to an exact time in nanoseconds since the epoch, _epochNs_, and returns a new exact time.
+          The returned exact time is not required to be valid according to IsValidEpochNanoseconds.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. Return _epochNs_ + ℤ(_d_.[[TotalNanoseconds]]).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-comparenormalizedtimeduration" type="abstract operation">
+      <h1>
+        CompareNormalizedTimeDuration (
+          _one_: a Normalized Time Duration Record,
+          _two_: a Normalized Time Duration Record,
+        ): -1, 0, or 1
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It performs a comparison of two Normalized Time Duration Records.</dd>
+      </dl>
+      <emu-alg>
+        1. If _one_.[[TotalNanoseconds]] &gt; _two_.[[TotalNanoseconds]], return 1.
+        1. If _one_.[[TotalNanoseconds]] &lt; _two_.[[TotalNanoseconds]], return -1.
+        1. Return 0.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-dividenormalizedtimeduration" type="abstract operation">
+      <h1>
+        DivideNormalizedTimeDuration (
+          _d_: a Normalized Time Duration Record,
+          _divisor_: an integer,
+        ): a mathematical value
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It divides the total number of nanoseconds in the normalized time duration _d_ by _divisor_.</dd>
+      </dl>
+      <emu-alg>
+        1. Assert: _divisor_ &ne; 0.
+        1. NOTE: The following step cannot be implemented directly using floating-point arithmetic when 𝔽(_d_.[[TotalNanoseconds]]) is not a safe integer. The division can be implemented in C++ with the `__float128` type if the compiler supports it, or with software emulation such as in the <a href="https://bellard.org/softfp/">SoftFP</a> library.
+        1. Return _d_.[[TotalNanoseconds]] / _divisor_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-normalizedtimedurationfromepochnanosecondsdifference" type="abstract operation">
+      <h1>
+        NormalizedTimeDurationFromEpochNanosecondsDifference (
+          _one_: a BigInt,
+          _two_: a BigInt,
+        ): a Normalized Time Duration Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates a Normalized Time Duration Record with the difference between two exact times in nanoseconds since the epoch, which must not be greater than the maximum normalized time duration.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _result_ be ℝ(_one_) - ℝ(_two_).
+        1. Assert: abs(_result_) &le; maxTimeDuration.
+        1. Return the Record { [[TotalNanoseconds]]: _result_ }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-normalizedtimedurationiszero" type="abstract operation">
+      <h1>
+        NormalizedTimeDurationIsZero (
+          _d_: a Normalized Time Duration Record,
+        ): a Boolean
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns *true* if _d_ is a zero duration, *false* otherwise.</dd>
+      </dl>
+      <emu-alg>
+        1. If _d_.[[TotalNanoseconds]] = 0, return *true*.
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-roundnormalizedtimedurationtoincrement" type="abstract operation">
+      <h1>
+        RoundNormalizedTimeDurationToIncrement (
+          _d_: a Normalized Time Duration Record,
+          _increment_: an integer,
+          _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+        ): either a normal completion containing a Normalized Time Duration Record, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It rounds the total number of nanoseconds in the normalized time duration _d_ to the nearest multiple of _increment_, up or down according to _roundingMode_.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _rounded_ be RoundNumberToIncrement(_d_.[[TotalNanoseconds]], _increment_, _roundingMode_).
+        1. If abs(_rounded_) &gt; maxTimeDuration, throw a *RangeError* exception.
+        1. Return the Record { [[TotalNanoseconds]]: _rounded_ }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-normalizedtimedurationseconds" type="abstract operation">
+      <h1>
+        NormalizedTimeDurationSeconds (
+          _d_: a Normalized Time Duration Record,
+        ): an integer in the interval from -2<sup>53</sup> (exclusive) to 2<sup>53</sup> (exclusive)
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the integer number of seconds in _d_.</dd>
+      </dl>
+      <emu-alg>
+        1. Return truncate(_d_.[[TotalNanoseconds]] / 10<sup>9</sup>).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-normalizedtimedurationsign" type="abstract operation">
+      <h1>
+        NormalizedTimeDurationSign (
+          _d_: a Normalized Time Duration Record,
+        ): -1, 0, or 1
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns 0 if the duration is zero, or &pm;1 depending on the sign of the duration.</dd>
+      </dl>
+      <emu-alg>
+        1. If _d_.[[TotalNanoseconds]] &lt; 0, return -1.
+        1. If _d_.[[TotalNanoseconds]] &gt; 0, return 1.
+        1. Return 0.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-normalizedtimedurationsubseconds" type="abstract operation">
+      <h1>
+        NormalizedTimeDurationSubseconds (
+          _d_: a Normalized Time Duration Record,
+        ): an integer in the interval from -10<sup>9</sup> (exclusive) to 10<sup>9</sup> (exclusive)
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the integer number of nanoseconds in the subsecond part of _d_.</dd>
+      </dl>
+      <emu-alg>
+        1. Return remainder(_d_.[[TotalNanoseconds]], 10<sup>9</sup>).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-subtractnormalizedtimeduration" type="abstract operation">
+      <h1>
+        SubtractNormalizedTimeDuration (
+          _one_: a Normalized Time Duration Record,
+          _two_: a Normalized Time Duration Record,
+        ): either a normal completion containing a Normalized Time Duration Record, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a normalized time duration that is the difference between _one_ and _two_, throwing an exception if the result is greater than the maximum normalized time duration.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _result_ be _one_.[[TotalNanoseconds]] - _two_.[[TotalNanoseconds]].
+        1. If abs(_result_) &gt; maxTimeDuration, throw a *RangeError* exception.
+        1. Return the Record { [[TotalNanoseconds]]: _result_ }.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-zerotimeduration" type="abstract operation">
+      <h1>
+        ZeroTimeDuration (
+        ): a Normalized Time Duration Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a normalized time duration of zero length.</dd>
+      </dl>
+      <emu-alg>
+        1. Return the Record { [[TotalNanoseconds]]: 0 }.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal-balancetimeduration" type="abstract operation">
       <h1>
         BalanceTimeDuration (
-          _days_: an integer,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
+          _norm_: a Normalized Time Duration Record,
           _largestUnit_: a String,
-        ): either a normal completion containing a Time Duration Record, or an abrupt completion
+        ): a Time Duration Record
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts the time units of a duration into a form where lower units are converted into higher units as much as possible, up to _largestUnit_. If the Number value for any unit is infinite, it returns abruptly with a *RangeError*.</dd>
+        <dd>It converts a normalized time duration into a time duration with separated units, up to _largestUnit_.</dd>
       </dl>
       <emu-alg>
-        1. Set _hours_ to _hours_ + _days_ &times; 24.
-        1. Set _nanoseconds_ to TotalDurationNanoseconds(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Set _days_, _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ to 0.
-        1. If _nanoseconds_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
-        1. Set _nanoseconds_ to abs(_nanoseconds_).
+        1. Let _days_, _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ be 0.
+        1. Let _sign_ be NormalizedTimeDurationSign(_norm_).
+        1. Let _nanoseconds_ be NormalizedTimeDurationAbs(_norm_).[[TotalNanoseconds]].
         1. If _largestUnit_ is *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
@@ -1267,7 +1672,7 @@
         1. Else,
           1. Assert: _largestUnit_ is *"nanosecond"*.
         1. NOTE: When _largestUnit_ is *"millisecond"*, *"microsecond"*, or *"nanosecond"*, _milliseconds_, _microseconds_, or _nanoseconds_ may be an unsafe integer. In this case, care must be taken when implementing the calculation using floating point arithmetic. It can be implemented in C++ using `std::fma()`. String manipulation will also give an exact result, since the multiplication is by a power of 10.
-        1. Return ? CreateTimeDurationRecord(_days_ &times; _sign_, _hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
+        1. Return ! CreateTimeDurationRecord(_days_ &times; _sign_, _hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
       </emu-alg>
     </emu-clause>
 
@@ -1275,16 +1680,11 @@
       <h1>
         BalanceTimeDurationRelative (
           _days_: an integer,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
+          _norm_: a Normalized Time Duration Record,
           _largestUnit_: a String,
           _zonedRelativeTo_: a Temporal.ZonedDateTime,
           _timeZoneRec_: a Time Zone Methods Record,
-          optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
+          _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
         ): either a normal completion containing a Time Duration Record, or an abrupt completion
       </h1>
       <dl class="header">
@@ -1295,24 +1695,25 @@
         This operation observably calls time zone and calendar methods.
       </p>
       <emu-alg>
-        1. If _precalculatedPlainDateTime_ is not present, let _precalculatedPlainDateTime_ be *undefined*.
-        1. Let _intermediateNs_ be _zonedRelativeTo_.[[Nanoseconds]].
-        1. Let _startInstant_ be ! CreateTemporalInstant(_zonedRelativeTo_.[[Nanoseconds]]).
+        1. Let _startNs_ be _zonedRelativeTo_.[[Nanoseconds]].
+        1. Let _startInstant_ be ! CreateTemporalInstant(_startNs_).
+        1. Let _intermediateNs_ be _startNs_.
         1. If _days_ &ne; 0, then
           1. If _precalculatedPlainDateTime_ is *undefined*, set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, *"iso8601"*).
           1. Let _intermediateResult_ be ? AddDaysToZonedDateTime(_startInstant_, _precalculatedPlainDateTime_, _timeZoneRec_, *"iso8601"*, _days_).
           1. Set _intermediateNs_ to _intermediateResult_.[[EpochNanoseconds]].
-        1. Let _endNs_ be ? AddInstant(_intermediateNs_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Set _nanoseconds_ to ℝ(_endNs_ - _zonedRelativeTo_.[[Nanoseconds]]).
-        1. If _nanoseconds_ = 0, return ! CreateTimeDurationRecord(0, 0, 0, 0, 0, 0, 0).
+        1. Let _endNs_ be ? AddInstant(_intermediateNs_, _norm_).
+        1. Set _norm_ to NormalizedTimeDurationFromEpochNanosecondsDifference(_endNs_, _startNs_).
+        1. If NormalizedTimeDurationIsZero(_norm_) is *true*, return ! CreateTimeDurationRecord(0, 0, 0, 0, 0, 0, 0).
         1. If _largestUnit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. If _precalculatedPlainDateTime_ is *undefined*, set _precalculatedPlainDateTime_ to ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, *"iso8601"*).
-          1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
+          1. Let _result_ be ? NormalizedTimeDurationToDays(_norm_, _zonedRelativeTo_, _timeZoneRec_, _precalculatedPlainDateTime_).
           1. Set _days_ to _result_.[[Days]].
+          1. Set _norm_ to _result_.[[NormalizedTime]].
           1. Set _largestUnit_ to *"hour"*.
         1. Else,
           1. Set _days_ to 0.
-        1. Let _balanceResult_ be ? BalanceTimeDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], _largestUnit_).
+        1. Let _balanceResult_ be BalanceTimeDuration(_norm_, _largestUnit_).
         1. Return ! CreateTimeDurationRecord(_days_, _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -1473,8 +1874,12 @@
         1. If _zonedRelativeTo_ is *undefined* and _plainRelativeTo_ is *undefined*, then
           1. If _largestUnit_ is one of *"year"*, *"month"*, or *"week"*, then
             1. Throw a *RangeError* exception.
-          1. Let _result_ be ? BalanceTimeDuration(_d1_ + _d2_, _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
-          1. Return ! CreateDurationRecord(0, 0, 0, _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+          1. Let _norm1_ be NormalizeTimeDuration(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
+          1. Let _norm2_ be NormalizeTimeDuration(_h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+          1. Let _normResult_ be ? AddNormalizedTimeDuration(_norm1_, _norm2_).
+          1. Set _normResult_ to ? Add24HourDaysToNormalizedTimeDuration(_normResult_, _d1_ + _d2_).
+          1. Let _result_ be BalanceTimeDuration(_normResult_, _largestUnit_).
+          1. Return CreateDurationRecord(0, 0, 0, _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. If _plainRelativeTo_ is not *undefined*, then
           1. Assert: _zonedRelativeTo_ is *undefined*.
           1. Let _dateDuration1_ be ! CreateTemporalDuration(_y1_, _mon1_, _w1_, _d1_, 0, 0, 0, 0, 0, 0).
@@ -1485,8 +1890,12 @@
           1. Let _differenceOptions_ be OrdinaryObjectCreate(*null*).
           1. Perform ! CreateDataPropertyOrThrow(_differenceOptions_, *"largestUnit"*, _dateLargestUnit_).
           1. Let _dateDifference_ be ? DifferenceDate(_calendarRec_, _plainRelativeTo_, _end_, _differenceOptions_).
-          1. Let _result_ be ? BalanceTimeDuration(_dateDifference_.[[Days]], _h1_ + _h2_, _min1_ + _min2_, _s1_ + _s2_, _ms1_ + _ms2_, _mus1_ + _mus2_, _ns1_ + _ns2_, _largestUnit_).
-          1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+          1. Let _norm1_ be NormalizeTimeDuration(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
+          1. Let _norm2_ be NormalizeTimeDuration(_h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+          1. Let _norm1WithDays_ be ? Add24HourDaysToNormalizedTimeDuration(_norm1_, _dateDifference_.[[Days]]).
+          1. Let _normResult_ be ? AddNormalizedTimeDuration(_norm1WithDays_, _norm2_).
+          1. Let _result_ be BalanceTimeDuration(_normResult_, _largestUnit_).
+          1. Return CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Assert: _zonedRelativeTo_ is not *undefined*.
         1. If _precalculatedPlainDateTime_ is not present, let _precalculatedPlainDateTime_ be *undefined*.
         1. If _largestUnit_ is *"year"*, or _largestUnit_ is *"month"*, or _largestUnit_ is *"week"*, or _largestUnit_ is *"day"*, let _startDateTimeNeeded_ be *true*; else let _startDateTimeNeeded_ be *false*.
@@ -1494,12 +1903,17 @@
           1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _zonedRelativeTo_.[[Nanoseconds]], _calendarRec_.[[Receiver]]).
         1. Else,
           1. Let _startDateTime_ be _precalculatedPlainDateTime_.
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _startDateTime_).
-        1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZoneRec_, _calendarRec_, _y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _norm1_ be NormalizeTimeDuration(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
+        1. Let _norm2_ be NormalizeTimeDuration(_h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _y1_, _mon1_, _w1_, _d1_, _norm1_, _startDateTime_).
+        1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZoneRec_, _calendarRec_, _y2_, _mon2_, _w2_, _d2_, _norm2_).
         1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-          1. Let _result_ be DifferenceInstant(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, 1, *"nanosecond"*, _largestUnit_, *"halfExpand"*).
-          1. Return ! CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
-        1. Return ? DifferenceZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, _timeZoneRec_, _calendarRec_, _largestUnit_, OrdinaryObjectCreate(*null*), _startDateTime_).
+          1. Let _norm_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_endNs_, _zonedRelativeTo_.[[Nanoseconds]]).
+          1. Let _result_ be BalanceTimeDuration(_norm_, _largestUnit_).
+          1. Return CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Let _diffResult_ be ? DifferenceZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, _timeZoneRec_, _calendarRec_, _largestUnit_, OrdinaryObjectCreate(*null*), _startDateTime_).
+        1. Let _timeResult_ be BalanceTimeDuration(_diffResult_.[[NormalizedTime]], *"hour"*).
+        1. Return CreateDurationRecord(_diffResult_.[[Years]], _diffResult_.[[Months]], _diffResult_.[[Weeks]], _diffResult_.[[Days]], _timeResult_.[[Hours]], _timeResult_.[[Minutes]], _timeResult_.[[Seconds]], _timeResult_.[[Milliseconds]], _timeResult_.[[Microseconds]], _timeResult_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
 
@@ -1567,7 +1981,7 @@
       <emu-alg>
         1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~get-offset-nanoseconds-for~) is *true*.
         1. Assert: TimeZoneMethodsRecordHasLookedUp(_timeZoneRec_, ~get-possible-instants-for~) is *true*.
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _years_, _months_, _weeks_, _days_, ZeroTimeDuration(), _precalculatedPlainDateTime_).
         1. Return ! CreateTemporalZonedDateTime(_intermediateNs_, _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
@@ -1579,12 +1993,7 @@
           _months_: an integer,
           _weeks_: an integer,
           _days_: an integer,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
+          _norm_: a Normalized Time Duration Record,
           _increment_: an integer,
           _unit_: a String,
           _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
@@ -1593,12 +2002,12 @@
           optional _zonedRelativeTo_: *undefined* or a Temporal.ZonedDateTime,
           optional _timeZoneRec_: *undefined* or a Time Zone Methods Record,
           optional _precalculatedPlainDateTime_: *undefined* or a Temporal.PlainDateTime,
-        ): either a normal completion containing a Record with fields [[DurationRecord]] (a Duration Record) and [[Total]] (a mathematical value), or a throw completion
+        ): either a normal completion containing a Record with fields [[NormalizedDuration]] (a Normalized Duration Record) and [[Total]] (a mathematical value), or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It rounds a duration (denoted by _years_ through _nanoseconds_) according to the rounding parameters _unit_, _increment_, and _roundingMode_, and returns a Record with the Duration Record result in its [[DurationRecord]] field.
+          It rounds a duration (denoted by _years_ through _nanoseconds_) according to the rounding parameters _unit_, _increment_, and _roundingMode_, and returns a Record with the Normalized Duration Record result in its [[NormalizedDuration]] field.
           It also returns the total of the smallest unit before the rounding operation in its [[Total]] field, for use in `Temporal.Duration.prototype.total`.
           For rounding involving calendar units, the _relativeTo_ parameter is required.
         </dd>
@@ -1614,17 +2023,14 @@
           1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~date-add~) is *true*.
           1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~date-until~) is *true*.
         1. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-          1. Let _nanoseconds_ be TotalDurationNanoseconds(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
           1. If _zonedRelativeTo_ is not *undefined*, then
             1. Let _intermediate_ be ? MoveRelativeZonedDateTime(_zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _years_, _months_, _weeks_, _days_, _precalculatedPlainDateTime_).
-            1. Let _result_ be ? NanosecondsToDays(_nanoseconds_, _intermediate_, _timeZoneRec_).
-            1. Let _fractionalDays_ be _days_ + _result_.[[Days]] + _result_.[[Nanoseconds]] / _result_.[[DayLength]].
+            1. Let _result_ be ? NormalizedTimeDurationToDays(_norm_, _intermediate_, _timeZoneRec_).
+            1. Let _fractionalDays_ be _days_ + _result_.[[Days]] + DivideNormalizedTimeDuration(_result_.[[Remainder]], _result_.[[DayLength]]).
           1. Else,
-            1. Let _fractionalDays_ be _days_ + _nanoseconds_ / nsPerDay.
-          1. Set _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
-          1. [declared="fractionalSeconds"] Assert: _fractionalSeconds_ is not used below.
+            1. Let _fractionalDays_ be _days_ + DivideNormalizedTimeDuration(_norm_, nsPerDay).
+          1. Set _days_ to 0.
         1. Else,
-          1. Let _fractionalSeconds_ be _nanoseconds_ &times; 10<sup>-9</sup> + _microseconds_ &times; 10<sup>-6</sup> + _milliseconds_ &times; 10<sup>-3</sup> + _seconds_.
           1. Assert: _fractionalDays_ is not used below.
         1. Let _total_ be ~unset~.
         1. If _unit_ is *"year"*, then
@@ -1656,6 +2062,7 @@
           1. Set _years_ to RoundNumberToIncrement(_fractionalYears_, _increment_, _roundingMode_).
           1. Set _total_ to _fractionalYears_.
           1. Set _months_ and _weeks_ to 0.
+          1. Set _norm_ to ZeroTimeDuration().
         1. Else if _unit_ is *"month"*, then
           1. Let _yearsMonths_ be ! CreateTemporalDuration(_years_, _months_, 0, 0, 0, 0, 0, 0, 0, 0).
           1. Let _yearsMonthsLater_ be ? AddDate(_calendarRec_, _plainRelativeTo_, _yearsMonths_).
@@ -1685,6 +2092,7 @@
           1. Set _months_ to RoundNumberToIncrement(_fractionalMonths_, _increment_, _roundingMode_).
           1. Set _total_ to _fractionalMonths_.
           1. Set _weeks_ to 0.
+          1. Set _norm_ to ZeroTimeDuration().
         1. Else if _unit_ is *"week"*, then
           1. Let _isoResult_ be ! AddISODate(_plainRelativeTo_.[[ISOYear]], _plainRelativeTo_.[[ISOMonth]], _plainRelativeTo_.[[ISODay]], 0, 0, 0, truncate(_fractionalDays_), *"constrain"*).
           1. Let _wholeDaysLater_ be ? CreateTemporalDate(_isoResult_.[[Year]], _isoResult_.[[Month]], _isoResult_.[[Day]], _calendarRec_.[[Receiver]]).
@@ -1706,40 +2114,37 @@
           1. Let _fractionalWeeks_ be _weeks_ + _fractionalDays_ / abs(_oneWeekDays_).
           1. Set _weeks_ to RoundNumberToIncrement(_fractionalWeeks_, _increment_, _roundingMode_).
           1. Set _total_ to _fractionalWeeks_.
+          1. Set _norm_ to ZeroTimeDuration().
         1. Else if _unit_ is *"day"*, then
           1. Set _days_ to RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
           1. Set _total_ to _fractionalDays_.
+          1. Set _norm_ to ZeroTimeDuration().
         1. Else if _unit_ is *"hour"*, then
-          1. Let _fractionalHours_ be (_fractionalSeconds_ / 60 + _minutes_) / 60 + _hours_.
-          1. Set _hours_ to RoundNumberToIncrement(_fractionalHours_, _increment_, _roundingMode_).
-          1. Set _total_ to _fractionalHours_.
-          1. Set _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
+          1. Let _divisor_ be 3.6 &times; 10<sup>12</sup>.
+          1. Set _total_ to DivideNormalizedTimeDuration(_norm_, _divisor_).
+          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
         1. Else if _unit_ is *"minute"*, then
-          1. Let _fractionalMinutes_ be _fractionalSeconds_ / 60 + _minutes_.
-          1. Set _minutes_ to RoundNumberToIncrement(_fractionalMinutes_, _increment_, _roundingMode_).
-          1. Set _total_ to _fractionalMinutes_.
-          1. Set _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
+          1. Let _divisor_ be 6 &times; 10<sup>10</sup>.
+          1. Set _total_ to DivideNormalizedTimeDuration(_norm_, _divisor_).
+          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
         1. Else if _unit_ is *"second"*, then
-          1. Set _seconds_ to RoundNumberToIncrement(_fractionalSeconds_, _increment_, _roundingMode_).
-          1. Set _total_ to _fractionalSeconds_.
-          1. Set _milliseconds_, _microseconds_, and _nanoseconds_ to 0.
+          1. Let _divisor_ be 10<sup>9</sup>.
+          1. Set _total_ to DivideNormalizedTimeDuration(_norm_, _divisor_).
+          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
         1. Else if _unit_ is *"millisecond"*, then
-          1. Let _fractionalMilliseconds_ be _nanoseconds_ &times; 10<sup>-6</sup> + _microseconds_ &times; 10<sup>-3</sup> + _milliseconds_.
-          1. Set _milliseconds_ to RoundNumberToIncrement(_fractionalMilliseconds_, _increment_, _roundingMode_).
-          1. Set _total_ to _fractionalMilliseconds_.
-          1. Set _microseconds_ and _nanoseconds_ to 0.
+          1. Let _divisor_ be 10<sup>6</sup>.
+          1. Set _total_ to DivideNormalizedTimeDuration(_norm_, _divisor_).
+          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
         1. Else if _unit_ is *"microsecond"*, then
-          1. Let _fractionalMicroseconds_ be _nanoseconds_ &times; 10<sup>-3</sup> + _microseconds_.
-          1. Set _microseconds_ to RoundNumberToIncrement(_fractionalMicroseconds_, _increment_, _roundingMode_).
-          1. Set _total_ to _fractionalMicroseconds_.
-          1. Set _nanoseconds_ to 0.
+          1. Let _divisor_ be 10<sup>3</sup>.
+          1. Set _total_ to DivideNormalizedTimeDuration(_norm_, _divisor_).
+          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
         1. Else,
           1. Assert: _unit_ is *"nanosecond"*.
-          1. Set _total_ to _nanoseconds_.
-          1. Set _nanoseconds_ to RoundNumberToIncrement(_nanoseconds_, _increment_, _roundingMode_).
-        1. Let _duration_ be ? CreateDurationRecord(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+          1. Set _total_ to NormalizedTimeDurationSeconds(_norm_) &times; 10<sup>9</sup> + NormalizedTimeDurationSubseconds(_norm_).
+          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _increment_, _roundingMode_).
         1. Return the Record {
-          [[DurationRecord]]: _duration_,
+          [[NormalizedDuration]]: ? CreateNormalizedDurationRecord(_years_, _months_, _weeks_, _days_, _norm_),
           [[Total]]: _total_
           }.
       </emu-alg>
@@ -1752,12 +2157,7 @@
           _months_: an integer,
           _weeks_: an integer,
           _days_: an integer,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
+          _norm_: a Normalized Time Duration Record,
           _increment_: an integer,
           _unit_: a String,
           _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
@@ -1765,7 +2165,7 @@
           _calendarRec_: a Calendar Methods Record,
           _timeZoneRec_: a Time Zone Methods Record,
           _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
-        ): either a normal completion containing a Duration Record, or a throw completion
+        ): either a normal completion containing a Normalized Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1777,24 +2177,20 @@
       </dl>
       <emu-alg>
         1. If _unit_ is one of *"year"*, *"month"*, *"week"*, or *"day"*; or _unit_ is *"nanosecond"* and _increment_ is 1, then
-          1. Return ! CreateDurationRecord(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+          1. Return ! CreateNormalizedDurationRecord(_years_, _months_, _weeks_, _days_, _norm_).
         1. Assert: _precalculatedPlainDateTime_ is not *undefined*.
-        1. Let _timeRemainderNs_ be TotalDurationNanoseconds(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. If _timeRemainderNs_ = 0, let _direction_ be 0.
-        1. Else if _timeRemainderNs_ &lt; 0, let _direction_ be -1.
-        1. Else, let _direction_ be 1.
-        1. Let _dayStart_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, _precalculatedPlainDateTime_).
+        1. Let _direction_ be NormalizedTimeDurationSign(_norm_).
+        1. Let _dayStart_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _years_, _months_, _weeks_, _days_, ZeroTimeDuration(), _precalculatedPlainDateTime_).
         1. Let _dayStartInstant_ be ! CreateTemporalInstant(_dayStart_).
         1. Let _dayStartDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _dayStartInstant_, _zonedRelativeTo_.[[Calendar]]).
         1. Let _dayEnd_ be ? AddDaysToZonedDateTime(_dayStartInstant_, _dayStartDateTime_, _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _direction_).[[EpochNanoseconds]].
-        1. Let _dayLengthNs_ be ℝ(_dayEnd_ - _dayStart_).
-        1. Let _oneDayLess_ be _timeRemainderNs_ - _dayLengthNs_.
-        1. If _oneDayLess_ &times; _direction_ &lt; 0, then
-          1. Return ! CreateDurationRecord(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+        1. Let _dayLengthNs_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_dayEnd_, _dayStart_).
+        1. Let _oneDayLess_ be ? SubtractNormalizedTimeDuration(_norm_, _dayLengthNs_).
+        1. If NormalizedTimeDurationSign(_oneDayLess_) &times; _direction_ &lt; 0, then
+          1. Return ! CreateNormalizedDurationRecord(_years_, _months_, _weeks_, _days_, _norm_).
         1. Let _adjustedDateDuration_ be ? AddDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0, 0, 0, 0, _direction_, 0, 0, 0, 0, 0, 0, *undefined*, _zonedRelativeTo_, _calendarRec_, _timeZoneRec_, _precalculatedPlainDateTime_).
-        1. Let _adjustedTimeDuration_ be ! RoundDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, _oneDayLess_, _increment_, _unit_, _roundingMode_).
-        1. Set _adjustedTimeDuration_ to ? BalanceTimeDuration(0, _adjustedTimeDuration_.[[Hours]], _adjustedTimeDuration_.[[Minutes]], _adjustedTimeDuration_.[[Seconds]], _adjustedTimeDuration_.[[Milliseconds]], _adjustedTimeDuration_.[[Microseconds]], _adjustedTimeDuration_.[[Nanoseconds]], *"hour"*).
-        1. Return ! CreateDurationRecord(_adjustedDateDuration_.[[Years]], _adjustedDateDuration_.[[Months]], _adjustedDateDuration_.[[Weeks]], _adjustedDateDuration_.[[Days]], _adjustedTimeDuration_.[[Hours]], _adjustedTimeDuration_.[[Minutes]], _adjustedTimeDuration_.[[Seconds]], _adjustedTimeDuration_.[[Milliseconds]], _adjustedTimeDuration_.[[Microseconds]], _adjustedTimeDuration_.[[Nanoseconds]]).
+        1. Let _roundRecord_ be ! RoundDuration(0, 0, 0, 0, _oneDayLess_, _increment_, _unit_, _roundingMode_).
+        1. Return ? CombineDateAndNormalizedTimeDuration(_adjustedDateDuration_, _roundRecord_.[[NormalizedDuration]].[[NormalizedTime]]).
       </emu-alg>
     </emu-clause>
 
@@ -1807,10 +2203,7 @@
           _days_: an integer,
           _hours_: an integer,
           _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
+          _normSeconds_: a Normalized Time Duration Record,
           _precision_: an integer between 0 and 9 inclusive, or *"auto"*,
         )
       </h1>
@@ -1819,13 +2212,7 @@
         <dd>It returns a String which is the ISO 8601 representation of the duration denoted by _years_ through _nanoseconds_, with the number of decimal places in the seconds value controlled by _precision_.</dd>
       </dl>
       <emu-alg>
-        1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Set _microseconds_ to _microseconds_ + truncate(_nanoseconds_ / 1000).
-        1. Set _nanoseconds_ to remainder(_nanoseconds_, 1000).
-        1. Set _milliseconds_ to _milliseconds_ + truncate(_microseconds_ / 1000).
-        1. Set _microseconds_ to remainder(_microseconds_, 1000).
-        1. Set _seconds_ to _seconds_ + truncate(_milliseconds_ / 1000).
-        1. Set _milliseconds_ to remainder(_milliseconds_, 1000).
+        1. Let _sign_ be ! DurationSign(_years_, _months_, _weeks_, _days_, _hours_, _minutes_, NormalizedTimeDurationSeconds(_normSeconds_), 0, 0, NormalizedTimeDurationSubseconds(_normSeconds_)).
         1. Let _datePart_ be *""*.
         1. If _years_ is not 0, then
           1. Set _datePart_ to the string concatenation of abs(_years_) formatted as a decimal number and the code unit 0x0059 (LATIN CAPITAL LETTER Y).
@@ -1840,14 +2227,11 @@
           1. Set _timePart_ to the string concatenation of abs(_hours_) formatted as a decimal number and the code unit 0x0048 (LATIN CAPITAL LETTER H).
         1. If _minutes_ is not 0, then
           1. Set _timePart_ to the string concatenation of _timePart_, abs(_minutes_) formatted as a decimal number, and the code unit 0x004D (LATIN CAPITAL LETTER M).
-        1. Let _nonzeroSecondsAndLower_ be *false*.
-        1. If _seconds_ &ne; 0, or _milliseconds_ &ne; 0, or _microseconds_ &ne; 0, or _nanoseconds_ &ne; 0, set _nonzeroSecondsAndLower_ to *true*.
         1. Let _zeroMinutesAndHigher_ be *false*.
         1. If _years_ = 0, and _months_ = 0, and _weeks_ = 0, and _days_ = 0, and _hours_ = 0, and _minutes_ = 0, set _zeroMinutesAndHigher_ to *true*.
-        1. If _nonzeroSecondsAndLower_ is *true*, or _zeroMinutesAndHigher_ is *true*, or _precision_ is not *"auto"*, then
-          1. Let _secondsPart_ be abs(_seconds_) formatted as a decimal number.
-          1. Let _subSecondNanoseconds_ be abs(_milliseconds_) &times; 10<sup>6</sup> + abs(_microseconds_) &times; 10<sup>3</sup> + abs(_nanoseconds_).
-          1. Let _subSecondsPart_ be FormatFractionalSeconds(_subSecondNanoseconds_, _precision_).
+        1. If NormalizedTimeDurationIsZero(_normSeconds_) is *false*, or _zeroMinutesAndHigher_ is *true*, or _precision_ is not *"auto"*, then
+          1. Let _secondsPart_ be abs(NormalizedTimeDurationSeconds(_normSeconds_)) formatted as a decimal number.
+          1. Let _subSecondsPart_ be FormatFractionalSeconds(abs(NormalizedTimeDurationSubseconds(_normSeconds_)), _precision_).
           1. Set _timePart_ to the string concatenation of _timePart_, _secondsPart_, _subSecondsPart_, and the code unit 0x0053 (LATIN CAPITAL LETTER S).
         1. Let _signPart_ be the code unit 0x002D (HYPHEN-MINUS) if _sign_ &lt; 0, and otherwise the empty String.
         1. Let _result_ be the string concatenation of _signPart_, the code unit 0x0050 (LATIN CAPITAL LETTER P) and _datePart_.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -552,12 +552,7 @@
       <h1>
         AddInstant (
           _epochNanoseconds_: a BigInt value,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
+          _norm_: a Normalized Time Duration Record,
         ): either a normal completion containing a BigInt, or a throw completion
       </h1>
       <dl class="header">
@@ -565,13 +560,8 @@
         <dd>It adds a duration in various time units to a number of nanoseconds since the epoch.</dd>
       </dl>
       <emu-alg>
-        1. Let _result_ be _epochNanoseconds_ + ℤ(_nanoseconds_) +
-            ℤ(_microseconds_) &times; *1000*<sub>ℤ</sub> +
-            ℤ(_milliseconds_) &times; ℤ(10<sup>6</sup>) +
-            ℤ(_seconds_) &times; ℤ(10<sup>9</sup>) +
-            ℤ(_minutes_) &times; *60*<sub>ℤ</sub> &times; ℤ(10<sup>9</sup>) +
-            ℤ(_hours_) &times; *3600*<sub>ℤ</sub> &times; ℤ(10<sup>9</sup>).
-        1. If IsValidEpochNanoseconds(_result_) is *false*, throw a *RangeError* exception.
+        1. Let _result_ be AddNormalizedTimeDurationToEpochNanoseconds(_norm_, _epochNanoseconds_).
+        1. If ! IsValidEpochNanoseconds(_result_) is *false*, throw a *RangeError* exception.
         1. Return _result_.
       </emu-alg>
     </emu-clause>
@@ -583,25 +573,19 @@
           _ns2_: a BigInt,
           _roundingIncrement_: a positive integer,
           _smallestUnit_: a String,
-          _largestUnit_: a String,
           _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
-        ): a Time Duration Record
+        ): a Normalized Time Duration Record
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It computes the difference between two exact times _ns1_ and _ns2_ expressed in nanoseconds since the epoch, and rounds the result according to the parameters _roundingIncrement_, _smallestUnit_, _largestUnit_, and _roundingMode_.</dd>
+        <dd>It computes the difference between two exact times _ns1_ and _ns2_ expressed in nanoseconds since the epoch, and rounds the result according to the parameters _roundingIncrement_, _smallestUnit_, and _roundingMode_.</dd>
       </dl>
       <emu-alg>
-        1. Let _difference_ be ℝ(_ns2_) - ℝ(_ns1_).
-        1. Let _nanoseconds_ be remainder(_difference_, 1000).
-        1. Let _microseconds_ be remainder(truncate(_difference_ / 1000), 1000).
-        1. Let _milliseconds_ be remainder(truncate(_difference_ / 10<sup>6</sup>), 1000).
-        1. Let _seconds_ be truncate(_difference_ / 10<sup>9</sup>).
+        1. Let _difference_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_ns2_, _ns1_).
         1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ is 1, then
-          1. Return ! BalanceTimeDuration(0, 0, 0, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _largestUnit_).
-        1. Let _roundResult_ be ! RoundDuration(0, 0, 0, 0, 0, 0, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Assert: _roundResult_.[[Days]] is 0.
-        1. Return ! BalanceTimeDuration(0, _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _largestUnit_).
+          1. Return _difference_.
+        1. Let _roundRecord_ be ! RoundDuration(0, 0, 0, 0, _difference_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Return _roundRecord_.[[NormalizedDuration]].[[NormalizedTime]].
       </emu-alg>
     </emu-clause>
 
@@ -672,7 +656,8 @@
         1. Set _other_ to ? ToTemporalInstant(_other_).
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, &laquo; &raquo;, *"nanosecond"*, *"second"*).
-        1. Let _result_ be DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[LargestUnit]], _settings_.[[RoundingMode]]).
+        1. Let _norm_ be DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+        1. Let _result_ be BalanceTimeDuration(_norm_, _settings_.[[LargestUnit]]).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -695,7 +680,8 @@
         1. If _duration_.[[Months]] is not 0, throw a *RangeError* exception.
         1. If _duration_.[[Weeks]] is not 0, throw a *RangeError* exception.
         1. If _duration_.[[Years]] is not 0, throw a *RangeError* exception.
-        1. Let _ns_ be ? AddInstant(_instant_.[[Nanoseconds]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
+        1. Let _norm_ be NormalizeTimeDuration(_sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
+        1. Let _ns_ be ? AddInstant(_instant_.[[Nanoseconds]], _norm_).
         1. Return ! CreateTemporalInstant(_ns_).
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -2312,11 +2312,12 @@
             1. Set _duration_ to ? ToTemporalDuration(_duration_).
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-            1. Let _balanceResult_ be ? BalanceTimeDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
+            1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+            1. Let _balanceResult_ be BalanceTimeDuration(_norm_, *"day"*).
             1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-              1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], _overflow_).
+              1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]] + _balanceResult_.[[Days]], _overflow_).
             1. Else,
-              1. Let _balancedDuration_ be ! CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]]).
+              1. Let _balancedDuration_ be ! CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]] + _balanceResult_.[[Days]]).
               1. Let _result_ be ? CalendarDateAddition(_calendar_.[[Identifier]], _date_, _balancedDuration_, _overflow_).
             1. Return ? CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendar_.[[Identifier]]).
           </emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -1030,7 +1030,8 @@
         1. If _duration_.[[Years]] &ne; 0, or _duration_.[[Months]] &ne; 0, or _duration_.[[Weeks]] &ne; 0, then
           1. Return ? CalendarDateAdd(_calendarRec_, _plainDate_, _duration_, _options_).
         1. Let _overflow_ be ? ToTemporalOverflow(_options_).
-        1. Let _days_ be ? BalanceTimeDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).[[Days]].
+        1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Let _days_ be _duration_.[[Days]] + BalanceTimeDuration(_norm_, *"day"*).[[Days]].
         1. Let _result_ be ? AddISODate(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], 0, 0, 0, _days_, _overflow_).
         1. Return ! CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendarRec_.[[Receiver]]).
       </emu-alg>
@@ -1075,8 +1076,8 @@
         1. Let _result_ be ? DifferenceDate(_calendarRec_, _temporalDate_, _other_, _resolvedOptions_).
         1. If _settings_.[[SmallestUnit]] is *"day"* and _settings_.[[RoundingIncrement]] = 1, let _roundingGranularityIsNoop_ be *true*; else let _roundingGranularityIsNoop_ be *false*.
         1. If _roundingGranularityIsNoop_ is *false*, then
-          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], 0, 0, 0, 0, 0, 0, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _temporalDate_, _calendarRec_).
-          1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
+          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], ZeroTimeDuration(), _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _temporalDate_, _calendarRec_).
+          1. Let _roundResult_ be _roundRecord_.[[NormalizedDuration]].
           1. Set _result_ to ? BalanceDateDurationRelative(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _settings_.[[LargestUnit]], _settings_.[[SmallestUnit]], _temporalDate_, _calendarRec_).
         1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], _sign_ &times; _result_.[[Weeks]], _sign_ &times; _result_.[[Days]], 0, 0, 0, 0, 0, 0).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1149,12 +1149,7 @@
           _months_: an integer,
           _weeks_: an integer,
           _days_: an integer,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
+          _norm_: a Normalized Time Duration Record,
           _options_: an Object or *undefined*,
         ): either a normal completion containing an ISO Date-Time Record, or a throw completion
       </h1>
@@ -1166,7 +1161,7 @@
       </dl>
       <emu-alg>
         1. Assert: ISODateTimeWithinLimits(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
-        1. Let _timeResult_ be AddTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+        1. Let _timeResult_ be AddTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _norm_).
         1. Let _datePart_ be ! CreateTemporalDate(_year_, _month_, _day_, _calendarRec_.[[Receiver]]).
         1. Let _dateDuration_ be ? CreateTemporalDuration(_years_, _months_, _weeks_, _days_ + _timeResult_.[[Days]], 0, 0, 0, 0, 0, 0).
         1. Let _addedDate_ be ? AddDate(_calendarRec_, _datePart_, _dateDuration_, _options_).
@@ -1249,7 +1244,7 @@
           _calendarRec_: a Calendar Methods Record,
           _largestUnit_: a String,
           _options_: an Object,
-        ): either a normal completion containing a Duration Record, or a throw completion
+        ): either a normal completion containing a Normalized Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1263,21 +1258,20 @@
         1. Assert: ISODateTimeWithinLimits(_y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_) is *true*.
         1. Assert: ISODateTimeWithinLimits(_y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_) is *true*.
         1. Assert: If _y1_ &ne; _y2_, and _mon1_ &ne; _mon2_, and _d1_ &ne; _d2_, and LargerOfTwoTemporalUnits(_largestUnit_, *"day"*) is not *"day"*, CalendarMethodsRecordHasLookedUp(_calendarRec_, ~date-until~) is *true*.
-        1. Let _timeDifference_ be ! DifferenceTime(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
-        1. Let _timeSign_ be ! DurationSign(0, 0, 0, 0, _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]]).
+        1. Let _timeDuration_ be ! DifferenceTime(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Let _timeSign_ be NormalizedTimeDurationSign(_timeDuration_).
         1. Let _dateSign_ be ! CompareISODate(_y2_, _mon2_, _d2_, _y1_, _mon1_, _d1_).
         1. Let _adjustedDate_ be CreateISODateRecord(_y1_, _mon1_, _d1_).
         1. If _timeSign_ is -_dateSign_, then
           1. Set _adjustedDate_ to BalanceISODate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]] - _timeSign_).
-          1. Set _timeDifference_ to ! BalanceTimeDuration(-_timeSign_, _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
+          1. Set _timeDuration_ to ? Add24HourDaysToNormalizedTimeDuration(_timeDuration_, -_timeSign_).
         1. Let _date1_ be ! CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendarRec_.[[Receiver]]).
         1. Let _date2_ be ! CreateTemporalDate(_y2_, _mon2_, _d2_, _calendarRec_.[[Receiver]]).
         1. Let _dateLargestUnit_ be LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
         1. Let _untilOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _dateLargestUnit_).
         1. Let _dateDifference_ be ? DifferenceDate(_calendarRec_, _date1_, _date2_, _untilOptions_).
-        1. Let _balanceResult_ be ! BalanceTimeDuration(_dateDifference_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]], _largestUnit_).
-        1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
+        1. Return ? CreateNormalizedDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _dateDifference_.[[Days]], _timeDuration_).
       </emu-alg>
     </emu-clause>
     <emu-clause id="sec-temporal-differencetemporalplaindatetime" type="abstract operation">
@@ -1305,16 +1299,20 @@
         1. If _datePartsIdentical_ is *true*, and _dateTime_.[[ISOHour]] = _other_.[[ISOHour]], and _dateTime_.[[ISOMinute]] = _other_.[[ISOMinute]], and _dateTime_.[[ISOSecond]] = _other_.[[ISOSecond]], and _dateTime_.[[ISOMillisecond]] = _other_.[[ISOMillisecond]], and _dateTime_.[[ISOMicrosecond]] = _other_.[[ISOMicrosecond]], and _dateTime_.[[ISONanosecond]] = _other_.[[ISONanosecond]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « ~date-add~, ~date-until~ »).
-        1. Let _diff_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _calendarRec_, _settings_.[[LargestUnit]], _resolvedOptions_).
+        1. Let _result_ be ? DifferenceISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _calendarRec_, _settings_.[[LargestUnit]], _resolvedOptions_).
         1. If _settings_.[[SmallestUnit]] is *"nanosecond"* and _settings_.[[RoundingIncrement]] = 1, let _roundingGranularityIsNoop_ be *true*; else let _roundingGranularityIsNoop_ be *false*.
-        1. If _roundingGranularityIsNoop_ is *true*, then
-          1. Return ! CreateTemporalDuration(_sign_ &times; _diff_.[[Years]], _sign_ &times; _diff_.[[Months]], _sign_ &times; _diff_.[[Weeks]], _sign_ &times; _diff_.[[Days]], _sign_ &times; _diff_.[[Hours]], _sign_ &times; _diff_.[[Minutes]], _sign_ &times; _diff_.[[Seconds]], _sign_ &times; _diff_.[[Milliseconds]], _sign_ &times; _diff_.[[Microseconds]], _sign_ &times; _diff_.[[Nanoseconds]]).
-        1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
-        1. Let _roundRecord_ be ? RoundDuration(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _diff_.[[Days]], _diff_.[[Hours]], _diff_.[[Minutes]], _diff_.[[Seconds]], _diff_.[[Milliseconds]], _diff_.[[Microseconds]], _diff_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _relativeTo_, _calendarRec_).
-        1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
-        1. Let _result_ be ? BalanceTimeDuration(_roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _settings_.[[LargestUnit]]).
-        1. Let _balanceResult_ be ? BalanceDateDurationRelative(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _result_.[[Days]], _settings_.[[LargestUnit]], _settings_.[[SmallestUnit]], _relativeTo_, _calendarRec_).
-        1. Return ! CreateTemporalDuration(_sign_ &times; _balanceResult_.[[Years]], _sign_ &times; _balanceResult_.[[Months]], _sign_ &times; _balanceResult_.[[Weeks]], _sign_ &times; _balanceResult_.[[Days]], _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
+        1. If _roundingGranularityIsNoop_ is *false*, then
+          1. Let _relativeTo_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
+          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[NormalizedTime]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _relativeTo_, _calendarRec_).
+          1. Let _roundResult_ be _roundRecord_.[[NormalizedDuration]].
+          1. Let _normWithDays_ be ? Add24HourDaysToNormalizedTimeDuration(_roundResult_.[[NormalizedTime]], _roundResult_.[[Days]]).
+          1. Let _timeResult_ be BalanceTimeDuration(_normWithDays_, _settings_.[[LargestUnit]]).
+          1. Let _balanceResult_ be ? BalanceDateDurationRelative(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _timeResult_.[[Days]], _settings_.[[LargestUnit]], _settings_.[[SmallestUnit]], _relativeTo_, _calendarRec_).
+        1. Else,
+          1. Let _normWithDays_ be ? Add24HourDaysToNormalizedTimeDuration(_result_.[[NormalizedTime]], _result_.[[Days]]).
+          1. Let _timeResult_ be BalanceTimeDuration(_normWithDays_, _settings_.[[LargestUnit]]).
+          1. Let _balanceResult_ be ! CreateDateDurationRecord(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _timeResult_.[[Days]]).
+        1. Return ! CreateTemporalDuration(_sign_ &times; _balanceResult_.[[Years]], _sign_ &times; _balanceResult_.[[Months]], _sign_ &times; _balanceResult_.[[Weeks]], _sign_ &times; _balanceResult_.[[Days]], _sign_ &times; _timeResult_.[[Hours]], _sign_ &times; _timeResult_.[[Minutes]], _sign_ &times; _timeResult_.[[Seconds]], _sign_ &times; _timeResult_.[[Milliseconds]], _sign_ &times; _timeResult_.[[Microseconds]], _sign_ &times; _timeResult_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
     <emu-clause id="sec-temporal-adddurationtoorsubtractdurationfromplaindatetime" type="abstract operation">
@@ -1335,7 +1333,8 @@
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « ~date-add~ »).
-        1. Let _result_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _calendarRec_, _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]], _options_).
+        1. Let _norm_ be NormalizeTimeDuration(_sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
+        1. Let _result_ be ? AddDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _calendarRec_, _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _norm_, _options_).
         1. Assert: IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
         1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -600,7 +600,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a Time Duration Record with the elapsed duration from a first wall-clock time, until a second wall-clock time.</dd>
+        <dd>It returns a Normalized Time Duration Record with the elapsed duration from a first wall-clock time, until a second wall-clock time.</dd>
       </dl>
       <emu-alg>
         1. Let _hours_ be _h2_ - _h1_.
@@ -609,10 +609,9 @@
         1. Let _milliseconds_ be _ms2_ - _ms1_.
         1. Let _microseconds_ be _mus2_ - _mus1_.
         1. Let _nanoseconds_ be _ns2_ - _ns1_.
-        1. Let _sign_ be ! DurationSign(0, 0, 0, 0, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Let _bt_ be BalanceTime(_hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
-        1. Assert: _bt_.[[Days]] is 0.
-        1. Return ! CreateTimeDurationRecord(0, _bt_.[[Hour]] &times; _sign_, _bt_.[[Minute]] &times; _sign_, _bt_.[[Second]] &times; _sign_, _bt_.[[Millisecond]] &times; _sign_, _bt_.[[Microsecond]] &times; _sign_, _bt_.[[Nanosecond]] &times; _sign_).
+        1. Let _norm_ be NormalizeTimeDuration(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+        1. Assert: NormalizedTimeDurationAbs(_norm_).[[TotalNanoseconds]] &lt; nsPerDay.
+        1. Return _norm_.
       </emu-alg>
     </emu-clause>
 
@@ -916,12 +915,7 @@
           _millisecond_: an integer in the inclusive range 0 to 999,
           _microsecond_: an integer in the inclusive range 0 to 999,
           _nanosecond_: an integer in the inclusive range 0 to 999,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
+          _norm_: a Normalized Time Duration Record,
         ): a Time Record
       </h1>
       <dl class="header">
@@ -929,12 +923,8 @@
         <dd></dd>
       </dl>
       <emu-alg>
-        1. Set _hour_ to _hour_ + _hours_.
-        1. Set _minute_ to _minute_ + _minutes_.
-        1. Set _second_ to _second_ + _seconds_.
-        1. Set _millisecond_ to _millisecond_ + _milliseconds_.
-        1. Set _microsecond_ to _microsecond_ + _microseconds_.
-        1. Set _nanosecond_ to _nanosecond_ + _nanoseconds_.
+        1. Set _second_ to _second_ + NormalizedTimeDurationSeconds(_norm_).
+        1. Set _nanosecond_ to _nanosecond_ + NormalizedTimeDurationSubseconds(_norm_).
         1. Return BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
       </emu-alg>
     </emu-clause>
@@ -1019,11 +1009,11 @@
         1. Set _other_ to ? ToTemporalTime(_other_).
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, &laquo; &raquo;, *"nanosecond"*, *"hour"*).
-        1. Let _result_ be ! DifferenceTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]]).
+        1. Let _norm_ be ! DifferenceTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]]).
         1. If _settings_.[[SmallestUnit]] is not *"nanosecond"* or _settings_.[[RoundingIncrement]] &ne; 1, then
-          1. Let _roundRecord_ be ! RoundDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-          1. Set _result_ to _roundRecord_.[[DurationRecord]].
-        1. Set _result_ to ! BalanceTimeDuration(0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]], _settings_.[[LargestUnit]]).
+          1. Let _roundRecord_ be ! RoundDuration(0, 0, 0, 0, _norm_, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+          1. Set _norm_ to _roundRecord_.[[NormalizedDuration]].[[NormalizedTime]].
+        1. Let _result_ be BalanceTimeDuration(_norm_, _settings_.[[LargestUnit]]).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
@@ -1042,8 +1032,8 @@
       <emu-alg>
         1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
         1. Let _duration_ be ? ToTemporalDurationRecord(_temporalDurationLike_).
-        1. Let _result_ be AddTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
-        1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
+        1. Let _norm_ be NormalizeTimeDuration(_sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
+        1. Let _result_ be AddTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _norm_).
         1. Return ! CreateTemporalTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]).
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -652,8 +652,8 @@
         1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
         1. Let _result_ be ? CalendarDateUntil(_calendarRec_, _thisDate_, _otherDate_, _resolvedOptions_).
         1. If _settings_.[[SmallestUnit]] is not *"month"* or _settings_.[[RoundingIncrement]] &ne; 1, then
-          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _thisDate_, _calendarRec_).
-          1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
+          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], 0, 0, ZeroTimeDuration(), _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _thisDate_, _calendarRec_).
+          1. Let _roundResult_ be _roundRecord_.[[NormalizedDuration]].
           1. Set _result_ to ? BalanceDateDurationRelative(_roundResult_.[[Years]], _roundResult_.[[Months]], 0, 0, _settings_.[[LargestUnit]], _settings_.[[SmallestUnit]], _thisDate_, _calendarRec_).
         1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], 0, 0, 0, 0, 0, 0, 0, 0).
       </emu-alg>
@@ -675,9 +675,11 @@
         1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. If _operation_ is ~subtract~, then
           1. Set _duration_ to ! CreateNegatedTemporalDuration(_duration_).
-        1. Let _balanceResult_ be ? BalanceTimeDuration(_duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], *"day"*).
         1. Set _options_ to ? GetOptionsObject(_options_).
-        1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Let _balanceResult_ be BalanceTimeDuration(_norm_, *"day"*).
+        1. Let _days_ be _duration_.[[Days]] + _balanceResult_.[[Days]].
+        1. Let _sign_ be ! DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _days_, 0, 0, 0, 0, 0, 0).
         1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_yearMonth_.[[Calendar]], « ~date-add~, ~date-from-fields~, ~day~, ~fields~, ~year-month-from-fields~ »).
         1. Let _fieldNames_ be ? CalendarFields(_calendarRec_, « *"monthCode"*, *"year"* »).
         1. Let _fields_ be ? PrepareTemporalFields(_yearMonth_, _fieldNames_, «»).
@@ -694,7 +696,7 @@
           1. Let _date_ be ? CalendarDateFromFields(_calendarRec_, _fieldsCopy_).
         1. Else,
           1. Let _date_ be _intermediateDate_.
-        1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _balanceResult_.[[Days]], 0, 0, 0, 0, 0, 0).
+        1. Let _durationToAdd_ be ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _days_, 0, 0, 0, 0, 0, 0).
         1. Let _optionsCopy_ be ? SnapshotOwnProperties(_options_, *null*).
         1. Let _addedDate_ be ? AddDate(_calendarRec_, _date_, _durationToAdd_, _options_).
         1. Let _addedDateFields_ be ? PrepareTemporalFields(_addedDate_, _fieldNames_, «»).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -938,14 +938,16 @@
         1. Let _offsetAfter_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _dayAfter_).
         1. Let _nanoseconds_ be _offsetAfter_ - _offsetBefore_.
         1. If _disambiguation_ is *"earlier"*, then
-          1. Let _earlierTime_ be AddTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], 0, 0, 0, 0, 0, -_nanoseconds_).
+          1. Let _norm_ be NormalizeTimeDuration(0, 0, 0, 0, 0, -_nanoseconds_).
+          1. Let _earlierTime_ be AddTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _norm_).
           1. Let _earlierDate_ be AddISODate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], 0, 0, 0, _earlierTime_.[[Days]], *"constrain"*).
           1. Let _earlierDateTime_ be ! CreateTemporalDateTime(_earlierDate_.[[Year]], _earlierDate_.[[Month]], _earlierDate_.[[Day]], _earlierTime_.[[Hour]], _earlierTime_.[[Minute]], _earlierTime_.[[Second]], _earlierTime_.[[Millisecond]], _earlierTime_.[[Microsecond]], _earlierTime_.[[Nanosecond]], *"iso8601"*).
           1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZoneRec_, _earlierDateTime_).
           1. If _possibleInstants_ is empty, throw a *RangeError* exception.
           1. Return _possibleInstants_[0].
         1. Assert: _disambiguation_ is *"compatible"* or *"later"*.
-        1. Let _laterTime_ be AddTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], 0, 0, 0, 0, 0, _nanoseconds_).
+        1. Let _norm_ be NormalizeTimeDuration(0, 0, 0, 0, 0, _nanoseconds_).
+        1. Let _laterTime_ be AddTime(_dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _norm_).
         1. Let _laterDate_ be AddISODate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], 0, 0, 0, _laterTime_.[[Days]], *"constrain"*).
         1. Let _laterDateTime_ be ! CreateTemporalDateTime(_laterDate_.[[Year]], _laterDate_.[[Month]], _laterDate_.[[Day]], _laterTime_.[[Hour]], _laterTime_.[[Minute]], _laterTime_.[[Second]], _laterTime_.[[Millisecond]], _laterTime_.[[Microsecond]], _laterTime_.[[Nanosecond]], *"iso8601"*).
         1. Set _possibleInstants_ to ? GetPossibleInstantsFor(_timeZoneRec_, _laterDateTime_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -454,8 +454,8 @@
         1. Let _tomorrow_ be ? CreateTemporalDateTime(_tomorrowFields_.[[Year]], _tomorrowFields_.[[Month]], _tomorrowFields_.[[Day]], 0, 0, 0, 0, 0, 0, *"iso8601"*).
         1. Let _todayInstant_ be ? GetInstantFor(_timeZoneRec_, _today_, *"compatible"*).
         1. Let _tomorrowInstant_ be ? GetInstantFor(_timeZoneRec_, _tomorrow_, *"compatible"*).
-        1. Let _diffNs_ be _tomorrowInstant_.[[Nanoseconds]] - _todayInstant_.[[Nanoseconds]].
-        1. Return 𝔽(_diffNs_ / (3.6 &times; 10<sup>12</sup>)).
+        1. Let _diff_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_tomorrowInstant_.[[Nanoseconds]], _todayInstant_.[[Nanoseconds]]).
+        1. Return 𝔽(DivideNormalizedTimeDuration(_diff_, 3.6 &times; 10<sup>12</sup>)).
       </emu-alg>
     </emu-clause>
 
@@ -1290,12 +1290,7 @@
           _months_: an integer,
           _weeks_: an integer,
           _days_: an integer,
-          _hours_: an integer,
-          _minutes_: an integer,
-          _seconds_: an integer,
-          _milliseconds_: an integer,
-          _microseconds_: an integer,
-          _nanoseconds_: an integer,
+          _norm_: a Normalized Time Duration Record,
           optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
           optional _options_: an Object,
         ): either a normal completion containing a BigInt or an abrupt completion
@@ -1315,7 +1310,7 @@
         1. If _options_ is not present, set _options_ to *undefined*.
         1. Assert: Type(_options_) is Object or Undefined.
         1. If _years_ = 0, _months_ = 0, _weeks_ = 0, and _days_ = 0, then
-          1. Return ? AddInstant(_epochNanoseconds_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+          1. Return ? AddInstant(_epochNanoseconds_, _norm_).
         1. Let _instant_ be ! CreateTemporalInstant(_epochNanoseconds_).
         1. If _precalculatedPlainDateTime_ is not *undefined*, then
           1. Let _temporalDateTime_ be _precalculatedPlainDateTime_.
@@ -1324,14 +1319,14 @@
         1. If _years_ = 0, and _months_ = 0, and _weeks_ = 0, then
           1. Let _overflow_ be ? ToTemporalOverflow(_options_).
           1. Let _intermediate_ be ? AddDaysToZonedDateTime(_instant_, _temporalDateTime_, _timeZoneRec_, _calendarRec_.[[Receiver]], _days_, _overflow_).[[EpochNanoseconds]].
-          1. Return ? AddInstant(_intermediate_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+          1. Return ? AddInstant(_intermediate_, _norm_).
         1. Assert: CalendarMethodsRecordHasLookedUp(_calendarRec_, ~date-add~) is *true*.
         1. Let _datePart_ be ! CreateTemporalDate(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _calendarRec_.[[Receiver]]).
         1. Let _dateDuration_ be ! CreateTemporalDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendarRec_, _datePart_, _dateDuration_, _options_).
         1. Let _intermediateDateTime_ be ? CreateTemporalDateTime(_addedDate_.[[ISOYear]], _addedDate_.[[ISOMonth]], _addedDate_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _calendarRec_.[[Receiver]]).
         1. Let _intermediateInstant_ be ? GetInstantFor(_timeZoneRec_, _intermediateDateTime_, *"compatible"*).
-        1. Return ? AddInstant(_intermediateInstant_.[[Nanoseconds]], _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+        1. Return ? AddInstant(_intermediateInstant_.[[Nanoseconds]], _norm_).
       </emu-alg>
     </emu-clause>
 
@@ -1385,7 +1380,7 @@
           _largestUnit_: a String,
           _options_: an Object,
           _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
-        ): either a normal completion containing a Duration Record or an abrupt completion
+        ): either a normal completion containing a Normalized Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1396,7 +1391,7 @@
       <p>Unless _ns1_ and _ns2_ are equal, _timeZoneRec_ must have looked up both `getOffsetNanosecondsFor` and `getPossibleInstantsFor`.</p>
       <emu-alg>
         1. If _ns1_ is _ns2_, then
-          1. Return ! CreateDurationRecord(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
+          1. Return ! CreateNormalizedDurationRecord(0, 0, 0, 0, ZeroTimeDuration()).
         1. If _precalculatedPlainDateTime_ is *undefined*, then
           1. Let _startInstant_ be ! CreateTemporalInstant(_ns1_).
           1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, _calendarRec_.[[Receiver]]).
@@ -1405,41 +1400,39 @@
         1. Let _endInstant_ be ! CreateTemporalInstant(_ns2_).
         1. Let _endDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _endInstant_, _calendarRec_.[[Receiver]]).
         1. Let _dateDifference_ be ? DifferenceISODateTime(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], _startDateTime_.[[ISOHour]], _startDateTime_.[[ISOMinute]], _startDateTime_.[[ISOSecond]], _startDateTime_.[[ISOMillisecond]], _startDateTime_.[[ISOMicrosecond]], _startDateTime_.[[ISONanosecond]], _endDateTime_.[[ISOYear]], _endDateTime_.[[ISOMonth]], _endDateTime_.[[ISODay]], _endDateTime_.[[ISOHour]], _endDateTime_.[[ISOMinute]], _endDateTime_.[[ISOSecond]], _endDateTime_.[[ISOMillisecond]], _endDateTime_.[[ISOMicrosecond]], _endDateTime_.[[ISONanosecond]], _calendarRec_, _largestUnit_, _options_).
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZoneRec_, _calendarRec_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], 0, 0, 0, 0, 0, 0, 0, _startDateTime_).
-        1. Let _timeRemainderNs_ be _ns2_ - _intermediateNs_.
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_ns1_, _timeZoneRec_, _calendarRec_, _dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], 0, ZeroTimeDuration(), _startDateTime_).
+        1. Let _norm_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_ns2_, _intermediateNs_).
         1. Let _intermediate_ be ! CreateTemporalZonedDateTime(_intermediateNs_, _timeZoneRec_.[[Receiver]], _calendarRec_.[[Receiver]]).
-        1. Let _result_ be ? NanosecondsToDays(ℝ(_timeRemainderNs_), _intermediate_, _timeZoneRec_).
-        1. Let _timeDifference_ be ! BalanceTimeDuration(0, 0, 0, 0, 0, 0, _result_.[[Nanoseconds]], *"hour"*).
-        1. Return ! CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _timeDifference_.[[Hours]], _timeDifference_.[[Minutes]], _timeDifference_.[[Seconds]], _timeDifference_.[[Milliseconds]], _timeDifference_.[[Microseconds]], _timeDifference_.[[Nanoseconds]]).
+        1. Let _result_ be ? NormalizedTimeDurationToDays(_norm_, _intermediate_, _timeZoneRec_).
+        1. Return ! CreateNormalizedDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Remainder]]).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-nanosecondstodays" type="abstract operation">
+    <emu-clause id="sec-temporal-normalizedtimedurationtodays" type="abstract operation">
       <h1>
-        NanosecondsToDays (
-          _nanoseconds_: an integer,
+        NormalizedTimeDurationToDays (
+          _norm_: a Normalized Time Duration Record,
           _zonedRelativeTo_: a Temporal.ZonedDateTime,
           _timeZoneRec_: a Time Zone Methods Record,
           optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime,
-        ): either a normal completion containing a Record with fields [[Days]] (an integer), [[Nanoseconds]] (an integer), and [[DayLength]] (an integer), or an abrupt completion
+        ): either a normal completion containing a Record with fields [[Days]] (an integer), [[Remainder]] (a Normalized Time Duration Record), and [[DayLength]] (an integer), or an abrupt completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It converts a number of _nanoseconds_ relative to a Temporal.ZonedDateTime _zonedRelativeTo_ (if supplied), and converts it into a number of days and remainder of nanoseconds, taking into account any offset changes in the time zone of _zonedRelativeTo_.
+          It converts a normalized time duration _norm_ relative to a Temporal.ZonedDateTime _zonedRelativeTo_, and converts it into a number of days and a remainder normalized time duration, taking into account any offset changes in the time zone of _zonedRelativeTo_.
           It also returns the length of the last day in nanoseconds, for rounding purposes.
         </dd>
       </dl>
       <p>Unless _nanoseconds_ = 0, _timeZoneRec_ must have looked up both `getOffsetNanosecondsFor` and `getPossibleInstantsFor`.</p>
       <emu-alg>
-        1. If _nanoseconds_ = 0, then
-          1. Return the Record { [[Days]]: 0, [[Nanoseconds]]: 0, [[DayLength]]: nsPerDay }.
-        1. If _nanoseconds_ &lt; 0, let _sign_ be -1; else, let _sign_ be 1.
-        1. Let _startNs_ be ℝ(_zonedRelativeTo_.[[Nanoseconds]]).
-        1. Let _startInstant_ be ! CreateTemporalInstant(ℤ(_startNs_)).
-        1. Let _endNs_ be _startNs_ + _nanoseconds_.
-        1. If IsValidEpochNanoseconds(ℤ(_endNs_)) is *false*, throw a *RangeError* exception.
-        1. Let _endInstant_ be ! CreateTemporalInstant(ℤ(_endNs_)).
+        1. Let _sign_ be NormalizedTimeDurationSign(_norm_).
+        1. If _sign_ = 0, then
+          1. Return the Record { [[Days]]: 0, [[Remainder]]: _norm_, [[DayLength]]: nsPerDay }.
+        1. Let _startNs_ be _zonedRelativeTo_.[[Nanoseconds]].
+        1. Let _startInstant_ be ! CreateTemporalInstant(_startNs_).
+        1. Let _endNs_ be ? AddInstant(_startNs_, _norm_).
+        1. Let _endInstant_ be ! CreateTemporalInstant(_endNs_).
         1. If _precalculatedPlainDateTime_ is present, let _startDateTime_ be _precalculatedPlainDateTime_; else let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _startInstant_, *"iso8601"*).
         1. Let _endDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _endInstant_, *"iso8601"*).
         1. Let _date1_ be ! CreateTemporalDate(_startDateTime_.[[ISOYear]], _startDateTime_.[[ISOMonth]], _startDateTime_.[[ISODay]], *"iso8601"*).
@@ -1455,28 +1448,29 @@
           1. Repeat, while _days_ &gt; 0 and ℝ(_relativeResult_.[[EpochNanoseconds]]) &gt; _endNs_,
             1. Set _days_ to _days_ - 1.
             1. Set _relativeResult_ to ? AddDaysToZonedDateTime(_startInstant_, _startDateTime_, _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _days_).
-        1. Set _nanoseconds_ to _endNs_ - ℝ(_relativeResult_.[[EpochNanoseconds]]).
+        1. Set _norm_ to NormalizedTimeDurationFromEpochNanosecondsDifference(_endNs_, _relativeResult_.[[EpochNanoseconds]]).
         1. Let _done_ be *false*.
         1. Let _dayLengthNs_ be ~unset~.
         1. Repeat, while _done_ is *false*,
           1. Let _oneDayFarther_ be ? AddDaysToZonedDateTime(_relativeResult_.[[Instant]], _relativeResult_.[[DateTime]], _timeZoneRec_, _zonedRelativeTo_.[[Calendar]], _sign_).
-          1. Set _dayLengthNs_ to ℝ(_oneDayFarther_.[[EpochNanoseconds]] - _relativeResult_.[[EpochNanoseconds]]).
-          1. If (_nanoseconds_ - _dayLengthNs_) &times; _sign_ &ge; 0, then
-            1. Set _nanoseconds_ to _nanoseconds_ - _dayLengthNs_.
+          1. Set _dayLengthNs_ to NormalizedTimeDurationFromEpochNanosecondsDifference(_oneDayFarther_.[[EpochNanoseconds]], _relativeResult_.[[EpochNanoseconds]]).
+          1. Let _oneDayLess_ be ! SubtractNormalizedTimeDuration(_norm_, _dayLengthNs_).
+          1. If NormalizedTimeDurationSign(_oneDayLess_) &times; _sign_ &ge; 0, then
+            1. Set _norm_ to _oneDayLess_.
             1. Set _relativeResult_ to _oneDayFarther_.
             1. Set _days_ to _days_ + _sign_.
           1. Else,
             1. Set _done_ to *true*.
         1. If _days_ &lt; 0 and _sign_ = 1, throw a *RangeError* exception.
         1. If _days_ &gt; 0 and _sign_ = -1, throw a *RangeError* exception.
-        1. If _nanoseconds_ &lt; 0, then
+        1. If NormalizedTimeDurationSign(_norm_) = -1, then
           1. Assert: _sign_ is -1.
-        1. If _nanoseconds_ &gt; 0 and _sign_ = -1, throw a *RangeError* exception.
-        1. Assert: The inequality abs(_nanoseconds_) &lt; abs(_dayLengthNs_) holds.
+        1. If NormalizedTimeDurationSign(_norm_) = 1 and _sign_ = -1, throw a *RangeError* exception.
+        1. Assert: CompareNormalizedTimeDuration(NormalizedTimeDurationAbs(_norm_), NormalizedTimeDurationAbs(_dayLengthNs_)) = -1.
         1. Return the Record {
           [[Days]]: _days_,
-          [[Nanoseconds]]: _nanoseconds_,
-          [[DayLength]]: abs(_dayLengthNs_)
+          [[Remainder]]: _norm_,
+          [[DayLength]]: ℝ(NormalizedTimeDurationAbs(_dayLengthNs_).[[TotalNanoseconds]])
           }.
       </emu-alg>
     </emu-clause>
@@ -1501,7 +1495,8 @@
         1. Let _resolvedOptions_ be ? SnapshotOwnProperties(? GetOptionsObject(_options_), *null*).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~datetime~, &laquo; &raquo;, *"nanosecond"*, *"hour"*).
         1. If _settings_.[[LargestUnit]] is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-          1. Let _result_ be DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[LargestUnit]], _settings_.[[RoundingMode]]).
+          1. Let _norm_ be DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+          1. Let _result_ be BalanceTimeDuration(_norm_, _settings_.[[LargestUnit]]).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then
           1. Throw a *RangeError* exception.
@@ -1513,15 +1508,18 @@
         1. Let _precalculatedPlainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
         1. Let _plainRelativeTo_ be ! CreateTemporalDate(_precalculatedPlainDateTime_.[[ISOYear]], _precalculatedPlainDateTime_.[[ISOMonth]], _precalculatedPlainDateTime_.[[ISODay]], _calendarRec_.[[Receiver]]).
         1. Perform ! CreateDataPropertyOrThrow(_resolvedOptions_, *"largestUnit"*, _settings_.[[LargestUnit]]).
-        1. Let _difference_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _settings_.[[LargestUnit]], _resolvedOptions_, _precalculatedPlainDateTime_).
+        1. Let _result_ be ? DifferenceZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _settings_.[[LargestUnit]], _resolvedOptions_, _precalculatedPlainDateTime_).
         1. If _settings_.[[SmallestUnit]] is *"nanosecond"* and _settings_.[[RoundingIncrement]] is 1, let _roundingGranularityIsNoop_ be *true*; else let _roundingGranularityIsNoop_ be *false*.
-        1. If _roundingGranularityIsNoop_ is *true*, then
-          1. Return ! CreateTemporalDuration(_sign_ &times; _difference_.[[Years]], _sign_ &times; _difference_.[[Months]], _sign_ &times; _difference_.[[Weeks]], _sign_ &times; _difference_.[[Days]], _sign_ &times; _difference_.[[Hours]], _sign_ &times; _difference_.[[Minutes]], _sign_ &times; _difference_.[[Seconds]], _sign_ &times; _difference_.[[Milliseconds]], _sign_ &times; _difference_.[[Microseconds]], _sign_ &times; _difference_.[[Nanoseconds]]).
-        1. Let _roundRecord_ be ? RoundDuration(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _difference_.[[Hours]], _difference_.[[Minutes]], _difference_.[[Seconds]], _difference_.[[Milliseconds]], _difference_.[[Microseconds]], _difference_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _plainRelativeTo_, _calendarRec_, _zonedDateTime_, _timeZoneRec_, _precalculatedPlainDateTime_).
-        1. Let _roundResult_ be _roundRecord_.[[DurationRecord]].
-        1. Let _adjustResult_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _zonedDateTime_, _calendarRec_, _timeZoneRec_, _precalculatedPlainDateTime_).
-        1. Let _result_ be ? BalanceDateDurationRelative(_adjustResult_.[[Years]], _adjustResult_.[[Months]], _adjustResult_.[[Weeks]], _adjustResult_.[[Days]], _settings_.[[LargestUnit]], _settings_.[[SmallestUnit]], _plainRelativeTo_, _calendarRec_).
-        1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], _sign_ &times; _result_.[[Weeks]], _sign_ &times; _result_.[[Days]], _sign_ &times; _adjustResult_.[[Hours]], _sign_ &times; _adjustResult_.[[Minutes]], _sign_ &times; _adjustResult_.[[Seconds]], _sign_ &times; _adjustResult_.[[Milliseconds]], _sign_ &times; _adjustResult_.[[Microseconds]], _sign_ &times; _adjustResult_.[[Nanoseconds]]).
+        1. If _roundingGranularityIsNoop_ is *false*, then
+          1. Let _roundRecord_ be ? RoundDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[NormalizedTime]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _plainRelativeTo_, _calendarRec_, _zonedDateTime_, _timeZoneRec_, _precalculatedPlainDateTime_).
+          1. Let _roundResult_ be _roundRecord_.[[NormalizedDuration]].
+          1. Let _daysResult_ be ! NormalizedTimeDurationToDays(_roundResult_.[[NormalizedTime]], _zonedDateTime_, _timeZoneRec_).
+          1. Let _days_ be _roundResult_.[[Days]] + _daysResult_.[[Days]].
+          1. Let _adjustResult_ be ? AdjustRoundedDurationDays(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _days_, _daysResult_.[[NormalizedTime]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]], _zonedDateTime_, _calendarRec_, _timeZoneRec_, _precalculatedPlainDateTime_).
+          1. Let _balanceResult_ be ? BalanceDateDurationRelative(_adjustResult_.[[Years]], _adjustResult_.[[Months]], _adjustResult_.[[Weeks]], _adjustResult_.[[Days]], _settings_.[[LargestUnit]], _settings_.[[SmallestUnit]], _plainRelativeTo_, _calendarRec_).
+          1. Set _result_ to ? CombineDateAndNormalizedTimeDuration(_balanceResult_, _adjustResult_.[[NormalizedTime]]).
+        1. Let _timeResult_ be BalanceTimeDuration(_result_.[[NormalizedTime]], *"hour"*).
+        1. Return ! CreateTemporalDuration(_sign_ &times; _result_.[[Years]], _sign_ &times; _result_.[[Months]], _sign_ &times; _result_.[[Weeks]], _sign_ &times; _result_.[[Days]], _sign_ &times; _timeResult_.[[Hours]], _sign_ &times; _timeResult_.[[Minutes]], _sign_ &times; _timeResult_.[[Seconds]], _sign_ &times; _timeResult_.[[Milliseconds]], _sign_ &times; _timeResult_.[[Microseconds]], _sign_ &times; _timeResult_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
     <emu-clause id="sec-temporal-adddurationtoOrsubtractdurationfromzoneddatetime" type="abstract operation">
@@ -1543,7 +1541,8 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~get-offset-nanoseconds-for~, ~get-possible-instants-for~ »).
         1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_zonedDateTime_.[[Calendar]], « ~date-add~ »).
-        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]], *undefined*, _options_).
+        1. Let _norm_ be NormalizeTimeDuration(_sign_ &times; _duration_.[[Hours]], _sign_ &times; _duration_.[[Minutes]], _sign_ &times; _duration_.[[Seconds]], _sign_ &times; _duration_.[[Milliseconds]], _sign_ &times; _duration_.[[Microseconds]], _sign_ &times; _duration_.[[Nanoseconds]]).
+        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _sign_ &times; _duration_.[[Years]], _sign_ &times; _duration_.[[Months]], _sign_ &times; _duration_.[[Weeks]], _sign_ &times; _duration_.[[Days]], _norm_, *undefined*, _options_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZoneRec_.[[Receiver]], _calendarRec_.[[Receiver]]).
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1420,7 +1420,7 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It converts a normalized time duration _norm_ relative to a Temporal.ZonedDateTime _zonedRelativeTo_, and converts it into a number of days and a remainder normalized time duration, taking into account any offset changes in the time zone of _zonedRelativeTo_.
+          It converts a normalized time duration _norm_ relative to a Temporal.ZonedDateTime _zonedRelativeTo_ into a number of days and a remainder normalized time duration, taking into account any offset changes in the time zone of _zonedRelativeTo_.
           It also returns the length of the last day in nanoseconds, for rounding purposes.
         </dd>
       </dl>
@@ -1467,10 +1467,13 @@
           1. Assert: _sign_ is -1.
         1. If NormalizedTimeDurationSign(_norm_) = 1 and _sign_ = -1, throw a *RangeError* exception.
         1. Assert: CompareNormalizedTimeDuration(NormalizedTimeDurationAbs(_norm_), NormalizedTimeDurationAbs(_dayLengthNs_)) = -1.
+        1. Let _dayLength_ be abs(ℝ(_dayLengthNs_.[[TotalNanoseconds]])).
+        1. If _dayLength_ &ge; 2<sup>53</sup>, throw a *RangeError* exception.
+        1. Assert: abs(_days_) &lt; 2<sup>53</sup> / (HoursPerDay &times; MinutesPerHour &times; SecondsPerMinute).
         1. Return the Record {
           [[Days]]: _days_,
           [[Remainder]]: _norm_,
-          [[DayLength]]: ℝ(NormalizedTimeDurationAbs(_dayLengthNs_).[[TotalNanoseconds]])
+          [[DayLength]]: _dayLength_
           }.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
~~(Note: stacked on top of #2722, will rebase as appropriate)~~

This includes everything from #2612 except the last commit, which I'm still checking for a potential bug. These are the changes that place the limits on each component of a Temporal.Duration, and implement the internal calculations in a "normalized form" - 32-bit years, months, weeks, and time units expressed as one <96-bit integer.