### PR TITLE
Editorial: More minor improvements

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -251,7 +251,7 @@ const BUILTIN_DEFAULTS = new Map([
 ]);
 
 // each item is [plural, singular, category]
-const SINGULAR_PLURAL_UNITS = [
+const TEMPORAL_UNITS = [
   ['years', 'year', 'date'],
   ['months', 'month', 'date'],
   ['weeks', 'week', 'date'],
@@ -263,9 +263,9 @@ const SINGULAR_PLURAL_UNITS = [
   ['microseconds', 'microsecond', 'time'],
   ['nanoseconds', 'nanosecond', 'time']
 ];
-const SINGULAR_FOR = new Map(SINGULAR_PLURAL_UNITS);
-const PLURAL_FOR = new Map(SINGULAR_PLURAL_UNITS.map(([p, s]) => [s, p]));
-const UNITS_DESCENDING = SINGULAR_PLURAL_UNITS.map(([, s]) => s);
+const SINGULAR_FOR = new Map(TEMPORAL_UNITS);
+const PLURAL_FOR = new Map(TEMPORAL_UNITS.map(([p, s]) => [s, p]));
+const UNITS_DESCENDING = TEMPORAL_UNITS.map(([, s]) => s);
 
 const DURATION_FIELDS = [
   'days',
@@ -981,8 +981,8 @@ export const REQUIRED = Symbol('~required~');
 
 export function GetTemporalUnit(options, key, unitGroup, requiredOrDefault, extraValues = []) {
   const allowedSingular = [];
-  for (let index = 0; index < SINGULAR_PLURAL_UNITS.length; index++) {
-    const unitInfo = SINGULAR_PLURAL_UNITS[index];
+  for (let index = 0; index < TEMPORAL_UNITS.length; index++) {
+    const unitInfo = TEMPORAL_UNITS[index];
     const singular = unitInfo[1];
     const category = unitInfo[2];
     if (unitGroup === 'datetime' || unitGroup === category) {
@@ -4022,7 +4022,7 @@ export function DifferenceZonedDateTime(
 }
 
 export function GetDifferenceSettings(op, options, group, disallowed, fallbackSmallest, smallestLargestDefaultUnit) {
-  const ALLOWED_UNITS = SINGULAR_PLURAL_UNITS.reduce((allowed, unitInfo) => {
+  const ALLOWED_UNITS = TEMPORAL_UNITS.reduce((allowed, unitInfo) => {
     const p = unitInfo[0];
     const s = unitInfo[1];
     const c = unitInfo[2];

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -5205,30 +5205,29 @@ export function RoundISODateTime(
 }
 
 export function RoundTime(hour, minute, second, millisecond, microsecond, nanosecond, increment, unit, roundingMode) {
-  let quantity = bigInt.zero;
+  let quantity;
   switch (unit) {
     case 'day':
     case 'hour':
-      quantity = bigInt(hour);
-    // fall through
+      quantity = ((((hour * 60 + minute) * 60 + second) * 1000 + millisecond) * 1000 + microsecond) * 1000 + nanosecond;
+      break;
     case 'minute':
-      quantity = quantity.multiply(60).plus(minute);
-    // fall through
+      quantity = (((minute * 60 + second) * 1000 + millisecond) * 1000 + microsecond) * 1000 + nanosecond;
+      break;
     case 'second':
-      quantity = quantity.multiply(60).plus(second);
-    // fall through
+      quantity = ((second * 1000 + millisecond) * 1000 + microsecond) * 1000 + nanosecond;
+      break;
     case 'millisecond':
-      quantity = quantity.multiply(1000).plus(millisecond);
-    // fall through
+      quantity = (millisecond * 1000 + microsecond) * 1000 + nanosecond;
+      break;
     case 'microsecond':
-      quantity = quantity.multiply(1000).plus(microsecond);
-    // fall through
+      quantity = microsecond * 1000 + nanosecond;
+      break;
     case 'nanosecond':
-      quantity = quantity.multiply(1000).plus(nanosecond);
+      quantity = nanosecond;
   }
   const nsPerUnit = NS_PER_TIME_UNIT.get(unit);
-  const rounded = RoundNumberToIncrement(quantity, nsPerUnit * increment, roundingMode);
-  const result = rounded.divide(nsPerUnit).toJSNumber();
+  const result = RoundJSNumberToIncrement(quantity, nsPerUnit * increment, roundingMode) / nsPerUnit;
   switch (unit) {
     case 'day':
       return { deltaDays: result, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -5534,46 +5534,15 @@ export function RoundDuration(
       norm = TimeDuration.ZERO;
       break;
     }
-    case 'day': {
+    case 'day':
       total = days + norm.fdiv(dayLengthNs);
       days = RoundJSNumberToIncrement(total, increment, roundingMode);
       norm = TimeDuration.ZERO;
       break;
-    }
-    case 'hour': {
-      const divisor = 3600e9;
+    default: {
+      const divisor = NS_PER_TIME_UNIT.get(unit);
       total = norm.fdiv(divisor);
       norm = norm.round(divisor * increment, roundingMode);
-      break;
-    }
-    case 'minute': {
-      const divisor = 60e9;
-      total = norm.fdiv(divisor);
-      norm = norm.round(divisor * increment, roundingMode);
-      break;
-    }
-    case 'second': {
-      const divisor = 1e9;
-      total = norm.fdiv(divisor);
-      norm = norm.round(divisor * increment, roundingMode);
-      break;
-    }
-    case 'millisecond': {
-      const divisor = 1e6;
-      total = norm.fdiv(divisor);
-      norm = norm.round(divisor * increment, roundingMode);
-      break;
-    }
-    case 'microsecond': {
-      const divisor = 1e3;
-      total = norm.fdiv(divisor);
-      norm = norm.round(divisor * increment, roundingMode);
-      break;
-    }
-    case 'nanosecond': {
-      total = norm.totalNs.toJSNumber();
-      norm = norm.round(increment, roundingMode);
-      break;
     }
   }
   CombineDateAndNormalizedTimeDuration(years, months, weeks, days, norm);

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -4,7 +4,6 @@ staging/Intl402/Temporal/old/date-time-format.js
 staging/Intl402/Temporal/old/datetime-toLocaleString.js
 staging/Intl402/Temporal/old/instant-toLocaleString.js
 staging/Intl402/Temporal/old/time-toLocaleString.js
-staging/Intl402/Temporal/old/zoneddatetime-toLocaleString.js
 intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
 intl402/DateTimeFormat/prototype/format/timedatestyle-en.js
 

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -318,8 +318,8 @@
     <h1>
       ToTemporalRoundingMode (
         _normalizedOptions_: an Object,
-        _fallback_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
-      ): either a normal completion containing a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>, or a throw completion
+        _fallback_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+      ): either a normal completion containing a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>, or a throw completion
     </h1>
     <dl class="header">
       <dt>description</dt>
@@ -329,7 +329,7 @@
       </dd>
     </dl>
     <emu-alg>
-      1. Let _roundingModes_ be the List of Strings from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>.
+      1. Let _roundingModes_ be the List of Strings from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>.
       1. Return ? GetOption(_normalizedOptions_, *"roundingMode"*, ~string~, _roundingModes_, _fallback_).
     </emu-alg>
     <!-- copied from ECMA-402 -->
@@ -441,8 +441,8 @@
   <emu-clause id="sec-temporal-negatetemporalroundingmode" type="abstract operation">
     <h1>
       NegateTemporalRoundingMode (
-        _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
-      ): a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>
+        _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+      ): a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>
     </h1>
     <dl class="header">
       <dt>description</dt>
@@ -704,9 +704,9 @@
     <emu-alg>
       1. Let _singularNames_ be a new empty List.
       1. For each row of <emu-xref href="#table-temporal-units"></emu-xref>, except the header row, in table order, do
-        1. Let _unit_ be the value in the Singular column of the row.
-        1. If the Category column of the row is ~date~ and _unitGroup_ is ~date~ or ~datetime~, append _unit_ to _singularNames_.
-        1. Else if the Category column of the row is ~time~ and _unitGroup_ is ~time~ or ~datetime~, append _unit_ to _singularNames_.
+        1. Let _unit_ be the value in the "Singular" column of the row.
+        1. If the "Category" column of the row is ~date~ and _unitGroup_ is ~date~ or ~datetime~, append _unit_ to _singularNames_.
+        1. Else if the "Category" column of the row is ~time~ and _unitGroup_ is ~time~ or ~datetime~, append _unit_ to _singularNames_.
       1. If _extraValues_ is present, then
         1. Set _singularNames_ to the list-concatenation of _singularNames_ and _extraValues_.
       1. If _default_ is ~required~, then
@@ -717,14 +717,14 @@
           1. Append _defaultValue_ to _singularNames_.
       1. Let _allowedValues_ be a copy of _singularNames_.
       1. For each element _singularName_ of _singularNames_, do
-        1. If _singularName_ is listed in the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>, then
-          1. Let _pluralName_ be the value in the Plural column of the corresponding row.
+        1. If _singularName_ is listed in the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>, then
+          1. Let _pluralName_ be the value in the "Plural" column of the corresponding row.
           1. Append _pluralName_ to _allowedValues_.
       1. NOTE: For each singular Temporal unit name that is contained within _allowedValues_, the corresponding plural name is also contained within it.
       1. Let _value_ be ? GetOption(_normalizedOptions_, _key_, ~string~, _allowedValues_, _defaultValue_).
       1. If _value_ is *undefined* and _default_ is ~required~, throw a *RangeError* exception.
-      1. If _value_ is listed in the Plural column of <emu-xref href="#table-temporal-units"></emu-xref>, then
-        1. Set _value_ to the value in the Singular column of the corresponding row.
+      1. If _value_ is listed in the "Plural" column of <emu-xref href="#table-temporal-units"></emu-xref>, then
+        1. Set _value_ to the value in the "Singular" column of the corresponding row.
       1. Return _value_.
     </emu-alg>
   </emu-clause>
@@ -809,9 +809,9 @@
   <emu-clause id="sec-temporal-largeroftwotemporalunits" type="abstract operation">
     <h1>
       LargerOfTwoTemporalUnits (
-        _u1_: a String from the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>,
-        _u2_: a String from the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>,
-      ): a String from the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>
+        _u1_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
+        _u2_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
+      ): a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>
     </h1>
     <dl class="header">
       <dt>description</dt>
@@ -819,7 +819,7 @@
     </dl>
     <emu-alg>
       1. For each row of <emu-xref href="#table-temporal-units"></emu-xref>, except the header row, in table order, do
-        1. Let _unit_ be the value in the Singular column of the row.
+        1. Let _unit_ be the value in the "Singular" column of the row.
         1. If SameValue(_u1_, _unit_) is *true*, return _unit_.
         1. If SameValue(_u2_, _unit_) is *true*, return _unit_.
     </emu-alg>
@@ -828,7 +828,7 @@
   <emu-clause id="sec-temporal-iscalendarunit" type="abstract operation">
     <h1>
       IsCalendarUnit (
-        _unit_: a String from the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>,
+        _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
       ): a Boolean
     </h1>
     <dl class="header">
@@ -846,7 +846,7 @@
   <emu-clause id="sec-temporal-maximumtemporaldurationroundingincrement" type="abstract operation">
     <h1>
       MaximumTemporalDurationRoundingIncrement (
-        _unit_: a String from the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>,
+        _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
       ): 24, 60, 1000, or *undefined*
     </h1>
     <dl class="header">
@@ -948,16 +948,16 @@
   <emu-clause id="sec-getunsignedroundingmode" type="abstract operation">
     <h1>
       GetUnsignedRoundingMode (
-        _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+        _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         _sign_: ~negative~ or ~positive~,
-      ): a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-unsigned-rounding-modes"></emu-xref>
+      ): a specification type from the "Unsigned Rounding Mode" column of <emu-xref href="#table-unsigned-rounding-modes"></emu-xref>
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It returns the rounding mode that should be applied to the absolute value of a number to produce the same result as if _roundingMode_, one of the String values in the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>, were applied to the signed value of the number (negative if _sign_ is ~negative~, or positive otherwise).</dd>
+      <dd>It returns the rounding mode that should be applied to the absolute value of a number to produce the same result as if _roundingMode_, one of the String values in the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>, were applied to the signed value of the number (negative if _sign_ is ~negative~, or positive otherwise).</dd>
     </dl>
     <emu-alg>
-      1. Return the specification type in the Unsigned Rounding Mode column of <emu-xref href="#table-unsigned-rounding-modes"></emu-xref> for the row where the value in the Identifier column is _roundingMode_ and the value in the Sign column is _sign_.
+      1. Return the specification type in the "Unsigned Rounding Mode" column of <emu-xref href="#table-unsigned-rounding-modes"></emu-xref> for the row where the value in the "Identifier" column is _roundingMode_ and the value in the "Sign" column is _sign_.
     </emu-alg>
     <emu-table id="table-unsigned-rounding-modes">
       <emu-caption>Conversion from rounding mode to unsigned rounding mode</emu-caption>
@@ -1061,7 +1061,7 @@
         _x_: a mathematical value,
         _r1_: a mathematical value,
         _r2_: a mathematical value,
-        _unsignedRoundingMode_: a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-unsigned-rounding-modes"></emu-xref>, or *undefined*,
+        _unsignedRoundingMode_: a specification type from the "Unsigned Rounding Mode" column of <emu-xref href="#table-unsigned-rounding-modes"></emu-xref>, or *undefined*,
       ): a mathematical value
     </h1>
     <dl class="header">
@@ -1093,7 +1093,7 @@
       RoundNumberToIncrement (
         _x_: a mathematical value,
         _increment_: an integer,
-        _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+        _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
       ): an integer
     </h1>
     <dl class="header">
@@ -1121,7 +1121,7 @@
       RoundNumberToIncrementAsIfPositive (
         _x_: a mathematical value,
         _increment_: an integer,
-        _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+        _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
       ): an integer
     </h1>
     <dl class="header">
@@ -2000,7 +2000,7 @@
           1. Let _value_ be ? Get(_fields_, _property_).
           1. If _value_ is not *undefined*, then
             1. Set _any_ to *true*.
-            1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
+            1. If _property_ is in the "Property" column of <emu-xref href="#table-temporal-field-requirements"></emu-xref> and there is a Conversion value in the same row, then
               1. Let _Conversion_ be the Conversion value of the same row.
               1. If _Conversion_ is ~to-integer-with-truncation~, then
                 1. Set _value_ to ? ToIntegerWithTruncation(_value_).
@@ -2020,7 +2020,7 @@
           1. Else if _requiredFields_ is a List, then
             1. If _requiredFields_ contains _property_, then
               1. Throw a *TypeError* exception.
-            1. If _property_ is in the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
+            1. If _property_ is in the "Property" column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>, then
               1. Set _value_ to the corresponding Default value of the same row.
             1. Perform ! CreateDataPropertyOrThrow(_result_, _property_, _value_).
         1. Else if _duplicateBehaviour_ is ~throw~, then
@@ -2119,12 +2119,12 @@
           <tr>
             <td>[[Property]]</td>
             <td>a String</td>
-            <td>The property name associated with the field, analogous to the Property column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>.</td>
+            <td>The property name associated with the field, analogous to the "Property" column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>.</td>
           </tr>
           <tr>
             <td>[[Conversion]]</td>
             <td>an Abstract Closure accepting a single ECMAScript language value and returning either a normal completion containing an ECMAScript language value representing purely static data or a throw completion.</td>
-            <td>The means by which purported values are coerced to a static representation of the correct type (or rejected if that fails), analogous to steps indicated by the Conversion column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>.</td>
+            <td>The means by which purported values are coerced to a static representation of the correct type (or rejected if that fails), analogous to steps indicated by the "Conversion" column of <emu-xref href="#table-temporal-field-requirements"></emu-xref>.</td>
           </tr>
           <tr>
             <td>[[Required]]</td>
@@ -2208,7 +2208,7 @@
         _disallowedUnits_: a List of Strings,
         _fallbackSmallestUnit_: a String,
         _smallestLargestDefaultUnit_: a String,
-      ): either a normal completion containing a Record with fields [[SmallestUnit]] (a String), [[LargestUnit]] (a String), [[RoundingMode]] (a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>), and [[RoundingIncrement]] (an integer in the inclusive interval from 1 to 10<sup>9</sup>), or a throw completion
+      ): either a normal completion containing a Record with fields [[SmallestUnit]] (a String), [[LargestUnit]] (a String), [[RoundingMode]] (a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>), and [[RoundingIncrement]] (an integer in the inclusive interval from 1 to 10<sup>9</sup>), or a throw completion
     </h1>
     <dl class="header">
       <dt>description</dt>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -147,6 +147,7 @@
             <th>Singular</th>
             <th>Plural</th>
             <th>Category</th>
+            <th>Length in nanoseconds</th>
           </tr>
         </thead>
         <tbody>
@@ -154,64 +155,78 @@
             <td>*"year"*</td>
             <td>*"years"*</td>
             <td>~date~</td>
+            <td>calendar-dependent</td>
           </tr>
 
           <tr>
             <td>*"month"*</td>
             <td>*"months"*</td>
             <td>~date~</td>
+            <td>calendar-dependent</td>
           </tr>
 
           <tr>
             <td>*"week"*</td>
             <td>*"weeks"*</td>
             <td>~date~</td>
+            <td>calendar-dependent</td>
           </tr>
 
           <tr>
             <td>*"day"*</td>
             <td>*"days"*</td>
             <td>~date~</td>
+            <td>nsPerDay</td>
           </tr>
 
           <tr>
             <td>*"hour"*</td>
             <td>*"hours"*</td>
             <td>~time~</td>
+            <td>3.6 &times; 10<sup>12</sup></td>
           </tr>
 
           <tr>
             <td>*"minute"*</td>
             <td>*"minutes"*</td>
             <td>~time~</td>
+            <td>6 &times; 10<sup>10</sup></td>
           </tr>
 
           <tr>
             <td>*"second"*</td>
             <td>*"seconds"*</td>
             <td>~time~</td>
+            <td>10<sup>9</sup></td>
           </tr>
 
           <tr>
             <td>*"millisecond"*</td>
             <td>*"milliseconds"*</td>
             <td>~time~</td>
+            <td>10<sup>6</sup></td>
           </tr>
 
           <tr>
             <td>*"microsecond"*</td>
             <td>*"microseconds"*</td>
             <td>~time~</td>
+            <td>10<sup>3</sup></td>
           </tr>
 
           <tr>
             <td>*"nanosecond"*</td>
             <td>*"nanoseconds"*</td>
             <td>~time~</td>
+            <td>1</td>
           </tr>
         </tbody>
       </table>
     </emu-table>
+    <emu-note>
+      The length of a day is given as nsPerDay in the table.
+      Note that changes in the UTC offset of a time zone may result in longer or shorter days, so care should be taken when using this value in the context of `Temporal.ZonedDateTime`.
+    </emu-note>
   </emu-clause>
 
   <!-- Copied from ECMA-402 GetOptionsObject -->

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -133,6 +133,87 @@
     <emu-note type="editor"> Note that the operation EpochTimeToMonthInYear(_t_) uses 0-based months unlike rest of Temporal since it's intended to be unified with MonthFromTime(_t_) when the above mentioned issue is fixed.</emu-note>
   </emu-clause>
 
+  <emu-clause id="sec-temporal-units">
+    <h1>Units</h1>
+    <p>
+      Time is reckoned using multiple units.
+      These units are listed in <emu-xref href="#table-temporal-units"></emu-xref>.
+    </p>
+    <emu-table id="table-temporal-units">
+      <emu-caption>Temporal units by descending magnitude</emu-caption>
+      <table class="real-table">
+        <thead>
+          <tr>
+            <th>Singular</th>
+            <th>Plural</th>
+            <th>Category</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>*"year"*</td>
+            <td>*"years"*</td>
+            <td>~date~</td>
+          </tr>
+
+          <tr>
+            <td>*"month"*</td>
+            <td>*"months"*</td>
+            <td>~date~</td>
+          </tr>
+
+          <tr>
+            <td>*"week"*</td>
+            <td>*"weeks"*</td>
+            <td>~date~</td>
+          </tr>
+
+          <tr>
+            <td>*"day"*</td>
+            <td>*"days"*</td>
+            <td>~date~</td>
+          </tr>
+
+          <tr>
+            <td>*"hour"*</td>
+            <td>*"hours"*</td>
+            <td>~time~</td>
+          </tr>
+
+          <tr>
+            <td>*"minute"*</td>
+            <td>*"minutes"*</td>
+            <td>~time~</td>
+          </tr>
+
+          <tr>
+            <td>*"second"*</td>
+            <td>*"seconds"*</td>
+            <td>~time~</td>
+          </tr>
+
+          <tr>
+            <td>*"millisecond"*</td>
+            <td>*"milliseconds"*</td>
+            <td>~time~</td>
+          </tr>
+
+          <tr>
+            <td>*"microsecond"*</td>
+            <td>*"microseconds"*</td>
+            <td>~time~</td>
+          </tr>
+
+          <tr>
+            <td>*"nanosecond"*</td>
+            <td>*"nanoseconds"*</td>
+            <td>~time~</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+
   <!-- Copied from ECMA-402 GetOptionsObject -->
   <emu-clause id="sec-getoptionsobject" type="abstract operation">
     <h1>
@@ -631,79 +712,6 @@
         1. Set _value_ to the value in the Singular column of the corresponding row.
       1. Return _value_.
     </emu-alg>
-    <emu-table id="table-temporal-units">
-      <emu-caption>Temporal units by descending magnitude</emu-caption>
-      <table class="real-table">
-        <thead>
-          <tr>
-            <th>Singular</th>
-            <th>Plural</th>
-            <th>Category</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>*"year"*</td>
-            <td>*"years"*</td>
-            <td>~date~</td>
-          </tr>
-
-          <tr>
-            <td>*"month"*</td>
-            <td>*"months"*</td>
-            <td>~date~</td>
-          </tr>
-
-          <tr>
-            <td>*"week"*</td>
-            <td>*"weeks"*</td>
-            <td>~date~</td>
-          </tr>
-
-          <tr>
-            <td>*"day"*</td>
-            <td>*"days"*</td>
-            <td>~date~</td>
-          </tr>
-
-          <tr>
-            <td>*"hour"*</td>
-            <td>*"hours"*</td>
-            <td>~time~</td>
-          </tr>
-
-          <tr>
-            <td>*"minute"*</td>
-            <td>*"minutes"*</td>
-            <td>~time~</td>
-          </tr>
-
-          <tr>
-            <td>*"second"*</td>
-            <td>*"seconds"*</td>
-            <td>~time~</td>
-          </tr>
-
-          <tr>
-            <td>*"millisecond"*</td>
-            <td>*"milliseconds"*</td>
-            <td>~time~</td>
-          </tr>
-
-          <tr>
-            <td>*"microsecond"*</td>
-            <td>*"microseconds"*</td>
-            <td>~time~</td>
-          </tr>
-
-          <tr>
-            <td>*"nanosecond"*</td>
-            <td>*"nanoseconds"*</td>
-            <td>~time~</td>
-          </tr>
-        </tbody>
-      </table>
-    </emu-table>
   </emu-clause>
 
   <emu-clause id="sec-temporal-torelativetemporalobject" type="abstract operation">

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1986,7 +1986,7 @@
           _days_: an integer,
           _norm_: a Normalized Time Duration Record,
           _increment_: an integer,
-          _unit_: a String,
+          _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
           _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
           optional _plainRelativeTo_: *undefined* or a Temporal.PlainDate,
           optional _calendarRec_: *undefined* or a Calendar Methods Record,
@@ -2109,30 +2109,11 @@
           1. Set _days_ to RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
           1. Let _total_ be _fractionalDays_.
           1. Set _norm_ to ZeroTimeDuration().
-        1. Else if _unit_ is *"hour"*, then
-          1. Let _divisor_ be 3.6 &times; 10<sup>12</sup>.
-          1. Let _total_ be DivideNormalizedTimeDuration(_norm_, _divisor_).
-          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
-        1. Else if _unit_ is *"minute"*, then
-          1. Let _divisor_ be 6 &times; 10<sup>10</sup>.
-          1. Let _total_ be DivideNormalizedTimeDuration(_norm_, _divisor_).
-          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
-        1. Else if _unit_ is *"second"*, then
-          1. Let _divisor_ be 10<sup>9</sup>.
-          1. Let _total_ be DivideNormalizedTimeDuration(_norm_, _divisor_).
-          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
-        1. Else if _unit_ is *"millisecond"*, then
-          1. Let _divisor_ be 10<sup>6</sup>.
-          1. Let _total_ be DivideNormalizedTimeDuration(_norm_, _divisor_).
-          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
-        1. Else if _unit_ is *"microsecond"*, then
-          1. Let _divisor_ be 10<sup>3</sup>.
-          1. Let _total_ be DivideNormalizedTimeDuration(_norm_, _divisor_).
-          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
         1. Else,
-          1. Assert: _unit_ is *"nanosecond"*.
-          1. Let _total_ be NormalizedTimeDurationSeconds(_norm_) &times; 10<sup>9</sup> + NormalizedTimeDurationSubseconds(_norm_).
-          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _increment_, _roundingMode_).
+          1. Assert: The value in the "Category" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Singular" column contains _unit_, is ~time~.
+          1. Let _divisor_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Singular" column contains _unit_.
+          1. Let _total_ be DivideNormalizedTimeDuration(_norm_, _divisor_).
+          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ &times; _increment_, _roundingMode_).
         1. Return the Record {
           [[NormalizedDuration]]: ? CreateNormalizedDurationRecord(_years_, _months_, _weeks_, _days_, _norm_),
           [[Total]]: _total_

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1223,7 +1223,7 @@
           _seconds_: an integer,
           _milliseconds_: an integer,
           _microseconds_: an integer,
-        ): a String from the Singular column of <emu-xref href="#table-temporal-units"></emu-xref>
+        ): a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1514,7 +1514,7 @@
         RoundNormalizedTimeDurationToIncrement (
           _d_: a Normalized Time Duration Record,
           _increment_: an integer,
-          _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+          _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): either a normal completion containing a Normalized Time Duration Record or a throw completion
       </h1>
       <dl class="header">
@@ -1987,7 +1987,7 @@
           _norm_: a Normalized Time Duration Record,
           _increment_: an integer,
           _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
-          _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+          _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
           optional _plainRelativeTo_: *undefined* or a Temporal.PlainDate,
           optional _calendarRec_: *undefined* or a Calendar Methods Record,
           optional _zonedRelativeTo_: *undefined* or a Temporal.ZonedDateTime,
@@ -2131,7 +2131,7 @@
           _norm_: a Normalized Time Duration Record,
           _increment_: an integer,
           _unit_: a String,
-          _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+          _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
           _zonedRelativeTo_: a Temporal.ZonedDateTime,
           _calendarRec_: a Calendar Methods Record,
           _timeZoneRec_: a Time Zone Methods Record,

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -589,7 +589,7 @@
           _ns2_: a BigInt,
           _roundingIncrement_: a positive integer,
           _smallestUnit_: a String,
-          _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+          _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): a Normalized Time Duration Record
       </h1>
       <dl class="header">
@@ -611,7 +611,7 @@
           _ns_: a BigInt,
           _increment_: a positive integer,
           _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
-          _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+          _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): a BigInt
       </h1>
       <dl class="header">

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -610,7 +610,7 @@
         RoundTemporalInstant (
           _ns_: a BigInt,
           _increment_: a positive integer,
-          _unit_: a String,
+          _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
           _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): a BigInt
       </h1>
@@ -619,19 +619,9 @@
         <dd>It rounds a number of nanoseconds _ns_ since the epoch to the given rounding increment.</dd>
       </dl>
       <emu-alg>
-        1. If _unit_ is *"hour"*, then
-          1. Let _incrementNs_ be _increment_ &times; 3.6 &times; 10<sup>12</sup>.
-        1. Else if _unit_ is *"minute"*, then
-          1. Let _incrementNs_ be _increment_ &times; 6 &times; 10<sup>10</sup>.
-        1. Else if _unit_ is *"second"*, then
-          1. Let _incrementNs_ be _increment_ &times; 10<sup>9</sup>.
-        1. Else if _unit_ is *"millisecond"*, then
-          1. Let _incrementNs_ be _increment_ &times; 10<sup>6</sup>.
-        1. Else if _unit_ is *"microsecond"*, then
-          1. Let _incrementNs_ be _increment_ &times; 10<sup>3</sup>.
-        1. Else,
-          1. Assert: _unit_ is *"nanosecond"*.
-          1. Let _incrementNs_ be _increment_.
+        1. Assert: The value in the "Category" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Singular" column contains _unit_, is ~time~.
+        1. Let _unitLength_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Singular" column contains _unit_.
+        1. Let _incrementNs_ be _increment_ &times; _unitLength_.
         1. Return ℤ(RoundNumberToIncrementAsIfPositive(ℝ(_ns_), _incrementNs_, _roundingMode_)).
       </emu-alg>
     </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -737,14 +737,14 @@
           1. <ins>Let _limitedOptions_ be a new Record.</ins>
           1. <ins>If _dateStyle_ is *undefined* and _timeStyle_ is *undefined*, then</ins>
             1. <ins>Set _needDefaults_ to *true*.</ins>
-            1. <ins>Let _fields_ be the List of fields in the Supported fields column of the row.</ins>
+            1. <ins>Let _fields_ be the List of fields in the "Supported fields" column of the row.</ins>
             1. <ins>For each property name _prop_ of _formatOptions_, do</ins>
               1. <ins>If _prop_ is in _fields_, then</ins>
                 1. <ins>Set _needDefaults_ to *false*.</ins>
                 1. <ins>Set _limitedOptions_.[[&lt;_prop_&gt;]] to _formatOptions_.[[&lt;_prop_&gt;]].</ins>
             1. <ins>If _needDefaults_ is *true*, then</ins>
-              1. <ins>Let _defaultFields_ be the List of fields in the Default fields column of the row.</ins>
-              1. <ins>If the Pattern column of the row is [[TemporalInstantPattern]], and _toLocaleStringTimeZone_ is present, append [[timeZoneName]] to _defaultFields_.</ins>
+              1. <ins>Let _defaultFields_ be the List of fields in the "Default fields" column of the row.</ins>
+              1. <ins>If the "Pattern" column of the row is [[TemporalInstantPattern]], and _toLocaleStringTimeZone_ is present, append [[timeZoneName]] to _defaultFields_.</ins>
               1. <ins>For each property name _prop_ of _defaultFields_, do</ins>
                 1. <ins>If _prop_ is [[timeZoneName]], then</ins>
                   1. <ins>Let _defaultValue_ be *"short"*.</ins>
@@ -754,7 +754,7 @@
           1. <ins>Set _bestFormat_ to ! GetDateTimeFormatPattern(~any~, _dateStyle_, _timeStyle_, _matcher_, _limitedOptions_, _dataLocaleData_, _resolvedCalendar_, _hasExplicitFormatComponents_).</ins>
           1. <ins>If _bestFormat_ does not have any fields that are in _fields_, then</ins>
             1. <ins>Set _bestFormat_ to *null*.</ins>
-          1. <ins>Set _dateTimeFormat_'s internal slot whose name is the Pattern column of the row to _bestFormat_.</ins>
+          1. <ins>Set _dateTimeFormat_'s internal slot whose name is the "Pattern" column of the row to _bestFormat_.</ins>
         1. Return _dateTimeFormat_.
       </emu-alg>
 

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1237,7 +1237,7 @@
           _nanosecond_: an integer in the inclusive interval from 0 to 999,
           _increment_: an integer,
           _unit_: *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
-          _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+          _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): an ISO Date-Time Record
       </h1>
       <dl class="header">

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -1026,7 +1026,7 @@
           _microsecond_: an integer in the inclusive interval from 0 to 999,
           _nanosecond_: an integer in the inclusive interval from 0 to 999,
           _increment_: an integer,
-          _unit_: *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
+          _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
           _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): a Time Record
       </h1>
@@ -1035,23 +1035,21 @@
         <dd>It rounds a time to the given increment.</dd>
       </dl>
       <emu-alg>
-        1. Let _fractionalSecond_ be _nanosecond_ &times; 10<sup>-9</sup> + _microsecond_ &times; 10<sup>-6</sup> + _millisecond_ &times; 10<sup>-3</sup> + _second_.
-        1. If _unit_ is *"day"*, then
-          1. Let _quantity_ be (((((_hour_ &times; 60 + _minute_) &times; 60 + _second_) &times; 1000 + _millisecond_) &times; 1000 + _microsecond_) &times; 1000 + _nanosecond_) / nsPerDay.
-        1. Else if _unit_ is *"hour"*, then
-          1. Let _quantity_ be (_fractionalSecond_ / 60 + _minute_) / 60 + _hour_.
+        1. If _unit_ is *"day"* or *"hour"*, then
+          1. Let _quantity_ be ((((_hour_ &times; 60 + _minute_) &times; 60 + _second_) &times; 1000 + _millisecond_) &times; 1000 + _microsecond_) &times; 1000 + _nanosecond_.
         1. Else if _unit_ is *"minute"*, then
-          1. Let _quantity_ be _fractionalSecond_ / 60 + _minute_.
+          1. Let _quantity_ be (((_minute_ &times; 60 + _second_) &times; 1000 + _millisecond_) &times; 1000 + _microsecond_) &times; 1000 + _nanosecond_.
         1. Else if _unit_ is *"second"*, then
-          1. Let _quantity_ be _fractionalSecond_.
+          1. Let _quantity_ be ((_second_ &times; 1000 + _millisecond_) &times; 1000 + _microsecond_) &times; 1000 + _nanosecond_.
         1. Else if _unit_ is *"millisecond"*, then
-          1. Let _quantity_ be _nanosecond_ &times; 10<sup>-6</sup> + _microsecond_ &times; 10<sup>-3</sup> + _millisecond_.
+          1. Let _quantity_ be (_millisecond_ &times; 1000 + _microsecond_) &times; 1000 + _nanosecond_.
         1. Else if _unit_ is *"microsecond"*, then
-          1. Let _quantity_ be _nanosecond_ &times; 10<sup>-3</sup> + _microsecond_.
+          1. Let _quantity_ be _microsecond_ &times; 1000 + _nanosecond_.
         1. Else,
           1. Assert: _unit_ is *"nanosecond"*.
           1. Let _quantity_ be _nanosecond_.
-        1. Let _result_ be RoundNumberToIncrement(_quantity_, _increment_, _roundingMode_).
+        1. Let _unitLength_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Singular" column contains _unit_.
+        1. Let _result_ be RoundNumberToIncrement(_quantity_, _increment_ &times; _unitLength_, _roundingMode_) / _unitLength_.
         1. If _unit_ is *"day"*, then
           1. Return Time Record {
             [[Days]]: _result_,

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -1027,7 +1027,7 @@
           _nanosecond_: an integer in the inclusive interval from 0 to 999,
           _increment_: an integer,
           _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
-          _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+          _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): a Time Record
       </h1>
       <dl class="header">

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1251,7 +1251,7 @@
           _showOffset_: one of *"auto"* or *"never"*,
           optional _increment_: an integer,
           optional _unit_: one of *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
-          optional _roundingMode_: a String from the Identifier column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
+          optional _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): either a normal completion containing a String or a throw completion
       </h1>
       <dl class="header">

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1382,7 +1382,7 @@
           _calendarRec_: a Calendar Methods Record,
           _largestUnit_: a String,
           _options_: an ordinary Object for which the value of the [[Prototype]] internal slot is *null* and every property is a data property,
-          _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
+          _precalculatedPlainDateTime_: a Temporal.PlainDateTime,
         ): either a normal completion containing a Normalized Duration Record, or a throw completion
       </h1>
       <dl class="header">


### PR DESCRIPTION
Put duration units in a table, and use that table to make operations easier to follow.

Address a couple of other minor editorial issues.