### PR TITLE
Editorial: Various improvements

### DIFF
--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -93,7 +93,7 @@ export class Instant {
     };
     ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximumIncrements[smallestUnit], true);
     const ns = GetSlot(this, EPOCHNANOSECONDS);
-    const roundedNs = ES.RoundInstant(ns, roundingIncrement, smallestUnit, roundingMode);
+    const roundedNs = ES.RoundTemporalInstant(ns, roundingIncrement, smallestUnit, roundingMode);
     return new Instant(roundedNs);
   }
   equals(other) {
@@ -114,7 +114,7 @@ export class Instant {
     if (timeZone !== undefined) timeZone = ES.ToTemporalTimeZoneSlotValue(timeZone);
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     const ns = GetSlot(this, EPOCHNANOSECONDS);
-    const roundedNs = ES.RoundInstant(ns, increment, unit, roundingMode);
+    const roundedNs = ES.RoundTemporalInstant(ns, increment, unit, roundingMode);
     const roundedInstant = new Instant(roundedNs);
     return ES.TemporalInstantToString(roundedInstant, timeZone, precision);
   }

--- a/polyfill/lib/math.mjs
+++ b/polyfill/lib/math.mjs
@@ -53,3 +53,39 @@ export function FMAPowerOf10(x, p, z) {
   const resStr = xStr + Call(StringPrototypePadStart, zStr, [p, '0']);
   return sign * NumberParseInt(resStr, 10);
 }
+
+export function GetUnsignedRoundingMode(mode, sign) {
+  const index = +(sign === 'negative'); // 0 = positive, 1 = negative
+  switch (mode) {
+    case 'ceil':
+      return ['infinity', 'zero'][index];
+    case 'floor':
+      return ['zero', 'infinity'][index];
+    case 'expand':
+      return 'infinity';
+    case 'trunc':
+      return 'zero';
+    case 'halfCeil':
+      return ['half-infinity', 'half-zero'][index];
+    case 'halfFloor':
+      return ['half-zero', 'half-infinity'][index];
+    case 'halfExpand':
+      return 'half-infinity';
+    case 'halfTrunc':
+      return 'half-zero';
+    case 'halfEven':
+      return 'half-even';
+  }
+}
+
+// Omits first step from spec algorithm so that it can be used both for
+// RoundNumberToIncrement and RoundNormalizedTimeDurationToIncrement
+export function ApplyUnsignedRoundingMode(r1, r2, cmp, evenCardinality, unsignedRoundingMode) {
+  if (unsignedRoundingMode === 'zero') return r1;
+  if (unsignedRoundingMode === 'infinity') return r2;
+  if (cmp < 0) return r1;
+  if (cmp > 0) return r2;
+  if (unsignedRoundingMode === 'half-zero') return r1;
+  if (unsignedRoundingMode === 'half-infinity') return r2;
+  return evenCardinality ? r1 : r2;
+}

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@babel/core": "^7.22.1",
     "@babel/preset-env": "^7.22.4",
-    "@js-temporal/temporal-test262-runner": "^0.10.0",
+    "@js-temporal/temporal-test262-runner": "js-temporal/temporal-test262-runner#main",
     "@pipobscure/demitasse": "^1.0.10",
     "@pipobscure/demitasse-pretty": "^1.0.10",
     "@pipobscure/demitasse-run": "^1.0.10",

--- a/polyfill/test/ecmascript.mjs
+++ b/polyfill/test/ecmascript.mjs
@@ -7,7 +7,6 @@ const { reporter } = Pretty;
 import { strict as assert } from 'assert';
 const { deepEqual, equal, throws } = assert;
 
-import bigInt from 'big-integer';
 import { readFileSync } from 'fs';
 
 import * as ES from '../lib/ecmascript.mjs';
@@ -40,26 +39,26 @@ describe('ECMAScript', () => {
   });
 
   describe('RoundNumberToIncrement', () => {
-    const increment = bigInt(100);
+    const increment = 100;
     const testValues = [-150, -100, -80, -50, -30, 0, 30, 50, 80, 100, 150];
     const expectations = {
-      ceil: [-100, -100, 0, 0, 0, 0, 100, 100, 100, 100, 200],
+      ceil: [-100, -100, -0, -0, -0, 0, 100, 100, 100, 100, 200],
       floor: [-200, -100, -100, -100, -100, 0, 0, 0, 0, 100, 100],
-      trunc: [-100, -100, 0, 0, 0, 0, 0, 0, 0, 100, 100],
+      trunc: [-100, -100, -0, -0, -0, 0, 0, 0, 0, 100, 100],
       expand: [-200, -100, -100, -100, -100, 0, 100, 100, 100, 100, 200],
-      halfCeil: [-100, -100, -100, 0, 0, 0, 0, 100, 100, 100, 200],
-      halfFloor: [-200, -100, -100, -100, 0, 0, 0, 0, 100, 100, 100],
-      halfTrunc: [-100, -100, -100, 0, 0, 0, 0, 0, 100, 100, 100],
-      halfExpand: [-200, -100, -100, -100, 0, 0, 0, 100, 100, 100, 200],
-      halfEven: [-200, -100, -100, 0, 0, 0, 0, 0, 100, 100, 200]
+      halfCeil: [-100, -100, -100, -0, -0, 0, 0, 100, 100, 100, 200],
+      halfFloor: [-200, -100, -100, -100, -0, 0, 0, 0, 100, 100, 100],
+      halfTrunc: [-100, -100, -100, -0, -0, 0, 0, 0, 100, 100, 100],
+      halfExpand: [-200, -100, -100, -100, -0, 0, 0, 100, 100, 100, 200],
+      halfEven: [-200, -100, -100, -0, -0, 0, 0, 0, 100, 100, 200]
     };
     for (const roundingMode of Object.keys(expectations)) {
       describe(roundingMode, () => {
         testValues.forEach((value, ix) => {
           const expected = expectations[roundingMode][ix];
           it(`rounds ${value} to ${expected}`, () => {
-            const result = ES.RoundNumberToIncrement(bigInt(value), increment, roundingMode);
-            equal(result.toJSNumber(), expected);
+            const result = ES.RoundNumberToIncrement(value, increment, roundingMode);
+            equal(result, expected);
           });
         });
       });

--- a/polyfill/test/ecmascript.mjs
+++ b/polyfill/test/ecmascript.mjs
@@ -7,6 +7,7 @@ const { reporter } = Pretty;
 import { strict as assert } from 'assert';
 const { deepEqual, equal, throws } = assert;
 
+import bigInt from 'big-integer';
 import { readFileSync } from 'fs';
 
 import * as ES from '../lib/ecmascript.mjs';
@@ -59,6 +60,33 @@ describe('ECMAScript', () => {
           it(`rounds ${value} to ${expected}`, () => {
             const result = ES.RoundNumberToIncrement(value, increment, roundingMode);
             equal(result, expected);
+          });
+        });
+      });
+    }
+  });
+
+  describe('RoundNumberToIncrementAsIfPositive', () => {
+    const increment = bigInt(100);
+    const testValues = [-150, -100, -80, -50, -30, 0, 30, 50, 80, 100, 150];
+    const expectations = {
+      ceil: [-100, -100, -0, -0, -0, 0, 100, 100, 100, 100, 200],
+      expand: [-100, -100, -0, -0, -0, 0, 100, 100, 100, 100, 200],
+      floor: [-200, -100, -100, -100, -100, 0, 0, 0, 0, 100, 100],
+      trunc: [-200, -100, -100, -100, -100, 0, 0, 0, 0, 100, 100],
+      halfCeil: [-100, -100, -100, -0, -0, 0, 0, 100, 100, 100, 200],
+      halfExpand: [-100, -100, -100, -0, -0, 0, 0, 100, 100, 100, 200],
+      halfFloor: [-200, -100, -100, -100, -0, 0, 0, 0, 100, 100, 100],
+      halfTrunc: [-200, -100, -100, -100, -0, 0, 0, 0, 100, 100, 100],
+      halfEven: [-200, -100, -100, -0, -0, 0, 0, 0, 100, 100, 200]
+    };
+    for (const roundingMode of Object.keys(expectations)) {
+      describe(roundingMode, () => {
+        testValues.forEach((value, ix) => {
+          const expected = expectations[roundingMode][ix];
+          it(`rounds ${value} to ${expected}`, () => {
+            const result = ES.RoundNumberToIncrementAsIfPositive(bigInt(value), increment, roundingMode);
+            equal(result.toJSNumber(), bigInt(expected).toJSNumber());
           });
         });
       });

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1991,7 +1991,7 @@
           1. Append _desc_.[[Property]] to _fieldNames_.
           1. If _desc_.[[Required]] is *true* and _requiredFields_ is a List, then
             1. Append _desc_.[[Property]] to _requiredFields_.
-      1. Let _sortedFieldNames_ be SortStringListByCodeUnit(_fieldNames_).
+      1. Let _sortedFieldNames_ be a List whose elements are the elements of _fieldNames_, sorted according to lexicographic code unit order.
       1. Let _previousProperty_ be *undefined*.
       1. For each property name _property_ of _sortedFieldNames_, do
         1. If _property_ is one of *"constructor"* or *"__proto__"*, then

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -49,11 +49,10 @@
         <dd>Each element in the returned List represents a calendar type supported by the implementation.</dd>
       </dl>
       <emu-alg>
-        1. Let _calendars_ be the List of String values representing calendar types supported by the implementation.
+        1. Let _calendars_ be the List of String values representing calendar types supported by the implementation, sorted according to lexicographic code unit order.
         1. Assert: _calendars_ contains *"iso8601"*.
         1. [declared="S"] Assert: _calendars_ does not contain any element _S_ for which the ASCII-lowercase of _S_ is not _S_.
         1. Assert: _calendars_ does not contain any element that does not identify a calendar type in the <a href="https://cldr.unicode.org/">Unicode Common Locale Data Repository (CLDR)</a>.
-        1. Return SortStringListByCodeUnit(_calendars_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -113,10 +113,9 @@
         </dl>
         <p>This definition supersedes the definition provided in <emu-xref href="#sec-availablenamedtimezoneidentifiers"></emu-xref>.</p>
         <emu-alg>
-          1. Let _identifiers_ be a List containing the String value of each Zone or Link name in the IANA Time Zone Database.
+          1. Let _identifiers_ be a List containing the String value of each Zone or Link name in the IANA Time Zone Database, sorted according to lexicographic code unit order.
           1. Assert: No element of _identifiers_ is an ASCII-case-insensitive match for any other element.
           1. Assert: Every element of _identifiers_ identifies a Zone or Link name in the IANA Time Zone Database.
-          1. Set _identifiers_ to SortStringListByCodeUnit(_identifiers_).
           1. Let _result_ be a new empty List.
           1. For each element _identifier_ of _identifiers_, do
             1. Let _primary_ be _identifier_.

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -66,25 +66,6 @@
     </emu-clause>
   </ins>
 
-  <ins class="block">
-    <emu-clause id="sec-sortstringlistbycodeunit" type="abstract operation">
-      <h1>
-        SortStringListByCodeUnit (
-          _strings_: a List of Strings,
-        ): a List of Strings
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>The returned List contains the same Strings as _strings_, but sorted lexicographically by UTF-16 code unit in ascending order.</dd>
-      </dl>
-      <emu-alg>
-        1. Let _result_ be a copy of _strings_.
-        1. [declared="comparefn"] Sort _result_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as _comparefn_.
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-  </ins>
-
   <emu-clause id="sec-mathematical-operations">
     <h1>Mathematical Operations</h1>
     <p>[...]</p>
@@ -231,45 +212,6 @@
         In time zone aware implementations, a primary time zone identifier is a Zone name, and a non-primary time zone identifier is a Link name, respectively, in the IANA Time Zone Database except as specifically overridden by AvailableNamedTimeZoneIdentifiers as specified in the ECMA-402 specification.
         Implementations that do not support the entire IANA Time Zone Database are still recommended to use IANA Time Zone Database names as identifiers to represent time zones.
       </p>
-    </emu-clause>
-
-    <emu-clause id="sec-availablenamedtimezoneidentifiers" type="implementation-defined abstract operation">
-      <h1>AvailableNamedTimeZoneIdentifiers ( ): a List of Time Zone Identifier Records</h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>
-          Its result describes all available named time zone identifiers in this implementation, as well as the primary time zone identifier corresponding to each available named time zone identifier.
-          The List is ordered according to the [[Identifier]] field of each Time Zone Identifier Record.
-        </dd>
-      </dl>
-      <p>
-        Time zone aware implementations, including all implementations that implement the ECMA-402 Internationalization API, must implement the AvailableNamedTimeZoneIdentifiers abstract operation as specified in the ECMA-402 specification.
-        For implementations that are not time zone aware, AvailableNamedTimeZoneIdentifiers performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. If the implementation does not include local political rules for any time zones, then
-          1. Return « the Time Zone Identifier Record { [[Identifier]]: *"UTC"*, [[PrimaryIdentifier]]: *"UTC"* } ».
-        1. Let _identifiers_ be the List of unique available named time zone identifiers.
-        1. <del>Sort _identifiers_ into the same order as if an Array of the same values had been sorted using %Array.prototype.sort% with *undefined* as the argument.</del>
-        1. <ins>Set _identifiers_ to SortStringListByCodeUnit(_identifiers_).</ins>
-        1. Let _result_ be a new empty List.
-        1. For each element _identifier_ of _identifiers_, do
-          1. Let _primary_ be _identifier_.
-          1. If _identifier_ is a non-primary time zone identifier in this implementation and _identifier_ is not *"UTC"*, then
-            1. Set _primary_ to the primary time zone identifier associated with _identifier_.
-            1. NOTE: An implementation may need to resolve _identifier_ iteratively to obtain the primary time zone identifier.
-          1. Let _record_ be the Time Zone Identifier Record { [[Identifier]]: _identifier_, [[PrimaryIdentifier]]: _primary_ }.
-          1. Append _record_ to _result_.
-        1. Assert: _result_ contains a Time Zone Identifier Record _r_ such that _r_.[[Identifier]] is *"UTC"* and _r_.[[PrimaryIdentifier]] is *"UTC"*.
-        1. Return _result_.
-      </emu-alg>
-
-      <emu-note>
-        Time zone identifiers in the IANA Time Zone Database can change over time.
-        At a minimum, implementations must limit changes to the result of AvailableNamedTimeZoneIdentifiers to the changes allowed by GetAvailableNamedTimeZoneIdentifier, for the lifetime of the surrounding agent.
-        That is, implementations must not remove support for or change the primary vs. non-primary status of an identifier that was already reported as available, and they must not add support for an identifier that was already reported as not available.
-        Due to the complexity of supporting these recommendations, it is recommended that the result of AvailableNamedTimeZoneIdentifiers remains the same for the lifetime of the surrounding agent.
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-systemtimezoneidentifier" oldids="sec-defaulttimezone" type="implementation-defined abstract operation">


### PR DESCRIPTION
- Incorporate "lexicographic code unit order" language from ECMA-262
- Make some operations in the reference code work more similarly to the spec text
- Use an updated temporal-test262-runner