### PR TITLE
Post-adjustment: Remove unnecessary object creation

### DIFF
--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -5,7 +5,6 @@ import { CalendarMethodRecord } from './methodrecord.mjs';
 import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, GetSlot } from './slots.mjs';
 
 const ArrayPrototypeConcat = Array.prototype.concat;
-const ObjectCreate = Object.create;
 
 export class PlainMonthDay {
   constructor(isoMonth, isoDay, calendar = 'iso8601', referenceISOYear = 1972) {
@@ -90,9 +89,7 @@ export class PlainMonthDay {
     let mergedFields = ES.CalendarMergeFields(calendarRec, fields, inputFields);
     const concatenatedFieldNames = ES.Call(ArrayPrototypeConcat, receiverFieldNames, inputFieldNames);
     mergedFields = ES.PrepareTemporalFields(mergedFields, concatenatedFieldNames, [], [], 'ignore');
-    const options = ObjectCreate(null);
-    options.overflow = 'constrain';
-    return ES.CalendarDateFromFields(calendarRec, mergedFields, options);
+    return ES.CalendarDateFromFields(calendarRec, mergedFields);
   }
   getISOFields() {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -5,7 +5,6 @@ import { CalendarMethodRecord } from './methodrecord.mjs';
 import { ISO_YEAR, ISO_MONTH, ISO_DAY, CALENDAR, GetSlot } from './slots.mjs';
 
 const ArrayPrototypeConcat = Array.prototype.concat;
-const ObjectCreate = Object.create;
 
 export class PlainYearMonth {
   constructor(isoYear, isoMonth, calendar = 'iso8601', referenceISODay = 1) {
@@ -131,9 +130,7 @@ export class PlainYearMonth {
     let mergedFields = ES.CalendarMergeFields(calendarRec, fields, inputFields);
     const concatenatedFieldNames = ES.Call(ArrayPrototypeConcat, receiverFieldNames, inputFieldNames);
     mergedFields = ES.PrepareTemporalFields(mergedFields, concatenatedFieldNames, [], [], 'ignore');
-    const options = ObjectCreate(null);
-    options.overflow = 'constrain';
-    return ES.CalendarDateFromFields(calendarRec, mergedFields, options);
+    return ES.CalendarDateFromFields(calendarRec, mergedFields);
   }
   getISOFields() {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -254,9 +254,7 @@
         1. Let _mergedFields_ be ? CalendarMergeFields(_calendarRec_, _fields_, _inputFields_).
         1. Let _concatenatedFieldNames_ be the list-concatenation of _receiverFieldNames_ and _inputFieldNames_.
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _concatenatedFieldNames_, «», «», ~ignore~).
-        1. Let _options_ be OrdinaryObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"constrain"*).
-        1. Return ? CalendarDateFromFields(_calendarRec_, _mergedFields_, _options_).
+        1. Return ? CalendarDateFromFields(_calendarRec_, _mergedFields_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -384,9 +384,7 @@
         1. Let _mergedFields_ be ? CalendarMergeFields(_calendarRec_, _fields_, _inputFields_).
         1. Let _concatenatedFieldNames_ be the list-concatenation of _receiverFieldNames_ and _inputFieldNames_.
         1. Set _mergedFields_ to ? PrepareTemporalFields(_mergedFields_, _concatenatedFieldNames_, «», «», ~ignore~).
-        1. Let _options_ be OrdinaryObjectCreate(*null*).
-        1. Perform ! CreateDataPropertyOrThrow(_options_, *"overflow"*, *"constrain"*).
-        1. Return ? CalendarDateFromFields(_calendarRec_, _mergedFields_, _options_).
+        1. Return ? CalendarDateFromFields(_calendarRec_, _mergedFields_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
This is to address belated feedback from Anba on #2718. The options object previously created here is unnecessary, because 'constrain' is always the default for this option. Not creating the options object here is consistent with the rest of the spec text.

Closes: #2803