### PR TITLE
Editorial: Next batch of minor editorial improvements

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -211,11 +211,11 @@ export class Duration {
   }
   add(other, options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    return ES.AddDurationToOrSubtractDurationFromDuration('add', this, other, options);
+    return ES.AddDurations('add', this, other, options);
   }
   subtract(other, options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    return ES.AddDurationToOrSubtractDurationFromDuration('subtract', this, other, options);
+    return ES.AddDurations('subtract', this, other, options);
   }
   round(roundTo) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -44,7 +44,7 @@
     <emu-alg>
       1. Let _resolvedYear_ be _year_ + floor(_month_ / 12).
       1. Let _resolvedMonth_ be _month_ modulo 12.
-      1. Find a time _t_ such that EpochTimeToEpochYear(_t_) is _resolvedYear_, EpochTimeToMonthInYear(_t_) is _resolvedMonth_, and EpochTimeToDate(_t_) is 1.
+      1. Find a time _t_ such that EpochTimeToEpochYear(_t_) = _resolvedYear_, EpochTimeToMonthInYear(_t_) = _resolvedMonth_, and EpochTimeToDate(_t_) = 1.
       1. Return EpochTimeToDayNumber(_t_) + _date_ - 1.
     </emu-alg>
     <emu-note type="editor"> This operation corresponds to ECMA-262 operation MakeDay(_year_, _month_, _date_). It calculates the result in mathematical values instead of Number values. These two operations would be unified when https://github.com/tc39/ecma262/issues/1087 is fixed.</emu-note>
@@ -88,8 +88,8 @@
     <p>The following function returns 1 for a time within leap year otherwise it returns 0:</p>
     <emu-eqn id="eqn-mathematicalinleapyear" aoid="MathematicalInLeapYear">
       MathematicalInLeapYear(_t_)
-        = 0 if MathematicalDaysInYear(EpochTimeToEpochYear(_t_)) is 365
-        = 1 if MathematicalDaysInYear(EpochTimeToEpochYear(_t_)) is 366
+        = 0 if MathematicalDaysInYear(EpochTimeToEpochYear(_t_)) = 365
+        = 1 if MathematicalDaysInYear(EpochTimeToEpochYear(_t_)) = 366
     </emu-eqn>
     <p>The month number for a time _t_ is given by:</p>
     <emu-eqn id="eqn-epochtimetomonthinyear" aoid="EpochTimeToMonthInYear">
@@ -113,18 +113,18 @@
     <p>The date number for a time _t_ is given by:</p>
     <emu-eqn id="eqn-epochtimetodate" aoid="EpochTimeToDate">
       EpochTimeToDate(_t_)
-        = EpochTimeToDayInYear(_t_) + 1 if EpochTimeToMonthInYear(_t_) is 0
-        = EpochTimeToDayInYear(_t_) - 30 if EpochTimeToMonthInYear(_t_) is 1
-        = EpochTimeToDayInYear(_t_) - 58 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 2
-        = EpochTimeToDayInYear(_t_) - 89 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 3
-        = EpochTimeToDayInYear(_t_) - 119 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 4
-        = EpochTimeToDayInYear(_t_) - 150 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 5
-        = EpochTimeToDayInYear(_t_) - 180 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 6
-        = EpochTimeToDayInYear(_t_) - 211 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 7
-        = EpochTimeToDayInYear(_t_) - 242 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 8
-        = EpochTimeToDayInYear(_t_) - 272 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 9
-        = EpochTimeToDayInYear(_t_) - 303 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 10
-        = EpochTimeToDayInYear(_t_) - 333 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) is 11
+        = EpochTimeToDayInYear(_t_) + 1 if EpochTimeToMonthInYear(_t_) = 0
+        = EpochTimeToDayInYear(_t_) - 30 if EpochTimeToMonthInYear(_t_) = 1
+        = EpochTimeToDayInYear(_t_) - 58 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 2
+        = EpochTimeToDayInYear(_t_) - 89 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 3
+        = EpochTimeToDayInYear(_t_) - 119 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 4
+        = EpochTimeToDayInYear(_t_) - 150 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 5
+        = EpochTimeToDayInYear(_t_) - 180 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 6
+        = EpochTimeToDayInYear(_t_) - 211 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 7
+        = EpochTimeToDayInYear(_t_) - 242 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 8
+        = EpochTimeToDayInYear(_t_) - 272 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 9
+        = EpochTimeToDayInYear(_t_) - 303 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 10
+        = EpochTimeToDayInYear(_t_) - 333 - MathematicalInLeapYear(_t_) if EpochTimeToMonthInYear(_t_) = 11
     </emu-eqn>
     <p>The weekday for a particular time _t_ is defined as:</p>
     <emu-eqn id="eqn-epochtimetoweekday" aoid="EpochTimeToWeekDay">EpochTimeToWeekDay(_t_) =(EpochTimeToDayNumber(_t_) + 4) modulo 7</emu-eqn>
@@ -654,25 +654,25 @@
             [[Unit]]: *"nanosecond"*,
             [[Increment]]: 1
           }.
-      1. If _fractionalDigitCount_ is 0, then
+      1. If _fractionalDigitCount_ = 0, then
         1. Return the Record {
             [[Precision]]: 0,
             [[Unit]]: *"second"*,
             [[Increment]]: 1
           }.
-      1. If _fractionalDigitCount_ is 1, 2, or 3, then
+      1. If _fractionalDigitCount_ is in the inclusive interval from 1 to 3, then
         1. Return the Record {
             [[Precision]]: _fractionalDigitCount_,
             [[Unit]]: *"millisecond"*,
             [[Increment]]: 10<sup>3 - _fractionalDigitCount_</sup>
           }.
-      1. If _fractionalDigitCount_ is 4, 5, or 6, then
+      1. If _fractionalDigitCount_ is in the inclusive interval from 4 to 6, then
         1. Return the Record {
             [[Precision]]: _fractionalDigitCount_,
             [[Unit]]: *"microsecond"*,
             [[Increment]]: 10<sup>6 - _fractionalDigitCount_</sup>
           }.
-      1. Assert: _fractionalDigitCount_ is 7, 8, or 9.
+      1. Assert: _fractionalDigitCount_ is in the inclusive interval from 7 to 9.
       1. Return the Record {
           [[Precision]]: _fractionalDigitCount_,
           [[Unit]]: *"nanosecond"*,
@@ -899,11 +899,11 @@
     </dl>
     <emu-alg>
       1. If _precision_ is *"auto"*, then
-        1. If _subSecondNanoseconds_ is 0, return the empty String.
+        1. If _subSecondNanoseconds_ = 0, return the empty String.
         1. Let _fractionString_ be ToZeroPaddedDecimalString(_subSecondNanoseconds_, 9).
         1. Set _fractionString_ to the longest prefix of _fractionString_ ending with a code unit other than 0x0030 (DIGIT ZERO).
       1. Else,
-        1. If _precision_ is 0, return the empty String.
+        1. If _precision_ = 0, return the empty String.
         1. Let _fractionString_ be ToZeroPaddedDecimalString(_subSecondNanoseconds_, 9).
         1. Set _fractionString_ to the substring of _fractionString_ from 0 to _precision_.
       1. Return the string-concatenation of the code unit 0x002E (FULL STOP) and _fractionString_.
@@ -1066,7 +1066,7 @@
       <dd>It considers _x_, bracketed below by _r1_ and above by _r2_, and returns either _r1_ or _r2_ according to _unsignedRoundingMode_.</dd>
     </dl>
     <emu-alg>
-      1. If _x_ is equal to _r1_, return _r1_.
+      1. If _x_ = _r1_, return _r1_.
       1. Assert: _r1_ &lt; _x_ &lt; _r2_.
       1. Assert: _unsignedRoundingMode_ is not *undefined*.
       1. If _unsignedRoundingMode_ is ~zero~, return _r1_.
@@ -1080,7 +1080,7 @@
       1. If _unsignedRoundingMode_ is ~half-infinity~, return _r2_.
       1. Assert: _unsignedRoundingMode_ is ~half-even~.
       1. Let _cardinality_ be <emu-eqn>(_r1_ / (_r2_ – _r1_)) modulo 2</emu-eqn>.
-      1. If _cardinality_ is 0, return _r1_.
+      1. If _cardinality_ = 0, return _r1_.
       1. Return _r2_.
     </emu-alg>
   </emu-clause>
@@ -1550,7 +1550,7 @@
         1. Let _secondMV_ be 0.
       1. Else,
         1. Let _secondMV_ be ℝ(StringToNumber(CodePointsToString(_second_))).
-        1. If _secondMV_ is 60, then
+        1. If _secondMV_ = 60, then
           1. Set _secondMV_ to 59.
       1. If _fSeconds_ is not empty, then
         1. Let _fSecondsDigits_ be the substring of CodePointsToString(_fSeconds_) from 1.

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1059,7 +1059,7 @@
       <emu-alg>
         1. If _month_ is 1, 3, 5, 7, 8, 10, or 12, return 31.
         1. If _month_ is 4, 6, 9, or 11, return 30.
-        1. Assert: _month_ is 2.
+        1. Assert: _month_ = 2.
         1. Return 28 + MathematicalInLeapYear(EpochTimeForYear(_year_)).
       </emu-alg>
     </emu-clause>
@@ -1090,12 +1090,12 @@
         1. If _week_ &lt; 1, then
           1. NOTE: This is the last week of the previous year.
           1. Let _dayOfJan1st_ be ToISODayOfWeek(_year_, 1, 1).
-          1. If _dayOfJan1st_ is _friday_, then
+          1. If _dayOfJan1st_ = _friday_, then
             1. Return Year-Week Record { [[Week]]: _maxWeekNumber_, [[Year]]: _year_ - 1 }.
-          1. If _dayOfJan1st_ is _saturday_, and MathematicalInLeapYear(EpochTimeForYear(_year_ - 1)) is 1, then
+          1. If _dayOfJan1st_ = _saturday_, and MathematicalInLeapYear(EpochTimeForYear(_year_ - 1)) = 1, then
             1. Return Year-Week Record { [[Week]]: _maxWeekNumber_. [[Year]]: _year_ - 1 }.
           1. Return Year-Week Record { [[Week]]: _maxWeekNumber_ - 1, [[Year]]: _year_ - 1 }.
-        1. If _week_ is _maxWeekNumber_, then
+        1. If _week_ = _maxWeekNumber_, then
           1. Let _daysInYear_ be MathematicalDaysInYear(_year_).
           1. Let _daysLaterInYear_ be _daysInYear_ - _dayOfYear_.
           1. Let _daysAfterThursday_ be _thursday_ - _dayOfWeek_.
@@ -2215,7 +2215,7 @@
         1. If _temporalDateLike_ is not an Object or _temporalDateLike_ does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], or [[InitializedTemporalYearMonth]] internal slot, then
           1. Set _temporalDateLike_ to ? ToTemporalDate(_temporalDateLike_).
         1. If _calendar_.[[Identifier]] is *"iso8601"*, then
-          1. If MathematicalInLeapYear(EpochTimeForYear(_temporalDateLike_.[[ISOYear]])) is 1, then
+          1. If MathematicalInLeapYear(EpochTimeForYear(_temporalDateLike_.[[ISOYear]])) = 1, then
             1. Let _inLeapYear_ be *true*.
           1. Else,
             1. Let _inLeapYear_ be *false*.

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1918,7 +1918,7 @@
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? GetTemporalOverflowOption(_options_).
         1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Let _balanceResult_ be BalanceTimeDuration(_norm_, *"day"*).
+        1. Let _balanceResult_ be ! BalanceTimeDuration(_norm_, *"day"*).
         1. If _calendar_.[[Identifier]] is *"iso8601"*, then
           1. Let _result_ be ? AddISODate(_date_.[[ISOYear]], _date_.[[ISOMonth]], _date_.[[ISODay]], _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]] + _balanceResult_.[[Days]], _overflow_).
         1. Else,

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -393,7 +393,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return ? AddDurationToOrSubtractDurationFromDuration(~add~, _duration_, _other_, _options_).
+        1. Return ? AddDurations(~add~, _duration_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -405,7 +405,7 @@
       <emu-alg>
         1. Let _duration_ be the *this* value.
         1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
-        1. Return ? AddDurationToOrSubtractDurationFromDuration(~subtract~, _duration_, _other_, _options_).
+        1. Return ? AddDurations(~subtract~, _duration_, _other_, _options_).
       </emu-alg>
     </emu-clause>
 
@@ -1699,88 +1699,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-addduration" type="abstract operation">
-      <h1>
-        AddDuration (
-          _y1_: an integer,
-          _mon1_: an integer,
-          _w1_: an integer,
-          _d1_: an integer,
-          _h1_: an integer,
-          _min1_: an integer,
-          _s1_: an integer,
-          _ms1_: an integer,
-          _mus1_: an integer,
-          _ns1_: an integer,
-          _y2_: an integer,
-          _mon2_: an integer,
-          _w2_: an integer,
-          _d2_: an integer,
-          _h2_: an integer,
-          _min2_: an integer,
-          _s2_: an integer,
-          _ms2_: an integer,
-          _mus2_: an integer,
-          _ns2_: an integer,
-          _plainRelativeTo_: a Temporal.PlainDate or *undefined*,
-          _calendarRec_: a Calendar Methods Record or *undefined*,
-          _zonedRelativeTo_: a Temporal.ZonedDateTime or *undefined*,
-          _timeZoneRec_: a Time Zone Methods Record or *undefined*,
-          optional _precalculatedPlainDateTime_: a Temporal.PlainDateTime or *undefined*,
-        ): either a normal completion containing a Duration Record or a throw completion
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It adds the components of a second duration represented by _y2_ through _ns2_ to those of a first duration represented by _y1_ through _ns1_, and balances the duration relative to the given date _zonedRelativeTo_ or _plainRelativeTo_, to ensure that no mixed signs remain in the result.</dd>
-      </dl>
-      <emu-alg>
-        1. Assert: If _zonedRelativeTo_ is not *undefined*, or _plainRelativeTo_ is not *undefined*, _calendarRec_ is not *undefined*.
-        1. Assert: If _zonedRelativeTo_ is not *undefined*, _timeZoneRec_ is not *undefined*.
-        1. Let _largestUnit1_ be DefaultTemporalLargestUnit(_y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_).
-        1. Let _largestUnit2_ be DefaultTemporalLargestUnit(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_).
-        1. Let _largestUnit_ be LargerOfTwoTemporalUnits(_largestUnit1_, _largestUnit2_).
-        1. Let _norm1_ be NormalizeTimeDuration(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
-        1. Let _norm2_ be NormalizeTimeDuration(_h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
-        1. If _zonedRelativeTo_ is *undefined* and _plainRelativeTo_ is *undefined*, then
-          1. If _largestUnit_ is one of *"year"*, *"month"*, or *"week"*, then
-            1. Throw a *RangeError* exception.
-          1. Let _normResult_ be ? AddNormalizedTimeDuration(_norm1_, _norm2_).
-          1. Set _normResult_ to ? Add24HourDaysToNormalizedTimeDuration(_normResult_, _d1_ + _d2_).
-          1. Let _result_ be BalanceTimeDuration(_normResult_, _largestUnit_).
-          1. Return CreateDurationRecord(0, 0, 0, _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
-        1. If _plainRelativeTo_ is not *undefined*, then
-          1. Assert: _zonedRelativeTo_ is *undefined*.
-          1. Let _dateDuration1_ be ! CreateTemporalDuration(_y1_, _mon1_, _w1_, _d1_, 0, 0, 0, 0, 0, 0).
-          1. Let _dateDuration2_ be ! CreateTemporalDuration(_y2_, _mon2_, _w2_, _d2_, 0, 0, 0, 0, 0, 0).
-          1. Let _intermediate_ be ? AddDate(_calendarRec_, _plainRelativeTo_, _dateDuration1_).
-          1. Let _end_ be ? AddDate(_calendarRec_, _intermediate_, _dateDuration2_).
-          1. Let _dateLargestUnit_ be LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
-          1. Let _differenceOptions_ be OrdinaryObjectCreate(*null*).
-          1. Perform ! CreateDataPropertyOrThrow(_differenceOptions_, *"largestUnit"*, _dateLargestUnit_).
-          1. Let _dateDifference_ be ? DifferenceDate(_calendarRec_, _plainRelativeTo_, _end_, _differenceOptions_).
-          1. Let _norm1WithDays_ be ? Add24HourDaysToNormalizedTimeDuration(_norm1_, _dateDifference_.[[Days]]).
-          1. Let _normResult_ be ? AddNormalizedTimeDuration(_norm1WithDays_, _norm2_).
-          1. Let _result_ be BalanceTimeDuration(_normResult_, _largestUnit_).
-          1. Return CreateDurationRecord(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
-        1. Assert: _zonedRelativeTo_ is not *undefined*.
-        1. If _precalculatedPlainDateTime_ is not present, let _precalculatedPlainDateTime_ be *undefined*.
-        1. If IsCalendarUnit(_largestUnit_) is *true*, or _largestUnit_ is *"day"*, let _startDateTimeNeeded_ be *true*; else let _startDateTimeNeeded_ be *false*.
-        1. If _precalculatedPlainDateTime_ is *undefined* and _startDateTimeNeeded_ is *true*, then
-          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _zonedRelativeTo_.[[Nanoseconds]], _calendarRec_.[[Receiver]]).
-        1. Else,
-          1. Let _startDateTime_ be _precalculatedPlainDateTime_.
-        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _y1_, _mon1_, _w1_, _d1_, _norm1_, _startDateTime_).
-        1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZoneRec_, _calendarRec_, _y2_, _mon2_, _w2_, _d2_, _norm2_).
-        1. If _largestUnit_ is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
-          1. Let _norm_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_endNs_, _zonedRelativeTo_.[[Nanoseconds]]).
-          1. Let _result_ be BalanceTimeDuration(_norm_, _largestUnit_).
-          1. Return CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
-        1. Let _diffResult_ be ? DifferenceZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, _timeZoneRec_, _calendarRec_, _largestUnit_, OrdinaryObjectCreate(*null*), _startDateTime_).
-        1. Let _timeResult_ be BalanceTimeDuration(_diffResult_.[[NormalizedTime]], *"hour"*).
-        1. Return CreateDurationRecord(_diffResult_.[[Years]], _diffResult_.[[Months]], _diffResult_.[[Weeks]], _diffResult_.[[Days]], _timeResult_.[[Hours]], _timeResult_.[[Minutes]], _timeResult_.[[Seconds]], _timeResult_.[[Milliseconds]], _timeResult_.[[Microseconds]], _timeResult_.[[Nanoseconds]]).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-daysuntil" type="abstract operation">
       <h1>
         DaysUntil (
@@ -2211,9 +2129,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-adddurationtoorsubtractdurationfromduration" type="abstract operation">
+    <emu-clause id="sec-temporal-adddurations" type="abstract operation">
       <h1>
-        AddDurationToOrSubtractDurationFromDuration (
+        AddDurations (
           _operation_: ~add~ or ~subtract~,
           _duration_: a Temporal.Duration,
           _other_: an ECMAScript language value,
@@ -2222,7 +2140,10 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It adds/subtracts _other_ to/from _duration_, resulting in a longer/shorter duration.</dd>
+        <dd>
+          It adds or subtracts the components of a second duration _other_ to or from those of a first duration _duration_, resulting in a longer or shorter duration.
+          It balances the result relative to the given `relativeTo` option, to ensure that no mixed signs remain in the result.
+        </dd>
       </dl>
       <emu-alg>
         1. If _operation_ is ~subtract~, let _sign_ be -1. Otherwise, let _sign_ be 1.
@@ -2233,8 +2154,65 @@
         1. Let _zonedRelativeTo_ be _relativeToRecord_.[[ZonedRelativeTo]].
         1. Let _timeZoneRec_ be _relativeToRecord_.[[TimeZoneRec]].
         1. Let _calendarRec_ be ? CreateCalendarMethodsRecordFromRelativeTo(_plainRelativeTo_, _zonedRelativeTo_, « ~date-add~, ~date-until~ »).
-        1. Let _result_ be ? AddDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]], _sign_ &times; _other_.[[Years]], _sign_ &times; _other_.[[Months]], _sign_ &times; _other_.[[Weeks]], _sign_ &times; _other_.[[Days]], _sign_ &times; _other_.[[Hours]], _sign_ &times; _other_.[[Minutes]], _sign_ &times; _other_.[[Seconds]], _sign_ &times; _other_.[[Milliseconds]], _sign_ &times; _other_.[[Microseconds]], _sign_ &times; _other_.[[Nanoseconds]], _plainRelativeTo_, _calendarRec_, _zonedRelativeTo_, _timeZoneRec_).
-        1. Return ! CreateTemporalDuration(_result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Let _y1_ be _duration_.[[Years]].
+        1. Let _mon1_ be _duration_.[[Months]].
+        1. Let _w1_ be _duration_.[[Weeks]].
+        1. Let _d1_ be _duration_.[[Days]].
+        1. Let _h1_ be _duration_.[[Hours]].
+        1. Let _min1_ be _duration_.[[Minutes]].
+        1. Let _s1_ be _duration_.[[Seconds]].
+        1. Let _ms1_ be _duration_.[[Milliseconds]].
+        1. Let _mus1_ be _duration_.[[Microseconds]].
+        1. Let _ns1_ be _duration_.[[Nanoseconds]].
+        1. Let _y2_ be _sign_ &times; _other_.[[Years]].
+        1. Let _mon2_ be _sign_ &times; _other_.[[Months]].
+        1. Let _w2_ be _sign_ &times; _other_.[[Weeks]].
+        1. Let _d2_ be _sign_ &times; _other_.[[Days]].
+        1. Let _h2_ be _sign_ &times; _other_.[[Hours]].
+        1. Let _min2_ be _sign_ &times; _other_.[[Minutes]].
+        1. Let _s2_ be _sign_ &times; _other_.[[Seconds]].
+        1. Let _ms2_ be _sign_ &times; _other_.[[Milliseconds]].
+        1. Let _mus2_ be _sign_ &times; _other_.[[Microseconds]].
+        1. Let _ns2_ be _sign_ &times; _other_.[[Nanoseconds]].
+        1. Let _largestUnit1_ be DefaultTemporalLargestUnit(_y1_, _mon1_, _w1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_).
+        1. Let _largestUnit2_ be DefaultTemporalLargestUnit(_y2_, _mon2_, _w2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_).
+        1. Let _largestUnit_ be LargerOfTwoTemporalUnits(_largestUnit1_, _largestUnit2_).
+        1. Let _norm1_ be NormalizeTimeDuration(_h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_).
+        1. Let _norm2_ be NormalizeTimeDuration(_h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. If _zonedRelativeTo_ is *undefined* and _plainRelativeTo_ is *undefined*, then
+          1. If IsCalendarUnit(_largestUnit_), throw a *RangeError* exception.
+          1. Let _normResult_ be ? AddNormalizedTimeDuration(_norm1_, _norm2_).
+          1. Set _normResult_ to ? Add24HourDaysToNormalizedTimeDuration(_normResult_, _d1_ + _d2_).
+          1. Let _result_ be BalanceTimeDuration(_normResult_, _largestUnit_).
+          1. Return ! CreateTemporalDuration(0, 0, 0, _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. If _plainRelativeTo_ is not *undefined*, then
+          1. Let _dateDuration1_ be ! CreateTemporalDuration(_y1_, _mon1_, _w1_, _d1_, 0, 0, 0, 0, 0, 0).
+          1. Let _dateDuration2_ be ! CreateTemporalDuration(_y2_, _mon2_, _w2_, _d2_, 0, 0, 0, 0, 0, 0).
+          1. Let _intermediate_ be ? AddDate(_calendarRec_, _plainRelativeTo_, _dateDuration1_).
+          1. Let _end_ be ? AddDate(_calendarRec_, _intermediate_, _dateDuration2_).
+          1. Let _dateLargestUnit_ be LargerOfTwoTemporalUnits(*"day"*, _largestUnit_).
+          1. Let _differenceOptions_ be OrdinaryObjectCreate(*null*).
+          1. Perform ! CreateDataPropertyOrThrow(_differenceOptions_, *"largestUnit"*, _dateLargestUnit_).
+          1. Let _dateDifference_ be ? DifferenceDate(_calendarRec_, _plainRelativeTo_, _end_, _differenceOptions_).
+          1. Let _norm1WithDays_ be ? Add24HourDaysToNormalizedTimeDuration(_norm1_, _dateDifference_.[[Days]]).
+          1. Let _normResult_ be ? AddNormalizedTimeDuration(_norm1WithDays_, _norm2_).
+          1. Let _result_ be BalanceTimeDuration(_normResult_, _largestUnit_).
+          1. Return ! CreateTemporalDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Assert: _zonedRelativeTo_ is not *undefined*.
+        1. Let _largestUnitCategory_ be the value in the "Category" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Singular" column contains _largestUnit_.
+        1. If _largestUnitCategory_ is ~date~, then
+          1. Let _startDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _zonedRelativeTo_.[[Nanoseconds]], _calendarRec_.[[Receiver]]).
+        1. Else,
+          1. Let _startDateTime_ be *undefined*.
+        1. Let _intermediateNs_ be ? AddZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _timeZoneRec_, _calendarRec_, _y1_, _mon1_, _w1_, _d1_, _norm1_, _startDateTime_).
+        1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZoneRec_, _calendarRec_, _y2_, _mon2_, _w2_, _d2_, _norm2_).
+        1. If _largestUnitCategory_ is ~time~, then
+          1. Let _norm_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_endNs_, _zonedRelativeTo_.[[Nanoseconds]]).
+          1. Let _result_ be BalanceTimeDuration(_norm_, _largestUnit_).
+          1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
+        1. Let _diffResult_ be ? DifferenceZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, _timeZoneRec_, _calendarRec_, _largestUnit_, OrdinaryObjectCreate(*null*), _startDateTime_).
+        1. Let _timeResult_ be BalanceTimeDuration(_diffResult_.[[NormalizedTime]], *"hour"*).
+        1. Return ! CreateTemporalDuration(_diffResult_.[[Years]], _diffResult_.[[Months]], _diffResult_.[[Weeks]], _diffResult_.[[Days]], _timeResult_.[[Hours]], _timeResult_.[[Minutes]], _timeResult_.[[Seconds]], _timeResult_.[[Milliseconds]], _timeResult_.[[Microseconds]], _timeResult_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -485,7 +485,7 @@
           1. If _calendarUnitsPresent_ is *true*, or IsCalendarUnit(_largestUnit_) is *true*, or IsCalendarUnit(_smallestUnit_) is *true*, throw a *RangeError* exception.
           1. Let _roundRecord_ be ? RoundTimeDuration(_duration_.[[Days]], _norm_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. Let _normWithDays_ be ? Add24HourDaysToNormalizedTimeDuration(_roundRecord_.[[NormalizedDuration]].[[Days]], _roundRecord_.[[NormalizedDuration]].[[NormalizedTime]]).
-          1. Let _balanceResult_ be BalanceTimeDuration(_normWithDays_, _largestUnit_).
+          1. Let _balanceResult_ be ? BalanceTimeDuration(_normWithDays_, _largestUnit_).
           1. Let _roundResult_ be CreateDurationRecord(0, 0, 0, _balanceResult_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]).
         1. Return ? CreateTemporalDuration(_roundResult_.[[Years]], _roundResult_.[[Months]], _roundResult_.[[Weeks]], _roundResult_.[[Days]], _roundResult_.[[Hours]], _roundResult_.[[Minutes]], _roundResult_.[[Seconds]], _roundResult_.[[Milliseconds]], _roundResult_.[[Microseconds]], _roundResult_.[[Nanoseconds]]).
       </emu-alg>
@@ -561,7 +561,7 @@
           1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]]).
           1. Let _roundRecord_ be ? RoundTimeDuration(0, _norm_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
           1. Set _norm_ to _roundRecord_.[[NormalizedDuration]].[[NormalizedTime]].
-          1. Let _result_ be BalanceTimeDuration(_norm_, LargerOfTwoTemporalUnits(_largestUnit_, *"second"*)).
+          1. Let _result_ be ! BalanceTimeDuration(_norm_, LargerOfTwoTemporalUnits(_largestUnit_, *"second"*)).
           1. Set _result_ to CreateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]] + _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Else,
           1. Let _result_ be _duration_.
@@ -1609,11 +1609,16 @@
         BalanceTimeDuration (
           _norm_: a Normalized Time Duration Record,
           _largestUnit_: a String,
-        ): a Time Duration Record
+        ): either a normal completion containing a Time Duration Record or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts a normalized time duration into a time duration with separated units, up to _largestUnit_.</dd>
+        <dd>
+          It converts a normalized time duration into a time duration with separated units, up to _largestUnit_.
+          The conversion may be lossy if _largestUnit_ is *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*.
+          In that case, the fields of the returned Time Duration Record may be unsafe (but float64-representable) integers.
+          The result of a lossy conversion may be outside the allowed range for Durations, even if the input was not.
+        </dd>
       </dl>
       <emu-alg>
         1. Let _days_, _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ be 0.
@@ -1670,6 +1675,7 @@
         1. Else,
           1. Assert: _largestUnit_ is *"nanosecond"*.
         1. NOTE: When _largestUnit_ is *"millisecond"*, *"microsecond"*, or *"nanosecond"*, _milliseconds_, _microseconds_, or _nanoseconds_ may be an unsafe integer. In this case, care must be taken when implementing the calculation using floating point arithmetic. It can be implemented in C++ using `std::fma()`. String manipulation will also give an exact result, since the multiplication is by a power of 10.
+        1. If IsValidDuration(0, 0, 0, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return CreateTimeDurationRecord(_days_ &times; _sign_, _hours_ &times; _sign_, _minutes_ &times; _sign_, _seconds_ &times; _sign_, _milliseconds_ &times; _sign_, _microseconds_ &times; _sign_, _nanoseconds_ &times; _sign_).
       </emu-alg>
     </emu-clause>
@@ -2074,7 +2080,7 @@
           1. Set _duration_ to ? BubbleRelativeDuration(_sign_, _duration_, _nudgeResult_.[[NudgedEpochNs]], _dateTime_, _calendarRec_, _timeZoneRec_, _largestUnit_, _startUnit_).
         1. If IsCalendarUnit(_largestUnit_) is *true* or _largestUnit_ is *"day"*, then
           1. Set _largestUnit_ to *"hour"*.
-        1. Let _balanceResult_ be BalanceTimeDuration(_duration_.[[NormalizedTime]], _largestUnit_).
+        1. Let _balanceResult_ be ? BalanceTimeDuration(_duration_.[[NormalizedTime]], _largestUnit_).
         1. Return the Record {
           [[Duration]]: CreateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _balanceResult_.[[Hours]], _balanceResult_.[[Minutes]], _balanceResult_.[[Seconds]], _balanceResult_.[[Milliseconds]], _balanceResult_.[[Microseconds]], _balanceResult_.[[Nanoseconds]]),
           [[Total]]: _nudgeResult_.[[Total]]
@@ -2183,7 +2189,7 @@
           1. If IsCalendarUnit(_largestUnit_), throw a *RangeError* exception.
           1. Let _normResult_ be ? AddNormalizedTimeDuration(_norm1_, _norm2_).
           1. Set _normResult_ to ? Add24HourDaysToNormalizedTimeDuration(_normResult_, _d1_ + _d2_).
-          1. Let _result_ be BalanceTimeDuration(_normResult_, _largestUnit_).
+          1. Let _result_ be ? BalanceTimeDuration(_normResult_, _largestUnit_).
           1. Return ! CreateTemporalDuration(0, 0, 0, _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. If _plainRelativeTo_ is not *undefined*, then
           1. Let _dateDuration1_ be ! CreateTemporalDuration(_y1_, _mon1_, _w1_, _d1_, 0, 0, 0, 0, 0, 0).
@@ -2196,7 +2202,7 @@
           1. Let _dateDifference_ be ? DifferenceDate(_calendarRec_, _plainRelativeTo_, _end_, _differenceOptions_).
           1. Let _norm1WithDays_ be ? Add24HourDaysToNormalizedTimeDuration(_norm1_, _dateDifference_.[[Days]]).
           1. Let _normResult_ be ? AddNormalizedTimeDuration(_norm1WithDays_, _norm2_).
-          1. Let _result_ be BalanceTimeDuration(_normResult_, _largestUnit_).
+          1. Let _result_ be ? BalanceTimeDuration(_normResult_, _largestUnit_).
           1. Return ! CreateTemporalDuration(_dateDifference_.[[Years]], _dateDifference_.[[Months]], _dateDifference_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Assert: _zonedRelativeTo_ is not *undefined*.
         1. Let _largestUnitCategory_ be the value in the "Category" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Singular" column contains _largestUnit_.
@@ -2208,10 +2214,10 @@
         1. Let _endNs_ be ? AddZonedDateTime(_intermediateNs_, _timeZoneRec_, _calendarRec_, _y2_, _mon2_, _w2_, _d2_, _norm2_).
         1. If _largestUnitCategory_ is ~time~, then
           1. Let _norm_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_endNs_, _zonedRelativeTo_.[[Nanoseconds]]).
-          1. Let _result_ be BalanceTimeDuration(_norm_, _largestUnit_).
+          1. Let _result_ be ? BalanceTimeDuration(_norm_, _largestUnit_).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
         1. Let _diffResult_ be ? DifferenceZonedDateTime(_zonedRelativeTo_.[[Nanoseconds]], _endNs_, _timeZoneRec_, _calendarRec_, _largestUnit_, OrdinaryObjectCreate(*null*), _startDateTime_).
-        1. Let _timeResult_ be BalanceTimeDuration(_diffResult_.[[NormalizedTime]], *"hour"*).
+        1. Let _timeResult_ be ! BalanceTimeDuration(_diffResult_.[[NormalizedTime]], *"hour"*).
         1. Return ! CreateTemporalDuration(_diffResult_.[[Years]], _diffResult_.[[Months]], _diffResult_.[[Weeks]], _diffResult_.[[Days]], _timeResult_.[[Hours]], _timeResult_.[[Minutes]], _timeResult_.[[Seconds]], _timeResult_.[[Milliseconds]], _timeResult_.[[Microseconds]], _timeResult_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -671,7 +671,7 @@
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, &laquo; &raquo;, *"nanosecond"*, *"second"*).
         1. Let _diffRecord_ be DifferenceInstant(_instant_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
         1. Let _norm_ be _diffRecord_.[[NormalizedTimeDuration]].
-        1. Let _result_ be BalanceTimeDuration(_norm_, _settings_.[[LargestUnit]]).
+        1. Let _result_ be ! BalanceTimeDuration(_norm_, _settings_.[[LargestUnit]]).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -831,7 +831,7 @@
       <emu-alg>
         1. Assert: IsValidISODate(_y2_, _m2_, _d2_).
         1. Let _comparison_ be CompareISODate(_y1_, _m1_, _d1_, _y2_, _m2_, _d2_).
-        1. If _sign_ &times; _comparison_ is 1, return *true*.
+        1. If _sign_ &times; _comparison_ = 1, return *true*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -1092,7 +1092,8 @@
           1. Return ? CalendarDateAdd(_calendarRec_, _plainDate_, _duration_, _options_).
         1. Let _overflow_ be ? GetTemporalOverflowOption(_options_).
         1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Let _days_ be _duration_.[[Days]] + BalanceTimeDuration(_norm_, *"day"*).[[Days]].
+        1. Let _balancedDuration_ be ! BalanceTimeDuration(_norm_, *"day"*).
+        1. Let _days_ be _duration_.[[Days]] + _balancedDuration_.[[Days]].
         1. Let _result_ be ? AddISODate(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], 0, 0, 0, _days_, _overflow_).
         1. Return ! CreateTemporalDate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _calendarRec_.[[Receiver]]).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -566,7 +566,7 @@
           1. Assert: _maximum_ is not *undefined*.
           1. Let _inclusive_ be *false*.
         1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, _inclusive_).
-        1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ is 1, then
+        1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ = 1, then
           1. Return ! CreateTemporalDateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _dateTime_.[[Calendar]]).
         1. Let _result_ be RoundISODateTime(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _dateTime_.[[Calendar]]).
@@ -1339,7 +1339,7 @@
         1. Let _timeSign_ be NormalizedTimeDurationSign(_timeDuration_).
         1. Let _dateSign_ be CompareISODate(_y2_, _mon2_, _d2_, _y1_, _mon1_, _d1_).
         1. Let _adjustedDate_ be CreateISODateRecord(_y1_, _mon1_, _d1_).
-        1. If _timeSign_ is -_dateSign_, then
+        1. If _timeSign_ = -_dateSign_, then
           1. Set _adjustedDate_ to BalanceISODate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]] - _timeSign_).
           1. Set _timeDuration_ to ? Add24HourDaysToNormalizedTimeDuration(_timeDuration_, -_timeSign_).
         1. Let _date1_ be ! CreateTemporalDate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]], _calendarRec_.[[Receiver]]).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1398,7 +1398,7 @@
         1. Let _diff_ be ? DifferenceISODateTime(_y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_, _calendarRec_, _largestUnit_, _resolvedOptions_).
         1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ = 1, then
           1. Let _normWithDays_ be ? Add24HourDaysToNormalizedTimeDuration(_diff_.[[NormalizedTime]], _diff_.[[Days]]).
-          1. Let _timeResult_ be BalanceTimeDuration(_normWithDays_, _largestUnit_).
+          1. Let _timeResult_ be ! BalanceTimeDuration(_normWithDays_, _largestUnit_).
           1. Let _total_ be NormalizedTimeDurationSeconds(_normWithDays_) × 10<sup>9</sup> + NormalizedTimeDurationSubseconds(_normWithDays_).
           1. Let _durationRecord_ be CreateDurationRecord(_diff_.[[Years]], _diff_.[[Months]], _diff_.[[Weeks]], _timeResult_.[[Days]], _timeResult_.[[Hours]], _timeResult_.[[Minutes]], _timeResult_.[[Seconds]], _timeResult_.[[Milliseconds]], _timeResult_.[[Microseconds]], _timeResult_.[[Nanoseconds]]).
           1. Return the Record { [[DurationRecord]]: _durationRecord_, [[Total]]: _total_ }.

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -1097,7 +1097,7 @@
         1. If _settings_.[[SmallestUnit]] is not *"nanosecond"* or _settings_.[[RoundingIncrement]] &ne; 1, then
           1. Let _roundRecord_ be ! RoundTimeDuration(0, _norm_, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
           1. Set _norm_ to _roundRecord_.[[NormalizedDuration]].[[NormalizedTime]].
-        1. Let _result_ be BalanceTimeDuration(_norm_, _settings_.[[LargestUnit]]).
+        1. Let _result_ be ! BalanceTimeDuration(_norm_, _settings_.[[LargestUnit]]).
         1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
       </emu-alg>
     </emu-clause>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -771,7 +771,7 @@
           1. Set _duration_ to CreateNegatedTemporalDuration(_duration_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Let _balanceResult_ be BalanceTimeDuration(_norm_, *"day"*).
+        1. Let _balanceResult_ be ! BalanceTimeDuration(_norm_, *"day"*).
         1. Let _days_ be _duration_.[[Days]] + _balanceResult_.[[Days]].
         1. Let _sign_ be DurationSign(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _days_, 0, 0, 0, 0, 0, 0).
         1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_yearMonth_.[[Calendar]], « ~date-add~, ~date-from-fields~, ~day~, ~fields~, ~year-month-from-fields~ »).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -625,9 +625,9 @@
       <emu-alg>
         1. If _year_ &lt; -271821 or _year_ &gt; 275760, then
           1. Return *false*.
-        1. If _year_ is -271821 and _month_ &lt; 4, then
+        1. If _year_ = -271821 and _month_ &lt; 4, then
           1. Return *false*.
-        1. If _year_ is 275760 and _month_ &gt; 9, then
+        1. If _year_ = 275760 and _month_ &gt; 9, then
           1. Return *false*.
         1. Return *true*.
       </emu-alg>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -595,7 +595,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-getianatimezonenexttransition" type="implementation-defined abstract operation">
+    <emu-clause id="sec-temporal-getnamedtimezonenexttransition" type="implementation-defined abstract operation">
       <h1>
         GetNamedTimeZoneNextTransition (
           _timeZoneIdentifier_: a String,
@@ -624,7 +624,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-getianatimezoneprevioustransition" type="implementation-defined abstract operation">
+    <emu-clause id="sec-temporal-getnamedtimezoneprevioustransition" type="implementation-defined abstract operation">
       <h1>
         GetNamedTimeZonePreviousTransition (
           _timeZoneIdentifier_: a String,

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1489,13 +1489,13 @@
         1. If IsCalendarUnit(_largestUnit_) is *false* and _largestUnit_ is not *"day"*, then
           1. Let _diffRecord_ be DifferenceInstant(_ns1_, _ns2_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. Let _norm_ be _diffRecord_.[[NormalizedTimeDuration]].
-          1. Let _result_ be BalanceTimeDuration(_norm_, _largestUnit_).
+          1. Let _result_ be ! BalanceTimeDuration(_norm_, _largestUnit_).
           1. Let _durationRecord_ be CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
           1. Return the Record { [[DurationRecord]]: _durationRecord_, [[Total]]: _diffRecord_.[[Total]] }.
         1. Let _difference_ be ? DifferenceZonedDateTime(_ns1_, _ns2_, _timeZoneRec_, _calendarRec_, _largestUnit_, _resolvedOptions_, _precalculatedPlainDateTime_).
         1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ = 1, let _roundingGranularityIsNoop_ be *true*; else let _roundingGranularityIsNoop_ be *false*.
         1. If _roundingGranularityIsNoop_ is *true*, then
-          1. Let _timeResult_ be BalanceTimeDuration(_difference_.[[NormalizedTime]], *"hour"*).
+          1. Let _timeResult_ be ! BalanceTimeDuration(_difference_.[[NormalizedTime]], *"hour"*).
           1. Let _total_ be NormalizedTimeDurationSeconds(_difference_.[[NormalizedTime]]) × 10<sup>9</sup> + NormalizedTimeDurationSubseconds(_difference_.[[NormalizedTime]]).
           1. Let _durationRecord_ be CreateDurationRecord(_difference_.[[Years]], _difference_.[[Months]], _difference_.[[Weeks]], _difference_.[[Days]], _timeResult_.[[Hours]], _timeResult_.[[Minutes]], _timeResult_.[[Seconds]], _timeResult_.[[Milliseconds]], _timeResult_.[[Microseconds]], _timeResult_.[[Nanoseconds]]).
           1. Return the Record { [[DurationRecord]]: _durationRecord_, [[Total]]: _total_ }.
@@ -1527,7 +1527,7 @@
         1. If _settings_.[[LargestUnit]] is not one of *"year"*, *"month"*, *"week"*, or *"day"*, then
           1. Let _diffRecord_ be DifferenceInstant(_zonedDateTime_.[[Nanoseconds]], _other_.[[Nanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
           1. Let _norm_ be _diffRecord_.[[NormalizedTimeDuration]].
-          1. Let _result_ be BalanceTimeDuration(_norm_, _settings_.[[LargestUnit]]).
+          1. Let _result_ be ! BalanceTimeDuration(_norm_, _settings_.[[LargestUnit]]).
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, _sign_ &times; _result_.[[Hours]], _sign_ &times; _result_.[[Minutes]], _sign_ &times; _result_.[[Seconds]], _sign_ &times; _result_.[[Milliseconds]], _sign_ &times; _result_.[[Microseconds]], _sign_ &times; _result_.[[Nanoseconds]]).
         1. NOTE: To calculate differences in two different time zones, _settings_.[[LargestUnit]] must be *"hour"* or smaller, because day lengths can vary between time zones due to DST and other UTC offset shifts.
         1. If ? TimeZoneEquals(_zonedDateTime_.[[TimeZone]], _other_.[[TimeZone]]) is *false*, then

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -793,7 +793,7 @@
           1. Assert: _maximum_ is not *undefined*.
           1. Let _inclusive_ be *false*.
         1. Perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, _inclusive_).
-        1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ is 1, then
+        1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ = 1, then
           1. Return ! CreateTemporalZonedDateTime(_zonedDateTime_.[[Nanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]]).
         1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~get-offset-nanoseconds-for~, ~get-possible-instants-for~ »).
         1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
@@ -1433,7 +1433,7 @@
       </dl>
       <p>Unless _ns1_ and _ns2_ are equal, _timeZoneRec_ must have looked up both `getOffsetNanosecondsFor` and `getPossibleInstantsFor`.</p>
       <emu-alg>
-        1. If _ns1_ is _ns2_, then
+        1. If _ns1_ = _ns2_, then
           1. Return ! CreateNormalizedDurationRecord(0, 0, 0, 0, ZeroTimeDuration()).
         1. Let _endInstant_ be ! CreateTemporalInstant(_ns2_).
         1. Let _endDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _endInstant_, _calendarRec_.[[Receiver]]).
@@ -1493,7 +1493,7 @@
           1. Let _durationRecord_ be CreateDurationRecord(0, 0, 0, 0, _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]).
           1. Return the Record { [[DurationRecord]]: _durationRecord_, [[Total]]: _diffRecord_.[[Total]] }.
         1. Let _difference_ be ? DifferenceZonedDateTime(_ns1_, _ns2_, _timeZoneRec_, _calendarRec_, _largestUnit_, _resolvedOptions_, _precalculatedPlainDateTime_).
-        1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ is 1, let _roundingGranularityIsNoop_ be *true*; else let _roundingGranularityIsNoop_ be *false*.
+        1. If _smallestUnit_ is *"nanosecond"* and _roundingIncrement_ = 1, let _roundingGranularityIsNoop_ be *true*; else let _roundingGranularityIsNoop_ be *false*.
         1. If _roundingGranularityIsNoop_ is *true*, then
           1. Let _timeResult_ be BalanceTimeDuration(_difference_.[[NormalizedTime]], *"hour"*).
           1. Let _total_ be NormalizedTimeDurationSeconds(_difference_.[[NormalizedTime]]) × 10<sup>9</sup> + NormalizedTimeDurationSubseconds(_difference_.[[NormalizedTime]]).


### PR DESCRIPTION
- After #2758, there is only one remaining caller of AddDuration. Inlining it into its caller makes it easier to implement / understand.
- Closes #2785 by making BalanceTimeDuration return a completion record, as @anba pointed out there are circumstances in which it can fail.
- Fix broken ESIDs
- Comparing numbers uses =, not "is"