### PR TITLE
Editorial: Add missing checks before calling ApplyUnsignedRoundingMode

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3805,6 +3805,10 @@ function NudgeToCalendarUnit(
       throw new Error('assert not reached');
   }
 
+  if ((sign === 1 && (r1 < 0 || r1 >= r2)) || (sign === -1 && (r1 > 0 || r1 <= r2))) {
+    throw new Error('assertion failed: ordering of r1, r2 according to sign');
+  }
+
   // Apply to origin, output PlainDateTimes
   const start = AddDateTime(
     dateTime.year,
@@ -3896,22 +3900,33 @@ function NudgeToCalendarUnit(
   }
 
   // Round the smallestUnit within the epoch-nanosecond span
-  if (endEpochNs.equals(startEpochNs)) {
+  if (
+    (sign === 1 && (startEpochNs.gt(destEpochNs) || destEpochNs.geq(endEpochNs))) ||
+    (sign === -1 && (endEpochNs.geq(destEpochNs) || destEpochNs.gt(startEpochNs)))
+  ) {
     throw new RangeError(`custom calendar reported a ${unit} that is 0 days long`);
+  }
+  if (endEpochNs.equals(startEpochNs)) {
+    throw new Error('assertion failed: startEpochNs ≠ endEpochNs');
   }
   const numerator = TimeDuration.fromEpochNsDiff(destEpochNs, startEpochNs);
   const denominator = TimeDuration.fromEpochNsDiff(endEpochNs, startEpochNs);
   const unsignedRoundingMode = GetUnsignedRoundingMode(roundingMode, sign < 0 ? 'negative' : 'positive');
   const cmp = numerator.add(numerator).abs().subtract(denominator.abs()).sign();
-  const even = (r1 / (increment * sign)) % 2 === 0;
-  const roundedUnit = numerator.isZero() ? r1 : ApplyUnsignedRoundingMode(r1, r2, cmp, even, unsignedRoundingMode);
+  const even = (MathAbs(r1) / increment) % 2 === 0;
+  const roundedUnit = numerator.isZero()
+    ? MathAbs(r1)
+    : ApplyUnsignedRoundingMode(MathAbs(r1), MathAbs(r2), cmp, even, unsignedRoundingMode);
 
   // Trick to minimize rounding error, due to the lack of fma() in JS
   const fakeNumerator = new TimeDuration(denominator.totalNs.times(r1).add(numerator.totalNs.times(increment * sign)));
   const total = fakeNumerator.fdiv(denominator.totalNs);
+  if (MathAbs(total) < MathAbs(r1) || MathAbs(total) >= MathAbs(r2)) {
+    throw new Error('assertion failed: r1 ≤ total < r2');
+  }
 
   // Determine whether expanded or contracted
-  const didExpandCalendarUnit = MathSign(roundedUnit - total) === sign;
+  const didExpandCalendarUnit = roundedUnit === MathAbs(r2);
   duration = didExpandCalendarUnit ? endDuration : startDuration;
 
   return {

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1100,15 +1100,15 @@
     <emu-alg>
       1. Let _quotient_ be _x_ / _increment_.
       1. If _quotient_ &lt; 0, then
-        1. Let _isNegative_ be *true*.
+        1. Let _isNegative_ be ~negative~.
         1. Set _quotient_ to -_quotient_.
       1. Else,
-        1. Let _isNegative_ be *false*.
+        1. Let _isNegative_ be ~positive~.
       1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_roundingMode_, _isNegative_).
       1. Let _r1_ be the largest integer such that _r1_ ≤ _quotient_.
       1. Let _r2_ be the smallest integer such that _r2_ &gt; _quotient_.
       1. Let _rounded_ be ApplyUnsignedRoundingMode(_quotient_, _r1_, _r2_, _unsignedRoundingMode_).
-      1. If _isNegative_ is *true*, set _rounded_ to -_rounded_.
+      1. If _isNegative_ is ~negative~, set _rounded_ to -_rounded_.
       1. Return _rounded_ &times; _increment_.
     </emu-alg>
   </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1861,6 +1861,8 @@
           1. Let _r2_ be _days_ + _increment_ &times; _sign_.
           1. Let _startDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _r1_, ZeroTimeDuration()).
           1. Let _endDuration_ be ? CreateNormalizedDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _r2_, ZeroTimeDuration()).
+        1. Assert: If _sign_ is 1, _r1_ &ge; 0 and _r1_ &lt; _r2_.
+        1. Assert: If _sign_ is -1, _r1_ &le; 0 and _r1_ &gt; _r2_.
         1. Let _start_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _startDuration_.[[Years]], _startDuration_.[[Months]], _startDuration_.[[Weeks]], _startDuration_.[[Days]], _startDuration_.[[NormalizedTime]], *undefined*).
         1. Let _end_ be ? AddDateTime(_dateTime_.[[Year]], _dateTime_.[[Month]], _dateTime_.[[Day]], _dateTime_.[[Hour]], _dateTime_.[[Minute]], _dateTime_.[[Second]], _dateTime_.[[Millisecond]], _dateTime_.[[Microsecond]], _dateTime_.[[Nanosecond]], _calendarRec_, _endDuration_.[[Years]], _endDuration_.[[Months]], _endDuration_.[[Weeks]], _endDuration_.[[Days]], _endDuration_.[[NormalizedTime]], *undefined*).
         1. If _timeZoneRec_ is ~unset~, then
@@ -1873,15 +1875,22 @@
           1. Let _endDateTime_ be ! CreateTemporalDateTime(_end_.[[Year]], _end_.[[Month]], _end_.[[Day]], _end_.[[Hour]], _end_.[[Minute]], _end_.[[Second]], _end_.[[Millisecond]], _end_.[[Microsecond]], _end_.[[Nanosecond]], _calendarRec_.[[Receiver]]).
           1. Let _endInstant_ be ? GetInstantFor(_timeZoneRec_, _endDateTime_, *"compatible"*).
           1. Let _endEpochNs_ be _endInstant_.[[Nanoseconds]].
-        1. If _endEpochNs_ = _startEpochNs_, throw a *RangeError* exception.
-        1. If _sign_ &lt; 0, let _isNegative_ be ~negative~; else let _isNegative_ be ~positive~.
-        1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_roundingMode_, _isNegative_).
+        1. If _sign_ is 1, then
+          1. If _startEpochNs_ &gt; _destEpochNs_ or _destEpochNs_ &ge; _endEpochNs_, throw a *RangeError* exception.
+          1. Assert: _startEpochNs_ &le; _destEpochNs_ &lt; _endEpochNs_.
+        1. Else,
+          1. If _endEpochNs_ &ge; _destEpochNs_ or _destEpochNs_ &gt; _startEpochNs_, throw a *RangeError* exception.
+          1. Assert: _endEpochNs_ &lt; _destEpochNs_ &le; _startEpochNs_.
+        1. Assert: _startEpochNs_ &ne; _endEpochNs_.
         1. Let _progress_ be (_destEpochNs_ - _startEpochNs_) / (_endEpochNs_ - _startEpochNs_).
         1. Let _total_ be _r1_ + _progress_ &times; _increment_ &times; _sign_.
         1. NOTE: The above two steps cannot be implemented directly using floating-point arithmetic. This division can be implemented as if constructing Normalized Time Duration Records for the denominator and numerator of _total_ and performing one division operation with a floating-point result.
-        1. Let _roundedUnit_ be ApplyUnsignedRoundingMode(_total_, _r1_, _r2_, _unsignedRoundingMode_).
-        1. If _roundedUnit_ - _total_ &lt 0, let _roundedSign_ be -1; else let _roundedSign_ be 1.
-        1. If _roundedSign_ = _sign_, then
+        1. Assert: 0 &le; _progress_ &lt; 1.
+        1. If _sign_ &lt; 0, let _isNegative_ be ~negative~; else let _isNegative_ be ~positive~.
+        1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_roundingMode_, _isNegative_).
+        1. Assert: abs(_r1_) &le; abs(_total_) &lt; abs(_r2_).
+        1. Let _roundedUnit_ be ApplyUnsignedRoundingMode(abs(_total_), abs(_r1_), abs(_r2_), _unsignedRoundingMode_).
+        1. If _roundedUnit_ is abs(_r2_), then
           1. Let _didExpandCalendarUnit_ be *true*.
           1. Let _resultDuration_ be _endDuration_.
           1. Let _nudgedEpochNs_ be _endEpochNs_.


### PR DESCRIPTION
Changes:
- I've inserted `abs` for all arguments passed to `ApplyUnsignedRoundingMode` to ensure the `r1 ≤ x < r2` requirement in `ApplyUnsignedRoundingMode` is fulfilled. 
- Furthermore `startEpochNs` and `endEpochNs` are now required to be correctly ordered. This ensures that `progress` is a proper fraction. (If it's not a proper fraction, then `abs(total)` can be larger than `abs(r2)`, which is invalid for `ApplyUnsignedRoundingMode`.)
- Also fixes #2893 by comparing `roundedUnit` against `abs(r2)`. 