### PR TITLE
Normative: Partial stack of removals

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,12 +37,9 @@ Several important concepts are explained elsewhere: [exact time, wall-clock time
 
 - `Temporal.Now.instant()` - get the current system exact time
 - `Temporal.Now.timeZoneId()` - get the current system time zone
-- `Temporal.Now.zonedDateTime(calendar)` - get the current date and wall-clock time in the system time zone and specified calendar
 - `Temporal.Now.zonedDateTimeISO()` - get the current date and wall-clock time in the system time zone and ISO-8601 calendar
-- `Temporal.Now.plainDate(calendar)` - get the current date in the system time zone and specified calendar
 - `Temporal.Now.plainDateISO()` - get the current date in the system time zone and ISO-8601 calendar
 - `Temporal.Now.plainTimeISO()` - get the current wall-clock time in the system time zone and ISO-8601 calendar
-- `Temporal.Now.plainDateTime(calendar)` - get the current system date/time in the system time zone, but return an object that doesn't remember its time zone so should NOT be used to derive other values (e.g. 12 hours later) in time zones that use Daylight Saving Time (DST).
 - `Temporal.Now.plainDateTimeISO()` - same as above, but return the DateTime in the ISO-8601 calendar
 
 ```js

--- a/docs/ambiguity.md
+++ b/docs/ambiguity.md
@@ -113,11 +113,11 @@ dateTime = Temporal.PlainDateTime.from('2019-12-17T07:48');
 zdt = dateTime.toZonedDateTime('Asia/Tokyo');
   // => 2019-12-17T07:48:00+09:00[Asia/Tokyo]
 
-// Get the exact time in seconds, milliseconds, or nanoseconds since the UNIX epoch.
+// Get the exact time in seconds, milliseconds or nanoseconds since the UNIX epoch.
 inst = zdt.toInstant();
 epochNano = inst.epochNanoseconds; // => 1576536480000000000n
 epochMilli = inst.epochMilliseconds; // => 1576536480000
-epochSecs = inst.epochSeconds; // => 1576536480
+epochSecs = Math.floor(inst.epochMilliseconds / 1000); // => 1576536480
 ```
 <!-- prettier-ignore-end -->
 

--- a/docs/cookbook/getTimeStamp.mjs
+++ b/docs/cookbook/getTimeStamp.mjs
@@ -9,5 +9,6 @@ const timeStamp = Temporal.Now.instant();
 
 // Timestamp in Milliseconds
 timeStamp.epochMilliseconds;
+
 // Timestamp in Seconds
-timeStamp.epochSeconds;
+Math.floor(timeStamp.epochMilliseconds / 1000);

--- a/docs/cookbook/makeExpandedTemporal.mjs
+++ b/docs/cookbook/makeExpandedTemporal.mjs
@@ -156,23 +156,11 @@ class ExpandedPlainDateTime extends Temporal.PlainDateTime {
   }
 }
 
-class ExpandedPlainTime extends Temporal.PlainTime {
-  toPlainDateTime(date) {
-    return ExpandedPlainDateTime._convert(super.toPlainDateTime(date), date.year);
-  }
-
-  static from(item) {
-    const { hour, minute, second, millisecond, microsecond, nanosecond } = super.from(item);
-    return new ExpandedPlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
-  }
-}
-
 function makeExpandedTemporal() {
   return {
     ...Temporal,
     PlainDate: ExpandedPlainDate,
-    PlainDateTime: ExpandedPlainDateTime,
-    PlainTime: ExpandedPlainTime
+    PlainDateTime: ExpandedPlainDateTime
   };
 }
 
@@ -180,7 +168,5 @@ const ExpandedTemporal = makeExpandedTemporal();
 
 const date = ExpandedTemporal.PlainDate.from({ year: 635427810, month: 2, day: 2 });
 assert.equal(date.toString(), '+0635427810-02-02');
-const dateTime = ExpandedTemporal.PlainTime.from('10:23').toPlainDateTime(date);
-assert.equal(dateTime.toString(), '+0635427810-02-02T10:23:00');
 const dateFromString = ExpandedTemporal.PlainDateTime.from('-0075529144-02-29T12:53:27.55');
 assert.equal(dateFromString.year, -75529144n);

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -134,29 +134,6 @@ instant === Temporal.Instant.from(instant); // => false
 ```
 <!-- prettier-ignore-end -->
 
-### Temporal.Instant.**fromEpochSeconds**(_epochSeconds_: number) : Temporal.Instant
-
-**Parameters:**
-
-- `epochSeconds` (number): A number of seconds.
-
-**Returns:** a new `Temporal.Instant` object.
-
-This static method creates a new `Temporal.Instant` object with seconds precision.
-`epochSeconds` is the number of seconds between the Unix epoch (midnight UTC on January 1, 1970) and the desired exact time.
-
-The number of seconds since the Unix epoch is a common measure of exact time in many computer systems.
-Use this method if you need to interface with such a system.
-
-Example usage:
-
-```js
-// Same examples as in new Temporal.Instant(), but with seconds precision
-instant = Temporal.Instant.fromEpochSeconds(1553906700);
-epoch = Temporal.Instant.fromEpochSeconds(0); // => 1970-01-01T00:00:00Z
-turnOfTheCentury = Temporal.Instant.fromEpochSeconds(-2208988800); // => 1900-01-01T00:00:00Z
-```
-
 ### Temporal.Instant.**fromEpochMilliseconds**(_epochMilliseconds_: number) : Temporal.Instant
 
 **Parameters:**
@@ -165,7 +142,11 @@ turnOfTheCentury = Temporal.Instant.fromEpochSeconds(-2208988800); // => 1900-01
 
 **Returns:** a new `Temporal.Instant` object.
 
-Same as `Temporal.Instant.fromEpochSeconds()`, but with millisecond (10<sup>&minus;3</sup> second) precision.
+This static method creates a new `Temporal.Instant` object with milliseconds precision (i.e., zero values in all units smaller than a millisecond).
+`epochMilliseconds` is the number of milliseconds from the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time) of January 1, 1970 at 00:00 UTC until the desired exact time, ignoring leap seconds.
+
+The number of seconds or milliseconds since the Unix epoch is a common measure of exact time in many computer systems.
+Use this method if you need to interface with such a system.
 
 The number of milliseconds since the Unix epoch is also returned from the `getTime()` and `valueOf()` methods of legacy JavaScript `Date` objects, as well as `Date.now()`.
 However, for conversion from legacy `Date` to `Temporal.Instant`, use `Date.prototype.toTemporalInstant`:
@@ -178,17 +159,11 @@ instant = legacyDate.toTemporalInstant(); // recommended
 
 // Use fromEpochMilliseconds, for example, if you have epoch millisecond data stored in a file
 todayMs = Temporal.Instant.fromEpochMilliseconds(msReadFromFile);
+
+// If you have epoch seconds data:
+epochSecs = 1553906700;  // e.g., read from a file
+instant = Temporal.Instant.fromEpochMilliseconds(epochSecs * 1000);
 ```
-
-### Temporal.Instant.**fromEpochMicroseconds**(_epochMicroseconds_ : bigint) : Temporal.Instant
-
-**Parameters:**
-
-- `epochMicroseconds` (bigint): A number of microseconds.
-
-**Returns:** a new `Temporal.Instant` object.
-
-Same as `Temporal.Instant.fromEpochSeconds()`, but with microsecond (10<sup>&minus;6</sup> second) precision.
 
 ### Temporal.Instant.**fromEpochNanoseconds**(_epochNanoseconds_ : bigint) : Temporal.Instant
 
@@ -198,8 +173,14 @@ Same as `Temporal.Instant.fromEpochSeconds()`, but with microsecond (10<sup>&min
 
 **Returns:** a new `Temporal.Instant` object.
 
-Same as `Temporal.Instant.fromEpochSeconds()`, but with nanosecond (10<sup>&minus;9</sup> second) precision.
+Same as `Temporal.Instant.fromEpochMilliseconds()`, but with nanosecond (10<sup>&minus;9</sup> second) precision.
 Also the same as `new Temporal.Instant(epochNanoseconds)`.
+
+If you have epoch microseconds data, you can use this function to create a `Temporal.Instant` from that:
+```js
+epochMicros = 1553906700_000_000n;
+instant = Temporal.Instant.fromEpochNanoseconds(epochMicros * 1000n);
+```
 
 ### Temporal.Instant.**compare**(_one_: Temporal.Instant | string, _two_: Temporal.Instant | string) : number
 
@@ -223,9 +204,9 @@ This function can be used to sort arrays of `Temporal.Instant` objects.
 For example:
 
 ```javascript
-one = Temporal.Instant.fromEpochSeconds(1.0e9);
-two = Temporal.Instant.fromEpochSeconds(1.1e9);
-three = Temporal.Instant.fromEpochSeconds(1.2e9);
+one = Temporal.Instant.fromEpochMilliseconds(1.0e12);
+two = Temporal.Instant.fromEpochMilliseconds(1.1e12);
+three = Temporal.Instant.fromEpochMilliseconds(1.2e12);
 sorted = [three, one, two].sort(Temporal.Instant.compare);
 sorted.join(' ');
 // => '2001-09-09T01:46:40Z 2004-11-09T11:33:20Z 2008-01-10T21:20:00Z'
@@ -233,25 +214,13 @@ sorted.join(' ');
 
 ## Properties
 
-### instant.**epochSeconds** : number
-
-The value of this property is an integer number of seconds between the Unix epoch (midnight UTC on January 1, 1970) and `instant`.
-This number will be negative if `instant` is before 1970.
-The number of seconds is truncated towards zero.
-
-Use this property if you need to interface with some other system that reckons time in seconds since the Unix epoch.
-
-Example usage:
-
-```js
-instant = Temporal.Instant.from('2019-03-30T01:45+01:00');
-instant.epochSeconds; // => 1553906700
-```
-
 ### instant.**epochMilliseconds** : number
 
-Same as `epochSeconds`, but with millisecond (10<sup>&minus;3</sup> second) precision.
-The number of seconds is truncated towards zero.
+The value of this property is an integer number of milliseconds from the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time) of January 1, 1970 at 00:00 UTC until `instant`, ignoring leap seconds.
+This number will be negative if `instant` is before 1970.
+The number of milliseconds is truncated towards the beginning of time.
+
+Use this property if you need to interface with some other system that reckons time in milliseconds since the Unix epoch.
 
 This method can be useful in particular to create an old-style JavaScript `Date` object, if one is needed.
 An example:
@@ -259,18 +228,24 @@ An example:
 ```js
 instant = Temporal.Instant.from('2019-03-30T00:45Z');
 new Date(instant.epochMilliseconds); // => 2019-03-30T00:45:00.000Z
+
+// If you need epoch seconds data:
+epochSecs = Math.floor(instant.epochMillieconds / 1000); // => 1553906700
 ```
-
-### instant.**epochMicroseconds** : bigint
-
-Same as `epochSeconds`, but the value is a bigint with microsecond (10<sup>&minus;6</sup> second) precision.
-The number of seconds is truncated towards zero.
 
 ### instant.**epochNanoseconds** : bigint
 
-Same as `epochSeconds`, but the value is a bigint with nanosecond (10<sup>&minus;9</sup> second) precision.
+Same as `epochMilliseconds`, but the value is a bigint with nanosecond (10<sup>&minus;9</sup> second) precision.
 
 The value of this property is suitable to be passed to `new Temporal.Instant()`.
+
+If you need epoch microseconds data, you can divide the epoch nanoseconds by 1000, but note that bigint division is a truncation, whereas you should use floor rounding to calculate epoch microseconds in the case of a negative value.
+That can be done with bigints like this:
+
+```js
+ns = instant.epochNanoseconds;
+epochMicros = ns / 1000n + ((ns % 1000n) < 0n ? -1n : 0n);
+```
 
 ## Methods
 
@@ -297,7 +272,7 @@ Example usage:
 
 ```js
 // Converting a specific exact time to a calendar date / wall-clock time
-timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
+timestamp = Temporal.Instant.fromEpochMilliseconds(1553993100_000);
 timestamp.toZonedDateTimeISO('Europe/Berlin'); // => 2019-03-31T01:45:00+01:00[Europe/Berlin]
 timestamp.toZonedDateTimeISO('UTC'); // => 2019-03-31T00:45:00+00:00[UTC]
 timestamp.toZonedDateTimeISO('-08:00'); // => 2019-03-30T16:45:00-08:00[-08:00]
@@ -325,7 +300,7 @@ Example usage:
 <!-- prettier-ignore-start -->
 ```js
 // What time was the Unix epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA) in the Gregorian calendar?
-epoch = Temporal.Instant.fromEpochSeconds(0);
+epoch = Temporal.Instant.fromEpochMilliseconds(0);
 timeZone = Temporal.TimeZone.from('America/New_York');
 epoch.toZonedDateTime({ timeZone, calendar: 'gregory' });
   // => 1969-12-31T19:00:00-05:00[America/New_York][u-ca=gregory]
@@ -470,8 +445,8 @@ approxMissionLength = startOfMoonMission.until(endOfMoonMission, {
   // => PT195H
 
 // A billion (10^9) seconds since the epoch in different units
-epoch = Temporal.Instant.fromEpochSeconds(0);
-billion = Temporal.Instant.fromEpochSeconds(1e9);
+epoch = Temporal.Instant.fromEpochMilliseconds(0);
+billion = Temporal.Instant.fromEpochMilliseconds(1e9);
 epoch.until(billion);
   // => PT1000000000S
 epoch.until(billion, { largestUnit: 'hour' });
@@ -612,8 +587,8 @@ If `other` is not a `Temporal.Instant` object, then it will be converted to one 
 Example usage:
 
 ```javascript
-one = Temporal.Instant.fromEpochSeconds(1.0e9);
-two = Temporal.Instant.fromEpochSeconds(1.1e9);
+one = Temporal.Instant.fromEpochMilliseconds(1.0e12);
+two = Temporal.Instant.fromEpochMilliseconds(1.1e12);
 one.equals(two); // => false
 one.equals(one); // => true
 ```

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -264,9 +264,8 @@ epochMicros = ns / 1000n + ((ns % 1000n) < 0n ? -1n : 0n);
 For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
 A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
 
-This method is one way to convert a `Temporal.Instant` to a `Temporal.ZonedDateTime`.
-It is the same as `toZonedDateTime()`, but always uses the ISO 8601 calendar.
-Use this method if you are not doing computations in other calendars.
+This method always returns a `Temporal.ZonedDateTime` with the ISO 8601 calendar.
+Remember to use `withCalendar()` on the result if you need to do computations in other calendars.
 
 Example usage:
 
@@ -276,39 +275,14 @@ timestamp = Temporal.Instant.fromEpochMilliseconds(1553993100_000);
 timestamp.toZonedDateTimeISO('Europe/Berlin'); // => 2019-03-31T01:45:00+01:00[Europe/Berlin]
 timestamp.toZonedDateTimeISO('UTC'); // => 2019-03-31T00:45:00+00:00[UTC]
 timestamp.toZonedDateTimeISO('-08:00'); // => 2019-03-30T16:45:00-08:00[-08:00]
-```
 
-### instant.**toZonedDateTime**(_item_: object) : Temporal.ZonedDateTime
-
-**Parameters:**
-
-- `item` (object): an object with properties to be combined with `instant`. The following properties are recognized:
-  - `calendar` (required calendar identifier string, `Temporal.Calendar` object, or object implementing the calendar protocol): the calendar in which to interpret `instant`.
-  - `timeZone` (required time zone identifier string, `Temporal.TimeZone` object, or object implementing the [time zone protocol](./timezone.md#custom-time-zones)): the time zone in which to interpret `instant`.
-
-**Returns:** a `Temporal.ZonedDateTime` object representing the calendar date, wall-clock time, time zone offset, and `timeZone`, according to the reckoning of `calendar`, at the exact time indicated by `instant`.
-
-For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
-A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
-
-For a list of calendar identifiers, see the documentation for [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#Parameters).
-
-If you only want to use the ISO 8601 calendar, use `toZonedDateTimeISO()`.
-
-Example usage:
-
-<!-- prettier-ignore-start -->
-```js
 // What time was the Unix epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA) in the Gregorian calendar?
 epoch = Temporal.Instant.fromEpochMilliseconds(0);
-timeZone = Temporal.TimeZone.from('America/New_York');
-epoch.toZonedDateTime({ timeZone, calendar: 'gregory' });
+epoch.toZonedDateTimeISO('America/New_York').withCalendar('gregory');
   // => 1969-12-31T19:00:00-05:00[America/New_York][u-ca=gregory]
 
 // What time was the Unix epoch in Tokyo in the Japanese calendar?
-timeZone = Temporal.TimeZone.from('Asia/Tokyo');
-calendar = Temporal.Calendar.from('japanese');
-zdt = epoch.toZonedDateTime({ timeZone, calendar });
+zdt = epoch.toZonedDateTimeISO('Asia/Tokyo').withCalendar('japanese');
   // => 1970-01-01T09:00:00+09:00[Asia/Tokyo][u-ca=japanese]
 console.log(zdt.eraYear, zdt.era);
   // => '45 showa'

--- a/docs/ja/ambiguity.md
+++ b/docs/ja/ambiguity.md
@@ -101,7 +101,7 @@ zdt = dateTime.toZonedDateTime('Asia/Tokyo');
 inst = zdt.toInstant();
 epochNano = inst.epochNanoseconds; // => 1576536480000000000n
 epochMilli = inst.epochMilliseconds; // => 1576536480000
-epochSecs = inst.epochSeconds; // => 1576536480
+epochSecs = Math.floor(inst.epochMilliseconds / 1000); // => 1576536480
 ```
 <!-- prettier-ignore-end -->
 

--- a/docs/now.md
+++ b/docs/now.md
@@ -25,7 +25,8 @@ The `Temporal.Now` object has several methods which give information about the c
 This method gets the current date, time, time zone, and time zone offset according to the system settings, in the reckoning of the ISO 8601 calendar system.
 Optionally a time zone can be given in which the time is computed, instead of the current system time zone.
 
-This method is the same as `zonedDateTime()`, but always uses the ISO 8601 calendar.
+This method always returns a `Temporal.ZonedDateTime` with the ISO 8601 calendar.
+Remember to use `withCalendar()` on the result if you need to do computations in other calendars.
 
 Example usage:
 
@@ -45,21 +46,6 @@ Object.entries(financialCentres).forEach(([name, timeZone]) => {
 // London: 2020-09-18T09:17:48.438068435+01:00[Europe/London]
 // Tokyo: 2020-09-18T17:17:48.441068438+09:00[Asia/Tokyo]
 ```
-
-### Temporal.Now.**zonedDateTime**(_calendar_: object | string, _timeZone_: object | string = Temporal.Now.timeZone()) : Temporal.ZonedDateTime
-
-**Parameters:**
-
-- `calendar` (`Temporal.Calendar`, plain object, or string): The calendar system to get the current date and time in.
-- `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#custom-time-zones), or a string.
-  If not given, the current system time zone will be used.
-
-**Returns:** a `Temporal.ZonedDateTime` object representing the current system date, time, time zone, and time zone offset.
-
-This method gets the current date, time, time zone, and time zone offset according to the system settings, in the reckoning of the given calendar system.
-Optionally a time zone can be given in which the time is computed, instead of the current system time zone.
-
-If you only want to use the ISO 8601 calendar, use `Temporal.Now.zonedDateTimeISO()`.
 
 ### Temporal.Now.**instant**() : Temporal.Instant
 
@@ -120,7 +106,8 @@ console.log(`At ${nextTransition.toZonedDateTimeISO(id)} the offset will change 
 This method gets the current calendar date and wall-clock time according to the system settings.
 Optionally a time zone can be given in which the time is computed, instead of the current system time zone.
 
-This method is the same as `dateTime()`, but always uses the ISO 8601 calendar.
+This method always returns a `Temporal.PlainDateTime` with the ISO 8601 calendar.
+Remember to use `withCalendar()` on the result if you need to do computations in other calendars.
 
 Example usage:
 
@@ -143,21 +130,6 @@ Object.entries(financialCentres).forEach(([name, timeZone]) => {
 ```
 <!-- prettier-ignore-end -->
 
-### Temporal.Now.**plainDateTime**(_calendar_: object | string, _timeZone_: object | string = Temporal.Now.timeZone()) : Temporal.PlainDateTime
-
-**Parameters:**
-
-- `calendar` (`Temporal.Calendar`, plain object, or string): The calendar system to get the current date and time in.
-- `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#custom-time-zones), or a string.
-  If not given, the current system time zone will be used.
-
-**Returns:** a `Temporal.PlainDateTime` object representing the current system date and time in the reckoning of the given calendar system.
-
-This method gets the current calendar date and wall-clock time according to the system settings.
-Optionally a time zone can be given in which the time is computed, instead of the current system time zone.
-
-If you only want to use the ISO 8601 calendar, use `Temporal.Now.plainDateTimeISO()`.
-
 ### Temporal.Now.**plainDateISO**(_timeZone_: object | string = Temporal.Now.timeZone()) : Temporal.PlainDate
 
 **Parameters:**
@@ -170,7 +142,8 @@ If you only want to use the ISO 8601 calendar, use `Temporal.Now.plainDateTimeIS
 This method gets the current calendar date according to the system settings.
 Optionally a time zone can be given in which the time is computed, instead of the current system time zone.
 
-This method is the same as `date()`, but always uses the ISO 8601 calendar.
+This method always returns a `Temporal.PlainDate` with the ISO 8601 calendar.
+Remember to use `withCalendar()` on the result if you need to do computations in other calendars.
 
 Example usage:
 
@@ -178,26 +151,9 @@ Example usage:
 // Is it New Year in the ISO 8601 calendar?
 date = Temporal.Now.plainDateISO();
 if (date.month === 1 && date.day === 1) console.log('New year!');
-```
 
-### Temporal.Now.**plainDate**(_calendar_: object | string, _timeZone_: object | string = Temporal.Now.timeZone()) : Temporal.PlainDate
-
-**Parameters:**
-
-- `calendar` (`Temporal.Calendar`, plain object, or string): The calendar system to get the current date and time in.
-- `timeZone` (optional object or string): The time zone to get the current date and time in, as a `Temporal.TimeZone` object, an object implementing the [time zone protocol](./timezone.md#custom-time-zones), or a string.
-  If not given, the current system time zone will be used.
-
-**Returns:** a `Temporal.PlainDate` object representing the current system date in the reckoning of the given calendar.
-
-This method gets the current calendar date according to the system settings.
-Optionally a time zone can be given in which the time is computed, instead of the current system time zone.
-
-If you only want to use the ISO 8601 calendar, use `Temporal.Now.plainDateISO()`.
-
-```js
 // Is it Nowruz (New Year in the Persian calendar)?
-date = Temporal.Now.plainDate('persian');
+date = Temporal.Now.plainDateISO().withCalendar('persian');
 if (date.month === 1 && date.day === 1) console.log('New year!');
 ```
 

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -512,50 +512,6 @@ dt.withPlainTime('12:34'); // => 2015-12-07T12:34:00
 dt.add({ days: 2, hours: 22 }).withPlainTime('00:00'); // => 2015-12-10T00:00:00
 ```
 
-### datetime.**withPlainDate**(_plainDate_: object | string) : Temporal.PlainDateTime
-
-**Parameters:**
-
-- `plainDate` (`Temporal.PlainDate` or plain object or string): The calendar date that should replace the current calendar date of `datetime`.
-
-**Returns:** a new `Temporal.PlainDateTime` object which is the date indicated by `datetime`, combined with the date represented by `plainDate`.
-
-Valid input to `withPlainDate` is the same as valid input to `Temporal.PlainDate.from`, including strings like `2000-03-01`, plain object property bags like `{ year: 2020, month: 3, day: 1 }`, or `Temporal` objects that contain a `year`, `month`, and `day` property, including `Temporal.PlainDate`, `Temporal.PlainDateTime`, or `Temporal.ZonedDateTime`.
-
-All three date units (`year`, `month`, and `day`) are required.
-`Temporal.YearMonth` and `Temporal.MonthDay` are not valid input because they lack all date units.
-Both of those types have a `toPlainDate` method that can be used to obtain a `Temporal.PlainDate` which can in turn be used as input to `withPlainDate`.
-
-If `plainDate` contains a non-ISO 8601 calendar, then the result of `withPlainDate` will be the calendar of `plainDate`.
-However, if `datetime.calendar` is already a non-ISO 8601 calendar, then this method will throw a `RangeError`.
-To resolve the error, first convert one of the instances to the same calendar or the ISO 8601 calendar, e.g. using `.withCalendar('iso8601')`.
-
-This method is similar to `with`, but with a few important differences:
-
-- `withPlainDate` accepts strings, Temporal objects, or object property bags.
-  `with` only accepts object property bags and does not accept strings nor `Temporal.PlainDate` objects because they can contain calendar information.
-- `withPlainDate` will update all date units, while `with` only changes individual units that are present in the input, e.g. setting the `day` to `1` while leaving `month` and `year` unchanged.
-
-If `plainDate` is a `Temporal.PlainDate` object, then this method returns the same result as `plainDate.toPlainDateTime(datetime)` but can be easier to use, especially when chained to previous operations that return a `Temporal.PlainDateTime`.
-
-Usage example:
-
-```javascript
-dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30');
-dt.withPlainDate({ year: 2000, month: 6, day: 1 }); // => 2000-06-01T03:24:30
-date = Temporal.PlainDate.from('2020-01-23');
-dt.withPlainDate(date); // => 2020-01-23T03:24:30
-dt.withPlainDate('2018-09-15'); // => 2018-09-15T03:24:30
-
-// easier for chaining
-dt.add({ hours: 12 }).withPlainDate('2000-06-01'); // => 2000-06-01T15:24:30
-
-// result contains a non-ISO calendar if present in the input
-dt.withCalendar('japanese').withPlainDate('2008-09-06'); // => 2008-09-06T03:24:30[u-ca=japanese]
-dt.withPlainDate('2017-09-06[u-ca=japanese]'); // => 2017-09-06T03:24:30[u-ca=japanese]
-/* WRONG */ dt.withCalendar('japanese').withPlainDate('2017-09-06[u-ca=hebrew]'); // => RangeError (calendar conflict)
-```
-
 ### datetime.**withCalendar**(_calendar_: object | string) : Temporal.PlainDateTime
 
 **Parameters:**

--- a/docs/plaindatetime.md
+++ b/docs/plaindatetime.md
@@ -986,29 +986,23 @@ If the result is earlier or later than the range that `Temporal.ZonedDateTime` c
 
 **Returns:** a `Temporal.PlainDate` object that is the same as the date portion of `datetime`.
 
-### datetime.**toPlainYearMonth**() : Temporal.PlainYearMonth
-
-**Returns:** a `Temporal.PlainYearMonth` object that is the same as the year and month of `datetime`.
-
-### datetime.**toPlainMonthDay**() : Temporal.PlainMonthDay
-
-**Returns:** a `Temporal.PlainMonthDay` object that is the same as the month and day of `datetime`.
-
 ### datetime.**toPlainTime**() : Temporal.PlainTime
 
 **Returns:** a `Temporal.PlainTime` object that is the same as the wall-clock time portion of `datetime`.
 
-The above four methods can be used to convert `Temporal.PlainDateTime` into a `Temporal.PlainDate`, `Temporal.PlainYearMonth`, `Temporal.PlainMonthDay`, or `Temporal.PlainTime` respectively.
+The above two methods can be used to convert `Temporal.PlainDateTime` into a `Temporal.PlainDate` or `Temporal.PlainTime` respectively.
 The converted object carries a copy of all the relevant fields of `datetime` (for example, in `toPlainDate()`, the `year`, `month`, and `day` properties are copied.)
+
+To convert to `Temporal.PlainYearMonth` or `Temporal.PlainMonthDay`, first use `toPlainDate()` and go from there.
 
 Usage example:
 
 ```javascript
 dt = Temporal.PlainDateTime.from('1995-12-07T03:24:30.000003500');
 dt.toPlainDate(); // => 1995-12-07
-dt.toPlainYearMonth(); // => 1995-12
-dt.toPlainMonthDay(); // => 12-07
 dt.toPlainTime(); // => 03:24:30.0000035
+dt.toPlainDate().toPlainYearMonth(); // => 1995-12
+dt.toPlainDate().toPlainMonthDay(); // => 12-07
 ```
 
 ### datetime.**getCalendar**(): object

--- a/docs/plaintime.md
+++ b/docs/plaintime.md
@@ -571,68 +571,6 @@ This method overrides `Object.prototype.valueOf()` and always throws an exceptio
 This is because it's not possible to compare `Temporal.PlainTime` objects with the relational operators `<`, `<=`, `>`, or `>=`.
 Use `Temporal.PlainTime.compare()` for this, or `time.equals()` for equality.
 
-### time.**toZonedDateTime**(_item_: object) : Temporal.ZonedDateTime
-
-**Parameters:**
-
-- `item` (object): an object with properties to be added to `time`. The following properties are recognized:
-  - `plainDate` (required `Temporal.PlainDate` or value convertible to one): a date used to merge into a `Temporal.ZonedDateTime` along with `time`.
-  - `timeZone` (required `Temporal.TimeZone` or value convertible to one, or an object implementing the [time zone protocol](./timezone.md#custom-time-zones)): the time zone in which to interpret `time` and `plainDate`.
-
-**Returns:** a `Temporal.ZonedDateTime` object that represents the clock `time` on the calendar `plainDate` projected into `timeZone`.
-
-This method can be used to convert `Temporal.PlainTime` into a `Temporal.ZonedDateTime`, by supplying the time zone and date.
-
-For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
-A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.
-
-In addition to the `timeZone`, the converted object carries a copy of all the relevant fields of `time` and `plainDate`.
-If `plainDate` is not a `Temporal.PlainDate` object, then it will be converted to one as if it were passed to `Temporal.PlainDate.from()`.
-This method produces identical results to [`Temporal.PlainDate.from(plainDate).toPlainDateTime(time).toZonedDateTime(timeZone)`](./plaindate.md#toZonedDateTime).
-
-In the case of ambiguity caused by DST or other time zone changes, the earlier time will be used for backward transitions and the later time for forward transitions.
-When interoperating with existing code or services, this matches the behavior of legacy `Date` as well as libraries like moment.js, Luxon, and date-fns.
-This mode also matches the behavior of cross-platform standards like [RFC 5545 (iCalendar)](https://tools.ietf.org/html/rfc5545).
-
-During "skipped" clock time like the hour after DST starts in the Spring, this method interprets invalid times using the pre-transition time zone offset.
-This behavior avoids exceptions when converting nonexistent date/time values to `Temporal.ZonedDateTime`, but it also means that values during these periods will result in a different `Temporal.PlainTime` value in "round-trip" conversions to `Temporal.ZonedDateTime` and back again.
-
-For usage examples and a more complete explanation of how this disambiguation works, see [Resolving ambiguity](./ambiguity.md).
-
-If the result is outside the range that `Temporal.ZonedDateTime` can represent (approximately half a million years centered on the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)), then a `RangeError` will be thrown.
-
-Usage example:
-
-```javascript
-plainTime = Temporal.PlainTime.from('15:23:30.003');
-plainDate = Temporal.PlainDate.from('2006-08-24');
-plainTime.toZonedDateTime({ timeZone: 'America/Los_Angeles', plainDate });
-// => 2006-08-24T15:23:30.003-07:00[America/Los_Angeles]
-```
-
-### time.**toPlainDateTime**(_date_: Temporal.PlainDate | object | string) : Temporal.PlainDateTime
-
-**Parameters:**
-
-- `date` (`Temporal.PlainDate` or value convertible to one): A calendar date on which to place `time`.
-
-**Returns:** a `Temporal.PlainDateTime` object that represents the wall-clock time `time` on the calendar date `date`.
-
-This method can be used to convert `Temporal.PlainTime` into a `Temporal.PlainDateTime`, by supplying the calendar date to use.
-The converted object carries a copy of all the relevant fields of `date` and `time`.
-
-This has identical results to [`Temporal.PlainDate.from(date).toPlainDateTime(time)`](./plaindate.md#toPlainDateTime).
-
-If `date` is not a `Temporal.PlainDate` object, then it will be converted to one as if it were passed to `Temporal.PlainDate.from()`.
-
-Usage example:
-
-```javascript
-time = Temporal.PlainTime.from('15:23:30.003');
-date = Temporal.PlainDate.from('2006-08-24');
-time.toPlainDateTime(date); // => 2006-08-24T15:23:30.003
-```
-
 ### time.**getISOFields**(): { isoHour: number, isoMinute: number, isoSecond: number, isoMillisecond: number, isoMicrosecond: number, isoNanosecond: number }
 
 **Returns:** a plain object with properties expressing `time` in the ISO 8601 calendar.

--- a/docs/timezone.md
+++ b/docs/timezone.md
@@ -306,7 +306,7 @@ Example usage:
 
 ```javascript
 // Getting the UTC offset for a time zone at a particular time
-timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
+timestamp = Temporal.Instant.fromEpochMilliseconds(1553993100_000);
 tz = Temporal.TimeZone.from('Europe/Berlin');
 tz.getOffsetNanosecondsFor(timestamp); // => 3600000000000
 
@@ -347,7 +347,7 @@ Example usage:
 
 ```javascript
 // Getting the UTC offset for a time zone at a particular time
-timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
+timestamp = Temporal.Instant.fromEpochMilliseconds(1553993100_000);
 tz = Temporal.TimeZone.from('Europe/Berlin');
 tz.getOffsetStringFor(timestamp); // => '+01:00'
 
@@ -381,12 +381,12 @@ Example usage:
 
 ```javascript
 // Converting an exact time to a calendar date / wall-clock time
-timestamp = Temporal.Instant.fromEpochSeconds(1553993100);
+timestamp = Temporal.Instant.fromEpochMilliseconds(1553993100_000);
 tz = Temporal.TimeZone.from('Europe/Berlin');
 tz.getPlainDateTimeFor(timestamp); // => 2019-03-31T01:45:00
 
 // What time was the Unix Epoch (timestamp 0) in Bell Labs (Murray Hill, New Jersey, USA)?
-epoch = Temporal.Instant.fromEpochSeconds(0);
+epoch = Temporal.Instant.fromEpochMilliseconds(0);
 tz = Temporal.TimeZone.from('America/New_York');
 tz.getPlainDateTimeFor(epoch); // => 1969-12-31T19:00:00
 ```

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -786,52 +786,6 @@ zdt.withPlainTime('12:34'); // => 2015-12-07T12:34:00-08:00[America/Los_Angeles]
 zdt.add({ days: 2, hours: 22 }).withPlainTime('00:00'); // => 2015-12-10T00:00:00-08:00[America/Los_Angeles]
 ```
 
-### zonedDateTime.**withPlainDate**(_plainDate_: object | string) : Temporal.ZonedDateTime
-
-**Parameters:**
-
-- `plainDate` (`Temporal.PlainDate` or plain object or string): The calendar date that should replace the current calendar date of `zonedDateTime`.
-
-**Returns:** a new `Temporal.ZonedDateTime` object which replaces the calendar date of `zonedDateTime` with the calendar date represented by `plainDate`.
-
-Valid input to `withPlainDate` is the same as valid input to `Temporal.PlainDate.from`, including strings like `2000-03-01`, plain object property bags like `{ year: 2020, month: 3, day: 1 }`, or `Temporal` objects that contain a `year`, `month`, and `day` property, including `Temporal.PlainDate`, `Temporal.ZonedDateTime`, or `Temporal.PlainDateTime`.
-
-All three date units (`year`, `month`, and `day`) are required.
-`Temporal.YearMonth` and `Temporal.MonthDay` are not valid input because they lack all date units.
-Both of those types have a `toPlainDate` method that can be used to obtain a `Temporal.PlainDate` which can in turn be used as input to `withPlainDate`.
-
-If `plainDate` contains a non-ISO 8601 calendar, then the result of `withPlainDate` will be the calendar of `plainDate`.
-However, if `zonedDateTime.calendar` is already a non-ISO 8601 calendar, then this method will throw a `RangeError`.
-To resolve the error, first convert one of the instances to the same calendar or the ISO 8601 calendar, e.g. using `.withCalendar('iso8601')`.
-
-This method is similar to `with`, but with a few important differences:
-
-- `withPlainDate` accepts strings, Temporal objects, or object property bags.
-  `with` only accepts object property bags and does not accept strings nor `Temporal.PlainDate` objects because they can contain calendar information.
-- `withPlainDate` will update all date units, while `with` only changes individual units that are present in the input, e.g. setting the `day` to `1` while leaving `month` and `year` unchanged.
-- `withPlainDate` does not accept options like `disambiguation` or `offset`.
-  For fine-grained control, use `with`.
-
-If `plainDate` is a `Temporal.PlainDate` object, then this method returns the same result as `plainDate.toZonedDateTime({ plainDate: zonedDateTime, timeZone: zonedDateTime})` but can be easier to use, especially when chained to previous operations that return a `Temporal.ZonedDateTime`.
-
-Usage example:
-
-```javascript
-zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30-08:00[America/Los_Angeles]');
-zdt.withPlainDate({ year: 2000, month: 6, day: 1 }); // => 2000-06-01T03:24:30-07:00[America/Los_Angeles]
-date = Temporal.PlainDate.from('2020-01-23');
-zdt.withPlainDate(date); // => 2020-01-23T03:24:30-08:00[America/Los_Angeles]
-zdt.withPlainDate('2018-09-15'); // => 2018-09-15T03:24:30-07:00[America/Los_Angeles]
-
-// easier for chaining
-zdt.add({ hours: 12 }).withPlainDate('2000-06-01'); // => 2000-06-01T15:24:30-07:00[America/Los_Angeles]
-
-// result contains a non-ISO calendar if present in the input
-zdt.withCalendar('japanese').withPlainDate('2008-09-06'); // => 2008-09-06T03:24:30-07:00[America/Los_Angeles][u-ca=japanese]
-zdt.withPlainDate('2017-09-06[u-ca=japanese]'); // => 2017-09-06T03:24:30-07:00[America/Los_Angeles][u-ca=japanese]
-/* WRONG */ zdt.withCalendar('japanese').withPlainDate('2017-09-06[u-ca=hebrew]'); // => RangeError (calendar conflict)
-```
-
 ### zonedDateTime.**withTimeZone**(_timeZone_: object | string) : Temporal.ZonedDateTime
 
 **Parameters:**

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -1355,16 +1355,10 @@ Use `Temporal.ZonedDateTime.compare()` for this, or `zonedDateTime.equals()` for
 > However, unless you perform those operations across a time zone offset transition, it's impossible to notice the difference.
 > Therefore, be very careful when performing this conversion because subsequent results may look correct most of the time while failing around time zone transitions like when DST starts or ends.
 
-### zonedDateTime.**toPlainYearMonth**() : Temporal.PlainYearMonth
-
-**Returns:** a `Temporal.PlainYearMonth` object that is the same as the year and month of `zonedDateTime`.
-
-### zonedDateTime.**toPlainMonthDay**() : Temporal.PlainMonthDay
-
-**Returns:** a `Temporal.PlainMonthDay` object that is the same as the month and day of `zonedDateTime`.
-
-The above six methods can be used to convert `Temporal.ZonedDateTime` into a `Temporal.Instant`, `Temporal.PlainDate`, `Temporal.PlainTime`, `Temporal.PlainDateTime`, `Temporal.PlainYearMonth`, or `Temporal.PlainMonthDay` respectively.
+The above four methods can be used to convert `Temporal.ZonedDateTime` into a `Temporal.Instant`, `Temporal.PlainDate`, `Temporal.PlainTime`, or `Temporal.PlainDateTime`, respectively.
 The converted object carries a copy of all the relevant data of `zonedDateTime` (for example, in `toPlainDate()`, the `year`, `month`, and `day` properties are the same.)
+
+To convert to `Temporal.PlainYearMonth` or `Temporal.PlainMonthDay`, first use `toPlainDate()` and go from there.
 
 Usage example:
 
@@ -1373,9 +1367,9 @@ zdt = Temporal.ZonedDateTime.from('1995-12-07T03:24:30+02:00[Africa/Johannesburg
 zdt.toInstant(); // => 1995-12-07T01:24:30Z
 zdt.toPlainDateTime(); // => 1995-12-07T03:24:30
 zdt.toPlainDate(); // => 1995-12-07
-zdt.toPlainYearMonth(); // => 1995-12
-zdt.toPlainMonthDay(); // => 12-07
 zdt.toPlainTime(); // => 03:24:30
+zdt.toPlainDate().toPlainYearMonth(); // => 1995-12
+zdt.toPlainDate().toPlainMonthDay(); // => 12-07
 ```
 
 ### zonedDateTime.**getCalendar**(): object

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -358,29 +358,23 @@ dt.nanosecond;  // => 500
 
 > **NOTE**: The possible values for the `month` property start at 1, which is different from legacy `Date` where months are represented by zero-based indices (0 to 11).
 
-### zonedDateTime.**epochSeconds**: number
-
 ### zonedDateTime.**epochMilliseconds**: number
-
-### zonedDateTime.**epochMicroseconds**: bigint
 
 ### zonedDateTime.**epochNanoseconds**: bigint
 
-The above read-only properties return the integer number of full seconds, milliseconds, microseconds, or nanoseconds between `zonedDateTime` and 00:00 UTC on 1970-01-01, otherwise known as the [UNIX Epoch](https://en.wikipedia.org/wiki/Unix_time).
+The above two read-only properties give the integer number of milliseconds or nanoseconds (respectively) from the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time) of January 1, 1970 at 00:00 UTC until `zonedDateTime`, ignoring leap seconds.
 
-These properties are equivalent to `zonedDateTime.toInstant().epochSeconds`, `zonedDateTime.toInstant().epochMilliseconds`, `zonedDateTime.toInstant().epochMicroseconds`, `zonedDateTime.toInstant().epochNanoseconds`, respectively.
-Any fractional remainders are truncated towards zero.
+These properties are equivalent to `zonedDateTime.toInstant().epochMilliseconds` and `zonedDateTime.toInstant().epochNanoseconds`, respectively.
+Any fractional milliseconds are truncated towards the beginning of time.
 The time zone is irrelevant to these properties, because there is only one epoch, not one per time zone.
 
-Note that the `epochSeconds` and `epochMilliseconds` properties are of type `number` (although only integers are returned) while the `epochMicroseconds` and `epochNanoseconds` are of type `bigint`.
+Note that the `epochMilliseconds` property is of type `number` (although only integers are returned) while the `epochNanoseconds` property is of type `bigint`.
 
 The `epochMilliseconds` property is the easiest way to construct a legacy `Date` object from a `Temporal.ZonedDateTime` instance.
 
 <!-- prettier-ignore-start -->
 ```javascript
 zdt = Temporal.ZonedDateTime.from('2020-02-01T12:30+09:00[Asia/Tokyo]');
-epochSecs = zdt.epochSeconds;
-  // => 1580527800
 epochMs = zdt.epochMilliseconds;
   // => 1580527800000
 zdt.toInstant().epochMilliseconds;
@@ -388,10 +382,18 @@ zdt.toInstant().epochMilliseconds;
 legacyDate = new Date(epochMs);
   // => 2020-02-01T03:30:00.000Z
   // (if the system time zone is America/Los_Angeles)
-epochMicros = zdt.epochMicroseconds;
-  // => 1580527800000000n
 epochNanos = zdt.epochNanoseconds;
   // => 1580527800000000000n
+
+// If you need epoch seconds data:
+epochSecs = Math.floor(zdt.epochMillieconds / 1000); // => 1553906700
+  // => 1580527800
+
+// If you need epoch microseconds data:
+// (Note the extra check for correct floor rounding with bigints)
+ns = zdt.epochNanoseconds;
+epochMicros = ns / 1000n + ((ns % 1000n) < 0n ? -1n : 0n);
+  // => 1580527800000000n
 ```
 <!-- prettier-ignore-end -->
 

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -569,16 +569,12 @@ export namespace Temporal {
    * See https://tc39.es/proposal-temporal/docs/instant.html for more details.
    */
   export class Instant {
-    static fromEpochSeconds(epochSeconds: number): Temporal.Instant;
     static fromEpochMilliseconds(epochMilliseconds: number): Temporal.Instant;
-    static fromEpochMicroseconds(epochMicroseconds: bigint): Temporal.Instant;
     static fromEpochNanoseconds(epochNanoseconds: bigint): Temporal.Instant;
     static from(item: Temporal.Instant | string): Temporal.Instant;
     static compare(one: Temporal.Instant | string, two: Temporal.Instant | string): ComparisonResult;
     constructor(epochNanoseconds: bigint);
-    readonly epochSeconds: number;
     readonly epochMilliseconds: number;
-    readonly epochMicroseconds: bigint;
     readonly epochNanoseconds: bigint;
     equals(other: Temporal.Instant | string): boolean;
     add(
@@ -1279,9 +1275,7 @@ export namespace Temporal {
     readonly inLeapYear: boolean;
     readonly offsetNanoseconds: number;
     readonly offset: string;
-    readonly epochSeconds: number;
     readonly epochMilliseconds: number;
-    readonly epochMicroseconds: bigint;
     readonly epochNanoseconds: bigint;
     equals(other: Temporal.ZonedDateTime | ZonedDateTimeLike | string): boolean;
     with(zonedDateTimeLike: ZonedDateTimeLike, options?: ZonedDateTimeAssignmentOptions): Temporal.ZonedDateTime;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1081,11 +1081,6 @@ export namespace Temporal {
     round(
       roundTo: RoundTo<'hour' | 'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>
     ): Temporal.PlainTime;
-    toPlainDateTime(temporalDate: Temporal.PlainDate | PlainDateLike | string): Temporal.PlainDateTime;
-    toZonedDateTime(timeZoneAndDate: {
-      timeZone: TimeZoneLike;
-      plainDate: Temporal.PlainDate | PlainDateLike | string;
-    }): Temporal.ZonedDateTime;
     getISOFields(): PlainTimeISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -941,7 +941,6 @@ export namespace Temporal {
     equals(other: Temporal.PlainDateTime | PlainDateTimeLike | string): boolean;
     with(dateTimeLike: PlainDateTimeLike, options?: AssignmentOptions): Temporal.PlainDateTime;
     withPlainTime(timeLike?: Temporal.PlainTime | PlainTimeLike | string): Temporal.PlainDateTime;
-    withPlainDate(dateLike: Temporal.PlainDate | PlainDateLike | string): Temporal.PlainDateTime;
     withCalendar(calendar: CalendarLike): Temporal.PlainDateTime;
     add(durationLike: Temporal.Duration | DurationLike | string, options?: ArithmeticOptions): Temporal.PlainDateTime;
     subtract(
@@ -1292,7 +1291,6 @@ export namespace Temporal {
     equals(other: Temporal.ZonedDateTime | ZonedDateTimeLike | string): boolean;
     with(zonedDateTimeLike: ZonedDateTimeLike, options?: ZonedDateTimeAssignmentOptions): Temporal.ZonedDateTime;
     withPlainTime(timeLike?: Temporal.PlainTime | PlainTimeLike | string): Temporal.ZonedDateTime;
-    withPlainDate(dateLike: Temporal.PlainDate | PlainDateLike | string): Temporal.ZonedDateTime;
     withCalendar(calendar: CalendarLike): Temporal.ZonedDateTime;
     withTimeZone(timeZone: TimeZoneLike): Temporal.ZonedDateTime;
     add(durationLike: Temporal.Duration | DurationLike | string, options?: ArithmeticOptions): Temporal.ZonedDateTime;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -594,7 +594,6 @@ export namespace Temporal {
     round(
       roundTo: RoundTo<'hour' | 'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>
     ): Temporal.Instant;
-    toZonedDateTime(calendarAndTimeZone: { timeZone: TimeZoneLike; calendar: CalendarLike }): Temporal.ZonedDateTime;
     toZonedDateTimeISO(tzLike: TimeZoneLike): Temporal.ZonedDateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
@@ -1335,26 +1334,6 @@ export namespace Temporal {
     instant: () => Temporal.Instant;
 
     /**
-     * Get the current calendar date and clock time in a specific calendar and
-     * time zone.
-     *
-     * The `calendar` parameter is required. When using the ISO 8601 calendar or
-     * if you don't understand the need for or implications of a calendar, then
-     * a more ergonomic alternative to this method is
-     * `Temporal.Now.zonedDateTimeISO()`.
-     *
-     * @param {CalendarLike} [calendar] - calendar identifier, or
-     * a `Temporal.Calendar` instance, or an object implementing the calendar
-     * protocol.
-     * @param {TimeZoneLike} [tzLike] -
-     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
-     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
-     * object implementing the time zone protocol. If omitted, the environment's
-     * current time zone will be used.
-     */
-    zonedDateTime: (calendar: CalendarLike, tzLike?: TimeZoneLike) => Temporal.ZonedDateTime;
-
-    /**
      * Get the current calendar date and clock time in a specific time zone,
      * using the ISO 8601 calendar.
      *
@@ -1365,31 +1344,6 @@ export namespace Temporal {
      * current time zone will be used.
      */
     zonedDateTimeISO: (tzLike?: TimeZoneLike) => Temporal.ZonedDateTime;
-
-    /**
-     * Get the current calendar date and clock time in a specific calendar and
-     * time zone.
-     *
-     * The calendar is required. When using the ISO 8601 calendar or if you
-     * don't understand the need for or implications of a calendar, then a more
-     * ergonomic alternative to this method is `Temporal.Now.plainDateTimeISO`.
-     *
-     * Note that the `Temporal.PlainDateTime` type does not persist the time zone,
-     * but retaining the time zone is required for most time-zone-related use
-     * cases. Therefore, it's usually recommended to use
-     * `Temporal.Now.zonedDateTimeISO` or `Temporal.Now.zonedDateTime` instead
-     * of this function.
-     *
-     * @param {CalendarLike} [calendar] - calendar identifier, or
-     * a `Temporal.Calendar` instance, or an object implementing the calendar
-     * protocol.
-     * @param {TimeZoneLike} [tzLike] -
-     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
-     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
-     * object implementing the time zone protocol. If omitted,
-     * the environment's current time zone will be used.
-     */
-    plainDateTime: (calendar: CalendarLike, tzLike?: TimeZoneLike) => Temporal.PlainDateTime;
 
     /**
      * Get the current date and clock time in a specific time zone, using the
@@ -1407,24 +1361,6 @@ export namespace Temporal {
      * current time zone will be used.
      */
     plainDateTimeISO: (tzLike?: TimeZoneLike) => Temporal.PlainDateTime;
-
-    /**
-     * Get the current calendar date in a specific calendar and time zone.
-     *
-     * The calendar is required. When using the ISO 8601 calendar or if you
-     * don't understand the need for or implications of a calendar, then a more
-     * ergonomic alternative to this method is `Temporal.Now.plainDateISO`.
-     *
-     * @param {CalendarLike} [calendar] - calendar identifier, or
-     * a `Temporal.Calendar` instance, or an object implementing the calendar
-     * protocol.
-     * @param {TimeZoneLike} [tzLike] -
-     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
-     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
-     * object implementing the time zone protocol. If omitted,
-     * the environment's current time zone will be used.
-     */
-    plainDate: (calendar: CalendarLike, tzLike?: TimeZoneLike) => Temporal.PlainDate;
 
     /**
      * Get the current date in a specific time zone, using the ISO 8601

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -960,8 +960,6 @@ export namespace Temporal {
     ): Temporal.PlainDateTime;
     toZonedDateTime(tzLike: TimeZoneLike, options?: ToInstantOptions): Temporal.ZonedDateTime;
     toPlainDate(): Temporal.PlainDate;
-    toPlainYearMonth(): Temporal.PlainYearMonth;
-    toPlainMonthDay(): Temporal.PlainMonthDay;
     toPlainTime(): Temporal.PlainTime;
     getISOFields(): PlainDateTimeISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
@@ -1306,8 +1304,6 @@ export namespace Temporal {
     toInstant(): Temporal.Instant;
     toPlainDateTime(): Temporal.PlainDateTime;
     toPlainDate(): Temporal.PlainDate;
-    toPlainYearMonth(): Temporal.PlainYearMonth;
-    toPlainMonthDay(): Temporal.PlainMonthDay;
     toPlainTime(): Temporal.PlainTime;
     getISOFields(): ZonedDateTimeISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2266,19 +2266,6 @@ export function ThrowIfCalendarsNotEqual(one, two, errorMessageAction) {
   }
 }
 
-export function ConsolidateCalendars(one, two) {
-  if (one === two) return two;
-  const sOne = ToTemporalCalendarIdentifier(one);
-  const sTwo = ToTemporalCalendarIdentifier(two);
-  if (sOne === sTwo || sOne === 'iso8601') {
-    return two;
-  } else if (sTwo === 'iso8601') {
-    return one;
-  } else {
-    throw new RangeError('irreconcilable calendars');
-  }
-}
-
 export function CalendarDateFromFields(calendarRec, fields, options) {
   const result = calendarRec.dateFromFields(fields, options);
   if (!calendarRec.isBuiltIn() && !IsTemporalDate(result)) throw new TypeError('invalid result');

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -119,23 +119,6 @@ export class Instant {
   valueOf() {
     ES.ValueOfThrows('Instant');
   }
-  toZonedDateTime(item) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(item) !== 'Object') {
-      throw new TypeError('invalid argument in toZonedDateTime');
-    }
-    const calendarLike = item.calendar;
-    if (calendarLike === undefined) {
-      throw new TypeError('missing calendar property in toZonedDateTime');
-    }
-    const calendar = ES.ToTemporalCalendarSlotValue(calendarLike);
-    const temporalTimeZoneLike = item.timeZone;
-    if (temporalTimeZoneLike === undefined) {
-      throw new TypeError('missing timeZone property in toZonedDateTime');
-    }
-    const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
-    return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, calendar);
-  }
   toZonedDateTimeISO(timeZone) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     timeZone = ES.ToTemporalTimeZoneSlotValue(timeZone);

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -34,20 +34,10 @@ export class Instant {
     }
   }
 
-  get epochSeconds() {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    const value = GetSlot(this, EPOCHNANOSECONDS);
-    return ES.BigIntFloorDiv(value, 1e9).toJSNumber();
-  }
   get epochMilliseconds() {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     const value = bigInt(GetSlot(this, EPOCHNANOSECONDS));
     return ES.BigIntFloorDiv(value, 1e6).toJSNumber();
-  }
-  get epochMicroseconds() {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    const value = GetSlot(this, EPOCHNANOSECONDS);
-    return ES.BigIntIfAvailable(ES.BigIntFloorDiv(value, 1e3));
   }
   get epochNanoseconds() {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
@@ -152,21 +142,9 @@ export class Instant {
     return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, 'iso8601');
   }
 
-  static fromEpochSeconds(epochSeconds) {
-    epochSeconds = ES.ToNumber(epochSeconds);
-    const epochNanoseconds = bigInt(epochSeconds).multiply(1e9);
-    ES.ValidateEpochNanoseconds(epochNanoseconds);
-    return new Instant(epochNanoseconds);
-  }
   static fromEpochMilliseconds(epochMilliseconds) {
     epochMilliseconds = ES.ToNumber(epochMilliseconds);
     const epochNanoseconds = bigInt(epochMilliseconds).multiply(1e6);
-    ES.ValidateEpochNanoseconds(epochNanoseconds);
-    return new Instant(epochNanoseconds);
-  }
-  static fromEpochMicroseconds(epochMicroseconds) {
-    epochMicroseconds = ES.ToBigInt(epochMicroseconds);
-    const epochNanoseconds = epochMicroseconds.multiply(1e3);
     ES.ValidateEpochNanoseconds(epochNanoseconds);
     return new Instant(epochNanoseconds);
   }

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -6,29 +6,15 @@ const instant = () => {
   const Instant = GetIntrinsic('%Temporal.Instant%');
   return new Instant(ES.SystemUTCEpochNanoSeconds());
 };
-const plainDateTime = (calendarLike, temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
-  const calendar = ES.ToTemporalCalendarSlotValue(calendarLike);
-  const inst = instant();
-  const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getOffsetNanosecondsFor']);
-  return ES.GetPlainDateTimeFor(timeZoneRec, inst, calendar);
-};
 const plainDateTimeISO = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
   const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
   const inst = instant();
   const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getOffsetNanosecondsFor']);
   return ES.GetPlainDateTimeFor(timeZoneRec, inst, 'iso8601');
 };
-const zonedDateTime = (calendarLike, temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
-  const calendar = ES.ToTemporalCalendarSlotValue(calendarLike);
-  return ES.CreateTemporalZonedDateTime(ES.SystemUTCEpochNanoSeconds(), timeZone, calendar);
-};
 const zonedDateTimeISO = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  return zonedDateTime('iso8601', temporalTimeZoneLike);
-};
-const plainDate = (calendarLike, temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  return ES.TemporalDateTimeToDate(plainDateTime(calendarLike, temporalTimeZoneLike));
+  const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
+  return ES.CreateTemporalZonedDateTime(ES.SystemUTCEpochNanoSeconds(), timeZone, 'iso8601');
 };
 const plainDateISO = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
   return ES.TemporalDateTimeToDate(plainDateTimeISO(temporalTimeZoneLike));
@@ -42,13 +28,10 @@ const timeZoneId = () => {
 
 export const Now = {
   instant,
-  plainDateTime,
   plainDateTimeISO,
-  plainDate,
   plainDateISO,
   plainTimeISO,
   timeZoneId,
-  zonedDateTime,
   zonedDateTimeISO
 };
 Object.defineProperty(Now, Symbol.toStringTag, {

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -205,36 +205,6 @@ export class PlainDateTime {
       GetSlot(this, CALENDAR)
     );
   }
-  withPlainDate(temporalDate) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-
-    temporalDate = ES.ToTemporalDate(temporalDate);
-    const year = GetSlot(temporalDate, ISO_YEAR);
-    const month = GetSlot(temporalDate, ISO_MONTH);
-    const day = GetSlot(temporalDate, ISO_DAY);
-    let calendar = GetSlot(temporalDate, CALENDAR);
-
-    const hour = GetSlot(this, ISO_HOUR);
-    const minute = GetSlot(this, ISO_MINUTE);
-    const second = GetSlot(this, ISO_SECOND);
-    const millisecond = GetSlot(this, ISO_MILLISECOND);
-    const microsecond = GetSlot(this, ISO_MICROSECOND);
-    const nanosecond = GetSlot(this, ISO_NANOSECOND);
-
-    calendar = ES.ConsolidateCalendars(GetSlot(this, CALENDAR), calendar);
-    return ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      calendar
-    );
-  }
   withCalendar(calendar) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     calendar = ES.ToTemporalCalendarSlotValue(calendar);

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -379,18 +379,6 @@ export class PlainDateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return ES.TemporalDateTimeToDate(this);
   }
-  toPlainYearMonth() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'yearMonthFromFields']);
-    const fields = ES.PrepareCalendarFields(calendarRec, this, ['monthCode', 'year'], [], []);
-    return ES.CalendarYearMonthFromFields(calendarRec, fields);
-  }
-  toPlainMonthDay() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'monthDayFromFields']);
-    const fields = ES.PrepareCalendarFields(calendarRec, this, ['day', 'monthCode'], [], []);
-    return ES.CalendarMonthDayFromFields(calendarRec, fields);
-  }
   toPlainTime() {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return ES.TemporalDateTimeToTime(this);

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -3,20 +3,14 @@
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
-import { TimeZoneMethodRecord } from './methodrecord.mjs';
 
 import {
-  ISO_YEAR,
-  ISO_MONTH,
-  ISO_DAY,
   ISO_HOUR,
   ISO_MINUTE,
   ISO_SECOND,
   ISO_MILLISECOND,
   ISO_MICROSECOND,
   ISO_NANOSECOND,
-  CALENDAR,
-  EPOCHNANOSECONDS,
   CreateSlots,
   GetSlot,
   SetSlot
@@ -221,81 +215,6 @@ export class PlainTime {
     ES.ValueOfThrows('PlainTime');
   }
 
-  toPlainDateTime(temporalDate) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
-
-    temporalDate = ES.ToTemporalDate(temporalDate);
-    const year = GetSlot(temporalDate, ISO_YEAR);
-    const month = GetSlot(temporalDate, ISO_MONTH);
-    const day = GetSlot(temporalDate, ISO_DAY);
-    const calendar = GetSlot(temporalDate, CALENDAR);
-
-    const hour = GetSlot(this, ISO_HOUR);
-    const minute = GetSlot(this, ISO_MINUTE);
-    const second = GetSlot(this, ISO_SECOND);
-    const millisecond = GetSlot(this, ISO_MILLISECOND);
-    const microsecond = GetSlot(this, ISO_MICROSECOND);
-    const nanosecond = GetSlot(this, ISO_NANOSECOND);
-
-    return ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      calendar
-    );
-  }
-  toZonedDateTime(item) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
-
-    if (ES.Type(item) !== 'Object') {
-      throw new TypeError('invalid argument');
-    }
-
-    const dateLike = item.plainDate;
-    if (dateLike === undefined) {
-      throw new TypeError('missing date property');
-    }
-    const temporalDate = ES.ToTemporalDate(dateLike);
-
-    const timeZoneLike = item.timeZone;
-    if (timeZoneLike === undefined) {
-      throw new TypeError('missing timeZone property');
-    }
-    const timeZone = ES.ToTemporalTimeZoneSlotValue(timeZoneLike);
-
-    const year = GetSlot(temporalDate, ISO_YEAR);
-    const month = GetSlot(temporalDate, ISO_MONTH);
-    const day = GetSlot(temporalDate, ISO_DAY);
-    const calendar = GetSlot(temporalDate, CALENDAR);
-    const hour = GetSlot(this, ISO_HOUR);
-    const minute = GetSlot(this, ISO_MINUTE);
-    const second = GetSlot(this, ISO_SECOND);
-    const millisecond = GetSlot(this, ISO_MILLISECOND);
-    const microsecond = GetSlot(this, ISO_MICROSECOND);
-    const nanosecond = GetSlot(this, ISO_NANOSECOND);
-
-    const dt = ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      calendar
-    );
-    const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getOffsetNanosecondsFor', 'getPossibleInstantsFor']);
-    const instant = ES.GetInstantFor(timeZoneRec, dt, 'compatible');
-    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
-  }
   getISOFields() {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     return {

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -258,43 +258,6 @@ export class ZonedDateTime {
 
     return ES.CreateTemporalZonedDateTime(epochNanoseconds, timeZoneRec.receiver, calendarRec.receiver);
   }
-  withPlainDate(temporalDate) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-
-    temporalDate = ES.ToTemporalDate(temporalDate);
-
-    const year = GetSlot(temporalDate, ISO_YEAR);
-    const month = GetSlot(temporalDate, ISO_MONTH);
-    const day = GetSlot(temporalDate, ISO_DAY);
-    let calendar = GetSlot(temporalDate, CALENDAR);
-    const timeZoneRec = new TimeZoneMethodRecord(GetSlot(this, TIME_ZONE), [
-      'getOffsetNanosecondsFor',
-      'getPossibleInstantsFor'
-    ]);
-    const thisDt = ES.GetPlainDateTimeFor(timeZoneRec, GetSlot(this, INSTANT), GetSlot(this, CALENDAR));
-    const hour = GetSlot(thisDt, ISO_HOUR);
-    const minute = GetSlot(thisDt, ISO_MINUTE);
-    const second = GetSlot(thisDt, ISO_SECOND);
-    const millisecond = GetSlot(thisDt, ISO_MILLISECOND);
-    const microsecond = GetSlot(thisDt, ISO_MICROSECOND);
-    const nanosecond = GetSlot(thisDt, ISO_NANOSECOND);
-
-    calendar = ES.ConsolidateCalendars(GetSlot(this, CALENDAR), calendar);
-    const dt = ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      calendar
-    );
-    const instant = ES.GetInstantFor(timeZoneRec, dt, 'compatible');
-    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZoneRec.receiver, calendar);
-  }
   withPlainTime(temporalTime = undefined) {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
 

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -557,20 +557,6 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return dateTime(this);
   }
-  toPlainYearMonth() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'yearMonthFromFields']);
-    const dt = dateTime(this);
-    const fields = ES.PrepareCalendarFields(calendarRec, dt, ['monthCode', 'year'], [], []);
-    return ES.CalendarYearMonthFromFields(calendarRec, fields);
-  }
-  toPlainMonthDay() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'monthDayFromFields']);
-    const dt = dateTime(this);
-    const fields = ES.PrepareCalendarFields(calendarRec, dt, ['day', 'monthCode'], [], []);
-    return ES.CalendarMonthDayFromFields(calendarRec, fields);
-  }
   getISOFields() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const timeZoneRec = new TimeZoneMethodRecord(GetSlot(this, TIME_ZONE), ['getOffsetNanosecondsFor']);

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -97,20 +97,10 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return ES.CalendarEraYear(GetSlot(this, CALENDAR), dateTime(this));
   }
-  get epochSeconds() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    const value = GetSlot(this, EPOCHNANOSECONDS);
-    return ES.BigIntFloorDiv(value, 1e9).toJSNumber();
-  }
   get epochMilliseconds() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const value = GetSlot(this, EPOCHNANOSECONDS);
     return ES.BigIntFloorDiv(value, 1e6).toJSNumber();
-  }
-  get epochMicroseconds() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    const value = GetSlot(this, EPOCHNANOSECONDS);
-    return ES.BigIntIfAvailable(ES.BigIntFloorDiv(value, 1e3));
   }
   get epochNanoseconds() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1020,31 +1020,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-consolidatecalendars" type="abstract operation">
-      <h1>
-        ConsolidateCalendars (
-          _one_: a String or Object,
-          _two_: a String or Object,
-        ): either a normal completion containing either a String or Object, or a throw completion
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>
-          It returns the calendar that should take priority when combining two Temporal objects with different calendars, or throws an exception if the calendars cannot be combined.
-          Calendars can be combined when they have the same identifier or exactly one of them has identifier *"iso8601"*, and _calendarTwo_ takes priority in any combination unless it is the calendar with that identifier.
-        </dd>
-      </dl>
-      <emu-alg>
-        1. If _one_ and _two_ are the same Object value, return _two_.
-        1. Let _calendarOne_ be ? ToTemporalCalendarIdentifier(_one_).
-        1. Let _calendarTwo_ be ? ToTemporalCalendarIdentifier(_two_).
-        1. If _calendarOne_ is _calendarTwo_, return _two_.
-        1. If _calendarOne_ is *"iso8601"*, return _two_.
-        1. If _calendarTwo_ is *"iso8601"*, return _one_.
-        1. Throw a *RangeError* exception.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-isodaysinmonth" type="abstract operation">
       <h1>
         ISODaysInMonth (

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -327,28 +327,6 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.instant.prototype.tozoneddatetime">
-      <h1>Temporal.Instant.prototype.toZonedDateTime ( _item_ )</h1>
-      <p>
-        This method performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _instant_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. If _item_ is not an Object, then
-          1. Throw a *TypeError* exception.
-        1. Let _calendarLike_ be ? Get(_item_, *"calendar"*).
-        1. If _calendarLike_ is *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _calendar_ be ? ToTemporalCalendarSlotValue(_calendarLike_).
-        1. Let _temporalTimeZoneLike_ be ? Get(_item_, *"timeZone"*).
-        1. If _temporalTimeZoneLike_ is *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _timeZone_ be ? ToTemporalTimeZoneSlotValue(_temporalTimeZoneLike_).
-        1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _calendar_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.instant.prototype.tozoneddatetimeiso">
       <h1>Temporal.Instant.prototype.toZonedDateTimeISO ( _timeZone_ )</h1>
       <p>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -61,20 +61,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.instant.fromepochseconds">
-      <h1>Temporal.Instant.fromEpochSeconds ( _epochSeconds_ )</h1>
-      <p>
-        This function performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Set _epochSeconds_ to ? ToNumber(_epochSeconds_).
-        1. Set _epochSeconds_ to ? NumberToBigInt(_epochSeconds_).
-        1. Let _epochNanoseconds_ be _epochSeconds_ &times; ℤ(10<sup>9</sup>).
-        1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
-        1. Return ! CreateTemporalInstant(_epochNanoseconds_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.instant.fromepochmilliseconds">
       <h1>Temporal.Instant.fromEpochMilliseconds ( _epochMilliseconds_ )</h1>
       <p>
@@ -84,19 +70,6 @@
         1. Set _epochMilliseconds_ to ? ToNumber(_epochMilliseconds_).
         1. Set _epochMilliseconds_ to ? NumberToBigInt(_epochMilliseconds_).
         1. Let _epochNanoseconds_ be _epochMilliseconds_ &times; ℤ(10<sup>6</sup>).
-        1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
-        1. Return ! CreateTemporalInstant(_epochNanoseconds_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal.instant.fromepochmicroseconds">
-      <h1>Temporal.Instant.fromEpochMicroseconds ( _epochMicroseconds_ )</h1>
-      <p>
-        This function performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Set _epochMicroseconds_ to ? ToBigInt(_epochMicroseconds_).
-        1. Let _epochNanoseconds_ be _epochMicroseconds_ &times; *1000*<sub>ℤ</sub>.
         1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>
@@ -152,21 +125,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-get-temporal.instant.prototype.epochseconds">
-      <h1>get Temporal.Instant.prototype.epochSeconds</h1>
-      <p>
-        `Temporal.Instant.prototype.epochSeconds` is an accessor property whose set accessor function is *undefined*.
-        Its get accessor function performs the following steps:
-      </p>
-      <emu-alg>
-        1. Let _instant_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. Let _ns_ be _instant_.[[Nanoseconds]].
-        1. Let _s_ be floor(ℝ(_ns_) / 10<sup>9</sup>).
-        1. Return 𝔽(_s_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-get-temporal.instant.prototype.epochmilliseconds">
       <h1>get Temporal.Instant.prototype.epochMilliseconds</h1>
       <p>
@@ -179,21 +137,6 @@
         1. Let _ns_ be _instant_.[[Nanoseconds]].
         1. Let _ms_ be floor(ℝ(_ns_) / 10<sup>6</sup>).
         1. Return 𝔽(_ms_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-get-temporal.instant.prototype.epochmicroseconds">
-      <h1>get Temporal.Instant.prototype.epochMicroseconds</h1>
-      <p>
-        `Temporal.Instant.prototype.epochMicroseconds` is an accessor property whose set accessor function is *undefined*.
-        Its get accessor function performs the following steps:
-      </p>
-      <emu-alg>
-        1. Let _instant_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_instant_, [[InitializedTemporalInstant]]).
-        1. Let _ns_ be _instant_.[[Nanoseconds]].
-        1. Let _µs_ be floor(ℝ(_ns_) / 10<sup>3</sup>).
-        1. Return ℤ(_µs_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -672,36 +672,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.plaindatetime.prototype.toplainyearmonth">
-      <h1>Temporal.PlainDateTime.prototype.toPlainYearMonth ( )</h1>
-      <p>
-        This method performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _dateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « ~fields~, ~year-month-from-fields~ »).
-        1. Let _fields_ be ? PrepareCalendarFields(_calendarRec_, _dateTime_, « *"monthCode"*, *"year"* », «», «»).
-        1. Return ? CalendarYearMonthFromFields(_calendarRec_, _fields_).
-        1. NOTE: The call to CalendarYearMonthFromFields is necessary in order to create a PlainYearMonth object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal.plaindatetime.prototype.toplainmonthday">
-      <h1>Temporal.PlainDateTime.prototype.toPlainMonthDay ( )</h1>
-      <p>
-        This method performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _dateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_dateTime_.[[Calendar]], « ~fields~, ~month-day-from-fields~ »).
-        1. Let _fields_ be ? PrepareCalendarFields(_calendarRec_, _dateTime_, « *"day"*, *"monthCode"* », «», «»).
-        1. Return ? CalendarMonthDayFromFields(_calendarRec_, _fields_).
-        1. NOTE: The call to CalendarMonthDayFromFields is necessary in order to create a PlainMonthDay object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.plaindatetime.prototype.toplaintime">
       <h1>Temporal.PlainDateTime.prototype.toPlainTime ( )</h1>
       <p>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -463,20 +463,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.plaindatetime.prototype.withplaindate">
-      <h1>Temporal.PlainDateTime.prototype.withPlainDate ( _plainDateLike_ )</h1>
-      <p>
-        This method performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _dateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_dateTime_, [[InitializedTemporalDateTime]]).
-        1. Let _plainDate_ be ? ToTemporalDate(_plainDateLike_).
-        1. Let _calendar_ be ? ConsolidateCalendars(_dateTime_.[[Calendar]], _plainDate_.[[Calendar]]).
-        1. Return ? CreateTemporalDateTime(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _calendar_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.plaindatetime.prototype.withcalendar">
       <h1>Temporal.PlainDateTime.prototype.withCalendar ( _calendarLike_ )</h1>
       <p>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -321,47 +321,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.plaintime.prototype.toplaindatetime">
-      <h1>Temporal.PlainTime.prototype.toPlainDateTime ( _temporalDate_ )</h1>
-      <p>
-        This method performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _temporalTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. Set _temporalDate_ to ? ToTemporalDate(_temporalDate_).
-        1. Return ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]],
-          _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]],
-          _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]],
-          _temporalDate_.[[Calendar]]).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal.plaintime.prototype.tozoneddatetime">
-      <h1>Temporal.PlainTime.prototype.toZonedDateTime ( _item_ )</h1>
-      <p>
-        This method performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _temporalTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_temporalTime_, [[InitializedTemporalTime]]).
-        1. If _item_ is not an Object, then
-          1. Throw a *TypeError* exception.
-        1. Let _temporalDateLike_ be ? Get(_item_, *"plainDate"*).
-        1. If _temporalDateLike_ is *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _temporalDate_ be ? ToTemporalDate(_temporalDateLike_).
-        1. Let _temporalTimeZoneLike_ be ? Get(_item_, *"timeZone"*).
-        1. If _temporalTimeZoneLike_ is *undefined*, then
-          1. Throw a *TypeError* exception.
-        1. Let _timeZone_ be ? ToTemporalTimeZoneSlotValue(_temporalTimeZoneLike_).
-        1. Let _temporalDateTime_ be ? CreateTemporalDateTime(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]], _temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _temporalDate_.[[Calendar]]).
-        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_timeZone_, « ~get-offset-nanoseconds-for~, ~get-possible-instants-for~ »).
-        1. Let _instant_ be ? GetInstantFor(_timeZoneRec_, _temporalDateTime_, *"compatible"*).
-        1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZone_, _temporalDate_.[[Calendar]]).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.plaintime.prototype.getisofields">
       <h1>Temporal.PlainTime.prototype.getISOFields ( )</h1>
       <p>

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -119,16 +119,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.now.plaindatetime">
-      <h1>Temporal.Now.plainDateTime ( _calendarLike_ [ , _temporalTimeZoneLike_ ] )</h1>
-      <p>
-        This function performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Return ? SystemDateTime(_temporalTimeZoneLike_, _calendarLike_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.now.plaindatetimeiso">
       <h1>Temporal.Now.plainDateTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
@@ -139,16 +129,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.now.zoneddatetime">
-      <h1>Temporal.Now.zonedDateTime ( _calendarLike_ [ , _temporalTimeZoneLike_ ] )</h1>
-      <p>
-        This function performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_, _calendarLike_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.now.zoneddatetimeiso">
       <h1>Temporal.Now.zonedDateTimeISO ( [ _temporalTimeZoneLike_ ] )</h1>
       <p>
@@ -156,17 +136,6 @@
       </p>
       <emu-alg>
         1. Return ? SystemZonedDateTime(_temporalTimeZoneLike_, *"iso8601"*).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal.now.plaindate">
-      <h1>Temporal.Now.plainDate ( _calendarLike_ [ , _temporalTimeZoneLike_ ] )</h1>
-      <p>
-        This function performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _dateTime_ be ? SystemDateTime(_temporalTimeZoneLike_, _calendarLike_).
-        1. Return ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
       </emu-alg>
     </emu-clause>
 

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -672,25 +672,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.zoneddatetime.prototype.withplaindate">
-      <h1>Temporal.ZonedDateTime.prototype.withPlainDate ( _plainDateLike_ )</h1>
-      <p>
-        This method performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _zonedDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _plainDate_ be ? ToTemporalDate(_plainDateLike_).
-        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~get-offset-nanoseconds-for~, ~get-possible-instants-for~ »).
-        1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _plainDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _zonedDateTime_.[[Calendar]]).
-        1. Let _calendar_ be ? ConsolidateCalendars(_zonedDateTime_.[[Calendar]], _plainDate_.[[Calendar]]).
-        1. Let _resultPlainDateTime_ be ? CreateTemporalDateTime(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], _plainDateTime_.[[ISOHour]], _plainDateTime_.[[ISOMinute]], _plainDateTime_.[[ISOSecond]], _plainDateTime_.[[ISOMillisecond]], _plainDateTime_.[[ISOMicrosecond]], _plainDateTime_.[[ISONanosecond]], _calendar_).
-        1. Set _instant_ to ? GetInstantFor(_timeZoneRec_, _resultPlainDateTime_, *"compatible"*).
-        1. Return ! CreateTemporalZonedDateTime(_instant_.[[Nanoseconds]], _timeZoneRec_.[[Receiver]], _calendar_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.zoneddatetime.prototype.withtimezone">
       <h1>Temporal.ZonedDateTime.prototype.withTimeZone ( _timeZoneLike_ )</h1>
       <p>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -344,21 +344,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-get-temporal.zoneddatetime.prototype.epochseconds">
-      <h1>get Temporal.ZonedDateTime.prototype.epochSeconds</h1>
-      <p>
-        `Temporal.ZonedDateTime.prototype.epochSeconds` is an accessor property whose set accessor function is *undefined*.
-        Its get accessor function performs the following steps:
-      </p>
-      <emu-alg>
-        1. Let _zonedDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _ns_ be _zonedDateTime_.[[Nanoseconds]].
-        1. Let _s_ be floor(ℝ(_ns_) / 10<sup>9</sup>).
-        1. Return 𝔽(_s_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-get-temporal.zoneddatetime.prototype.epochmilliseconds">
       <h1>get Temporal.ZonedDateTime.prototype.epochMilliseconds</h1>
       <p>
@@ -371,21 +356,6 @@
         1. Let _ns_ be _zonedDateTime_.[[Nanoseconds]].
         1. Let _ms_ be floor(ℝ(_ns_) / 10<sup>6</sup>).
         1. Return 𝔽(_ms_).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-get-temporal.zoneddatetime.prototype.epochmicroseconds">
-      <h1>get Temporal.ZonedDateTime.prototype.epochMicroseconds</h1>
-      <p>
-        `Temporal.ZonedDateTime.prototype.epochMicroseconds` is an accessor property whose set accessor function is *undefined*.
-        Its get accessor function performs the following steps:
-      </p>
-      <emu-alg>
-        1. Let _zonedDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _ns_ be _zonedDateTime_.[[Nanoseconds]].
-        1. Let _µs_ be floor(ℝ(_ns_) / 10<sup>3</sup>).
-        1. Return ℤ(_µs_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -934,42 +934,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal.zoneddatetime.prototype.toplainyearmonth">
-      <h1>Temporal.ZonedDateTime.prototype.toPlainYearMonth ( )</h1>
-      <p>
-        This method performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _zonedDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_zonedDateTime_.[[Calendar]], « ~fields~, ~year-month-from-fields~ »).
-        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~get-offset-nanoseconds-for~ »).
-        1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
-        1. Let _fields_ be ? PrepareCalendarFields(_calendarRec_, _temporalDateTime_, « *"monthCode"*, *"year"* », «», «»).
-        1. Return ? CalendarYearMonthFromFields(_calendarRec_, _fields_).
-        1. NOTE: The call to CalendarYearMonthFromFields is necessary in order to create a PlainYearMonth object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal.zoneddatetime.prototype.toplainmonthday">
-      <h1>Temporal.ZonedDateTime.prototype.toPlainMonthDay ( )</h1>
-      <p>
-        This method performs the following steps when called:
-      </p>
-      <emu-alg>
-        1. Let _zonedDateTime_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _calendarRec_ be ? CreateCalendarMethodsRecord(_zonedDateTime_.[[Calendar]], « ~fields~, ~month-day-from-fields~ »).
-        1. Let _timeZoneRec_ be ? CreateTimeZoneMethodsRecord(_zonedDateTime_.[[TimeZone]], « ~get-offset-nanoseconds-for~ »).
-        1. Let _instant_ be ! CreateTemporalInstant(_zonedDateTime_.[[Nanoseconds]]).
-        1. Let _temporalDateTime_ be ? GetPlainDateTimeFor(_timeZoneRec_, _instant_, _calendarRec_.[[Receiver]]).
-        1. Let _fields_ be ? PrepareCalendarFields(_calendarRec_, _temporalDateTime_, « *"day"*, *"monthCode"* », «», «»).
-        1. Return ? CalendarMonthDayFromFields(_calendarRec_, _fields_).
-        1. NOTE: The call to CalendarMonthDayFromFields is necessary in order to create a PlainMonthDay object with the [[ISOYear]], [[ISOMonth]], and [[ISODay]] internal slots set correctly.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal.zoneddatetime.prototype.getisofields">
       <h1>Temporal.ZonedDateTime.prototype.getISOFields ( )</h1>
       <p>


### PR DESCRIPTION
Here is an implementation of part of the slate of API removals that reached consensus in the TC39 meeting of 2024-06-12. This consists of all removals except for calendars and time zones and things related to them such as getISOFields, which will follow in a later PR.

This PR contains documentation updates, removals from the spec text, removals from the reference code, removals from the suggested TypeScript definitions, and adjustments of the cookbook examples.

Here is what's removed exactly:
- Temporal.PlainDateTime.p.withPlainDate
- Temporal.ZonedDateTime.p.withPlainDate
- Temporal.PlainTime.p.toPlainDateTime
- Temporal.PlainTime.p.toZonedDateTime
- Temporal.Instant.fromEpochSeconds
- Temporal.Instant.fromEpochMicroseconds
- Temporal.Instant.p.epochSeconds
- Temporal.Instant.p.epochMicroseconds
- Temporal.ZonedDateTime.p.epochSeconds
- Temporal.ZonedDateTime.p.epochMicroseconds
- Temporal.PlainDateTime.p.toPlainYearMonth
- Temporal.PlainDateTime.p.toPlainMonthDay
- Temporal.ZonedDateTime.p.toPlainYearMonth
- Temporal.ZonedDateTime.p.toPlainMonthDay
- Temporal.Instant.p.toZonedDateTime
- Temporal.Now.zonedDateTime
- Temporal.Now.plainDateTime
- Temporal.Now.plainDate

Tests are in tc39/test262#4108.

Closes: #2846, #2847, #2848, #2849