### PR TITLE
Editorial: Return new objects from ToXXX operations

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -429,20 +429,6 @@ export class Duration {
     ES.ValueOfThrows('Duration');
   }
   static from(item) {
-    if (ES.IsTemporalDuration(item)) {
-      return new Duration(
-        GetSlot(item, YEARS),
-        GetSlot(item, MONTHS),
-        GetSlot(item, WEEKS),
-        GetSlot(item, DAYS),
-        GetSlot(item, HOURS),
-        GetSlot(item, MINUTES),
-        GetSlot(item, SECONDS),
-        GetSlot(item, MILLISECONDS),
-        GetSlot(item, MICROSECONDS),
-        GetSlot(item, NANOSECONDS)
-      );
-    }
     return ES.ToTemporalDuration(item);
   }
   static compare(one, two, options = undefined) {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1163,7 +1163,12 @@ export function ToTemporalDate(item, options = undefined) {
   if (Type(item) === 'Object') {
     if (IsTemporalDate(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return item;
+      return CreateTemporalDate(
+        GetSlot(item, ISO_YEAR),
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, ISO_DAY),
+        GetSlot(item, CALENDAR)
+      );
     }
     if (IsTemporalZonedDateTime(item)) {
       const isoDateTime = GetISODateTimeFor(GetSlot(item, TIME_ZONE), GetSlot(item, EPOCHNANOSECONDS));
@@ -1214,7 +1219,18 @@ export function ToTemporalDateTime(item, options = undefined) {
   if (Type(item) === 'Object') {
     if (IsTemporalDateTime(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return item;
+      return CreateTemporalDateTime(
+        GetSlot(item, ISO_YEAR),
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, ISO_DAY),
+        GetSlot(item, ISO_HOUR),
+        GetSlot(item, ISO_MINUTE),
+        GetSlot(item, ISO_SECOND),
+        GetSlot(item, ISO_MILLISECOND),
+        GetSlot(item, ISO_MICROSECOND),
+        GetSlot(item, ISO_NANOSECOND),
+        GetSlot(item, CALENDAR)
+      );
     }
     if (IsTemporalZonedDateTime(item)) {
       const isoDateTime = GetISODateTimeFor(GetSlot(item, TIME_ZONE), GetSlot(item, EPOCHNANOSECONDS));
@@ -1286,7 +1302,21 @@ export function ToTemporalDateTime(item, options = undefined) {
 }
 
 export function ToTemporalDuration(item) {
-  if (IsTemporalDuration(item)) return item;
+  const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
+  if (IsTemporalDuration(item)) {
+    return new TemporalDuration(
+      GetSlot(item, YEARS),
+      GetSlot(item, MONTHS),
+      GetSlot(item, WEEKS),
+      GetSlot(item, DAYS),
+      GetSlot(item, HOURS),
+      GetSlot(item, MINUTES),
+      GetSlot(item, SECONDS),
+      GetSlot(item, MILLISECONDS),
+      GetSlot(item, MICROSECONDS),
+      GetSlot(item, NANOSECONDS)
+    );
+  }
   if (Type(item) !== 'Object') {
     return ParseTemporalDurationString(RequireString(item));
   }
@@ -1310,7 +1340,6 @@ export function ToTemporalDuration(item) {
       result[property] = value;
     }
   }
-  const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
   return new TemporalDuration(
     result.years,
     result.months,
@@ -1326,10 +1355,9 @@ export function ToTemporalDuration(item) {
 }
 
 export function ToTemporalInstant(item) {
+  const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
   if (Type(item === 'Object')) {
-    if (IsTemporalInstant(item)) return item;
-    if (IsTemporalZonedDateTime(item)) {
-      const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+    if (IsTemporalInstant(item) || IsTemporalZonedDateTime(item)) {
       return new TemporalInstant(GetSlot(item, EPOCHNANOSECONDS));
     }
     item = ToPrimitive(item, StringCtor);
@@ -1359,8 +1387,6 @@ export function ToTemporalInstant(item) {
     offsetNanoseconds
   );
   ValidateEpochNanoseconds(epochNanoseconds);
-
-  const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
   return new TemporalInstant(epochNanoseconds);
 }
 
@@ -1368,7 +1394,12 @@ export function ToTemporalMonthDay(item, options = undefined) {
   if (Type(item) === 'Object') {
     if (IsTemporalMonthDay(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return item;
+      return CreateTemporalMonthDay(
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, ISO_DAY),
+        GetSlot(item, CALENDAR),
+        GetSlot(item, ISO_YEAR)
+      );
     }
     let calendar;
     if (HasSlot(item, CALENDAR)) {
@@ -1407,9 +1438,16 @@ export function ToTemporalTime(item, options = undefined) {
   let hour, minute, second, millisecond, microsecond, nanosecond;
   const TemporalPlainTime = GetIntrinsic('%Temporal.PlainTime%');
   if (Type(item) === 'Object') {
-    if (IsTemporalTime(item)) {
+    if (IsTemporalTime(item) || IsTemporalDateTime(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return item;
+      return new TemporalPlainTime(
+        GetSlot(item, ISO_HOUR),
+        GetSlot(item, ISO_MINUTE),
+        GetSlot(item, ISO_SECOND),
+        GetSlot(item, ISO_MILLISECOND),
+        GetSlot(item, ISO_MICROSECOND),
+        GetSlot(item, ISO_NANOSECOND)
+      );
     }
     if (IsTemporalZonedDateTime(item)) {
       const isoDateTime = GetISODateTimeFor(GetSlot(item, TIME_ZONE), GetSlot(item, EPOCHNANOSECONDS));
@@ -1421,17 +1459,6 @@ export function ToTemporalTime(item, options = undefined) {
         isoDateTime.millisecond,
         isoDateTime.microsecond,
         isoDateTime.nanosecond
-      );
-    }
-    if (IsTemporalDateTime(item)) {
-      GetTemporalOverflowOption(GetOptionsObject(options));
-      return new TemporalPlainTime(
-        GetSlot(item, ISO_HOUR),
-        GetSlot(item, ISO_MINUTE),
-        GetSlot(item, ISO_SECOND),
-        GetSlot(item, ISO_MILLISECOND),
-        GetSlot(item, ISO_MICROSECOND),
-        GetSlot(item, ISO_NANOSECOND)
       );
     }
     ({ hour, minute, second, millisecond, microsecond, nanosecond } = ToTemporalTimeRecord(item));
@@ -1463,7 +1490,12 @@ export function ToTemporalYearMonth(item, options = undefined) {
   if (Type(item) === 'Object') {
     if (IsTemporalYearMonth(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return item;
+      return CreateTemporalYearMonth(
+        GetSlot(item, ISO_YEAR),
+        GetSlot(item, ISO_MONTH),
+        GetSlot(item, CALENDAR),
+        GetSlot(item, ISO_DAY)
+      );
     }
     const calendar = GetTemporalCalendarIdentifierWithISODefault(item);
     const fields = PrepareCalendarFields(calendar, item, ['month', 'monthCode', 'year'], [], []);
@@ -1581,7 +1613,11 @@ export function ToTemporalZonedDateTime(item, options = undefined) {
       GetTemporalDisambiguationOption(options); // validate and ignore
       GetTemporalOffsetOption(options, 'reject');
       GetTemporalOverflowOption(options);
-      return item;
+      return CreateTemporalZonedDateTime(
+        GetSlot(item, EPOCHNANOSECONDS),
+        GetSlot(item, TIME_ZONE),
+        GetSlot(item, CALENDAR)
+      );
     }
     calendar = GetTemporalCalendarIdentifierWithISODefault(item);
     const fields = PrepareCalendarFields(

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -146,9 +146,6 @@ export class Instant {
     return new Instant(epochNanoseconds);
   }
   static from(item) {
-    if (ES.IsTemporalInstant(item)) {
-      return new Instant(GetSlot(item, EPOCHNANOSECONDS));
-    }
     return ES.ToTemporalInstant(item);
   }
   static compare(one, two) {

--- a/polyfill/lib/plaindate.mjs
+++ b/polyfill/lib/plaindate.mjs
@@ -247,15 +247,6 @@ export class PlainDate {
   }
 
   static from(item, options = undefined) {
-    if (ES.IsTemporalDate(item)) {
-      ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
-      return ES.CreateTemporalDate(
-        GetSlot(item, ISO_YEAR),
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, ISO_DAY),
-        GetSlot(item, CALENDAR)
-      );
-    }
     return ES.ToTemporalDate(item, options);
   }
   static compare(one, two) {

--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -448,21 +448,6 @@ export class PlainDateTime {
   }
 
   static from(item, options = undefined) {
-    if (ES.IsTemporalDateTime(item)) {
-      ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
-      return ES.CreateTemporalDateTime(
-        GetSlot(item, ISO_YEAR),
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, ISO_DAY),
-        GetSlot(item, ISO_HOUR),
-        GetSlot(item, ISO_MINUTE),
-        GetSlot(item, ISO_SECOND),
-        GetSlot(item, ISO_MILLISECOND),
-        GetSlot(item, ISO_MICROSECOND),
-        GetSlot(item, ISO_NANOSECOND),
-        GetSlot(item, CALENDAR)
-      );
-    }
     return ES.ToTemporalDateTime(item, options);
   }
   static compare(one, two) {

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -92,15 +92,6 @@ export class PlainMonthDay {
   }
 
   static from(item, options = undefined) {
-    if (ES.IsTemporalMonthDay(item)) {
-      ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
-      return ES.CreateTemporalMonthDay(
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, ISO_DAY),
-        GetSlot(item, CALENDAR),
-        GetSlot(item, ISO_YEAR)
-      );
-    }
     return ES.ToTemporalMonthDay(item, options);
   }
 }

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -224,17 +224,6 @@ export class PlainTime {
   }
 
   static from(item, options = undefined) {
-    if (ES.IsTemporalTime(item)) {
-      ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
-      return new PlainTime(
-        GetSlot(item, ISO_HOUR),
-        GetSlot(item, ISO_MINUTE),
-        GetSlot(item, ISO_SECOND),
-        GetSlot(item, ISO_MILLISECOND),
-        GetSlot(item, ISO_MICROSECOND),
-        GetSlot(item, ISO_NANOSECOND)
-      );
-    }
     return ES.ToTemporalTime(item, options);
   }
   static compare(one, two) {

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -141,15 +141,6 @@ export class PlainYearMonth {
   }
 
   static from(item, options = undefined) {
-    if (ES.IsTemporalYearMonth(item)) {
-      ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
-      return ES.CreateTemporalYearMonth(
-        GetSlot(item, ISO_YEAR),
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, CALENDAR),
-        GetSlot(item, ISO_DAY)
-      );
-    }
     return ES.ToTemporalYearMonth(item, options);
   }
   static compare(one, two) {

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -544,17 +544,6 @@ export class ZonedDateTime {
   }
 
   static from(item, options = undefined) {
-    if (ES.IsTemporalZonedDateTime(item)) {
-      options = ES.GetOptionsObject(options);
-      ES.GetTemporalDisambiguationOption(options); // validate and ignore
-      ES.GetTemporalOffsetOption(options, 'reject');
-      ES.GetTemporalOverflowOption(options);
-      return ES.CreateTemporalZonedDateTime(
-        GetSlot(item, EPOCHNANOSECONDS),
-        GetSlot(item, TIME_ZONE),
-        GetSlot(item, CALENDAR)
-      );
-    }
     return ES.ToTemporalZonedDateTime(item, options);
   }
   static compare(one, two) {

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -75,8 +75,6 @@
       <h1>Temporal.Duration.from ( _item_ )</h1>
       <p>The `Temporal.Duration.from` function performs the following steps when called:</p>
       <emu-alg>
-        1. If _item_ is an Object and _item_ has an [[InitializedTemporalDuration]] internal slot, then
-          1. Return ! CreateTemporalDuration(_item_.[[Years]], _item_.[[Months]], _item_.[[Weeks]], _item_.[[Days]], _item_.[[Hours]], _item_.[[Minutes]], _item_.[[Seconds]], _item_.[[Milliseconds]], _item_.[[Microseconds]], _item_.[[Nanoseconds]]).
         1. Return ? ToTemporalDuration(_item_).
       </emu-alg>
     </emu-clause>
@@ -1104,11 +1102,11 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns its argument _item_ if it is already a Temporal.Duration instance, converts _item_ to a new Temporal.Duration instance if possible and returns that, and throws otherwise.</dd>
+        <dd>Converts _item_ to a new Temporal.Duration instance if possible and returns that, and throws otherwise.</dd>
       </dl>
       <emu-alg>
         1. If _item_ is an Object and _item_ has an [[InitializedTemporalDuration]] internal slot, then
-          1. Return _item_.
+          1. Return ! CreateTemporalDuration(_item_.[[Years]], _item_.[[Months]], _item_.[[Weeks]], _item_.[[Days]], _item_.[[Hours]], _item_.[[Minutes]], _item_.[[Seconds]], _item_.[[Milliseconds]], _item_.[[Microseconds]], _item_.[[Nanoseconds]]).
         1. If _item_ is not an Object, then
           1. If _item_ is not a String, throw a *TypeError* exception.
           1. Return ? ParseTemporalDurationString(_item_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -404,9 +404,7 @@
       </dl>
       <emu-alg>
         1. If _item_ is an Object, then
-          1. If _item_ has an [[InitializedTemporalInstant]] internal slot, then
-            1. Return ! CreateTemporalInstant(_item_.[[EpochNanoseconds]]).
-          1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
+          1. If _item_ has an [[InitializedTemporalInstant]] or [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Return ! CreateTemporalInstant(_item_.[[EpochNanoseconds]]).
           1. NOTE: This use of ToPrimitive allows Instant-like objects to be converted.
           1. Set _item_ to ? ToPrimitive(_item_, ~string~).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -51,8 +51,6 @@
       <h1>Temporal.Instant.from ( _item_ )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If _item_ is an Object and _item_ has an [[InitializedTemporalInstant]] internal slot, then
-          1. Return ! CreateTemporalInstant(_item_.[[EpochNanoseconds]]).
         1. Return ? ToTemporalInstant(_item_).
       </emu-alg>
     </emu-clause>
@@ -402,12 +400,12 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns its argument _item_ if it is already a Temporal.Instant instance, converts _item_ to a new Temporal.Instant instance if possible, and throws otherwise.</dd>
+        <dd>Converts _item_ to a new Temporal.Instant instance if possible, and throws otherwise.</dd>
       </dl>
       <emu-alg>
         1. If _item_ is an Object, then
           1. If _item_ has an [[InitializedTemporalInstant]] internal slot, then
-            1. Return _item_.
+            1. Return ! CreateTemporalInstant(_item_.[[EpochNanoseconds]]).
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Return ! CreateTemporalInstant(_item_.[[EpochNanoseconds]]).
           1. NOTE: This use of ToPrimitive allows Instant-like objects to be converted.

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -62,10 +62,6 @@
       <h1>Temporal.PlainDate.from ( _item_ [ , _options_ ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If _item_ is an Object and _item_ has an [[InitializedTemporalDate]] internal slot, then
-          1. Set _options_ to ? GetOptionsObject(_options_).
-          1. Perform ? GetTemporalOverflowOption(_options_).
-          1. Return ! CreateTemporalDate(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[Calendar]]).
         1. Return ? ToTemporalDate(_item_, _options_).
       </emu-alg>
     </emu-clause>
@@ -728,7 +724,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns its argument _item_ if it is already a Temporal.PlainDate instance, converts _item_ to a new Temporal.PlainDate instance if possible, and throws otherwise.</dd>
+        <dd>Converts _item_ to a new Temporal.PlainDate instance if possible, and throws otherwise.</dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
@@ -736,7 +732,7 @@
           1. If _item_ has an [[InitializedTemporalDate]] internal slot, then
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Perform ? GetTemporalOverflowOption(_options_).
-            1. Return _item_.
+            1. Return ! CreateTemporalDate(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[Calendar]]).
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Let _isoDateTime_ be GetISODateTimeFor(_item_.[[TimeZone]], _item_.[[EpochNanoseconds]]).
             1. Set _options_ to ? GetOptionsObject(_options_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -62,10 +62,6 @@
       <h1>Temporal.PlainDateTime.from ( _item_ [ , _options_ ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If _item_ is an Object and _item_ has an [[InitializedTemporalDateTime]] internal slot, then
-          1. Set _options_ to ? GetOptionsObject(_options_).
-          1. Perform ? GetTemporalOverflowOption(_options_).
-          1. Return ! CreateTemporalDateTime(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]], _item_.[[Calendar]]).
         1. Return ? ToTemporalDateTime(_item_, _options_).
       </emu-alg>
     </emu-clause>
@@ -928,7 +924,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns its argument _item_ if it is already a Temporal.PlainDateTime instance, converts _item_ to a new Temporal.PlainDateTime instance if possible, and throws otherwise.</dd>
+        <dd>Converts _item_ to a new Temporal.PlainDateTime instance if possible, and throws otherwise.</dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
@@ -936,7 +932,7 @@
           1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Perform ? GetTemporalOverflowOption(_options_).
-            1. Return _item_.
+            1. Return ! CreateTemporalDateTime(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]], _item_.[[Calendar]]).
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Let _isoDateTime_ be GetISODateTimeFor(_item_.[[TimeZone]], _item_.[[EpochNanoseconds]]).
             1. Set _options_ to ? GetOptionsObject(_options_).

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -58,10 +58,6 @@
       <h1>Temporal.PlainMonthDay.from ( _item_ [ , _options_ ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If _item_ is an Object and _item_ has an [[InitializedTemporalMonthDay]] internal slot, then
-          1. Set _options_ to ? GetOptionsObject(_options_).
-          1. Perform ? GetTemporalOverflowOption(_options_).
-          1. Return ! CreateTemporalMonthDay(_item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[Calendar]], _item_.[[ISOYear]]).
         1. Return ? ToTemporalMonthDay(_item_, _options_).
       </emu-alg>
     </emu-clause>
@@ -308,7 +304,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns its argument _item_ if it is already a Temporal.PlainMonthDay instance, converts _item_ to a new Temporal.PlainMonthDay instance if possible, and throws otherwise.</dd>
+        <dd>Converts _item_ to a new Temporal.PlainMonthDay instance if possible, and throws otherwise.</dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
@@ -316,7 +312,7 @@
           1. If _item_ has an [[InitializedTemporalMonthDay]] internal slot, then
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Perform ? GetTemporalOverflowOption(_options_).
-            1. Return _item_.
+            1. Return ! CreateTemporalMonthDay(_item_.[[ISOMonth]], _item_.[[ISODay]], _item_.[[Calendar]], _item_.[[ISOYear]]).
           1. Let _calendar_ be ? GetTemporalCalendarIdentifierWithISODefault(_item_).
           1. Let _fields_ be ? PrepareCalendarFields(_calendar_, _item_, « ~day~, ~month~, ~month-code~, ~year~ », «», «»).
           1. Set _options_ to ? GetOptionsObject(_options_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -61,10 +61,6 @@
       <h1>Temporal.PlainTime.from ( _item_ [ , _options_ ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If _item_ is an Object and _item_ has an [[InitializedTemporalTime]] internal slot, then
-          1. Set _options_ to ? GetOptionsObject(_options_).
-          1. Perform ? GetTemporalOverflowOption(_options_).
-          1. Return ! CreateTemporalTime(_item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]]).
         1. Return ? ToTemporalTime(_item_, _options_).
       </emu-alg>
     </emu-clause>
@@ -535,7 +531,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns its argument _item_ if it is already a Temporal.PlainTime instance, converts _item_ to a new Temporal.PlainTime instance if possible, and throws otherwise.</dd>
+        <dd>Converts _item_ to a new Temporal.PlainTime instance if possible, and throws otherwise.</dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
@@ -543,7 +539,7 @@
           1. If _item_ has an [[InitializedTemporalTime]] internal slot, then
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Perform ? GetTemporalOverflowOption(_options_).
-            1. Return _item_.
+            1. Return ! CreateTemporalTime(_item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]]).
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
             1. Let _isoDateTime_ be GetISODateTimeFor(_item_.[[TimeZone]], _item_.[[EpochNanoseconds]]).
             1. Set _options_ to ? GetOptionsObject(_options_).
@@ -575,7 +571,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns its argument _item_ if it is already a Temporal.PlainTime instance, converts _item_ to a new Temporal.PlainTime instance if possible, considering *undefined* to be the same as midnight, and throws otherwise.</dd>
+        <dd>Converts _item_ to a new Temporal.PlainTime instance if possible, considering *undefined* to be the same as midnight, and throws otherwise.</dd>
       </dl>
       <emu-alg>
         1. If _item_ is *undefined*, return ! CreateTemporalTime(0, 0, 0, 0, 0, 0).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -536,7 +536,7 @@
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
         1. If _item_ is an Object, then
-          1. If _item_ has an [[InitializedTemporalTime]] internal slot, then
+          1. If _item_ has an [[InitializedTemporalTime]] or [[InitializedTemporalDateTime]] internal slot, then
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Perform ? GetTemporalOverflowOption(_options_).
             1. Return ! CreateTemporalTime(_item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]]).
@@ -545,10 +545,6 @@
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Perform ? GetTemporalOverflowOption(_options_).
             1. Return ! CreateTemporalTime(_isoDateTime_.[[Hour]], _isoDateTime_.[[Minute]], _isoDateTime_.[[Second]], _isoDateTime_.[[Millisecond]], _isoDateTime_.[[Microsecond]], _isoDateTime_.[[Nanosecond]]).
-          1. If _item_ has an [[InitializedTemporalDateTime]] internal slot, then
-            1. Set _options_ to ? GetOptionsObject(_options_).
-            1. Perform ? GetTemporalOverflowOption(_options_).
-            1. Return ! CreateTemporalTime(_item_.[[ISOHour]], _item_.[[ISOMinute]], _item_.[[ISOSecond]], _item_.[[ISOMillisecond]], _item_.[[ISOMicrosecond]], _item_.[[ISONanosecond]]).
           1. Let _result_ be ? ToTemporalTimeRecord(_item_).
           1. Set _options_ to ? GetOptionsObject(_options_).
           1. Let _overflow_ be ? GetTemporalOverflowOption(_options_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -58,10 +58,6 @@
       <h1>Temporal.PlainYearMonth.from ( _item_ [ , _options_ ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If _item_ is an Object and _item_ has an [[InitializedTemporalYearMonth]] internal slot, then
-          1. Set _options_ to ? GetOptionsObject(_options_).
-          1. Perform ? GetTemporalOverflowOption(_options_).
-          1. Return ! CreateTemporalYearMonth(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[Calendar]], _item_.[[ISODay]]).
         1. Return ? ToTemporalYearMonth(_item_, _options_).
       </emu-alg>
     </emu-clause>
@@ -487,7 +483,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns its argument _item_ if it is already a Temporal.PlainYearMonth instance, converts _item_ to a new Temporal.PlainYearMonth instance if possible, and throws otherwise.</dd>
+        <dd>Converts _item_ to a new Temporal.PlainYearMonth instance if possible, and throws otherwise.</dd>
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
@@ -495,7 +491,7 @@
           1. If _item_ has an [[InitializedTemporalYearMonth]] internal slot, then
             1. Set _options_ to ? GetOptionsObject(_options_).
             1. Perform ? GetTemporalOverflowOption(_options_).
-            1. Return _item_.
+            1. Return ! CreateTemporalYearMonth(_item_.[[ISOYear]], _item_.[[ISOMonth]], _item_.[[Calendar]], _item_.[[ISODay]]).
           1. Let _calendar_ be ? GetTemporalCalendarIdentifierWithISODefault(_item_).
           1. Let _fields_ be ? PrepareCalendarFields(_calendar_, _item_, « ~month~, ~month-code~, ~year~ », «», «»).
           1. Set _options_ to ? GetOptionsObject(_options_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -63,12 +63,6 @@
       <h1>Temporal.ZonedDateTime.from ( _item_ [ , _options_ ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If _item_ is an Object and _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
-          1. Set _options_ to ? GetOptionsObject(_options_).
-          1. Perform ? GetTemporalDisambiguationOption(_options_).
-          1. Perform ? GetTemporalOffsetOption(_options_, *"reject"*).
-          1. Perform ? GetTemporalOverflowOption(_options_).
-          1. Return ! CreateTemporalZonedDateTime(_item_.[[EpochNanoseconds]], _item_.[[TimeZone]], _item_.[[Calendar]]).
         1. Return ? ToTemporalZonedDateTime(_item_, _options_).
       </emu-alg>
     </emu-clause>
@@ -960,7 +954,7 @@
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It returns its argument _item_ if it is already a Temporal.ZonedDateTime instance, converts _item_ to a new Temporal.ZonedDateTime instance if possible, and throws otherwise.
+          Converts _item_ to a new Temporal.ZonedDateTime instance if possible, and throws otherwise.
         </dd>
       </dl>
       <emu-alg>
@@ -974,7 +968,7 @@
             1. Perform ? GetTemporalDisambiguationOption(_options_).
             1. Perform ? GetTemporalOffsetOption(_options_, *"reject"*).
             1. Perform ? GetTemporalOverflowOption(_options_).
-            1. Return _item_.
+            1. Return ! CreateTemporalZonedDateTime(_item_.[[EpochNanoseconds]], _item_.[[TimeZone]], _item_.[[Calendar]]).
           1. Let _calendar_ be ? GetTemporalCalendarIdentifierWithISODefault(_item_).
           1. Let _fields_ be ? PrepareCalendarFields(_calendar_, _item_, « ~day~, ~month~, ~month-code~, ~year~ », « ~hour~, ~microsecond~, ~millisecond~, ~minute~, ~nanosecond~, ~offset~, ~second~, ~time-zone~ », « ~time-zone~ »).
           1. Let _timeZone_ be ? ToTemporalTimeZoneIdentifier(_fields_.[[TimeZone]]).


### PR DESCRIPTION
Without user-defined calendars and time zones, it's no longer observable when new objects are returned. This helps to simplify the various `from` methods.

Implementations can easily avoid these allocations. (They should probably already doing this when the `ToXXX` operations are called without actually returning the new object to user code.)