### PR TITLE
Improve roundToNearestMonth example

### DIFF
--- a/docs/cookbook/roundToNearestMonth.mjs
+++ b/docs/cookbook/roundToNearestMonth.mjs
@@ -1,11 +1,12 @@
 const date = Temporal.PlainDate.from('2018-09-16');
 
-let { year, month } = date;
-if ((date.day - 1) / date.daysInMonth >= 0.5) month++;
-if (month > 12) {
-  month %= 12;
-  year++;
-}
-const nearestMonth = Temporal.PlainDate.from({ year, month, day: 1 });
+const firstOfCurrentMonth = date.with({ day: 1 });
+const firstOfNextMonth = firstOfCurrentMonth.add({ months: 1 });
+
+const sinceCurrent = date.since(firstOfCurrentMonth);
+const untilNext = date.until(firstOfNextMonth);
+
+const isCloserToNextMonth = Temporal.Duration.compare(sinceCurrent, untilNext) >= 0;
+const nearestMonth = isCloserToNextMonth ? firstOfNextMonth : firstOfCurrentMonth;
 
 assert.equal(nearestMonth.toString(), '2018-10-01');


### PR DESCRIPTION
Fixes #2751 

In addition to removing the use of hardcoded 12, I found that using Duration to find the closest option was more readable than the day of month arithmetic.