### PR TITLE
Editorial: Use upper case for "String" value

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1347,7 +1347,7 @@
     <emu-clause id="sec-temporal.calendar.prototype-@@tostringtag">
       <h1>Temporal.Calendar.prototype[ @@toStringTag ]</h1>
       <p>
-        The initial value of the @@toStringTag property is the string value *"Temporal.Calendar"*.
+        The initial value of the @@toStringTag property is the String value *"Temporal.Calendar"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -147,7 +147,7 @@
 
     <emu-clause id="sec-temporal.duration.prototype-@@tostringtag">
       <h1>Temporal.Duration.prototype[ @@toStringTag ]</h1>
-      <p>The initial value of the @@toStringTag property is the string value *"Temporal.Duration"*.</p>
+      <p>The initial value of the @@toStringTag property is the String value *"Temporal.Duration"*.</p>
       <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
     </emu-clause>
 

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -145,7 +145,7 @@
     <emu-clause id="sec-temporal.instant.prototype-@@tostringtag">
       <h1>Temporal.Instant.prototype[ @@toStringTag ]</h1>
       <p>
-        The initial value of the @@toStringTag property is the string value *"Temporal.Instant"*.
+        The initial value of the @@toStringTag property is the String value *"Temporal.Instant"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -104,7 +104,7 @@
     <emu-clause id="sec-temporal.plaindate.prototype-@@tostringtag">
       <h1>Temporal.PlainDate.prototype[ @@toStringTag ]</h1>
       <p>
-        The initial value of the @@toStringTag property is the string value *"Temporal.PlainDate"*.
+        The initial value of the @@toStringTag property is the String value *"Temporal.PlainDate"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -107,7 +107,7 @@
     <emu-clause id="sec-temporal.plaindatetime.prototype-@@tostringtag">
       <h1>Temporal.PlainDateTime.prototype[ @@toStringTag ]</h1>
       <p>
-        The initial value of the @@toStringTag property is the string value *"Temporal.PlainDateTime"*.
+        The initial value of the @@toStringTag property is the String value *"Temporal.PlainDateTime"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -90,7 +90,7 @@
     <emu-clause id="sec-temporal.plainmonthday.prototype-@@tostringtag">
       <h1>Temporal.PlainMonthDay.prototype[ @@toStringTag ]</h1>
       <p>
-        The initial value of the @@toStringTag property is the string value *"Temporal.PlainMonthDay"*.
+        The initial value of the @@toStringTag property is the String value *"Temporal.PlainMonthDay"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -100,7 +100,7 @@
     <emu-clause id="sec-temporal.plaintime.prototype-@@tostringtag">
       <h1>Temporal.PlainTime.prototype[ @@toStringTag ]</h1>
       <p>
-        The initial value of the @@toStringTag property is the string value *"Temporal.PlainTime"*.
+        The initial value of the @@toStringTag property is the String value *"Temporal.PlainTime"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -102,7 +102,7 @@
     <emu-clause id="sec-temporal.plainyearmonth.prototype-@@tostringtag">
       <h1>Temporal.PlainYearMonth.prototype[ @@toStringTag ]</h1>
       <p>
-        The initial value of the @@toStringTag property is the string value *"Temporal.PlainYearMonth"*.
+        The initial value of the @@toStringTag property is the String value *"Temporal.PlainYearMonth"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -85,7 +85,7 @@
     <emu-clause id="sec-temporal.timezone.prototype-@@tostringtag">
       <h1>Temporal.TimeZone.prototype[ @@toStringTag ]</h1>
       <p>
-        The initial value of the @@toStringTag property is the string value *"Temporal.TimeZone"*.
+        The initial value of the @@toStringTag property is the String value *"Temporal.TimeZone"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -105,7 +105,7 @@
     <emu-clause id="sec-temporal.zoneddatetime.prototype-@@tostringtag">
       <h1>Temporal.ZonedDateTime.prototype[ @@toStringTag ]</h1>
       <p>
-        The initial value of the @@toStringTag property is the string value *"Temporal.ZonedDateTime"*.
+        The initial value of the @@toStringTag property is the String value *"Temporal.ZonedDateTime"*.
       </p>
       <p>
         This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.


### PR DESCRIPTION
ECMAScript sepc uses "... is the String value ..."