### PR TITLE
Normative: Fix ZonedDateTime::round incorrect results with smallestUnit:day

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -5176,8 +5176,7 @@ export function RoundISODateTime(
   nanosecond,
   increment,
   unit,
-  roundingMode,
-  dayLengthNs = 86400e9
+  roundingMode
 ) {
   let deltaDays = 0;
   ({ deltaDays, hour, minute, second, millisecond, microsecond, nanosecond } = RoundTime(
@@ -5189,25 +5188,13 @@ export function RoundISODateTime(
     nanosecond,
     increment,
     unit,
-    roundingMode,
-    dayLengthNs
+    roundingMode
   ));
   ({ year, month, day } = BalanceISODate(year, month, day + deltaDays));
   return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
 }
 
-export function RoundTime(
-  hour,
-  minute,
-  second,
-  millisecond,
-  microsecond,
-  nanosecond,
-  increment,
-  unit,
-  roundingMode,
-  dayLengthNs = 86400e9
-) {
+export function RoundTime(hour, minute, second, millisecond, microsecond, nanosecond, increment, unit, roundingMode) {
   let quantity = bigInt.zero;
   switch (unit) {
     case 'day':
@@ -5229,7 +5216,7 @@ export function RoundTime(
     case 'nanosecond':
       quantity = quantity.multiply(1000).plus(nanosecond);
   }
-  const nsPerUnit = unit === 'day' ? dayLengthNs : nsPerTimeUnit[unit];
+  const nsPerUnit = nsPerTimeUnit[unit];
   const rounded = RoundNumberToIncrement(quantity, nsPerUnit * increment, roundingMode);
   const result = rounded.divide(nsPerUnit).toJSNumber();
   switch (unit) {
@@ -5775,6 +5762,7 @@ function bisect(getState, left, right, lstate = getState(left), rstate = getStat
 }
 
 const nsPerTimeUnit = {
+  day: 86400e9,
   hour: 3600e9,
   minute: 60e9,
   second: 1e9,

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1197,7 +1197,6 @@
           _increment_: an integer,
           _unit_: *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
           _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
-          optional _dayLength_: an integer,
         ): an ISO Date-Time Record
       </h1>
       <dl class="header">
@@ -1206,8 +1205,7 @@
       </dl>
       <emu-alg>
         1. Assert: ISODateTimeWithinLimits(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_) is *true*.
-        1. If _dayLength_ is not present, set _dayLength_ to nsPerDay.
-        1. Let _roundedTime_ be RoundTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_, _dayLength_).
+        1. Let _roundedTime_ be RoundTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _increment_, _unit_, _roundingMode_).
         1. Let _balanceResult_ be BalanceISODate(_year_, _month_, _day_ + _roundedTime_.[[Days]]).
         1. Return the Record {
             [[Year]]: _balanceResult_.[[Year]],

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -962,18 +962,16 @@
           _increment_: an integer,
           _unit_: *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
           _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
-          optional _dayLengthNs_: an integer,
         ): a Time Record
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It rounds a time to the given increment, optionally adjusting for a non-24-hour day.</dd>
+        <dd>It rounds a time to the given increment.</dd>
       </dl>
       <emu-alg>
         1. Let _fractionalSecond_ be _nanosecond_ &times; 10<sup>-9</sup> + _microsecond_ &times; 10<sup>-6</sup> + _millisecond_ &times; 10<sup>-3</sup> + _second_.
         1. If _unit_ is *"day"*, then
-          1. If _dayLengthNs_ is not present, set _dayLengthNs_ to nsPerDay.
-          1. Let _quantity_ be (((((_hour_ &times; 60 + _minute_) &times; 60 + _second_) &times; 1000 + _millisecond_) &times; 1000 + _microsecond_) &times; 1000 + _nanosecond_) / _dayLengthNs_.
+          1. Let _quantity_ be (((((_hour_ &times; 60 + _minute_) &times; 60 + _second_) &times; 1000 + _millisecond_) &times; 1000 + _microsecond_) &times; 1000 + _nanosecond_) / nsPerDay.
         1. Else if _unit_ is *"hour"*, then
           1. Let _quantity_ be (_fractionalSecond_ / 60 + _minute_) / 60 + _hour_.
         1. Else if _unit_ is *"minute"*, then

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -761,15 +761,24 @@
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _offsetNanoseconds_ be ? GetOffsetNanosecondsFor(_timeZoneRec_, _instant_).
         1. Let _temporalDateTime_ be ! GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendar_, _offsetNanoseconds_).
-        1. Let _dtStart_ be ? CreateTemporalDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], 0, 0, 0, 0, 0, 0, *"iso8601"*).
-        1. Let _instantStart_ be ? GetInstantFor(_timeZoneRec_, _dtStart_, *"compatible"*).
-        1. Let _startNs_ be _instantStart_.[[Nanoseconds]].
-        1. Let _endNs_ be ? AddDaysToZonedDateTime(_instantStart_, _dtStart_, _timeZoneRec_, _calendar_, 1).[[EpochNanoseconds]].
-        1. Let _dayLengthNs_ be ℝ(_endNs_ - _startNs_).
-        1. If _dayLengthNs_ &le; 0, then
-          1. Throw a *RangeError* exception.
-        1. Let _roundResult_ be RoundISODateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_, _dayLengthNs_).
-        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_.[[Year]], _roundResult_.[[Month]], _roundResult_.[[Day]], _roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZoneRec_, *"compatible"*, *"prefer"*, ~match-exactly~).
+        1. If _smallestUnit_ is *"day"*, then
+          1. Let _dtStart_ be ? CreateTemporalDateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], 0, 0, 0, 0, 0, 0, *"iso8601"*).
+          1. Let _dateEnd_ be BalanceISODate(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]] + 1).
+          1. Let _dtEnd_ be ? CreateTemporalDateTime(_dateEnd_.[[Year]], _dateEnd_.[[Month]], _dateEnd_.[[Day]], 0, 0, 0, 0, 0, 0, *"iso8601"*).
+          1. Let _thisNs_ be _zonedDateTime_.[[Nanoseconds]].
+          1. Let _instantStart_ be ? GetInstantFor(_timeZoneRec_, _dtStart_, *"compatible"*).
+          1. Let _startNs_ be _instantStart_.[[Nanoseconds]].
+          1. If _thisNs_ &lt; _startNs_, throw a *RangeError* exception.
+          1. Let _instantEnd_ be ? GetInstantFor(_timeZoneRec_, _dtEnd_, *"compatible"*).
+          1. Let _endNs_ be _instantEnd_.[[Nanoseconds]].
+          1. If _thisNs_ &geq; _endNs_, throw a *RangeError* exception.
+          1. Let _dayLengthNs_ be ℝ(_endNs_ - _startNs_).
+          1. Let _dayProgressNs_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_thisNs_, _startNs_).
+          1. Let _roundedDayNs_ be ! RoundNormalizedTimeDurationToIncrement(_dayProgressNs_, _dayLengthNs_, _roundingMode_).
+          1. Let _epochNanoseconds_ be _startNs_ + _roundedDayNs_.[[TotalNanoseconds]].
+        1. Else,
+          1. Let _roundResult_ be RoundISODateTime(_temporalDateTime_.[[ISOYear]], _temporalDateTime_.[[ISOMonth]], _temporalDateTime_.[[ISODay]], _temporalDateTime_.[[ISOHour]], _temporalDateTime_.[[ISOMinute]], _temporalDateTime_.[[ISOSecond]], _temporalDateTime_.[[ISOMillisecond]], _temporalDateTime_.[[ISOMicrosecond]], _temporalDateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+          1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_.[[Year]], _roundResult_.[[Month]], _roundResult_.[[Day]], _roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZoneRec_, *"compatible"*, *"prefer"*, ~match-exactly~).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZoneRec_.[[Receiver]], _calendar_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
This is my proposed fix to #2790

Adjusted tests:
https://github.com/tc39/test262/compare/main...fullcalendar:test262:temporal-2790-round-zdt-day

Could someone please review?