### PR TITLE
Polyfill: Fix daysInYear and inLeapYear in Islamic calendars

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1254,9 +1254,10 @@ const helperIslamic = ObjectAssign({}, nonIsoHelperBase, {
   id: 'islamic',
   calendarType: 'lunar',
   inLeapYear(calendarDate, cache) {
-    // In leap years, the 12th month has 30 days. In non-leap years: 29.
-    const days = this.daysInMonth({ year: calendarDate.year, month: 12, day: 1 }, cache);
-    return days === 30;
+    const startOfYearCalendar = { year: calendarDate.year, month: 1, monthCode: 'M01', day: 1 };
+    const startOfNextYearCalendar = { year: calendarDate.year + 1, month: 1, monthCode: 'M01', day: 1 };
+    const result = this.calendarDaysUntil(startOfYearCalendar, startOfNextYearCalendar, cache);
+    return result === 355;
   },
   monthsInYear(/* calendarYear, cache */) {
     return 12;
@@ -1276,9 +1277,8 @@ const helperPersian = ObjectAssign({}, nonIsoHelperBase, {
   id: 'persian',
   calendarType: 'solar',
   inLeapYear(calendarDate, cache) {
-    // Same logic (count days in the last month) for Persian as for Islamic,
-    // even though Persian is solar and Islamic is lunar.
-    return helperIslamic.inLeapYear(calendarDate, cache);
+    // If the last month has 30 days, it's a leap year.
+    return this.daysInMonth({ year: calendarDate.year, month: 12, day: 1 }, cache) === 30;
   },
   monthsInYear(/* calendarYear, cache */) {
     return 12;
@@ -2086,7 +2086,7 @@ const nonIsoGeneralImpl = {
   },
   dayOfYear(date) {
     const cache = OneObjectCache.getCacheForObject(date);
-    const calendarDate = this.helper.isoToCalendarDate(date, cache);
+    const calendarDate = this.helper.temporalToCalendarDate(date, cache);
     const startOfYear = this.helper.startOfCalendarYear(calendarDate);
     const diffDays = this.helper.calendarDaysUntil(startOfYear, calendarDate, cache);
     return diffDays + 1;


### PR DESCRIPTION
Fixes #2740. There were two separate problems with the islamic calendar implementation in the Temporal polyfill, both fixed in this PR:
* Previous implementation assumed that when the 12th month had 30 days, then it was a leap year. But the `islamic-umalqura` calendar appears to break this rule. New implementation calculates the number of days in the year; if 355 then it's a leap year.
* Previous implementation had a bug where it was using ISO date instead of calendar date when calculating `daysInYear`.