### PR TITLE
Optimize the slow test

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -40,6 +40,7 @@ import {
   DatePrototypeGetUTCMilliseconds,
   DatePrototypeSetUTCFullYear,
   DatePrototypeSetUTCHours,
+  DateUTC,
   IntlDateTimeFormat,
   IntlDateTimeFormatPrototypeGetFormat,
   IntlDateTimeFormatPrototypeResolvedOptions,
@@ -132,6 +133,7 @@ import bigInt from 'big-integer';
 const DAY_MS = 86400_000;
 const DAY_NANOS = DAY_MS * 1e6;
 // Instant range is 100 million days (inclusive) before or after epoch.
+const MS_MAX = DAY_MS * 1e8;
 const NS_MIN = bigInt(DAY_NANOS).multiply(-1e8);
 const NS_MAX = bigInt(DAY_NANOS).multiply(1e8);
 // PlainDateTime range is 24 hours wider (exclusive) than the Instant range on
@@ -145,7 +147,7 @@ const DATETIME_NS_MAX = NS_MAX.add(DAY_NANOS).subtract(bigInt.one);
 const MS_IN_400_YEAR_CYCLE = (400 * 365 + 97) * DAY_MS;
 const YEAR_MIN = -271821;
 const YEAR_MAX = 275760;
-const BEFORE_FIRST_DST = bigInt(-388152).multiply(1e13); // 1847-01-01T00:00:00Z
+const BEFORE_FIRST_DST = DateUTC(1847, 0, 1); // 1847-01-01T00:00:00Z
 
 const BUILTIN_CALENDAR_IDS = [
   'iso8601',
@@ -2427,16 +2429,19 @@ export function GetAvailableNamedTimeZoneIdentifier(identifier) {
   return { identifier: Call(ArrayPrototypeJoin, segments, ['/']), primaryIdentifier };
 }
 
-export function GetNamedTimeZoneOffsetNanoseconds(id, epochNanoseconds) {
-  // Optimization: We get the offset nanoseconds only with millisecond
-  // resolution, assuming that time zone offset changes don't happen in the
-  // middle of a millisecond
-  const epochMilliseconds = epochNsToMs(epochNanoseconds, 'floor');
+function GetNamedTimeZoneOffsetNanosecondsImpl(id, epochMilliseconds) {
   const { year, month, day, hour, minute, second } = GetFormatterParts(id, epochMilliseconds);
   let millisecond = epochMilliseconds % 1000;
   if (millisecond < 0) millisecond += 1000;
   const utc = GetUTCEpochMilliseconds(year, month, day, hour, minute, second, millisecond);
   return (utc - epochMilliseconds) * 1e6;
+}
+
+export function GetNamedTimeZoneOffsetNanoseconds(id, epochNanoseconds) {
+  // Optimization: We get the offset nanoseconds only with millisecond
+  // resolution, assuming that time zone offset changes don't happen in the
+  // middle of a millisecond
+  return GetNamedTimeZoneOffsetNanosecondsImpl(id, epochNsToMs(epochNanoseconds, 'floor'));
 }
 
 export function FormatOffsetTimeZoneIdentifier(offsetMinutes) {
@@ -2506,48 +2511,58 @@ export function GetNamedTimeZoneDateTimeParts(id, epochNanoseconds) {
 }
 
 export function GetNamedTimeZoneNextTransition(id, epochNanoseconds) {
-  if (epochNanoseconds.lesser(BEFORE_FIRST_DST)) {
-    return GetNamedTimeZoneNextTransition(id, BEFORE_FIRST_DST);
+  // Optimization: we floor the instant to the previous millisecond boundary
+  // so that we can do Number math instead of BigInt math. This assumes that
+  // time zone transitions don't happen in the middle of a millisecond.
+  const epochMilliseconds = epochNsToMs(epochNanoseconds, 'floor');
+  if (epochMilliseconds < BEFORE_FIRST_DST) {
+    return GetNamedTimeZoneNextTransition(id, bigInt(BEFORE_FIRST_DST).multiply(1e6));
   }
+
   // Optimization: the farthest that we'll look for a next transition is 3 years
   // after the later of epochNanoseconds or the current time. If there are no
   // transitions found before then, we'll assume that there will not be any more
   // transitions after that.
-  const now = SystemUTCEpochNanoSeconds();
-  const base = epochNanoseconds.greater(now) ? epochNanoseconds : now;
-  const uppercap = base.plus(bigInt(DAY_NANOS).multiply(366 * 3));
-  let leftNanos = epochNanoseconds;
-  let leftOffsetNs = GetNamedTimeZoneOffsetNanoseconds(id, leftNanos);
-  let rightNanos = leftNanos;
+  const now = DateNow();
+  const base = MathMax(epochMilliseconds, now);
+  const uppercap = base + DAY_MS * 366 * 3;
+  let leftMs = epochMilliseconds;
+  let leftOffsetNs = GetNamedTimeZoneOffsetNanosecondsImpl(id, leftMs);
+  let rightMs = leftMs;
   let rightOffsetNs = leftOffsetNs;
-  while (leftOffsetNs === rightOffsetNs && bigInt(leftNanos).compare(uppercap) === -1) {
-    rightNanos = bigInt(leftNanos).plus(bigInt(DAY_NANOS).multiply(2 * 7));
-    if (rightNanos.greater(NS_MAX)) return null;
-    rightOffsetNs = GetNamedTimeZoneOffsetNanoseconds(id, rightNanos);
+  while (leftOffsetNs === rightOffsetNs && leftMs < uppercap) {
+    rightMs = leftMs + DAY_MS * 2 * 7;
+    if (rightMs > MS_MAX) return null;
+    rightOffsetNs = GetNamedTimeZoneOffsetNanosecondsImpl(id, rightMs);
     if (leftOffsetNs === rightOffsetNs) {
-      leftNanos = rightNanos;
+      leftMs = rightMs;
     }
   }
   if (leftOffsetNs === rightOffsetNs) return null;
   const result = bisect(
-    (epochNs) => GetNamedTimeZoneOffsetNanoseconds(id, epochNs),
-    leftNanos,
-    rightNanos,
+    (epochMs) => GetNamedTimeZoneOffsetNanosecondsImpl(id, epochMs),
+    leftMs,
+    rightMs,
     leftOffsetNs,
     rightOffsetNs
   );
-  return result;
+  return bigInt(result).multiply(1e6);
 }
 
 export function GetNamedTimeZonePreviousTransition(id, epochNanoseconds) {
+  // Optimization: we raise the instant to the next millisecond boundary so
+  // that we can do Number math instead of BigInt math. This assumes that time
+  // zone transitions don't happen in the middle of a millisecond.
+  const epochMilliseconds = epochNsToMs(epochNanoseconds, 'ceil');
+
   // Optimization: if the instant is more than 3 years in the future and there
   // are no transitions between the present day and 3 years from now, assume
   // there are none after.
-  const now = SystemUTCEpochNanoSeconds();
-  const lookahead = now.plus(bigInt(DAY_NANOS).multiply(366 * 3));
-  if (epochNanoseconds.gt(lookahead)) {
-    const prevBeforeLookahead = GetNamedTimeZonePreviousTransition(id, lookahead);
-    if (prevBeforeLookahead === null || prevBeforeLookahead.lt(now)) {
+  const now = DateNow();
+  const lookahead = now + DAY_MS * 366 * 3;
+  if (epochMilliseconds > lookahead) {
+    const prevBeforeLookahead = GetNamedTimeZonePreviousTransition(id, bigInt(lookahead).multiply(1e6));
+    if (prevBeforeLookahead === null || prevBeforeLookahead.lt(bigInt(now).multiply(1e6))) {
       return prevBeforeLookahead;
     }
   }
@@ -2560,34 +2575,34 @@ export function GetNamedTimeZonePreviousTransition(id, epochNanoseconds) {
   // the previous transition for an instant far in the future may take an
   // extremely long time as it loops backward 2 weeks at a time.
   if (id === 'Africa/Casablanca' || id === 'Africa/El_Aaiun') {
-    const lastPrecomputed = GetSlot(ToTemporalInstant('2088-01-01T00Z'), EPOCHNANOSECONDS);
-    if (lastPrecomputed.lesser(epochNanoseconds)) {
-      return GetNamedTimeZonePreviousTransition(id, lastPrecomputed);
+    const lastPrecomputed = DateUTC(2088, 0, 1); // 2088-01-01T00Z
+    if (lastPrecomputed < epochMilliseconds) {
+      return GetNamedTimeZonePreviousTransition(id, bigInt(lastPrecomputed).multiply(1e6));
     }
   }
 
-  let rightNanos = bigInt(epochNanoseconds).minus(1);
-  if (rightNanos.lesser(BEFORE_FIRST_DST)) return null;
-  let rightOffsetNs = GetNamedTimeZoneOffsetNanoseconds(id, rightNanos);
-  let leftNanos = rightNanos;
+  let rightMs = epochMilliseconds - 1;
+  if (rightMs < BEFORE_FIRST_DST) return null;
+  let rightOffsetNs = GetNamedTimeZoneOffsetNanosecondsImpl(id, rightMs);
+  let leftMs = rightMs;
   let leftOffsetNs = rightOffsetNs;
-  while (rightOffsetNs === leftOffsetNs && bigInt(rightNanos).compare(BEFORE_FIRST_DST) === 1) {
-    leftNanos = bigInt(rightNanos).minus(bigInt(DAY_NANOS).multiply(2 * 7));
-    if (leftNanos.lesser(BEFORE_FIRST_DST)) return null;
-    leftOffsetNs = GetNamedTimeZoneOffsetNanoseconds(id, leftNanos);
+  while (rightOffsetNs === leftOffsetNs && rightMs > BEFORE_FIRST_DST) {
+    leftMs = rightMs - DAY_MS * 2 * 7;
+    if (leftMs < BEFORE_FIRST_DST) return null;
+    leftOffsetNs = GetNamedTimeZoneOffsetNanosecondsImpl(id, leftMs);
     if (rightOffsetNs === leftOffsetNs) {
-      rightNanos = leftNanos;
+      rightMs = leftMs;
     }
   }
   if (rightOffsetNs === leftOffsetNs) return null;
   const result = bisect(
-    (epochNs) => GetNamedTimeZoneOffsetNanoseconds(id, epochNs),
-    leftNanos,
-    rightNanos,
+    (epochMs) => GetNamedTimeZoneOffsetNanosecondsImpl(id, epochMs),
+    leftMs,
+    rightMs,
     leftOffsetNs,
     rightOffsetNs
   );
-  return result;
+  return bigInt(result).multiply(1e6);
 }
 
 export function GetFormatterParts(timeZone, epochMilliseconds) {
@@ -4642,10 +4657,8 @@ const OFFSET = new RegExpCtor(`^${PARSE.offset.source}$`);
 const OFFSET_WITH_PARTS = new RegExpCtor(`^${PARSE.offsetWithParts.source}$`);
 
 function bisect(getState, left, right, lstate = getState(left), rstate = getState(right)) {
-  left = bigInt(left);
-  right = bigInt(right);
-  while (right.minus(left).greater(1)) {
-    let middle = left.plus(right).divide(2);
+  while (right - left > 1) {
+    let middle = MathTrunc((left + right) / 2);
     const mstate = getState(middle);
     if (mstate === lstate) {
       left = middle;

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2592,9 +2592,10 @@ export function GetNamedTimeZonePreviousTransition(id, epochNanoseconds) {
 
 export function GetFormatterParts(timeZone, epochMilliseconds) {
   const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
-  // Using `format` instead of `formatToParts` for compatibility with older clients
+  // Using `format` instead of `formatToParts` for compatibility with older
+  // clients and because it is twice as fast
   const boundFormat = Call(IntlDateTimeFormatPrototypeGetFormat, formatter, []);
-  const datetime = Call(boundFormat, formatter, [new DateCtor(epochMilliseconds)]);
+  const datetime = Call(boundFormat, formatter, [epochMilliseconds]);
   const splits = Call(StringPrototypeSplit, datetime, [/[^\w]+/]);
   const month = splits[0];
   const day = splits[1];
@@ -2604,7 +2605,7 @@ export function GetFormatterParts(timeZone, epochMilliseconds) {
   const minute = splits[5];
   const second = splits[6];
   return {
-    year: Call(StringPrototypeStartsWith, Call(StringPrototypeToUpperCase, era, []), ['B']) ? -year + 1 : +year,
+    year: era[0] === 'b' || era[0] === 'B' ? -year + 1 : +year,
     month: +month,
     day: +day,
     hour: hour === '24' ? 0 : +hour, // bugs.chromium.org/p/chromium/issues/detail?id=1045791

--- a/polyfill/lib/instant.mjs
+++ b/polyfill/lib/instant.mjs
@@ -46,7 +46,7 @@ export class Instant {
   get epochMilliseconds() {
     if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');
     const value = bigInt(GetSlot(this, EPOCHNANOSECONDS));
-    return ES.BigIntFloorDiv(value, 1e6).toJSNumber();
+    return ES.epochNsToMs(value, 'floor');
   }
   get epochNanoseconds() {
     if (!ES.IsTemporalInstant(this)) throw new TypeErrorCtor('invalid receiver');

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -229,16 +229,12 @@ function resolvedOptions() {
   return resolved;
 }
 
-function epochNsToMs(epochNs) {
-  return ES.BigIntFloorDiv(epochNs, 1e6).toJSNumber();
-}
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function format(datetime, ...rest) {
   let { epochNs, formatter } = extractOverrides(datetime, this);
   let formatArgs;
   if (formatter) {
-    formatArgs = [epochNsToMs(epochNs)];
+    formatArgs = [ES.epochNsToMs(epochNs, 'floor')];
   } else {
     formatter = GetSlot(this, ORIGINAL);
     formatArgs = ES.Call(ArrayPrototypeSlice, arguments, []);
@@ -252,7 +248,7 @@ function formatToParts(datetime, ...rest) {
   let { epochNs, formatter } = extractOverrides(datetime, this);
   let formatArgs;
   if (formatter) {
-    formatArgs = [epochNsToMs(epochNs)];
+    formatArgs = [ES.epochNsToMs(epochNs, 'floor')];
   } else {
     formatter = GetSlot(this, ORIGINAL);
     formatArgs = ES.Call(ArrayPrototypeSlice, arguments, []);
@@ -272,7 +268,7 @@ function formatRange(a, b) {
     if (aformatter) {
       assert(bformatter == aformatter, 'formatters for same Temporal type should be identical');
       formatter = aformatter;
-      formatArgs = [epochNsToMs(aa), epochNsToMs(bb)];
+      formatArgs = [ES.epochNsToMs(aa, 'floor'), ES.epochNsToMs(bb, 'floor')];
     }
   } else {
     formatter = GetSlot(this, ORIGINAL);
@@ -292,7 +288,7 @@ function formatRangeToParts(a, b) {
     if (aformatter) {
       assert(bformatter == aformatter, 'formatters for same Temporal type should be identical');
       formatter = aformatter;
-      formatArgs = [epochNsToMs(aa), epochNsToMs(bb)];
+      formatArgs = [ES.epochNsToMs(aa, 'floor'), ES.epochNsToMs(bb, 'floor')];
     }
   } else {
     formatter = GetSlot(this, ORIGINAL);

--- a/polyfill/lib/primordials.mjs
+++ b/polyfill/lib/primordials.mjs
@@ -76,7 +76,8 @@ export const {
     setUTCMilliseconds: DatePrototypeSetUTCMilliseconds,
     toLocaleDateString: DatePrototypeToLocaleDateString,
     valueOf: DatePrototypeValueOf
-  }
+  },
+  UTC: DateUTC
 } = Date;
 export const {
   supportedValuesOf: IntlSupportedValuesOf,

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -110,7 +110,7 @@ export class ZonedDateTime {
   get epochMilliseconds() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const value = GetSlot(this, EPOCHNANOSECONDS);
-    return ES.BigIntFloorDiv(value, 1e6).toJSNumber();
+    return ES.epochNsToMs(value, 'floor');
   }
   get epochNanoseconds() {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');

--- a/polyfill/test/ecmascript.mjs
+++ b/polyfill/test/ecmascript.mjs
@@ -236,6 +236,75 @@ describe('ECMAScript', () => {
       );
     });
   });
+
+  describe('epochNsToMs', () => {
+    it('returns 0 for 0n', () => {
+      equal(ES.epochNsToMs(bigInt.zero, 'floor'), 0);
+      equal(ES.epochNsToMs(bigInt.zero, 'ceil'), 0);
+    });
+
+    const oneBillionSeconds = bigInt(1e18);
+
+    it('for a positive value already on ms boundary, divides by 1e6', () => {
+      equal(ES.epochNsToMs(oneBillionSeconds, 'floor'), 1e12);
+      equal(ES.epochNsToMs(oneBillionSeconds, 'ceil'), 1e12);
+    });
+
+    it('positive value just ahead of ms boundary', () => {
+      const plusOne = oneBillionSeconds.plus(bigInt.one);
+      equal(ES.epochNsToMs(plusOne, 'floor'), 1e12);
+      equal(ES.epochNsToMs(plusOne, 'ceil'), 1e12 + 1);
+    });
+
+    it('positive value just behind ms boundary', () => {
+      const minusOne = oneBillionSeconds.minus(bigInt.one);
+      equal(ES.epochNsToMs(minusOne, 'floor'), 1e12 - 1);
+      equal(ES.epochNsToMs(minusOne, 'ceil'), 1e12);
+    });
+
+    it('positive value just behind next ms boundary', () => {
+      const plus999999 = oneBillionSeconds.plus(999999);
+      equal(ES.epochNsToMs(plus999999, 'floor'), 1e12);
+      equal(ES.epochNsToMs(plus999999, 'ceil'), 1e12 + 1);
+    });
+
+    it('positive value just behind ms boundary', () => {
+      const minus999999 = oneBillionSeconds.minus(999999);
+      equal(ES.epochNsToMs(minus999999, 'floor'), 1e12 - 1);
+      equal(ES.epochNsToMs(minus999999, 'ceil'), 1e12);
+    });
+
+    const minusOneBillionSeconds = bigInt(-1e18);
+
+    it('for a negative value already on ms boundary, divides by 1e6', () => {
+      equal(ES.epochNsToMs(minusOneBillionSeconds, 'floor'), -1e12);
+      equal(ES.epochNsToMs(minusOneBillionSeconds, 'ceil'), -1e12);
+    });
+
+    it('negative value just ahead of ms boundary', () => {
+      const plusOne = minusOneBillionSeconds.plus(bigInt.one);
+      equal(ES.epochNsToMs(plusOne, 'floor'), -1e12);
+      equal(ES.epochNsToMs(plusOne, 'ceil'), -1e12 + 1);
+    });
+
+    it('negative value just behind ms boundary', () => {
+      const minusOne = minusOneBillionSeconds.minus(bigInt.one);
+      equal(ES.epochNsToMs(minusOne, 'floor'), -1e12 - 1);
+      equal(ES.epochNsToMs(minusOne, 'ceil'), -1e12);
+    });
+
+    it('negative value just behind next ms boundary', () => {
+      const plus999999 = minusOneBillionSeconds.plus(999999);
+      equal(ES.epochNsToMs(plus999999, 'floor'), -1e12);
+      equal(ES.epochNsToMs(plus999999, 'ceil'), -1e12 + 1);
+    });
+
+    it('negative value just behind ms boundary', () => {
+      const minus999999 = minusOneBillionSeconds.minus(999999);
+      equal(ES.epochNsToMs(minus999999, 'floor'), -1e12 - 1);
+      equal(ES.epochNsToMs(minus999999, 'ceil'), -1e12);
+    });
+  });
 });
 
 import { normalize } from 'path';


### PR DESCRIPTION
There is one test262 test that has annoyed me for over a year because it takes 30 seconds to execute with the reference polyfill: `intl402/Temporal/ZonedDateTime/prototype/getTimeZoneTransition/transition-at-instant-boundaries.js`. I assumed it was slow because we use DateTimeFormat to figure out the UTC offset of a time zone many times in a loop. Finally I decided to profile it. It's true that DateTimeFormat is a significant part of the profile, but there was a lot more unnecessary work being done there.

The key optimization in this PR is that we assume there are no time zone transitions that occur in the middle of a millisecond. This means, we assume the UTC offsets at these two times are always the same:

  2024-09-25T16:47.123456789
  2024-09-25T16:47.123

This is the case in all modern time zone transitions. It is also currently the case in all records in the TZDB, although it's possible that could change for historical transitions if the TZDB decides to define them with sub-millisecond resolution.

When we look for a time zone transition, that involves bisecting to find the exact moment of the transition. Assuming that the exact moment is on a millisecond boundary, allows performing all the math with Numbers instead of bigIntegers, giving a significant speedup.

Now the slow test executes in 5–7 seconds, and the whole test suite takes 30–40 seconds less than it did before.

**This PR makes no change in the proposal.** It's purely to give myself (and others) a better developer experience as we run the test262 tests repeatedly to verify that these last editorial changes are not observable, and while writing further test262 coverage.