### PR TITLE
Editorial: Add missing constructor properties of the Temporal object

### DIFF
--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -25,6 +25,10 @@
 
   <emu-clause id="sec-constructor-properties-of-the-temporal-object">
     <h1>Constructor Properties of the Temporal Object</h1>
+    <emu-clause id="sec-temporal-calendar">
+      <h1>Temporal.Calendar ( . . . )</h1>
+      <p>See <emu-xref href="#sec-temporal-calendar-objects"></emu-xref>.</p>
+    </emu-clause>
     <emu-clause id="sec-temporal-instant">
       <h1>Temporal.Instant ( . . . )</h1>
       <p>See <emu-xref href="#sec-temporal-instant-objects"></emu-xref>.</p>
@@ -56,6 +60,10 @@
     <emu-clause id="sec-temporal-duration">
       <h1>Temporal.Duration ( . . . )</h1>
       <p>See <emu-xref href="#sec-temporal-duration-objects"></emu-xref>.</p>
+    </emu-clause>
+    <emu-clause id="sec-temporal-zoneddatetime">
+      <h1>Temporal.ZonedDateTime ( . . . )</h1>
+      <p>See <emu-xref href="#sec-temporal-zoneddatetime-objects"></emu-xref>.</p>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
`Temporal.Calendar` and `Temporal.ZonedDateTime` are missing from the `Temporal` object's property