### PR TITLE
Normative: Never ignore a specified year in CalendarMonthDayToISOReferenceDate

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -858,12 +858,14 @@ const nonIsoHelperBase = {
   // Override if calendar uses eras
   hasEra: false,
   monthDayFromFields(fields, overflow, cache) {
-    let { monthCode, day } = fields;
+    let { year, era, eraYear, monthCode, day } = fields;
+    let validateDate = monthCode === undefined || (year !== undefined || era !== undefined || eraYear !== undefined);
     if (monthCode === undefined) {
-      let { year, era, eraYear } = fields;
       if (year === undefined && (era === undefined || eraYear === undefined)) {
         throw new TypeError('when `monthCode` is omitted, `year` (or `era` and `eraYear`) and `month` are required');
       }
+    }
+    if (validateDate) {
       // Apply overflow behaviour to year/month/day, to get correct monthCode/day
       ({ monthCode, day } = this.isoToCalendarDate(this.calendarToIsoDate(fields, overflow, cache), cache));
     }

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1181,12 +1181,15 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It performs implementation-defined processing to convert _fields_, which represents a date or year and month or month and day in the built-in calendar identified by _calendar_, to a corresponding representative date in the ISO 8601 calendar, subject to processing specified by _overflow_.
+          It performs implementation-defined processing to convert _fields_, which represents either a date or a year and month in the built-in calendar identified by _calendar_, to a corresponding representative date in the ISO 8601 calendar, subject to overflow correction specified by _overflow_.
           For *"reject"*, values that do not form a valid date cause an exception to be thrown, as described below.
-          For *"constrain"*, values that do not form a valid date are clamped to the correct range.
-          It then returns an ISO Date Record with the corresponding ISO 8601 date.
+          For *"constrain"*, values that do not form a valid date are clamped to their respective valid range.
         </dd>
       </dl>
+      <p>
+        Like RegulateISODate, the operation throws a *RangeError* exception when _overflow_ is *"reject"* and the date described by _fields_ does not exist.
+        It also throws a *RangeError* exception if the date described by _fields_ is outside the range allowed by ISODateWithinLimits.
+      </p>
       <p>
         Clamping an invalid date to the correct range when _overflow_ is *"constrain"* is a behaviour specific to each built-in calendar, but all built-in calendars follow this guideline:
       </p>
@@ -1196,10 +1199,6 @@
         <li>Otherwise, pick the closest date that is still in the same year. If there are two equally-close dates in that year, pick the later one.</li>
         <li>If the entire year doesn't exist, pick the closest date in a different year. If there are two equally-close dates, pick the later one.</li>
       </ul>
-      <p>
-        Like RegulateISODate, the operation throws a *RangeError* exception if _overflow_ is *"reject"* and the date described by _fields_ does not exist.
-        It also throws a *RangeError* exception if the date described by _fields_ is outside the range allowed by ISODateWithinLimits.
-      </p>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendarmonthdaytoisoreferencedate" type="implementation-defined abstract operation">
@@ -1213,17 +1212,16 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It performs implementation-defined processing to convert _fields_, which represents a calendar date without a year (i.e., month code and day pair, or equivalent) in the built-in calendar identified by _calendar_, to a corresponding reference date in the ISO 8601 calendar as described below, subject to processing specified by _overflow_.
+          It performs implementation-defined processing to convert _fields_, which represents a calendar date without a year (i.e., month code and day pair, or equivalent) in the built-in calendar identified by _calendar_, to a corresponding reference date in the ISO 8601 calendar as described below, subject to overflow correction specified by _overflow_.
           For *"reject"*, values that do not form a valid date cause an exception to be thrown.
-          For *"constrain"*, values that do not form a valid date are clamped to the correct range as in CalendarDateToISO.
-          It then returns a Record representing the reference ISO 8601 date.
+          For *"constrain"*, values that do not form a valid date are clamped to their respective valid range as in CalendarDateToISO.
         </dd>
       </dl>
       <p>
-        The fields of the returned Record represent a reference date in the ISO 8601 calendar that, when converted to the built-in calendar identified by _calendar_, corresponds to the month code and day of _fields_ in an arbitrary but deterministically chosen reference year.
+        The fields of the returned ISO Date Record represent a reference date in the ISO 8601 calendar that, when converted to the built-in calendar identified by _calendar_, corresponds to the month code and day of _fields_ in an arbitrary but deterministically chosen reference year.
         The reference date is the latest ISO 8601 date corresponding to the calendar date, that is also earlier than or equal to the ISO 8601 date December 31, 1972.
         If that calendar date never occurs on or before the ISO 8601 date December 31, 1972, then the reference date is the earliest ISO 8601 date corresponding to that calendar date.
-        The reference year is almost always 1972 (the first ISO 8601 leap year after the epoch), with exceptions for calendars where some dates (e.g. leap days or days in leap months) didn't occur during that ISO 8601 year. For example, Hebrew calendar leap month Adar I was a part of calendar years 5730 and 5733 (respectively overlapping ISO 8601 February/March 1970 and February/March 1973), but did not occur between them.
+        The reference year is almost always 1972 (the first ISO 8601 leap year after the epoch), with exceptions for calendars where some dates (e.g. leap days or days in leap months) didn't occur during that ISO 8601 year. For example, Hebrew calendar leap month Adar I occurred in calendar years 5730 and 5733 (respectively overlapping ISO 8601 February/March 1970 and February/March 1973), but did not occur between them, so the reference year for for days of that month is 1970.
       </p>
       <p>
         Like RegulateISODate, the operation throws a *RangeError* exception if _overflow_ is *"reject"* and the month and day described by _fields_ does not exist.

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1228,6 +1228,10 @@
         For example, when _calendar_ is *"gregory"* and _overflow_ is *"reject"*, _fields_ values of { [[MonthCode]]: *"M01"*, [[Day]]: 32 } and { [[Year]]: 2001, [[Month]]: 2, [[Day]]: 29 } would both cause a *RangeError* to be thrown.
         In the latter case, even though February 29 is a date in leap years of the Gregorian calendar, 2001 was not a leap year and a month code cannot be determined from the nonexistent date 2001-02-29 with the specified month index.
       </p>
+      <p>
+        Also like RegulateISODate, if _overflow_ is *"constrain"* and the date or month and day described by _fields_ does not exist (or does not exist within the year described by fields when there is such a year), the values of those fields are clamped to their respective valid range. As in CalendarDateToISO, such clamping is calendar-specific.
+		For example, when _calendar_ is *"gregory"* and _overflow_ is *"constrain"*, a _fields_ value of { [[MonthCode]]: *"M02"*, [[Day]]: 30 } is clamped to { [[Year]]: 1972, [[Month]]: 2, [[Day]]: 29 } (because 29 is the maximum valid day for February) while _fields_ values of { [[Year]]: 2001, [[MonthCode]]: *"M02"*, [[Day]]: 30 } and { [[Era]]: *"ce"*, [[EraYear]]: 2001, [[Month]]: 2, [[Day]]: 30 } (or an equivalent with a supported value for [[Era]] representing the Common Era beginning in ISO 8601 year 1) are clamped to { [[Year]]: 1972, [[Month]]: 2, [[Day]]: 28 } (because 28 is the maximum valid day for February 2001, which did not include a leap day).
+      </p>
     </emu-clause>
 
     <emu-clause id="sec-temporal-calendardateaddition" type="implementation-defined abstract operation">

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -908,9 +908,9 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It performs the overflow correction given by _overflow_ on the values _year_, _month_, and _day_, in order to arrive at a valid date in the ISO 8601 calendar, as determined by IsValidISODate.
+          It performs the overflow correction specified by _overflow_ on the values _year_, _month_, and _day_, in order to arrive at a valid date in the ISO 8601 calendar, as determined by IsValidISODate.
           For *"reject"*, values that do not form a valid date cause an exception to be thrown.
-          For *"constrain"*, values that do not form a valid date are clamped to the correct range.
+          For *"constrain"*, values that do not form a valid date are independently clamped to their respective valid range in order of descending unit magnitude.
         </dd>
       </dl>
       <emu-alg>


### PR DESCRIPTION
Fixes #2863

Help wanted with tests (assuming there is in fact coverage for this code).