### PR TITLE
Editorial: Fewer GetOffsetNanosecondsFor calls during InterpretISODateTimeOffset (prefer/reject)

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1494,9 +1494,20 @@ export function InterpretISODateTimeOffset(
   // "prefer" or "reject"
   const possibleEpochNs = GetPossibleEpochNanoseconds(timeZone, dt);
   if (possibleEpochNs.length > 0) {
+    const utcEpochNs = GetUTCEpochNanoseconds(
+      year,
+      month,
+      day,
+      time.hour,
+      time.minute,
+      time.second,
+      time.millisecond,
+      time.microsecond,
+      time.nanosecond
+    );
     for (let index = 0; index < possibleEpochNs.length; index++) {
       const candidate = possibleEpochNs[index];
-      const candidateOffset = GetOffsetNanosecondsFor(timeZone, candidate);
+      const candidateOffset = utcEpochNs - candidate;
       const roundedCandidateOffset = RoundNumberToIncrement(candidateOffset, 60e9, 'halfExpand');
       if (candidateOffset === offsetNs || (matchMinute && roundedCandidateOffset === offsetNs)) {
         return candidate;

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -992,8 +992,9 @@
         1. Assert: _offsetOption_ is *"prefer"* or *"reject"*.
         1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).
         1. If _possibleEpochNs_ is not empty, then
+          1. Let _utcEpochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]]).
           1. For each element _candidate_ of _possibleEpochNs_, do
-            1. Let _candidateOffset_ be GetOffsetNanosecondsFor(_timeZone_, _candidate_).
+            1. Let _candidateOffset_ be _utcEpochNanoseconds_ - _candidate_.
             1. If _candidateOffset_ = _offsetNanoseconds_, then
               1. Return _candidate_.
             1. If _matchBehaviour_ is ~match-minutes~, then


### PR DESCRIPTION
It's possible to avoid the `GetOffsetNanosecondsFor` call. For each candidate instant, you can derive its offset by comparing it to the UTC-zoned year/month/day/etc. Applicable to offset:prefer/reject only.

Modified (and passing) test262:
https://github.com/tc39/test262/compare/main...fullcalendar:test262:temporal-fewer-calls-offset-prefer-reject