### PR TITLE
Editorial: Avoid GetUTCEpochNanoseconds modification

### DIFF
--- a/spec/instant.html
+++ b/spec/instant.html
@@ -416,7 +416,7 @@
           1. Let _time_ be Time Record { [[Days]]: 0, [[Hour]]: 0, [[Minute]]: 0, [[Second]]: 0, [[Millisecond]]: 0, [[Microsecond]]: 0, [[Nanosecond]]: 0 }.
         1. Else,
           1. Let _time_ be _parsed_.[[Time]].
-        1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_parsed_.[[Year]], _parsed_.[[Month]], _parsed_.[[Day]], _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]], _offsetNanoseconds_).
+        1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_parsed_.[[Year]], _parsed_.[[Month]], _parsed_.[[Day]], _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]]) - ℤ(_offsetNanoseconds_).
         1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -77,41 +77,6 @@
 
     <p>[...]</p>
 
-    <emu-clause id="sec-temporal-getutcepochnanoseconds" type="abstract operation">
-      <h1>
-        GetUTCEpochNanoseconds (
-          _year_: an integer,
-          _month_: an integer,
-          _day_: an integer,
-          _hour_: an integer in the inclusive interval from 0 to 23,
-          _minute_: an integer in the inclusive interval from 0 to 59,
-          _second_: an integer in the inclusive interval from 0 to 59,
-          _millisecond_: an integer in the inclusive interval from 0 to 999,
-          _microsecond_: an integer in the inclusive interval from 0 to 999,
-          _nanosecond_: an integer in the inclusive interval from 0 to 999,
-          <ins>optional _offsetNanoseconds_: an integer in the interval from -nsPerDay (exclusive) to nsPerDay (exclusive),</ins>
-        ): a BigInt
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>
-          The returned value represents a number of nanoseconds since the epoch that corresponds to the given ISO 8601 calendar date and wall-clock time in UTC.
-          <ins>If a UTC offset is provided, the returned value will be adjusted by that offset.</ins>
-        </dd>
-      </dl>
-      <emu-alg>
-        1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.
-        1. Let _date_ be MakeDay(𝔽(_year_), 𝔽(_month_ - 1), 𝔽(_day_)).
-        1. Let _time_ be MakeTime(𝔽(_hour_), 𝔽(_minute_), 𝔽(_second_), 𝔽(_millisecond_)).
-        1. Let _ms_ be MakeDate(_date_, _time_).
-        1. Assert: _ms_ is an integral Number.
-        1. <del>Return ℤ(ℝ(_ms_) × 10<sup>6</sup> + _microsecond_ × 10<sup>3</sup> + _nanosecond_).</del>
-        1. <ins>Let _epochNanoseconds_ be ℝ(_ms_) × 10<sup>6</sup> + _microsecond_ × 10<sup>3</sup> + _nanosecond_.</ins>
-        1. <ins>If _offsetNanoseconds_ is present and _offsetNanoseconds_ ≠ 0, set _epochNanoseconds_ to _epochNanoseconds_ - _offsetNanoseconds_.</ins>
-        1. <ins>Return ℤ(_epochNanoseconds_).</ins>
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-time-zone-identifiers">
       <h1>Time Zone Identifiers</h1>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -357,7 +357,8 @@
       <emu-alg>
         1. Let _parseResult_ be ! ParseTimeZoneIdentifier(_timeZone_).
         1. If _parseResult_.[[OffsetMinutes]] is not ~empty~, then
-          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]], _isoDateTime_.[[Hour]], _isoDateTime_.[[Minute]], _isoDateTime_.[[Second]], _isoDateTime_.[[Millisecond]], _isoDateTime_.[[Microsecond]], _isoDateTime_.[[Nanosecond]], _parseResult_.[[OffsetMinutes]] × (60 × 10<sup>9</sup>)).
+          1. Let _offsetNanoseconds_ be _parseResult_.[[OffsetMinutes]] × (60 × 10<sup>9</sup>).
+          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]], _isoDateTime_.[[Hour]], _isoDateTime_.[[Minute]], _isoDateTime_.[[Second]], _isoDateTime_.[[Millisecond]], _isoDateTime_.[[Microsecond]], _isoDateTime_.[[Nanosecond]]) - ℤ(_offsetNanoseconds_).
           1. Let _possibleEpochNanoseconds_ be « _epochNanoseconds_ ».
         1. Else,
           1. Let _possibleEpochNanoseconds_ be GetNamedTimeZoneEpochNanoseconds(_parseResult_.[[Name]], _isoDateTime_.[[Year]], _isoDateTime_.[[Month]], _isoDateTime_.[[Day]], _isoDateTime_.[[Hour]], _isoDateTime_.[[Minute]], _isoDateTime_.[[Second]], _isoDateTime_.[[Millisecond]], _isoDateTime_.[[Microsecond]], _isoDateTime_.[[Nanosecond]]).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -922,23 +922,22 @@
         1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, _time_).
         1. If _offsetBehaviour_ is ~wall~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is *"ignore"*, then
           1. Return ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, _disambiguation_).
+        1. Let _utcEpochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]]).
         1. If _offsetBehaviour_ is ~exact~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is *"use"*, then
-          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]], _offsetNanoseconds_).
+          1. Let _epochNanoseconds_ be _utcEpochNanoseconds_ - ℤ(_offsetNanoseconds_).
           1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
           1. Return _epochNanoseconds_.
         1. Assert: _offsetBehaviour_ is ~option~.
         1. Assert: _offsetOption_ is *"prefer"* or *"reject"*.
         1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).
-        1. If _possibleEpochNs_ is not empty, then
-          1. Let _utcEpochNanoseconds_ be GetUTCEpochNanoseconds(_year_, _month_, _day_, _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]]).
-          1. For each element _candidate_ of _possibleEpochNs_, do
-            1. Let _candidateOffset_ be _utcEpochNanoseconds_ - _candidate_.
-            1. If _candidateOffset_ = _offsetNanoseconds_, then
+        1. For each element _candidate_ of _possibleEpochNs_, do
+          1. Let _candidateOffset_ be _utcEpochNanoseconds_ - _candidate_.
+          1. If _candidateOffset_ = _offsetNanoseconds_, then
+            1. Return _candidate_.
+          1. If _matchBehaviour_ is ~match-minutes~, then
+            1. Let _roundedCandidateNanoseconds_ be RoundNumberToIncrement(_candidateOffset_, 60 × 10<sup>9</sup>, *"halfExpand"*).
+            1. If _roundedCandidateNanoseconds_ = _offsetNanoseconds_, then
               1. Return _candidate_.
-            1. If _matchBehaviour_ is ~match-minutes~, then
-              1. Let _roundedCandidateNanoseconds_ be RoundNumberToIncrement(_candidateOffset_, 60 × 10<sup>9</sup>, *"halfExpand"*).
-              1. If _roundedCandidateNanoseconds_ = _offsetNanoseconds_, then
-                1. Return _candidate_.
         1. If _offsetOption_ is *"reject"*, throw a *RangeError* exception.
         1. Return ? DisambiguatePossibleEpochNanoseconds(_possibleEpochNs_, _timeZone_, _isoDateTime_, _disambiguation_).
       </emu-alg>


### PR DESCRIPTION
`GetUTCEpochNanoseconds` was changed to include a subtraction. There are currently exactly three callers which require this change. All other callers, which are in the majority, don't use this optional offset parameter.

Instead of modifying `GetUTCEpochNanoseconds`, perform this subtraction in the caller. Also change `InterpretISODateTimeOffset` to perform a single call to `GetUTCEpochNanoseconds`.

Also don't bother to µ-optimise `InterpretISODateTimeOffset` to avoid calling `GetUTCEpochNanoseconds` when `possibleEpochNs` is empty. This case happens too rarely to bother optimising it.