### PR TITLE
Normative: Fix bug with PlainDateTime since/until near month boundaries

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3606,8 +3606,10 @@ export function DifferenceISODateTime(
 
   const timeSign = timeDuration.sign();
   const dateSign = CompareISODate(y2, mon2, d2, y1, mon1, d1);
+
+  // back-off a day from date2 so that the signs of the date a time diff match
   if (dateSign === -timeSign) {
-    ({ year: y1, month: mon1, day: d1 } = BalanceISODate(y1, mon1, d1 - timeSign));
+    ({ year: y2, month: mon2, day: d2 } = BalanceISODate(y2, mon2, d2 + timeSign));
     timeDuration = timeDuration.add24HourDays(-timeSign);
   }
 

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1338,12 +1338,12 @@
         1. Let _timeDuration_ be DifferenceTime(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. Let _timeSign_ be NormalizedTimeDurationSign(_timeDuration_).
         1. Let _dateSign_ be CompareISODate(_y2_, _mon2_, _d2_, _y1_, _mon1_, _d1_).
-        1. Let _adjustedDate_ be CreateISODateRecord(_y1_, _mon1_, _d1_).
+        1. Let _adjustedDate_ be CreateISODateRecord(_y2_, _mon2_, _d2_).
         1. If _timeSign_ = -_dateSign_, then
-          1. Set _adjustedDate_ to BalanceISODate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]] - _timeSign_).
+          1. Set _adjustedDate_ to BalanceISODate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]] + _timeSign_).
           1. Set _timeDuration_ to ? Add24HourDaysToNormalizedTimeDuration(_timeDuration_, -_timeSign_).
-        1. Let _date1_ be ! CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendarRec_.[[Receiver]]).
-        1. Let _date2_ be ! CreateTemporalDate(_y2_, _mon2_, _d2_, _calendarRec_.[[Receiver]]).
+        1. Let _date1_ be ! CreateTemporalDate(_y1_, _mon1_, _d1_, _calendarRec_.[[Receiver]]).
+        1. Let _date2_ be ! CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendarRec_.[[Receiver]]).
         1. Let _dateLargestUnit_ be LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
         1. Let _untilOptions_ be ! SnapshotOwnProperties(_options_, *null*).
         1. Perform ! CreateDataPropertyOrThrow(_untilOptions_, *"largestUnit"*, _dateLargestUnit_).


### PR DESCRIPTION
Fix for https://github.com/tc39/proposal-temporal/issues/2820

Fix bug where PlainDateTime since/until would maintain date/time-diff sign compatibility by backing-off from wrong end and erroneously falling across month boundaries

Tests: https://github.com/tc39/test262/pull/4078/files