### PR TITLE
Normative: Handle "start of day" separately from "midnight"

### DIFF
--- a/docs/plaindate.md
+++ b/docs/plaindate.md
@@ -736,7 +736,7 @@ Use `Temporal.PlainDate.compare()` for this, or `date.equals()` for equality.
 
 This method can be used to convert `Temporal.PlainDate` into a `Temporal.ZonedDateTime`, by supplying the time zone and time of day.
 The default `plainTime`, if it's not provided, is the first valid local time in `timeZone` on the calendar date `date`.
-Usually this is midnight (`00:00`), but may be a different time in rare circumstances like DST starting at midnight or calendars like `ethiopic` where each day doesn't start at midnight.
+Usually this is midnight (`00:00`), but may be a different time in rare circumstances like DST skipping midnight.
 
 For a list of IANA time zone names, see the current version of the [IANA time zone database](https://www.iana.org/time-zones).
 A convenient list is also available [on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), although it might not reflect the latest official status.

--- a/docs/zoneddatetime.md
+++ b/docs/zoneddatetime.md
@@ -803,11 +803,13 @@ zdt.with({ year: 2015, minute: 31 }); // => 2015-12-07T03:31:00-06:00[America/Ch
 **Parameters:**
 
 - `plainTime` (optional `Temporal.PlainTime` or plain object or string): The clock time that should replace the current clock time of `zonedDateTime`.
-  If omitted, the clock time of the result will be `00:00:00`.
 
 **Returns:** a new `Temporal.ZonedDateTime` object which replaces the clock time of `zonedDateTime` with the clock time represented by `plainTime`.
 
-Valid input to `withPlainTime` is the same as valid input to `Temporal.PlainTime.from`, including strings like `12:15:36`, plain object property bags like `{ hour: 20, minute: 30 }`, or `Temporal` objects that contain time fields: `Temporal.PlainTime`, `Temporal.ZonedDateTime`, or `Temporal.PlainDateTime`.
+The default `plainTime`, if it's not provided, is the first valid local time in `zonedDateTime`'s time zone on its calendar date.
+Usually this is midnight (`00:00`), but may be a different time in rare circumstances like DST skipping midnight.
+
+If provided, valid input to `withPlainTime` is the same as valid input to `Temporal.PlainTime.from`, including strings like `12:15:36`, plain object property bags like `{ hour: 20, minute: 30 }`, or `Temporal` objects that contain time fields: `Temporal.PlainTime`, `Temporal.ZonedDateTime`, or `Temporal.PlainDateTime`.
 
 This method is similar to `with`, but with a few important differences:
 
@@ -1179,7 +1181,7 @@ zdt.round({ roundingIncrement: 30, smallestUnit: 'minute', roundingMode: 'floor'
 **Returns:** A new `Temporal.ZonedDateTime` instance representing the earliest valid local clock time during the current calendar day and time zone of `zonedDateTime`.
 
 This method returns a new `Temporal.ZonedDateTime` indicating the start of the day.
-The local time of the result is almost always `00:00`, but in rare cases it could be a later time e.g. if DST starts at midnight in a time zone. For example:
+The local time of the result is almost always `00:00`, but in rare cases it could be a later time e.g. if DST skips midnight in a time zone. For example:
 
 ```javascript
 const zdt = Temporal.ZonedDateTime.from('2015-10-18T12:00-02:00[America/Sao_Paulo]');

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -206,19 +206,27 @@ export class PlainDate {
     }
 
     const calendar = GetSlot(this, CALENDAR);
-    temporalTime = ES.ToTemporalTimeOrMidnight(temporalTime);
-    const dt = {
-      year: GetSlot(this, ISO_YEAR),
-      month: GetSlot(this, ISO_MONTH),
-      day: GetSlot(this, ISO_DAY),
-      hour: GetSlot(temporalTime, ISO_HOUR),
-      minute: GetSlot(temporalTime, ISO_MINUTE),
-      second: GetSlot(temporalTime, ISO_SECOND),
-      millisecond: GetSlot(temporalTime, ISO_MILLISECOND),
-      microsecond: GetSlot(temporalTime, ISO_MICROSECOND),
-      nanosecond: GetSlot(temporalTime, ISO_NANOSECOND)
-    };
-    const epochNs = ES.GetEpochNanosecondsFor(timeZone, dt, 'compatible');
+    const year = GetSlot(this, ISO_YEAR);
+    const month = GetSlot(this, ISO_MONTH);
+    const day = GetSlot(this, ISO_DAY);
+    let epochNs;
+    if (temporalTime === undefined) {
+      epochNs = ES.GetStartOfDay(timeZone, { year, month, day });
+    } else {
+      temporalTime = ES.ToTemporalTime(temporalTime);
+      const dt = {
+        year,
+        month,
+        day,
+        hour: GetSlot(temporalTime, ISO_HOUR),
+        minute: GetSlot(temporalTime, ISO_MINUTE),
+        second: GetSlot(temporalTime, ISO_SECOND),
+        millisecond: GetSlot(temporalTime, ISO_MILLISECOND),
+        microsecond: GetSlot(temporalTime, ISO_MICROSECOND),
+        nanosecond: GetSlot(temporalTime, ISO_NANOSECOND)
+      };
+      epochNs = ES.GetEpochNanosecondsFor(timeZone, dt, 'compatible');
+    }
     return ES.CreateTemporalZonedDateTime(epochNs, timeZone, calendar);
   }
   toPlainYearMonth() {

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -186,8 +186,15 @@ export class PlainDateTime {
     fields = ES.CalendarMergeFields(calendar, fields, partialDateTime);
 
     const overflow = ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
-    const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
-      ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
+    const { year, month, day, time } = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
+    const {
+      hour = 0,
+      minute = 0,
+      second = 0,
+      millisecond = 0,
+      microsecond = 0,
+      nanosecond = 0
+    } = time === 'start-of-day' ? {} : time;
 
     return ES.CreateTemporalDateTime(
       year,

--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -501,6 +501,10 @@ function fuzzMode(mode) {
     try {
       const parsingMethod = ES[`ParseTemporal${mode}StringRaw`] ?? ES[`ParseTemporal${mode}String`];
       const parsed = parsingMethod(fuzzed);
+      if (parsed.time === 'start-of-day') {
+        parsed.time = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
+      }
+      if (parsed.time) Object.assign(parsed, parsed.time);
       for (let prop of comparisonItems[mode]) {
         let expected = generatedData[prop];
         if (!['tzAnnotation', 'offset', 'calendar'].includes(prop)) expected ??= prop === 'z' ? false : 0;

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -779,7 +779,7 @@
         1. Let _offsetNs_ be ? ParseDateTimeUTCOffset(_offsetString_).
       1. Else,
         1. Let _offsetNs_ be 0.
-      1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNs_, _timeZone_, *"compatible"*, *"reject"*, _matchBehaviour_).
+      1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Time]], _offsetBehaviour_, _offsetNs_, _timeZone_, *"compatible"*, *"reject"*, _matchBehaviour_).
       1. Let _zonedRelativeTo_ be ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       1. Return the Record { [[PlainRelativeTo]]: *undefined*, [[ZonedRelativeTo]]: _zonedRelativeTo_ }.
     </emu-alg>
@@ -1533,7 +1533,7 @@
       An <dfn variants="ISO Date-Time Parse Records">ISO Date-Time Parse Record</dfn> is a Record value used to represent the result of parsing an ISO 8601 string.
     </p>
     <p>
-      ISO Date-Time Parse Records have all the fields of ISO Date-Time Records, in addition to those listed in <emu-xref href="#table-temporal-iso-date-time-parse-record-fields"></emu-xref>.
+      ISO Date-Time Parse Records have the fields listed in <emu-xref href="#table-temporal-iso-date-time-parse-record-fields"></emu-xref>.
     </p>
     <emu-table id="table-temporal-iso-date-time-parse-record-fields" caption="ISO Date-Time Parse Record Fields">
       <table class="real-table">
@@ -1541,6 +1541,34 @@
           <th>Field Name</th>
           <th>Value</th>
           <th>Meaning</th>
+        </tr>
+        <tr>
+          <td>[[Year]]</td>
+          <td>an integer</td>
+          <td>
+            The year in the ISO 8601 calendar.
+          </td>
+        </tr>
+        <tr>
+          <td>[[Month]]</td>
+          <td>an integer between 1 and 12, inclusive</td>
+          <td>
+            The number of the month in the ISO 8601 calendar.
+          </td>
+        </tr>
+        <tr>
+          <td>[[Day]]</td>
+          <td>an integer between 1 and 31, inclusive</td>
+          <td>
+            The number of the day of the month in the ISO 8601 calendar.
+          </td>
+        </tr>
+        <tr>
+          <td>[[Time]]</td>
+          <td>either a Time Record with [[Days]] value 0, or ~start-of-day~</td>
+          <td>
+            The time of day, or ~start-of-day~ if the time was omitted from the string.
+          </td>
         </tr>
         <tr>
           <td>[[TimeZone]]</td>
@@ -1631,6 +1659,10 @@
         1. Let _nanosecondMV_ be 0.
       1. Assert: IsValidISODate(_yearMV_, _monthMV_, _dayMV_) is *true*.
       1. Assert: IsValidTime(_hourMV_, _minuteMV_, _secondMV_, _millisecondMV_, _microsecondMV_, _nanosecondMV_) is *true*.
+      1. If _hour_ is empty, then
+        1. Let _time_ be ~start-of-day~.
+      1. Else,
+        1. Let _time_ be Time Record { [[Days]]: 0, [[Hour]]: _hourMV_, [[Minute]]: _minuteMV_, [[Second]]: _secondMV_, [[Millisecond]]: _millisecondMV_, [[Microsecond]]: _microsecondMV_, [[Nanosecond]]: _nanosecondMV_ }.
       1. Let _timeZoneResult_ be ISO String Time Zone Parse Record { [[Z]]: *false*, [[OffsetString]]: ~empty~, [[TimeZoneAnnotation]]: ~empty~ }.
       1. If _parseResult_ contains a |TimeZoneIdentifier| Parse Node, then
         1. Let _identifier_ be the source text matched by the |TimeZoneIdentifier| Parse Node contained within _parseResult_.
@@ -1644,12 +1676,7 @@
           [[Year]]: _yearMV_,
           [[Month]]: _monthMV_,
           [[Day]]: _dayMV_,
-          [[Hour]]: _hourMV_,
-          [[Minute]]: _minuteMV_,
-          [[Second]]: _secondMV_,
-          [[Millisecond]]: _millisecondMV_,
-          [[Microsecond]]: _microsecondMV_,
-          [[Nanosecond]]: _nanosecondMV_,
+          [[Time]]: _time_,
           [[TimeZone]]: _timeZoneResult_,
           [[Calendar]]: _calendar_
         }.
@@ -1943,7 +1970,9 @@
     <emu-alg>
       1. Let _parseResult_ be ParseText(StringToCodePoints(_isoString_), |TemporalTimeString|).
       1. If _parseResult_ is a List of errors, throw a *RangeError* exception.
-      1. Return ? ParseISODateTime(_isoString_).
+      1. Let _result_ be ? ParseISODateTime(_isoString_).
+      1. Assert: _result_.[[Time]] is not ~start-of-day~.
+      1. Return _result_.
     </emu-alg>
     <emu-note>
       <p>A successful parse using |TemporalTimeString| guarantees absence of ambiguity with respect to any ISO 8601 date-only, year-month, or month-day representation.</p>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -461,7 +461,11 @@
         1. Let _parsed_ be ? ParseTemporalInstantString(_item_).
         1. If _parsed_.[[TimeZone]].[[Z]] is *true*, let _offsetNanoseconds_ be 0; otherwise, let _offsetNanoseconds_ be ! ParseDateTimeUTCOffset(_parsed_.[[TimeZone]].[[OffsetString]]).
         1. If abs(ISODateToEpochDays(_parsed_.[[Year]], _parsed_.[[Month]] - 1, _parsed_.[[Day]])) > 10<sup>8</sup>, throw a *RangeError* exception.
-        1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_parsed_.[[Year]], _parsed_.[[Month]], _parsed_.[[Day]], _parsed_.[[Hour]], _parsed_.[[Minute]], _parsed_.[[Second]], _parsed_.[[Millisecond]], _parsed_.[[Microsecond]], _parsed_.[[Nanosecond]], _offsetNanoseconds_).
+        1. If _parsed_.[[Time]] is ~start-of-day~, then
+          1. Let _time_ be Time Record { [[Days]]: 0, [[Hour]]: 0, [[Minute]]: 0, [[Second]]: 0, [[Millisecond]]: 0, [[Microsecond]]: 0, [[Nanosecond]]: 0 }.
+        1. Else,
+          1. Let _time_ be _parsed_.[[Time]].
+        1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_parsed_.[[Year]], _parsed_.[[Month]], _parsed_.[[Day]], _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]], _offsetNanoseconds_).
         1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -507,10 +507,14 @@
         1. Else,
           1. Let _timeZone_ be ? ToTemporalTimeZoneIdentifier(_item_).
           1. Let _temporalTime_ be *undefined*.
-        1. Set _temporalTime_ to ? ToTemporalTimeOrMidnight(_temporalTime_).
-        1. Let _isoDateTime_ be ISO Date-Time Record { [[Year]]: _temporalDate_.[[ISOYear]], [[Month]]: _temporalDate_.[[ISOMonth]], [[Day]]: _temporalDate_.[[ISODay]], [[Hour]]: _temporalTime_.[[ISOHour]], [[Minute]]: _temporalTime_.[[ISOMinute]], [[Second]]: _temporalTime_.[[ISOSecond]], [[Millisecond]]: _temporalTime_.[[ISOMillisecond]], [[Microsecond]]: _temporalTime_.[[ISOMicrosecond]], [[Nanosecond]]: _temporalTime_.[[ISONanosecond]] }.
-        1. If ISODateTimeWithinLimits(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]], _isoDateTime_.[[Hour]], _isoDateTime_.[[Minute]], _isoDateTime_.[[Second]], _isoDateTime_.[[Millisecond]], _isoDateTime_.[[Microsecond]], _isoDateTime_.[[Nanosecond]]) is *false*, throw a *RangeError* exception.
-        1. Let _epochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, *"compatible"*).
+        1. If _temporalTime_ is *undefined*, then
+          1. Let _isoDate_ be CreateISODateRecord(_temporalDate_.[[ISOYear]], _temporalDate_.[[ISOMonth]], _temporalDate_.[[ISODay]]).
+          1. Let _epochNs_ be ? GetStartOfDay(_timeZone_, _isoDate_).
+        1. Else,
+          1. Set _temporalTime_ to ? ToTemporalTime(_temporalTime_).
+          1. Let _isoDateTime_ be ISO Date-Time Record { [[Year]]: _temporalDate_.[[ISOYear]], [[Month]]: _temporalDate_.[[ISOMonth]], [[Day]]: _temporalDate_.[[ISODay]], [[Hour]]: _temporalTime_.[[ISOHour]], [[Minute]]: _temporalTime_.[[ISOMinute]], [[Second]]: _temporalTime_.[[ISOSecond]], [[Millisecond]]: _temporalTime_.[[ISOMillisecond]], [[Microsecond]]: _temporalTime_.[[ISOMicrosecond]], [[Nanosecond]]: _temporalTime_.[[ISONanosecond]] }.
+          1. If ISODateTimeWithinLimits(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]], _isoDateTime_.[[Hour]], _isoDateTime_.[[Minute]], _isoDateTime_.[[Second]], _isoDateTime_.[[Millisecond]], _isoDateTime_.[[Microsecond]], _isoDateTime_.[[Nanosecond]]) is *false*, throw a *RangeError* exception.
+          1. Let _epochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, *"compatible"*).
         1. Return ! CreateTemporalZonedDateTime(_epochNs_, _timeZone_, _temporalDate_.[[Calendar]]).
       </emu-alg>
     </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -447,8 +447,12 @@
         1. Let _overflow_ be ? GetTemporalOverflowOption(_resolvedOptions_).
         1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _overflow_).
         1. Assert: IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
-        1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
-        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
+        1. If _result_.[[Time]] is ~start-of-day~, then
+          1. Let _time_ be Time Record { [[Hour]]: 0, [[Minute]]: 0, [[Second]]: 0, [[Millisecond]]: 0, [[Microsecond]]: 0, [[Nanosecond]]: 0 }.
+        1. Else,
+          1. Let _time_ be _result_.[[Time]].
+        1. Assert: IsValidTime(_time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]]) is *true*.
+        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>
 
@@ -950,7 +954,7 @@
           _calendar_: a String,
           _fields_: a Calendar Fields Record,
           _overflow_: *"constrain"* or *"reject"*,
-        ): either a normal completion containing an ISO Date-Time Record or a throw completion
+        ): either a normal completion containing a Record with fields [[Year]], [[Month]], [[Day]] (as in ISO Date-Time Record) and [[Time]] (a Time Record), or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -959,7 +963,7 @@
       <emu-alg>
         1. Let _isoDate_ be ? CalendarDateFromFields(_calendar_, _fields_, _overflow_).
         1. Let _time_ be ? RegulateTime(_fields_.[[Hour]], _fields_.[[Minute]], _fields_.[[Second]], _fields_.[[Millisecond]], _fields_.[[Microsecond]], _fields_.[[Nanosecond]], _overflow_).
-        1. Return CombineISODateAndTimeRecord(_isoDate_, _time_).
+        1. Return the Record { [[Year]]: _isoDate_.[[Year]], [[Month]]: _isoDate_.[[Month]], [[Day]]: _isoDate_.[[Day]], [[Time]]: _time_ }.
       </emu-alg>
     </emu-clause>
 
@@ -998,15 +1002,16 @@
         1. Else,
           1. If _item_ is not a String, throw a *TypeError* exception.
           1. Let _result_ be ? ParseTemporalDateTimeString(_item_).
+          1. If _result_.[[Time]] is ~start-of-day~, set _result_.[[Time]] to Time Record { [[Days]]: 0, [[Hour]]: 0, [[Minute]]: 0, [[Second]]: 0, [[Millisecond]]: 0, [[Microsecond]]: 0, [[Nanosecond]]: 0 }.
           1. Assert: IsValidISODate(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]) is *true*.
-          1. Assert: IsValidTime(_result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]]) is *true*.
+          1. Assert: IsValidTime(_result_.[[Time]].[[Hour]], _result_.[[Time]].[[Minute]], _result_.[[Time]].[[Second]], _result_.[[Time]].[[Millisecond]], _result_.[[Time]].[[Microsecond]], _result_.[[Time]].[[Nanosecond]]) is *true*.
           1. Let _calendar_ be _result_.[[Calendar]].
           1. If _calendar_ is ~empty~, set _calendar_ to *"iso8601"*.
           1. If IsBuiltinCalendar(_calendar_) is *false*, throw a *RangeError* exception.
           1. Set _calendar_ to CanonicalizeUValue(*"ca"*, _calendar_).
           1. Set _options_ to ? GetOptionsObject(_options_).
           1. Perform ? GetTemporalOverflowOption(_options_).
-        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _calendar_).
+        1. Return ? CreateTemporalDateTime(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Time]].[[Hour]], _result_.[[Time]].[[Minute]], _result_.[[Time]].[[Second]], _result_.[[Time]].[[Millisecond]], _result_.[[Time]].[[Microsecond]], _result_.[[Time]].[[Nanosecond]], _calendar_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -379,6 +379,28 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-temporal-getstartofday" type="abstract operation">
+      <h1>
+        GetStartOfDay (
+          _timeZone_: a String,
+          _isoDate_: an ISO Date Record,
+        ): either a normal completion containing a BigInt or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It determines the exact time that corresponds to the first valid wall-clock time in the calendar date _isoDate_ in _timeZone_.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _isoDateTime_ be ISO Date-Time Record { [[Year]]: _isoDate_.[[Year]], [[Month]]: _isoDate_.[[Month]], [[Day]]: _isoDate_.[[Day]], [[Hour]]: 0, [[Minute]]: 0, [[Second]]: 0, [[Millisecond]]: 0, [[Microsecond]]: 0, [[Nanosecond]]: 0 }.
+        1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).
+        1. If _possibleEpochNs_ is not empty, return _possibleEpochNs_[0].
+        1. Assert: IsOffsetTimeZoneIdentifier(_timeZone_) is *false*.
+        1. [declared="isoDateTimeAfter"] Let _possibleEpochNsAfter_ be GetNamedTimeZoneEpochNanoseconds(_timeZone_, _isoDateTimeAfter_.[[Year]], _isoDateTimeAfter_.[[Month]], _isoDateTimeAfter_.[[Day]], _isoDateTimeAfter_.[[Hour]], _isoDateTimeAfter_.[[Minute]], _isoDateTimeAfter_.[[Second]], _isoDateTimeAfter_.[[Millisecond]], _isoDateTimeAfter_.[[Microsecond]], _isoDateTimeAfter_.[[Nanosecond]]), where _isoDateTimeAfter_ is the ISO Date-Time Record for which ! DifferenceISODateTime(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]], _isoDateTime_.[[Hour]], _isoDateTime_.[[Minute]], _isoDateTime_.[[Second]], _isoDateTime_.[[Millisecond]], _isoDateTime_.[[Microsecond]], _isoDateTime_.[[Nanosecond]], _isoDateTimeAfter_.[[Year]], _isoDateTimeAfter_.[[Month]], _isoDateTimeAfter_.[[Day]], _isoDateTimeAfter_.[[Hour]], _isoDateTimeAfter_.[[Minute]], _isoDateTimeAfter_.[[Second]], _isoDateTimeAfter_.[[Millisecond]], _isoDateTimeAfter_.[[Microsecond]], _isoDateTimeAfter_.[[Nanosecond]], *"iso8601"*, *"hour"*).[[Norm]] is the smallest possible value &gt; 0 for which _possibleEpochNsAfter_ is not empty (i.e., _isoDateTimeAfter_ represents the first local time after the transition).
+        1. Assert: _possibleEpochNsAfter_'s length = 1.
+        1. Return _possibleEpochNsAfter_[0].
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-temporal-timezoneequals" type="abstract operation">
       <h1>
         TimeZoneEquals (

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -416,12 +416,10 @@
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _zonedDateTime_.[[Nanoseconds]]).
-        1. Let _midnight_ be a Time Record with all fields set to 0.
-        1. Let _today_ be CombineISODateAndTimeRecord(_isoDateTime_, _midnight_).
-        1. Let _tomorrowISODate_ be BalanceISODate(_today_.[[Year]], _today_.[[Month]], _today_.[[Day]] + 1).
-        1. Let _tomorrow_ be CombineISODateAndTimeRecord(_tomorrowISODate_, _midnight_).
-        1. Let _todayNs_ be ? GetEpochNanosecondsFor(_timeZone_, _today_, *"compatible"*).
-        1. Let _tomorrowNs_ be ? GetEpochNanosecondsFor(_timeZone_, _tomorrow_, *"compatible"*).
+        1. Let _today_ be CreateISODateRecord(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]]).
+        1. Let _tomorrow_ be BalanceISODate(_today_.[[Year]], _today_.[[Month]], _today_.[[Day]] + 1).
+        1. Let _todayNs_ be ? GetStartOfDay(_timeZone_, _today_).
+        1. Let _tomorrowNs_ be ? GetStartOfDay(_timeZone_, _tomorrow_).
         1. Let _diff_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_tomorrowNs_, _todayNs_).
         1. Return 𝔽(DivideNormalizedTimeDuration(_diff_, 3.6 × 10<sup>12</sup>)).
       </emu-alg>
@@ -554,7 +552,7 @@
         1. Let _overflow_ be ? GetTemporalOverflowOption(_options_).
         1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _overflow_).
         1. Let _newOffsetNanoseconds_ be ? ParseDateTimeUTCOffset(_fields_.[[OffsetString]]).
-        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Hour]], _dateTimeResult_.[[Minute]], _dateTimeResult_.[[Second]], _dateTimeResult_.[[Millisecond]], _dateTimeResult_.[[Microsecond]], _dateTimeResult_.[[Nanosecond]], ~option~, _newOffsetNanoseconds_, _timeZone_, _disambiguation_, _offset_, ~match-exactly~).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[Year]], _dateTimeResult_.[[Month]], _dateTimeResult_.[[Day]], _dateTimeResult_.[[Time]], ~option~, _newOffsetNanoseconds_, _timeZone_, _disambiguation_, _offset_, ~match-exactly~).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -567,13 +565,17 @@
       <emu-alg>
         1. Let _zonedDateTime_ be the *this* value.
         1. Perform ? RequireInternalSlot(_zonedDateTime_, [[InitializedTemporalZonedDateTime]]).
-        1. Let _plainTime_ be ? ToTemporalTimeOrMidnight(_plainTimeLike_).
-        1. Let _time_ be Time Record { [[Days]]: 0, [[Hour]]: _plainTime_.[[ISOHour]], [[Minute]]: _plainTime_.[[ISOMinute]], [[Second]]: _plainTime_.[[ISOSecond]], [[Millisecond]]: _plainTime_.[[ISOMillisecond]], [[Microsecond]]: _plainTime_.[[ISOMicrosecond]], [[Nanosecond]]: _plainTime_.[[ISONanosecond]] }.
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _zonedDateTime_.[[Nanoseconds]]).
-        1. Let _resultISODateTime_ be CombineISODateAndTimeRecord(_isoDateTime_, _time_).
-        1. Let _epochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _resultISODateTime_, *"compatible"*).
+        1. If _plainTimeLike_ is *undefined*, then
+          1. Let _isoDate_ be CreateISODateRecord(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]]).
+          1. Let _epochNs_ be ? GetStartOfDay(_timeZone_, _isoDate_).
+        1. Else,
+          1. Let _plainTime_ be ? ToTemporalTime(_plainTimeLike_).
+          1. Let _time_ be Time Record { [[Days]]: 0, [[Hour]]: _plainTime_.[[ISOHour]], [[Minute]]: _plainTime_.[[ISOMinute]], [[Second]]: _plainTime_.[[ISOSecond]], [[Millisecond]]: _plainTime_.[[ISOMillisecond]], [[Microsecond]]: _plainTime_.[[ISOMicrosecond]], [[Nanosecond]]: _plainTime_.[[ISONanosecond]] }.
+          1. Let _resultISODateTime_ be CombineISODateAndTimeRecord(_isoDateTime_, _time_).
+          1. Let _epochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _resultISODateTime_, *"compatible"*).
         1. Return ! CreateTemporalZonedDateTime(_epochNs_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -687,13 +689,11 @@
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _thisNs_).
         1. If _smallestUnit_ is *"day"*, then
-          1. Let _midnight_ be a Time Record with all fields set to 0.
-          1. Let _dtStart_ be CombineISODateAndTimeRecord(_isoDateTime_, _midnight_).
+          1. Let _dateStart_ be CreateISODateRecord(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]]).
           1. Let _dateEnd_ be BalanceISODate(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]] + 1).
-          1. Let _dtEnd_ be CombineISODateAndTimeRecord(_dateEnd_, _midnight_).
-          1. Let _startNs_ be ? GetEpochNanosecondsFor(_timeZone_, _dtStart_, *"compatible"*).
+          1. Let _startNs_ be ? GetStartOfDay(_timeZone_, _dateStart_).
           1. Assert: _thisNs_ ≥ _startNs_.
-          1. Let _endNs_ be ? GetEpochNanosecondsFor(_timeZone_, _dtEnd_, *"compatible"*).
+          1. Let _endNs_ be ? GetStartOfDay(_timeZone_, _dateEnd_).
           1. Assert: _thisNs_ &lt; _endNs_.
           1. Let _dayLengthNs_ be ℝ(_endNs_ - _startNs_).
           1. Let _dayProgressNs_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_thisNs_, _startNs_).
@@ -702,7 +702,8 @@
         1. Else,
           1. Let _roundResult_ be RoundISODateTime(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]], _isoDateTime_.[[Hour]], _isoDateTime_.[[Minute]], _isoDateTime_.[[Second]], _isoDateTime_.[[Millisecond]], _isoDateTime_.[[Microsecond]], _isoDateTime_.[[Nanosecond]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. Let _offsetNanoseconds_ be GetOffsetNanosecondsFor(_timeZone_, _thisNs_).
-          1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_.[[Year]], _roundResult_.[[Month]], _roundResult_.[[Day]], _roundResult_.[[Hour]], _roundResult_.[[Minute]], _roundResult_.[[Second]], _roundResult_.[[Millisecond]], _roundResult_.[[Microsecond]], _roundResult_.[[Nanosecond]], ~option~, _offsetNanoseconds_, _timeZone_, *"compatible"*, *"prefer"*, ~match-exactly~).
+          1. Let _time_ be Time Record { [[Hour]]: _roundResult_.[[Hour]], [[Minute]]: _roundResult_.[[Minute]], [[Second]]: _roundResult_.[[Second]], [[Millisecond]]: _roundResult_.[[Millisecond]], [[Microsecond]]: _roundResult_.[[Microsecond]], [[Nanosecond]]: _roundResult_.[[Nanosecond]] }.
+          1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_.[[Year]], _roundResult_.[[Month]], _roundResult_.[[Day]], _time_, ~option~, _offsetNanoseconds_, _timeZone_, *"compatible"*, *"prefer"*, ~match-exactly~).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -803,9 +804,8 @@
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _zonedDateTime_.[[Nanoseconds]]).
-        1. Let _midnight_ be a Time Record with all fields set to 0.
-        1. Let _startDateTime_ be CombineISODateAndTimeRecord(_isoDateTime_, _midnight_).
-        1. Let _epochNanoseconds_ be ? GetEpochNanosecondsFor(_timeZone_, _startDateTime_, *"compatible"*).
+        1. Let _isoDate_ be CreateISODateRecord(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]]).
+        1. Let _epochNanoseconds_ be ? GetStartOfDay(_timeZone_, _isoDate_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -953,12 +953,7 @@
           _year_: an integer,
           _month_: an integer,
           _day_: an integer,
-          _hour_: an integer in the inclusive interval from 0 to 23,
-          _minute_: an integer in the inclusive interval from 0 to 59,
-          _second_: an integer in the inclusive interval from 0 to 59,
-          _millisecond_: an integer in the inclusive interval from 0 to 999,
-          _microsecond_: an integer in the inclusive interval from 0 to 999,
-          _nanosecond_: an integer in the inclusive interval from 0 to 999,
+          _time_: a Time Record or ~start-of-day~,
           _offsetBehaviour_: one of ~option~, ~exact~, or ~wall~,
           _offsetNanoseconds_: an integer,
           _timeZone_: a String,
@@ -981,12 +976,16 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.
-        1. Let _isoDateTime_ be ISO Date-Time Record { [[Year]]: _year_, [[Month]]: _month_, [[Day]]: _day_, [[Hour]]: _hour_, [[Minute]]: _minute_, [[Second]]: _second_, [[Millisecond]]: _millisecond_, [[Microsecond]]: _microsecond_, [[Nanosecond]]: _nanosecond_ }.
+        1. Let _isoDate_ be CreateISODateRecord(_year_, _month_, _day_).
+        1. If _time_ is ~start-of-day~, then
+          1. Assert: _offsetBehaviour_ is ~wall~.
+          1. Assert: _offsetNanoseconds_ is 0.
+          1. Return ? GetStartOfDay(_timeZone_, _isoDate_).
+        1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, _time_).
         1. If _offsetBehaviour_ is ~wall~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is *"ignore"*, then
           1. Return ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, _disambiguation_).
         1. If _offsetBehaviour_ is ~exact~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is *"use"*, then
-          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_, _offsetNanoseconds_).
+          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]], _offsetNanoseconds_).
           1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
           1. Return _epochNanoseconds_.
         1. Assert: _offsetBehaviour_ is ~option~.
@@ -1065,7 +1064,7 @@
         1. Let _offsetNanoseconds_ be 0.
         1. If _offsetBehaviour_ is ~option~, then
           1. Set _offsetNanoseconds_ to ? ParseDateTimeUTCOffset(_offsetString_).
-        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Hour]], _result_.[[Minute]], _result_.[[Second]], _result_.[[Millisecond]], _result_.[[Microsecond]], _result_.[[Nanosecond]], _offsetBehaviour_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offsetOption_, _matchBehaviour_).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]], _result_.[[Time]], _offsetBehaviour_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offsetOption_, _matchBehaviour_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Fixes calculations of start of day in `ZonedDateTime.prototype.hoursInDay`, `ZonedDateTime.prototype.startOfDay()`, and `ZonedDateTime.prototype.round()` with smallestUnit: "day".

Updates the following operations to explicitly mean "start of day" and not
"midnight":
- `PlainDate.prototype.toZonedDateTime(timeZoneString)`
- `PlainDate.prototype.toZonedDateTime(options)` with omitted or undefined `plainTime` option
- `ZonedDateTime.prototype.withPlainTime()` with no argument or undefined
- Parsing `YYYY-MM-DD[Zone]` anywhere a ZonedDateTime string is expected

This is in order to handle one corner case from the TZDB where clocks were set one hour ahead in America/Toronto at 23:30 on March 30, 1919, meaning that the DST skipped hour encompassed midnight but did not start or end at midnight. (This was probably just in the city of Toronto and maybe some other towns, because time was still locally administered at that time.)

Closes: #2910