### PR TITLE
Editorial: Remove duplicated grammar definitions

### DIFF
--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -188,10 +188,10 @@ function seq(...productions) {
 // Grammar productions, based on the grammar in RFC 3339
 
 // characters
-const sign = character('+-−');
+const temporalSign = character('+-−');
 const hour = zeroPaddedInclusive(0, 23, 2);
 const minuteSecond = zeroPaddedInclusive(0, 59, 2);
-const decimalSeparator = character('.,');
+const temporalDecimalSeparator = character('.,');
 const daysDesignator = character('Dd');
 const hoursDesignator = character('Hh');
 const minutesDesignator = character('Mm');
@@ -206,11 +206,11 @@ const utcDesignator = withCode(character('Zz'), (data) => {
   data.z = true;
 });
 const annotationCriticalFlag = character('!');
-const fraction = seq(decimalSeparator, between(1, 9, digit()));
+const temporalDecimalFraction = seq(temporalDecimalSeparator, between(1, 9, digit()));
 
 const dateFourDigitYear = repeat(4, digit());
 
-const dateExtendedYear = withSyntaxConstraints(seq(sign, repeat(6, digit())), (result) => {
+const dateExtendedYear = withSyntaxConstraints(seq(temporalSign, repeat(6, digit())), (result) => {
   if (result === '-000000' || result === '−000000') {
     throw new SyntaxError('Negative zero extended year');
   }
@@ -235,15 +235,13 @@ function saveSecond(data, result) {
 const timeHour = withCode(hour, saveHour);
 const timeMinute = withCode(minuteSecond, saveMinute);
 const timeSecond = withCode(choice(minuteSecond, '60'), saveSecond);
-const timeFraction = withCode(fraction, (data, result) => {
+const timeFraction = withCode(temporalDecimalFraction, (data, result) => {
   result = result.slice(1);
   const fraction = result.padEnd(9, '0');
   data.millisecond = +fraction.slice(0, 3);
   data.microsecond = +fraction.slice(3, 6);
   data.nanosecond = +fraction.slice(6, 9);
 });
-const temporalSign = sign;
-const temporalDecimalFraction = fraction;
 function saveOffset(data, result) {
   data.offset = ES.ParseDateTimeUTCOffset(result);
 }
@@ -259,7 +257,7 @@ const utcOffsetSubMinutePrecision = withCode(
   saveOffset
 );
 const dateTimeUTCOffset = choice(utcDesignator, utcOffsetSubMinutePrecision);
-const timeZoneUTCOffsetName = seq(sign, hour, choice([minuteSecond], seq(':', minuteSecond)));
+const timeZoneUTCOffsetName = seq(temporalSign, hour, choice([minuteSecond], seq(':', minuteSecond)));
 const timeZoneIANAName = choice(...timezoneNames);
 const timeZoneIdentifier = withCode(
   choice(timeZoneUTCOffsetName, timeZoneIANAName),
@@ -336,14 +334,14 @@ const annotatedMonthDay = withSyntaxConstraints(
   }
 );
 
-const durationSecondsFraction = withCode(fraction, (data, result) => {
+const durationSecondsFraction = withCode(temporalDecimalFraction, (data, result) => {
   result = result.slice(1);
   const fraction = result.padEnd(9, '0');
   data.milliseconds = +fraction.slice(0, 3) * data.factor;
   data.microseconds = +fraction.slice(3, 6) * data.factor;
   data.nanoseconds = +fraction.slice(6, 9) * data.factor;
 });
-const durationMinutesFraction = withCode(fraction, (data, result) => {
+const durationMinutesFraction = withCode(temporalDecimalFraction, (data, result) => {
   result = result.slice(1);
   const ns = +result.padEnd(9, '0') * 60;
   data.seconds = Math.trunc(ns / 1e9) * data.factor;
@@ -351,7 +349,7 @@ const durationMinutesFraction = withCode(fraction, (data, result) => {
   data.microseconds = Math.trunc((ns % 1e6) / 1e3) * data.factor;
   data.nanoseconds = Math.trunc(ns % 1e3) * data.factor;
 });
-const durationHoursFraction = withCode(fraction, (data, result) => {
+const durationHoursFraction = withCode(temporalDecimalFraction, (data, result) => {
   result = result.slice(1);
   const ns = +result.padEnd(9, '0') * 3600;
   data.minutes = Math.trunc(ns / 6e10) * data.factor;
@@ -399,7 +397,7 @@ const durationYears = seq(
 );
 const durationDate = seq(choice(durationYears, durationMonths, durationWeeks, durationDays), [durationTime]);
 const duration = seq(
-  withCode([sign], (data, result) => (data.factor = result === '-' || result === '\u2212' ? -1 : 1)),
+  withCode([temporalSign], (data, result) => (data.factor = result === '-' || result === '\u2212' ? -1 : 1)),
   durationDesignator,
   choice(durationDate, durationTime)
 );

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1156,32 +1156,6 @@
           `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`
           `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
 
-      ASCIISign ::: one of
-          `+` `-`
-
-      Sign :::
-          ASCIISign
-          U+2212
-
-      Hour :::
-          `0` DecimalDigit
-          `1` DecimalDigit
-          `20`
-          `21`
-          `22`
-          `23`
-
-      MinuteSecond :::
-          `0` DecimalDigit
-          `1` DecimalDigit
-          `2` DecimalDigit
-          `3` DecimalDigit
-          `4` DecimalDigit
-          `5` DecimalDigit
-
-      DecimalSeparator ::: one of
-          `.` `,`
-
       DaysDesignator ::: one of
           `D` `d`
 
@@ -1222,7 +1196,7 @@
 
       DateYear :::
           DecimalDigit DecimalDigit DecimalDigit DecimalDigit
-          Sign DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+          TemporalSign DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
 
       DateMonth :::
           `0` NonZeroDigit
@@ -1268,31 +1242,19 @@
           MinuteSecond
           `60`
 
-      Fraction :::
-          > Readability note: This production matches a decimal separator followed by 1 to 9 digits
-          DecimalSeparator DecimalDigit
-          DecimalSeparator DecimalDigit DecimalDigit
-          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit
-          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit
-          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
-          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
-          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
-          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
-          DecimalSeparator DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
-
       TimeFraction :::
-          Fraction
+          TemporalDecimalFraction
 
       UTCOffsetWithSubMinuteComponents[Extended] :::
-          Sign Hour TimeSeparator[?Extended] MinuteSecond TimeSeparator[?Extended] MinuteSecond Fraction?
+          TemporalSign Hour TimeSeparator[?Extended] MinuteSecond TimeSeparator[?Extended] MinuteSecond TemporalDecimalFraction?
 
       NormalizedUTCOffset :::
           ASCIISign Hour `:` MinuteSecond
 
       UTCOffsetMinutePrecision :::
-          Sign Hour
-          Sign Hour TimeSeparator[+Extended] MinuteSecond
-          Sign Hour TimeSeparator[~Extended] MinuteSecond
+          TemporalSign Hour
+          TemporalSign Hour TimeSeparator[+Extended] MinuteSecond
+          TemporalSign Hour TimeSeparator[~Extended] MinuteSecond
 
       UTCOffsetSubMinutePrecision :::
           UTCOffsetMinutePrecision
@@ -1459,8 +1421,8 @@
           DurationDaysPart DurationTime?
 
       Duration :::
-          Sign? DurationDesignator DurationDate
-          Sign? DurationDesignator DurationTime
+          TemporalSign? DurationDesignator DurationDate
+          TemporalSign? DurationDesignator DurationTime
 
       TemporalInstantString :::
           Date DateTimeSeparator TimeSpec DateTimeUTCOffset TimeZoneAnnotation? Annotations?
@@ -1488,7 +1450,7 @@
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
         DateYear :::
-          Sign DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
+          TemporalSign DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
       </emu-grammar>
       <ul>
         <li>
@@ -1717,7 +1679,7 @@
     <emu-alg>
       1. Let _duration_ be ParseText(StringToCodePoints(_isoString_), |TemporalDurationString|).
       1. If _duration_ is a List of errors, throw a *RangeError* exception.
-      1. Let each of _sign_, _years_, _months_, _weeks_, _days_, _hours_, _fHours_, _minutes_, _fMinutes_, _seconds_, and _fSeconds_ be the source text matched by the respective |Sign|, |DurationYears|, |DurationMonths|, |DurationWeeks|, |DurationDays|, |DurationWholeHours|, |DurationHoursFraction|, |DurationWholeMinutes|, |DurationMinutesFraction|, |DurationWholeSeconds|, and |DurationSecondsFraction| Parse Node contained within _duration_, or an empty sequence of code points if not present.
+      1. Let each of _sign_, _years_, _months_, _weeks_, _days_, _hours_, _fHours_, _minutes_, _fMinutes_, _seconds_, and _fSeconds_ be the source text matched by the respective |TemporalSign|, |DurationYears|, |DurationMonths|, |DurationWeeks|, |DurationDays|, |DurationWholeHours|, |DurationHoursFraction|, |DurationWholeMinutes|, |DurationMinutesFraction|, |DurationWholeSeconds|, and |DurationSecondsFraction| Parse Node contained within _duration_, or an empty sequence of code points if not present.
       1. Let _yearsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_years_)).
       1. Let _monthsMV_ be ? ToIntegerWithTruncation(CodePointsToString(_months_)).
       1. Let _weeksMV_ be ? ToIntegerWithTruncation(CodePointsToString(_weeks_)).

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -85,30 +85,6 @@
     </emu-clause>
   </ins>
 
-  <emu-clause id="sec-literals-numeric-literals">
-    <h1><a href="https://tc39.es/ecma262/#sec-literals-numeric-literals">Numeric Literals</a></h1>
-    <emu-note type="editor">
-      <p>
-        No changes, but these productions must be present for symbol references because biblio.json contents are not propagated to grammarkdown.
-      </p>
-    </emu-note>
-    <emu-grammar type="definition">
-      NumericLiteralSeparator ::
-        `_`
-
-      DecimalDigits[Sep] ::
-        DecimalDigit
-        DecimalDigits[?Sep] DecimalDigit
-        [+Sep] DecimalDigits[+Sep] NumericLiteralSeparator DecimalDigit
-
-      DecimalDigit :: one of
-        `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
-
-      NonZeroDigit :: one of
-        `1` `2` `3` `4` `5` `6` `7` `8` `9`
-    </emu-grammar>
-  </emu-clause>
-
   <emu-clause id="sec-mathematical-operations">
     <h1>Mathematical Operations</h1>
     <p>[...]</p>


### PR DESCRIPTION
Now that biblio.json contents are propagated to grammarkdown, these duplicated parts of the ISO 8601 grammar can be removed.