### PR TITLE
Normative: Fix date difference for end-of-month edge cases

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3708,8 +3708,7 @@ export function RejectDuration(y, mon, w, d, h, min, s, ms, µs, ns) {
 }
 
 function ISODateSurpasses(sign, y1, m1, d1, y2, m2, d2) {
-  const constrained = ConstrainISODate(y1, m1, d1);
-  const cmp = CompareISODate(constrained.year, constrained.month, constrained.day, y2, m2, d2);
+  const cmp = CompareISODate(y1, m1, d1, y2, m2, d2);
   return sign * cmp === 1;
 }
 

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -799,8 +799,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _constrained_ be ! RegulateISODate(_y1_, _m1_, _d1_, *"constrain"*).
-        1. Let _comparison_ be CompareISODate(_constrained_.[[Year]], _constrained_.[[Month]], _constrained_.[[Day]], _y2_, _m2_, _d2_).
+        1. Let _comparison_ be CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_).
         1. If _sign_ &times; _comparison_ is 1, return *true*.
         1. Return *false*.
       </emu-alg>


### PR DESCRIPTION
This adjusts the difference algorithm for Gregorian-year dates so that when an intermediate date occurs past the end of a month, it is not shifted to the end of that month.

Previously, in some edge cases where taking the difference in months or years would return a number of months and zero days, we now return one month less and 28, 29, or 30 days instead.

Example: 1970-01-29 until 1971-02-28, largestUnit years
Old result: 1 year, 1 month
New result: 1 year, 30 days

Note that largestUnit weeks and largestUnit days, the latter of which is the default, are not affected.

~~(**Note:** Stacked on top of an editorial change which I will eventually make a separate PR for.)~~

Closes: #2535