### PR TITLE
Fix the doc markup for PlainDate properties

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -178,7 +178,7 @@ The above read-only properties allow accessing each component of a date individu
   For common (non-leap) months, `monthCode` should be `` `M${month}` ``, where `month` is zero padded up to two digits.
   For uncommon (leap) months in lunisolar calendars like Hebrew or Chinese, the month code is the previous month's code with an "L" suffix appended.
   Examples: `'M02'` => February; `'M08L'` => repeated 8th month in the Chinese calendar; `'M05L'` => Adar I in the Hebrew calendar.
-  - `day` is a positive integer representing the day of the month.
+- `day` is a positive integer representing the day of the month.
 
 Either `month` or `monthCode` can be used in `from` or `with` to refer to the month.
 Similarly, in calendars that user eras an `era`/`eraYear` pair can be used in place of `year` when calling `from` or `with`.


### PR DESCRIPTION
day is not a subfield of monthCode