### PR TITLE
Cookbook example showing how to do Hijri days adjustments (without custom calendar)

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -559,3 +559,9 @@ Since they are generally larger than these cookbook recipes, they're on their ow
 Extend `Temporal` to support arbitrarily-large years (e.g., **+635427810-02-02**) for astronomical purposes.
 
 → [Extra-expanded years](cookbook-expandedyears.md)
+
+### Adjustable Hijri calendar
+
+Extend `Temporal` to support adjustment days for the Hijri calendars, which are sometimes required when the start of the month is based on astronomical observations.
+
+→ [Adjustable Hijri calendar](hijri-days-adjustments.md)

--- a/docs/cookbook/hijriDaysAdjustments.mjs
+++ b/docs/cookbook/hijriDaysAdjustments.mjs
@@ -1,0 +1,138 @@
+/* eslint-disable no-console */
+import * as Temporal from '../../polyfill/lib/temporal.mjs';
+
+/**
+ * AdjustableHijriPlainDate: A class for customizing Hijri date display.
+ *
+ * This class allows for adjustment of Hijri dates by shifting days forward or backward.
+ * It's designed to:
+ * 1. Help users synchronize displayed Hijri dates with their local Hijri calendar.
+ * 2. Facilitate the use of alternative Hijri calendar epochs.
+ *
+ * Key points:
+ * - It adjusts the display of Hijri dates without modifying the underlying calendar system.
+ * - The adjustment is a simple day shift and does not alter month lengths or other calendar rules.
+ * - This approach is useful for visual alignment but does not implement comprehensive
+ *   calendar customization or detailed Hijri calendar variants.
+ *
+ * Note: For more complex Hijri calendar adjustments or variants, a more sophisticated
+ * implementation would be necessary.
+ */
+
+class AdjustableHijriTemporal {
+  #temporal;
+  #daysToShift;
+  #adjustedDate;
+
+  constructor(temporal, calendar = 'islamic-umalqura', daysToShift = 0) {
+    this.#temporal = temporal.withCalendar(calendar);
+    this.#daysToShift = daysToShift;
+    this.#adjustedDate = this.#temporal.add({ days: this.#daysToShift });
+  }
+
+  get day() {
+    return this.#adjustedDate.day;
+  }
+  get dayOfWeek() {
+    return this.#temporal.dayOfWeek;
+  }
+  get dayOfYear() {
+    return this.#adjustedDate.dayOfYear;
+  }
+  get daysInMonth() {
+    return this.#adjustedDate.daysInMonth;
+  }
+  get daysInYear() {
+    return this.#adjustedDate.daysInYear;
+  }
+  get month() {
+    return this.#adjustedDate.month;
+  }
+  get monthCode() {
+    return this.#adjustedDate.monthCode;
+  }
+  get monthsInYear() {
+    return this.#adjustedDate.monthsInYear;
+  }
+  get year() {
+    return this.#adjustedDate.year;
+  }
+  get inLeapYear() {
+    return this.#adjustedDate.inLeapYear;
+  }
+
+  toString(options) {
+    return this.#adjustedDate.toString(options);
+  }
+
+  toJSON() {
+    return this.#adjustedDate.toJSON();
+  }
+
+  toLocaleString(locales, options) {
+    const formatter = new Intl.DateTimeFormat(locales, options);
+    const originalParts = formatter.formatToParts(this.#temporal);
+    const adjustedParts = formatter.formatToParts(this.#adjustedDate);
+    for (let i = 0; i < adjustedParts.length; i++) {
+      if (adjustedParts[i].type === 'weekday') {
+        adjustedParts[i].value = originalParts[i].value;
+        break;
+      }
+    }
+    return adjustedParts.map((part) => part.value).join('');
+  }
+
+  add(durationLike, options) {
+    return this.#adjustedDate.add(durationLike, options);
+  }
+
+  subtract(durationLike, options) {
+    return this.#adjustedDate.subtract(durationLike, options);
+  }
+
+  until(other, options) {
+    return this.#adjustedDate.until(other, options);
+  }
+
+  since(other, options) {
+    return this.#adjustedDate.since(other, options);
+  }
+
+  with(dateLike, options) {
+    return this.#adjustedDate.with(dateLike, options);
+  }
+
+  withCalendar(calendar) {
+    return this.#adjustedDate.withCalendar(calendar);
+  }
+
+  equals(other) {
+    if (other instanceof AdjustableHijriTemporal) return this.#adjustedDate.equals(other.#adjustedDate);
+
+    return this.#adjustedDate.equals(other);
+  }
+}
+
+const Hdate = new Temporal.PlainDate(2024, 7, 6, 'islamic-umalqura');
+const AHdate = new AdjustableHijriTemporal(Hdate, 'islamic-umalqura', 1);
+
+console.log(
+  Hdate.day,
+  Hdate.dayOfWeek,
+  Hdate.month,
+  Hdate.year,
+  Hdate.toLocaleString('en-SG', {
+    dateStyle: 'full',
+    calendar: 'islamic-umalqura'
+  })
+); // 30 6 12 1445 Saturday, 30 Dhuʻl-Hijjah 1445 AH
+console.log(
+  AHdate.day,
+  AHdate.dayOfWeek,
+  AHdate.month,
+  AHdate.year,
+  AHdate.toLocaleString('en-SG', {
+    dateStyle: 'full',
+    calendar: 'islamic-umalqura'
+  })
+); // 1 6 1 1446 Saturday, 1 Muharram 1446 AH

--- a/docs/cookbook/hijriDaysAdjustments.mjs
+++ b/docs/cookbook/hijriDaysAdjustments.mjs
@@ -2,7 +2,7 @@
 import * as Temporal from '../../polyfill/lib/temporal.mjs';
 
 /**
- * AdjustableHijriPlainDate: A class for customizing Hijri date display.
+ * AdjustableHijriTemporal: A class for customizing Hijri date display.
  *
  * This class allows for adjustment of Hijri dates by shifting days forward or backward.
  * It's designed to:

--- a/docs/hijri-days-adjustments.md
+++ b/docs/hijri-days-adjustments.md
@@ -15,4 +15,6 @@ Key features of this implementation:
 
 > **NOTE**: This example is intended for basic Hijri date adjustments and visual alignment. It does not implement comprehensive calendar customization or detailed Hijri calendar variants. For more complex Hijri calendar adjustments or variants, a more sophisticated implementation would be necessary.
 
+```javascript
 {{cookbook/hijriDaysAdjustments.mjs}}
+```

--- a/docs/hijri-days-adjustments.md
+++ b/docs/hijri-days-adjustments.md
@@ -1,0 +1,18 @@
+# Hijri Days Adjustments
+
+This example demonstrates an approach to customize the display of Hijri dates in Temporal by implementing an `AdjustableHijriTemporal` class. This class allows for shifting Hijri dates forward or backward by a specified number of days.
+
+The code below showcases how to:
+
+1. Synchronize displayed Hijri dates with local Hijri calendars
+2. Facilitate the use of alternative Hijri calendar epochs
+
+Key features of this implementation:
+
+- Adjusts the display of Hijri dates without modifying the underlying calendar system
+- Applies a simple day shift without altering month lengths or other calendar rules
+- Provides visual alignment for different Hijri calendar variants
+
+> **NOTE**: This example is intended for basic Hijri date adjustments and visual alignment. It does not implement comprehensive calendar customization or detailed Hijri calendar variants. For more complex Hijri calendar adjustments or variants, a more sophisticated implementation would be necessary.
+
+{{cookbook/hijriDaysAdjustments.mjs}}


### PR DESCRIPTION
This PR implements the `AdjustableHijriTemporal`  class for customizing Hijri date display.

This class allows for adjustment of Hijri dates by shifting days forward or backward. It's designed to:
- Help users synchronize displayed Hijri dates with their local Hijri calendar.
- Facilitate the use of alternative Hijri calendar epochs.

Key points:
- It adjusts the display of Hijri dates without modifying the underlying calendar system.
- The adjustment is a simple day shift and does not alter month lengths or other calendar rules.
- This approach is useful for visual alignment but does not implement comprehensive calendar customization or detailed Hijri calendar variants.

Notes to maintainers: The implementation uses composition instead of inheritance and I have made it so that one class can accommodate for `PlainDate`, `PlainDateTime` and `ZonedDateTime` as such the class doesn't implement the following functions:

- with the exception of `toPlainYearMonth` and `toPlainMonthDay` that exist in all the Temporal objects aforementioned. the rest of toX functions are not implemented here and would like to hear your thoughts on how the implementation would look like. for example how would `toZonedDateTime` behave on a `ZonedDateTime` underlying object.
- `from` and `fromX` where not implemented because of the same complexity mentioned above. but if there is an agreement on how they should behave I can proceed with the implementation.