### PR TITLE
Editorial: Split total() code path out of RoundRelativeDuration

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -10,7 +10,6 @@ import {
 
   // class static functions and methods
   MathAbs,
-  NumberIsNaN,
   ObjectCreate,
   ObjectDefineProperty,
 
@@ -236,7 +235,7 @@ export class Duration {
       const calendar = GetSlot(zonedRelativeTo, CALENDAR);
       const relativeEpochNs = GetSlot(zonedRelativeTo, EPOCHNANOSECONDS);
       const targetEpochNs = ES.AddZonedDateTime(relativeEpochNs, timeZone, calendar, duration);
-      ({ duration } = ES.DifferenceZonedDateTimeWithRounding(
+      duration = ES.DifferenceZonedDateTimeWithRounding(
         relativeEpochNs,
         targetEpochNs,
         timeZone,
@@ -245,7 +244,7 @@ export class Duration {
         roundingIncrement,
         smallestUnit,
         roundingMode
-      ));
+      );
       if (ES.TemporalUnitCategory(largestUnit) === 'date') largestUnit = 'hour';
       return ES.UnnormalizeDuration(duration, largestUnit);
     }
@@ -260,7 +259,7 @@ export class Duration {
       const dateDuration = ES.AdjustDateDurationRecord(duration.date, targetTime.deltaDays);
       const targetDate = ES.CalendarDateAdd(calendar, isoRelativeToDate, dateDuration, 'constrain');
 
-      ({ duration } = ES.DifferencePlainDateTimeWithRounding(
+      duration = ES.DifferencePlainDateTimeWithRounding(
         isoRelativeToDate.year,
         isoRelativeToDate.month,
         isoRelativeToDate.day,
@@ -284,7 +283,7 @@ export class Duration {
         roundingIncrement,
         smallestUnit,
         roundingMode
-      ));
+      );
       return ES.UnnormalizeDuration(duration, largestUnit);
     }
 
@@ -297,7 +296,7 @@ export class Duration {
     }
     assert(!ES.IsCalendarUnit(smallestUnit), 'smallestUnit was larger than largestUnit');
     let duration = ES.NormalizeDurationWith24HourDays(this);
-    ({ duration } = ES.RoundTimeDuration(duration, roundingIncrement, smallestUnit, roundingMode));
+    duration = ES.RoundTimeDuration(duration, roundingIncrement, smallestUnit, roundingMode);
     return ES.UnnormalizeDuration(duration, largestUnit);
   }
   total(totalOf) {
@@ -320,18 +319,7 @@ export class Duration {
       const calendar = GetSlot(zonedRelativeTo, CALENDAR);
       const relativeEpochNs = GetSlot(zonedRelativeTo, EPOCHNANOSECONDS);
       const targetEpochNs = ES.AddZonedDateTime(relativeEpochNs, timeZone, calendar, duration);
-      const { total } = ES.DifferenceZonedDateTimeWithRounding(
-        relativeEpochNs,
-        targetEpochNs,
-        timeZone,
-        calendar,
-        unit,
-        1,
-        unit,
-        'trunc'
-      );
-      assert(!NumberIsNaN(total), 'total went through NudgeToZonedTime code path');
-      return total;
+      return ES.DifferenceZonedDateTimeWithTotal(relativeEpochNs, targetEpochNs, timeZone, calendar, unit);
     }
 
     if (plainRelativeTo) {
@@ -344,7 +332,7 @@ export class Duration {
       const dateDuration = ES.AdjustDateDurationRecord(duration.date, targetTime.deltaDays);
       const targetDate = ES.CalendarDateAdd(calendar, isoRelativeToDate, dateDuration, 'constrain');
 
-      const { total } = ES.DifferencePlainDateTimeWithRounding(
+      return ES.DifferencePlainDateTimeWithTotal(
         isoRelativeToDate.year,
         isoRelativeToDate.month,
         isoRelativeToDate.day,
@@ -364,13 +352,8 @@ export class Duration {
         targetTime.microsecond,
         targetTime.nanosecond,
         calendar,
-        unit,
-        1,
-        unit,
-        'trunc'
+        unit
       );
-      assert(!NumberIsNaN(total), 'total went through NudgeToZonedTime code path');
-      return total;
     }
 
     // No reference date to calculate difference relative to
@@ -382,8 +365,7 @@ export class Duration {
       throw new RangeErrorCtor(`a starting point is required for ${unit}s total`);
     }
     const duration = ES.NormalizeDurationWith24HourDays(this);
-    const { total } = ES.RoundTimeDuration(duration, 1, unit, 'trunc');
-    return total;
+    return ES.TotalTimeDuration(duration.norm, unit);
   }
   toString(options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
@@ -400,7 +382,7 @@ export class Duration {
 
     const largestUnit = ES.DefaultTemporalLargestUnit(this);
     let duration = ES.NormalizeDuration(this);
-    ({ duration } = ES.RoundTimeDuration(duration, increment, unit, roundingMode));
+    duration = ES.RoundTimeDuration(duration, increment, unit, roundingMode);
     const roundedDuration = ES.UnnormalizeDuration(duration, ES.LargerOfTwoTemporalUnits(largestUnit, 'second'));
     return ES.TemporalDurationToString(roundedDuration, precision);
   }

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -432,9 +432,9 @@
           1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
           1. Let _relativeEpochNs_ be _zonedRelativeTo_.[[EpochNanoseconds]].
           1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _normalizedDuration_, ~constrain~).
-          1. Let _roundRecord_ be ? DifferenceZonedDateTimeWithRounding(_relativeEpochNs_, _targetEpochNs_, _timeZone_, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+          1. Set _normalizedDuration_ to ? DifferenceZonedDateTimeWithRounding(_relativeEpochNs_, _targetEpochNs_, _timeZone_, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. If TemporalUnitCategory(_largestUnit_) is ~date~, set _largestUnit_ to ~hour~.
-          1. Return ? UnnormalizeDuration(_roundRecord_.[[NormalizedDuration]], _largestUnit_).
+          1. Return ? UnnormalizeDuration(_normalizedDuration_, _largestUnit_).
         1. If _plainRelativeTo_ is not *undefined*, then
           1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
           1. Let _targetTime_ be AddTime(0, 0, 0, 0, 0, 0, _normalizedDuration_.[[NormalizedTime]]).
@@ -442,12 +442,12 @@
           1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
           1. Let _dateDuration_ be ! AdjustDateDurationRecord(_normalizedDuration_.[[Date]], _targetTime_.[[Days]]).
           1. Let _targetDate_ be ? CalendarDateAdd(_calendar_, _isoRelativeToDate_, _dateDuration_, ~constrain~).
-          1. Let _roundRecord_ be ? DifferencePlainDateTimeWithRounding(_isoRelativeToDate_.[[Year]], _isoRelativeToDate_.[[Month]], _isoRelativeToDate_.[[Day]], 0, 0, 0, 0, 0, 0, _targetDate_.[[Year]], _targetDate_.[[Month]], _targetDate_.[[Day]], _targetTime_.[[Hour]], _targetTime_.[[Minute]], _targetTime_.[[Second]], _targetTime_.[[Millisecond]], _targetTime_.[[Microsecond]], _targetTime_.[[Nanosecond]], _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Return ? UnnormalizeDuration(_roundRecord_.[[NormalizedDuration]], _largestUnit_).
+          1. Set _normalizedDuration_ to ? DifferencePlainDateTimeWithRounding(_isoRelativeToDate_.[[Year]], _isoRelativeToDate_.[[Month]], _isoRelativeToDate_.[[Day]], 0, 0, 0, 0, 0, 0, _targetDate_.[[Year]], _targetDate_.[[Month]], _targetDate_.[[Day]], _targetTime_.[[Hour]], _targetTime_.[[Minute]], _targetTime_.[[Second]], _targetTime_.[[Millisecond]], _targetTime_.[[Microsecond]], _targetTime_.[[Nanosecond]], _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+          1. Return ? UnnormalizeDuration(_normalizedDuration_, _largestUnit_).
         1. If IsCalendarUnit(_existingLargestUnit_) is *true*, or IsCalendarUnit(_largestUnit_) is *true*, throw a *RangeError* exception.
         1. Assert: IsCalendarUnit(_smallestUnit_) is *false*.
         1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
-        1. Set _normalizedDuration_ to ? RoundTimeDuration(_normalizedDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).[[NormalizedDuration]].
+        1. Set _normalizedDuration_ to ? RoundTimeDuration(_normalizedDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Return ? UnnormalizeDuration(_normalizedDuration_, _largestUnit_).
       </emu-alg>
     </emu-clause>
@@ -476,7 +476,7 @@
           1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
           1. Let _relativeEpochNs_ be _zonedRelativeTo_.[[EpochNanoseconds]].
           1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _normalizedDuration_, ~constrain~).
-          1. Let _roundRecord_ be ? DifferenceZonedDateTimeWithRounding(_relativeEpochNs_, _targetEpochNs_, _timeZone_, _calendar_, _unit_, 1, _unit_, ~trunc~).
+          1. Let _total_ be ? DifferenceZonedDateTimeWithTotal(_relativeEpochNs_, _targetEpochNs_, _timeZone_, _calendar_, _unit_).
         1. Else if _plainRelativeTo_ is not *undefined*, then
           1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
           1. Let _targetTime_ be AddTime(0, 0, 0, 0, 0, 0, _normalizedDuration_.[[NormalizedTime]]).
@@ -484,14 +484,13 @@
           1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
           1. Let _dateDuration_ be ! AdjustDateDurationRecord(_normalizedDuration_.[[Date]], _targetTime_.[[Days]]).
           1. Let _targetDate_ be ? CalendarDateAdd(_calendar_, _isoRelativeToDate_, _dateDuration_, ~constrain~).
-          1. Let _roundRecord_ be ? DifferencePlainDateTimeWithRounding(_isoRelativeToDate_.[[Year]], _isoRelativeToDate_.[[Month]], _isoRelativeToDate_.[[Day]], 0, 0, 0, 0, 0, 0, _targetDate_.[[Year]], _targetDate_.[[Month]], _targetDate_.[[Day]], _targetTime_.[[Hour]], _targetTime_.[[Minute]], _targetTime_.[[Second]], _targetTime_.[[Millisecond]], _targetTime_.[[Microsecond]], _targetTime_.[[Nanosecond]], _calendar_, _unit_, 1, _unit_, ~trunc~).
+          1. Let _total_ be ? DifferencePlainDateTimeWithTotal(_isoRelativeToDate_.[[Year]], _isoRelativeToDate_.[[Month]], _isoRelativeToDate_.[[Day]], 0, 0, 0, 0, 0, 0, _targetDate_.[[Year]], _targetDate_.[[Month]], _targetDate_.[[Day]], _targetTime_.[[Hour]], _targetTime_.[[Minute]], _targetTime_.[[Second]], _targetTime_.[[Millisecond]], _targetTime_.[[Microsecond]], _targetTime_.[[Nanosecond]], _calendar_, _unit_).
         1. Else,
           1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_).
           1. If IsCalendarUnit(_largestUnit_) is *true*, or IsCalendarUnit(_unit_) is *true*, throw a *RangeError* exception.
           1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
-          1. Let _roundRecord_ be ? RoundTimeDuration(_normalizedDuration_, 1, _unit_, ~trunc~).
-        1. Assert: _roundRecord_.[[Total]] is not ~unset~.
-        1. Return 𝔽(_roundRecord_.[[Total]]).
+          1. Let _total_ be TotalTimeDuration(_normalizedDuration_, _unit_).
+        1. Return 𝔽(_total_).
       </emu-alg>
     </emu-clause>
 
@@ -512,9 +511,9 @@
           1. Return TemporalDurationToString(_duration_, _precision_.[[Precision]]).
         1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_).
         1. Let _normalizedDuration_ be NormalizeDuration(_duration_).
-        1. Let _roundRecord_ be ? RoundTimeDuration(_normalizedDuration_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Set _normalizedDuration_ to ? RoundTimeDuration(_normalizedDuration_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Let _roundedLargestUnit_ be LargerOfTwoTemporalUnits(_largestUnit_, ~second~).
-        1. Let _roundedDuration_ be ! UnnormalizeDuration(_roundRecord_.[[NormalizedDuration]], _roundedLargestUnit_).
+        1. Let _roundedDuration_ be ! UnnormalizeDuration(_normalizedDuration_, _roundedLargestUnit_).
         1. Return TemporalDurationToString(_roundedDuration_, _precision_.[[Precision]]).
       </emu-alg>
     </emu-clause>
@@ -1586,33 +1585,41 @@
           _increment_: a positive integer,
           _unit_: a time unit or ~day~,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Record with fields [[NormalizedDuration]] (a Normalized Duration Record) and [[Total]] (a mathematical value), or a throw completion
+        ): either a normal completion containing a Normalized Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It rounds a _duration_ according to the rounding parameters _unit_, _increment_, and _roundingMode_, and returns a Record with the Normalized Duration Record result in its [[NormalizedDuration]] field.
-          It also returns the total of the smallest unit before the rounding operation in its [[Total]] field, for use in `Temporal.Duration.prototype.total`.
+          It rounds a _duration_ according to the rounding parameters _unit_, _increment_, and _roundingMode_, and returns the Normalized Duration Record result.
         </dd>
       </dl>
       <emu-alg>
-        1. Let _days_ be _duration_.[[Date]].[[Days]].
-        1. Let _norm_ be _duration_.[[NormalizedTime]].
         1. If _unit_ is ~day~, then
-          1. Let _fractionalDays_ be _days_ + DivideNormalizedTimeDuration(_norm_, nsPerDay).
-          1. Set _days_ to RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
-          1. Let _total_ be _fractionalDays_.
-          1. Set _norm_ to ZeroTimeDuration().
-        1. Else,
-          1. Assert: TemporalUnitCategory(_unit_) is ~time~.
-          1. Let _divisor_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _unit_.
-          1. Let _total_ be DivideNormalizedTimeDuration(_norm_, _divisor_).
-          1. Set _norm_ to ? RoundNormalizedTimeDurationToIncrement(_norm_, _divisor_ × _increment_, _roundingMode_).
-        1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _days_).
-        1. Return the Record {
-          [[NormalizedDuration]]: ? CombineDateAndNormalizedTimeDuration(_dateDuration_, _norm_),
-          [[Total]]: _total_
-          }.
+          1. Let _fractionalDays_ be _duration_.[[Date]].[[Days]] + DivideNormalizedTimeDuration(_duration_.[[NormalizedTime]], nsPerDay).
+          1. Let _days_ be RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
+          1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _days_).
+          1. Return ! CombineDateAndNormalizedTimeDuration(_dateDuration_, ZeroTimeDuration()).
+        1. Assert: TemporalUnitCategory(_unit_) is ~time~.
+        1. Let _divisor_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _unit_.
+        1. Let _norm_ be ? RoundNormalizedTimeDurationToIncrement(_duration_.[[NormalizedTime]], _divisor_ × _increment_, _roundingMode_).
+        1. Return ? CombineDateAndNormalizedTimeDuration(_duration_.[[Date]], _norm_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-totaltimeduration" type="abstract operation">
+      <h1>
+        TotalTimeDuration (
+          _norm_: a Normalized Time Duration Record,
+          _unit_: a time unit or ~day~,
+        ): a mathematical value
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the total number of _unit_ in _duration_.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _divisor_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _unit_.
+        1. Return DivideNormalizedTimeDuration(_norm_, _divisor_).
       </emu-alg>
     </emu-clause>
 
@@ -1632,13 +1639,6 @@
             <td>a Normalized Duration Record</td>
             <td>
               The resulting duration.
-            </td>
-          </tr>
-          <tr>
-            <td>[[Total]]</td>
-            <td>a mathematical value or ~unset~</td>
-            <td>
-              The possibly fractional total of the smallest unit before the rounding operation, for use in `Temporal.Duration.prototype.total`, or ~unset~ if not relevant.
             </td>
           </tr>
           <tr>
@@ -1671,7 +1671,7 @@
           _increment_: a positive integer,
           _unit_: a date unit,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Duration Nudge Result Record or a throw completion
+        ): either a normal completion containing a Record with fields [[NudgeResult]] (a Duration Nudge Result Record) and [[Total]] (a mathematical value), or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1748,7 +1748,8 @@
           1. Let _resultDuration_ be _startDuration_.
           1. Let _nudgedEpochNs_ be _startEpochNs_.
         1. Set _resultDuration_ to ! CombineDateAndNormalizedTimeDuration(_resultDuration_, ZeroTimeDuration()).
-        1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[Total]]: _total_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandCalendarUnit_ }.
+        1. Let _nudgeResult_ be Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandCalendarUnit_ }.
+        1. Return the Record { [[NudgeResult]]: _nudgeResult_, [[Total]]: _total_ }.
       </emu-alg>
     </emu-clause>
 
@@ -1795,7 +1796,7 @@
           1. Let _nudgedEpochNs_ be AddNormalizedTimeDurationToEpochNanoseconds(_roundedNorm_, _startEpochNs_).
         1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _duration_.[[Date]].[[Days]] + _dayDelta_).
         1. Let _resultDuration_ be ? CombineDateAndNormalizedTimeDuration(_dateDuration_, _roundedNorm_).
-        1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[Total]]: ~unset~, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didRoundBeyondDay_ }.
+        1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didRoundBeyondDay_ }.
       </emu-alg>
     </emu-clause>
 
@@ -1819,7 +1820,6 @@
       <emu-alg>
         1. Let _norm_ be ! Add24HourDaysToNormalizedTimeDuration(_duration_.[[NormalizedTime]], _duration_.[[Date]].[[Days]]).
         1. Let _unitLength_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _smallestUnit_.
-        1. Let _total_ be DivideNormalizedTimeDuration(_norm_, _unitLength_).
         1. Let _roundedNorm_ be ? RoundNormalizedTimeDurationToIncrement(_norm_, _unitLength_ × _increment_, _roundingMode_).
         1. Let _diffNorm_ be ! SubtractNormalizedTimeDuration(_roundedNorm_, _norm_).
         1. Let _wholeDays_ be truncate(DivideNormalizedTimeDuration(_norm_, nsPerDay)).
@@ -1835,7 +1835,7 @@
           1. Set _remainder_ to ! SubtractNormalizedTimeDuration(_roundedNorm_, NormalizeTimeDuration(_roundedWholeDays_ * HoursPerDay, 0, 0, 0, 0, 0)).
         1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _days_).
         1. Let _resultDuration_ be ? CombineDateAndNormalizedTimeDuration(_dateDuration_, _remainder_).
-        1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[Total]]: _total_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandDays_ }.
+        1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandDays_ }.
       </emu-alg>
     </emu-clause>
 
@@ -1907,13 +1907,12 @@
           _increment_: a positive integer,
           _smallestUnit_: a Temporal unit,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Record with fields [[NormalizedDuration]] (a NormalizedDurationRecord) and [[Total]] (a mathematical value or ~unset~), or a throw completion
+        ): either a normal completion containing a Normalized Duration Record or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It rounds a duration _duration_ relative to _dateTime_ according to the rounding parameters _smallestUnit_, _increment_, and _roundingMode_, bubbles overflows up to the next highest unit until _largestUnit_, and returns a normalized duration in its [[NormalizedDuration]] field.
-          It also returns the total of the smallest unit before the rounding operation in its [[Total]] field, for use in `Temporal.Duration.prototype.total`.
+          It rounds a duration _duration_ relative to _dateTime_ according to the rounding parameters _smallestUnit_, _increment_, and _roundingMode_, bubbles overflows up to the next highest unit until _largestUnit_, and returns a normalized duration.
         </dd>
       </dl>
       <emu-alg>
@@ -1922,7 +1921,8 @@
         1. If _timeZone_ is not ~unset~ and _smallestUnit_ is ~day~, set _irregularLengthUnit_ to *true*.
         1. If NormalizedDurationSign(_duration_) &lt; 0, let _sign_ be -1; else let _sign_ be 1.
         1. If _irregularLengthUnit_ is *true*, then
-          1. Let _nudgeResult_ be ? NudgeToCalendarUnit(_sign_, _duration_, _destEpochNs_, _dateTime_, _timeZone_, _calendar_, _increment_, _smallestUnit_, _roundingMode_).
+          1. Let _record_ be ? NudgeToCalendarUnit(_sign_, _duration_, _destEpochNs_, _dateTime_, _timeZone_, _calendar_, _increment_, _smallestUnit_, _roundingMode_).
+          1. Let _nudgeResult_ be _record_.[[NudgeResult]].
         1. Else if _timeZone_ is not ~unset~, then
           1. Let _nudgeResult_ be ? NudgeToZonedTime(_sign_, _duration_, _dateTime_, _timeZone_, _calendar_, _increment_, _smallestUnit_, _roundingMode_).
         1. Else,
@@ -1931,10 +1931,32 @@
         1. If _nudgeResult_.[[DidExpandCalendarUnit]] is *true* and _smallestUnit_ is not ~week~, then
           1. Let _startUnit_ be LargerOfTwoTemporalUnits(_smallestUnit_, ~day~).
           1. Set _duration_ to ? BubbleRelativeDuration(_sign_, _duration_, _nudgeResult_.[[NudgedEpochNs]], _dateTime_, _timeZone_, _calendar_, _largestUnit_, _startUnit_).
-        1. Return the Record {
-          [[NormalizedDuration]]: _duration_,
-          [[Total]]: _nudgeResult_.[[Total]]
-          }.
+        1. Return _duration_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-totalrelativeduration" type="abstract operation">
+      <h1>
+        TotalRelativeDuration (
+          _duration_: a Normalized Duration Record,
+          _destEpochNs_: a BigInt,
+          _dateTime_: an ISO Date-Time Record,
+          _timeZone_: an available time zone identifier or ~unset~,
+          _calendar_: a calendar type,
+          _unit_: a Temporal unit,
+        ): either a normal completion containing a mathematical value, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns the total number of _unit_ in _duration_, relative to _dateTime_ if a starting point is necessary for calendar units.</dd>
+      </dl>
+      <emu-alg>
+        1. If IsCalendarUnit(_unit_) is *true*, or _timeZone_ is not ~unset~ and _unit_ is ~day~, then
+          1. Let _sign_ be NormalizedDurationSign(_duration_).
+          1. Let _record_ be ? NudgeToCalendarUnit(_sign_, _duration_, _destEpochNs_, _dateTime_, _timeZone_, _calendar_, 1, _unit_, ~trunc~).
+          1. Return _record_.[[Total]].
+        1. Let _norm_ be ! Add24HourDaysToNormalizedTimeDuration(_duration_.[[NormalizedTime]], _duration_.[[Date]].[[Days]]).
+        1. Return TotalTimeDuration(_norm_, _unit_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -466,7 +466,7 @@
           _roundingIncrement_: a positive integer,
           _smallestUnit_: a time unit or ~day~,
           _roundingMode_: a rounding mode,
-        ): a Record with fields [[NormalizedDuration]] (a Normalized Duration Record) and [[Total]] (a mathematical value)
+        ): a Normalized Duration Record
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -543,8 +543,8 @@
         1. Set _other_ to ? ToTemporalInstant(_other_).
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, « », ~nanosecond~, ~second~).
-        1. Let _diffRecord_ be DifferenceInstant(_instant_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ! UnnormalizeDuration(_diffRecord_.[[NormalizedDuration]], _settings_.[[LargestUnit]]).
+        1. Let _normalizedDuration_ be DifferenceInstant(_instant_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+        1. Let _result_ be ! UnnormalizeDuration(_normalizedDuration_, _settings_.[[LargestUnit]]).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1206,7 +1206,7 @@
           _roundingIncrement_: a positive integer,
           _smallestUnit_: a Temporal unit,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Record with fields [[NormalizedDuration]] (a Normalized Duration Record) and [[Total]] (a mathematical value), or a throw completion
+        ): either a normal completion containing a Normalized Duration Record or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1216,14 +1216,54 @@
         1. Assert: IsValidISODate(_y1_, _mon1_, _d1_) is *true*.
         1. Assert: IsValidISODate(_y2_, _mon2_, _d2_) is *true*.
         1. If CompareISODateTime(_y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_) = 0, then
-          1. Let _duration_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), ZeroTimeDuration()).
-          1. Return the Record { [[NormalizedDuration]]: _duration_, [[Total]]: 0 }.
+          1. Return ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), ZeroTimeDuration()).
         1. Let _diff_ be ? DifferenceISODateTime(_y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_, _calendar_, _largestUnit_).
-        1. If _smallestUnit_ is ~nanosecond~ and _roundingIncrement_ = 1, then
-          1. Return the Record { [[NormalizedDuration]]: _diff_, [[Total]]: _diff_.[[NormalizedTime]].[[TotalNanoseconds]] }.
+        1. If _smallestUnit_ is ~nanosecond~ and _roundingIncrement_ = 1, return _diff_.
         1. Let _dateTime_ be ISO Date-Time Record { [[Year]]: _y1_, [[Month]]: _mon1_, [[Day]]: _d1_, [[Hour]]: _h1_, [[Minute]]: _min1_, [[Second]]: _s1_, [[Millisecond]]: _ms1_, [[Microsecond]]: _mus1_, [[Nanosecond]]: _ns1_ }.
         1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
         1. Return ? RoundRelativeDuration(_diff_, _destEpochNs_, _dateTime_, ~unset~, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-differenceplaindatetimewithtotal" type="abstract operation">
+      <h1>
+        DifferencePlainDateTimeWithTotal (
+          _y1_: an integer,
+          _mon1_: an integer,
+          _d1_: an integer,
+          _h1_: an integer in the inclusive interval from 0 to 23,
+          _min1_: an integer in the inclusive interval from 0 to 59,
+          _s1_: an integer in the inclusive interval from 0 to 59,
+          _ms1_: an integer in the inclusive interval from 0 to 999,
+          _mus1_: an integer in the inclusive interval from 0 to 999,
+          _ns1_: an integer in the inclusive interval from 0 to 999,
+          _y2_: an integer,
+          _mon2_: an integer,
+          _d2_: an integer,
+          _h2_: an integer in the inclusive interval from 0 to 23,
+          _min2_: an integer in the inclusive interval from 0 to 59,
+          _s2_: an integer in the inclusive interval from 0 to 59,
+          _ms2_: an integer in the inclusive interval from 0 to 999,
+          _mus2_: an integer in the inclusive interval from 0 to 999,
+          _ns2_: an integer in the inclusive interval from 0 to 999,
+          _calendar_: a calendar type,
+          _unit_: a Temporal unit,
+        ): either a normal completion containing a mathematical value or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
+      </dl>
+      <emu-alg>
+        1. Assert: IsValidISODate(_y1_, _mon1_, _d1_) is *true*.
+        1. Assert: IsValidISODate(_y2_, _mon2_, _d2_) is *true*.
+        1. If CompareISODateTime(_y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_) = 0, then
+          1. Return 0.
+        1. Let _diff_ be ? DifferenceISODateTime(_y1_, _mon1_, _d1_, _h1_, _min1_, _s1_, _ms1_, _mus1_, _ns1_, _y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_, _calendar_, _unit_).
+        1. If _unit_ is ~nanosecond~, return _diff_.[[NormalizedTime]].[[TotalNanoseconds]].
+        1. Let _dateTime_ be ISO Date-Time Record { [[Year]]: _y1_, [[Month]]: _mon1_, [[Day]]: _d1_, [[Hour]]: _h1_, [[Minute]]: _min1_, [[Second]]: _s1_, [[Millisecond]]: _ms1_, [[Microsecond]]: _mus1_, [[Nanosecond]]: _ns1_ }.
+        1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_y2_, _mon2_, _d2_, _h2_, _min2_, _s2_, _ms2_, _mus2_, _ns2_).
+        1. Return ? TotalRelativeDuration(_diff_, _destEpochNs_, _dateTime_, ~unset~, _calendar_, _unit_).
       </emu-alg>
     </emu-clause>
 
@@ -1248,8 +1288,8 @@
         1. If _dateTime_.[[ISOYear]] = _other_.[[ISOYear]], and _dateTime_.[[ISOMonth]] = _other_.[[ISOMonth]], and _dateTime_.[[ISODay]] = _other_.[[ISODay]], and _dateTime_.[[ISOHour]] = _other_.[[ISOHour]], and _dateTime_.[[ISOMinute]] = _other_.[[ISOMinute]], and _dateTime_.[[ISOSecond]] = _other_.[[ISOSecond]], and _dateTime_.[[ISOMillisecond]] = _other_.[[ISOMillisecond]], and _dateTime_.[[ISOMicrosecond]] = _other_.[[ISOMicrosecond]], and _dateTime_.[[ISONanosecond]] = _other_.[[ISONanosecond]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _plainDate_ be ! CreateTemporalDate(_dateTime_.[[ISOYear]], _dateTime_.[[ISOMonth]], _dateTime_.[[ISODay]], _dateTime_.[[Calendar]]).
-        1. Let _resultRecord_ be ? DifferencePlainDateTimeWithRounding(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ? UnnormalizeDuration(_resultRecord_.[[NormalizedDuration]], _settings_.[[LargestUnit]]).
+        1. Let _normalizedDuration_ be ? DifferencePlainDateTimeWithRounding(_plainDate_.[[ISOYear]], _plainDate_.[[ISOMonth]], _plainDate_.[[ISODay]], _dateTime_.[[ISOHour]], _dateTime_.[[ISOMinute]], _dateTime_.[[ISOSecond]], _dateTime_.[[ISOMillisecond]], _dateTime_.[[ISOMicrosecond]], _dateTime_.[[ISONanosecond]], _other_.[[ISOYear]], _other_.[[ISOMonth]], _other_.[[ISODay]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]], _dateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+        1. Let _result_ be ? UnnormalizeDuration(_normalizedDuration_, _settings_.[[LargestUnit]]).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -999,8 +999,7 @@
         1. Let _norm_ be DifferenceTime(_temporalTime_.[[ISOHour]], _temporalTime_.[[ISOMinute]], _temporalTime_.[[ISOSecond]], _temporalTime_.[[ISOMillisecond]], _temporalTime_.[[ISOMicrosecond]], _temporalTime_.[[ISONanosecond]], _other_.[[ISOHour]], _other_.[[ISOMinute]], _other_.[[ISOSecond]], _other_.[[ISOMillisecond]], _other_.[[ISOMicrosecond]], _other_.[[ISONanosecond]]).
         1. Let _duration_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), _norm_).
         1. If _settings_.[[SmallestUnit]] is not ~nanosecond~ or _settings_.[[RoundingIncrement]] ≠ 1, then
-          1. Let _roundRecord_ be ! RoundTimeDuration(_duration_, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-          1. Set _duration_ to _roundRecord_.[[NormalizedDuration]].
+          1. Set _duration_ to ! RoundTimeDuration(_duration_, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
         1. Let _result_ be ! UnnormalizeDuration(_duration_, _settings_.[[LargestUnit]]).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -677,8 +677,7 @@
           1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_otherDate_.[[Year]], _otherDate_.[[Month]], _otherDate_.[[Day]], 0, 0, 0, 0, 0, 0).
           1. Let _midnight_ be a Time Record with all fields set to 0.
           1. Let _dateTime_ be CombineISODateAndTimeRecord(_thisDate_, _midnight_).
-          1. Let _roundResult_ be ? RoundRelativeDuration(_duration_, _destEpochNs_, _dateTime_, ~unset~, _calendar_, _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).[[Duration]].
-          1. Set _duration_ to _roundResult_.[[NormalizedDuration]].
+          1. Set _duration_ to ? RoundRelativeDuration(_duration_, _destEpochNs_, _dateTime_, ~unset~, _calendar_, _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).[[Duration]].
         1. Let _result_ be ? UnnormalizeDuration(_duration_, ~day~).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1157,7 +1157,7 @@
           _roundingIncrement_: a positive integer,
           _smallestUnit_: a Temporal unit,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Record with fields [[NormalizedDuration]] (a Normalized Duration Record) and [[Total]] (a mathematical value or ~unset~), or a throw completion
+        ): either a normal completion containing a Normalized Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1167,10 +1167,33 @@
         1. If TemporalUnitCategory(_largestUnit_) is ~time~, then
           1. Return DifferenceInstant(_ns1_, _ns2_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Let _difference_ be ? DifferenceZonedDateTime(_ns1_, _ns2_, _timeZone_, _calendar_, _largestUnit_).
-        1. If _smallestUnit_ is ~nanosecond~ and _roundingIncrement_ = 1, then
-          1. Return the Record { [[NormalizedDuration]]: _difference_, [[Total]]: _difference_.[[NormalizedTime]].[[TotalNanoseconds]] }.
+        1. If _smallestUnit_ is ~nanosecond~ and _roundingIncrement_ = 1, return _difference_.
         1. Let _dateTime_ be GetISODateTimeFor(_timeZone_, _ns1_).
         1. Return ? RoundRelativeDuration(_difference_, _ns2_, _dateTime_, _timeZone_, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-differencezoneddatetimewithtotal" type="abstract operation">
+      <h1>
+        DifferenceZonedDateTimeWithTotal (
+          _ns1_: a BigInt,
+          _ns2_: a BigInt,
+          _timeZone_: an available time zone identifier,
+          _calendar_: a calendar type,
+          _unit_: a Temporal unit,
+        ): either a normal completion containing a mathematical value, or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd></dd>
+      </dl>
+      <emu-alg>
+        1. If TemporalUnitCategory(_unit_) is ~time~, then
+          1. Let _difference_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_ns2_, _ns1_).
+          1. Return TotalTimeDuration(_difference_, _unit_).
+        1. Let _difference_ be ? DifferenceZonedDateTime(_ns1_, _ns2_, _timeZone_, _calendar_, _unit_).
+        1. Let _dateTime_ be GetISODateTimeFor(_timeZone_, _ns1_).
+        1. Return ? TotalRelativeDuration(_difference_, _ns2_, _dateTime_, _timeZone_, _calendar_, _unit_).
       </emu-alg>
     </emu-clause>
 
@@ -1203,8 +1226,8 @@
           1. Throw a *RangeError* exception.
         1. If _zonedDateTime_.[[EpochNanoseconds]] = _other_.[[EpochNanoseconds]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-        1. Let _resultRecord_ be ? DifferenceZonedDateTimeWithRounding(_zonedDateTime_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ? UnnormalizeDuration(_resultRecord_.[[Duration]], ~hour~).
+        1. Let _normalizedDuration_ be ? DifferenceZonedDateTimeWithRounding(_zonedDateTime_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+        1. Let _result_ be ? UnnormalizeDuration(_normalizedDuration_, ~hour~).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>


### PR DESCRIPTION
In #2758 we kept the code paths for Duration.p.round() and Duration.p.total() the same. However, it is actually simpler to separate them in most places, except for NudgeToCalendarUnit.

- Splits TotalRelativeDuration out of RoundRelativeDuration
- Splits TotalTimeDuration out of RoundTimeDuration
- Splits DifferenceZonedDateTimeWithTotal out of DifferenceZonedDateTimeWithRounding
- Splits DifferencePlainDateTimeWithTotal out of DifferencePlainDateTimeWithRounding
- Removes [[Total]] field from Nudge Result Record
- Changes NudgeToCalendarUnit to return a record of { [[NudgeResult]], [[Total]] }

Closes: #2947