### PR TITLE
Editorial: Replace AddDateTime with AddDate 

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1866,13 +1866,13 @@
         1. Let _start_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _startDuration_.[[Years]], _startDuration_.[[Months]], _startDuration_.[[Weeks]], _startDuration_.[[Days]], ZeroTimeDuration(), *undefined*).
         1. Let _end_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _endDuration_.[[Years]], _endDuration_.[[Months]], _endDuration_.[[Weeks]], _endDuration_.[[Days]], ZeroTimeDuration(), *undefined*).
         1. If _timeZoneRec_ is ~unset~, then
-          1. Let _startEpochNs_ be GetUTCEpochNanoseconds(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]], _start_.[[Hour]], _start_.[[Minute]], _start_.[[Second]], _start_.[[Millisecond]], _start_.[[Microsecond]], _start_.[[Nanosecond]]).
-          1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _end_.[[Hour]], _end_.[[Minute]], _end_.[[Second]], _end_.[[Millisecond]], _end_.[[Microsecond]], _end_.[[Nanosecond]]).
+          1. Let _startEpochNs_ be GetUTCEpochNanoseconds(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]]).
+          1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]]).
         1. Else,
-          1. Let _startDateTime_ be ! CreateTemporalDateTime(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]], _start_.[[Hour]], _start_.[[Minute]], _start_.[[Second]], _start_.[[Millisecond]], _start_.[[Microsecond]], _start_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
+          1. Let _startDateTime_ be ! CreateTemporalDateTime(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
           1. Let _startInstant_ be ? GetInstantFor(_timeZoneRec_, _startDateTime_, *"compatible"*).
           1. Let _startEpochNs_ be _startInstant_.[[Nanoseconds]].
-          1. Let _endDateTime_ be ! CreateTemporalDateTime(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _end_.[[Hour]], _end_.[[Minute]], _end_.[[Second]], _end_.[[Millisecond]], _end_.[[Microsecond]], _end_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
+          1. Let _endDateTime_ be ! CreateTemporalDateTime(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
           1. Let _endInstant_ be ? GetInstantFor(_timeZoneRec_, _endDateTime_, *"compatible"*).
           1. Let _endEpochNs_ be _endInstant_.[[Nanoseconds]].
         1. If _sign_ is 1, then

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1863,16 +1863,18 @@
           1. Let _endDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _r2_).
         1. Assert: If _sign_ is 1, _r1_ &ge; 0 and _r1_ &lt; _r2_.
         1. Assert: If _sign_ is -1, _r1_ &le; 0 and _r1_ &gt; _r2_.
-        1. Let _start_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _startDuration_.[[Years]], _startDuration_.[[Months]], _startDuration_.[[Weeks]], _startDuration_.[[Days]], ZeroTimeDuration(), *undefined*).
-        1. Let _end_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _endDuration_.[[Years]], _endDuration_.[[Months]], _endDuration_.[[Weeks]], _endDuration_.[[Days]], ZeroTimeDuration(), *undefined*).
+        1. Let _startDate_ be ! CreateTemporalDate(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _calendarRec_.[[Receiver]]).
+        1. Let _start_ be ? AddDate(_calendarRec_, _startDate_, ! CreateTemporalDuration(_startDuration_.[[Years]], _startDuration_.[[Months]], _startDuration_.[[Weeks]], _startDuration_.[[Days]], 0, 0, 0, 0, 0, 0)).
+        1. Let _endDate_ be ! CreateTemporalDate(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _calendarRec_.[[Receiver]]).
+        1. Let _end_ be ? AddDate(_calendarRec_, _endDate_, ! CreateTemporalDuration(_endDuration_.[[Years]], _endDuration_.[[Months]], _endDuration_.[[Weeks]], _endDuration_.[[Days]], 0, 0, 0, 0, 0, 0)).
         1. If _timeZoneRec_ is ~unset~, then
-          1. Let _startEpochNs_ be GetUTCEpochNanoseconds(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]]).
-          1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]]).
+          1. Let _startEpochNs_ be GetUTCEpochNanoseconds(_start_.[[ISOYear]], _start_.[[ISOMonth]], _start_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]]).
+          1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_end_.[[ISOYear]], _end_.[[ISOMonth]], _end_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]]).
         1. Else,
-          1. Let _startDateTime_ be ! CreateTemporalDateTime(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
+          1. Let _startDateTime_ be ! CreateTemporalDateTime(_start_.[[ISOYear]], _start_.[[ISOMonth]], _start_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
           1. Let _startInstant_ be ? GetInstantFor(_timeZoneRec_, _startDateTime_, *"compatible"*).
           1. Let _startEpochNs_ be _startInstant_.[[Nanoseconds]].
-          1. Let _endDateTime_ be ! CreateTemporalDateTime(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
+          1. Let _endDateTime_ be ! CreateTemporalDateTime(_end_.[[ISOYear]], _end_.[[ISOMonth]], _end_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
           1. Let _endInstant_ be ? GetInstantFor(_timeZoneRec_, _endDateTime_, *"compatible"*).
           1. Let _endEpochNs_ be _endInstant_.[[Nanoseconds]].
         1. If _sign_ is 1, then

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -2027,28 +2027,29 @@
           1. If _unit_ is not *"week"*, or _largestUnit_ is *"week"*, then
             1. If _unit_ is *"year"*, then
               1. Let _years_ be _duration_.[[Years]] + _sign_.
-              1. Let _endDuration_ be ? CreateNormalizedDurationRecord(_years_, 0, 0, 0, ZeroTimeDuration()).
+              1. Let _endDuration_ be ? CreateDateDurationRecord(_years_, 0, 0, 0).
             1. Else if _unit_ is *"month"*, then
               1. Let _months_ be _duration_.[[Months]] + _sign_.
-              1. Let _endDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _months_, 0, 0, ZeroTimeDuration()).
+              1. Let _endDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _months_, 0, 0).
             1. Else if _unit_ is *"week"*, then
               1. Let _weeks_ be _duration_.[[Weeks]] + _sign_.
-              1. Let _endDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _weeks_, 0, ZeroTimeDuration()).
+              1. Let _endDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _weeks_, 0).
             1. Else,
               1. Assert: _unit_ is *"day"*.
               1. Let _days_ be _duration_.[[Days]] + _sign_.
-              1. Let _endDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _days_, ZeroTimeDuration()).
-            1. Let _end_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _endDuration_.[[Years]], _endDuration_.[[Months]], _endDuration_.[[Weeks]], _endDuration_.[[Days]], _endDuration_.[[NormalizedTime]], *undefined*).
+              1. Let _endDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _days_).
+            1. Let _date_ be ! CreateTemporalDate(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _calendarRec_.[[Receiver]]).
+            1. Let _end_ be ? AddDate(_calendarRec_, _date_, ! CreateTemporalDuration(_endDuration_.[[Years]], _endDuration_.[[Months]], _endDuration_.[[Weeks]], _endDuration_.[[Days]], 0, 0, 0, 0, 0, 0)).
             1. If _timeZoneRec_ is ~unset~, then
-              1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _end_.[[Hour]], _end_.[[Minute]], _end_.[[Second]], _end_.[[Millisecond]], _end_.[[Microsecond]], _end_.[[Nanosecond]]).
+              1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_end_.[[ISOYear]], _end_.[[ISOMonth]], _end_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]]).
             1. Else,
-              1. Let _endDateTime_ be ! CreateTemporalDateTime(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _end_.[[Hour]], _end_.[[Minute]], _end_.[[Second]], _end_.[[Millisecond]], _end_.[[Microsecond]], _end_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
+              1. Let _endDateTime_ be ! CreateTemporalDateTime(_end_.[[ISOYear]], _end_.[[ISOMonth]], _end_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
               1. Let _endInstant_ be ? GetInstantFor(_timeZoneRec_, _endDateTime_, *"compatible"*).
               1. Let _endEpochNs_ be _endInstant_.[[Nanoseconds]].
             1. Let _beyondEnd_ be _nudgedEpochNs_ - _endEpochNs_.
             1. If _beyondEnd_ &lt; 0, let _beyondEndSign_ be -1; else if _beyondEnd_ &gt; 0, let _beyondEndSign_ be 1; else let _beyondEndSign_ be 0.
             1. If _beyondEndSign_ &ne; -_sign_, then
-              1. Set _duration_ to _endDuration_.
+              1. Set _duration_ to ! CombineDateAndNormalizedTimeDuration(_endDuration_, ZeroTimeDuration()).
             1. Else,
               1. Set _done_ to *true*.
           1. Set _unitIndex_ to _unitIndex_ - 1.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1926,10 +1926,11 @@
       </dl>
       <emu-alg>
         1. Assert: The value in the "Category" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Singular" column contains _unit_, is ~time~.
-        1. Let _start_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], ZeroTimeDuration(), *undefined*).
-        1. Let _startDateTime_ be ! CreateTemporalDateTime(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]], _start_.[[Hour]], _start_.[[Minute]], _start_.[[Second]], _start_.[[Millisecond]], _start_.[[Microsecond]], _start_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
-        1. Let _endDate_ be BalanceISODate(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]] + _sign_).
-        1. Let _endDateTime_ be ? CreateTemporalDateTime(_endDate_.[[Year]], _endDate_.[[Month]], _endDate_.[[Day]], _start_.[[Hour]], _start_.[[Minute]], _start_.[[Second]], _start_.[[Millisecond]], _start_.[[Microsecond]], _start_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
+        1. Let _date_ be ! CreateTemporalDate(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _calendarRec_.[[Receiver]]).
+        1. Let _start_ be ? AddDate(_calendarRec_, _date_, ! CreateTemporalDuration(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], 0, 0, 0, 0, 0, 0)).
+        1. Let _startDateTime_ be ! CreateTemporalDateTime(_start_.[[ISOYear]], _start_.[[ISOMonth]], _start_.[[ISODay]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
+        1. Let _endDate_ be BalanceISODate(_start_.[[ISOYear]], _start_.[[ISOMonth]], _start_.[[ISODay]] + _sign_).
+        1. Let _endDateTime_ be ? CreateTemporalDateTime(_endDate_.[[Year]], _endDate_.[[Month]], _endDate_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
         1. Let _startInstant_ be ? GetInstantFor(_timeZoneRec_, _startDateTime_, *"compatible"*).
         1. Let _startEpochNs_ be _startInstant_.[[Nanoseconds]].
         1. Let _endInstant_ be ? GetInstantFor(_timeZoneRec_, _endDateTime_, *"compatible"*).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1833,14 +1833,14 @@
           1. Let _years_ be RoundNumberToIncrement(_duration_.[[Years]], _increment_, *"trunc"*).
           1. Let _r1_ be _years_.
           1. Let _r2_ be _years_ + _increment_ &times; _sign_.
-          1. Let _startDuration_ be ? CreateNormalizedDurationRecord(_r1_, 0, 0, 0, ZeroTimeDuration()).
-          1. Let _endDuration_ be ? CreateNormalizedDurationRecord(_r2_, 0, 0, 0, ZeroTimeDuration()).
+          1. Let _startDuration_ be ? CreateDateDurationRecord(_r1_, 0, 0, 0).
+          1. Let _endDuration_ be ? CreateDateDurationRecord(_r2_, 0, 0, 0).
         1. Else if _unit_ is *"month"*, then
           1. Let _months_ be RoundNumberToIncrement(_duration_.[[Months]], _increment_, *"trunc"*).
           1. Let _r1_ be _months_.
           1. Let _r2_ be _months_ + _increment_ &times; _sign_.
-          1. Let _startDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _r1_, 0, 0, ZeroTimeDuration()).
-          1. Let _endDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _r2_, 0, 0, ZeroTimeDuration()).
+          1. Let _startDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _r1_, 0, 0).
+          1. Let _endDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _r2_, 0, 0).
         1. Else if _unit_ is *"week"*, then
           1. Let _isoResult1_ be BalanceISODate(_dateTime_.[[Year]] + _duration_.[[Years]], _dateTime_.[[Month]] + _duration_.[[Months]], _dateTime_.[[Day]]).
           1. Let _isoResult2_ be BalanceISODate(_dateTime_.[[Year]] + _duration_.[[Years]], _dateTime_.[[Month]] + _duration_.[[Months]], _dateTime_.[[Day]] + _duration_.[[Days]]).
@@ -1852,19 +1852,19 @@
           1. Let _weeks_ be RoundNumberToIncrement(_duration_.[[Weeks]] + _untilResult_.[[Weeks]], _increment_, *"trunc"*).
           1. Let _r1_ be _weeks_.
           1. Let _r2_ be _weeks_ + _increment_ &times; _sign_.
-          1. Let _startDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _r1_, 0, ZeroTimeDuration()).
-          1. Let _endDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _r2_, 0, ZeroTimeDuration()).
+          1. Let _startDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _r1_, 0).
+          1. Let _endDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _r2_, 0).
         1. Else,
           1. Assert: _unit_ is *"day"*.
           1. Let _days_ be RoundNumberToIncrement(_duration_.[[Days]], _increment_, *"trunc"*).
           1. Let _r1_ be _days_.
           1. Let _r2_ be _days_ + _increment_ &times; _sign_.
-          1. Let _startDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _r1_, ZeroTimeDuration()).
-          1. Let _endDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _r2_, ZeroTimeDuration()).
+          1. Let _startDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _r1_).
+          1. Let _endDuration_ be ? CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _r2_).
         1. Assert: If _sign_ is 1, _r1_ &ge; 0 and _r1_ &lt; _r2_.
         1. Assert: If _sign_ is -1, _r1_ &le; 0 and _r1_ &gt; _r2_.
-        1. Let _start_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _startDuration_.[[Years]], _startDuration_.[[Months]], _startDuration_.[[Weeks]], _startDuration_.[[Days]], _startDuration_.[[NormalizedTime]], *undefined*).
-        1. Let _end_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _endDuration_.[[Years]], _endDuration_.[[Months]], _endDuration_.[[Weeks]], _endDuration_.[[Days]], _endDuration_.[[NormalizedTime]], *undefined*).
+        1. Let _start_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _startDuration_.[[Years]], _startDuration_.[[Months]], _startDuration_.[[Weeks]], _startDuration_.[[Days]], ZeroTimeDuration(), *undefined*).
+        1. Let _end_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _endDuration_.[[Years]], _endDuration_.[[Months]], _endDuration_.[[Weeks]], _endDuration_.[[Days]], ZeroTimeDuration(), *undefined*).
         1. If _timeZoneRec_ is ~unset~, then
           1. Let _startEpochNs_ be GetUTCEpochNanoseconds(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]], _start_.[[Hour]], _start_.[[Minute]], _start_.[[Second]], _start_.[[Millisecond]], _start_.[[Microsecond]], _start_.[[Nanosecond]]).
           1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _end_.[[Hour]], _end_.[[Minute]], _end_.[[Second]], _end_.[[Millisecond]], _end_.[[Microsecond]], _end_.[[Nanosecond]]).
@@ -1898,6 +1898,7 @@
           1. Let _didExpandCalendarUnit_ be *false*.
           1. Let _resultDuration_ be _startDuration_.
           1. Let _nudgedEpochNs_ be _startEpochNs_.
+        1. Set _resultDuration_ to ! CombineDateAndNormalizedTimeDuration(_resultDuration_, ZeroTimeDuration()).
         1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[Total]]: _total_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandCalendarUnit_ }.
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1903,6 +1903,10 @@
         1. Set _resultDuration_ to ! CombineDateAndNormalizedTimeDuration(_resultDuration_, ZeroTimeDuration()).
         1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[Total]]: _total_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandCalendarUnit_ }.
       </emu-alg>
+
+      <emu-note type="editor">
+        _startDate_ and _endDate_ are distinct objects because they're potentially passed to user-code when _calendarRec_.[[Receiver]] is a user-defined calendar.
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-temporal-nudgetozonedtime" type="abstract operation">


### PR DESCRIPTION
Replacing AddDateTime with AddDate makes it easier (for implementers) to see why it's okay to skip all time duration normalization steps.

e283b594f199f06e210bd80b9216c9668d4d6030:
- Avoid creating a normalized duration record whose time component is always zero.

9e220c77f52beda604d3402607a2ccd12466ade8:
- Read time components directly from input date-time.

0739c719946f22d95e411d2285448ac697ac01e1:
- And finally replace AddDateTime with AddDate in NudgeToCalendarUnit.

aee35382c4d64dbeb31c31d7224100e2c944ee47:
- Same changes as the first three commits, but this time for NudgeToZonedTime.

5776d1a33ae7f56a5f40ec5f9d94c905521c4df4:
- Same changes as the first three commits, but this time for BubbleRelativeDuration.
