### PR TITLE
Editorial: Consistently mark increment as "positive integer"

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1089,7 +1089,7 @@
     <h1>
       RoundNumberToIncrement (
         _x_: a mathematical value,
-        _increment_: an integer,
+        _increment_: a positive integer,
         _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
       ): an integer
     </h1>
@@ -1117,7 +1117,7 @@
     <h1>
       RoundNumberToIncrementAsIfPositive (
         _x_: a mathematical value,
-        _increment_: an integer,
+        _increment_: a positive integer,
         _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
       ): an integer
     </h1>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1510,7 +1510,7 @@
       <h1>
         RoundNormalizedTimeDurationToIncrement (
           _d_: a Normalized Time Duration Record,
-          _increment_: an integer,
+          _increment_: a positive integer,
           _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): either a normal completion containing a Normalized Time Duration Record or a throw completion
       </h1>
@@ -1729,7 +1729,7 @@
         RoundTimeDuration (
           _days_: an integer,
           _norm_: a Normalized Time Duration Record,
-          _increment_: an integer,
+          _increment_: a positive integer,
           _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
           _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): either a normal completion containing a Record with fields [[NormalizedDuration]] (a Normalized Duration Record) and [[Total]] (a mathematical value), or a throw completion
@@ -1816,7 +1816,7 @@
           _dateTime_: an ISO Date-Time Record,
           _calendarRec_: a Calendar Method Record,
           _timeZoneRec_: a Time Zone Method Record or ~unset~,
-          _increment_: an integer,
+          _increment_: a positive integer,
           _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
           _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): either a normal completion containing a Duration Nudge Result Record or a throw completion
@@ -1900,7 +1900,7 @@
           _dateTime_: an ISO Date-Time Record,
           _calendarRec_: a Calendar Method Record,
           _timeZoneRec_: a Time Zone Method Record,
-          _increment_: an integer,
+          _increment_: a positive integer,
           _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
           _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): either a normal completion containing a Duration Nudge Result Record or a throw completion
@@ -1946,7 +1946,7 @@
           _duration_: a Normalized Duration Record,
           _destEpochNs_: a BigInt,
           _largestUnit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
-          _increment_: an integer,
+          _increment_: a positive integer,
           _smallestUnit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
           _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): either a normal completion containing a Duration Nudge Result Record or a throw completion
@@ -2051,7 +2051,7 @@
           _calendarRec_: a Calendar Method Record,
           _timeZoneRec_: a Time Zone Method Record or ~unset~,
           _largestUnit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
-          _increment_: an integer,
+          _increment_: a positive integer,
           _smallestUnit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
           _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): either a normal completion containing a Record with fields [[Duration]] (a Duration Record) and [[Total]] (a mathematical value or ~unset~), or a throw completion

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1269,7 +1269,7 @@
           _millisecond_: an integer in the inclusive interval from 0 to 999,
           _microsecond_: an integer in the inclusive interval from 0 to 999,
           _nanosecond_: an integer in the inclusive interval from 0 to 999,
-          _increment_: an integer,
+          _increment_: a positive integer,
           _unit_: *"day"*, *"hour"*, *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
           _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): an ISO Date-Time Record
@@ -1377,7 +1377,7 @@
           _ns2_: an integer in the inclusive interval from 0 to 999,
           _calendarRec_: a Calendar Methods Record,
           _largestUnit_: a String etc,
-          _roundingIncrement_: an integer,
+          _roundingIncrement_: a positive integer,
           _smallestUnit_: a String,
           _roundingMode_: a String,
           _resolvedOptions_: an Object with [[Prototype]] slot *null*,

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -1025,7 +1025,7 @@
           _millisecond_: an integer in the inclusive interval from 0 to 999,
           _microsecond_: an integer in the inclusive interval from 0 to 999,
           _nanosecond_: an integer in the inclusive interval from 0 to 999,
-          _increment_: an integer,
+          _increment_: a positive integer,
           _unit_: a String from the "Singular" column of <emu-xref href="#table-temporal-units"></emu-xref>,
           _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): a Time Record

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1289,7 +1289,7 @@
           _showCalendar_: one of *"auto"*, *"always"*, *"never"*, or *"critical"*,
           _showTimeZone_: one of *"auto"*, *"never"*, or *"critical"*,
           _showOffset_: one of *"auto"* or *"never"*,
-          optional _increment_: an integer,
+          optional _increment_: a positive integer,
           optional _unit_: one of *"minute"*, *"second"*, *"millisecond"*, *"microsecond"*, or *"nanosecond"*,
           optional _roundingMode_: a String from the "Identifier" column of <emu-xref href="#table-temporal-rounding-modes"></emu-xref>,
         ): either a normal completion containing a String or a throw completion
@@ -1476,7 +1476,7 @@
           _precalculatedPlainDateTime_: a Temporal.PlainDateTime,
           _resolvedOptions_: an Object with [[Prototype]] slot *null*,
           _largestUnit_: a String,
-          _roundingIncrement_: an integer,
+          _roundingIncrement_: a positive integer,
           _smallestUnit_: a String,
           _roundingMode_: a String,
         ): either a normal completion containing a Record with fields [[DurationRecord]] (a Duration Record) and [[Total]] (a mathematical value), or a throw completion


### PR DESCRIPTION
This makes it easier to validate the math in NudgeToCalendarUnit when calling ApplyUnsignedRoundingMode. It also matches other operations which already require that `increment` is a positive integer.

(Cherry-picked from #2884.)