### PR TITLE
Polyfill: Be more robust against post-load environment changes

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1,13 +1,13 @@
 import {
   // constructors and similar
-  Date as Date,
-  Map as Map,
-  Set as Set,
-  WeakMap as WeakMap,
+  Date as DateCtor,
+  Map as MapCtor,
+  Set as SetCtor,
+  WeakMap as WeakMapCtor,
 
   // error constructors
-  RangeError as RangeError,
-  TypeError as TypeError,
+  RangeError as RangeErrorCtor,
+  TypeError as TypeErrorCtor,
 
   // class static functions and methods
   ArrayFrom,
@@ -154,7 +154,7 @@ impl['iso8601'] = {
     return [];
   },
   fieldKeysToIgnore(keys) {
-    const result = new Set();
+    const result = new SetCtor();
     for (let ix = 0; ix < keys.length; ix++) {
       const key = keys[ix];
       Call(SetPrototypeAdd, result, [key]);
@@ -237,10 +237,10 @@ impl['iso8601'] = {
 
 function monthCodeNumberPart(monthCode) {
   if (!Call(StringPrototypeStartsWith, monthCode, ['M'])) {
-    throw new RangeError(`Invalid month code: ${monthCode}.  Month codes must start with M.`);
+    throw new RangeErrorCtor(`Invalid month code: ${monthCode}.  Month codes must start with M.`);
   }
   const month = +Call(StringPrototypeSlice, monthCode, [1]);
-  if (NumberIsNaN(month)) throw new RangeError(`Invalid month code: ${monthCode}`);
+  if (NumberIsNaN(month)) throw new RangeErrorCtor(`Invalid month code: ${monthCode}`);
   return month;
 }
 
@@ -252,7 +252,7 @@ function requireFields(fields, requiredFieldNames) {
   for (let index = 0; index < requiredFieldNames.length; index++) {
     const fieldName = requiredFieldNames[index];
     if (fields[fieldName] === undefined) {
-      throw new TypeError(`${fieldName} is required`);
+      throw new TypeErrorCtor(`${fieldName} is required`);
     }
   }
 }
@@ -265,7 +265,7 @@ function requireFields(fields, requiredFieldNames) {
 function resolveNonLunisolarMonth(calendarDate, overflow = undefined, monthsPerYear = 12) {
   let { month, monthCode } = calendarDate;
   if (monthCode === undefined) {
-    if (month === undefined) throw new TypeError('Either month or monthCode are required');
+    if (month === undefined) throw new TypeErrorCtor('Either month or monthCode are required');
     // The ISO calendar uses the default (undefined) value because it does
     // constrain/reject after this method returns. Non-ISO calendars, however,
     // rely on this function to constrain/reject out-of-range `month` values.
@@ -275,13 +275,13 @@ function resolveNonLunisolarMonth(calendarDate, overflow = undefined, monthsPerY
   } else {
     const numberPart = monthCodeNumberPart(monthCode);
     if (month !== undefined && month !== numberPart) {
-      throw new RangeError(`monthCode ${monthCode} and month ${month} must match if both are present`);
+      throw new RangeErrorCtor(`monthCode ${monthCode} and month ${month} must match if both are present`);
     }
     if (monthCode !== buildMonthCode(numberPart)) {
-      throw new RangeError(`Invalid month code: ${monthCode}`);
+      throw new RangeErrorCtor(`Invalid month code: ${monthCode}`);
     }
     month = numberPart;
-    if (month < 1 || month > monthsPerYear) throw new RangeError(`Invalid monthCode: ${monthCode}`);
+    if (month < 1 || month > monthsPerYear) throw new RangeErrorCtor(`Invalid monthCode: ${monthCode}`);
   }
   return { ...calendarDate, month, monthCode };
 }
@@ -312,7 +312,7 @@ function weekNumber(firstDayOfWeek, minimalDaysInFirstWeek, desiredDay, dayOfWee
  */
 class OneObjectCache {
   constructor(cacheToClone = undefined) {
-    this.map = new Map();
+    this.map = new MapCtor();
     this.calls = 0;
     this.now = now();
     this.hits = 0;
@@ -352,12 +352,12 @@ class OneObjectCache {
     */
   }
   setObject(obj) {
-    if (Call(WeakMapPrototypeGet, OneObjectCache.objectMap, [obj])) throw new RangeError('object already cached');
+    if (Call(WeakMapPrototypeGet, OneObjectCache.objectMap, [obj])) throw new RangeErrorCtor('object already cached');
     Call(WeakMapPrototypeSet, OneObjectCache.objectMap, [obj, this]);
     this.report();
   }
 }
-OneObjectCache.objectMap = new WeakMap();
+OneObjectCache.objectMap = new WeakMapCtor();
 OneObjectCache.MAX_CACHE_ENTRIES = 1000;
 /**
  * Returns a WeakMap-backed cache that's used to store expensive results
@@ -422,9 +422,9 @@ const nonIsoHelperBase = {
     let parts, isoString;
     try {
       isoString = toUtcIsoDateString({ isoYear, isoMonth, isoDay });
-      parts = ES.Call(IntlDateTimeFormatPrototypeFormatToParts, dateTimeFormat, [new Date(isoString)]);
+      parts = ES.Call(IntlDateTimeFormatPrototypeFormatToParts, dateTimeFormat, [new DateCtor(isoString)]);
     } catch (e) {
-      throw new RangeError(`Invalid ISO date: ${JSONStringify({ isoYear, isoMonth, isoDay })}`);
+      throw new RangeErrorCtor(`Invalid ISO date: ${JSONStringify({ isoYear, isoMonth, isoDay })}`);
     }
     const result = {};
     for (let i = 0; i < parts.length; i++) {
@@ -439,7 +439,7 @@ const nonIsoHelperBase = {
       if (type === 'month') {
         const matches = ES.Call(RegExpPrototypeExec, /^([0-9]*)(.*?)$/, [value]);
         if (!matches || matches.length != 3 || (!matches[1] && !matches[2])) {
-          throw new RangeError(`Unexpected month: ${value}`);
+          throw new RangeErrorCtor(`Unexpected month: ${value}`);
         }
         // If the month has no numeric part (should only see this for the Hebrew
         // calendar with newer FF / Chromium versions; see
@@ -449,13 +449,13 @@ const nonIsoHelperBase = {
         // `monthExtra`.
         result.month = matches[1] ? +matches[1] : 1;
         if (result.month < 1) {
-          throw new RangeError(
+          throw new RangeErrorCtor(
             `Invalid month ${value} from ${isoString}[u-ca-${this.id}]` +
               ' (probably due to https://bugs.chromium.org/p/v8/issues/detail?id=10527)'
           );
         }
         if (result.month > 13) {
-          throw new RangeError(
+          throw new RangeErrorCtor(
             `Invalid month ${value} from ${isoString}[u-ca-${this.id}]` +
               ' (probably due to https://bugs.chromium.org/p/v8/issues/detail?id=10529)'
           );
@@ -487,7 +487,7 @@ const nonIsoHelperBase = {
     if (this.hasEra && result.eraYear === undefined) {
       // Node 12 has outdated ICU data that lacks the `relatedYear` field in the
       // output of Intl.DateTimeFormat.formatToParts.
-      throw new RangeError(
+      throw new RangeErrorCtor(
         `Intl.DateTimeFormat.formatToParts lacks relatedYear in ${this.id} calendar. Try Node 14+ or modern browsers.`
       );
     }
@@ -505,9 +505,11 @@ const nonIsoHelperBase = {
     }
     if (this.checkIcuBugs) this.checkIcuBugs(isoDate);
     const calendarDate = this.adjustCalendarDate(result, cache, 'constrain', true);
-    if (calendarDate.year === undefined) throw new RangeError(`Missing year converting ${JSONStringify(isoDate)}`);
-    if (calendarDate.month === undefined) throw new RangeError(`Missing month converting ${JSONStringify(isoDate)}`);
-    if (calendarDate.day === undefined) throw new RangeError(`Missing day converting ${JSONStringify(isoDate)}`);
+    if (calendarDate.year === undefined) throw new RangeErrorCtor(`Missing year converting ${JSONStringify(isoDate)}`);
+    if (calendarDate.month === undefined) {
+      throw new RangeErrorCtor(`Missing month converting ${JSONStringify(isoDate)}`);
+    }
+    if (calendarDate.day === undefined) throw new RangeErrorCtor(`Missing day converting ${JSONStringify(isoDate)}`);
     cache.set(key, calendarDate);
     // Also cache the reverse mapping
     const cacheReverse = (overflow) => {
@@ -528,23 +530,23 @@ const nonIsoHelperBase = {
     const { month, year, day, eraYear, monthCode, monthExtra } = calendarDate;
     // When there's a suffix (e.g. "5bis" for a leap month in Chinese calendar)
     // the derived class must deal with it.
-    if (monthExtra !== undefined) throw new RangeError('Unexpected `monthExtra` value');
-    if (year === undefined && eraYear === undefined) throw new TypeError('year or eraYear is required');
-    if (month === undefined && monthCode === undefined) throw new TypeError('month or monthCode is required');
-    if (day === undefined) throw new RangeError('Missing day');
+    if (monthExtra !== undefined) throw new RangeErrorCtor('Unexpected `monthExtra` value');
+    if (year === undefined && eraYear === undefined) throw new TypeErrorCtor('year or eraYear is required');
+    if (month === undefined && monthCode === undefined) throw new TypeErrorCtor('month or monthCode is required');
+    if (day === undefined) throw new RangeErrorCtor('Missing day');
     if (monthCode !== undefined) {
       if (typeof monthCode !== 'string') {
-        throw new RangeError(
+        throw new RangeErrorCtor(
           `monthCode must be a string, not ${ES.Call(StringPrototypeToLowerCase, Type(monthCode), [])}`
         );
       }
       if (!ES.Call(RegExpPrototypeTest, /^M([01]?\d)(L?)$/, [monthCode])) {
-        throw new RangeError(`Invalid monthCode: ${monthCode}`);
+        throw new RangeErrorCtor(`Invalid monthCode: ${monthCode}`);
       }
     }
     if (this.hasEra) {
       if ((calendarDate['era'] === undefined) !== (calendarDate['eraYear'] === undefined)) {
-        throw new TypeError("properties 'era' and 'eraYear' must be provided together");
+        throw new TypeErrorCtor("properties 'era' and 'eraYear' must be provided together");
       }
     }
   },
@@ -560,7 +562,7 @@ const nonIsoHelperBase = {
    * - non-lunisolar calendar (no leap months)
    * */
   adjustCalendarDate(calendarDate, cache, overflow /*, fromLegacyDate = false */) {
-    if (this.calendarType === 'lunisolar') throw new RangeError('Override required for lunisolar calendars');
+    if (this.calendarType === 'lunisolar') throw new RangeErrorCtor('Override required for lunisolar calendars');
     this.validateCalendarDate(calendarDate);
     const largestMonth = this.monthsInYear(calendarDate, cache);
     let { month, monthCode } = calendarDate;
@@ -634,7 +636,7 @@ const nonIsoHelperBase = {
         let testCalendarDate = this.isoToCalendarDate(testIsoEstimate, cache);
         while (testCalendarDate.month !== month || testCalendarDate.year !== year) {
           if (overflow === 'reject') {
-            throw new RangeError(`day ${day} does not exist in month ${month} of year ${year}`);
+            throw new RangeErrorCtor(`day ${day} does not exist in month ${month} of year ${year}`);
           }
           // Back up a day at a time until we're not hanging over the month end
           testIsoEstimate = this.addDaysIso(testIsoEstimate, -1);
@@ -683,7 +685,7 @@ const nonIsoHelperBase = {
             // original date was an invalid value that will be constrained or
             // rejected here.
             if (overflow === 'reject') {
-              throw new RangeError(`Can't find ISO date from calendar date: ${JSONStringify({ ...originalDate })}`);
+              throw new RangeErrorCtor(`Can't find ISO date from calendar date: ${JSONStringify({ ...originalDate })}`);
             } else {
               // To constrain, pick the earliest value
               const order = this.compareCalendarDates(roundtripEstimate, oldRoundtripEstimate);
@@ -704,7 +706,7 @@ const nonIsoHelperBase = {
       date.monthCode === undefined ||
       (this.hasEra && (date.era === undefined || date.eraYear === undefined))
     ) {
-      throw new RangeError('Unexpected missing property');
+      throw new RangeErrorCtor('Unexpected missing property');
     }
     return isoEstimate;
   },
@@ -761,7 +763,7 @@ const nonIsoHelperBase = {
       }
     }
     if (overflow === 'reject' && calendarDate.day !== day) {
-      throw new RangeError(`Day ${day} does not exist in resulting calendar month`);
+      throw new RangeErrorCtor(`Day ${day} does not exist in resulting calendar month`);
     }
     return calendarDate;
   },
@@ -900,7 +902,9 @@ const nonIsoHelperBase = {
     if (monthCode === undefined) {
       let { year, era, eraYear } = fields;
       if (year === undefined && (era === undefined || eraYear === undefined)) {
-        throw new TypeError('when `monthCode` is omitted, `year` (or `era` and `eraYear`) and `month` are required');
+        throw new TypeErrorCtor(
+          'when `monthCode` is omitted, `year` (or `era` and `eraYear`) and `month` are required'
+        );
       }
       // Apply overflow behaviour to year/month/day, to get correct monthCode/day
       ({ monthCode, day } = this.isoToCalendarDate(this.calendarToIsoDate(fields, overflow, cache), cache));
@@ -940,7 +944,7 @@ const nonIsoHelperBase = {
       }
     }
     if (overflow === 'constrain' && closestIso !== undefined) return closestIso;
-    throw new RangeError(`No recent ${this.id} year with monthCode ${monthCode} and day ${day}`);
+    throw new RangeErrorCtor(`No recent ${this.id} year with monthCode ${monthCode} and day ${day}`);
   }
 };
 
@@ -969,7 +973,7 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
     const { month, year } = calendarDate;
     const monthCode = this.getMonthCode(year, month);
     const monthInfo = ES.Call(ArrayPrototypeFind, ObjectEntries(this.months), [(m) => m[1].monthCode === monthCode]);
-    if (monthInfo === undefined) throw new RangeError(`unmatched Hebrew month: ${month}`);
+    if (monthInfo === undefined) throw new RangeErrorCtor(`unmatched Hebrew month: ${month}`);
     const daysInMonth = monthInfo[1].days;
     return typeof daysInMonth === 'number' ? daysInMonth : daysInMonth[minOrMax];
   },
@@ -1003,7 +1007,7 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
   },
   adjustCalendarDate(calendarDate, cache, overflow = 'constrain', fromLegacyDate = false) {
     let { year, month, monthCode, day, monthExtra } = calendarDate;
-    if (year === undefined) throw new TypeError('Missing property: "year"');
+    if (year === undefined) throw new TypeErrorCtor('Missing property: "year"');
     if (fromLegacyDate) {
       // In Pre Node-14 V8, DateTimeFormat.formatToParts `month: 'numeric'`
       // output returns the numeric equivalent of `month` as a string, meaning
@@ -1014,7 +1018,7 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
       // correct `month` using the string name as a key.
       if (monthExtra) {
         const monthInfo = this.months[monthExtra];
-        if (!monthInfo) throw new RangeError(`Unrecognized month from formatToParts: ${monthExtra}`);
+        if (!monthInfo) throw new RangeErrorCtor(`Unrecognized month from formatToParts: ${monthExtra}`);
         month = this.inLeapYear({ year }) ? monthInfo.leap : monthInfo.regular;
       }
       monthCode = this.getMonthCode(year, month);
@@ -1026,12 +1030,12 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
       if (month === undefined) {
         if (ES.Call(StringPrototypeEndsWith, monthCode, ['L'])) {
           if (monthCode !== 'M05L') {
-            throw new RangeError(`Hebrew leap month must have monthCode M05L, not ${monthCode}`);
+            throw new RangeErrorCtor(`Hebrew leap month must have monthCode M05L, not ${monthCode}`);
           }
           month = 6;
           if (!this.inLeapYear({ year })) {
             if (overflow === 'reject') {
-              throw new RangeError(`Hebrew monthCode M05L is invalid in year ${year} which is not a leap year`);
+              throw new RangeErrorCtor(`Hebrew monthCode M05L is invalid in year ${year} which is not a leap year`);
             } else {
               // constrain to same day of next month (Adar)
               month = 6;
@@ -1043,7 +1047,7 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
           // if leap month is before this one, the month index is one more than the month code
           if (this.inLeapYear({ year }) && month >= 6) month++;
           const largestMonth = this.monthsInYear({ year });
-          if (month < 1 || month > largestMonth) throw new RangeError(`Invalid monthCode: ${monthCode}`);
+          if (month < 1 || month > largestMonth) throw new RangeErrorCtor(`Invalid monthCode: ${monthCode}`);
         }
       } else {
         if (overflow === 'reject') {
@@ -1058,7 +1062,9 @@ const helperHebrew = ObjectAssign({}, nonIsoHelperBase, {
         } else {
           const calculatedMonthCode = this.getMonthCode(year, month);
           if (calculatedMonthCode !== monthCode) {
-            throw new RangeError(`monthCode ${monthCode} doesn't correspond to month ${month} in Hebrew year ${year}`);
+            throw new RangeErrorCtor(
+              `monthCode ${monthCode} doesn't correspond to month ${month} in Hebrew year ${year}`
+            );
           }
         }
       }
@@ -1159,7 +1165,7 @@ const helperIndian = ObjectAssign({}, nonIsoHelperBase, {
   getMonthInfo(calendarDate) {
     const { month } = calendarDate;
     let monthInfo = this.months[month];
-    if (monthInfo === undefined) throw new RangeError(`Invalid month: ${month}`);
+    if (monthInfo === undefined) throw new RangeErrorCtor(`Invalid month: ${month}`);
     if (this.inLeapYear(calendarDate) && monthInfo.leap) monthInfo = monthInfo.leap;
     return monthInfo;
   },
@@ -1179,13 +1185,13 @@ const helperIndian = ObjectAssign({}, nonIsoHelperBase, {
   // in Node 12 0000-01-01 is calculated as 6146/12/-583 instead of 10/11/-79 as
   // expected.
   vulnerableToBceBug:
-    ES.Call(DatePrototypeToLocaleDateString, new Date('0000-01-01T00:00Z'), [
+    ES.Call(DatePrototypeToLocaleDateString, new DateCtor('0000-01-01T00:00Z'), [
       'en-US-u-ca-indian',
       { timeZone: 'UTC' }
     ]) !== '10/11/-79 Saka',
   checkIcuBugs(isoDate) {
     if (this.vulnerableToBceBug && isoDate.year < 1) {
-      throw new RangeError(
+      throw new RangeErrorCtor(
         `calendar '${this.id}' is broken for ISO dates before 0001-01-01` +
           ' (see https://bugs.chromium.org/p/v8/issues/detail?id=10529)'
       );
@@ -1238,16 +1244,16 @@ const helperIndian = ObjectAssign({}, nonIsoHelperBase, {
  * */
 function adjustEras(eras) {
   if (eras.length === 0) {
-    throw new RangeError('Invalid era data: eras are required');
+    throw new RangeErrorCtor('Invalid era data: eras are required');
   }
   if (eras.length === 1 && eras[0].reverseOf) {
-    throw new RangeError('Invalid era data: anchor era cannot count years backwards');
+    throw new RangeErrorCtor('Invalid era data: anchor era cannot count years backwards');
   }
   if (eras.length === 1 && !eras[0].name) {
-    throw new RangeError('Invalid era data: at least one named era is required');
+    throw new RangeErrorCtor('Invalid era data: at least one named era is required');
   }
   if (ES.Call(ArrayPrototypeFilter, eras, [(e) => e.reverseOf != null]).length > 1) {
-    throw new RangeError('Invalid era data: only one era can count years backwards');
+    throw new RangeErrorCtor('Invalid era data: only one era can count years backwards');
   }
 
   // Find the "anchor era" which is the era used for (era-less) `year`. Reversed
@@ -1257,11 +1263,11 @@ function adjustEras(eras) {
   ES.Call(ArrayPrototypeForEach, eras, [
     (e) => {
       if (e.isAnchor || (!e.anchorEpoch && !e.reverseOf)) {
-        if (anchorEra) throw new RangeError('Invalid era data: cannot have multiple anchor eras');
+        if (anchorEra) throw new RangeErrorCtor('Invalid era data: cannot have multiple anchor eras');
         anchorEra = e;
         e.anchorEpoch = { year: e.hasYearZero ? 0 : 1 };
       } else if (!e.name) {
-        throw new RangeError('If era name is blank, it must be the anchor era');
+        throw new RangeErrorCtor('If era name is blank, it must be the anchor era');
       }
     }
   ]);
@@ -1280,7 +1286,9 @@ function adjustEras(eras) {
       const { reverseOf } = e;
       if (reverseOf) {
         const reversedEra = ES.Call(ArrayPrototypeFind, eras, [(era) => era.name === reverseOf]);
-        if (reversedEra === undefined) throw new RangeError(`Invalid era data: unmatched reverseOf era: ${reverseOf}`);
+        if (reversedEra === undefined) {
+          throw new RangeErrorCtor(`Invalid era data: unmatched reverseOf era: ${reverseOf}`);
+        }
         e.reverseOf = reversedEra;
         e.anchorEpoch = reversedEra.anchorEpoch;
         e.isoEpoch = reversedEra.isoEpoch;
@@ -1297,7 +1305,7 @@ function adjustEras(eras) {
     (e1, e2) => {
       if (e1.reverseOf) return 1;
       if (e2.reverseOf) return -1;
-      if (!e1.isoEpoch || !e2.isoEpoch) throw new RangeError('Invalid era data: missing ISO epoch');
+      if (!e1.isoEpoch || !e2.isoEpoch) throw new RangeErrorCtor('Invalid era data: missing ISO epoch');
       return e2.isoEpoch.year - e1.isoEpoch.year;
     }
   ]);
@@ -1306,7 +1314,9 @@ function adjustEras(eras) {
   // being reversed.
   const lastEraReversed = eras[eras.length - 1].reverseOf;
   if (lastEraReversed) {
-    if (lastEraReversed !== eras[eras.length - 2]) throw new RangeError('Invalid era data: invalid reverse-sign era');
+    if (lastEraReversed !== eras[eras.length - 2]) {
+      throw new RangeErrorCtor('Invalid era data: invalid reverse-sign era');
+    }
   }
 
   // Finally, add a "genericName" property in the format "era{n} where `n` is
@@ -1390,7 +1400,7 @@ const makeHelperGregorian = (id, originalEras) => {
       const checkField = (name, value) => {
         const currentValue = calendarDate[name];
         if (currentValue != null && currentValue != value) {
-          throw new RangeError(`Input ${name} ${currentValue} doesn't match calculated value ${value}`);
+          throw new RangeErrorCtor(`Input ${name} ${currentValue} doesn't match calculated value ${value}`);
         }
       };
       const eraFromYear = (year) => {
@@ -1402,7 +1412,7 @@ const makeHelperGregorian = (id, originalEras) => {
               if (e.reverseOf) {
                 // This is a reverse-sign era (like BCE) which must be the oldest
                 // era. Count years backwards.
-                if (year > 0) throw new RangeError(`Signed year ${year} is invalid for era ${e.name}`);
+                if (year > 0) throw new RangeErrorCtor(`Signed year ${year} is invalid for era ${e.name}`);
                 eraYear = e.anchorEpoch.year - year;
                 return true;
               }
@@ -1419,7 +1429,7 @@ const makeHelperGregorian = (id, originalEras) => {
             return false;
           }
         ]);
-        if (!matchingEra) throw new RangeError(`Year ${year} was not matched by any era`);
+        if (!matchingEra) throw new RangeErrorCtor(`Year ${year} was not matched by any era`);
         return { eraYear, era: matchingEra.name };
       };
 
@@ -1429,13 +1439,13 @@ const makeHelperGregorian = (id, originalEras) => {
         checkField('era', era);
         checkField('eraYear', eraYear);
       } else if (eraYear != null) {
-        if (era === undefined) throw new RangeError('era and eraYear must be provided together');
+        if (era === undefined) throw new RangeErrorCtor('era and eraYear must be provided together');
         const matchingEra = ES.Call(ArrayPrototypeFind, this.eras, [
           ({ name, aliases = [] }) => name === era || ES.Call(ArrayPrototypeIncludes, aliases, [era])
         ]);
-        if (!matchingEra) throw new RangeError(`Era ${era} (ISO year ${eraYear}) was not matched by any era`);
+        if (!matchingEra) throw new RangeErrorCtor(`Era ${era} (ISO year ${eraYear}) was not matched by any era`);
         if (eraYear < 1 && matchingEra.reverseOf) {
-          throw new RangeError(`Years in ${era} era must be positive, not ${year}`);
+          throw new RangeErrorCtor(`Years in ${era} era must be positive, not ${year}`);
         }
         if (matchingEra.reverseOf) {
           year = matchingEra.anchorEpoch.year - eraYear;
@@ -1449,7 +1459,7 @@ const makeHelperGregorian = (id, originalEras) => {
         // the `year`.
         ({ eraYear, era } = eraFromYear(year));
       } else {
-        throw new RangeError('Either `year` or `eraYear` and `era` are required');
+        throw new RangeErrorCtor('Either `year` or `eraYear` and `era` are required');
       }
       return { ...calendarDate, year, eraYear, era };
     },
@@ -1642,7 +1652,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
   maximumMonthLength: (/* calendarDate */) => 30,
   getMonthList(calendarYear, cache) {
     if (calendarYear === undefined) {
-      throw new TypeError('Missing year');
+      throw new TypeErrorCtor('Missing year');
     }
     const key = JSONStringify({ func: 'getMonthList', calendarYear, id: this.id });
     const cached = cache.get(key);
@@ -1650,7 +1660,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
     const dateTimeFormat = this.getFormatter();
     const getCalendarDate = (isoYear, daysPastFeb1) => {
       const isoStringFeb1 = toUtcIsoDateString({ isoYear, isoMonth: 2, isoDay: 1 });
-      const legacyDate = new Date(isoStringFeb1);
+      const legacyDate = new DateCtor(isoStringFeb1);
       // Now add the requested number of days, which may wrap to the next month.
       ES.Call(DatePrototypeSetUTCDate, legacyDate, [daysPastFeb1 + 1]);
       const newYearGuess = ES.Call(IntlDateTimeFormatPrototypeFormatToParts, dateTimeFormat, [legacyDate]);
@@ -1662,7 +1672,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
       } else {
         // Node 12 has outdated ICU data that lacks the `relatedYear` field in the
         // output of Intl.DateTimeFormat.formatToParts.
-        throw new RangeError(
+        throw new RangeErrorCtor(
           `Intl.DateTimeFormat.formatToParts lacks relatedYear in ${this.id} calendar. Try Node 14+ or modern browsers.`
         );
       }
@@ -1717,17 +1727,17 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
   },
   adjustCalendarDate(calendarDate, cache, overflow = 'constrain', fromLegacyDate = false) {
     let { year, month, monthExtra, day, monthCode } = calendarDate;
-    if (year === undefined) throw new TypeError('Missing property: "year"');
+    if (year === undefined) throw new TypeErrorCtor('Missing property: "year"');
     if (fromLegacyDate) {
       // Legacy Date output returns a string that's an integer with an optional
       // "bis" suffix used only by the Chinese/Dangi calendar to indicate a leap
       // month. Below we'll normalize the output.
-      if (monthExtra && monthExtra !== 'bis') throw new RangeError(`Unexpected leap month suffix: ${monthExtra}`);
+      if (monthExtra && monthExtra !== 'bis') throw new RangeErrorCtor(`Unexpected leap month suffix: ${monthExtra}`);
       const monthCode = buildMonthCode(month, monthExtra !== undefined);
       const monthString = `${month}${monthExtra || ''}`;
       const months = this.getMonthList(year, cache);
       const monthInfo = months[monthString];
-      if (monthInfo === undefined) throw new RangeError(`Unmatched month ${monthString} in Chinese year ${year}`);
+      if (monthInfo === undefined) throw new RangeErrorCtor(`Unmatched month ${monthString} in Chinese year ${year}`);
       month = monthInfo.monthIndex;
       return { year, month, day, monthCode };
     } else {
@@ -1756,7 +1766,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
           }
         }
         if (month === undefined) {
-          throw new RangeError(`Unmatched month ${monthCode} in Chinese year ${year}`);
+          throw new RangeErrorCtor(`Unmatched month ${monthCode} in Chinese year ${year}`);
         }
       } else if (monthCode === undefined) {
         const months = this.getMonthList(year, cache);
@@ -1773,7 +1783,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
           (entry) => entry[1].monthIndex === month
         ]);
         if (matchingMonthEntry === undefined) {
-          throw new RangeError(`Invalid month ${month} in Chinese year ${year}`);
+          throw new RangeErrorCtor(`Invalid month ${month} in Chinese year ${year}`);
         }
         monthCode = buildMonthCode(
           ES.Call(StringPrototypeReplace, matchingMonthEntry[0], ['bis', '']),
@@ -1785,9 +1795,11 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
         let numberPart = ES.Call(StringPrototypeReplace, monthCode, [/^M|L$/g, (ch) => (ch === 'L' ? 'bis' : '')]);
         if (numberPart[0] === '0') numberPart = ES.Call(StringPrototypeSlice, numberPart, [1]);
         const monthInfo = months[numberPart];
-        if (!monthInfo) throw new RangeError(`Unmatched monthCode ${monthCode} in Chinese year ${year}`);
+        if (!monthInfo) throw new RangeErrorCtor(`Unmatched monthCode ${monthCode} in Chinese year ${year}`);
         if (month !== monthInfo.monthIndex) {
-          throw new RangeError(`monthCode ${monthCode} doesn't correspond to month ${month} in Chinese year ${year}`);
+          throw new RangeErrorCtor(
+            `monthCode ${monthCode} doesn't correspond to month ${month} in Chinese year ${year}`
+          );
         }
       }
       return { ...calendarDate, year, month, monthCode, day };
@@ -1831,7 +1843,7 @@ const nonIsoGeneralImpl = {
     return result;
   },
   fieldKeysToIgnore(keys) {
-    const result = new Set();
+    const result = new SetCtor();
     for (let ix = 0; ix < keys.length; ix++) {
       const key = keys[ix];
       Call(SetPrototypeAdd, result, [key]);

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -1,5 +1,24 @@
 /* global __debug__ */
 
+import {
+  // constructors and similar
+  IntlDurationFormat,
+
+  // error constructors
+  Error as Error,
+  RangeError as RangeError,
+  TypeError as TypeError,
+
+  // class static functions and methods
+  MathAbs,
+  NumberIsNaN,
+  ObjectCreate,
+  ObjectDefineProperty,
+
+  // miscellaneous
+  warn
+} from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
 import {
@@ -21,9 +40,6 @@ import {
   TIME_ZONE
 } from './slots.mjs';
 import { TimeDuration } from './timeduration.mjs';
-
-const NumberIsNaN = Number.isNaN;
-const ObjectCreate = Object.create;
 
 export class Duration {
   constructor(
@@ -65,7 +81,7 @@ export class Duration {
 
     if (typeof __debug__ !== 'undefined' && __debug__) {
       const normSeconds = TimeDuration.normalize(0, 0, seconds, milliseconds, microseconds, nanoseconds);
-      Object.defineProperty(this, '_repr_', {
+      ObjectDefineProperty(this, '_repr_', {
         value: `Temporal.Duration <${ES.TemporalDurationToString(
           years,
           months,
@@ -177,16 +193,16 @@ export class Duration {
   abs() {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
     return new Duration(
-      Math.abs(GetSlot(this, YEARS)),
-      Math.abs(GetSlot(this, MONTHS)),
-      Math.abs(GetSlot(this, WEEKS)),
-      Math.abs(GetSlot(this, DAYS)),
-      Math.abs(GetSlot(this, HOURS)),
-      Math.abs(GetSlot(this, MINUTES)),
-      Math.abs(GetSlot(this, SECONDS)),
-      Math.abs(GetSlot(this, MILLISECONDS)),
-      Math.abs(GetSlot(this, MICROSECONDS)),
-      Math.abs(GetSlot(this, NANOSECONDS))
+      MathAbs(GetSlot(this, YEARS)),
+      MathAbs(GetSlot(this, MONTHS)),
+      MathAbs(GetSlot(this, WEEKS)),
+      MathAbs(GetSlot(this, DAYS)),
+      MathAbs(GetSlot(this, HOURS)),
+      MathAbs(GetSlot(this, MINUTES)),
+      MathAbs(GetSlot(this, SECONDS)),
+      MathAbs(GetSlot(this, MILLISECONDS)),
+      MathAbs(GetSlot(this, MICROSECONDS)),
+      MathAbs(GetSlot(this, NANOSECONDS))
     );
   }
   add(other) {
@@ -507,10 +523,10 @@ export class Duration {
   }
   toLocaleString(locales = undefined, options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    if (typeof Intl !== 'undefined' && typeof Intl.DurationFormat !== 'undefined') {
-      return new Intl.DurationFormat(locales, options).format(this);
+    if (typeof IntlDurationFormat === 'function') {
+      return new IntlDurationFormat(locales, options).format(this);
     }
-    console.warn('Temporal.Duration.prototype.toLocaleString() requires Intl.DurationFormat.');
+    warn('Temporal.Duration.prototype.toLocaleString() requires Intl.DurationFormat.');
     const normSeconds = TimeDuration.normalize(
       0,
       0,

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -5,9 +5,9 @@ import {
   IntlDurationFormat,
 
   // error constructors
-  Error as Error,
-  RangeError as RangeError,
-  TypeError as TypeError,
+  Error as ErrorCtor,
+  RangeError as RangeErrorCtor,
+  TypeError as TypeErrorCtor,
 
   // class static functions and methods
   MathAbs,
@@ -98,47 +98,47 @@ export class Duration {
     }
   }
   get years() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, YEARS);
   }
   get months() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, MONTHS);
   }
   get weeks() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, WEEKS);
   }
   get days() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, DAYS);
   }
   get hours() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, HOURS);
   }
   get minutes() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, MINUTES);
   }
   get seconds() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, SECONDS);
   }
   get milliseconds() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, MILLISECONDS);
   }
   get microseconds() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, MICROSECONDS);
   }
   get nanoseconds() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, NANOSECONDS);
   }
   get sign() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DurationSign(
       GetSlot(this, YEARS),
       GetSlot(this, MONTHS),
@@ -153,7 +153,7 @@ export class Duration {
     );
   }
   get blank() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return (
       ES.DurationSign(
         GetSlot(this, YEARS),
@@ -170,7 +170,7 @@ export class Duration {
     );
   }
   with(durationLike) {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     const partialDuration = ES.ToTemporalPartialDurationRecord(durationLike);
     const {
       years = GetSlot(this, YEARS),
@@ -187,11 +187,11 @@ export class Duration {
     return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
   negated() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CreateNegatedTemporalDuration(this);
   }
   abs() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return new Duration(
       MathAbs(GetSlot(this, YEARS)),
       MathAbs(GetSlot(this, MONTHS)),
@@ -206,16 +206,16 @@ export class Duration {
     );
   }
   add(other) {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurations('add', this, other);
   }
   subtract(other) {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurations('subtract', this, other);
   }
   round(roundTo) {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    if (roundTo === undefined) throw new TypeError('options parameter is required');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
+    if (roundTo === undefined) throw new TypeErrorCtor('options parameter is required');
     let years = GetSlot(this, YEARS);
     let months = GetSlot(this, MONTHS);
     let weeks = GetSlot(this, WEEKS);
@@ -255,10 +255,10 @@ export class Duration {
     }
     if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
     if (!smallestUnitPresent && !largestUnitPresent) {
-      throw new RangeError('at least one of smallestUnit or largestUnit is required');
+      throw new RangeErrorCtor('at least one of smallestUnit or largestUnit is required');
     }
     if (ES.LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
-      throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+      throw new RangeErrorCtor(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
     }
 
     const maximumIncrements = {
@@ -276,7 +276,7 @@ export class Duration {
       (ES.IsCalendarUnit(smallestUnit) || smallestUnit === 'day') &&
       largestUnit !== smallestUnit
     ) {
-      throw new RangeError('For calendar units with roundingIncrement > 1, use largestUnit = smallestUnit');
+      throw new RangeErrorCtor('For calendar units with roundingIncrement > 1, use largestUnit = smallestUnit');
     }
 
     let norm = TimeDuration.normalize(hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
@@ -341,13 +341,13 @@ export class Duration {
     } else {
       // No reference date to calculate difference relative to
       if (years !== 0 || months !== 0 || weeks !== 0) {
-        throw new RangeError('a starting point is required for years, months, or weeks balancing');
+        throw new RangeErrorCtor('a starting point is required for years, months, or weeks balancing');
       }
       if (ES.IsCalendarUnit(largestUnit)) {
-        throw new RangeError(`a starting point is required for ${largestUnit}s balancing`);
+        throw new RangeErrorCtor(`a starting point is required for ${largestUnit}s balancing`);
       }
       if (ES.IsCalendarUnit(smallestUnit)) {
-        throw new Error('assertion failed: smallestUnit was larger than largestUnit');
+        throw new ErrorCtor('assertion failed: smallestUnit was larger than largestUnit');
       }
       ({ days, norm } = ES.RoundTimeDuration(days, norm, roundingIncrement, smallestUnit, roundingMode));
       ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceTimeDuration(
@@ -359,7 +359,7 @@ export class Duration {
     return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
   total(totalOf) {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     let years = GetSlot(this, YEARS);
     let months = GetSlot(this, MONTHS);
     let weeks = GetSlot(this, WEEKS);
@@ -371,7 +371,7 @@ export class Duration {
     let microseconds = GetSlot(this, MICROSECONDS);
     let nanoseconds = GetSlot(this, NANOSECONDS);
 
-    if (totalOf === undefined) throw new TypeError('options argument is required');
+    if (totalOf === undefined) throw new TypeErrorCtor('options argument is required');
     if (ES.Type(totalOf) === 'String') {
       const stringParam = totalOf;
       totalOf = ObjectCreate(null);
@@ -404,7 +404,7 @@ export class Duration {
         unit,
         'trunc'
       );
-      if (NumberIsNaN(total)) throw new Error('assertion failed: total hit unexpected code path');
+      if (NumberIsNaN(total)) throw new ErrorCtor('assertion failed: total hit unexpected code path');
       return total;
     }
 
@@ -442,29 +442,29 @@ export class Duration {
         unit,
         'trunc'
       );
-      if (NumberIsNaN(total)) throw new Error('assertion failed: total hit unexpected code path');
+      if (NumberIsNaN(total)) throw new ErrorCtor('assertion failed: total hit unexpected code path');
       return total;
     }
 
     // No reference date to calculate difference relative to
     if (years !== 0 || months !== 0 || weeks !== 0) {
-      throw new RangeError('a starting point is required for years, months, or weeks total');
+      throw new RangeErrorCtor('a starting point is required for years, months, or weeks total');
     }
     if (ES.IsCalendarUnit(unit)) {
-      throw new RangeError(`a starting point is required for ${unit}s total`);
+      throw new RangeErrorCtor(`a starting point is required for ${unit}s total`);
     }
     norm = norm.add24HourDays(days);
     const { total } = ES.RoundTimeDuration(0, norm, 1, unit, 'trunc');
     return total;
   }
   toString(options = undefined) {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     options = ES.GetOptionsObject(options);
     const digits = ES.GetTemporalFractionalSecondDigitsOption(options);
     const roundingMode = ES.GetRoundingModeOption(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnitValuedOption(options, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour' || smallestUnit === 'minute') {
-      throw new RangeError('smallestUnit must be a time unit other than "hours" or "minutes"');
+      throw new RangeErrorCtor('smallestUnit must be a time unit other than "hours" or "minutes"');
     }
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
 
@@ -502,7 +502,7 @@ export class Duration {
     return ES.TemporalDurationToString(years, months, weeks, days, hours, minutes, normSeconds, precision);
   }
   toJSON() {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     const normSeconds = TimeDuration.normalize(
       0,
       0,
@@ -522,7 +522,7 @@ export class Duration {
     );
   }
   toLocaleString(locales = undefined, options = undefined) {
-    if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     if (typeof IntlDurationFormat === 'function') {
       return new IntlDurationFormat(locales, options).format(this);
     }
@@ -624,7 +624,7 @@ export class Duration {
 
     if (calendarUnitsPresent) {
       if (!plainRelativeTo) {
-        throw new RangeError('A starting point is required for years, months, or weeks comparison');
+        throw new RangeErrorCtor('A starting point is required for years, months, or weeks comparison');
       }
       d1 = ES.UnbalanceDateDurationRelative(y1, mon1, w1, d1, plainRelativeTo);
       d2 = ES.UnbalanceDateDurationRelative(y2, mon2, w2, d2, plainRelativeTo);

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2,20 +2,20 @@
 
 import {
   // constructors and similar
-  BigInt as BigInt,
-  Date as Date,
-  Map as Map,
-  Number as Number,
-  RegExp as RegExp,
-  Set as Set,
-  String as String,
-  Symbol as Symbol,
+  BigInt as BigIntCtor,
+  Date as DateCtor,
+  Map as MapCtor,
+  Number as NumberCtor,
+  RegExp as RegExpCtor,
+  Set as SetCtor,
+  String as StringCtor,
+  Symbol as SymbolCtor,
 
   // error constructors
-  Error as Error,
-  RangeError as RangeError,
-  SyntaxError as SyntaxError,
-  TypeError as TypeError,
+  Error as ErrorCtor,
+  RangeError as RangeErrorCtor,
+  SyntaxError as SyntaxErrorCtor,
+  TypeError as TypeErrorCtor,
 
   // class static functions and methods
   ArrayPrototypeConcat,
@@ -169,7 +169,7 @@ const BUILTIN_CALENDAR_IDS = [
   'gregory'
 ];
 
-const ICU_LEGACY_TIME_ZONE_IDS = new Set([
+const ICU_LEGACY_TIME_ZONE_IDS = new SetCtor([
   'ACT',
   'AET',
   'AGT',
@@ -201,7 +201,7 @@ export function ToIntegerWithTruncation(value) {
   const number = ToNumber(value);
   if (number === 0) return 0;
   if (NumberIsNaN(number) || !NumberIsFinite(number)) {
-    throw new RangeError('invalid number value');
+    throw new RangeErrorCtor('invalid number value');
   }
   const integer = MathTrunc(number);
   if (integer === 0) return 0; // ℝ(value) in spec text; converts -0 to 0
@@ -212,17 +212,17 @@ export function ToPositiveIntegerWithTruncation(value, property) {
   const integer = ToIntegerWithTruncation(value);
   if (integer <= 0) {
     if (property !== undefined) {
-      throw new RangeError(`property '${property}' cannot be a a number less than one`);
+      throw new RangeErrorCtor(`property '${property}' cannot be a a number less than one`);
     }
-    throw new RangeError('Cannot convert a number less than one to a positive integer');
+    throw new RangeErrorCtor('Cannot convert a number less than one to a positive integer');
   }
   return integer;
 }
 
 export function ToIntegerIfIntegral(value) {
   const number = ToNumber(value);
-  if (!NumberIsFinite(number)) throw new RangeError('infinity is out of range');
-  if (!IsIntegralNumber(number)) throw new RangeError(`unsupported fractional value ${value}`);
+  if (!NumberIsFinite(number)) throw new RangeErrorCtor('infinity is out of range');
+  if (!IsIntegralNumber(number)) throw new RangeErrorCtor(`unsupported fractional value ${value}`);
   if (number === 0) return 0; // ℝ(value) in spec text; converts -0 to 0
   return number;
 }
@@ -232,7 +232,7 @@ export function ToIntegerIfIntegral(value) {
 export function RequireString(value) {
   if (Type(value) !== 'String') {
     // Use String() to ensure that Symbols won't throw
-    throw new TypeError(`expected a string, not ${String(value)}`);
+    throw new TypeErrorCtor(`expected a string, not ${StringCtor(value)}`);
   }
   return value;
 }
@@ -240,7 +240,7 @@ export function RequireString(value) {
 // This function is an enum in the spec, but it's helpful to make it a
 // function in the polyfill.
 function ToPrimitiveAndRequireString(value) {
-  value = ToPrimitive(value, String);
+  value = ToPrimitive(value, StringCtor);
   return RequireString(value);
 }
 
@@ -261,7 +261,7 @@ const CALENDAR_FIELD_KEYS = [
   'timeZone'
 ];
 
-const BUILTIN_CASTS = new Map([
+const BUILTIN_CASTS = new MapCtor([
   ['era', ToString],
   ['eraYear', ToIntegerWithTruncation],
   ['year', ToIntegerWithTruncation],
@@ -278,7 +278,7 @@ const BUILTIN_CASTS = new Map([
   ['timeZone', ToTemporalTimeZoneIdentifier]
 ]);
 
-const BUILTIN_DEFAULTS = new Map([
+const BUILTIN_DEFAULTS = new MapCtor([
   ['hour', 0],
   ['minute', 0],
   ['second', 0],
@@ -300,11 +300,13 @@ const TEMPORAL_UNITS = [
   ['microseconds', 'microsecond', 'time', 1e3],
   ['nanoseconds', 'nanosecond', 'time', 1]
 ];
-const SINGULAR_FOR = new Map(TEMPORAL_UNITS);
+const SINGULAR_FOR = new MapCtor(TEMPORAL_UNITS);
 // Iterable destructuring is acceptable in this first-run code.
-const PLURAL_FOR = new Map(Call(ArrayPrototypeMap, TEMPORAL_UNITS, [([p, s]) => [s, p]]));
+const PLURAL_FOR = new MapCtor(Call(ArrayPrototypeMap, TEMPORAL_UNITS, [([p, s]) => [s, p]]));
 const UNITS_DESCENDING = Call(ArrayPrototypeMap, TEMPORAL_UNITS, [([, s]) => s]);
-const NS_PER_TIME_UNIT = new Map(Call(ArrayPrototypeFlatMap, TEMPORAL_UNITS, [([, s, , l]) => (l ? [[s, l]] : [])]));
+const NS_PER_TIME_UNIT = new MapCtor(
+  Call(ArrayPrototypeFlatMap, TEMPORAL_UNITS, [([, s, , l]) => (l ? [[s, l]] : [])])
+);
 
 const DURATION_FIELDS = [
   'days',
@@ -323,7 +325,7 @@ import * as PARSE from './regex.mjs';
 
 export { Call, CopyDataProperties, GetMethod, HasOwnProperty, ToNumber, ToObject, ToString, Type };
 
-const IntlDateTimeFormatEnUsCache = new Map();
+const IntlDateTimeFormatEnUsCache = new MapCtor();
 
 function getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier) {
   const lowercaseIdentifier = ASCIILowercase(timeZoneIdentifier);
@@ -393,16 +395,16 @@ export function IsTemporalZonedDateTime(item) {
 
 export function RejectTemporalLikeObject(item) {
   if (HasSlot(item, CALENDAR) || HasSlot(item, TIME_ZONE)) {
-    throw new TypeError('with() does not support a calendar or timeZone property');
+    throw new TypeErrorCtor('with() does not support a calendar or timeZone property');
   }
   if (IsTemporalTime(item)) {
-    throw new TypeError('with() does not accept Temporal.PlainTime, use withPlainTime() instead');
+    throw new TypeErrorCtor('with() does not accept Temporal.PlainTime, use withPlainTime() instead');
   }
   if (item.calendar !== undefined) {
-    throw new TypeError('with() does not support a calendar property');
+    throw new TypeErrorCtor('with() does not support a calendar property');
   }
   if (item.timeZone !== undefined) {
-    throw new TypeError('with() does not support a timeZone property');
+    throw new TypeErrorCtor('with() does not support a timeZone property');
   }
 }
 
@@ -435,10 +437,12 @@ function processAnnotations(annotations) {
         calendar = value;
         calendarWasCritical = critical === '!';
       } else if (critical === '!' || calendarWasCritical) {
-        throw new RangeError(`Invalid annotations in ${annotations}: more than one u-ca present with critical flag`);
+        throw new RangeErrorCtor(
+          `Invalid annotations in ${annotations}: more than one u-ca present with critical flag`
+        );
       }
     } else if (critical === '!') {
-      throw new RangeError(`Unrecognized annotation: !${key}=${value}`);
+      throw new RangeErrorCtor(`Unrecognized annotation: !${key}=${value}`);
     }
   }
   return calendar;
@@ -447,10 +451,10 @@ function processAnnotations(annotations) {
 export function ParseISODateTime(isoString) {
   // ZDT is the superset of fields for every other Temporal type
   const match = Call(RegExpPrototypeExec, PARSE.zoneddatetime, [isoString]);
-  if (!match) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
+  if (!match) throw new RangeErrorCtor(`invalid ISO 8601 string: ${isoString}`);
   const calendar = processAnnotations(match[16]);
   let yearString = match[1];
-  if (yearString === '-000000') throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
+  if (yearString === '-000000') throw new RangeErrorCtor(`invalid ISO 8601 string: ${isoString}`);
   const year = +yearString;
   const month = +(match[2] ?? match[4] ?? 1);
   const day = +(match[3] ?? match[5] ?? 1);
@@ -487,13 +491,13 @@ export function ParseISODateTime(isoString) {
 
 export function ParseTemporalInstantString(isoString) {
   const result = ParseISODateTime(isoString);
-  if (!result.z && !result.offset) throw new RangeError('Temporal.Instant requires a time zone offset');
+  if (!result.z && !result.offset) throw new RangeErrorCtor('Temporal.Instant requires a time zone offset');
   return result;
 }
 
 export function ParseTemporalZonedDateTimeString(isoString) {
   const result = ParseISODateTime(isoString);
-  if (!result.tzAnnotation) throw new RangeError('Temporal.ZonedDateTime requires a time zone ID in brackets');
+  if (!result.tzAnnotation) throw new RangeErrorCtor('Temporal.ZonedDateTime requires a time zone ID in brackets');
   return result;
 }
 
@@ -518,11 +522,11 @@ export function ParseTemporalTimeString(isoString) {
     millisecond = +Call(StringPrototypeSlice, fraction, [0, 3]);
     microsecond = +Call(StringPrototypeSlice, fraction, [3, 6]);
     nanosecond = +Call(StringPrototypeSlice, fraction, [6, 9]);
-    if (match[8]) throw new RangeError('Z designator not supported for PlainTime');
+    if (match[8]) throw new RangeErrorCtor('Z designator not supported for PlainTime');
   } else {
     const { time, z } = ParseISODateTime(isoString);
-    if (time === 'start-of-day') throw new RangeError(`time is missing in string: ${isoString}`);
-    if (z) throw new RangeError('Z designator not supported for PlainTime');
+    if (time === 'start-of-day') throw new RangeErrorCtor(`time is missing in string: ${isoString}`);
+    if (z) throw new RangeErrorCtor('Z designator not supported for PlainTime');
     ({ hour, minute, second, millisecond, microsecond, nanosecond } = time);
   }
   // if it's a date-time string, OK
@@ -541,7 +545,7 @@ export function ParseTemporalTimeString(isoString) {
       return { hour, minute, second, millisecond, microsecond, nanosecond };
     }
   }
-  throw new RangeError(`invalid ISO 8601 time-only string ${isoString}; may need a T prefix`);
+  throw new RangeErrorCtor(`invalid ISO 8601 time-only string ${isoString}; may need a T prefix`);
 }
 
 export function ParseTemporalYearMonthString(isoString) {
@@ -550,17 +554,17 @@ export function ParseTemporalYearMonthString(isoString) {
   if (match) {
     calendar = processAnnotations(match[3]);
     let yearString = match[1];
-    if (yearString === '-000000') throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
+    if (yearString === '-000000') throw new RangeErrorCtor(`invalid ISO 8601 string: ${isoString}`);
     year = +yearString;
     month = +match[2];
     referenceISODay = 1;
     if (calendar !== undefined && calendar !== 'iso8601') {
-      throw new RangeError('YYYY-MM format is only valid with iso8601 calendar');
+      throw new RangeErrorCtor('YYYY-MM format is only valid with iso8601 calendar');
     }
   } else {
     let z;
     ({ year, month, calendar, day: referenceISODay, z } = ParseISODateTime(isoString));
-    if (z) throw new RangeError('Z designator not supported for PlainYearMonth');
+    if (z) throw new RangeErrorCtor('Z designator not supported for PlainYearMonth');
   }
   return { year, month, calendar, referenceISODay };
 }
@@ -573,18 +577,18 @@ export function ParseTemporalMonthDayString(isoString) {
     month = +match[1];
     day = +match[2];
     if (calendar !== undefined && calendar !== 'iso8601') {
-      throw new RangeError('MM-DD format is only valid with iso8601 calendar');
+      throw new RangeErrorCtor('MM-DD format is only valid with iso8601 calendar');
     }
   } else {
     let z;
     ({ month, day, calendar, year: referenceISOYear, z } = ParseISODateTime(isoString));
-    if (z) throw new RangeError('Z designator not supported for PlainMonthDay');
+    if (z) throw new RangeErrorCtor('Z designator not supported for PlainMonthDay');
   }
   return { month, day, calendar, referenceISOYear };
 }
 
-const TIMEZONE_IDENTIFIER = new RegExp(`^${PARSE.timeZoneID.source}$`, 'i');
-const OFFSET_IDENTIFIER = new RegExp(`^${PARSE.offsetIdentifier.source}$`);
+const TIMEZONE_IDENTIFIER = new RegExpCtor(`^${PARSE.timeZoneID.source}$`, 'i');
+const OFFSET_IDENTIFIER = new RegExpCtor(`^${PARSE.offsetIdentifier.source}$`);
 
 function throwBadTimeZoneStringError(timeZoneString) {
   // Offset identifiers only support minute precision, but offsets in ISO
@@ -594,7 +598,7 @@ function throwBadTimeZoneStringError(timeZoneString) {
   const msg = Call(RegExpPrototypeTest, OFFSET, [timeZoneString])
     ? 'Seconds not allowed in offset time zone'
     : 'Invalid time zone';
-  throw new RangeError(`${msg}: ${timeZoneString}`);
+  throw new RangeErrorCtor(`${msg}: ${timeZoneString}`);
 }
 
 export function ParseTimeZoneIdentifier(identifier) {
@@ -634,14 +638,14 @@ export function ParseTemporalTimeZoneString(stringIdent) {
   if (tzAnnotation) return ParseTimeZoneIdentifier(tzAnnotation);
   if (z) return ParseTimeZoneIdentifier('UTC');
   if (offset) return ParseTimeZoneIdentifier(offset);
-  throw new Error('this line should not be reached');
+  throw new ErrorCtor('this line should not be reached');
 }
 
 export function ParseTemporalDurationString(isoString) {
   const match = Call(RegExpPrototypeExec, PARSE.duration, [isoString]);
-  if (!match) throw new RangeError(`invalid duration: ${isoString}`);
+  if (!match) throw new RangeErrorCtor(`invalid duration: ${isoString}`);
   if (Call(ArrayPrototypeEvery, match, [(part, i) => i < 2 || part === undefined])) {
-    throw new RangeError(`invalid duration: ${isoString}`);
+    throw new RangeErrorCtor(`invalid duration: ${isoString}`);
   }
   const sign = match[1] === '-' ? -1 : 1;
   const years = match[2] === undefined ? 0 : ToIntegerWithTruncation(match[2]) * sign;
@@ -661,14 +665,14 @@ export function ParseTemporalDurationString(isoString) {
 
   if (fHours !== undefined) {
     if (minutesStr ?? fMinutes ?? secondsStr ?? fSeconds ?? false) {
-      throw new RangeError('only the smallest unit can be fractional');
+      throw new RangeErrorCtor('only the smallest unit can be fractional');
     }
     excessNanoseconds = ToIntegerWithTruncation(Call(StringPrototypeSlice, fHours + '000000000', [0, 9])) * 3600 * sign;
   } else {
     minutes = minutesStr === undefined ? 0 : ToIntegerWithTruncation(minutesStr) * sign;
     if (fMinutes !== undefined) {
       if (secondsStr ?? fSeconds ?? false) {
-        throw new RangeError('only the smallest unit can be fractional');
+        throw new RangeErrorCtor('only the smallest unit can be fractional');
       }
       excessNanoseconds =
         ToIntegerWithTruncation(Call(StringPrototypeSlice, fMinutes + '000000000', [0, 9])) * 60 * sign;
@@ -779,7 +783,7 @@ export function ToTemporalDurationRecord(item) {
 
 export function ToTemporalPartialDurationRecord(temporalDurationLike) {
   if (Type(temporalDurationLike) !== 'Object') {
-    throw new TypeError('invalid duration-like');
+    throw new TypeErrorCtor('invalid duration-like');
   }
   const result = {
     years: undefined,
@@ -803,7 +807,7 @@ export function ToTemporalPartialDurationRecord(temporalDurationLike) {
     }
   }
   if (!any) {
-    throw new TypeError('invalid duration-like');
+    throw new TypeErrorCtor('invalid duration-like');
   }
   return result;
 }
@@ -900,7 +904,7 @@ export function GetRoundingIncrementOption(options) {
   if (increment === undefined) return 1;
   const integerIncrement = ToIntegerWithTruncation(increment);
   if (integerIncrement < 1 || integerIncrement > 1e9) {
-    throw new RangeError(`roundingIncrement must be at least 1 and at most 1e9, not ${increment}`);
+    throw new RangeErrorCtor(`roundingIncrement must be at least 1 and at most 1e9, not ${increment}`);
   }
   return integerIncrement;
 }
@@ -908,10 +912,10 @@ export function GetRoundingIncrementOption(options) {
 export function ValidateTemporalRoundingIncrement(increment, dividend, inclusive) {
   const maximum = inclusive ? dividend : dividend - 1;
   if (increment > maximum) {
-    throw new RangeError(`roundingIncrement must be at least 1 and less than ${maximum}, not ${increment}`);
+    throw new RangeErrorCtor(`roundingIncrement must be at least 1 and less than ${maximum}, not ${increment}`);
   }
   if (dividend % increment !== 0) {
-    throw new RangeError(`Rounding increment must divide evenly into ${dividend}`);
+    throw new RangeErrorCtor(`Rounding increment must divide evenly into ${dividend}`);
   }
 }
 
@@ -920,13 +924,13 @@ export function GetTemporalFractionalSecondDigitsOption(options) {
   if (digitsValue === undefined) return 'auto';
   if (Type(digitsValue) !== 'Number') {
     if (ToString(digitsValue) !== 'auto') {
-      throw new RangeError(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digitsValue}`);
+      throw new RangeErrorCtor(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digitsValue}`);
     }
     return 'auto';
   }
   const digitCount = MathFloor(digitsValue);
   if (!NumberIsFinite(digitCount) || digitCount < 0 || digitCount > 9) {
-    throw new RangeError(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digitsValue}`);
+    throw new RangeErrorCtor(`fractionalSecondDigits must be 'auto' or 0 through 9, not ${digitsValue}`);
   }
   return digitCount;
 }
@@ -965,7 +969,7 @@ export function ToSecondsStringPrecisionRecord(smallestUnit, precision) {
   }
 }
 
-export const REQUIRED = Symbol('~required~');
+export const REQUIRED = SymbolCtor('~required~');
 
 export function GetTemporalUnitValuedOption(options, key, unitGroup, requiredOrDefault, extraValues = []) {
   const allowedSingular = [];
@@ -993,7 +997,7 @@ export function GetTemporalUnitValuedOption(options, key, unitGroup, requiredOrD
   }
   let retval = GetOption(options, key, allowedValues, defaultVal);
   if (retval === undefined && requiredOrDefault === REQUIRED) {
-    throw new RangeError(`${key} is required`);
+    throw new RangeErrorCtor(`${key} is required`);
   }
   if (Call(MapPrototypeHas, SINGULAR_FOR, [retval])) retval = Call(MapPrototypeGet, SINGULAR_FOR, [retval]);
   return retval;
@@ -1042,12 +1046,12 @@ export function GetTemporalRelativeToOption(options) {
       }
       matchMinutes = true;
     } else if (z) {
-      throw new RangeError(
+      throw new RangeErrorCtor(
         'Z designator not supported for PlainDate relativeTo; either remove the Z or add a bracketed time zone'
       );
     }
     if (!calendar) calendar = 'iso8601';
-    if (!IsBuiltinCalendar(calendar)) throw new RangeError(`invalid calendar identifier ${calendar}`);
+    if (!IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`invalid calendar identifier ${calendar}`);
     calendar = CanonicalizeCalendar(calendar);
   }
   if (timeZone === undefined) return { plainRelativeTo: CreateTemporalDate(year, month, day, calendar) };
@@ -1131,13 +1135,13 @@ export function PrepareCalendarFields(calendar, bag, calendarFieldNames, nonCale
       result[property] = Call(MapPrototypeGet, BUILTIN_CASTS, [property])(value);
     } else if (requiredFields !== 'partial') {
       if (Call(ArrayPrototypeIncludes, requiredFields, [property])) {
-        throw new TypeError(`required property '${property}' missing or undefined`);
+        throw new TypeErrorCtor(`required property '${property}' missing or undefined`);
       }
       result[property] = Call(MapPrototypeGet, BUILTIN_DEFAULTS, [property]);
     }
   }
   if (requiredFields === 'partial' && !any) {
-    throw new TypeError('no supported properties found');
+    throw new TypeErrorCtor('no supported properties found');
   }
   return result;
 }
@@ -1156,7 +1160,7 @@ export function ToTemporalTimeRecord(bag, completeness = 'complete') {
       result[field] = 0;
     }
   }
-  if (!any) throw new TypeError('invalid time-like');
+  if (!any) throw new TypeErrorCtor('invalid time-like');
   return result;
 }
 
@@ -1187,9 +1191,9 @@ export function ToTemporalDate(item, options = undefined) {
     return CreateTemporalDate(year, month, day, calendar);
   }
   let { year, month, day, calendar, z } = ParseTemporalDateString(RequireString(item));
-  if (z) throw new RangeError('Z designator not supported for PlainDate');
+  if (z) throw new RangeErrorCtor('Z designator not supported for PlainDate');
   if (!calendar) calendar = 'iso8601';
-  if (!IsBuiltinCalendar(calendar)) throw new RangeError(`invalid calendar identifier ${calendar}`);
+  if (!IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`invalid calendar identifier ${calendar}`);
   calendar = CanonicalizeCalendar(calendar);
   GetTemporalOverflowOption(GetOptionsObject(options)); // validate and ignore
   return CreateTemporalDate(year, month, day, calendar);
@@ -1262,7 +1266,7 @@ export function ToTemporalDateTime(item, options = undefined) {
   } else {
     let z;
     ({ year, month, day, time, calendar, z } = ParseTemporalDateTimeString(RequireString(item)));
-    if (z) throw new RangeError('Z designator not supported for PlainDateTime');
+    if (z) throw new RangeErrorCtor('Z designator not supported for PlainDateTime');
     if (time === 'start-of-day') {
       time = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
     }
@@ -1278,7 +1282,7 @@ export function ToTemporalDateTime(item, options = undefined) {
       time.nanosecond
     );
     if (!calendar) calendar = 'iso8601';
-    if (!IsBuiltinCalendar(calendar)) throw new RangeError(`invalid calendar identifier ${calendar}`);
+    if (!IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`invalid calendar identifier ${calendar}`);
     calendar = CanonicalizeCalendar(calendar);
     GetTemporalOverflowOption(GetOptionsObject(options));
   }
@@ -1312,7 +1316,7 @@ export function ToTemporalInstant(item) {
       const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
       return new TemporalInstant(GetSlot(item, EPOCHNANOSECONDS));
     }
-    item = ToPrimitive(item, String);
+    item = ToPrimitive(item, StringCtor);
   }
   const { year, month, day, time, offset, z } = ParseTemporalInstantString(RequireString(item));
   const {
@@ -1366,13 +1370,13 @@ export function ToTemporalMonthDay(item, options = undefined) {
 
   let { month, day, referenceISOYear, calendar } = ParseTemporalMonthDayString(RequireString(item));
   if (calendar === undefined) calendar = 'iso8601';
-  if (!IsBuiltinCalendar(calendar)) throw new RangeError(`invalid calendar identifier ${calendar}`);
+  if (!IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`invalid calendar identifier ${calendar}`);
   calendar = CanonicalizeCalendar(calendar);
 
   GetTemporalOverflowOption(GetOptionsObject(options));
   if (referenceISOYear === undefined) {
     if (calendar !== 'iso8601') {
-      throw new Error(`assertion failed: missing year with non-"iso8601" calendar identifier ${calendar}`);
+      throw new ErrorCtor(`assertion failed: missing year with non-"iso8601" calendar identifier ${calendar}`);
     }
     const isoCalendarReferenceYear = 1972; // First leap year after Unix epoch
     return CreateTemporalMonthDay(month, day, calendar, isoCalendarReferenceYear);
@@ -1454,7 +1458,7 @@ export function ToTemporalYearMonth(item, options = undefined) {
 
   let { year, month, referenceISODay, calendar } = ParseTemporalYearMonthString(RequireString(item));
   if (calendar === undefined) calendar = 'iso8601';
-  if (!IsBuiltinCalendar(calendar)) throw new RangeError(`invalid calendar identifier ${calendar}`);
+  if (!IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`invalid calendar identifier ${calendar}`);
   calendar = CanonicalizeCalendar(calendar);
 
   const result = ISODateToFields(calendar, { year, month, day: referenceISODay }, 'year-month');
@@ -1480,7 +1484,7 @@ export function InterpretISODateTimeOffset(
   // behaviour collapses into ~WALL~, which is equivalent to offset: "ignore".
   if (time === 'start-of-day') {
     if (offsetBehaviour !== 'wall' || offsetNs !== 0) {
-      throw new Error('assertion failure: offset cannot be provided in YYYY-MM-DD[Zone] string');
+      throw new ErrorCtor('assertion failure: offset cannot be provided in YYYY-MM-DD[Zone] string');
     }
     return GetStartOfDay(timeZone, { year, month, day });
   }
@@ -1543,7 +1547,7 @@ export function InterpretISODateTimeOffset(
   if (offsetOpt === 'reject') {
     const offsetStr = FormatUTCOffsetNanoseconds(offsetNs);
     const dtStr = TemporalDateTimeToString(dt, 'iso8601', 'auto');
-    throw new RangeError(`Offset ${offsetStr} is invalid for ${dtStr} in ${timeZone}`);
+    throw new RangeErrorCtor(`Offset ${offsetStr} is invalid for ${dtStr} in ${timeZone}`);
   }
   // fall through: offsetOpt === 'prefer', but the offset doesn't match
   // so fall back to use the time zone instead.
@@ -1593,7 +1597,7 @@ export function ToTemporalZonedDateTime(item, options = undefined) {
       offsetBehaviour = 'wall';
     }
     if (!calendar) calendar = 'iso8601';
-    if (!IsBuiltinCalendar(calendar)) throw new RangeError(`invalid calendar identifier ${calendar}`);
+    if (!IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`invalid calendar identifier ${calendar}`);
     calendar = CanonicalizeCalendar(calendar);
     matchMinute = true; // ISO strings may specify offset with less precision
     options = GetOptionsObject(options);
@@ -1884,7 +1888,7 @@ export function ToTemporalCalendarIdentifier(calendarLike) {
     }
   }
   if (!calendar) calendar = 'iso8601';
-  if (!IsBuiltinCalendar(calendar)) throw new RangeError(`invalid calendar identifier ${calendar}`);
+  if (!IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`invalid calendar identifier ${calendar}`);
   return CanonicalizeCalendar(calendar);
 }
 
@@ -1923,7 +1927,7 @@ export function ToTemporalTimeZoneIdentifier(temporalTimeZoneLike) {
   }
   // if offsetMinutes is undefined, then tzName must be present
   const record = GetAvailableNamedTimeZoneIdentifier(tzName);
-  if (!record) throw new RangeError(`Unrecognized time zone ${tzName}`);
+  if (!record) throw new RangeErrorCtor(`Unrecognized time zone ${tzName}`);
   return record.identifier;
 }
 
@@ -2012,12 +2016,12 @@ export function DisambiguatePossibleEpochNanoseconds(possibleEpochNs, timeZone, 
       case 'later':
         return possibleEpochNs[numInstants - 1];
       case 'reject': {
-        throw new RangeError('multiple instants found');
+        throw new RangeErrorCtor('multiple instants found');
       }
     }
   }
 
-  if (disambiguation === 'reject') throw new RangeError('multiple instants found');
+  if (disambiguation === 'reject') throw new RangeErrorCtor('multiple instants found');
   const {
     year,
     month,
@@ -2039,7 +2043,7 @@ export function DisambiguatePossibleEpochNanoseconds(possibleEpochNs, timeZone, 
   const offsetAfter = GetOffsetNanosecondsFor(timeZone, dayAfter);
   const nanoseconds = offsetAfter - offsetBefore;
   if (MathAbs(nanoseconds) > DAY_NANOS) {
-    throw new Error('assertion failure: UTC offset shift longer than 24 hours');
+    throw new ErrorCtor('assertion failure: UTC offset shift longer than 24 hours');
   }
 
   switch (disambiguation) {
@@ -2059,10 +2063,10 @@ export function DisambiguatePossibleEpochNanoseconds(possibleEpochNs, timeZone, 
       return possible[possible.length - 1];
     }
     case 'reject': {
-      throw new Error('should not be reached: reject handled earlier');
+      throw new ErrorCtor('should not be reached: reject handled earlier');
     }
   }
-  throw new Error(`assertion failed: invalid disambiguation value ${disambiguation}`);
+  throw new ErrorCtor(`assertion failed: invalid disambiguation value ${disambiguation}`);
 }
 
 export function GetPossibleEpochNanoseconds(timeZone, isoDateTime) {
@@ -2108,7 +2112,7 @@ export function GetStartOfDay(timeZone, isoDate) {
   // Otherwise, 00:00:00 lies within a DST gap. Compute an epochNs that's
   // guaranteed to be before the transition
   if (IsOffsetTimeZoneIdentifier(timeZone)) {
-    throw new Error('assertion failure: should only be reached with named time zone');
+    throw new ErrorCtor('assertion failure: should only be reached with named time zone');
   }
 
   const utcns = GetUTCEpochNanoseconds(isoDate.year, isoDate.month, isoDate.day, 0, 0, 0, 0, 0, 0);
@@ -2287,7 +2291,7 @@ export function IsOffsetTimeZoneIdentifier(string) {
 export function ParseDateTimeUTCOffset(string) {
   const match = Call(RegExpPrototypeExec, OFFSET_WITH_PARTS, [string]);
   if (!match) {
-    throw new RangeError(`invalid time zone offset: ${string}`);
+    throw new RangeErrorCtor(`invalid time zone offset: ${string}`);
   }
   const sign = match[1] === '-' ? -1 : +1;
   const hours = +match[2];
@@ -2308,7 +2312,7 @@ export function GetAvailableNamedTimeZoneIdentifier(identifier) {
   if (canonicalTimeZoneIdsCache === undefined) {
     const canonicalTimeZoneIds = IntlSupportedValuesOf?.('timeZone');
     if (canonicalTimeZoneIds) {
-      canonicalTimeZoneIdsCache = new Map();
+      canonicalTimeZoneIdsCache = new MapCtor();
       for (let ix = 0; ix < canonicalTimeZoneIds.length; ix++) {
         const id = canonicalTimeZoneIds[ix];
         Call(MapPrototypeSet, canonicalTimeZoneIdsCache, [ASCIILowercase(id), id]);
@@ -2337,7 +2341,9 @@ export function GetAvailableNamedTimeZoneIdentifier(identifier) {
   // Reject them even if the implementation's Intl supports them, as they are
   // not present in the IANA time zone database.
   if (Call(SetPrototypeHas, ICU_LEGACY_TIME_ZONE_IDS, [identifier])) {
-    throw new RangeError(`${identifier} is a legacy time zone identifier from ICU. Use ${primaryIdentifier} instead`);
+    throw new RangeErrorCtor(
+      `${identifier} is a legacy time zone identifier from ICU. Use ${primaryIdentifier} instead`
+    );
   }
 
   // The identifier is an alias (a deprecated identifier that's a synonym for a
@@ -2445,7 +2451,7 @@ export function GetUTCEpochNanoseconds(
 
   // Note: Date.UTC() interprets one and two-digit years as being in the
   // 20th century, so don't use it
-  const legacyDate = new Date();
+  const legacyDate = new DateCtor();
   Call(DatePrototypeSetUTCHours, legacyDate, [hour, minute, second, millisecond]);
   Call(DatePrototypeSetUTCFullYear, legacyDate, [reducedYear, month - 1, day]);
   const ms = Call(DatePrototypeGetTime, legacyDate, []);
@@ -2469,7 +2475,7 @@ export function GetISOPartsFromEpoch(epochNanoseconds) {
   const microsecond = MathFloor(nanos / 1e3) % 1e3;
   const nanosecond = nanos % 1e3;
 
-  const item = new Date(epochMilliseconds);
+  const item = new DateCtor(epochMilliseconds);
   const year = Call(DatePrototypeGetUTCFullYear, item, []);
   const month = Call(DatePrototypeGetUTCMonth, item, []) + 1;
   const day = Call(DatePrototypeGetUTCDate, item, []);
@@ -2576,7 +2582,7 @@ export function GetFormatterParts(timeZone, epochMilliseconds) {
   const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
   // Using `format` instead of `formatToParts` for compatibility with older clients
   const boundFormat = Call(IntlDateTimeFormatPrototypeGetFormat, formatter, []);
-  const datetime = Call(boundFormat, formatter, [new Date(epochMilliseconds)]);
+  const datetime = Call(boundFormat, formatter, [new DateCtor(epochMilliseconds)]);
   const splits = Call(StringPrototypeSplit, datetime, [/[^\w]+/]);
   const month = splits[0];
   const day = splits[1];
@@ -2677,7 +2683,7 @@ export function DurationSign(y, mon, w, d, h, min, s, ms, µs, ns) {
 }
 
 export function BalanceISOYearMonth(year, month) {
-  if (!NumberIsFinite(year) || !NumberIsFinite(month)) throw new RangeError('infinity is out of range');
+  if (!NumberIsFinite(year) || !NumberIsFinite(month)) throw new RangeErrorCtor('infinity is out of range');
   month -= 1;
   year += MathFloor(month / 12);
   month %= 12;
@@ -2687,7 +2693,7 @@ export function BalanceISOYearMonth(year, month) {
 }
 
 export function BalanceISODate(year, month, day) {
-  if (!NumberIsFinite(day)) throw new RangeError('infinity is out of range');
+  if (!NumberIsFinite(day)) throw new RangeErrorCtor('infinity is out of range');
   ({ year, month } = BalanceISOYearMonth(year, month));
 
   // The pattern of leap years in the ISO 8601 calendar repeats every 400
@@ -2846,7 +2852,7 @@ export function BalanceTimeDuration(norm, largestUnit) {
       seconds = 0;
       break;
     default:
-      throw new Error('assert not reached');
+      throw new ErrorCtor('assert not reached');
   }
 
   days *= sign;
@@ -2910,7 +2916,7 @@ export function ConstrainTime(hour, minute, second, millisecond, microsecond, na
 }
 
 export function RejectToRange(value, min, max) {
-  if (value < min || value > max) throw new RangeError(`value out of range: ${min} <= ${value} <= ${max}`);
+  if (value < min || value > max) throw new RangeErrorCtor(`value out of range: ${min} <= ${value} <= ${max}`);
 }
 
 export function RejectISODate(year, month, day) {
@@ -2952,7 +2958,7 @@ export function RejectDateTimeRange(year, month, day, hour, minute, second, mill
 // place so that we can DRY the throwing code.
 export function ValidateEpochNanoseconds(epochNanoseconds) {
   if (epochNanoseconds.lesser(NS_MIN) || epochNanoseconds.greater(NS_MAX)) {
-    throw new RangeError('date/time value is outside of supported range');
+    throw new RangeErrorCtor('date/time value is outside of supported range');
   }
 }
 
@@ -2970,12 +2976,14 @@ export function RejectDuration(y, mon, w, d, h, min, s, ms, µs, ns) {
   const fields = [y, mon, w, d, h, min, s, ms, µs, ns];
   for (let index = 0; index < fields.length; index++) {
     const prop = fields[index];
-    if (!NumberIsFinite(prop)) throw new RangeError('infinite values not allowed as duration fields');
+    if (!NumberIsFinite(prop)) throw new RangeErrorCtor('infinite values not allowed as duration fields');
     const propSign = MathSign(prop);
-    if (propSign !== 0 && propSign !== sign) throw new RangeError('mixed-sign values not allowed as duration fields');
+    if (propSign !== 0 && propSign !== sign) {
+      throw new RangeErrorCtor('mixed-sign values not allowed as duration fields');
+    }
   }
   if (MathAbs(y) >= 2 ** 32 || MathAbs(mon) >= 2 ** 32 || MathAbs(w) >= 2 ** 32) {
-    throw new RangeError('years, months, and weeks must be < 2³²');
+    throw new RangeErrorCtor('years, months, and weeks must be < 2³²');
   }
   const msResult = TruncatingDivModByPowerOf10(ms, 3);
   const µsResult = TruncatingDivModByPowerOf10(µs, 6);
@@ -2983,7 +2991,7 @@ export function RejectDuration(y, mon, w, d, h, min, s, ms, µs, ns) {
   const remainderSec = TruncatingDivModByPowerOf10(msResult.mod * 1e6 + µsResult.mod * 1e3 + nsResult.mod, 9).div;
   const totalSec = d * 86400 + h * 3600 + min * 60 + s + msResult.div + µsResult.div + nsResult.div + remainderSec;
   if (!NumberIsSafeInteger(totalSec)) {
-    throw new RangeError('total of duration time units cannot exceed 9007199254740991.999999999 s');
+    throw new RangeErrorCtor('total of duration time units cannot exceed 9007199254740991.999999999 s');
   }
 }
 
@@ -2996,7 +3004,7 @@ function CombineDateAndNormalizedTimeDuration(y, m, w, d, norm) {
   const dateSign = DurationSign(y, m, w, d, 0, 0, 0, 0, 0, 0);
   const timeSign = norm.sign();
   if (dateSign !== 0 && timeSign !== 0 && dateSign !== timeSign) {
-    throw new RangeError('mixed-sign values not allowed as duration fields');
+    throw new RangeErrorCtor('mixed-sign values not allowed as duration fields');
   }
 }
 
@@ -3062,7 +3070,7 @@ export function DifferenceTime(h1, min1, s1, ms1, µs1, ns1, h2, min2, s2, ms2, 
   const nanoseconds = ns2 - ns1;
   const norm = TimeDuration.normalize(hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 
-  if (norm.abs().sec >= 86400) throw new Error('assertion failure in DifferenceTime: _bt_.[[Days]] should be 0');
+  if (norm.abs().sec >= 86400) throw new ErrorCtor('assertion failure in DifferenceTime: _bt_.[[Days]] should be 0');
 
   return norm;
 }
@@ -3204,7 +3212,7 @@ export function DifferenceZonedDateTime(ns1, ns2, timeZone, calendar, largestUni
   }
 
   if (dayCorrection > maxDayCorrection) {
-    throw new Error(`assertion failed: more than ${maxDayCorrection} day correction needed`);
+    throw new ErrorCtor(`assertion failed: more than ${maxDayCorrection} day correction needed`);
   }
 
   // Similar to what happens in DifferenceISODateTime with date parts only:
@@ -3263,11 +3271,11 @@ function NudgeToCalendarUnit(sign, duration, destEpochNs, dateTime, timeZone, ca
       break;
     }
     default:
-      throw new Error('assert not reached');
+      throw new ErrorCtor('assert not reached');
   }
 
   if ((sign === 1 && (r1 < 0 || r1 >= r2)) || (sign === -1 && (r1 > 0 || r1 <= r2))) {
-    throw new Error('assertion failed: ordering of r1, r2 according to sign');
+    throw new ErrorCtor('assertion failed: ordering of r1, r2 according to sign');
   }
 
   // Apply to origin, output PlainDateTimes
@@ -3312,10 +3320,10 @@ function NudgeToCalendarUnit(sign, duration, destEpochNs, dateTime, timeZone, ca
     (sign === 1 && (startEpochNs.gt(destEpochNs) || destEpochNs.gt(endEpochNs))) ||
     (sign === -1 && (endEpochNs.gt(destEpochNs) || destEpochNs.gt(startEpochNs)))
   ) {
-    throw new RangeError(`custom calendar reported a ${unit} that is 0 days long`);
+    throw new RangeErrorCtor(`custom calendar reported a ${unit} that is 0 days long`);
   }
   if (endEpochNs.equals(startEpochNs)) {
-    throw new Error('assertion failed: startEpochNs ≠ endEpochNs');
+    throw new ErrorCtor('assertion failed: startEpochNs ≠ endEpochNs');
   }
   const numerator = TimeDuration.fromEpochNsDiff(destEpochNs, startEpochNs);
   const denominator = TimeDuration.fromEpochNsDiff(endEpochNs, startEpochNs);
@@ -3332,7 +3340,7 @@ function NudgeToCalendarUnit(sign, duration, destEpochNs, dateTime, timeZone, ca
   const fakeNumerator = new TimeDuration(denominator.totalNs.times(r1).add(numerator.totalNs.times(increment * sign)));
   const total = fakeNumerator.fdiv(denominator.totalNs);
   if (MathAbs(total) < MathAbs(r1) || MathAbs(total) > MathAbs(r2)) {
-    throw new Error('assertion failed: r1 ≤ total ≤ r2');
+    throw new ErrorCtor('assertion failed: r1 ≤ total ≤ r2');
   }
 
   // Determine whether expanded or contracted
@@ -3373,7 +3381,7 @@ function NudgeToZonedTime(sign, duration, dateTime, timeZone, calendar, incremen
 
   // The signed amount of time from the start of the whole-day interval to the end
   const daySpan = TimeDuration.fromEpochNsDiff(endEpochNs, startEpochNs);
-  if (daySpan.sign() !== sign) throw new RangeError('time zone returned inconsistent Instants');
+  if (daySpan.sign() !== sign) throw new RangeErrorCtor('time zone returned inconsistent Instants');
 
   // Compute time parts of the duration to nanoseconds and round
   // Result could be negative
@@ -3498,7 +3506,7 @@ function BubbleRelativeDuration(
         break;
       }
       default:
-        throw new Error('assert not reached');
+        throw new ErrorCtor('assert not reached');
     }
 
     // Compute end-of-unit in epoch-nanoseconds
@@ -3790,7 +3798,7 @@ export function GetDifferenceSettings(op, options, group, disallowed, fallbackSm
 
   let largestUnit = GetTemporalUnitValuedOption(options, 'largestUnit', group, 'auto');
   if (Call(ArrayPrototypeIncludes, disallowed, [largestUnit])) {
-    throw new RangeError(
+    throw new RangeErrorCtor(
       `largestUnit must be one of ${Call(ArrayPrototypeJoin, ALLOWED_UNITS, [', '])}, not ${largestUnit}`
     );
   }
@@ -3802,7 +3810,7 @@ export function GetDifferenceSettings(op, options, group, disallowed, fallbackSm
 
   const smallestUnit = GetTemporalUnitValuedOption(options, 'smallestUnit', group, fallbackSmallest);
   if (Call(ArrayPrototypeIncludes, disallowed, [smallestUnit])) {
-    throw new RangeError(
+    throw new RangeErrorCtor(
       `smallestUnit must be one of ${Call(ArrayPrototypeJoin, ALLOWED_UNITS, [', '])}, not ${smallestUnit}`
     );
   }
@@ -3810,7 +3818,7 @@ export function GetDifferenceSettings(op, options, group, disallowed, fallbackSm
   const defaultLargestUnit = LargerOfTwoTemporalUnits(smallestLargestDefaultUnit, smallestUnit);
   if (largestUnit === 'auto') largestUnit = defaultLargestUnit;
   if (LargerOfTwoTemporalUnits(largestUnit, smallestUnit) !== largestUnit) {
-    throw new RangeError(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
+    throw new RangeErrorCtor(`largestUnit ${largestUnit} cannot be smaller than smallestUnit ${smallestUnit}`);
   }
   const MAX_DIFFERENCE_INCREMENTS = {
     hour: 24,
@@ -3867,7 +3875,7 @@ export function DifferenceTemporalPlainDate(operation, plainDate, other, options
   const calendar = GetSlot(plainDate, CALENDAR);
   const otherCalendar = GetSlot(other, CALENDAR);
   if (!CalendarEquals(calendar, otherCalendar)) {
-    throw new RangeError(`cannot compute difference between dates of ${calendar} and ${otherCalendar} calendars`);
+    throw new RangeErrorCtor(`cannot compute difference between dates of ${calendar} and ${otherCalendar} calendars`);
   }
 
   const resolvedOptions = GetOptionsObject(options);
@@ -3920,7 +3928,7 @@ export function DifferenceTemporalPlainDateTime(operation, plainDateTime, other,
   const calendar = GetSlot(plainDateTime, CALENDAR);
   const otherCalendar = GetSlot(other, CALENDAR);
   if (!CalendarEquals(calendar, otherCalendar)) {
-    throw new RangeError(`cannot compute difference between dates of ${calendar} and ${otherCalendar} calendars`);
+    throw new RangeErrorCtor(`cannot compute difference between dates of ${calendar} and ${otherCalendar} calendars`);
   }
 
   const resolvedOptions = GetOptionsObject(options);
@@ -4031,7 +4039,7 @@ export function DifferenceTemporalPlainYearMonth(operation, yearMonth, other, op
   const calendar = GetSlot(yearMonth, CALENDAR);
   const otherCalendar = GetSlot(other, CALENDAR);
   if (!CalendarEquals(calendar, otherCalendar)) {
-    throw new RangeError(`cannot compute difference between months of ${calendar} and ${otherCalendar} calendars`);
+    throw new RangeErrorCtor(`cannot compute difference between months of ${calendar} and ${otherCalendar} calendars`);
   }
 
   const resolvedOptions = GetOptionsObject(options);
@@ -4090,7 +4098,7 @@ export function DifferenceTemporalZonedDateTime(operation, zonedDateTime, other,
   const calendar = GetSlot(zonedDateTime, CALENDAR);
   const otherCalendar = GetSlot(other, CALENDAR);
   if (!CalendarEquals(calendar, otherCalendar)) {
-    throw new RangeError(`cannot compute difference between dates of ${calendar} and ${otherCalendar} calendars`);
+    throw new RangeErrorCtor(`cannot compute difference between dates of ${calendar} and ${otherCalendar} calendars`);
   }
 
   const resolvedOptions = GetOptionsObject(options);
@@ -4127,7 +4135,7 @@ export function DifferenceTemporalZonedDateTime(operation, zonedDateTime, other,
   } else {
     const timeZone = GetSlot(zonedDateTime, TIME_ZONE);
     if (!TimeZoneEquals(timeZone, GetSlot(other, TIME_ZONE))) {
-      throw new RangeError(
+      throw new RangeErrorCtor(
         "When calculating difference between time zones, largestUnit must be 'hours' " +
           'or smaller because day lengths can vary between time zones due to DST or time zone offset changes.'
       );
@@ -4272,7 +4280,9 @@ export function AddDurations(operation, duration, other) {
   );
 
   if (IsCalendarUnit(largestUnit)) {
-    throw new RangeError('For years, months, or weeks arithmetic, use date arithmetic relative to a starting point');
+    throw new RangeErrorCtor(
+      'For years, months, or weeks arithmetic, use date arithmetic relative to a starting point'
+    );
   }
   const { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(
     norm1.add(norm2).add24HourDays(GetSlot(duration, DAYS) + GetSlot(other, DAYS)),
@@ -4287,7 +4297,7 @@ export function AddDurationToOrSubtractDurationFromInstant(operation, instant, d
   if (operation === 'subtract') duration = CreateNegatedTemporalDuration(duration);
   const largestUnit = DefaultTemporalLargestUnit(duration);
   if (IsCalendarUnit(largestUnit) || largestUnit === 'day') {
-    throw new RangeError(
+    throw new RangeErrorCtor(
       `Duration field ${largestUnit} not supported by Temporal.Instant. Try Temporal.ZonedDateTime instead.`
     );
   }
@@ -4640,7 +4650,7 @@ export function BigIntFloorDiv(left, right) {
 }
 
 export function BigIntIfAvailable(wrapper) {
-  return typeof BigInt === 'undefined' ? wrapper : wrapper.value;
+  return typeof BigIntCtor === 'undefined' ? wrapper : wrapper.value;
 }
 
 export function ToBigInt(arg) {
@@ -4648,24 +4658,24 @@ export function ToBigInt(arg) {
     return arg;
   }
 
-  const prim = ToPrimitive(arg, Number);
+  const prim = ToPrimitive(arg, NumberCtor);
   switch (typeof prim) {
     case 'undefined':
     case 'object':
     case 'number':
     case 'symbol':
-      throw new TypeError(`cannot convert ${typeof arg} to bigint`);
+      throw new TypeErrorCtor(`cannot convert ${typeof arg} to bigint`);
     case 'string':
       if (!Call(StringPrototypeMatch, prim, [/^\s*(?:[+-]?\d+\s*)?$/])) {
-        throw new SyntaxError('invalid BigInt syntax');
+        throw new SyntaxErrorCtor('invalid BigInt syntax');
       }
     // eslint: no-fallthrough: false
     case 'bigint':
       try {
         return bigInt(prim);
       } catch (e) {
-        if (e instanceof Error && Call(StringPrototypeStartsWith, e.message, ['Invalid integer'])) {
-          throw new SyntaxError(e.message);
+        if (e instanceof ErrorCtor && Call(StringPrototypeStartsWith, e.message, ['Invalid integer'])) {
+          throw new SyntaxErrorCtor(e.message);
         }
         throw e;
       }
@@ -4703,7 +4713,9 @@ export function ComparisonResult(value) {
 export function GetOptionsObject(options) {
   if (options === undefined) return ObjectCreate(null);
   if (Type(options) === 'Object') return options;
-  throw new TypeError(`Options parameter must be an object, not ${options === null ? 'null' : `a ${typeof options}`}`);
+  throw new TypeErrorCtor(
+    `Options parameter must be an object, not ${options === null ? 'null' : `a ${typeof options}`}`
+  );
 }
 
 export function GetOption(options, property, allowedValues, fallback) {
@@ -4711,13 +4723,13 @@ export function GetOption(options, property, allowedValues, fallback) {
   if (value !== undefined) {
     value = ToString(value);
     if (!Call(ArrayPrototypeIncludes, allowedValues, [value])) {
-      throw new RangeError(
+      throw new RangeErrorCtor(
         `${property} must be one of ${Call(ArrayPrototypeJoin, allowedValues, [', '])}, not ${value}`
       );
     }
     return value;
   }
-  if (fallback === REQUIRED) throw new RangeError(`${property} option is required`);
+  if (fallback === REQUIRED) throw new RangeErrorCtor(`${property} option is required`);
   return fallback;
 }
 
@@ -4773,7 +4785,7 @@ export function ValueOfThrows(constructorName) {
       ? 'Temporal.PlainDate.compare(obj1.toPlainDate(year), obj2.toPlainDate(year))'
       : `Temporal.${constructorName}.compare(obj1, obj2)`;
 
-  throw new TypeError(
+  throw new TypeErrorCtor(
     'Do not use built-in arithmetic operators with Temporal objects. ' +
       `When comparing, use ${compareCode}, not obj1 > obj2. ` +
       "When coercing to strings, use `${obj}` or String(obj), not '' + obj. " +
@@ -4783,8 +4795,8 @@ export function ValueOfThrows(constructorName) {
   );
 }
 
-const OFFSET = new RegExp(`^${PARSE.offset.source}$`);
-const OFFSET_WITH_PARTS = new RegExp(`^${PARSE.offsetWithParts.source}$`);
+const OFFSET = new RegExpCtor(`^${PARSE.offset.source}$`);
+const OFFSET_WITH_PARTS = new RegExpCtor(`^${PARSE.offsetWithParts.source}$`);
 
 function bisect(getState, left, right, lstate = getState(left), rstate = getState(right)) {
   left = bigInt(left);
@@ -4799,7 +4811,7 @@ function bisect(getState, left, right, lstate = getState(left), rstate = getStat
       right = middle;
       rstate = mstate;
     } else {
-      throw new Error(`invalid state in bisection ${lstate} - ${mstate} - ${rstate}`);
+      throw new ErrorCtor(`invalid state in bisection ${lstate} - ${mstate} - ${rstate}`);
     }
   }
   return right;

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -2,8 +2,8 @@
 
 import {
   // error constructors
-  RangeError as RangeError,
-  TypeError as TypeError,
+  RangeError as RangeErrorCtor,
+  TypeError as TypeErrorCtor,
 
   // class static functions and methods
   ObjectCreate,
@@ -23,7 +23,7 @@ export class Instant {
     // Note: if the argument is not passed, ToBigInt(undefined) will throw. This check exists only
     //       to improve the error message.
     if (arguments.length < 1) {
-      throw new TypeError('missing argument: epochNanoseconds is required');
+      throw new TypeErrorCtor('missing argument: epochNanoseconds is required');
     }
 
     const ns = ES.ToBigInt(epochNanoseconds);
@@ -44,34 +44,34 @@ export class Instant {
   }
 
   get epochMilliseconds() {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     const value = bigInt(GetSlot(this, EPOCHNANOSECONDS));
     return ES.BigIntFloorDiv(value, 1e6).toJSNumber();
   }
   get epochNanoseconds() {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.BigIntIfAvailable(GetSlot(this, EPOCHNANOSECONDS));
   }
 
   add(temporalDurationLike) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromInstant('add', this, temporalDurationLike);
   }
   subtract(temporalDurationLike) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromInstant('subtract', this, temporalDurationLike);
   }
   until(other, options = undefined) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalInstant('until', this, other, options);
   }
   since(other, options = undefined) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalInstant('since', this, other, options);
   }
   round(roundTo) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    if (roundTo === undefined) throw new TypeError('options parameter is required');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
+    if (roundTo === undefined) throw new TypeErrorCtor('options parameter is required');
     if (ES.Type(roundTo) === 'String') {
       const stringParam = roundTo;
       roundTo = ObjectCreate(null);
@@ -96,19 +96,19 @@ export class Instant {
     return new Instant(roundedNs);
   }
   equals(other) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     other = ES.ToTemporalInstant(other);
     const one = GetSlot(this, EPOCHNANOSECONDS);
     const two = GetSlot(other, EPOCHNANOSECONDS);
     return bigInt(one).equals(two);
   }
   toString(options = undefined) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     options = ES.GetOptionsObject(options);
     const digits = ES.GetTemporalFractionalSecondDigitsOption(options);
     const roundingMode = ES.GetRoundingModeOption(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnitValuedOption(options, 'smallestUnit', 'time', undefined);
-    if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
+    if (smallestUnit === 'hour') throw new RangeErrorCtor('smallestUnit must be a time unit other than "hour"');
     let timeZone = options.timeZone;
     if (timeZone !== undefined) timeZone = ES.ToTemporalTimeZoneIdentifier(timeZone);
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
@@ -118,18 +118,18 @@ export class Instant {
     return ES.TemporalInstantToString(roundedInstant, timeZone, precision);
   }
   toJSON() {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.TemporalInstantToString(this, undefined, 'auto');
   }
   toLocaleString(locales = undefined, options = undefined) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
     ES.ValueOfThrows('Instant');
   }
   toZonedDateTimeISO(timeZone) {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     timeZone = ES.ToTemporalTimeZoneIdentifier(timeZone);
     return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, 'iso8601');
   }

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -1,13 +1,22 @@
 /* global __debug__ */
 
+import {
+  // error constructors
+  RangeError as RangeError,
+  TypeError as TypeError,
+
+  // class static functions and methods
+  ObjectCreate,
+  ObjectDefineProperty,
+  SymbolToStringTag
+} from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
 import { EPOCHNANOSECONDS, CreateSlots, GetSlot, SetSlot } from './slots.mjs';
 
 import bigInt from 'big-integer';
-
-const ObjectCreate = Object.create;
 
 export class Instant {
   constructor(epochNanoseconds) {
@@ -25,8 +34,8 @@ export class Instant {
     if (typeof __debug__ !== 'undefined' && __debug__) {
       const iso = ES.GetISOPartsFromEpoch(ns);
       const repr = ES.TemporalDateTimeToString(iso, 'iso8601', 'auto', 'never') + 'Z';
-      Object.defineProperty(this, '_repr_', {
-        value: `${this[Symbol.toStringTag]} <${repr}>`,
+      ObjectDefineProperty(this, '_repr_', {
+        value: `${this[SymbolToStringTag]} <${repr}>`,
         writable: false,
         enumerable: false,
         configurable: false

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -1,11 +1,11 @@
 import {
   // constructors and similar
-  Symbol as Symbol,
+  Symbol as SymbolCtor,
 
   // error constructors
-  Error as Error,
-  RangeError as RangeError,
-  TypeError as TypeError,
+  Error as ErrorCtor,
+  RangeError as RangeErrorCtor,
+  TypeError as TypeErrorCtor,
 
   // class static functions and methods
   ArrayPrototypeSlice,
@@ -41,18 +41,18 @@ import {
   CALENDAR
 } from './slots.mjs';
 
-const DATE = Symbol('date');
-const YM = Symbol('ym');
-const MD = Symbol('md');
-const TIME = Symbol('time');
-const DATETIME = Symbol('datetime');
-const INST = Symbol('instant');
-const ORIGINAL = Symbol('original');
-const TZ_CANONICAL = Symbol('timezone-canonical');
-const TZ_ORIGINAL = Symbol('timezone-original');
-const CAL_ID = Symbol('calendar-id');
-const LOCALE = Symbol('locale');
-const OPTIONS = Symbol('options');
+const DATE = SymbolCtor('date');
+const YM = SymbolCtor('ym');
+const MD = SymbolCtor('md');
+const TIME = SymbolCtor('time');
+const DATETIME = SymbolCtor('datetime');
+const INST = SymbolCtor('instant');
+const ORIGINAL = SymbolCtor('original');
+const TZ_CANONICAL = SymbolCtor('timezone-canonical');
+const TZ_ORIGINAL = SymbolCtor('timezone-original');
+const CAL_ID = SymbolCtor('calendar-id');
+const LOCALE = SymbolCtor('locale');
+const OPTIONS = SymbolCtor('options');
 
 // Construction of built-in Intl.DateTimeFormat objects is sloooooow,
 // so we'll only create those instances when we need them.
@@ -157,10 +157,10 @@ function createDateTimeFormat(dtf, locale, options) {
     const id = ES.ToString(timeZoneOption);
     if (ES.IsOffsetTimeZoneIdentifier(id)) {
       // Note: https://github.com/tc39/ecma402/issues/683 will remove this
-      throw new RangeError('Intl.DateTimeFormat does not currently support offset time zones');
+      throw new RangeErrorCtor('Intl.DateTimeFormat does not currently support offset time zones');
     }
     const record = ES.GetAvailableNamedTimeZoneIdentifier(id);
-    if (!record) throw new RangeError(`Intl.DateTimeFormat formats built-in time zones, not ${id}`);
+    if (!record) throw new RangeErrorCtor(`Intl.DateTimeFormat formats built-in time zones, not ${id}`);
     SetSlot(dtf, TZ_ORIGINAL, record.identifier);
   }
 }
@@ -171,7 +171,7 @@ class DateTimeFormatImpl {
   }
 
   get format() {
-    if (!HasSlot(this, ORIGINAL)) throw new TypeError('invalid receiver');
+    if (!HasSlot(this, ORIGINAL)) throw new TypeErrorCtor('invalid receiver');
     const boundFormat = (...args) => ES.Call(format, this, args);
     ObjectDefineProperties(boundFormat, {
       length: { value: 1, enumerable: false, writable: false, configurable: true },
@@ -181,24 +181,24 @@ class DateTimeFormatImpl {
   }
 
   formatRange(a, b) {
-    if (!HasSlot(this, ORIGINAL)) throw new TypeError('invalid receiver');
+    if (!HasSlot(this, ORIGINAL)) throw new TypeErrorCtor('invalid receiver');
     return ES.Call(formatRange, this, [a, b]);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   formatToParts(datetime, ...rest) {
-    if (!HasSlot(this, ORIGINAL)) throw new TypeError('invalid receiver');
+    if (!HasSlot(this, ORIGINAL)) throw new TypeErrorCtor('invalid receiver');
     const args = ES.Call(ArrayPrototypeSlice, arguments, []);
     return ES.Call(formatToParts, this, args);
   }
 
   formatRangeToParts(a, b) {
-    if (!HasSlot(this, ORIGINAL)) throw new TypeError('invalid receiver');
+    if (!HasSlot(this, ORIGINAL)) throw new TypeErrorCtor('invalid receiver');
     return ES.Call(formatRangeToParts, this, [a, b]);
   }
 
   resolvedOptions() {
-    if (!HasSlot(this, ORIGINAL)) throw new TypeError('invalid receiver');
+    if (!HasSlot(this, ORIGINAL)) throw new TypeErrorCtor('invalid receiver');
     return ES.Call(resolvedOptions, this, []);
   }
 }
@@ -269,13 +269,13 @@ function formatRange(a, b) {
   let formatter;
   if (isTemporalObject(a) || isTemporalObject(b)) {
     if (!sameTemporalType(a, b)) {
-      throw new TypeError('Intl.DateTimeFormat.formatRange accepts two values of the same type');
+      throw new TypeErrorCtor('Intl.DateTimeFormat.formatRange accepts two values of the same type');
     }
     const { epochNs: aa, formatter: aformatter } = extractOverrides(a, this);
     const { epochNs: bb, formatter: bformatter } = extractOverrides(b, this);
     if (aformatter) {
       if (bformatter !== aformatter) {
-        throw new Error('assertion failed: formatters for same Temporal type should be identical');
+        throw new ErrorCtor('assertion failed: formatters for same Temporal type should be identical');
       }
       formatter = aformatter;
       formatArgs = [epochNsToMs(aa), epochNsToMs(bb)];
@@ -291,13 +291,13 @@ function formatRangeToParts(a, b) {
   let formatter;
   if (isTemporalObject(a) || isTemporalObject(b)) {
     if (!sameTemporalType(a, b)) {
-      throw new TypeError('Intl.DateTimeFormat.formatRangeToParts accepts two values of the same type');
+      throw new TypeErrorCtor('Intl.DateTimeFormat.formatRangeToParts accepts two values of the same type');
     }
     const { epochNs: aa, formatter: aformatter } = extractOverrides(a, this);
     const { epochNs: bb, formatter: bformatter } = extractOverrides(b, this);
     if (aformatter) {
       if (bformatter !== aformatter) {
-        throw new Error('assertion failed: formatters for same Temporal type should be identical');
+        throw new ErrorCtor('assertion failed: formatters for same Temporal type should be identical');
       }
       formatter = aformatter;
       formatArgs = [epochNsToMs(aa), epochNsToMs(bb)];
@@ -514,7 +514,7 @@ function extractOverrides(temporalObj, main) {
     const calendar = GetSlot(temporalObj, CALENDAR);
     const mainCalendar = GetSlot(main, CAL_ID);
     if (calendar !== mainCalendar) {
-      throw new RangeError(
+      throw new RangeErrorCtor(
         `cannot format PlainYearMonth with calendar ${calendar} in locale with calendar ${mainCalendar}`
       );
     }
@@ -534,7 +534,7 @@ function extractOverrides(temporalObj, main) {
     const calendar = GetSlot(temporalObj, CALENDAR);
     const mainCalendar = GetSlot(main, CAL_ID);
     if (calendar !== mainCalendar) {
-      throw new RangeError(
+      throw new RangeErrorCtor(
         `cannot format PlainMonthDay with calendar ${calendar} in locale with calendar ${mainCalendar}`
       );
     }
@@ -554,7 +554,9 @@ function extractOverrides(temporalObj, main) {
     const calendar = GetSlot(temporalObj, CALENDAR);
     const mainCalendar = GetSlot(main, CAL_ID);
     if (calendar !== 'iso8601' && calendar !== mainCalendar) {
-      throw new RangeError(`cannot format PlainDate with calendar ${calendar} in locale with calendar ${mainCalendar}`);
+      throw new RangeErrorCtor(
+        `cannot format PlainDate with calendar ${calendar} in locale with calendar ${mainCalendar}`
+      );
     }
     const isoDateTime = {
       year: GetSlot(temporalObj, ISO_YEAR),
@@ -572,7 +574,7 @@ function extractOverrides(temporalObj, main) {
     const calendar = GetSlot(temporalObj, CALENDAR);
     const mainCalendar = GetSlot(main, CAL_ID);
     if (calendar !== 'iso8601' && calendar !== mainCalendar) {
-      throw new RangeError(
+      throw new RangeErrorCtor(
         `cannot format PlainDateTime with calendar ${calendar} in locale with calendar ${mainCalendar}`
       );
     }
@@ -584,7 +586,7 @@ function extractOverrides(temporalObj, main) {
   }
 
   if (ES.IsTemporalZonedDateTime(temporalObj)) {
-    throw new TypeError(
+    throw new TypeErrorCtor(
       'Temporal.ZonedDateTime not supported in DateTimeFormat methods. Use toLocaleString() instead.'
     );
   }

--- a/polyfill/lib/legacydate.mjs
+++ b/polyfill/lib/legacydate.mjs
@@ -1,9 +1,9 @@
+import { DatePrototypeValueOf } from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { Instant } from './instant.mjs';
 
 import bigInt from 'big-integer';
-
-const DatePrototypeValueOf = Date.prototype.valueOf;
 
 export function toTemporalInstant() {
   const epochNanoseconds = bigInt(ES.Call(DatePrototypeValueOf, this, [])).multiply(1e6);

--- a/polyfill/lib/math.mjs
+++ b/polyfill/lib/math.mjs
@@ -1,12 +1,14 @@
-const MathAbs = Math.abs;
-const MathLog10 = Math.log10;
-const MathSign = Math.sign;
-const MathTrunc = Math.trunc;
-const NumberParseInt = Number.parseInt;
-const NumberPrototypeToPrecision = Number.prototype.toPrecision;
-const StringPrototypePadStart = String.prototype.padStart;
-const StringPrototypeRepeat = String.prototype.repeat;
-const StringPrototypeSlice = String.prototype.slice;
+import {
+  MathAbs,
+  MathLog10,
+  MathSign,
+  MathTrunc,
+  NumberParseInt,
+  NumberPrototypeToPrecision,
+  StringPrototypePadStart,
+  StringPrototypeRepeat,
+  StringPrototypeSlice
+} from './primordials.mjs';
 
 import Call from 'es-abstract/2024/Call.js';
 

--- a/polyfill/lib/now.mjs
+++ b/polyfill/lib/now.mjs
@@ -1,3 +1,5 @@
+import { ObjectDefineProperty, SymbolToStringTag } from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { GetIntrinsic } from './intrinsicclass.mjs';
 
@@ -43,7 +45,7 @@ export const Now = {
   timeZoneId,
   zonedDateTimeISO
 };
-Object.defineProperty(Now, Symbol.toStringTag, {
+ObjectDefineProperty(Now, SymbolToStringTag, {
   value: 'Temporal.Now',
   writable: false,
   enumerable: false,

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -1,4 +1,4 @@
-import { RangeError as RangeError, TypeError as TypeError } from './primordials.mjs';
+import { RangeError as RangeErrorCtor, TypeError as TypeErrorCtor } from './primordials.mjs';
 
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
@@ -23,94 +23,94 @@ export class PlainDate {
     isoMonth = ES.ToIntegerWithTruncation(isoMonth);
     isoDay = ES.ToIntegerWithTruncation(isoDay);
     calendar = calendar === undefined ? 'iso8601' : ES.RequireString(calendar);
-    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeError(`unknown calendar ${calendar}`);
+    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`unknown calendar ${calendar}`);
     calendar = ES.CanonicalizeCalendar(calendar);
 
     ES.CreateTemporalDateSlots(this, isoYear, isoMonth, isoDay, calendar);
   }
   get calendarId() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, CALENDAR);
   }
   get era() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarEra(GetSlot(this, CALENDAR), isoDate);
   }
   get eraYear() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarEraYear(GetSlot(this, CALENDAR), isoDate);
   }
   get year() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarYear(GetSlot(this, CALENDAR), isoDate);
   }
   get month() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonth(GetSlot(this, CALENDAR), isoDate);
   }
   get monthCode() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonthCode(GetSlot(this, CALENDAR), isoDate);
   }
   get day() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDay(GetSlot(this, CALENDAR), isoDate);
   }
   get dayOfWeek() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDayOfWeek(GetSlot(this, CALENDAR), isoDate);
   }
   get dayOfYear() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDayOfYear(GetSlot(this, CALENDAR), isoDate);
   }
   get weekOfYear() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarWeekOfYear(GetSlot(this, CALENDAR), isoDate);
   }
   get yearOfWeek() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarYearOfWeek(GetSlot(this, CALENDAR), isoDate);
   }
   get daysInWeek() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDaysInWeek(GetSlot(this, CALENDAR), isoDate);
   }
   get daysInMonth() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDaysInMonth(GetSlot(this, CALENDAR), isoDate);
   }
   get daysInYear() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDaysInYear(GetSlot(this, CALENDAR), isoDate);
   }
   get monthsInYear() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonthsInYear(GetSlot(this, CALENDAR), isoDate);
   }
   get inLeapYear() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarInLeapYear(GetSlot(this, CALENDAR), isoDate);
   }
   with(temporalDateLike, options = undefined) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     if (ES.Type(temporalDateLike) !== 'Object') {
-      throw new TypeError('invalid argument');
+      throw new TypeErrorCtor('invalid argument');
     }
     ES.RejectTemporalLikeObject(temporalDateLike);
 
@@ -130,28 +130,28 @@ export class PlainDate {
     return ES.CreateTemporalDate(year, month, day, calendar);
   }
   withCalendar(calendar) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     calendar = ES.ToTemporalCalendarIdentifier(calendar);
     return ES.CreateTemporalDate(GetSlot(this, ISO_YEAR), GetSlot(this, ISO_MONTH), GetSlot(this, ISO_DAY), calendar);
   }
   add(temporalDurationLike, options = undefined) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToDate('add', this, temporalDurationLike, options);
   }
   subtract(temporalDurationLike, options = undefined) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToDate('subtract', this, temporalDurationLike, options);
   }
   until(other, options = undefined) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalPlainDate('until', this, other, options);
   }
   since(other, options = undefined) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalPlainDate('since', this, other, options);
   }
   equals(other) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     other = ES.ToTemporalDate(other);
     if (GetSlot(this, ISO_YEAR) !== GetSlot(other, ISO_YEAR)) return false;
     if (GetSlot(this, ISO_MONTH) !== GetSlot(other, ISO_MONTH)) return false;
@@ -159,24 +159,24 @@ export class PlainDate {
     return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
   }
   toString(options = undefined) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     options = ES.GetOptionsObject(options);
     const showCalendar = ES.GetTemporalShowCalendarNameOption(options);
     return ES.TemporalDateToString(this, showCalendar);
   }
   toJSON() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.TemporalDateToString(this);
   }
   toLocaleString(locales = undefined, options = undefined) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
     ES.ValueOfThrows('PlainDate');
   }
   toPlainDateTime(temporalTime = undefined) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     temporalTime = ES.ToTemporalTimeOrMidnight(temporalTime);
     return ES.CreateTemporalDateTime(
       GetSlot(this, ISO_YEAR),
@@ -192,7 +192,7 @@ export class PlainDate {
     );
   }
   toZonedDateTime(item) {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
 
     let timeZone, temporalTime;
     if (ES.Type(item) === 'Object') {
@@ -232,14 +232,14 @@ export class PlainDate {
     return ES.CreateTemporalZonedDateTime(epochNs, timeZone, calendar);
   }
   toPlainYearMonth() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
     const fields = ES.TemporalObjectToFields(this);
     const { year, month, day } = ES.CalendarYearMonthFromFields(calendar, fields);
     return ES.CreateTemporalYearMonth(year, month, calendar, day);
   }
   toPlainMonthDay() {
-    if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
     const fields = ES.TemporalObjectToFields(this);
     const { year, month, day } = ES.CalendarMonthDayFromFields(calendar, fields);

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -1,3 +1,5 @@
+import { RangeError as RangeError, TypeError as TypeError } from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -1,4 +1,11 @@
-import { RangeError as RangeError, TypeError as TypeError, ObjectCreate } from './primordials.mjs';
+import {
+  // error constructors
+  RangeError as RangeErrorCtor,
+  TypeError as TypeErrorCtor,
+
+  // class static functions and methods
+  ObjectCreate
+} from './primordials.mjs';
 
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
@@ -41,7 +48,7 @@ export class PlainDateTime {
     microsecond = microsecond === undefined ? 0 : ES.ToIntegerWithTruncation(microsecond);
     nanosecond = nanosecond === undefined ? 0 : ES.ToIntegerWithTruncation(nanosecond);
     calendar = calendar === undefined ? 'iso8601' : ES.RequireString(calendar);
-    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeError(`unknown calendar ${calendar}`);
+    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`unknown calendar ${calendar}`);
     calendar = ES.CanonicalizeCalendar(calendar);
 
     ES.CreateTemporalDateTimeSlots(
@@ -59,112 +66,112 @@ export class PlainDateTime {
     );
   }
   get calendarId() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, CALENDAR);
   }
   get year() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarYear(GetSlot(this, CALENDAR), isoDate);
   }
   get month() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonth(GetSlot(this, CALENDAR), isoDate);
   }
   get monthCode() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonthCode(GetSlot(this, CALENDAR), isoDate);
   }
   get day() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDay(GetSlot(this, CALENDAR), isoDate);
   }
   get hour() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_HOUR);
   }
   get minute() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_MINUTE);
   }
   get second() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_SECOND);
   }
   get millisecond() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_MILLISECOND);
   }
   get microsecond() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_MICROSECOND);
   }
   get nanosecond() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_NANOSECOND);
   }
   get era() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarEra(GetSlot(this, CALENDAR), isoDate);
   }
   get eraYear() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarEraYear(GetSlot(this, CALENDAR), isoDate);
   }
   get dayOfWeek() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDayOfWeek(GetSlot(this, CALENDAR), isoDate);
   }
   get dayOfYear() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDayOfYear(GetSlot(this, CALENDAR), isoDate);
   }
   get weekOfYear() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarWeekOfYear(GetSlot(this, CALENDAR), isoDate);
   }
   get yearOfWeek() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarYearOfWeek(GetSlot(this, CALENDAR), isoDate);
   }
   get daysInWeek() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDaysInWeek(GetSlot(this, CALENDAR), isoDate);
   }
   get daysInYear() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDaysInYear(GetSlot(this, CALENDAR), isoDate);
   }
   get daysInMonth() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDaysInMonth(GetSlot(this, CALENDAR), isoDate);
   }
   get monthsInYear() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonthsInYear(GetSlot(this, CALENDAR), isoDate);
   }
   get inLeapYear() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarInLeapYear(GetSlot(this, CALENDAR), isoDate);
   }
   with(temporalDateTimeLike, options = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     if (ES.Type(temporalDateTimeLike) !== 'Object') {
-      throw new TypeError('invalid argument');
+      throw new TypeErrorCtor('invalid argument');
     }
     ES.RejectTemporalLikeObject(temporalDateTimeLike);
 
@@ -210,7 +217,7 @@ export class PlainDateTime {
     );
   }
   withPlainTime(temporalTime = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     temporalTime = ES.ToTemporalTimeOrMidnight(temporalTime);
     return ES.CreateTemporalDateTime(
       GetSlot(this, ISO_YEAR),
@@ -226,7 +233,7 @@ export class PlainDateTime {
     );
   }
   withCalendar(calendar) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     calendar = ES.ToTemporalCalendarIdentifier(calendar);
     return ES.CreateTemporalDateTime(
       GetSlot(this, ISO_YEAR),
@@ -242,24 +249,24 @@ export class PlainDateTime {
     );
   }
   add(temporalDurationLike, options = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromPlainDateTime('add', this, temporalDurationLike, options);
   }
   subtract(temporalDurationLike, options = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromPlainDateTime('subtract', this, temporalDurationLike, options);
   }
   until(other, options = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalPlainDateTime('until', this, other, options);
   }
   since(other, options = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalPlainDateTime('since', this, other, options);
   }
   round(roundTo) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    if (roundTo === undefined) throw new TypeError('options parameter is required');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
+    if (roundTo === undefined) throw new TypeErrorCtor('options parameter is required');
     if (ES.Type(roundTo) === 'String') {
       const stringParam = roundTo;
       roundTo = ObjectCreate(null);
@@ -335,7 +342,7 @@ export class PlainDateTime {
     );
   }
   equals(other) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     other = ES.ToTemporalDateTime(other);
     if (
       ES.CompareISODateTime(
@@ -364,13 +371,13 @@ export class PlainDateTime {
     return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
   }
   toString(options = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     options = ES.GetOptionsObject(options);
     const showCalendar = ES.GetTemporalShowCalendarNameOption(options);
     const digits = ES.GetTemporalFractionalSecondDigitsOption(options);
     const roundingMode = ES.GetRoundingModeOption(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnitValuedOption(options, 'smallestUnit', 'time', undefined);
-    if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
+    if (smallestUnit === 'hour') throw new RangeErrorCtor('smallestUnit must be a time unit other than "hour"');
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     const result = ES.RoundISODateTime(
       GetSlot(this, ISO_YEAR),
@@ -400,7 +407,7 @@ export class PlainDateTime {
     return ES.TemporalDateTimeToString(result, GetSlot(this, CALENDAR), precision, showCalendar);
   }
   toJSON() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDateTime = {
       year: GetSlot(this, ISO_YEAR),
       month: GetSlot(this, ISO_MONTH),
@@ -415,7 +422,7 @@ export class PlainDateTime {
     return ES.TemporalDateTimeToString(isoDateTime, GetSlot(this, CALENDAR), 'auto');
   }
   toLocaleString(locales = undefined, options = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
@@ -423,7 +430,7 @@ export class PlainDateTime {
   }
 
   toZonedDateTime(temporalTimeZoneLike, options = undefined) {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const timeZone = ES.ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
     options = ES.GetOptionsObject(options);
     const disambiguation = ES.GetTemporalDisambiguationOption(options);
@@ -432,11 +439,11 @@ export class PlainDateTime {
     return ES.CreateTemporalZonedDateTime(epochNs, timeZone, GetSlot(this, CALENDAR));
   }
   toPlainDate() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.TemporalDateTimeToDate(this);
   }
   toPlainTime() {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.TemporalDateTimeToTime(this);
   }
 

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -1,3 +1,5 @@
+import { RangeError as RangeError, TypeError as TypeError, ObjectCreate } from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
@@ -15,8 +17,6 @@ import {
   CALENDAR,
   GetSlot
 } from './slots.mjs';
-
-const ObjectCreate = Object.create;
 
 export class PlainDateTime {
   constructor(

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -1,4 +1,4 @@
-import { RangeError as RangeError, TypeError as TypeError } from './primordials.mjs';
+import { RangeError as RangeErrorCtor, TypeError as TypeErrorCtor } from './primordials.mjs';
 
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
@@ -10,7 +10,7 @@ export class PlainMonthDay {
     isoMonth = ES.ToIntegerWithTruncation(isoMonth);
     isoDay = ES.ToIntegerWithTruncation(isoDay);
     calendar = calendar === undefined ? 'iso8601' : ES.RequireString(calendar);
-    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeError(`unknown calendar ${calendar}`);
+    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`unknown calendar ${calendar}`);
     calendar = ES.CanonicalizeCalendar(calendar);
     referenceISOYear = ES.ToIntegerWithTruncation(referenceISOYear);
 
@@ -18,24 +18,24 @@ export class PlainMonthDay {
   }
 
   get monthCode() {
-    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonthCode(GetSlot(this, CALENDAR), isoDate);
   }
   get day() {
-    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDay(GetSlot(this, CALENDAR), isoDate);
   }
   get calendarId() {
-    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, CALENDAR);
   }
 
   with(temporalMonthDayLike, options = undefined) {
-    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeErrorCtor('invalid receiver');
     if (ES.Type(temporalMonthDayLike) !== 'Object') {
-      throw new TypeError('invalid argument');
+      throw new TypeErrorCtor('invalid argument');
     }
     ES.RejectTemporalLikeObject(temporalMonthDayLike);
 
@@ -55,7 +55,7 @@ export class PlainMonthDay {
     return ES.CreateTemporalMonthDay(month, day, calendar, year);
   }
   equals(other) {
-    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeErrorCtor('invalid receiver');
     other = ES.ToTemporalMonthDay(other);
     if (GetSlot(this, ISO_YEAR) !== GetSlot(other, ISO_YEAR)) return false;
     if (GetSlot(this, ISO_MONTH) !== GetSlot(other, ISO_MONTH)) return false;
@@ -63,25 +63,25 @@ export class PlainMonthDay {
     return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
   }
   toString(options = undefined) {
-    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeErrorCtor('invalid receiver');
     options = ES.GetOptionsObject(options);
     const showCalendar = ES.GetTemporalShowCalendarNameOption(options);
     return ES.TemporalMonthDayToString(this, showCalendar);
   }
   toJSON() {
-    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.TemporalMonthDayToString(this);
   }
   toLocaleString(locales = undefined, options = undefined) {
-    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeErrorCtor('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
     ES.ValueOfThrows('PlainMonthDay');
   }
   toPlainDate(item) {
-    if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(item) !== 'Object') throw new TypeError('argument should be an object');
+    if (!ES.IsTemporalMonthDay(this)) throw new TypeErrorCtor('invalid receiver');
+    if (ES.Type(item) !== 'Object') throw new TypeErrorCtor('argument should be an object');
     const calendar = GetSlot(this, CALENDAR);
 
     const fields = ES.TemporalObjectToFields(this);

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -1,3 +1,5 @@
+import { RangeError as RangeError, TypeError as TypeError } from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -2,8 +2,8 @@
 
 import {
   // error constructors
-  RangeError as RangeError,
-  TypeError as TypeError,
+  RangeError as RangeErrorCtor,
+  TypeError as TypeErrorCtor,
 
   // class static functions and methods
   ArrayPrototypeEvery,
@@ -85,34 +85,34 @@ export class PlainTime {
   }
 
   get hour() {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_HOUR);
   }
   get minute() {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_MINUTE);
   }
   get second() {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_SECOND);
   }
   get millisecond() {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_MILLISECOND);
   }
   get microsecond() {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_MICROSECOND);
   }
   get nanosecond() {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, ISO_NANOSECOND);
   }
 
   with(temporalTimeLike, options = undefined) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     if (ES.Type(temporalTimeLike) !== 'Object') {
-      throw new TypeError('invalid argument');
+      throw new TypeErrorCtor('invalid argument');
     }
     ES.RejectTemporalLikeObject(temporalTimeLike);
 
@@ -133,24 +133,24 @@ export class PlainTime {
     return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
   }
   add(temporalDurationLike) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromPlainTime('add', this, temporalDurationLike);
   }
   subtract(temporalDurationLike) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromPlainTime('subtract', this, temporalDurationLike);
   }
   until(other, options = undefined) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalPlainTime('until', this, other, options);
   }
   since(other, options = undefined) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalPlainTime('since', this, other, options);
   }
   round(roundTo) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
-    if (roundTo === undefined) throw new TypeError('options parameter is required');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
+    if (roundTo === undefined) throw new TypeErrorCtor('options parameter is required');
     if (ES.Type(roundTo) === 'String') {
       const stringParam = roundTo;
       roundTo = ObjectCreate(null);
@@ -192,7 +192,7 @@ export class PlainTime {
     return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
   }
   equals(other) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     other = ES.ToTemporalTime(other);
     return ES.Call(
       ArrayPrototypeEvery,
@@ -202,21 +202,21 @@ export class PlainTime {
   }
 
   toString(options = undefined) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     options = ES.GetOptionsObject(options);
     const digits = ES.GetTemporalFractionalSecondDigitsOption(options);
     const roundingMode = ES.GetRoundingModeOption(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnitValuedOption(options, 'smallestUnit', 'time', undefined);
-    if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
+    if (smallestUnit === 'hour') throw new RangeErrorCtor('smallestUnit must be a time unit other than "hour"');
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     return TemporalTimeToString(this, precision, { unit, increment, roundingMode });
   }
   toJSON() {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return TemporalTimeToString(this, 'auto');
   }
   toLocaleString(locales = undefined, options = undefined) {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -1,5 +1,18 @@
 /* global __debug__ */
 
+import {
+  // error constructors
+  RangeError as RangeError,
+  TypeError as TypeError,
+
+  // class static functions and methods
+  ArrayPrototypeEvery,
+  ObjectAssign,
+  ObjectCreate,
+  ObjectDefineProperty,
+  SymbolToStringTag
+} from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
@@ -15,9 +28,6 @@ import {
   GetSlot,
   SetSlot
 } from './slots.mjs';
-
-const ObjectAssign = Object.assign;
-const ObjectCreate = Object.create;
 
 function TemporalTimeToString(time, precision, options = undefined) {
   let hour = GetSlot(time, ISO_HOUR);
@@ -65,8 +75,8 @@ export class PlainTime {
     SetSlot(this, ISO_NANOSECOND, isoNanosecond);
 
     if (typeof __debug__ !== 'undefined' && __debug__) {
-      Object.defineProperty(this, '_repr_', {
-        value: `${this[Symbol.toStringTag]} <${TemporalTimeToString(this, 'auto')}>`,
+      ObjectDefineProperty(this, '_repr_', {
+        value: `${this[SymbolToStringTag]} <${TemporalTimeToString(this, 'auto')}>`,
         writable: false,
         enumerable: false,
         configurable: false
@@ -184,12 +194,11 @@ export class PlainTime {
   equals(other) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     other = ES.ToTemporalTime(other);
-    for (const slot of [ISO_HOUR, ISO_MINUTE, ISO_SECOND, ISO_MILLISECOND, ISO_MICROSECOND, ISO_NANOSECOND]) {
-      const val1 = GetSlot(this, slot);
-      const val2 = GetSlot(other, slot);
-      if (val1 !== val2) return false;
-    }
-    return true;
+    return ES.Call(
+      ArrayPrototypeEvery,
+      [ISO_HOUR, ISO_MINUTE, ISO_SECOND, ISO_MILLISECOND, ISO_MICROSECOND, ISO_NANOSECOND],
+      [(slot) => GetSlot(this, slot) === GetSlot(other, slot)]
+    );
   }
 
   toString(options = undefined) {

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -1,4 +1,4 @@
-import { RangeError as RangeError, TypeError as TypeError } from './primordials.mjs';
+import { RangeError as RangeErrorCtor, TypeError as TypeErrorCtor } from './primordials.mjs';
 
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
@@ -10,65 +10,65 @@ export class PlainYearMonth {
     isoYear = ES.ToIntegerWithTruncation(isoYear);
     isoMonth = ES.ToIntegerWithTruncation(isoMonth);
     calendar = calendar === undefined ? 'iso8601' : ES.RequireString(calendar);
-    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeError(`unknown calendar ${calendar}`);
+    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`unknown calendar ${calendar}`);
     calendar = ES.CanonicalizeCalendar(calendar);
     referenceISODay = ES.ToIntegerWithTruncation(referenceISODay);
 
     ES.CreateTemporalYearMonthSlots(this, isoYear, isoMonth, calendar, referenceISODay);
   }
   get year() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarYear(GetSlot(this, CALENDAR), isoDate);
   }
   get month() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonth(GetSlot(this, CALENDAR), isoDate);
   }
   get monthCode() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonthCode(GetSlot(this, CALENDAR), isoDate);
   }
   get calendarId() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, CALENDAR);
   }
   get era() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarEra(GetSlot(this, CALENDAR), isoDate);
   }
   get eraYear() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarEraYear(GetSlot(this, CALENDAR), isoDate);
   }
   get daysInMonth() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDaysInMonth(GetSlot(this, CALENDAR), isoDate);
   }
   get daysInYear() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarDaysInYear(GetSlot(this, CALENDAR), isoDate);
   }
   get monthsInYear() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarMonthsInYear(GetSlot(this, CALENDAR), isoDate);
   }
   get inLeapYear() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDate = ES.TemporalObjectToISODateRecord(this);
     return ES.CalendarInLeapYear(GetSlot(this, CALENDAR), isoDate);
   }
   with(temporalYearMonthLike, options = undefined) {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     if (ES.Type(temporalYearMonthLike) !== 'Object') {
-      throw new TypeError('invalid argument');
+      throw new TypeErrorCtor('invalid argument');
     }
     ES.RejectTemporalLikeObject(temporalYearMonthLike);
 
@@ -88,23 +88,23 @@ export class PlainYearMonth {
     return ES.CreateTemporalYearMonth(year, month, calendar, day);
   }
   add(temporalDurationLike, options = undefined) {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromPlainYearMonth('add', this, temporalDurationLike, options);
   }
   subtract(temporalDurationLike, options = undefined) {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromPlainYearMonth('subtract', this, temporalDurationLike, options);
   }
   until(other, options = undefined) {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalPlainYearMonth('until', this, other, options);
   }
   since(other, options = undefined) {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalPlainYearMonth('since', this, other, options);
   }
   equals(other) {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     other = ES.ToTemporalYearMonth(other);
     if (GetSlot(this, ISO_YEAR) !== GetSlot(other, ISO_YEAR)) return false;
     if (GetSlot(this, ISO_MONTH) !== GetSlot(other, ISO_MONTH)) return false;
@@ -112,25 +112,25 @@ export class PlainYearMonth {
     return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
   }
   toString(options = undefined) {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     options = ES.GetOptionsObject(options);
     const showCalendar = ES.GetTemporalShowCalendarNameOption(options);
     return ES.TemporalYearMonthToString(this, showCalendar);
   }
   toJSON() {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.TemporalYearMonthToString(this);
   }
   toLocaleString(locales = undefined, options = undefined) {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
   valueOf() {
     ES.ValueOfThrows('PlainYearMonth');
   }
   toPlainDate(item) {
-    if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(item) !== 'Object') throw new TypeError('argument should be an object');
+    if (!ES.IsTemporalYearMonth(this)) throw new TypeErrorCtor('invalid receiver');
+    if (ES.Type(item) !== 'Object') throw new TypeErrorCtor('argument should be an object');
     const calendar = GetSlot(this, CALENDAR);
 
     const fields = ES.TemporalObjectToFields(this);

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -1,3 +1,5 @@
+import { RangeError as RangeError, TypeError as TypeError } from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';

--- a/polyfill/lib/primordials.mjs
+++ b/polyfill/lib/primordials.mjs
@@ -1,0 +1,152 @@
+import Call from 'es-abstract/2024/Call.js';
+
+// Function Properties of the Global Object
+export const { isFinite, isNaN, parseFloat, parseInt } = globalThis;
+
+// Constructor Properties of the Global Object
+export const {
+  Array,
+  BigInt,
+  Date,
+  Function,
+  Map,
+  Number,
+  Object,
+  Promise,
+  RegExp,
+  Set,
+  String,
+  Symbol,
+  WeakMap,
+  WeakSet
+} = globalThis;
+
+// Error constructors
+export const { Error, RangeError, SyntaxError, TypeError } = globalThis;
+
+// Other Properties of the Global Object
+export const { Intl, JSON, Math, Reflect } = globalThis;
+
+export const {
+  assign: ObjectAssign,
+  create: ObjectCreate,
+  getOwnPropertyDescriptor: ObjectGetOwnPropertyDescriptor,
+  getOwnPropertyNames: ObjectGetOwnPropertyNames,
+  defineProperty: ObjectDefineProperty,
+  defineProperties: ObjectDefineProperties,
+  entries: ObjectEntries
+} = Object;
+
+export const {
+  from: ArrayFrom,
+  prototype: {
+    concat: ArrayPrototypeConcat,
+    filter: ArrayPrototypeFilter,
+    every: ArrayPrototypeEvery,
+    find: ArrayPrototypeFind,
+    flatMap: ArrayPrototypeFlatMap,
+    forEach: ArrayPrototypeForEach,
+    includes: ArrayPrototypeIncludes,
+    indexOf: ArrayPrototypeIndexOf,
+    join: ArrayPrototypeJoin,
+    map: ArrayPrototypeMap,
+    push: ArrayPrototypePush,
+    reduce: ArrayPrototypeReduce,
+    slice: ArrayPrototypeSlice,
+    sort: ArrayPrototypeSort
+  }
+} = Array;
+export const {
+  now: DateNow,
+  prototype: {
+    getTime: DatePrototypeGetTime,
+    getUTCFullYear: DatePrototypeGetUTCFullYear,
+    getUTCMonth: DatePrototypeGetUTCMonth,
+    getUTCDate: DatePrototypeGetUTCDate,
+    getUTCHours: DatePrototypeGetUTCHours,
+    getUTCMinutes: DatePrototypeGetUTCMinutes,
+    getUTCSeconds: DatePrototypeGetUTCSeconds,
+    getUTCMilliseconds: DatePrototypeGetUTCMilliseconds,
+    setUTCFullYear: DatePrototypeSetUTCFullYear,
+    setUTCMonth: DatePrototypeSetUTCMonth,
+    setUTCDate: DatePrototypeSetUTCDate,
+    setUTCHours: DatePrototypeSetUTCHours,
+    setUTCMinutes: DatePrototypeSetUTCMinutes,
+    setUTCSeconds: DatePrototypeSetUTCSeconds,
+    setUTCMilliseconds: DatePrototypeSetUTCMilliseconds,
+    toLocaleDateString: DatePrototypeToLocaleDateString,
+    valueOf: DatePrototypeValueOf
+  }
+} = Date;
+export const {
+  supportedValuesOf: IntlSupportedValuesOf,
+  DateTimeFormat: IntlDateTimeFormat,
+  DurationFormat: IntlDurationFormat
+} = Intl;
+export const { get: IntlDateTimeFormatPrototypeGetFormat } =
+  ObjectGetOwnPropertyDescriptor(IntlDateTimeFormat?.prototype || ObjectCreate(null), 'format') || ObjectCreate(null);
+export const {
+  formatRange: IntlDateTimeFormatPrototypeFormatRange,
+  formatRangeToParts: IntlDateTimeFormatPrototypeFormatRangeToParts,
+  formatToParts: IntlDateTimeFormatPrototypeFormatToParts,
+  resolvedOptions: IntlDateTimeFormatPrototypeResolvedOptions
+} = IntlDateTimeFormat?.prototype || ObjectCreate(null);
+export const { stringify: JSONStringify } = JSON;
+export const {
+  prototype: { entries: MapPrototypeEntries, get: MapPrototypeGet, has: MapPrototypeHas, set: MapPrototypeSet }
+} = Map;
+export const {
+  abs: MathAbs,
+  floor: MathFloor,
+  log10: MathLog10,
+  max: MathMax,
+  min: MathMin,
+  sign: MathSign,
+  trunc: MathTrunc
+} = Math;
+export const {
+  MAX_SAFE_INTEGER: NumberMaxSafeInteger,
+  isFinite: NumberIsFinite,
+  isInteger: NumberIsInteger,
+  isNaN: NumberIsNaN,
+  isSafeInteger: NumberIsSafeInteger,
+  parseInt: NumberParseInt,
+  prototype: { toPrecision: NumberPrototypeToPrecision, toString: NumberPrototypeToString }
+} = Number;
+export const {
+  prototype: { exec: RegExpPrototypeExec, test: RegExpPrototypeTest }
+} = RegExp;
+export const {
+  prototype: { add: SetPrototypeAdd, has: SetPrototypeHas, values: SetPrototypeValues }
+} = Set;
+export const {
+  fromCharCode: StringFromCharCode,
+  prototype: {
+    charCodeAt: StringPrototypeCharCodeAt,
+    endsWith: StringPrototypeEndsWith,
+    indexOf: StringPrototypeIndexOf,
+    match: StringPrototypeMatch,
+    normalize: StringPrototypeNormalize,
+    padStart: StringPrototypePadStart,
+    repeat: StringPrototypeRepeat,
+    replace: StringPrototypeReplace,
+    slice: StringPrototypeSlice,
+    split: StringPrototypeSplit,
+    startsWith: StringPrototypeStartsWith,
+    toLowerCase: StringPrototypeToLowerCase,
+    toUpperCase: StringPrototypeToUpperCase
+  }
+} = String;
+export const { iterator: SymbolIterator, for: SymbolFor, toStringTag: SymbolToStringTag } = Symbol;
+export const {
+  prototype: { get: WeakMapPrototypeGet, set: WeakMapPrototypeSet }
+} = WeakMap;
+
+export const MapIterator = Call(MapPrototypeEntries, new Map(), []);
+export const MapIteratorPrototypeNext = MapIterator.next;
+export const SetIterator = Call(SetPrototypeValues, new Set(), []);
+export const SetIteratorPrototypeNext = SetIterator.next;
+
+export const { console, performance } = globalThis;
+export const { log, warn } = console;
+export const now = performance && performance.now ? performance.now.bind(performance) : Date.now;

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -1,3 +1,7 @@
+import { RegExp as RegExp, ArrayPrototypeJoin } from './primordials.mjs';
+
+import Call from 'es-abstract/2024/Call.js';
+
 const offsetIdentifierNoCapture = /(?:[+-](?:[01][0-9]|2[0-3])(?::?[0-5][0-9])?)/;
 const tzComponent = /[A-Za-z._][A-Za-z._0-9+-]*/;
 export const timeZoneID = new RegExp(
@@ -18,21 +22,29 @@ export const offsetIdentifier = /([+-])([01][0-9]|2[0-3])(?::?([0-5][0-9])?)?/;
 export const annotation = /\[(!)?([a-z_][a-z0-9_-]*)=([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\]/g;
 
 export const zoneddatetime = new RegExp(
-  [
-    `^${datesplit.source}`,
-    `(?:(?:[tT]|\\s+)${timesplit.source}(?:${offsetpart.source})?)?`,
-    `(?:\\[!?(${timeZoneID.source})\\])?`,
-    `((?:${annotation.source})*)$`
-  ].join('')
+  Call(
+    ArrayPrototypeJoin,
+    [
+      `^${datesplit.source}`,
+      `(?:(?:[tT]|\\s+)${timesplit.source}(?:${offsetpart.source})?)?`,
+      `(?:\\[!?(${timeZoneID.source})\\])?`,
+      `((?:${annotation.source})*)$`
+    ],
+    ['']
+  )
 );
 
 export const time = new RegExp(
-  [
-    `^[tT]?${timesplit.source}`,
-    `(?:${offsetpart.source})?`,
-    `(?:\\[!?${timeZoneID.source}\\])?`,
-    `((?:${annotation.source})*)$`
-  ].join('')
+  Call(
+    ArrayPrototypeJoin,
+    [
+      `^[tT]?${timesplit.source}`,
+      `(?:${offsetpart.source})?`,
+      `(?:\\[!?${timeZoneID.source}\\])?`,
+      `((?:${annotation.source})*)$`
+    ],
+    ['']
+  )
 );
 
 // The short forms of YearMonth and MonthDay are only for the ISO calendar, but

--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -1,27 +1,27 @@
-import { RegExp as RegExp, ArrayPrototypeJoin } from './primordials.mjs';
+import { RegExp as RegExpCtor, ArrayPrototypeJoin } from './primordials.mjs';
 
 import Call from 'es-abstract/2024/Call.js';
 
 const offsetIdentifierNoCapture = /(?:[+-](?:[01][0-9]|2[0-3])(?::?[0-5][0-9])?)/;
 const tzComponent = /[A-Za-z._][A-Za-z._0-9+-]*/;
-export const timeZoneID = new RegExp(
+export const timeZoneID = new RegExpCtor(
   `(?:${offsetIdentifierNoCapture.source}|(?:${tzComponent.source})(?:\\/(?:${tzComponent.source}))*)`
 );
 
 const yearpart = /(?:[+-]\d{6}|\d{4})/;
 const monthpart = /(?:0[1-9]|1[0-2])/;
 const daypart = /(?:0[1-9]|[12]\d|3[01])/;
-export const datesplit = new RegExp(
+export const datesplit = new RegExpCtor(
   `(${yearpart.source})(?:-(${monthpart.source})-(${daypart.source})|(${monthpart.source})(${daypart.source}))`
 );
 const timesplit = /(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?|(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?/;
 export const offsetWithParts = /([+-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5][0-9])(?:[.,](\d{1,9}))?)?)?/;
 export const offset = /((?:[+-])(?:[01][0-9]|2[0-3])(?::?(?:[0-5][0-9])(?::?(?:[0-5][0-9])(?:[.,](?:\d{1,9}))?)?)?)/;
-const offsetpart = new RegExp(`([zZ])|${offset.source}?`);
+const offsetpart = new RegExpCtor(`([zZ])|${offset.source}?`);
 export const offsetIdentifier = /([+-])([01][0-9]|2[0-3])(?::?([0-5][0-9])?)?/;
 export const annotation = /\[(!)?([a-z_][a-z0-9_-]*)=([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\]/g;
 
-export const zoneddatetime = new RegExp(
+export const zoneddatetime = new RegExpCtor(
   Call(
     ArrayPrototypeJoin,
     [
@@ -34,7 +34,7 @@ export const zoneddatetime = new RegExp(
   )
 );
 
-export const time = new RegExp(
+export const time = new RegExpCtor(
   Call(
     ArrayPrototypeJoin,
     [
@@ -57,15 +57,15 @@ export const time = new RegExp(
 // Not ambiguous with HHMMSS because that requires a 'T' prefix
 // UTC offsets are not allowed, because they are not allowed with any date-only
 // format; also, YYYY-MM-UU is ambiguous with YYYY-MM-DD
-export const yearmonth = new RegExp(
+export const yearmonth = new RegExpCtor(
   `^(${yearpart.source})-?(${monthpart.source})(?:\\[!?${timeZoneID.source}\\])?((?:${annotation.source})*)$`
 );
-export const monthday = new RegExp(
+export const monthday = new RegExpCtor(
   `^(?:--)?(${monthpart.source})-?(${daypart.source})(?:\\[!?${timeZoneID.source}\\])?((?:${annotation.source})*)$`
 );
 
 const fraction = /(\d+)(?:[.,](\d{1,9}))?/;
 
 const durationDate = /(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?/;
-const durationTime = new RegExp(`(?:${fraction.source}H)?(?:${fraction.source}M)?(?:${fraction.source}S)?`);
-export const duration = new RegExp(`^([+-])?P${durationDate.source}(?:T(?!$)${durationTime.source})?$`, 'i');
+const durationTime = new RegExpCtor(`(?:${fraction.source}H)?(?:${fraction.source}M)?(?:${fraction.source}S)?`);
+export const duration = new RegExpCtor(`^([+-])?P${durationDate.source}(?:T(?!$)${durationTime.source})?$`, 'i');

--- a/polyfill/lib/shim.mjs
+++ b/polyfill/lib/shim.mjs
@@ -2,18 +2,25 @@
 // object. This is used only for the browser playground and the test262 tests.
 // See the note in index.mjs.
 
+import {
+  ObjectDefineProperty,
+  ObjectGetOwnPropertyDescriptor,
+  ObjectGetOwnPropertyNames,
+  SymbolToStringTag
+} from './primordials.mjs';
+
 import * as Temporal from './temporal.mjs';
 import * as Intl from './intl.mjs';
 import { toTemporalInstant } from './legacydate.mjs';
 
-Object.defineProperty(globalThis, 'Temporal', {
+ObjectDefineProperty(globalThis, 'Temporal', {
   value: {},
   writable: true,
   enumerable: false,
   configurable: true
 });
 copy(globalThis.Temporal, Temporal);
-Object.defineProperty(globalThis.Temporal, Symbol.toStringTag, {
+ObjectDefineProperty(globalThis.Temporal, SymbolToStringTag, {
   value: 'Temporal',
   writable: false,
   enumerable: false,
@@ -21,7 +28,7 @@ Object.defineProperty(globalThis.Temporal, Symbol.toStringTag, {
 });
 copy(globalThis.Temporal.Now, Temporal.Now);
 copy(globalThis.Intl, Intl);
-Object.defineProperty(globalThis.Date.prototype, 'toTemporalInstant', {
+ObjectDefineProperty(globalThis.Date.prototype, 'toTemporalInstant', {
   value: toTemporalInstant,
   writable: true,
   enumerable: false,
@@ -29,8 +36,10 @@ Object.defineProperty(globalThis.Date.prototype, 'toTemporalInstant', {
 });
 
 function copy(target, source) {
-  for (const prop of Object.getOwnPropertyNames(source)) {
-    Object.defineProperty(target, prop, {
+  const props = ObjectGetOwnPropertyNames(source);
+  for (let i = 0; i < props.length; i++) {
+    const prop = props[i];
+    ObjectDefineProperty(target, prop, {
       value: source[prop],
       writable: true,
       enumerable: false,
@@ -51,13 +60,14 @@ const types = [
   globalThis.Temporal.PlainYearMonth,
   globalThis.Temporal.ZonedDateTime
 ];
-for (const type of types) {
-  const descriptor = Object.getOwnPropertyDescriptor(type, 'prototype');
+for (let i = 0; i < types.length; i++) {
+  const type = types[i];
+  const descriptor = ObjectGetOwnPropertyDescriptor(type, 'prototype');
   if (descriptor.configurable || descriptor.enumerable || descriptor.writable) {
     descriptor.configurable = false;
     descriptor.enumerable = false;
     descriptor.writable = false;
-    Object.defineProperty(type, 'prototype', descriptor);
+    ObjectDefineProperty(type, 'prototype', descriptor);
   }
 }
 

--- a/polyfill/lib/slots.mjs
+++ b/polyfill/lib/slots.mjs
@@ -1,3 +1,15 @@
+import {
+  WeakMap as WeakMap,
+
+  // class static functions and methods
+  ArrayPrototypeReduce,
+  ObjectCreate,
+  WeakMapPrototypeGet,
+  WeakMapPrototypeSet
+} from './primordials.mjs';
+
+import Call from 'es-abstract/2024/Call.js';
+
 // Instant
 export const EPOCHNANOSECONDS = 'slot-epochNanoSeconds';
 
@@ -34,15 +46,15 @@ export const NANOSECONDS = 'slot-nanoseconds';
 
 const slots = new WeakMap();
 export function CreateSlots(container) {
-  slots.set(container, Object.create(null));
+  Call(WeakMapPrototypeSet, slots, [container, ObjectCreate(null)]);
 }
 function GetSlots(container) {
-  return slots.get(container);
+  return Call(WeakMapPrototypeGet, slots, [container]);
 }
 export function HasSlot(container, ...ids) {
   if (!container || 'object' !== typeof container) return false;
   const myslots = GetSlots(container);
-  return !!myslots && ids.reduce((all, id) => all && id in myslots, true);
+  return !!myslots && Call(ArrayPrototypeReduce, ids, [(all, id) => all && id in myslots, true]);
 }
 export function GetSlot(container, id) {
   return GetSlots(container)[id];

--- a/polyfill/lib/slots.mjs
+++ b/polyfill/lib/slots.mjs
@@ -1,5 +1,5 @@
 import {
-  WeakMap as WeakMap,
+  WeakMap as WeakMapCtor,
 
   // class static functions and methods
   ArrayPrototypeReduce,
@@ -44,7 +44,7 @@ export const MILLISECONDS = 'slot-milliseconds';
 export const MICROSECONDS = 'slot-microseconds';
 export const NANOSECONDS = 'slot-nanoseconds';
 
-const slots = new WeakMap();
+const slots = new WeakMapCtor();
 export function CreateSlots(container) {
   Call(WeakMapPrototypeSet, slots, [container, ObjectCreate(null)]);
 }

--- a/polyfill/lib/timeduration.mjs
+++ b/polyfill/lib/timeduration.mjs
@@ -1,11 +1,25 @@
-import bigInt from 'big-integer';
+import {
+  // constructors and similar
+  Number as Number,
+
+  // error constructors
+  Error as Error,
+  RangeError as RangeError,
+
+  // class static functions and methods
+  ArrayPrototypeJoin,
+  ArrayPrototypePush,
+  MathAbs,
+  MathSign,
+  NumberIsInteger,
+  NumberIsSafeInteger
+} from './primordials.mjs';
+
+import Call from 'es-abstract/2024/Call.js';
 
 import { ApplyUnsignedRoundingMode, GetUnsignedRoundingMode } from './math.mjs';
 
-const MathAbs = Math.abs;
-const MathSign = Math.sign;
-const NumberIsInteger = Number.isInteger;
-const NumberIsSafeInteger = Number.isSafeInteger;
+import bigInt from 'big-integer';
 
 export class TimeDuration {
   static MAX = bigInt('9007199254740991999999999');
@@ -89,9 +103,9 @@ export class TimeDuration {
     while (!remainder.isZero() && decimalDigits.length < precision) {
       remainder = remainder.multiply(10);
       ({ quotient: digit, remainder } = remainder.divmod(n));
-      decimalDigits.push(MathAbs(digit.toJSNumber()));
+      Call(ArrayPrototypePush, decimalDigits, [MathAbs(digit.toJSNumber())]);
     }
-    return sign * Number(quotient.abs().toString() + '.' + decimalDigits.join(''));
+    return sign * Number(quotient.abs().toString() + '.' + Call(ArrayPrototypeJoin, decimalDigits, ['']));
   }
 
   isZero() {

--- a/polyfill/lib/timeduration.mjs
+++ b/polyfill/lib/timeduration.mjs
@@ -1,10 +1,10 @@
 import {
   // constructors and similar
-  Number as Number,
+  Number as NumberCtor,
 
   // error constructors
-  Error as Error,
-  RangeError as RangeError,
+  Error as ErrorCtor,
+  RangeError as RangeErrorCtor,
 
   // class static functions and methods
   ArrayPrototypeJoin,
@@ -26,20 +26,20 @@ export class TimeDuration {
   static ZERO = new TimeDuration(bigInt.zero);
 
   constructor(totalNs) {
-    if (typeof totalNs === 'number') throw new Error('assertion failed: big integer required');
+    if (typeof totalNs === 'number') throw new ErrorCtor('assertion failed: big integer required');
     this.totalNs = bigInt(totalNs);
-    if (this.totalNs.abs().greater(TimeDuration.MAX)) throw new Error('assertion failed: integer too big');
+    if (this.totalNs.abs().greater(TimeDuration.MAX)) throw new ErrorCtor('assertion failed: integer too big');
 
     const { quotient, remainder } = this.totalNs.divmod(1e9);
     this.sec = quotient.toJSNumber();
     this.subsec = remainder.toJSNumber();
-    if (!NumberIsSafeInteger(this.sec)) throw new Error('assertion failed: seconds too big');
-    if (MathAbs(this.subsec) > 999_999_999) throw new Error('assertion failed: subseconds too big');
+    if (!NumberIsSafeInteger(this.sec)) throw new ErrorCtor('assertion failed: seconds too big');
+    if (MathAbs(this.subsec) > 999_999_999) throw new ErrorCtor('assertion failed: subseconds too big');
   }
 
   static #validateNew(totalNs, operation) {
     if (totalNs.abs().greater(TimeDuration.MAX)) {
-      throw new RangeError(`${operation} of duration time units cannot exceed ${TimeDuration.MAX} s`);
+      throw new RangeErrorCtor(`${operation} of duration time units cannot exceed ${TimeDuration.MAX} s`);
     }
     return new TimeDuration(totalNs);
   }
@@ -69,7 +69,7 @@ export class TimeDuration {
   }
 
   add24HourDays(days) {
-    if (!NumberIsInteger(days)) throw new Error('assertion failed: days is an integer');
+    if (!NumberIsInteger(days)) throw new ErrorCtor('assertion failed: days is an integer');
     return TimeDuration.#validateNew(this.totalNs.add(bigInt(days).multiply(86400e9)), 'sum');
   }
 
@@ -82,7 +82,7 @@ export class TimeDuration {
   }
 
   divmod(n) {
-    if (n === 0) throw new Error('division by zero');
+    if (n === 0) throw new ErrorCtor('division by zero');
     const { quotient, remainder } = this.totalNs.divmod(n);
     const q = quotient.toJSNumber();
     const r = new TimeDuration(remainder);
@@ -91,7 +91,7 @@ export class TimeDuration {
 
   fdiv(n) {
     n = bigInt(n);
-    if (n.isZero()) throw new Error('division by zero');
+    if (n.isZero()) throw new ErrorCtor('division by zero');
     let { quotient, remainder } = this.totalNs.divmod(n);
 
     // Perform long division to calculate the fractional part of the quotient
@@ -105,7 +105,7 @@ export class TimeDuration {
       ({ quotient: digit, remainder } = remainder.divmod(n));
       Call(ArrayPrototypePush, decimalDigits, [MathAbs(digit.toJSNumber())]);
     }
-    return sign * Number(quotient.abs().toString() + '.' + Call(ArrayPrototypeJoin, decimalDigits, ['']));
+    return sign * NumberCtor(quotient.abs().toString() + '.' + Call(ArrayPrototypeJoin, decimalDigits, ['']));
   }
 
   isZero() {

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -1,4 +1,12 @@
-import { Error as Error, RangeError as RangeError, TypeError as TypeError, ObjectCreate } from './primordials.mjs';
+import {
+  // error constructors
+  Error as ErrorCtor,
+  RangeError as RangeErrorCtor,
+  TypeError as TypeErrorCtor,
+
+  // class static functions and methods
+  ObjectCreate
+} from './primordials.mjs';
 
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
@@ -26,7 +34,7 @@ export class ZonedDateTime {
     // Note: if the argument is not passed, ToBigInt(undefined) will throw. This check exists only
     //       to improve the error message.
     if (arguments.length < 1) {
-      throw new TypeError('missing argument: epochNanoseconds is required');
+      throw new TypeErrorCtor('missing argument: epochNanoseconds is required');
     }
     epochNanoseconds = ES.ToBigInt(epochNanoseconds);
     timeZone = ES.RequireString(timeZone);
@@ -34,100 +42,100 @@ export class ZonedDateTime {
     if (offsetMinutes === undefined) {
       // if offsetMinutes is undefined, then tzName must be present
       const record = ES.GetAvailableNamedTimeZoneIdentifier(tzName);
-      if (!record) throw new RangeError(`unknown time zone ${tzName}`);
+      if (!record) throw new RangeErrorCtor(`unknown time zone ${tzName}`);
       timeZone = record.identifier;
     } else {
       timeZone = ES.FormatOffsetTimeZoneIdentifier(offsetMinutes);
     }
     calendar = calendar === undefined ? 'iso8601' : ES.RequireString(calendar);
-    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeError(`unknown calendar ${calendar}`);
+    if (!ES.IsBuiltinCalendar(calendar)) throw new RangeErrorCtor(`unknown calendar ${calendar}`);
     calendar = ES.CanonicalizeCalendar(calendar);
 
     ES.CreateTemporalZonedDateTimeSlots(this, epochNanoseconds, timeZone, calendar);
   }
   get calendarId() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, CALENDAR);
   }
   get timeZoneId() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return GetSlot(this, TIME_ZONE);
   }
   get year() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarYear(GetSlot(this, CALENDAR), dateTime(this));
   }
   get month() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarMonth(GetSlot(this, CALENDAR), dateTime(this));
   }
   get monthCode() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarMonthCode(GetSlot(this, CALENDAR), dateTime(this));
   }
   get day() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarDay(GetSlot(this, CALENDAR), dateTime(this));
   }
   get hour() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return dateTime(this).hour;
   }
   get minute() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return dateTime(this).minute;
   }
   get second() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return dateTime(this).second;
   }
   get millisecond() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return dateTime(this).millisecond;
   }
   get microsecond() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return dateTime(this).microsecond;
   }
   get nanosecond() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return dateTime(this).nanosecond;
   }
   get era() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarEra(GetSlot(this, CALENDAR), dateTime(this));
   }
   get eraYear() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarEraYear(GetSlot(this, CALENDAR), dateTime(this));
   }
   get epochMilliseconds() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const value = GetSlot(this, EPOCHNANOSECONDS);
     return ES.BigIntFloorDiv(value, 1e6).toJSNumber();
   }
   get epochNanoseconds() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.BigIntIfAvailable(GetSlot(this, EPOCHNANOSECONDS));
   }
   get dayOfWeek() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarDayOfWeek(GetSlot(this, CALENDAR), dateTime(this));
   }
   get dayOfYear() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarDayOfYear(GetSlot(this, CALENDAR), dateTime(this));
   }
   get weekOfYear() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarWeekOfYear(GetSlot(this, CALENDAR), dateTime(this));
   }
   get yearOfWeek() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarYearOfWeek(GetSlot(this, CALENDAR), dateTime(this));
   }
   get hoursInDay() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const timeZone = GetSlot(this, TIME_ZONE);
     const { year, month, day } = ES.GetISODateTimeFor(timeZone, GetSlot(this, EPOCHNANOSECONDS));
     const today = { year, month, day };
@@ -138,38 +146,38 @@ export class ZonedDateTime {
     return diff.fdiv(3.6e12);
   }
   get daysInWeek() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarDaysInWeek(GetSlot(this, CALENDAR), dateTime(this));
   }
   get daysInMonth() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarDaysInMonth(GetSlot(this, CALENDAR), dateTime(this));
   }
   get daysInYear() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarDaysInYear(GetSlot(this, CALENDAR), dateTime(this));
   }
   get monthsInYear() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarMonthsInYear(GetSlot(this, CALENDAR), dateTime(this));
   }
   get inLeapYear() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.CalendarInLeapYear(GetSlot(this, CALENDAR), dateTime(this));
   }
   get offset() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const offsetNs = ES.GetOffsetNanosecondsFor(GetSlot(this, TIME_ZONE), GetSlot(this, EPOCHNANOSECONDS));
     return ES.FormatUTCOffsetNanoseconds(offsetNs);
   }
   get offsetNanoseconds() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.GetOffsetNanosecondsFor(GetSlot(this, TIME_ZONE), GetSlot(this, EPOCHNANOSECONDS));
   }
   with(temporalZonedDateTimeLike, options = undefined) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     if (ES.Type(temporalZonedDateTimeLike) !== 'Object') {
-      throw new TypeError('invalid zoned-date-time-like');
+      throw new TypeErrorCtor('invalid zoned-date-time-like');
     }
     ES.RejectTemporalLikeObject(temporalZonedDateTimeLike);
 
@@ -218,7 +226,7 @@ export class ZonedDateTime {
     return ES.CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar);
   }
   withPlainTime(temporalTime = undefined) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
 
     const timeZone = GetSlot(this, TIME_ZONE);
     const calendar = GetSlot(this, CALENDAR);
@@ -243,34 +251,34 @@ export class ZonedDateTime {
     return ES.CreateTemporalZonedDateTime(epochNs, timeZone, calendar);
   }
   withTimeZone(timeZone) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     timeZone = ES.ToTemporalTimeZoneIdentifier(timeZone);
     return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, GetSlot(this, CALENDAR));
   }
   withCalendar(calendar) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     calendar = ES.ToTemporalCalendarIdentifier(calendar);
     return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), GetSlot(this, TIME_ZONE), calendar);
   }
   add(temporalDurationLike, options = undefined) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromZonedDateTime('add', this, temporalDurationLike, options);
   }
   subtract(temporalDurationLike, options = undefined) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.AddDurationToOrSubtractDurationFromZonedDateTime('subtract', this, temporalDurationLike, options);
   }
   until(other, options = undefined) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalZonedDateTime('until', this, other, options);
   }
   since(other, options = undefined) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.DifferenceTemporalZonedDateTime('since', this, other, options);
   }
   round(roundTo) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    if (roundTo === undefined) throw new TypeError('options parameter is required');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
+    if (roundTo === undefined) throw new TypeErrorCtor('options parameter is required');
     if (ES.Type(roundTo) === 'String') {
       const stringParam = roundTo;
       roundTo = ObjectCreate(null);
@@ -317,7 +325,7 @@ export class ZonedDateTime {
 
       const startNs = ES.GetStartOfDay(timeZone, dtStart);
       if (thisNs.lesser(startNs)) {
-        throw new Error(
+        throw new ErrorCtor(
           'assertion failure: cannot produce an instant during a day that ' +
             'occurs before another instant it deems start-of-day'
         );
@@ -325,7 +333,7 @@ export class ZonedDateTime {
 
       const endNs = ES.GetStartOfDay(timeZone, dtEnd);
       if (thisNs.greaterOrEquals(endNs)) {
-        throw new Error(
+        throw new ErrorCtor(
           'assertion failure: cannot produce an instant during a day that ' +
             'occurs on or after another instant it deems end-of-day'
         );
@@ -375,7 +383,7 @@ export class ZonedDateTime {
     return ES.CreateTemporalZonedDateTime(epochNanoseconds, timeZone, GetSlot(this, CALENDAR));
   }
   equals(other) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     other = ES.ToTemporalZonedDateTime(other);
     const one = GetSlot(this, EPOCHNANOSECONDS);
     const two = GetSlot(other, EPOCHNANOSECONDS);
@@ -384,14 +392,14 @@ export class ZonedDateTime {
     return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
   }
   toString(options = undefined) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     options = ES.GetOptionsObject(options);
     const showCalendar = ES.GetTemporalShowCalendarNameOption(options);
     const digits = ES.GetTemporalFractionalSecondDigitsOption(options);
     const showOffset = ES.GetTemporalShowOffsetOption(options);
     const roundingMode = ES.GetRoundingModeOption(options, 'trunc');
     const smallestUnit = ES.GetTemporalUnitValuedOption(options, 'smallestUnit', 'time', undefined);
-    if (smallestUnit === 'hour') throw new RangeError('smallestUnit must be a time unit other than "hour"');
+    if (smallestUnit === 'hour') throw new RangeErrorCtor('smallestUnit must be a time unit other than "hour"');
     const showTimeZone = ES.GetTemporalShowTimeZoneNameOption(options);
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     return ES.TemporalZonedDateTimeToString(this, precision, showCalendar, showTimeZone, showOffset, {
@@ -401,7 +409,7 @@ export class ZonedDateTime {
     });
   }
   toLocaleString(locales = undefined, options = undefined) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     options = ES.GetOptionsObject(options);
 
     // This is not quite per specification, but this polyfill's DateTimeFormat
@@ -412,7 +420,7 @@ export class ZonedDateTime {
     ES.CopyDataProperties(optionsCopy, options, ['timeZone']);
 
     if (options.timeZone !== undefined) {
-      throw new TypeError('ZonedDateTime toLocaleString does not accept a timeZone option');
+      throw new TypeErrorCtor('ZonedDateTime toLocaleString does not accept a timeZone option');
     }
 
     if (
@@ -435,10 +443,10 @@ export class ZonedDateTime {
     const timeZoneIdentifier = GetSlot(this, TIME_ZONE);
     if (ES.IsOffsetTimeZoneIdentifier(timeZoneIdentifier)) {
       // Note: https://github.com/tc39/ecma402/issues/683 will remove this
-      throw new RangeError('toLocaleString does not currently support offset time zones');
+      throw new RangeErrorCtor('toLocaleString does not currently support offset time zones');
     } else {
       const record = ES.GetAvailableNamedTimeZoneIdentifier(timeZoneIdentifier);
-      if (!record) throw new RangeError(`toLocaleString formats built-in time zones, not ${timeZoneIdentifier}`);
+      if (!record) throw new RangeErrorCtor(`toLocaleString formats built-in time zones, not ${timeZoneIdentifier}`);
       optionsCopy.timeZone = record.identifier;
     }
 
@@ -451,7 +459,7 @@ export class ZonedDateTime {
       localeCalendarIdentifier !== 'iso8601' &&
       !ES.CalendarEquals(localeCalendarIdentifier, calendarIdentifier)
     ) {
-      throw new RangeError(
+      throw new RangeErrorCtor(
         `cannot format ZonedDateTime with calendar ${calendarIdentifier}` +
           ` in locale with calendar ${localeCalendarIdentifier}`
       );
@@ -461,14 +469,14 @@ export class ZonedDateTime {
     return formatter.format(new Instant(GetSlot(this, EPOCHNANOSECONDS)));
   }
   toJSON() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     return ES.TemporalZonedDateTimeToString(this, 'auto');
   }
   valueOf() {
     ES.ValueOfThrows('ZonedDateTime');
   }
   startOfDay() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const timeZone = GetSlot(this, TIME_ZONE);
     const calendar = GetSlot(this, CALENDAR);
     const { year, month, day } = ES.GetISODateTimeFor(timeZone, GetSlot(this, EPOCHNANOSECONDS));
@@ -476,10 +484,10 @@ export class ZonedDateTime {
     return ES.CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar);
   }
   getTimeZoneTransition(directionParam) {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const timeZone = GetSlot(this, TIME_ZONE);
 
-    if (directionParam === undefined) throw new TypeError('options parameter is required');
+    if (directionParam === undefined) throw new TypeErrorCtor('options parameter is required');
     if (ES.Type(directionParam) === 'String') {
       const stringParam = directionParam;
       directionParam = ObjectCreate(null);
@@ -488,7 +496,7 @@ export class ZonedDateTime {
       directionParam = ES.GetOptionsObject(directionParam);
     }
     const direction = ES.GetDirectionOption(directionParam);
-    if (direction === undefined) throw new TypeError('direction option is required');
+    if (direction === undefined) throw new TypeErrorCtor('direction option is required');
 
     // Offset time zones or UTC have no transitions
     if (ES.IsOffsetTimeZoneIdentifier(timeZone) || timeZone === 'UTC') {
@@ -503,23 +511,23 @@ export class ZonedDateTime {
     return epochNanoseconds === null ? null : new ZonedDateTime(epochNanoseconds, timeZone, GetSlot(this, CALENDAR));
   }
   toInstant() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
     return new TemporalInstant(GetSlot(this, EPOCHNANOSECONDS));
   }
   toPlainDate() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const { year, month, day } = dateTime(this);
     return ES.CreateTemporalDate(year, month, day, GetSlot(this, CALENDAR));
   }
   toPlainTime() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const { hour, minute, second, millisecond, microsecond, nanosecond } = dateTime(this);
     const PlainTime = GetIntrinsic('%Temporal.PlainTime%');
     return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
   }
   toPlainDateTime() {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
+    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDateTime = dateTime(this);
     return ES.CreateTemporalDateTime(
       isoDateTime.year,

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -1,3 +1,5 @@
+import { Error as Error, RangeError as RangeError, TypeError as TypeError, ObjectCreate } from './primordials.mjs';
+
 import * as ES from './ecmascript.mjs';
 import { DateTimeFormat } from './intl.mjs';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass.mjs';
@@ -18,7 +20,6 @@ import { TimeDuration } from './timeduration.mjs';
 import bigInt from 'big-integer';
 
 const customResolvedOptions = DateTimeFormat.prototype.resolvedOptions;
-const ObjectCreate = Object.create;
 
 export class ZonedDateTime {
   constructor(epochNanoseconds, timeZone, calendar = 'iso8601') {


### PR DESCRIPTION
While working on #2940, I noticed that the polyfill was vulnerable to post-load manipulation of primordials. This PR addresses every such pattern I could find... the first PR is semi-mechanical replacement of dynamic-lookup method invocations (includes those hidden by iterable spread/destructuring or for..of), the second fully so.

The result is slightly less readable, but hews more closely to the spec and doubles down on the `ES.Call` protections that are already commonplace.