### PR TITLE
Editorial: Use early errors and parameterization to simplify ISO 8601 grammar

### DIFF
--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -245,23 +245,28 @@ const timeFraction = withCode(temporalDecimalFraction, (data, result) => {
   data.microsecond = +fraction.slice(3, 6);
   data.nanosecond = +fraction.slice(6, 9);
 });
+
 function saveOffset(data, result) {
   data.offset = ES.ParseDateTimeUTCOffset(result);
 }
-
-const utcOffsetWithSubMinuteComponents = (extended) =>
-  seq(temporalSign, hour, timeSeparator(extended), minuteSecond, timeSeparator(extended), minuteSecond, [
-    temporalDecimalFraction
+const utcOffset = (subMinutePrecision) =>
+  seq(temporalSign, hour, [
+    choice(
+      seq(
+        timeSeparator(true),
+        minuteSecond,
+        subMinutePrecision ? [timeSeparator(true), minuteSecond, [temporalDecimalFraction]] : empty
+      ),
+      seq(
+        timeSeparator(false),
+        minuteSecond,
+        subMinutePrecision ? [timeSeparator(false), minuteSecond, [temporalDecimalFraction]] : empty
+      )
+    )
   ]);
-const utcOffsetMinutePrecision = seq(temporalSign, hour, [
-  choice(seq(timeSeparator(true), minuteSecond), seq(timeSeparator(false), minuteSecond))
-]);
-const utcOffsetSubMinutePrecision = withCode(
-  choice(utcOffsetMinutePrecision, utcOffsetWithSubMinuteComponents(true), utcOffsetWithSubMinuteComponents(false)),
-  saveOffset
-);
-const dateTimeUTCOffset = (z) => (z ? choice(utcDesignator, utcOffsetSubMinutePrecision) : utcOffsetSubMinutePrecision);
-const timeZoneUTCOffsetName = utcOffsetMinutePrecision;
+const dateTimeUTCOffset = (z) =>
+  z ? choice(utcDesignator, withCode(utcOffset(true), saveOffset)) : withCode(utcOffset(true), saveOffset);
+const timeZoneUTCOffsetName = utcOffset(false);
 const timeZoneIANAName = choice(...timezoneNames);
 const timeZoneIdentifier = withCode(
   choice(timeZoneUTCOffsetName, timeZoneIANAName),

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -260,7 +260,7 @@ const utcOffsetSubMinutePrecision = withCode(
   choice(utcOffsetMinutePrecision, utcOffsetWithSubMinuteComponents(true), utcOffsetWithSubMinuteComponents(false)),
   saveOffset
 );
-const dateTimeUTCOffset = choice(utcDesignator, utcOffsetSubMinutePrecision);
+const dateTimeUTCOffset = (z) => (z ? choice(utcDesignator, utcOffsetSubMinutePrecision) : utcOffsetSubMinutePrecision);
 const timeZoneUTCOffsetName = utcOffsetMinutePrecision;
 const timeZoneIANAName = choice(...timezoneNames);
 const timeZoneIdentifier = withCode(
@@ -303,11 +303,11 @@ const dateSpec = (extended) =>
     validateDayOfMonth
   );
 const date = choice(dateSpec(true), dateSpec(false));
-const dateTime = seq(date, [dateTimeSeparator, time, [dateTimeUTCOffset]]);
+const dateTime = (z) => seq(date, [dateTimeSeparator, time, [dateTimeUTCOffset(z)]]);
 const annotatedTime = choice(
-  seq(timeDesignator, time, [dateTimeUTCOffset], [timeZoneAnnotation], [annotations]),
+  seq(timeDesignator, time, [dateTimeUTCOffset(false)], [timeZoneAnnotation], [annotations]),
   seq(
-    withSyntaxConstraints(seq(time, [dateTimeUTCOffset]), (result) => {
+    withSyntaxConstraints(seq(time, [dateTimeUTCOffset(false)]), (result) => {
       if (/^(?:(?!02-?30)(?:0[1-9]|1[012])-?(?:0[1-9]|[12][0-9]|30)|(?:0[13578]|10|12)-?31)$/.test(result)) {
         throw new SyntaxError('valid PlainMonthDay');
       }
@@ -319,12 +319,13 @@ const annotatedTime = choice(
     [annotations]
   )
 );
-const annotatedDateTime = seq(dateTime, [timeZoneAnnotation], [annotations]);
+const annotatedDateTime = (zoned) =>
+  seq(dateTime(zoned), zoned ? timeZoneAnnotation : [timeZoneAnnotation], [annotations]);
 const annotatedDateTimeTimeRequired = seq(
   date,
   dateTimeSeparator,
   time,
-  [dateTimeUTCOffset],
+  [dateTimeUTCOffset(false)],
   [timeZoneAnnotation],
   [annotations]
 );
@@ -438,19 +439,19 @@ const duration = withSyntaxConstraints(
   }
 );
 
-const instant = seq(date, dateTimeSeparator, time, dateTimeUTCOffset, [timeZoneAnnotation], [annotations]);
-const zonedDateTime = seq(dateTime, timeZoneAnnotation, [annotations]);
+const instant = seq(date, dateTimeSeparator, time, dateTimeUTCOffset(true), [timeZoneAnnotation], [annotations]);
+const zonedDateTime = annotatedDateTime(true);
 
 // goal elements
 const goals = {
   Instant: instant,
-  Date: annotatedDateTime,
-  DateTime: annotatedDateTime,
+  Date: annotatedDateTime(false),
+  DateTime: annotatedDateTime(false),
   Duration: duration,
-  MonthDay: choice(annotatedMonthDay, annotatedDateTime),
+  MonthDay: choice(annotatedMonthDay, annotatedDateTime(false)),
   Time: choice(annotatedTime, annotatedDateTimeTimeRequired),
   TimeZone: choice(timeZoneIdentifier, zonedDateTime, instant),
-  YearMonth: choice(annotatedYearMonth, annotatedDateTime),
+  YearMonth: choice(annotatedYearMonth, annotatedDateTime(false)),
   ZonedDateTime: zonedDateTime
 };
 
@@ -478,16 +479,12 @@ const comparisonItems = {
   YearMonth: ['year', 'month', 'calendar'],
   ZonedDateTime: [...dateItems, ...timeItems, 'offset', 'z', 'tzAnnotation', 'calendar']
 };
-const plainModes = ['Date', 'DateTime', 'MonthDay', 'Time', 'YearMonth'];
 
 function fuzzMode(mode) {
   console.log('// starting to fuzz ' + mode);
   for (let count = 0; count < 1000; count++) {
-    let generatedData, fuzzed;
-    do {
-      generatedData = {};
-      fuzzed = goals[mode].generate(generatedData);
-    } while (plainModes.includes(mode) && /[0-9][zZ]/.test(fuzzed));
+    const generatedData = {};
+    const fuzzed = goals[mode].generate(generatedData);
     try {
       const parsingMethod = ES[`ParseTemporal${mode}StringRaw`] ?? ES[`ParseTemporal${mode}String`];
       const parsed = parsingMethod(fuzzed);

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -303,7 +303,13 @@ const dateSpec = (extended) =>
     validateDayOfMonth
   );
 const date = choice(dateSpec(true), dateSpec(false));
-const dateTime = (z) => seq(date, [dateTimeSeparator, time, [dateTimeUTCOffset(z)]]);
+const dateTime = (z, timeRequired) =>
+  seq(
+    date,
+    timeRequired
+      ? seq(dateTimeSeparator, time, [dateTimeUTCOffset(z)])
+      : [dateTimeSeparator, time, [dateTimeUTCOffset(z)]]
+  );
 const annotatedTime = choice(
   seq(timeDesignator, time, [dateTimeUTCOffset(false)], [timeZoneAnnotation], [annotations]),
   seq(
@@ -319,16 +325,8 @@ const annotatedTime = choice(
     [annotations]
   )
 );
-const annotatedDateTime = (zoned) =>
-  seq(dateTime(zoned), zoned ? timeZoneAnnotation : [timeZoneAnnotation], [annotations]);
-const annotatedDateTimeTimeRequired = seq(
-  date,
-  dateTimeSeparator,
-  time,
-  [dateTimeUTCOffset(false)],
-  [timeZoneAnnotation],
-  [annotations]
-);
+const annotatedDateTime = (zoned, timeRequired) =>
+  seq(dateTime(zoned, timeRequired), zoned ? timeZoneAnnotation : [timeZoneAnnotation], [annotations]);
 const annotatedYearMonth = withSyntaxConstraints(
   seq(dateSpecYearMonth, [timeZoneAnnotation], [annotations]),
   (result, data) => {
@@ -440,18 +438,18 @@ const duration = withSyntaxConstraints(
 );
 
 const instant = seq(date, dateTimeSeparator, time, dateTimeUTCOffset(true), [timeZoneAnnotation], [annotations]);
-const zonedDateTime = annotatedDateTime(true);
+const zonedDateTime = annotatedDateTime(true, false);
 
 // goal elements
 const goals = {
   Instant: instant,
-  Date: annotatedDateTime(false),
-  DateTime: annotatedDateTime(false),
+  Date: annotatedDateTime(false, false),
+  DateTime: annotatedDateTime(false, false),
   Duration: duration,
-  MonthDay: choice(annotatedMonthDay, annotatedDateTime(false)),
-  Time: choice(annotatedTime, annotatedDateTimeTimeRequired),
+  MonthDay: choice(annotatedMonthDay, annotatedDateTime(false, false)),
+  Time: choice(annotatedTime, annotatedDateTime(false, true)),
   TimeZone: choice(timeZoneIdentifier, zonedDateTime, instant),
-  YearMonth: choice(annotatedYearMonth, annotatedDateTime(false)),
+  YearMonth: choice(annotatedYearMonth, annotatedDateTime(false, false)),
   ZonedDateTime: zonedDateTime
 };
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1274,7 +1274,7 @@
           TemporalSign Hour TimeSeparator[?Extended] MinuteSecond TimeSeparator[?Extended] MinuteSecond TemporalDecimalFraction?
 
       NormalizedUTCOffset :::
-          ASCIISign Hour `:` MinuteSecond
+          ASCIISign Hour TimeSeparator[+Extended] MinuteSecond
 
       UTCOffsetMinutePrecision :::
           TemporalSign Hour
@@ -1346,27 +1346,29 @@
       Annotations :::
           Annotation Annotations?
 
-      TimeSpec :::
+      TimeSpec[Extended] :::
           TimeHour
-          TimeHour `:` TimeMinute
-          TimeHour TimeMinute
-          TimeHour `:` TimeMinute `:` TimeSecond TimeFraction?
-          TimeHour TimeMinute TimeSecond TimeFraction?
+          TimeHour TimeSeparator[?Extended] TimeMinute
+          TimeHour TimeSeparator[?Extended] TimeMinute TimeSeparator[?Extended] TimeSecond TimeFraction?
+
+      Time :::
+          TimeSpec[+Extended]
+          TimeSpec[~Extended]
 
       DateTime :::
           Date
-          Date DateTimeSeparator TimeSpec DateTimeUTCOffset?
+          Date DateTimeSeparator Time DateTimeUTCOffset?
 
       AnnotatedTime :::
-          TimeDesignator TimeSpec DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
-          TimeSpec DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
+          TimeDesignator Time DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
+          Time DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
 
       AnnotatedDateTime[Zoned] :::
           [~Zoned] DateTime TimeZoneAnnotation? Annotations?
           [+Zoned] DateTime TimeZoneAnnotation Annotations?
 
       AnnotatedDateTimeTimeRequired :::
-          Date DateTimeSeparator TimeSpec DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
+          Date DateTimeSeparator Time DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
 
       AnnotatedYearMonth :::
           DateSpecYearMonth TimeZoneAnnotation? Annotations?
@@ -1447,7 +1449,7 @@
           TemporalSign? DurationDesignator DurationTime
 
       TemporalInstantString :::
-          Date DateTimeSeparator TimeSpec DateTimeUTCOffset TimeZoneAnnotation? Annotations?
+          Date DateTimeSeparator Time DateTimeUTCOffset TimeZoneAnnotation? Annotations?
 
       TemporalDateTimeString[Zoned] :::
           AnnotatedDateTime[?Zoned]
@@ -1507,14 +1509,14 @@
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
         AnnotatedTime :::
-          TimeSpec DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
+          Time DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if IsValidMonthDay of ParseText(|TimeSpec| |DateTimeUTCOffset|, |DateSpecMonthDay|) is *true*.
+          It is a Syntax Error if IsValidMonthDay of ParseText(|Time| |DateTimeUTCOffset|, |DateSpecMonthDay|) is *true*.
         </li>
         <li>
-          It is a Syntax Error if ParseText(|TimeSpec| |DateTimeUTCOffset|, |DateSpecYearMonth|) is a Parse Node.
+          It is a Syntax Error if ParseText(|Time| |DateTimeUTCOffset|, |DateSpecYearMonth|) is a Parse Node.
         </li>
       </ul>
       <emu-grammar>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1294,8 +1294,8 @@
           UTCOffsetWithSubMinuteComponents[+Extended]
           UTCOffsetWithSubMinuteComponents[~Extended]
 
-      DateTimeUTCOffset :::
-          UTCDesignator
+      DateTimeUTCOffset[Z] :::
+          [+Z] UTCDesignator
           UTCOffsetSubMinutePrecision
 
       TimeZoneUTCOffsetName :::
@@ -1363,20 +1363,20 @@
           TimeSpec[+Extended]
           TimeSpec[~Extended]
 
-      DateTime :::
+      DateTime[Z] :::
           Date
-          Date DateTimeSeparator Time DateTimeUTCOffset?
+          Date DateTimeSeparator Time DateTimeUTCOffset[?Z]?
 
       AnnotatedTime :::
-          TimeDesignator Time DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
-          Time DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
+          TimeDesignator Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
+          Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
 
       AnnotatedDateTime[Zoned] :::
-          [~Zoned] DateTime TimeZoneAnnotation? Annotations?
-          [+Zoned] DateTime TimeZoneAnnotation Annotations?
+          [~Zoned] DateTime[~Z] TimeZoneAnnotation? Annotations?
+          [+Zoned] DateTime[+Z] TimeZoneAnnotation Annotations?
 
       AnnotatedDateTimeTimeRequired :::
-          Date DateTimeSeparator Time DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
+          Date DateTimeSeparator Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
 
       AnnotatedYearMonth :::
           DateSpecYearMonth TimeZoneAnnotation? Annotations?
@@ -1457,7 +1457,7 @@
           TemporalSign? DurationDesignator DurationTime
 
       TemporalInstantString :::
-          Date DateTimeSeparator Time DateTimeUTCOffset TimeZoneAnnotation? Annotations?
+          Date DateTimeSeparator Time DateTimeUTCOffset[+Z] TimeZoneAnnotation? Annotations?
 
       TemporalDateTimeString[Zoned] :::
           AnnotatedDateTime[?Zoned]
@@ -1515,14 +1515,14 @@
       <h1>Static Semantics: Early Errors</h1>
       <emu-grammar>
         AnnotatedTime :::
-          Time DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
+          Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if IsValidMonthDay of ParseText(|Time| |DateTimeUTCOffset|, |DateSpecMonthDay|) is *true*.
+          It is a Syntax Error if IsValidMonthDay of ParseText(|Time| |DateTimeUTCOffset[~Z]|, |DateSpecMonthDay|) is *true*.
         </li>
         <li>
-          It is a Syntax Error if ParseText(|Time| |DateTimeUTCOffset|, |DateSpecYearMonth|) is a Parse Node.
+          It is a Syntax Error if ParseText(|Time| |DateTimeUTCOffset[~Z]|, |DateSpecYearMonth|) is a Parse Node.
         </li>
       </ul>
       <emu-grammar>
@@ -1754,9 +1754,8 @@
       <dd>It parses the argument as an ISO 8601 string and returns a Record representing each date and time component needed to construct a Temporal.PlainDateTime instance as a distinct field.</dd>
     </dl>
     <emu-alg>
-      1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalDateTimeString|).
+      1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalDateTimeString[~Zoned]|).
       1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
-      1. If _parseResult_ contains a |UTCDesignator| Parse Node, throw a *RangeError* exception.
       1. Return ? ParseISODateTime(_isoString_).
     </emu-alg>
   </emu-clause>
@@ -1838,7 +1837,6 @@
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalMonthDayString|).
       1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
-      1. If _parseResult_ contains a |UTCDesignator| Parse Node, throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Let _year_ be _result_.[[Year]].
       1. If _parseResult_ does not contain a |DateYear| Parse Node, then
@@ -1865,7 +1863,6 @@
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalDateTimeString|).
       1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
-      1. If _parseResult_ contains a |UTCDesignator| ParseNode but no |TimeZoneAnnotation| Parse Node, throw a *RangeError* exception.
       1. Return ? ParseISODateTime(_isoString_).
     </emu-alg>
   </emu-clause>
@@ -1883,7 +1880,6 @@
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalTimeString|).
       1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
-      1. If _parseResult_ contains a |UTCDesignator| Parse Node, throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Return the Record {
         [[Hour]]: _result_.[[Hour]],
@@ -1950,7 +1946,6 @@
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalYearMonthString|).
       1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
-      1. If _parseResult_ contains a |UTCDesignator| Parse Node, throw a *RangeError* exception.
       1. Let _result_ be ? ParseISODateTime(_isoString_).
       1. Return the Record {
         [[Year]]: _result_.[[Year]],

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1191,6 +1191,10 @@
           `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`
           `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
 
+      DateSeparator[Extended] :::
+          [+Extended] `-`
+          [~Extended] [empty]
+
       DaysDesignator ::: one of
           `D` `d`
 
@@ -1247,15 +1251,19 @@
           `31`
 
       DateSpecYearMonth :::
-          DateYear `-`? DateMonth
+          DateYear DateSeparator[+Extended] DateMonth
+          DateYear DateSeparator[~Extended] DateMonth
 
       DateSpecMonthDay :::
-          `--` DateMonth `-`? DateDay
-          DateMonth `-`? DateDay
+          `--`? DateMonth DateSeparator[+Extended] DateDay
+          `--`? DateMonth DateSeparator[~Extended] DateDay
+
+      DateSpec[Extended] :::
+          DateYear DateSeparator[?Extended] DateMonth DateSeparator[?Extended] DateDay
 
       Date :::
-          DateYear `-` DateMonth `-` DateDay
-          DateYear DateMonth DateDay
+          DateSpec[+Extended]
+          DateSpec[~Extended]
 
       TimeHour :::
           Hour
@@ -1474,13 +1482,12 @@
       <h1>Static Semantics: IsValidMonthDay ( ): a Boolean</h1>
       <dl class="header"></dl>
       <emu-grammar>
-        Date :::
-          DateYear `-` DateMonth `-` DateDay
-          DateYear DateMonth DateDay
+        DateSpec[Extended] :::
+          DateYear DateSeparator[?Extended] DateMonth DateSeparator[?Extended] DateDay
 
         DateSpecMonthDay :::
-          `--` DateMonth `-`? DateDay
-          DateMonth `-`? DateDay
+          `--`? DateMonth DateSeparator[+Extended] DateDay
+          `--`? DateMonth DateSeparator[~Extended] DateDay
       </emu-grammar>
       <emu-alg>
         1. If |DateDay| is *"31"* and |DateMonth| is *"02"*, *"04"*, *"06"*, *"09"*, *"11"*, return *false*.
@@ -1493,12 +1500,11 @@
       <h1>Static Semantics: IsValidDate ( ): a Boolean</h1>
       <dl class="header"></dl>
       <emu-grammar>
-        Date :::
-          DateYear `-` DateMonth `-` DateDay
-          DateYear DateMonth DateDay
+        DateSpec[Extended] :::
+          DateYear DateSeparator[?Extended] DateMonth DateSeparator[?Extended] DateDay
       </emu-grammar>
       <emu-alg>
-        1. If IsValidMonthDay of |Date| is *false*, return *false*.
+        1. If IsValidMonthDay of |DateSpec| is *false*, return *false*.
         1. Let _year_ be ℝ(StringToNumber(CodePointsToString(|DateYear|))).
         1. If |DateMonth| is *"02"* and |DateDay| is *"29"* and MathematicalInLeapYear(EpochTimeForYear(_year_)) = 0, return *false*.
         1. Return *true*.
@@ -1520,19 +1526,18 @@
         </li>
       </ul>
       <emu-grammar>
-        Date :::
-          DateYear `-` DateMonth `-` DateDay
-          DateYear DateMonth DateDay
+        DateSpec[Extended] :::
+          DateYear DateSeparator[?Extended] DateMonth DateSeparator[?Extended] DateDay
       </emu-grammar>
       <ul>
         <li>
-          It is a Syntax Error if IsValidDate of |Date| is *false*.
+          It is a Syntax Error if IsValidDate of |DateSpec| is *false*.
         </li>
       </ul>
       <emu-grammar>
         DateSpecMonthDay :::
-          `--` DateMonth `-`? DateDay
-          DateMonth `-`? DateDay
+          `--`? DateMonth DateSeparator[+Extended] DateDay
+          `--`? DateMonth DateSeparator[~Extended] DateDay
       </emu-grammar>
       <ul>
         <li>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1363,20 +1363,17 @@
           TimeSpec[+Extended]
           TimeSpec[~Extended]
 
-      DateTime[Z] :::
-          Date
+      DateTime[Z, TimeRequired] :::
+          [~TimeRequired] Date
           Date DateTimeSeparator Time DateTimeUTCOffset[?Z]?
 
       AnnotatedTime :::
           TimeDesignator Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
           Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
 
-      AnnotatedDateTime[Zoned] :::
-          [~Zoned] DateTime[~Z] TimeZoneAnnotation? Annotations?
-          [+Zoned] DateTime[+Z] TimeZoneAnnotation Annotations?
-
-      AnnotatedDateTimeTimeRequired :::
-          Date DateTimeSeparator Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
+      AnnotatedDateTime[Zoned, TimeRequired] :::
+          [~Zoned] DateTime[~Z, ?TimeRequired] TimeZoneAnnotation? Annotations?
+          [+Zoned] DateTime[+Z, ?TimeRequired] TimeZoneAnnotation Annotations?
 
       AnnotatedYearMonth :::
           DateSpecYearMonth TimeZoneAnnotation? Annotations?
@@ -1460,22 +1457,22 @@
           Date DateTimeSeparator Time DateTimeUTCOffset[+Z] TimeZoneAnnotation? Annotations?
 
       TemporalDateTimeString[Zoned] :::
-          AnnotatedDateTime[?Zoned]
+          AnnotatedDateTime[?Zoned, ~TimeRequired]
 
       TemporalDurationString :::
           Duration
 
       TemporalMonthDayString :::
           AnnotatedMonthDay
-          AnnotatedDateTime[~Zoned]
+          AnnotatedDateTime[~Zoned, ~TimeRequired]
 
       TemporalTimeString :::
           AnnotatedTime
-          AnnotatedDateTimeTimeRequired
+          AnnotatedDateTime[~Zoned, +TimeRequired]
 
       TemporalYearMonthString :::
           AnnotatedYearMonth
-          AnnotatedDateTime[~Zoned]
+          AnnotatedDateTime[~Zoned, ~TimeRequired]
     </emu-grammar>
 
     <emu-clause id="sec-temporal-iso8601grammar-static-semantics-isvalidmonthday" type="sdo">

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1278,28 +1278,22 @@
       TimeFraction :::
           TemporalDecimalFraction
 
-      UTCOffsetWithSubMinuteComponents[Extended] :::
-          TemporalSign Hour TimeSeparator[?Extended] MinuteSecond TimeSeparator[?Extended] MinuteSecond TemporalDecimalFraction?
-
       NormalizedUTCOffset :::
           ASCIISign Hour TimeSeparator[+Extended] MinuteSecond
 
-      UTCOffsetMinutePrecision :::
+      UTCOffset[SubMinutePrecision] :::
           TemporalSign Hour
           TemporalSign Hour TimeSeparator[+Extended] MinuteSecond
           TemporalSign Hour TimeSeparator[~Extended] MinuteSecond
-
-      UTCOffsetSubMinutePrecision :::
-          UTCOffsetMinutePrecision
-          UTCOffsetWithSubMinuteComponents[+Extended]
-          UTCOffsetWithSubMinuteComponents[~Extended]
+          [+SubMinutePrecision] TemporalSign Hour TimeSeparator[+Extended] MinuteSecond TimeSeparator[+Extended] MinuteSecond TemporalDecimalFraction?
+          [+SubMinutePrecision] TemporalSign Hour TimeSeparator[~Extended] MinuteSecond TimeSeparator[~Extended] MinuteSecond TemporalDecimalFraction?
 
       DateTimeUTCOffset[Z] :::
           [+Z] UTCDesignator
-          UTCOffsetSubMinutePrecision
+          UTCOffset[+SubMinutePrecision]
 
       TimeZoneUTCOffsetName :::
-          UTCOffsetMinutePrecision
+          UTCOffset[~SubMinutePrecision]
 
       TZLeadingChar :::
           Alpha
@@ -1631,8 +1625,8 @@
         1. Set _timeZoneResult_.[[TimeZoneAnnotation]] to CodePointsToString(_identifier_).
       1. If _parseResult_ contains a |UTCDesignator| Parse Node, then
         1. Set _timeZoneResult_.[[Z]] to *true*.
-      1. Else if _parseResult_ contains a |UTCOffsetSubMinutePrecision| Parse Node, then
-        1. Let _offset_ be the source text matched by the |UTCOffsetSubMinutePrecision| Parse Node contained within _parseResult_.
+      1. Else if _parseResult_ contains a |UTCOffset[+SubMinutePrecision]| Parse Node, then
+        1. Let _offset_ be the source text matched by the |UTCOffset[+SubMinutePrecision]| Parse Node contained within _parseResult_.
         1. Set _timeZoneResult_.[[OffsetString]] to CodePointsToString(_offset_).
       1. Return the Record {
           [[Year]]: _yearMV_,

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1481,8 +1481,63 @@
           AnnotatedDateTime[~Zoned]
     </emu-grammar>
 
+    <emu-clause id="sec-temporal-iso8601grammar-static-semantics-isvalidmonthday" type="sdo">
+      <h1>Static Semantics: IsValidMonthDay ( ): a Boolean</h1>
+      <dl class="header"></dl>
+      <emu-grammar>
+        Date :::
+          DateYear `-` DateMonth `-` DateDay
+          DateYear DateMonth DateDay
+
+        DateSpecMonthDay :::
+          `--` DateMonth `-`? DateDay
+          DateMonth `-`? DateDay
+      </emu-grammar>
+      <emu-alg>
+        1. If |DateDay| is *"31"* and |DateMonth| is *"02"*, *"04"*, *"06"*, *"09"*, *"11"*, return *false*.
+        1. If |DateMonth| is *"02"* and |DateDay| is *"30"*, return *false*.
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-iso8601grammar-static-semantics-isvaliddate" type="sdo">
+      <h1>Static Semantics: IsValidDate ( ): a Boolean</h1>
+      <dl class="header"></dl>
+      <emu-grammar>
+        Date :::
+          DateYear `-` DateMonth `-` DateDay
+          DateYear DateMonth DateDay
+      </emu-grammar>
+      <emu-alg>
+        1. If IsValidMonthDay of |Date| is *false*, return *false*.
+        1. Let _year_ be ℝ(StringToNumber(CodePointsToString(|DateYear|))).
+        1. If |DateMonth| is *"02"* and |DateDay| is *"29"* and MathematicalInLeapYear(EpochTimeForYear(_year_)) = 0, return *false*.
+        1. Return *true*.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-iso8601grammar-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
+      <emu-grammar>
+        Date :::
+          DateYear `-` DateMonth `-` DateDay
+          DateYear DateMonth DateDay
+      </emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if IsValidDate of |Date| is *false*.
+        </li>
+      </ul>
+      <emu-grammar>
+        DateSpecMonthDay :::
+          `--` DateMonth `-`? DateDay
+          DateMonth `-`? DateDay
+      </emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if IsValidMonthDay of |DateSpecMonthDay| is *false*.
+        </li>
+      </ul>
       <emu-grammar>
         DateYear :::
           TemporalSign DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
@@ -1565,8 +1620,8 @@
         1. Let _millisecondMV_ be 0.
         1. Let _microsecondMV_ be 0.
         1. Let _nanosecondMV_ be 0.
-      1. If IsValidISODate(_yearMV_, _monthMV_, _dayMV_) is *false*, throw a *RangeError* exception.
-      1. If IsValidTime(_hourMV_, _minuteMV_, _secondMV_, _millisecondMV_, _microsecondMV_, _nanosecondMV_) is *false*, throw a *RangeError* exception.
+      1. Assert: IsValidISODate(_yearMV_, _monthMV_, _dayMV_) is *true*.
+      1. Assert: IsValidTime(_hourMV_, _minuteMV_, _secondMV_, _millisecondMV_, _microsecondMV_, _nanosecondMV_) is *true*.
       1. Let _timeZoneResult_ be the Record { [[Z]]: *false*, [[OffsetString]]: *undefined*, [[TimeZoneAnnotation]]: *undefined* }.
       1. If _parseResult_ contains a |TimeZoneIdentifier| Parse Node, then
         1. Let _identifier_ be the source text matched by the |TimeZoneIdentifier| Parse Node contained within _parseResult_.

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1239,9 +1239,6 @@
           `11`
           `12`
 
-      DateMonthWithThirtyOneDays ::: one of
-          `01` `03` `05` `07` `08` `10` `12`
-
       DateDay :::
           `0` NonZeroDigit
           `1` DecimalDigit
@@ -1255,13 +1252,6 @@
       DateSpecMonthDay :::
           `--` DateMonth `-`? DateDay
           DateMonth `-`? DateDay
-
-      ValidMonthDay :::
-          DateMonth `-`? `0` NonZeroDigit
-          DateMonth `-`? `1` DecimalDigit
-          DateMonth `-`? `2` DecimalDigit
-          DateMonth `-`? `30` but not one of `0230` or `02-30`
-          DateMonthWithThirtyOneDays `-`? `31`
 
       Date :::
           DateYear `-` DateMonth `-` DateDay
@@ -1363,16 +1353,13 @@
           TimeHour `:` TimeMinute `:` TimeSecond TimeFraction?
           TimeHour TimeMinute TimeSecond TimeFraction?
 
-      TimeSpecWithOptionalOffsetNotAmbiguous :::
-          TimeSpec DateTimeUTCOffset? but not one of ValidMonthDay or DateSpecYearMonth
-
       DateTime :::
           Date
           Date DateTimeSeparator TimeSpec DateTimeUTCOffset?
 
       AnnotatedTime :::
           TimeDesignator TimeSpec DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
-          TimeSpecWithOptionalOffsetNotAmbiguous TimeZoneAnnotation? Annotations?
+          TimeSpec DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
 
       AnnotatedDateTime[Zoned] :::
           [~Zoned] DateTime TimeZoneAnnotation? Annotations?
@@ -1518,6 +1505,18 @@
 
     <emu-clause id="sec-temporal-iso8601grammar-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
+      <emu-grammar>
+        AnnotatedTime :::
+          TimeSpec DateTimeUTCOffset? TimeZoneAnnotation? Annotations?
+      </emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if IsValidMonthDay of ParseText(|TimeSpec| |DateTimeUTCOffset|, |DateSpecMonthDay|) is *true*.
+        </li>
+        <li>
+          It is a Syntax Error if ParseText(|TimeSpec| |DateTimeUTCOffset|, |DateSpecYearMonth|) is a Parse Node.
+        </li>
+      </ul>
       <emu-grammar>
         Date :::
           DateYear `-` DateMonth `-` DateDay

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -650,7 +650,7 @@
           1. <ins>If _toLocaleStringTimeZone_ is present, throw a *TypeError* exception.</ins>
           1. Set _timeZone_ to ? ToString(_timeZone_).
         1. If IsTimeZoneOffsetString(_timeZone_) is *true*, then
-          1. Let _parseResult_ be ParseText(StringToCodePoints(_timeZone_), <del>|UTCOffset|</del><ins>|UTCOffsetMinutePrecision|</ins>).
+          1. Let _parseResult_ be ParseText(StringToCodePoints(_timeZone_), <del>|UTCOffset|</del><ins>|UTCOffset[~SubMinutePrecision]|</ins>).
           1. Assert: _parseResult_ is a Parse Node.
           1. <del>If _parseResult_ contains more than one |MinuteSecond| Parse Node, throw a *RangeError* exception.</del>
           1. Let _offsetNanoseconds_ be <del>ParseTimeZoneOffsetString</del><ins>? ParseDateTimeUTCOffset</ins>(_timeZone_).

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -252,8 +252,8 @@
       <ins class="block">
       <p>
         ECMAScript defines string interchange formats for UTC offsets, derived from ISO 8601.
-        UTC offsets that represent offset time zone identifiers, or that are intended for interoperability with ISO 8601, use only hours and minutes and are specified by |UTCOffsetMinutePrecision|.
-        UTC offsets that represent the offset of a named or custom time zone can be more precise, and are specified by |UTCOffsetSubMinutePrecision|.
+        UTC offsets that represent offset time zone identifiers, or that are intended for interoperability with ISO 8601, use only hours and minutes and are specified by |UTCOffset[~SubMinutePrecision]|.
+        UTC offsets that represent the offset of a named or custom time zone can be more precise, and are specified by |UTCOffset[+SubMinutePrecision]|.
       </p>
       <p>
         These formats are described by the ISO String grammar in <emu-xref href="#sec-temporal-iso8601grammar"></emu-xref>.
@@ -461,7 +461,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _parseResult_ be ParseText(StringToCodePoints(_offsetString_), <del>|UTCOffset|</del><ins>|UTCOffsetSubMinutePrecision|</ins>).
+        1. Let _parseResult_ be ParseText(StringToCodePoints(_offsetString_), <del>|UTCOffset|</del><ins>|UTCOffset[+SubMinutePrecision]|</ins>).
         1. <del>Assert: _parseResult_ is not a List of errors.</del>
         1. <ins>If _parseResult_ is a List of errors, throw a *RangeError* exception.</ins>
         1. Assert: _parseResult_ contains a |TemporalSign| Parse Node.


### PR DESCRIPTION
In the ISO 8601 grammar, we can use early errors and parameterization to avoid such bizarre productions like TimeHourNotThirtyOneDayMonth and TimeSpecWithOptionalOffsetNotAmbiguous, etc.

Best reviewed commit by commit.

Closes: #1984