### PR TITLE
Normative: Disallow rounding to increment while balancing to calendar unit

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -266,6 +266,13 @@ export class Duration {
     };
     const maximum = maximumIncrements[smallestUnit];
     if (maximum !== undefined) ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false);
+    if (
+      roundingIncrement > 1 &&
+      (ES.IsCalendarUnit(smallestUnit) || smallestUnit === 'day') &&
+      largestUnit !== smallestUnit
+    ) {
+      throw new RangeError('For calendar units with roundingIncrement > 1, use largestUnit = smallestUnit');
+    }
 
     let norm = TimeDuration.normalize(hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -448,6 +448,8 @@
         1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
         1. Let _maximum_ be MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
         1. If _maximum_ is not *undefined*, perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
+        1. If _roundingIncrement_ &gt; 1, and _largestUnit_ is not _smallestUnit_, and IsCalendarUnit(_smallestUnit_) is *true* or _smallestUnit_ is *"day"*, then
+          1. Throw a *RangeError* exception.
         1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. If _zonedRelativeTo_ is not *undefined*, then
           1. Let _timeZone_ be _zonedRelativeTo_.[[TimeZone]].


### PR DESCRIPTION
The corner case of rounding to a >1 increment of a calendar smallest unit while simultaneously balancing to a larger calendar unit is ambiguous. This use case was probably never considered.

```js
const d1 = Temporal.Duration.from({months: 9});
d1.round({
  relativeTo: '2024-01-01',
  largestUnit: 'years',
  smallestUnit: 'months',
  roundingIncrement: 8,
  roundingMode: 'ceil',
});  // => 1 year? 1 year 4 months?
```

This never came up in real-world usage. Disallow it explicitly, to leave space for a future proposal if it ever comes up.

Closes: #2902