### PR TITLE
Editorial: Use consistent capitalization for Abstract Operations

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -2,7 +2,7 @@
 <meta charset="utf8">
 
 <emu-clause id="sec-temporal-abstract-ops">
-  <h1>Abstract operations</h1>
+  <h1>Abstract Operations</h1>
 
   <!-- Based on ECMA-262 IteratorToList -->
   <emu-clause id="sec-iteratortolistoftype" type="abstract operation">

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -472,7 +472,7 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-instant-abstract-ops">
-    <h1>Abstract operations</h1>
+    <h1>Abstract Operations</h1>
 
     <emu-clause id="sec-temporal-isvalidepochnanoseconds" aoid="IsValidEpochNanoseconds">
       <h1>IsValidEpochNanoseconds ( _epochNanoseconds_ )</h1>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -280,7 +280,7 @@
   </emu-clause>
 
   <emu-clause id="sec-datetimeformat-abstracts">
-    <h1><a href="https://tc39.es/ecma402/#sec-datetimeformat-abstracts">Abstract Operations For DateTimeFormat Objects</a></h1>
+    <h1><a href="https://tc39.es/ecma402/#sec-datetimeformat-abstracts">Abstract Operations for DateTimeFormat Objects</a></h1>
 
     <emu-clause id="sec-temporal-initializedatetimeformat" aoid="InitializeDateTimeFormat">
       <h1>InitializeDateTimeFormat ( _dateTimeFormat_, _locales_, _options_ [ , <ins>_toLocaleStringTimeZone_</ins> ] )</h1>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -841,7 +841,7 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-plaindatetime-abstract-ops">
-    <h1>Abstract operations</h1>
+    <h1>Abstract Operations</h1>
 
     <emu-clause id="sec-temporal-iso-date-time-records">
       <h1>ISO Date-Time Records</h1>

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -349,7 +349,7 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-plainmonthday-abstract-ops">
-    <h1>Abstract operations</h1>
+    <h1>Abstract Operations</h1>
 
     <emu-clause id="sec-temporal-totemporalmonthday" type="abstract operation">
       <h1>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -524,7 +524,7 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-plaintime-abstract-ops">
-    <h1>Abstract operations</h1>
+    <h1>Abstract Operations</h1>
 
     <emu-clause id="sec-temporal-time-records">
       <h1>Time Records</h1>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -479,7 +479,7 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-plainyearmonth-abstract-ops">
-    <h1>Abstract operations</h1>
+    <h1>Abstract Operations</h1>
 
     <emu-clause id="sec-temporal-totemporalyearmonth" type="abstract operation">
       <h1>

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -186,7 +186,7 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-now-abstract-ops">
-    <h1>Abstract operations</h1>
+    <h1>Abstract Operations</h1>
 
     <emu-clause id="sec-hostsystemutcepochnanoseconds" type="host-defined abstract operation">
       <h1>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -309,7 +309,7 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-timezone-abstract-ops">
-    <h1>Abstract operations</h1>
+    <h1>Abstract Operations</h1>
 
     <emu-note type="editor">
       In ECMA-262, many time-zone-related sections and abstract operations are contained in the <a href="https://tc39.es/ecma262/#sec-date-objects">Date Objects</a> section of the specification.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1082,7 +1082,7 @@
   </emu-clause>
 
   <emu-clause id="sec-temporal-zoneddatetime-abstract-ops">
-    <h1>Abstract operations</h1>
+    <h1>Abstract Operations</h1>
 
     <emu-clause id="sec-temporal-interpretisodatetimeoffset" type="abstract operation">
       <h1>


### PR DESCRIPTION
ECMAScript spec uses "Abstract Operations" and "Abstract Operations for Something" as the capitalization in the heading.