### PR TITLE
Editorial: Followups from re-sync of ECMA-402

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -73,7 +73,7 @@ export class Calendar {
     let stringId = ES.RequireString(id);
     if (!ES.IsBuiltinCalendar(stringId)) throw new RangeError(`invalid calendar identifier ${stringId}`);
     CreateSlots(this);
-    stringId = ES.ASCIILowercase(stringId);
+    stringId = ES.CanonicalizeCalendar(stringId);
     SetSlot(this, CALENDAR_ID, stringId);
 
     if (typeof __debug__ !== 'undefined' && __debug__) {

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -39,21 +39,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-availablecalendars" type="implementation-defined abstract operation">
+    <emu-clause id="sec-availablecalendars" type="implementation-defined abstract operation">
       <h1>
         AvailableCalendars (
         ): a List of Strings
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>Each element in the returned List represents a calendar type supported by the implementation.</dd>
+        <dd>The returned List is sorted according to lexicographic code unit order, and contains unique calendar types in canonical form (<emu-xref href="#sec-calendar-types"></emu-xref>) identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects, including their aliases (e.g., either both or neither of *"islamicc"* and *"islamic-civil"*). The List must include *"iso8601"*.</dd>
       </dl>
-      <emu-alg>
-        1. Let _calendars_ be the List of String values representing calendar types supported by the implementation, sorted according to lexicographic code unit order.
-        1. Assert: _calendars_ contains *"iso8601"*.
-        1. [declared="S"] Assert: _calendars_ does not contain any element _S_ for which the ASCII-lowercase of _S_ is not _S_.
-        1. Assert: _calendars_ does not contain any element that does not identify a calendar type in the <a href="https://cldr.unicode.org/">Unicode Common Locale Data Repository (CLDR)</a>.
-      </emu-alg>
     </emu-clause>
   </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -214,6 +214,29 @@
   </emu-clause>
   </del>
 
+  <del class="block">
+  <emu-clause id="sec-calendar-types-deleted">
+    <h1>Calendar Types</h1>
+
+    <p>
+      This specification identifies calendars using a calendar type as defined by <a href="https://unicode.org/reports/tr35/tr35-dates.html#Calendar_Elements">Unicode Technical Standard #35 Part 4 Dates, Section 2 Calendar Elements</a>. Their canonical form is a string containing only Unicode Basic Latin lowercase letters (U+0061 LATIN SMALL LETTER A through U+007A LATIN SMALL LETTER Z) with zero or more medial hyphens (U+002D HYPHEN-MINUS).
+    </p>
+
+    <emu-clause id="sec-availablecalendars-deleted" type="abstract operation">
+      <h1>
+        AvailableCalendars (
+        ): a List of Strings
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>The returned List is sorted according to lexicographic code unit order, and contains unique calendar types in canonical form (<emu-xref href="#sec-calendar-types"></emu-xref>) identifying the calendars for which the implementation provides the functionality of Intl.DateTimeFormat objects, including their aliases (e.g., either both or neither of *"islamicc"* and *"islamic-civil"*). The List must include *"iso8601"*.</dd>
+        <dt>redefinition</dt>
+        <dd>true</dd>
+      </dl>
+    </emu-clause>
+  </emu-clause>
+  </del>
+
   <emu-clause id="intl-object">
     <h1>The Intl Object</h1>
     <p>[...]</p>


### PR DESCRIPTION
Anba re-synced the spec text with the latest draft of ECMA-402 in #2904. That brought in AvailableCalendars which now needs to move into ECMA-262 as part of Temporal, and also brought in calendar canonicalization which I've implemented support for in the reference code. Also brings in a test262 update with improved coverage for calendar canonicalization.