### PR TITLE
Fewer CalendarDay/CalendarDateFromFields calls during PlainYearMonth add/subtract

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4409,9 +4409,7 @@ export function AddDurationToOrSubtractDurationFromPlainYearMonth(operation, yea
   let startDate = CalendarDateFromFields(calendar, fields, 'constrain');
   if (sign < 0) {
     const nextMonth = CalendarDateAdd(calendar, startDate, { months: 1 }, 'constrain');
-    const endOfMonth = BalanceISODate(nextMonth.year, nextMonth.month, nextMonth.day - 1);
-    fields.day = CalendarDay(calendar, endOfMonth);
-    startDate = CalendarDateFromFields(calendar, fields, 'constrain');
+    startDate = BalanceISODate(nextMonth.year, nextMonth.month, nextMonth.day - 1);
   }
   RejectDateRange(startDate.year, startDate.month, startDate.day);
   const addedDate = CalendarDateAdd(calendar, startDate, { years, months, weeks, days }, overflow);

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -759,10 +759,8 @@
         1. If _sign_ &lt; 0, then
           1. Let _oneMonthDuration_ be ! CreateDateDurationRecord(0, 1, 0, 0).
           1. Let _nextMonth_ be ? CalendarDateAdd(_calendar_, _intermediateDate_, _oneMonthDuration_, *"constrain"*).
-          1. Let _endOfMonth_ be BalanceISODate(_nextMonth_.[[Year]], _nextMonth_.[[Month]], _nextMonth_.[[Day]] - 1).
-          1. Assert: ISODateWithinLimits(_endOfMonth_.[[Year]], _endOfMonth_.[[Month]], _endOfMonth_.[[Day]]) is *true*.
-          1. Set _fields_.[[Day]] to CalendarDay(_calendar_, _endOfMonth_).
-          1. Let _date_ be ? CalendarDateFromFields(_calendar_, _fields_, *"constrain"*).
+          1. Let _date_ be BalanceISODate(_nextMonth_.[[Year]], _nextMonth_.[[Month]], _nextMonth_.[[Day]] - 1).
+          1. Assert: ISODateWithinLimits(_date_.[[Year]], _date_.[[Month]], _date_.[[Day]]) is *true*.
         1. Else,
           1. Let _date_ be _intermediateDate_.
         1. Let _durationToAdd_ be ? CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _days_).


### PR DESCRIPTION
While investigating for #2794 (ultimately unsuccessful), I uncovered a way to have less user-code calls from PlainYearMonth add/subtract.

I don't see it in the [calendar invariants list](https://tc39.es/proposal-temporal/docs/calendar.html#invariants-across-calendars), but this axiom probably goes without saying: *the day before the first day of one month is the last day of the previous month.*

If add/subtract moves backward in time, the algorithm requires us to determine the last day of the current month before proceeding with PlainDate-style add/subtract.

Right now, the last day is being determined, but seems unnecessary to thread it back through `CalendarDateFromFields`, no?

Adjusted tests:
https://github.com/tc39/test262/compare/main...fullcalendar:test262:temporal-fewer-calls-pym-math