### PR TITLE
Relax error checking requiring exclusive end in NudgeToCalendarUnit

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3868,7 +3868,9 @@ function NudgeToCalendarUnit(
   const even = (MathAbs(r1) / increment) % 2 === 0;
   const roundedUnit = numerator.isZero()
     ? MathAbs(r1)
-    : ApplyUnsignedRoundingMode(MathAbs(r1), MathAbs(r2), cmp, even, unsignedRoundingMode);
+    : !numerator.cmp(denominator) // equal?
+      ? MathAbs(r2)
+      : ApplyUnsignedRoundingMode(MathAbs(r1), MathAbs(r2), cmp, even, unsignedRoundingMode);
 
   // Trick to minimize rounding error, due to the lack of fma() in JS
   const fakeNumerator = new TimeDuration(denominator.totalNs.times(r1).add(numerator.totalNs.times(increment * sign)));

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3853,8 +3853,8 @@ function NudgeToCalendarUnit(
 
   // Round the smallestUnit within the epoch-nanosecond span
   if (
-    (sign === 1 && (startEpochNs.gt(destEpochNs) || destEpochNs.geq(endEpochNs))) ||
-    (sign === -1 && (endEpochNs.geq(destEpochNs) || destEpochNs.gt(startEpochNs)))
+    (sign === 1 && (startEpochNs.gt(destEpochNs) || destEpochNs.gt(endEpochNs))) ||
+    (sign === -1 && (endEpochNs.gt(destEpochNs) || destEpochNs.gt(startEpochNs)))
   ) {
     throw new RangeError(`custom calendar reported a ${unit} that is 0 days long`);
   }
@@ -3873,7 +3873,7 @@ function NudgeToCalendarUnit(
   // Trick to minimize rounding error, due to the lack of fma() in JS
   const fakeNumerator = new TimeDuration(denominator.totalNs.times(r1).add(numerator.totalNs.times(increment * sign)));
   const total = fakeNumerator.fdiv(denominator.totalNs);
-  if (MathAbs(total) < MathAbs(r1) || MathAbs(total) >= MathAbs(r2)) {
+  if (MathAbs(total) < MathAbs(r1) || MathAbs(total) > MathAbs(r2)) {
     throw new Error('assertion failed: r1 ≤ total < r2');
   }
 

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3874,7 +3874,7 @@ function NudgeToCalendarUnit(
   const fakeNumerator = new TimeDuration(denominator.totalNs.times(r1).add(numerator.totalNs.times(increment * sign)));
   const total = fakeNumerator.fdiv(denominator.totalNs);
   if (MathAbs(total) < MathAbs(r1) || MathAbs(total) > MathAbs(r2)) {
-    throw new Error('assertion failed: r1 ≤ total < r2');
+    throw new Error('assertion failed: r1 ≤ total ≤ r2');
   }
 
   // Determine whether expanded or contracted

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3854,12 +3854,10 @@ function NudgeToCalendarUnit(
   // Round the smallestUnit within the epoch-nanosecond span
   if (
     (sign === 1 && (startEpochNs.gt(destEpochNs) || destEpochNs.gt(endEpochNs))) ||
-    (sign === -1 && (endEpochNs.gt(destEpochNs) || destEpochNs.gt(startEpochNs)))
+    (sign === -1 && (endEpochNs.gt(destEpochNs) || destEpochNs.gt(startEpochNs))) ||
+    endEpochNs.equals(startEpochNs)
   ) {
     throw new RangeError(`custom calendar reported a ${unit} that is 0 days long`);
-  }
-  if (endEpochNs.equals(startEpochNs)) {
-    throw new Error('assertion failed: startEpochNs ≠ endEpochNs');
   }
   const numerator = TimeDuration.fromEpochNsDiff(destEpochNs, startEpochNs);
   const denominator = TimeDuration.fromEpochNsDiff(endEpochNs, startEpochNs);

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1883,7 +1883,7 @@
         1. Else,
           1. If _endEpochNs_ &gt; _destEpochNs_ or _destEpochNs_ &gt; _startEpochNs_, throw a *RangeError* exception.
           1. Assert: _endEpochNs_ ≤ _destEpochNs_ ≤ _startEpochNs_.
-        1. Assert: _startEpochNs_ ≠ _endEpochNs_.
+        1. If _endEpochNs_ = _startEpochNs_, throw a *RangeError* exception.
         1. Let _progress_ be (_destEpochNs_ - _startEpochNs_) / (_endEpochNs_ - _startEpochNs_).
         1. Let _total_ be _r1_ + _progress_ × _increment_ × _sign_.
         1. NOTE: The above two steps cannot be implemented directly using floating-point arithmetic. This division can be implemented as if constructing Normalized Time Duration Records for the denominator and numerator of _total_ and performing one division operation with a floating-point result.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1878,20 +1878,23 @@
           1. Let _endInstant_ be ? GetInstantFor(_timeZoneRec_, _endDateTime_, *"compatible"*).
           1. Let _endEpochNs_ be _endInstant_.[[Nanoseconds]].
         1. If _sign_ is 1, then
-          1. If _startEpochNs_ &gt; _destEpochNs_ or _destEpochNs_ ≥ _endEpochNs_, throw a *RangeError* exception.
-          1. Assert: _startEpochNs_ ≤ _destEpochNs_ &lt; _endEpochNs_.
+          1. If _startEpochNs_ &gt; _destEpochNs_ or _destEpochNs_ &gt; _endEpochNs_, throw a *RangeError* exception.
+          1. Assert: _startEpochNs_ ≤ _destEpochNs_ ≤ _endEpochNs_.
         1. Else,
-          1. If _endEpochNs_ ≥ _destEpochNs_ or _destEpochNs_ &gt; _startEpochNs_, throw a *RangeError* exception.
-          1. Assert: _endEpochNs_ &lt; _destEpochNs_ ≤ _startEpochNs_.
+          1. If _endEpochNs_ &gt; _destEpochNs_ or _destEpochNs_ &gt; _startEpochNs_, throw a *RangeError* exception.
+          1. Assert: _endEpochNs_ ≤ _destEpochNs_ ≤ _startEpochNs_.
         1. Assert: _startEpochNs_ ≠ _endEpochNs_.
         1. Let _progress_ be (_destEpochNs_ - _startEpochNs_) / (_endEpochNs_ - _startEpochNs_).
         1. Let _total_ be _r1_ + _progress_ × _increment_ × _sign_.
         1. NOTE: The above two steps cannot be implemented directly using floating-point arithmetic. This division can be implemented as if constructing Normalized Time Duration Records for the denominator and numerator of _total_ and performing one division operation with a floating-point result.
-        1. Assert: 0 ≤ _progress_ &lt; 1.
+        1. Assert: 0 ≤ _progress_ ≤ 1.
         1. If _sign_ &lt; 0, let _isNegative_ be ~negative~; else let _isNegative_ be ~positive~.
         1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_roundingMode_, _isNegative_).
-        1. Assert: abs(_r1_) ≤ abs(_total_) &lt; abs(_r2_).
-        1. Let _roundedUnit_ be ApplyUnsignedRoundingMode(abs(_total_), abs(_r1_), abs(_r2_), _unsignedRoundingMode_).
+        1. If _progress_ = 1, then
+          1. Let _roundedUnit_ be abs(_r2_).
+        1. Else,
+          1. Assert: abs(_r1_) ≤ abs(_total_) &lt; abs(_r2_).
+          1. Let _roundedUnit_ be ApplyUnsignedRoundingMode(abs(_total_), abs(_r1_), abs(_r2_), _unsignedRoundingMode_).
         1. If _roundedUnit_ is abs(_r2_), then
           1. Let _didExpandCalendarUnit_ be *true*.
           1. Let _resultDuration_ be _endDuration_.


### PR DESCRIPTION
Fix for https://github.com/tc39/proposal-temporal/issues/2919

Looks like the sanity checking was a little too aggressive. Was asserting a range with an exclusive end. Should be inclusive end instead. To see what I mean, I'll breaking down the operations from #2919 ...

```js
// original recreation
const dur = Temporal.Duration.from({ months: 11 });
const relativeTo = Temporal.PlainDate.from("2023-05-31");
dur.round({ relativeTo, smallestUnit: "months", roundingMode: "ceil" });

// granular operations
const durBalanced = relativeTo.until(relativeTo.add(dur), { largestUnit: 'months' }); // P10M30D
const months0 = 10 // because we trunc P10M30D down to 10 months
const months1 = 11 // because 10 plus roundingInc (1) is 11 months
const windowPd0 = relativeTo.add({ months: months0 }) // 2024-03-31
const windowPd1 = relativeTo.add({ months: months1 }) // 2024-04-30
const destPd = relativeTo.add(dur) // 2024-04-30

/*
You then must determine how far `destPd` is between `windowPd0` <-> `windowPd1`
As you can see, `destPd` === `windowPd1`, which should be allowed
*/
```