### PR TITLE
Editorial: Rename "normalize" and "unnormalize" for durations

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -252,7 +252,7 @@ export class Duration {
 
     if (plainRelativeTo) {
       let duration = ES.ToInternalDurationRecordWith24HourDays(this);
-      const targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.norm);
+      const targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.time);
 
       // Delegate the date part addition to the calendar
       const isoRelativeToDate = GetSlot(plainRelativeTo, ISO_DATE);
@@ -311,7 +311,7 @@ export class Duration {
 
     if (plainRelativeTo) {
       const duration = ES.ToInternalDurationRecordWith24HourDays(this);
-      let targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.norm);
+      let targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.time);
 
       // Delegate the date part addition to the calendar
       const isoRelativeToDate = GetSlot(plainRelativeTo, ISO_DATE);
@@ -333,7 +333,7 @@ export class Duration {
       throw new RangeErrorCtor(`a starting point is required for ${unit}s total`);
     }
     const duration = ES.ToInternalDurationRecordWith24HourDays(this);
-    return ES.TotalTimeDuration(duration.norm, unit);
+    return ES.TotalTimeDuration(duration.time, unit);
   }
   toString(options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
@@ -423,9 +423,9 @@ export class Duration {
       d1 = ES.DateDurationDays(duration1.date, plainRelativeTo);
       d2 = ES.DateDurationDays(duration2.date, plainRelativeTo);
     }
-    const norm1 = duration1.norm.add24HourDays(d1);
-    const norm2 = duration2.norm.add24HourDays(d2);
-    return norm1.cmp(norm2);
+    const timeDuration1 = duration1.time.add24HourDays(d1);
+    const timeDuration2 = duration2.time.add24HourDays(d2);
+    return timeDuration1.cmp(timeDuration2);
   }
 }
 

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -420,8 +420,8 @@ export class Duration {
       if (!plainRelativeTo) {
         throw new RangeErrorCtor('A starting point is required for years, months, or weeks comparison');
       }
-      d1 = ES.UnbalanceDateDurationRelative(duration1.date, plainRelativeTo);
-      d2 = ES.UnbalanceDateDurationRelative(duration2.date, plainRelativeTo);
+      d1 = ES.DateDurationDays(duration1.date, plainRelativeTo);
+      d2 = ES.DateDurationDays(duration2.date, plainRelativeTo);
     }
     const norm1 = duration1.norm.add24HourDays(d1);
     const norm2 = duration2.norm.add24HourDays(d2);

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -231,7 +231,7 @@ export class Duration {
     }
 
     if (zonedRelativeTo) {
-      let duration = ES.NormalizeDuration(this);
+      let duration = ES.ToInternalDurationRecord(this);
       const timeZone = GetSlot(zonedRelativeTo, TIME_ZONE);
       const calendar = GetSlot(zonedRelativeTo, CALENDAR);
       const relativeEpochNs = GetSlot(zonedRelativeTo, EPOCHNANOSECONDS);
@@ -251,7 +251,7 @@ export class Duration {
     }
 
     if (plainRelativeTo) {
-      let duration = ES.NormalizeDurationWith24HourDays(this);
+      let duration = ES.ToInternalDurationRecordWith24HourDays(this);
       const targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.norm);
 
       // Delegate the date part addition to the calendar
@@ -282,7 +282,7 @@ export class Duration {
       throw new RangeErrorCtor(`a starting point is required for ${largestUnit}s balancing`);
     }
     assert(!ES.IsCalendarUnit(smallestUnit), 'smallestUnit was larger than largestUnit');
-    let duration = ES.NormalizeDurationWith24HourDays(this);
+    let duration = ES.ToInternalDurationRecordWith24HourDays(this);
     duration = ES.RoundTimeDuration(duration, roundingIncrement, smallestUnit, roundingMode);
     return ES.UnnormalizeDuration(duration, largestUnit);
   }
@@ -301,7 +301,7 @@ export class Duration {
     const unit = ES.GetTemporalUnitValuedOption(totalOf, 'unit', 'datetime', ES.REQUIRED);
 
     if (zonedRelativeTo) {
-      const duration = ES.NormalizeDuration(this);
+      const duration = ES.ToInternalDurationRecord(this);
       const timeZone = GetSlot(zonedRelativeTo, TIME_ZONE);
       const calendar = GetSlot(zonedRelativeTo, CALENDAR);
       const relativeEpochNs = GetSlot(zonedRelativeTo, EPOCHNANOSECONDS);
@@ -310,7 +310,7 @@ export class Duration {
     }
 
     if (plainRelativeTo) {
-      const duration = ES.NormalizeDurationWith24HourDays(this);
+      const duration = ES.ToInternalDurationRecordWith24HourDays(this);
       let targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.norm);
 
       // Delegate the date part addition to the calendar
@@ -332,7 +332,7 @@ export class Duration {
     if (ES.IsCalendarUnit(unit)) {
       throw new RangeErrorCtor(`a starting point is required for ${unit}s total`);
     }
-    const duration = ES.NormalizeDurationWith24HourDays(this);
+    const duration = ES.ToInternalDurationRecordWith24HourDays(this);
     return ES.TotalTimeDuration(duration.norm, unit);
   }
   toString(options = undefined) {
@@ -349,7 +349,7 @@ export class Duration {
     if (unit === 'nanosecond' && increment === 1) return ES.TemporalDurationToString(this, precision);
 
     const largestUnit = ES.DefaultTemporalLargestUnit(this);
-    let duration = ES.NormalizeDuration(this);
+    let duration = ES.ToInternalDurationRecord(this);
     duration = ES.RoundTimeDuration(duration, increment, unit, roundingMode);
     const roundedDuration = ES.UnnormalizeDuration(duration, ES.LargerOfTwoTemporalUnits(largestUnit, 'second'));
     return ES.TemporalDurationToString(roundedDuration, precision);
@@ -395,8 +395,8 @@ export class Duration {
 
     const largestUnit1 = ES.DefaultTemporalLargestUnit(one);
     const largestUnit2 = ES.DefaultTemporalLargestUnit(two);
-    const duration1 = ES.NormalizeDuration(one);
-    const duration2 = ES.NormalizeDuration(two);
+    const duration1 = ES.ToInternalDurationRecord(one);
+    const duration2 = ES.ToInternalDurationRecord(two);
 
     if (
       zonedRelativeTo &&

--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -247,7 +247,7 @@ export class Duration {
         roundingMode
       );
       if (ES.TemporalUnitCategory(largestUnit) === 'date') largestUnit = 'hour';
-      return ES.UnnormalizeDuration(duration, largestUnit);
+      return ES.TemporalDurationFromInternal(duration, largestUnit);
     }
 
     if (plainRelativeTo) {
@@ -271,7 +271,7 @@ export class Duration {
         smallestUnit,
         roundingMode
       );
-      return ES.UnnormalizeDuration(duration, largestUnit);
+      return ES.TemporalDurationFromInternal(duration, largestUnit);
     }
 
     // No reference date to calculate difference relative to
@@ -284,7 +284,7 @@ export class Duration {
     assert(!ES.IsCalendarUnit(smallestUnit), 'smallestUnit was larger than largestUnit');
     let duration = ES.ToInternalDurationRecordWith24HourDays(this);
     duration = ES.RoundTimeDuration(duration, roundingIncrement, smallestUnit, roundingMode);
-    return ES.UnnormalizeDuration(duration, largestUnit);
+    return ES.TemporalDurationFromInternal(duration, largestUnit);
   }
   total(totalOf) {
     if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
@@ -351,7 +351,10 @@ export class Duration {
     const largestUnit = ES.DefaultTemporalLargestUnit(this);
     let duration = ES.ToInternalDurationRecord(this);
     duration = ES.RoundTimeDuration(duration, increment, unit, roundingMode);
-    const roundedDuration = ES.UnnormalizeDuration(duration, ES.LargerOfTwoTemporalUnits(largestUnit, 'second'));
+    const roundedDuration = ES.TemporalDurationFromInternal(
+      duration,
+      ES.LargerOfTwoTemporalUnits(largestUnit, 'second')
+    );
     return ES.TemporalDurationToString(roundedDuration, precision);
   }
   toJSON() {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2697,7 +2697,7 @@ export function BalanceTime(hour, minute, second, millisecond, microsecond, nano
   return { deltaDays, hour, minute, second, millisecond, microsecond, nanosecond };
 }
 
-export function UnbalanceDateDurationRelative(dateDuration, plainRelativeTo) {
+export function DateDurationDays(dateDuration, plainRelativeTo) {
   const yearsMonthsWeeksDuration = AdjustDateDurationRecord(dateDuration, 0);
   if (DateDurationSign(yearsMonthsWeeksDuration) === 0) return dateDuration.days;
 

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2871,7 +2871,7 @@ function ToDateDurationRecordWithoutTime(duration) {
   return { ...internalDuration.date, days };
 }
 
-export function UnnormalizeDuration(internalDuration, largestUnit) {
+export function TemporalDurationFromInternal(internalDuration, largestUnit) {
   const sign = internalDuration.norm.sign();
   let nanoseconds = internalDuration.norm.abs().subsec;
   let microseconds = 0;
@@ -3603,7 +3603,7 @@ export function DifferenceTemporalInstant(operation, instant, other, options) {
     settings.smallestUnit,
     settings.roundingMode
   );
-  let result = UnnormalizeDuration(duration, settings.largestUnit);
+  let result = TemporalDurationFromInternal(duration, settings.largestUnit);
   if (operation === 'since') result = CreateNegatedTemporalDuration(result);
   return result;
 }
@@ -3645,7 +3645,7 @@ export function DifferenceTemporalPlainDate(operation, plainDate, other, options
     );
   }
 
-  let result = UnnormalizeDuration(duration, 'day');
+  let result = TemporalDurationFromInternal(duration, 'day');
   if (operation === 'since') result = CreateNegatedTemporalDuration(result);
   return result;
 }
@@ -3676,7 +3676,7 @@ export function DifferenceTemporalPlainDateTime(operation, plainDateTime, other,
     settings.roundingMode
   );
 
-  let result = UnnormalizeDuration(duration, settings.largestUnit);
+  let result = TemporalDurationFromInternal(duration, settings.largestUnit);
   if (operation === 'since') result = CreateNegatedTemporalDuration(result);
   return result;
 }
@@ -3693,7 +3693,7 @@ export function DifferenceTemporalPlainTime(operation, plainTime, other, options
     duration = RoundTimeDuration(duration, settings.roundingIncrement, settings.smallestUnit, settings.roundingMode);
   }
 
-  let result = UnnormalizeDuration(duration, settings.largestUnit);
+  let result = TemporalDurationFromInternal(duration, settings.largestUnit);
   if (operation === 'since') result = CreateNegatedTemporalDuration(result);
   return result;
 }
@@ -3740,7 +3740,7 @@ export function DifferenceTemporalPlainYearMonth(operation, yearMonth, other, op
     );
   }
 
-  let result = UnnormalizeDuration(duration, 'day');
+  let result = TemporalDurationFromInternal(duration, 'day');
   if (operation === 'since') result = CreateNegatedTemporalDuration(result);
   return result;
 }
@@ -3771,7 +3771,7 @@ export function DifferenceTemporalZonedDateTime(operation, zonedDateTime, other,
       settings.smallestUnit,
       settings.roundingMode
     );
-    result = UnnormalizeDuration(duration, settings.largestUnit);
+    result = TemporalDurationFromInternal(duration, settings.largestUnit);
   } else {
     const timeZone = GetSlot(zonedDateTime, TIME_ZONE);
     if (!TimeZoneEquals(timeZone, GetSlot(other, TIME_ZONE))) {
@@ -3793,7 +3793,7 @@ export function DifferenceTemporalZonedDateTime(operation, zonedDateTime, other,
       settings.smallestUnit,
       settings.roundingMode
     );
-    result = UnnormalizeDuration(duration, 'hour');
+    result = TemporalDurationFromInternal(duration, 'hour');
   }
 
   if (operation === 'since') result = CreateNegatedTemporalDuration(result);
@@ -3851,7 +3851,7 @@ export function AddDurations(operation, duration, other) {
   const d1 = ToInternalDurationRecordWith24HourDays(duration);
   const d2 = ToInternalDurationRecordWith24HourDays(other);
   const result = CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), d1.norm.add(d2.norm));
-  return UnnormalizeDuration(result, largestUnit);
+  return TemporalDurationFromInternal(result, largestUnit);
 }
 
 export function AddDurationToInstant(operation, instant, durationLike) {

--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3269,7 +3269,7 @@ function NudgeToDayOrTime(duration, destEpochNs, largestUnit, increment, smalles
   let remainder = roundedNorm;
   if (TemporalUnitCategory(largestUnit) === 'date') {
     days = roundedWholeDays;
-    remainder = roundedNorm.subtract(TimeDuration.fromComponents(roundedWholeDays * 24, 0, 0, 0, 0, 0));
+    remainder = roundedNorm.add(TimeDuration.fromComponents(-roundedWholeDays * 24, 0, 0, 0, 0, 0));
   }
 
   const dateDuration = AdjustDateDurationRecord(duration.date, days);

--- a/polyfill/lib/math.mjs
+++ b/polyfill/lib/math.mjs
@@ -81,7 +81,7 @@ export function GetUnsignedRoundingMode(mode, sign) {
 }
 
 // Omits first step from spec algorithm so that it can be used both for
-// RoundNumberToIncrement and RoundNormalizedTimeDurationToIncrement
+// RoundNumberToIncrement and RoundTimeDurationToIncrement
 export function ApplyUnsignedRoundingMode(r1, r2, cmp, evenCardinality, unsignedRoundingMode) {
   if (unsignedRoundingMode === 'zero') return r1;
   if (unsignedRoundingMode === 'infinity') return r2;

--- a/polyfill/lib/timeduration.mjs
+++ b/polyfill/lib/timeduration.mjs
@@ -50,7 +50,7 @@ export class TimeDuration {
     return new TimeDuration(diff);
   }
 
-  static normalize(h, min, s, ms, µs, ns) {
+  static fromComponents(h, min, s, ms, µs, ns) {
     const totalNs = bigInt(ns)
       .add(bigInt(µs).multiply(1e3))
       .add(bigInt(ms).multiply(1e6))

--- a/polyfill/test/timeduration.mjs
+++ b/polyfill/test/timeduration.mjs
@@ -82,40 +82,40 @@ describe('Normalized time duration', () => {
     });
   });
 
-  describe('normalize()', () => {
+  describe('fromComponents()', () => {
     it('basic', () => {
-      check(TimeDuration.normalize(1, 1, 1, 1, 1, 1), 3661, 1001001);
-      check(TimeDuration.normalize(-1, -1, -1, -1, -1, -1), -3661, -1001001);
+      check(TimeDuration.fromComponents(1, 1, 1, 1, 1, 1), 3661, 1001001);
+      check(TimeDuration.fromComponents(-1, -1, -1, -1, -1, -1), -3661, -1001001);
     });
 
     it('overflow from one unit to another', () => {
-      check(TimeDuration.normalize(1, 61, 61, 998, 1000, 1000), 7321, 999001000);
-      check(TimeDuration.normalize(-1, -61, -61, -998, -1000, -1000), -7321, -999001000);
+      check(TimeDuration.fromComponents(1, 61, 61, 998, 1000, 1000), 7321, 999001000);
+      check(TimeDuration.fromComponents(-1, -61, -61, -998, -1000, -1000), -7321, -999001000);
     });
 
     it('overflow from subseconds to seconds', () => {
-      check(TimeDuration.normalize(0, 0, 1, 1000, 0, 0), 2, 0);
-      check(TimeDuration.normalize(0, 0, -1, -1000, 0, 0), -2, 0);
+      check(TimeDuration.fromComponents(0, 0, 1, 1000, 0, 0), 2, 0);
+      check(TimeDuration.fromComponents(0, 0, -1, -1000, 0, 0), -2, 0);
     });
 
     it('multiple overflows from subseconds to seconds', () => {
-      check(TimeDuration.normalize(0, 0, 0, 1234567890, 1234567890, 1234567890), 1235803, 692457890);
-      check(TimeDuration.normalize(0, 0, 0, -1234567890, -1234567890, -1234567890), -1235803, -692457890);
+      check(TimeDuration.fromComponents(0, 0, 0, 1234567890, 1234567890, 1234567890), 1235803, 692457890);
+      check(TimeDuration.fromComponents(0, 0, 0, -1234567890, -1234567890, -1234567890), -1235803, -692457890);
     });
 
     it('fails on overflow', () => {
-      throws(() => TimeDuration.normalize(2501999792984, 0, 0, 0, 0, 0), RangeError);
-      throws(() => TimeDuration.normalize(-2501999792984, 0, 0, 0, 0, 0), RangeError);
-      throws(() => TimeDuration.normalize(0, 150119987579017, 0, 0, 0, 0), RangeError);
-      throws(() => TimeDuration.normalize(0, -150119987579017, 0, 0, 0, 0), RangeError);
-      throws(() => TimeDuration.normalize(0, 0, 2 ** 53, 0, 0, 0), RangeError);
-      throws(() => TimeDuration.normalize(0, 0, -(2 ** 53), 0, 0, 0), RangeError);
-      throws(() => TimeDuration.normalize(0, 0, Number.MAX_SAFE_INTEGER, 1000, 0, 0), RangeError);
-      throws(() => TimeDuration.normalize(0, 0, -Number.MAX_SAFE_INTEGER, -1000, 0, 0), RangeError);
-      throws(() => TimeDuration.normalize(0, 0, Number.MAX_SAFE_INTEGER, 0, 1000000, 0), RangeError);
-      throws(() => TimeDuration.normalize(0, 0, -Number.MAX_SAFE_INTEGER, 0, -1000000, 0), RangeError);
-      throws(() => TimeDuration.normalize(0, 0, Number.MAX_SAFE_INTEGER, 0, 0, 1000000000), RangeError);
-      throws(() => TimeDuration.normalize(0, 0, -Number.MAX_SAFE_INTEGER, 0, 0, -1000000000), RangeError);
+      throws(() => TimeDuration.fromComponents(2501999792984, 0, 0, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(-2501999792984, 0, 0, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(0, 150119987579017, 0, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(0, -150119987579017, 0, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(0, 0, 2 ** 53, 0, 0, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(0, 0, -(2 ** 53), 0, 0, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(0, 0, Number.MAX_SAFE_INTEGER, 1000, 0, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(0, 0, -Number.MAX_SAFE_INTEGER, -1000, 0, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(0, 0, Number.MAX_SAFE_INTEGER, 0, 1000000, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(0, 0, -Number.MAX_SAFE_INTEGER, 0, -1000000, 0), RangeError);
+      throws(() => TimeDuration.fromComponents(0, 0, Number.MAX_SAFE_INTEGER, 0, 0, 1000000000), RangeError);
+      throws(() => TimeDuration.fromComponents(0, 0, -Number.MAX_SAFE_INTEGER, 0, 0, -1000000000), RangeError);
     });
   });
 
@@ -343,7 +343,7 @@ describe('Normalized time duration', () => {
     });
 
     it('quotient larger than seconds', () => {
-      const d = TimeDuration.normalize(25 + 5 * 24, 0, 86401, 333, 666, 999);
+      const d = TimeDuration.fromComponents(25 + 5 * 24, 0, 86401, 333, 666, 999);
       const { quotient, remainder } = d.divmod(86400e9);
       equal(quotient, 7);
       check(remainder, 3601, 333666999);
@@ -401,7 +401,7 @@ describe('Normalized time duration', () => {
     });
 
     it('quotient larger than seconds', () => {
-      const d = TimeDuration.normalize(25 + 5 * 24, 0, 86401, 333, 666, 999);
+      const d = TimeDuration.fromComponents(25 + 5 * 24, 0, 86401, 333, 666, 999);
       checkFloat(d.fdiv(86400e9), 7.041682102627303);
     });
 

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -110,9 +110,9 @@
         1. Else,
           1. Let _days1_ be _one_.[[Days]].
           1. Let _days2_ be _two_.[[Days]].
-        1. Let _norm1_ be ? Add24HourDaysToNormalizedTimeDuration(_duration1_.[[NormalizedTime]], _days1_).
-        1. Let _norm2_ be ? Add24HourDaysToNormalizedTimeDuration(_duration2_.[[NormalizedTime]], _days2_).
-        1. Return 𝔽(CompareNormalizedTimeDuration(_norm1_, _norm2_)).
+        1. Let _timeDuration1_ be ? Add24HourDaysToTimeDuration(_duration1_.[[Time]], _days1_).
+        1. Let _timeDuration2_ be ? Add24HourDaysToTimeDuration(_duration2_.[[Time]], _days2_).
+        1. Return 𝔽(CompareTimeDuration(_timeDuration1_, _timeDuration2_)).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -437,7 +437,7 @@
           1. Return ? TemporalDurationFromInternal(_internalDuration_, _largestUnit_).
         1. If _plainRelativeTo_ is not *undefined*, then
           1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
-          1. Let _targetTime_ be AddTime(MidnightTimeRecord(), _internalDuration_.[[NormalizedTime]]).
+          1. Let _targetTime_ be AddTime(MidnightTimeRecord(), _internalDuration_.[[Time]]).
           1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
           1. Let _dateDuration_ be ! AdjustDateDurationRecord(_internalDuration_.[[Date]], _targetTime_.[[Days]]).
           1. Let _targetDate_ be ? CalendarDateAdd(_calendar_, _plainRelativeTo_.[[ISODate]], _dateDuration_, ~constrain~).
@@ -480,7 +480,7 @@
           1. Let _total_ be ? DifferenceZonedDateTimeWithTotal(_relativeEpochNs_, _targetEpochNs_, _timeZone_, _calendar_, _unit_).
         1. Else if _plainRelativeTo_ is not *undefined*, then
           1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
-          1. Let _targetTime_ be AddTime(MidnightTimeRecord(), _internalDuration_.[[NormalizedTime]]).
+          1. Let _targetTime_ be AddTime(MidnightTimeRecord(), _internalDuration_.[[Time]]).
           1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
           1. Let _dateDuration_ be ! AdjustDateDurationRecord(_internalDuration_.[[Date]], _targetTime_.[[Days]]).
           1. Let _targetDate_ be ? CalendarDateAdd(_calendar_, _plainRelativeTo_.[[ISODate]], _dateDuration_, ~constrain~).
@@ -812,41 +812,18 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalized-time-duration-records">
-      <h1>Normalized Time Duration Records</h1>
-      <p>
-        A <dfn variants="Normalized Time Duration Records">Normalized Time Duration Record</dfn> is a Record value used to represent the portion of a Temporal.Duration object that deals with time units, but as a combined value.
-        Normalized Time Duration Records are produced by the abstract operation NormalizeTimeDuration, among others.
-      </p>
-      <p>Normalized Time Duration Records have the fields listed in <emu-xref href="#table-temporal-normalized-time-duration-record-fields"></emu-xref>.</p>
-      <emu-table id="table-temporal-normalized-time-duration-record-fields" caption="Normalized Time Duration Record Fields">
-        <table class="real-table">
-          <tr>
-            <th>Field Name</th>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-          <tr>
-            <td>[[TotalNanoseconds]]</td>
-            <td>
-              an integer in the inclusive interval from -maxTimeDuration to maxTimeDuration, where
-              <emu-eqn id="eqn-maxTimeDuration" aoid="maxTimeDuration">
-                maxTimeDuration = 2<sup>53</sup> × 10<sup>9</sup> - 1 = 9,007,199,254,740,991,999,999,999
-              </emu-eqn>
-            </td>
-            <td>
-              The number of nanoseconds in the duration.
-            </td>
-          </tr>
-        </table>
-      </emu-table>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-internal-duration-records">
       <h1>Internal Duration Records</h1>
       <p>
-        A <dfn variants="Internal Duration Records">Internal Duration Record</dfn> is a Record value used to represent the combination of a Date Duration Record with a Normalized Time Duration Record.
+        A <dfn variants="Internal Duration Records">Internal Duration Record</dfn> is a Record value used to represent the combination of a Date Duration Record with a time duration.
         Such Records are used by operations that deal with both date and time portions of durations, such as RoundTimeDuration.
+      </p>
+      <p>
+        A <dfn>time duration</dfn> is an integer in the inclusive interval from -maxTimeDuration to maxTimeDuration, where
+        <emu-eqn id="eqn-maxTimeDuration" aoid="maxTimeDuration">
+          maxTimeDuration = 2<sup>53</sup> × 10<sup>9</sup> - 1 = 9,007,199,254,740,991,999,999,999
+        </emu-eqn>
+        It represents the portion of a Temporal.Duration object that deals with time units, but as a combined value of total nanoseconds.
       </p>
       <p>Internal Duration Records have the fields listed in <emu-xref href="#table-temporal-normalized-duration-record-fields"></emu-xref>.</p>
       <emu-table id="table-temporal-normalized-duration-record-fields" caption="Internal Duration Record Fields">
@@ -864,8 +841,8 @@
             </td>
           </tr>
           <tr>
-            <td>[[NormalizedTime]]</td>
-            <td>a Normalized Time Duration Record</td>
+            <td>[[Time]]</td>
+            <td>a time duration</td>
             <td>
               The time portion of the duration.
             </td>
@@ -893,12 +870,12 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _duration_ into its internal form, for use in duration calculations that may involve time zones. The duration's days are kept separate and not converted into the [[NormalizedTime]] field.</dd>
+        <dd>It converts _duration_ into its internal form, for use in duration calculations that may involve time zones. The duration's days are kept separate and not converted into the [[Time]] field.</dd>
       </dl>
       <emu-alg>
         1. Let _dateDuration_ be ! CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]]).
-        1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Return ! CombineDateAndNormalizedTimeDuration(_dateDuration_, _norm_).
+        1. Let _timeDuration_ be TimeDurationFromComponents(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Return ! CombineDateAndTimeDuration(_dateDuration_, _timeDuration_).
       </emu-alg>
     </emu-clause>
 
@@ -910,13 +887,13 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _duration_ into its internal form, for use in duration calculations that do not involve time zones. The duration's days are assumed to be uniformly 24 hours, and the [[Date]].[[Days]] field of the returned Record is set to 0, while the [[NormalizedTime]] field includes the days.</dd>
+        <dd>It converts _duration_ into its internal form, for use in duration calculations that do not involve time zones. The duration's days are assumed to be uniformly 24 hours, and the [[Date]].[[Days]] field of the returned Record is set to 0, while the [[Time]] field includes the days.</dd>
       </dl>
       <emu-alg>
-        1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. Set _norm_ to ! Add24HourDaysToNormalizedTimeDuration(_norm_, _duration_.[[Days]]).
+        1. Let _timeDuration_ be TimeDurationFromComponents(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. Set _timeDuration_ to ! Add24HourDaysToTimeDuration(_timeDuration_, _duration_.[[Days]]).
         1. Let _dateDuration_ be ! CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], 0).
-        1. Return ! CombineDateAndNormalizedTimeDuration(_dateDuration_, _norm_).
+        1. Return ! CombineDateAndTimeDuration(_dateDuration_, _timeDuration_).
       </emu-alg>
     </emu-clause>
 
@@ -932,7 +909,7 @@
       </dl>
       <emu-alg>
         1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
-        1. Let _days_ be truncate(NormalizedTimeDurationSeconds(_internalDuration_.[[NormalizedTime]]) / 86400).
+        1. Let _days_ be truncate(TimeDurationSeconds(_internalDuration_.[[Time]]) / 86400).
         1. Return ? CreateDateDurationRecord(_internalDuration_.[[Date]].[[Years]], _internalDuration_.[[Date]].[[Months]], _internalDuration_.[[Date]].[[Weeks]], _days_).
       </emu-alg>
     </emu-clause>
@@ -956,8 +933,8 @@
       </dl>
       <emu-alg>
         1. Let _days_, _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ be 0.
-        1. Let _sign_ be NormalizedTimeDurationSign(_internalDuration_.[[NormalizedTime]]).
-        1. Let _nanoseconds_ be abs(_internalDuration_.[[NormalizedTime]].[[TotalNanoseconds]]).
+        1. Let _sign_ be TimeDurationSign(_internalDuration_.[[Time]]).
+        1. Let _nanoseconds_ be abs(_internalDuration_.[[Time]]).
         1. If TemporalUnitCategory(_largestUnit_) is ~date~, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
@@ -1057,11 +1034,11 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-combinedateandnormalizedtimeduration" type="abstract operation">
+    <emu-clause id="sec-temporal-combinedateandtimeduration" type="abstract operation">
       <h1>
-        CombineDateAndNormalizedTimeDuration (
+        CombineDateAndTimeDuration (
           _dateDuration_: a Date Duration Record,
-          _norm_: a Normalized Time Duration Record,
+          _timeDuration_: a time duration,
         ): either a normal completion containing an Internal Duration Record or a throw completion
       </h1>
       <dl class="header">
@@ -1070,11 +1047,11 @@
       </dl>
       <emu-alg>
         1. Let _dateSign_ be DateDurationSign(_dateDuration_).
-        1. Let _timeSign_ be NormalizedTimeDurationSign(_norm_).
+        1. Let _timeSign_ be TimeDurationSign(_timeDuration_).
         1. If _dateSign_ ≠ 0 and _timeSign_ ≠ 0 and _dateSign_ ≠ _timeSign_, throw a *RangeError* exception.
         1. Return Internal Duration Record {
           [[Date]]: _dateDuration_,
-          [[NormalizedTime]]: _norm_
+          [[Time]]: _timeDuration_
           }.
       </emu-alg>
     </emu-clause>
@@ -1160,7 +1137,7 @@
       <emu-alg>
         1. Let _dateSign_ be DateDurationSign(_internalDuration_.[[Date]]).
         1. If _dateSign_ ≠ 0, return _dateSign_.
-        1. Return NormalizedTimeDurationSign(_internalDuration_.[[NormalizedTime]]).
+        1. Return TimeDurationSign(_internalDuration_.[[Time]]).
       </emu-alg>
     </emu-clause>
 
@@ -1196,9 +1173,9 @@
         1. If abs(_years_) ≥ 2<sup>32</sup>, return *false*.
         1. If abs(_months_) ≥ 2<sup>32</sup>, return *false*.
         1. If abs(_weeks_) ≥ 2<sup>32</sup>, return *false*.
-        1. Let _normalizedSeconds_ be _days_ × 86,400 + _hours_ × 3600 + _minutes_ × 60 + _seconds_ + ℝ(𝔽(_milliseconds_)) × 10<sup>-3</sup> + ℝ(𝔽(_microseconds_)) × 10<sup>-6</sup> + ℝ(𝔽(_nanoseconds_)) × 10<sup>-9</sup>.
+        1. Let _totalFractionalSeconds_ be _days_ × 86,400 + _hours_ × 3600 + _minutes_ × 60 + _seconds_ + ℝ(𝔽(_milliseconds_)) × 10<sup>-3</sup> + ℝ(𝔽(_microseconds_)) × 10<sup>-6</sup> + ℝ(𝔽(_nanoseconds_)) × 10<sup>-9</sup>.
         1. NOTE: The above step cannot be implemented directly using floating-point arithmetic. Multiplying by 10<sup>-3</sup>, 10<sup>-6</sup>, and 10<sup>-9</sup> respectively may be imprecise when _milliseconds_, _microseconds_, or _nanoseconds_ is an unsafe integer. This multiplication can be implemented in C++ with an implementation of `std::remquo()` with sufficient bits in the quotient. String manipulation will also give an exact result, since the multiplication is by a power of 10.
-        1. If abs(_normalizedSeconds_) ≥ 2<sup>53</sup>, return *false*.
+        1. If abs(_totalFractionalSeconds_) ≥ 2<sup>53</sup>, return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>
@@ -1320,23 +1297,23 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalizetimeduration" type="abstract operation">
+    <emu-clause id="sec-temporal-timedurationfromcomponents" type="abstract operation">
       <h1>
-        NormalizeTimeDuration (
+        TimeDurationFromComponents (
           _hours_: an integer,
           _minutes_: an integer,
           _seconds_: an integer,
           _milliseconds_: an integer,
           _microseconds_: an integer,
           _nanoseconds_: an integer,
-        ): a Normalized Time Duration Record
+        ): a time duration
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          From the given units, it computes a normalized time duration consisting of whole seconds, and subseconds expressed in nanoseconds.
-          The normalized time duration can be stored losslessly in two 64-bit floating point numbers.
-          Alternatively, _normalizedSeconds_ × 10<sup>9</sup> + _subseconds_ can be stored as a 96-bit integer.
+          From the given units, it computes a time duration consisting of total nanoseconds.
+          The time duration can be stored losslessly in two 64-bit floating point numbers consisting of truncate(_nanoseconds_ / 10<sup>9</sup>) and remainder(_nanoseconds_, 10<sup>9</sup>).
+          Alternatively, _nanoseconds_ can be stored as a 96-bit integer.
         </dd>
       </dl>
       <emu-alg>
@@ -1346,145 +1323,145 @@
         1. Set _microseconds_ to _microseconds_ + _milliseconds_ × 1000.
         1. Set _nanoseconds_ to _nanoseconds_ + _microseconds_ × 1000.
         1. Assert: abs(_nanoseconds_) ≤ maxTimeDuration.
-        1. Return Normalized Time Duration Record { [[TotalNanoseconds]]: _nanoseconds_ }.
+        1. Return _nanoseconds_.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-addnormalizedtimeduration" type="abstract operation">
+    <emu-clause id="sec-temporal-addtimeduration" type="abstract operation">
       <h1>
-        AddNormalizedTimeDuration (
-          _one_: a Normalized Time Duration Record,
-          _two_: a Normalized Time Duration Record,
-        ): either a normal completion containing a Normalized Time Duration Record or a throw completion
+        AddTimeDuration (
+          _one_: a time duration,
+          _two_: a time duration,
+        ): either a normal completion containing a time duration or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a normalized time duration that is the sum of _one_ and _two_, throwing an exception if the result is greater than the maximum normalized time duration.</dd>
+        <dd>It returns a time duration that is the sum of _one_ and _two_, throwing an exception if the result is greater than the maximum time duration.</dd>
       </dl>
       <emu-alg>
-        1. Let _result_ be _one_.[[TotalNanoseconds]] + _two_.[[TotalNanoseconds]].
+        1. Let _result_ be _one_ + _two_.
         1. If abs(_result_) > maxTimeDuration, throw a *RangeError* exception.
-        1. Return Normalized Time Duration Record { [[TotalNanoseconds]]: _result_ }.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal-add24hourdaystonormalizedtimeduration" type="abstract operation">
       <h1>
-        Add24HourDaysToNormalizedTimeDuration (
-          _d_: a Normalized Time Duration Record,
+        Add24HourDaysToTimeDuration (
+          _d_: a time duration,
           _days_: an integer,
-        ): either a normal completion containing a Normalized Time Duration Record or a throw completion
+        ): either a normal completion containing a time duration or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It returns a normalized time duration that is the sum of _d_ and the number of 24-hour days indicated by _days_, throwing an exception if the result is greater than the maximum normalized time duration.
+          It returns a time duration that is the sum of _d_ and the number of 24-hour days indicated by _days_, throwing an exception if the result is greater than the maximum time duration.
           This operation should not be used when adding days relative to a Temporal.ZonedDateTime, since the days may not be 24 hours long.
         </dd>
       </dl>
       <emu-alg>
-        1. Let _result_ be _d_.[[TotalNanoseconds]] + _days_ × nsPerDay.
+        1. Let _result_ be _d_ + _days_ × nsPerDay.
         1. If abs(_result_) > maxTimeDuration, throw a *RangeError* exception.
-        1. Return Normalized Time Duration Record { [[TotalNanoseconds]]: _result_ }.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-addnormalizedtimedurationtoepochnanoseconds" type="abstract operation">
+    <emu-clause id="sec-temporal-addtimedurationtoepochnanoseconds" type="abstract operation">
       <h1>
-        AddNormalizedTimeDurationToEpochNanoseconds (
-          _d_: a Normalized Time Duration Record,
+        AddTimeDurationToEpochNanoseconds (
+          _d_: a time duration,
           _epochNs_: a BigInt,
         ): a BigInt
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It adds a normalized time duration _d_ to an exact time in nanoseconds since the epoch, _epochNs_, and returns a new exact time.
+          It adds a time duration _d_ to an exact time in nanoseconds since the epoch, _epochNs_, and returns a new exact time.
           The returned exact time is not required to be valid according to IsValidEpochNanoseconds.
         </dd>
       </dl>
       <emu-alg>
-        1. Return _epochNs_ + ℤ(_d_.[[TotalNanoseconds]]).
+        1. Return _epochNs_ + ℤ(_d_).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-comparenormalizedtimeduration" type="abstract operation">
+    <emu-clause id="sec-temporal-comparetimeduration" type="abstract operation">
       <h1>
-        CompareNormalizedTimeDuration (
-          _one_: a Normalized Time Duration Record,
-          _two_: a Normalized Time Duration Record,
+        CompareTimeDuration (
+          _one_: a time duration,
+          _two_: a time duration,
         ): -1, 0, or 1
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It performs a comparison of two Normalized Time Duration Records.</dd>
+        <dd>It performs a comparison of two time durations.</dd>
       </dl>
       <emu-alg>
-        1. If _one_.[[TotalNanoseconds]] > _two_.[[TotalNanoseconds]], return 1.
-        1. If _one_.[[TotalNanoseconds]] &lt; _two_.[[TotalNanoseconds]], return -1.
+        1. If _one_ > _two_, return 1.
+        1. If _one_ &lt; _two_, return -1.
         1. Return 0.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-dividenormalizedtimeduration" type="abstract operation">
+    <emu-clause id="sec-temporal-dividetimeduration" type="abstract operation">
       <h1>
-        DivideNormalizedTimeDuration (
-          _d_: a Normalized Time Duration Record,
+        DivideTimeDuration (
+          _d_: a time duration,
           _divisor_: an integer,
         ): a mathematical value
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It divides the total number of nanoseconds in the normalized time duration _d_ by _divisor_.</dd>
+        <dd>It divides the total number of nanoseconds in the time duration _d_ by _divisor_.</dd>
       </dl>
       <emu-alg>
         1. Assert: _divisor_ ≠ 0.
-        1. NOTE: The following step cannot be implemented directly using floating-point arithmetic when 𝔽(_d_.[[TotalNanoseconds]]) is not a safe integer. The division can be implemented in C++ with the `__float128` type if the compiler supports it, or with software emulation such as in the <a href="https://bellard.org/softfp/">SoftFP</a> library.
-        1. Return _d_.[[TotalNanoseconds]] / _divisor_.
+        1. NOTE: The following step cannot be implemented directly using floating-point arithmetic when 𝔽(_d_) is not a safe integer. The division can be implemented in C++ with the `__float128` type if the compiler supports it, or with software emulation such as in the <a href="https://bellard.org/softfp/">SoftFP</a> library.
+        1. Return _d_ / _divisor_.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalizedtimedurationfromepochnanosecondsdifference" type="abstract operation">
+    <emu-clause id="sec-temporal-timedurationfromepochnanosecondsdifference" type="abstract operation">
       <h1>
-        NormalizedTimeDurationFromEpochNanosecondsDifference (
+        TimeDurationFromEpochNanosecondsDifference (
           _one_: a BigInt,
           _two_: a BigInt,
-        ): a Normalized Time Duration Record
+        ): a time duration
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It creates a Normalized Time Duration Record with the difference between two exact times in nanoseconds since the epoch, which must not be greater than the maximum normalized time duration.</dd>
+        <dd>The returned time duration is the difference between two exact times in nanoseconds since the epoch, which must not be greater than the maximum time duration.</dd>
       </dl>
       <emu-alg>
         1. Let _result_ be ℝ(_one_) - ℝ(_two_).
         1. Assert: abs(_result_) ≤ maxTimeDuration.
-        1. Return Normalized Time Duration Record { [[TotalNanoseconds]]: _result_ }.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-roundnormalizedtimedurationtoincrement" type="abstract operation">
+    <emu-clause id="sec-temporal-roundtimedurationtoincrement" type="abstract operation">
       <h1>
-        RoundNormalizedTimeDurationToIncrement (
-          _d_: a Normalized Time Duration Record,
+        RoundTimeDurationToIncrement (
+          _d_: a time duration,
           _increment_: a positive integer,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Normalized Time Duration Record or a throw completion
+        ): either a normal completion containing a time duration or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It rounds the total number of nanoseconds in the normalized time duration _d_ to the nearest multiple of _increment_, up or down according to _roundingMode_.</dd>
+        <dd>It rounds the total number of nanoseconds in the time duration _d_ to the nearest multiple of _increment_, up or down according to _roundingMode_.</dd>
       </dl>
       <emu-alg>
-        1. Let _rounded_ be RoundNumberToIncrement(_d_.[[TotalNanoseconds]], _increment_, _roundingMode_).
+        1. Let _rounded_ be RoundNumberToIncrement(_d_, _increment_, _roundingMode_).
         1. If abs(_rounded_) > maxTimeDuration, throw a *RangeError* exception.
-        1. Return Normalized Time Duration Record { [[TotalNanoseconds]]: _rounded_ }.
+        1. Return _rounded_.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalizedtimedurationseconds" type="abstract operation">
+    <emu-clause id="sec-temporal-timedurationseconds" type="abstract operation">
       <h1>
-        NormalizedTimeDurationSeconds (
-          _d_: a Normalized Time Duration Record,
+        TimeDurationSeconds (
+          _d_: a time duration,
         ): an integer in the interval from -2<sup>53</sup> (exclusive) to 2<sup>53</sup> (exclusive)
       </h1>
       <dl class="header">
@@ -1492,14 +1469,14 @@
         <dd>It returns the integer number of seconds in _d_.</dd>
       </dl>
       <emu-alg>
-        1. Return truncate(_d_.[[TotalNanoseconds]] / 10<sup>9</sup>).
+        1. Return truncate(_d_ / 10<sup>9</sup>).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalizedtimedurationsign" type="abstract operation">
+    <emu-clause id="sec-temporal-timedurationsign" type="abstract operation">
       <h1>
-        NormalizedTimeDurationSign (
-          _d_: a Normalized Time Duration Record,
+        TimeDurationSign (
+          _d_: a time duration,
         ): -1, 0, or 1
       </h1>
       <dl class="header">
@@ -1507,16 +1484,16 @@
         <dd>It returns 0 if the duration is zero, or ±1 depending on the sign of the duration.</dd>
       </dl>
       <emu-alg>
-        1. If _d_.[[TotalNanoseconds]] &lt; 0, return -1.
-        1. If _d_.[[TotalNanoseconds]] > 0, return 1.
+        1. If _d_ &lt; 0, return -1.
+        1. If _d_ > 0, return 1.
         1. Return 0.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalizedtimedurationsubseconds" type="abstract operation">
+    <emu-clause id="sec-temporal-timedurationsubseconds" type="abstract operation">
       <h1>
-        NormalizedTimeDurationSubseconds (
-          _d_: a Normalized Time Duration Record,
+        TimeDurationSubseconds (
+          _d_: a time duration,
         ): an integer in the interval from -10<sup>9</sup> (exclusive) to 10<sup>9</sup> (exclusive)
       </h1>
       <dl class="header">
@@ -1524,36 +1501,36 @@
         <dd>It returns the integer number of nanoseconds in the subsecond part of _d_.</dd>
       </dl>
       <emu-alg>
-        1. Return remainder(_d_.[[TotalNanoseconds]], 10<sup>9</sup>).
+        1. Return remainder(_d_, 10<sup>9</sup>).
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-subtractnormalizedtimeduration" type="abstract operation">
+    <emu-clause id="sec-temporal-subtracttimeduration" type="abstract operation">
       <h1>
-        SubtractNormalizedTimeDuration (
-          _one_: a Normalized Time Duration Record,
-          _two_: a Normalized Time Duration Record,
-        ): either a normal completion containing a Normalized Time Duration Record or a throw completion
+        SubtractTimeDuration (
+          _one_: a time duration,
+          _two_: a time duration,
+        ): either a normal completion containing a time duration or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a normalized time duration that is the difference between _one_ and _two_, throwing an exception if the result is greater than the maximum normalized time duration.</dd>
+        <dd>It returns a time duration that is the difference between _one_ and _two_, throwing an exception if the result is greater than the maximum time duration.</dd>
       </dl>
       <emu-alg>
-        1. Let _result_ be _one_.[[TotalNanoseconds]] - _two_.[[TotalNanoseconds]].
+        1. Let _result_ be _one_ - _two_.
         1. If abs(_result_) > maxTimeDuration, throw a *RangeError* exception.
-        1. Return Normalized Time Duration Record { [[TotalNanoseconds]]: _result_ }.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-zerotimeduration" type="abstract operation">
-      <h1>ZeroTimeDuration ( ): a Normalized Time Duration Record</h1>
+      <h1>ZeroTimeDuration ( ): a time duration</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns a normalized time duration of zero length.</dd>
+        <dd>It returns a time duration of zero length.</dd>
       </dl>
       <emu-alg>
-        1. Return Normalized Time Duration Record { [[TotalNanoseconds]]: 0 }.
+        1. Return 0.
       </emu-alg>
     </emu-clause>
 
@@ -1596,21 +1573,21 @@
       </dl>
       <emu-alg>
         1. If _unit_ is ~day~, then
-          1. Let _fractionalDays_ be _duration_.[[Date]].[[Days]] + DivideNormalizedTimeDuration(_duration_.[[NormalizedTime]], nsPerDay).
+          1. Let _fractionalDays_ be _duration_.[[Date]].[[Days]] + DivideTimeDuration(_duration_.[[Time]], nsPerDay).
           1. Let _days_ be RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
           1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _days_).
-          1. Return ! CombineDateAndNormalizedTimeDuration(_dateDuration_, ZeroTimeDuration()).
+          1. Return ! CombineDateAndTimeDuration(_dateDuration_, ZeroTimeDuration()).
         1. Assert: TemporalUnitCategory(_unit_) is ~time~.
         1. Let _divisor_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _unit_.
-        1. Let _norm_ be ? RoundNormalizedTimeDurationToIncrement(_duration_.[[NormalizedTime]], _divisor_ × _increment_, _roundingMode_).
-        1. Return ? CombineDateAndNormalizedTimeDuration(_duration_.[[Date]], _norm_).
+        1. Let _rounded_ be ? RoundTimeDurationToIncrement(_duration_.[[Time]], _divisor_ × _increment_, _roundingMode_).
+        1. Return ? CombineDateAndTimeDuration(_duration_.[[Date]], _rounded_).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal-totaltimeduration" type="abstract operation">
       <h1>
         TotalTimeDuration (
-          _norm_: a Normalized Time Duration Record,
+          _timeDuration_: a time duration,
           _unit_: a time unit or ~day~,
         ): a mathematical value
       </h1>
@@ -1620,7 +1597,7 @@
       </dl>
       <emu-alg>
         1. Let _divisor_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _unit_.
-        1. Return DivideNormalizedTimeDuration(_norm_, _divisor_).
+        1. Return DivideTimeDuration(_timeDuration_, _divisor_).
       </emu-alg>
     </emu-clause>
 
@@ -1729,7 +1706,7 @@
         1. Assert: _startEpochNs_ ≠ _endEpochNs_.
         1. Let _progress_ be (_destEpochNs_ - _startEpochNs_) / (_endEpochNs_ - _startEpochNs_).
         1. Let _total_ be _r1_ + _progress_ × _increment_ × _sign_.
-        1. NOTE: The above two steps cannot be implemented directly using floating-point arithmetic. This division can be implemented as if constructing Normalized Time Duration Records for the denominator and numerator of _total_ and performing one division operation with a floating-point result.
+        1. NOTE: The above two steps cannot be implemented directly using floating-point arithmetic. This division can be implemented as if expressing the denominator and numerator of _total_ as two time durations, and performing one division operation with a floating-point result.
         1. Assert: 0 ≤ _progress_ ≤ 1.
         1. If _sign_ &lt; 0, let _isNegative_ be ~negative~; else let _isNegative_ be ~positive~.
         1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_roundingMode_, _isNegative_).
@@ -1746,7 +1723,7 @@
           1. Let _didExpandCalendarUnit_ be *false*.
           1. Let _resultDuration_ be _startDuration_.
           1. Let _nudgedEpochNs_ be _startEpochNs_.
-        1. Set _resultDuration_ to ! CombineDateAndNormalizedTimeDuration(_resultDuration_, ZeroTimeDuration()).
+        1. Set _resultDuration_ to ! CombineDateAndTimeDuration(_resultDuration_, ZeroTimeDuration()).
         1. Let _nudgeResult_ be Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandCalendarUnit_ }.
         1. Return the Record { [[NudgeResult]]: _nudgeResult_, [[Total]]: _total_ }.
       </emu-alg>
@@ -1778,22 +1755,22 @@
         1. Let _endDateTime_ be CombineISODateAndTimeRecord(_endDate_, _isoDateTime_.[[Time]]).
         1. Let _startEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _startDateTime_, ~compatible~).
         1. Let _endEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _endDateTime_, ~compatible~).
-        1. Let _daySpan_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_endEpochNs_, _startEpochNs_).
-        1. Assert: NormalizedTimeDurationSign(_daySpan_) = _sign_.
+        1. Let _daySpan_ be TimeDurationFromEpochNanosecondsDifference(_endEpochNs_, _startEpochNs_).
+        1. Assert: TimeDurationSign(_daySpan_) = _sign_.
         1. Let _unitLength_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _unit_.
-        1. Let _roundedNorm_ be ? RoundNormalizedTimeDurationToIncrement(_duration_.[[NormalizedTime]], _increment_ × _unitLength_, _roundingMode_).
-        1. Let _beyondDaySpan_ be ? SubtractNormalizedTimeDuration(_roundedNorm_, _daySpan_).
-        1. If NormalizedTimeDurationSign(_beyondDaySpan_) ≠ -_sign_, then
+        1. Let _roundedTimeDuration_ be ? RoundTimeDurationToIncrement(_duration_.[[Time]], _increment_ × _unitLength_, _roundingMode_).
+        1. Let _beyondDaySpan_ be ? SubtractTimeDuration(_roundedTimeDuration_, _daySpan_).
+        1. If TimeDurationSign(_beyondDaySpan_) ≠ -_sign_, then
           1. Let _didRoundBeyondDay_ be *true*.
           1. Let _dayDelta_ be _sign_.
-          1. Set _roundedNorm_ to ? RoundNormalizedTimeDurationToIncrement(_beyondDaySpan_, _increment_ × _unitLength_, _roundingMode_).
-          1. Let _nudgedEpochNs_ be AddNormalizedTimeDurationToEpochNanoseconds(_roundedNorm_, _endEpochNs_).
+          1. Set _roundedTimeDuration_ to ? RoundTimeDurationToIncrement(_beyondDaySpan_, _increment_ × _unitLength_, _roundingMode_).
+          1. Let _nudgedEpochNs_ be AddTimeDurationToEpochNanoseconds(_roundedTimeDuration_, _endEpochNs_).
         1. Else,
           1. Let _didRoundBeyondDay_ be *false*.
           1. Let _dayDelta_ be 0.
-          1. Let _nudgedEpochNs_ be AddNormalizedTimeDurationToEpochNanoseconds(_roundedNorm_, _startEpochNs_).
+          1. Let _nudgedEpochNs_ be AddTimeDurationToEpochNanoseconds(_roundedTimeDuration_, _startEpochNs_).
         1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _duration_.[[Date]].[[Days]] + _dayDelta_).
-        1. Let _resultDuration_ be ? CombineDateAndNormalizedTimeDuration(_dateDuration_, _roundedNorm_).
+        1. Let _resultDuration_ be ? CombineDateAndTimeDuration(_dateDuration_, _roundedTimeDuration_).
         1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didRoundBeyondDay_ }.
       </emu-alg>
     </emu-clause>
@@ -1816,23 +1793,23 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Let _norm_ be ! Add24HourDaysToNormalizedTimeDuration(_duration_.[[NormalizedTime]], _duration_.[[Date]].[[Days]]).
+        1. Let _timeDuration_ be ! Add24HourDaysToTimeDuration(_duration_.[[Time]], _duration_.[[Date]].[[Days]]).
         1. Let _unitLength_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _smallestUnit_.
-        1. Let _roundedNorm_ be ? RoundNormalizedTimeDurationToIncrement(_norm_, _unitLength_ × _increment_, _roundingMode_).
-        1. Let _diffNorm_ be ! SubtractNormalizedTimeDuration(_roundedNorm_, _norm_).
-        1. Let _wholeDays_ be truncate(DivideNormalizedTimeDuration(_norm_, nsPerDay)).
-        1. Let _roundedWholeDays_ be truncate(DivideNormalizedTimeDuration(_roundedNorm_, nsPerDay)).
+        1. Let _roundedNorm_ be ? RoundTimeDurationToIncrement(_timeDuration_, _unitLength_ × _increment_, _roundingMode_).
+        1. Let _diffNorm_ be ! SubtractTimeDuration(_roundedNorm_, _timeDuration_).
+        1. Let _wholeDays_ be truncate(DivideTimeDuration(_timeDuration_, nsPerDay)).
+        1. Let _roundedWholeDays_ be truncate(DivideTimeDuration(_roundedNorm_, nsPerDay)).
         1. Let _dayDelta_ be _roundedWholeDays_ - _wholeDays_.
         1. If _dayDelta_ &lt; 0, let _dayDeltaSign_ be -1; else if _dayDelta_ > 0, let _dayDeltaSign_ be 1; else let _dayDeltaSign_ be 0.
-        1. If _dayDeltaSign_ = NormalizedTimeDurationSign(_norm_), let _didExpandDays_ be *true*; else let _didExpandDays_ be *false*.
-        1. Let _nudgedEpochNs_ be AddNormalizedTimeDurationToEpochNanoseconds(_diffNorm_, _destEpochNs_).
+        1. If _dayDeltaSign_ = TimeDurationSign(_timeDuration_), let _didExpandDays_ be *true*; else let _didExpandDays_ be *false*.
+        1. Let _nudgedEpochNs_ be AddTimeDurationToEpochNanoseconds(_diffNorm_, _destEpochNs_).
         1. Let _days_ be 0.
         1. Let _remainder_ be _roundedNorm_.
         1. If TemporalUnitCategory(_largestUnit_) is ~date~, then
           1. Set _days_ to _roundedWholeDays_.
-          1. Set _remainder_ to ! SubtractNormalizedTimeDuration(_roundedNorm_, NormalizeTimeDuration(_roundedWholeDays_ * HoursPerDay, 0, 0, 0, 0, 0)).
+          1. Set _remainder_ to ! SubtractTimeDuration(_roundedNorm_, TimeDurationFromComponents(_roundedWholeDays_ * HoursPerDay, 0, 0, 0, 0, 0)).
         1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _days_).
-        1. Let _resultDuration_ be ? CombineDateAndNormalizedTimeDuration(_dateDuration_, _remainder_).
+        1. Let _resultDuration_ be ? CombineDateAndTimeDuration(_dateDuration_, _remainder_).
         1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandDays_ }.
       </emu-alg>
     </emu-clause>
@@ -1884,7 +1861,7 @@
             1. Let _beyondEnd_ be _nudgedEpochNs_ - _endEpochNs_.
             1. If _beyondEnd_ &lt; 0, let _beyondEndSign_ be -1; else if _beyondEnd_ > 0, let _beyondEndSign_ be 1; else let _beyondEndSign_ be 0.
             1. If _beyondEndSign_ ≠ -_sign_, then
-              1. Set _duration_ to ! CombineDateAndNormalizedTimeDuration(_endDuration_, ZeroTimeDuration()).
+              1. Set _duration_ to ! CombineDateAndTimeDuration(_endDuration_, ZeroTimeDuration()).
             1. Else,
               1. Set _done_ to *true*.
           1. Set _unitIndex_ to _unitIndex_ - 1.
@@ -1952,8 +1929,8 @@
           1. Let _sign_ be InternalDurationSign(_duration_).
           1. Let _record_ be ? NudgeToCalendarUnit(_sign_, _duration_, _destEpochNs_, _isoDateTime_, _timeZone_, _calendar_, 1, _unit_, ~trunc~).
           1. Return _record_.[[Total]].
-        1. Let _norm_ be ! Add24HourDaysToNormalizedTimeDuration(_duration_.[[NormalizedTime]], _duration_.[[Date]].[[Days]]).
-        1. Return TotalTimeDuration(_norm_, _unit_).
+        1. Let _timeDuration_ be ! Add24HourDaysToTimeDuration(_duration_.[[Time]], _duration_.[[Date]].[[Days]]).
+        1. Return TotalTimeDuration(_timeDuration_, _unit_).
       </emu-alg>
     </emu-clause>
 
@@ -1986,10 +1963,10 @@
           1. Set _timePart_ to the string concatenation of _timePart_, abs(_duration_.[[Minutes]]) formatted as a decimal number, and the code unit 0x004D (LATIN CAPITAL LETTER M).
         1. Let _zeroMinutesAndHigher_ be *false*.
         1. If DefaultTemporalLargestUnit(_duration_) is ~second~, ~millisecond~, ~microsecond~, or ~nanosecond~, set _zeroMinutesAndHigher_ to *true*.
-        1. Let _normSeconds_ be NormalizeTimeDuration(0, 0, _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
-        1. If _normSeconds_.[[TotalNanoseconds]] ≠ 0, or _zeroMinutesAndHigher_ is *true*, or _precision_ is not ~auto~, then
-          1. Let _secondsPart_ be abs(NormalizedTimeDurationSeconds(_normSeconds_)) formatted as a decimal number.
-          1. Let _subSecondsPart_ be FormatFractionalSeconds(abs(NormalizedTimeDurationSubseconds(_normSeconds_)), _precision_).
+        1. Let _secondsDuration_ be TimeDurationFromComponents(0, 0, _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
+        1. If _secondsDuration_ ≠ 0, or _zeroMinutesAndHigher_ is *true*, or _precision_ is not ~auto~, then
+          1. Let _secondsPart_ be abs(TimeDurationSeconds(_secondsDuration_)) formatted as a decimal number.
+          1. Let _subSecondsPart_ be FormatFractionalSeconds(abs(TimeDurationSubseconds(_secondsDuration_)), _precision_).
           1. Set _timePart_ to the string concatenation of _timePart_, _secondsPart_, _subSecondsPart_, and the code unit 0x0053 (LATIN CAPITAL LETTER S).
         1. Let _signPart_ be the code unit 0x002D (HYPHEN-MINUS) if _sign_ &lt; 0, and otherwise the empty String.
         1. Let _result_ be the string concatenation of _signPart_, the code unit 0x0050 (LATIN CAPITAL LETTER P) and _datePart_.
@@ -2023,8 +2000,8 @@
         1. If IsCalendarUnit(_largestUnit_) is *true*, throw a *RangeError* exception.
         1. Let _d1_ be ToInternalDurationRecordWith24HourDays(_duration_).
         1. Let _d2_ be ToInternalDurationRecordWith24HourDays(_other_).
-        1. Let _normResult_ be ? AddNormalizedTimeDuration(_d1_.[[NormalizedTime]], _d2_.[[NormalizedTime]]).
-        1. Let _result_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), _normResult_).
+        1. Let _timeResult_ be ? AddTimeDuration(_d1_.[[Time]], _d2_.[[Time]]).
+        1. Let _result_ be ! CombineDateAndTimeDuration(ZeroDateDuration(), _timeResult_).
         1. Return ? TemporalDurationFromInternal(_result_, _largestUnit_).
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -434,7 +434,7 @@
           1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _internalDuration_, ~constrain~).
           1. Set _internalDuration_ to ? DifferenceZonedDateTimeWithRounding(_relativeEpochNs_, _targetEpochNs_, _timeZone_, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. If TemporalUnitCategory(_largestUnit_) is ~date~, set _largestUnit_ to ~hour~.
-          1. Return ? UnnormalizeDuration(_internalDuration_, _largestUnit_).
+          1. Return ? TemporalDurationFromInternal(_internalDuration_, _largestUnit_).
         1. If _plainRelativeTo_ is not *undefined*, then
           1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
           1. Let _targetTime_ be AddTime(MidnightTimeRecord(), _internalDuration_.[[NormalizedTime]]).
@@ -444,12 +444,12 @@
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_plainRelativeTo_.[[ISODate]], MidnightTimeRecord()).
           1. Let _targetDateTime_ be CombineISODateAndTimeRecord(_targetDate_, _targetTime_).
           1. Set _internalDuration_ to ? DifferencePlainDateTimeWithRounding(_isoDateTime_, _targetDateTime_, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Return ? UnnormalizeDuration(_internalDuration_, _largestUnit_).
+          1. Return ? TemporalDurationFromInternal(_internalDuration_, _largestUnit_).
         1. If IsCalendarUnit(_existingLargestUnit_) is *true*, or IsCalendarUnit(_largestUnit_) is *true*, throw a *RangeError* exception.
         1. Assert: IsCalendarUnit(_smallestUnit_) is *false*.
         1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
         1. Set _internalDuration_ to ? RoundTimeDuration(_internalDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Return ? UnnormalizeDuration(_internalDuration_, _largestUnit_).
+        1. Return ? TemporalDurationFromInternal(_internalDuration_, _largestUnit_).
       </emu-alg>
     </emu-clause>
 
@@ -515,7 +515,7 @@
         1. Let _internalDuration_ be ToInternalDurationRecord(_duration_).
         1. Set _internalDuration_ to ? RoundTimeDuration(_internalDuration_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Let _roundedLargestUnit_ be LargerOfTwoTemporalUnits(_largestUnit_, ~second~).
-        1. Let _roundedDuration_ be ! UnnormalizeDuration(_internalDuration_, _roundedLargestUnit_).
+        1. Let _roundedDuration_ be ! TemporalDurationFromInternal(_internalDuration_, _roundedLargestUnit_).
         1. Return TemporalDurationToString(_roundedDuration_, _precision_.[[Precision]]).
       </emu-alg>
     </emu-clause>
@@ -937,9 +937,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-unnormalizeduration" type="abstract operation">
+    <emu-clause id="sec-temporal-temporaldurationfrominternal" type="abstract operation">
       <h1>
-        UnnormalizeDuration (
+        TemporalDurationFromInternal (
           _internalDuration_: an Internal Duration Record,
           _largestUnit_: a Temporal unit,
         ): either a normal completion containing a Temporal.Duration, or a throw completion
@@ -2025,7 +2025,7 @@
         1. Let _d2_ be ToInternalDurationRecordWith24HourDays(_other_).
         1. Let _normResult_ be ? AddNormalizedTimeDuration(_d1_.[[NormalizedTime]], _d2_.[[NormalizedTime]]).
         1. Let _result_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), _normResult_).
-        1. Return ? UnnormalizeDuration(_result_, _largestUnit_).
+        1. Return ? TemporalDurationFromInternal(_result_, _largestUnit_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1475,17 +1475,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-zerotimeduration" type="abstract operation">
-      <h1>ZeroTimeDuration ( ): a time duration</h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns a time duration of zero length.</dd>
-      </dl>
-      <emu-alg>
-        1. Return 0.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-datedurationdays" type="abstract operation">
       <h1>
         DateDurationDays (
@@ -1528,7 +1517,7 @@
           1. Let _fractionalDays_ be _duration_.[[Date]].[[Days]] + DivideTimeDuration(_duration_.[[Time]], nsPerDay).
           1. Let _days_ be RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
           1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _days_).
-          1. Return ! CombineDateAndTimeDuration(_dateDuration_, ZeroTimeDuration()).
+          1. Return ! CombineDateAndTimeDuration(_dateDuration_, 0).
         1. Assert: TemporalUnitCategory(_unit_) is ~time~.
         1. Let _divisor_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _unit_.
         1. Let _rounded_ be ? RoundTimeDurationToIncrement(_duration_.[[Time]], _divisor_ × _increment_, _roundingMode_).
@@ -1675,7 +1664,7 @@
           1. Let _didExpandCalendarUnit_ be *false*.
           1. Let _resultDuration_ be _startDuration_.
           1. Let _nudgedEpochNs_ be _startEpochNs_.
-        1. Set _resultDuration_ to ! CombineDateAndTimeDuration(_resultDuration_, ZeroTimeDuration()).
+        1. Set _resultDuration_ to ! CombineDateAndTimeDuration(_resultDuration_, 0).
         1. Let _nudgeResult_ be Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandCalendarUnit_ }.
         1. Return the Record { [[NudgeResult]]: _nudgeResult_, [[Total]]: _total_ }.
       </emu-alg>
@@ -1813,7 +1802,7 @@
             1. Let _beyondEnd_ be _nudgedEpochNs_ - _endEpochNs_.
             1. If _beyondEnd_ &lt; 0, let _beyondEndSign_ be -1; else if _beyondEnd_ > 0, let _beyondEndSign_ be 1; else let _beyondEndSign_ be 0.
             1. If _beyondEndSign_ ≠ -_sign_, then
-              1. Set _duration_ to ! CombineDateAndTimeDuration(_endDuration_, ZeroTimeDuration()).
+              1. Set _duration_ to ! CombineDateAndTimeDuration(_endDuration_, 0).
             1. Else,
               1. Set _done_ to *true*.
           1. Set _unitIndex_ to _unitIndex_ - 1.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1475,24 +1475,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-subtracttimeduration" type="abstract operation">
-      <h1>
-        SubtractTimeDuration (
-          _one_: a time duration,
-          _two_: a time duration,
-        ): either a normal completion containing a time duration or a throw completion
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns a time duration that is the difference between _one_ and _two_, throwing an exception if the result is greater than the maximum time duration.</dd>
-      </dl>
-      <emu-alg>
-        1. Let _result_ be _one_ - _two_.
-        1. If abs(_result_) > maxTimeDuration, throw a *RangeError* exception.
-        1. Return _result_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-zerotimeduration" type="abstract operation">
       <h1>ZeroTimeDuration ( ): a time duration</h1>
       <dl class="header">
@@ -1729,7 +1711,7 @@
         1. Assert: TimeDurationSign(_daySpan_) = _sign_.
         1. Let _unitLength_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _unit_.
         1. Let _roundedTimeDuration_ be ? RoundTimeDurationToIncrement(_duration_.[[Time]], _increment_ × _unitLength_, _roundingMode_).
-        1. Let _beyondDaySpan_ be ? SubtractTimeDuration(_roundedTimeDuration_, _daySpan_).
+        1. Let _beyondDaySpan_ be ? AddTimeDuration(_roundedTimeDuration_, -_daySpan_).
         1. If TimeDurationSign(_beyondDaySpan_) ≠ -_sign_, then
           1. Let _didRoundBeyondDay_ be *true*.
           1. Let _dayDelta_ be _sign_.
@@ -1766,7 +1748,7 @@
         1. Let _timeDuration_ be ! Add24HourDaysToTimeDuration(_duration_.[[Time]], _duration_.[[Date]].[[Days]]).
         1. Let _unitLength_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _smallestUnit_.
         1. Let _roundedNorm_ be ? RoundTimeDurationToIncrement(_timeDuration_, _unitLength_ × _increment_, _roundingMode_).
-        1. Let _diffNorm_ be ! SubtractTimeDuration(_roundedNorm_, _timeDuration_).
+        1. Let _diffNorm_ be ! AddTimeDuration(_roundedNorm_, -_timeDuration_).
         1. Let _wholeDays_ be truncate(DivideTimeDuration(_timeDuration_, nsPerDay)).
         1. Let _roundedWholeDays_ be truncate(DivideTimeDuration(_roundedNorm_, nsPerDay)).
         1. Let _dayDelta_ be _roundedWholeDays_ - _wholeDays_.
@@ -1777,7 +1759,7 @@
         1. Let _remainder_ be _roundedNorm_.
         1. If TemporalUnitCategory(_largestUnit_) is ~date~, then
           1. Set _days_ to _roundedWholeDays_.
-          1. Set _remainder_ to ! SubtractTimeDuration(_roundedNorm_, TimeDurationFromComponents(_roundedWholeDays_ * HoursPerDay, 0, 0, 0, 0, 0)).
+          1. Set _remainder_ to ! AddTimeDuration(_roundedNorm_, TimeDurationFromComponents(-_roundedWholeDays_ * HoursPerDay, 0, 0, 0, 0, 0)).
         1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _days_).
         1. Let _resultDuration_ be ? CombineDateAndTimeDuration(_dateDuration_, _remainder_).
         1. Return Duration Nudge Result Record { [[Duration]]: _resultDuration_, [[NudgedEpochNs]]: _nudgedEpochNs_, [[DidExpandCalendarUnit]]: _didExpandDays_ }.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -105,8 +105,8 @@
           1. Return *+0*<sub>𝔽</sub>.
         1. If IsCalendarUnit(_largestUnit1_) is *true* or IsCalendarUnit(_largestUnit2_) is *true*, then
           1. If _plainRelativeTo_ is *undefined*, throw a *RangeError* exception.
-          1. Let _days1_ be ? UnbalanceDateDurationRelative(_duration1_.[[Date]], _plainRelativeTo_).
-          1. Let _days2_ be ? UnbalanceDateDurationRelative(_duration2_.[[Date]], _plainRelativeTo_).
+          1. Let _days1_ be ? DateDurationDays(_duration1_.[[Date]], _plainRelativeTo_).
+          1. Let _days2_ be ? DateDurationDays(_duration2_.[[Date]], _plainRelativeTo_).
         1. Else,
           1. Let _days1_ be _one_.[[Days]].
           1. Let _days2_ be _two_.[[Days]].
@@ -1557,9 +1557,9 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-unbalancedatedurationrelative" type="abstract operation">
+    <emu-clause id="sec-temporal-datedurationdays" type="abstract operation">
       <h1>
-        UnbalanceDateDurationRelative (
+        DateDurationDays (
           _dateDuration_: a Date Duration Record,
           _plainRelativeTo_: a Temporal.PlainDate,
         ): either a normal completion containing an integer or a throw completion

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -909,7 +909,7 @@
       </dl>
       <emu-alg>
         1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
-        1. Let _days_ be truncate(TimeDurationSeconds(_internalDuration_.[[Time]]) / 86400).
+        1. Let _days_ be truncate(_internalDuration_.[[Time]] / nsPerDay).
         1. Return ? CreateDateDurationRecord(_internalDuration_.[[Date]].[[Years]], _internalDuration_.[[Date]].[[Months]], _internalDuration_.[[Date]].[[Weeks]], _days_).
       </emu-alg>
     </emu-clause>
@@ -1458,21 +1458,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-timedurationseconds" type="abstract operation">
-      <h1>
-        TimeDurationSeconds (
-          _d_: a time duration,
-        ): an integer in the interval from -2<sup>53</sup> (exclusive) to 2<sup>53</sup> (exclusive)
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns the integer number of seconds in _d_.</dd>
-      </dl>
-      <emu-alg>
-        1. Return truncate(_d_ / 10<sup>9</sup>).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-timedurationsign" type="abstract operation">
       <h1>
         TimeDurationSign (
@@ -1487,21 +1472,6 @@
         1. If _d_ &lt; 0, return -1.
         1. If _d_ > 0, return 1.
         1. Return 0.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-temporal-timedurationsubseconds" type="abstract operation">
-      <h1>
-        TimeDurationSubseconds (
-          _d_: a time duration,
-        ): an integer in the interval from -10<sup>9</sup> (exclusive) to 10<sup>9</sup> (exclusive)
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd>It returns the integer number of nanoseconds in the subsecond part of _d_.</dd>
-      </dl>
-      <emu-alg>
-        1. Return remainder(_d_, 10<sup>9</sup>).
       </emu-alg>
     </emu-clause>
 
@@ -1965,8 +1935,8 @@
         1. If DefaultTemporalLargestUnit(_duration_) is ~second~, ~millisecond~, ~microsecond~, or ~nanosecond~, set _zeroMinutesAndHigher_ to *true*.
         1. Let _secondsDuration_ be TimeDurationFromComponents(0, 0, _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
         1. If _secondsDuration_ ≠ 0, or _zeroMinutesAndHigher_ is *true*, or _precision_ is not ~auto~, then
-          1. Let _secondsPart_ be abs(TimeDurationSeconds(_secondsDuration_)) formatted as a decimal number.
-          1. Let _subSecondsPart_ be FormatFractionalSeconds(abs(TimeDurationSubseconds(_secondsDuration_)), _precision_).
+          1. Let _secondsPart_ be abs(truncate(_secondsDuration_ / 10<sup>9</sup>)) formatted as a decimal number.
+          1. Let _subSecondsPart_ be FormatFractionalSeconds(abs(remainder(_secondsDuration_, 10<sup>9</sup>)), _precision_).
           1. Set _timePart_ to the string concatenation of _timePart_, _secondsPart_, _subSecondsPart_, and the code unit 0x0053 (LATIN CAPITAL LETTER S).
         1. Let _signPart_ be the code unit 0x002D (HYPHEN-MINUS) if _sign_ &lt; 0, and otherwise the empty String.
         1. Let _result_ be the string concatenation of _signPart_, the code unit 0x0050 (LATIN CAPITAL LETTER P) and _datePart_.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -93,8 +93,8 @@
         1. Let _plainRelativeTo_ be _relativeToRecord_.[[PlainRelativeTo]].
         1. Let _largestUnit1_ be DefaultTemporalLargestUnit(_one_).
         1. Let _largestUnit2_ be DefaultTemporalLargestUnit(_two_).
-        1. Let _duration1_ be NormalizeDuration(_one_).
-        1. Let _duration2_ be NormalizeDuration(_two_).
+        1. Let _duration1_ be ToInternalDurationRecord(_one_).
+        1. Let _duration2_ be ToInternalDurationRecord(_two_).
         1. If _zonedRelativeTo_ is not *undefined*, and either TemporalUnitCategory(_largestUnit1_) or TemporalUnitCategory(_largestUnit2_) is ~date~, then
           1. Let _timeZone_ be _zonedRelativeTo_.[[TimeZone]].
           1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
@@ -427,29 +427,29 @@
         1. If _maximum_ is not ~unset~, perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
         1. If _roundingIncrement_ > 1, and _largestUnit_ is not _smallestUnit_, and TemporalUnitCategory(_smallestUnit_) is ~date~, throw a *RangeError* exception.
         1. If _zonedRelativeTo_ is not *undefined*, then
-          1. Let _normalizedDuration_ be NormalizeDuration(_duration_).
+          1. Let _internalDuration_ be ToInternalDurationRecord(_duration_).
           1. Let _timeZone_ be _zonedRelativeTo_.[[TimeZone]].
           1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
           1. Let _relativeEpochNs_ be _zonedRelativeTo_.[[EpochNanoseconds]].
-          1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _normalizedDuration_, ~constrain~).
-          1. Set _normalizedDuration_ to ? DifferenceZonedDateTimeWithRounding(_relativeEpochNs_, _targetEpochNs_, _timeZone_, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+          1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _internalDuration_, ~constrain~).
+          1. Set _internalDuration_ to ? DifferenceZonedDateTimeWithRounding(_relativeEpochNs_, _targetEpochNs_, _timeZone_, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. If TemporalUnitCategory(_largestUnit_) is ~date~, set _largestUnit_ to ~hour~.
-          1. Return ? UnnormalizeDuration(_normalizedDuration_, _largestUnit_).
+          1. Return ? UnnormalizeDuration(_internalDuration_, _largestUnit_).
         1. If _plainRelativeTo_ is not *undefined*, then
-          1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
-          1. Let _targetTime_ be AddTime(MidnightTimeRecord(), _normalizedDuration_.[[NormalizedTime]]).
+          1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
+          1. Let _targetTime_ be AddTime(MidnightTimeRecord(), _internalDuration_.[[NormalizedTime]]).
           1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
-          1. Let _dateDuration_ be ! AdjustDateDurationRecord(_normalizedDuration_.[[Date]], _targetTime_.[[Days]]).
+          1. Let _dateDuration_ be ! AdjustDateDurationRecord(_internalDuration_.[[Date]], _targetTime_.[[Days]]).
           1. Let _targetDate_ be ? CalendarDateAdd(_calendar_, _plainRelativeTo_.[[ISODate]], _dateDuration_, ~constrain~).
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_plainRelativeTo_.[[ISODate]], MidnightTimeRecord()).
           1. Let _targetDateTime_ be CombineISODateAndTimeRecord(_targetDate_, _targetTime_).
-          1. Set _normalizedDuration_ to ? DifferencePlainDateTimeWithRounding(_isoDateTime_, _targetDateTime_, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
-          1. Return ? UnnormalizeDuration(_normalizedDuration_, _largestUnit_).
+          1. Set _internalDuration_ to ? DifferencePlainDateTimeWithRounding(_isoDateTime_, _targetDateTime_, _calendar_, _largestUnit_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+          1. Return ? UnnormalizeDuration(_internalDuration_, _largestUnit_).
         1. If IsCalendarUnit(_existingLargestUnit_) is *true*, or IsCalendarUnit(_largestUnit_) is *true*, throw a *RangeError* exception.
         1. Assert: IsCalendarUnit(_smallestUnit_) is *false*.
-        1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
-        1. Set _normalizedDuration_ to ? RoundTimeDuration(_normalizedDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
-        1. Return ? UnnormalizeDuration(_normalizedDuration_, _largestUnit_).
+        1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
+        1. Set _internalDuration_ to ? RoundTimeDuration(_internalDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Return ? UnnormalizeDuration(_internalDuration_, _largestUnit_).
       </emu-alg>
     </emu-clause>
 
@@ -472,17 +472,17 @@
         1. Let _plainRelativeTo_ be _relativeToRecord_.[[PlainRelativeTo]].
         1. Let _unit_ be ? GetTemporalUnitValuedOption(_totalOf_, *"unit"*, ~datetime~, ~required~).
         1. If _zonedRelativeTo_ is not *undefined*, then
-          1. Let _normalizedDuration_ be NormalizeDuration(_duration_).
+          1. Let _internalDuration_ be ToInternalDurationRecord(_duration_).
           1. Let _timeZone_ be _zonedRelativeTo_.[[TimeZone]].
           1. Let _calendar_ be _zonedRelativeTo_.[[Calendar]].
           1. Let _relativeEpochNs_ be _zonedRelativeTo_.[[EpochNanoseconds]].
-          1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _normalizedDuration_, ~constrain~).
+          1. Let _targetEpochNs_ be ? AddZonedDateTime(_relativeEpochNs_, _timeZone_, _calendar_, _internalDuration_, ~constrain~).
           1. Let _total_ be ? DifferenceZonedDateTimeWithTotal(_relativeEpochNs_, _targetEpochNs_, _timeZone_, _calendar_, _unit_).
         1. Else if _plainRelativeTo_ is not *undefined*, then
-          1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
-          1. Let _targetTime_ be AddTime(MidnightTimeRecord(), _normalizedDuration_.[[NormalizedTime]]).
+          1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
+          1. Let _targetTime_ be AddTime(MidnightTimeRecord(), _internalDuration_.[[NormalizedTime]]).
           1. Let _calendar_ be _plainRelativeTo_.[[Calendar]].
-          1. Let _dateDuration_ be ! AdjustDateDurationRecord(_normalizedDuration_.[[Date]], _targetTime_.[[Days]]).
+          1. Let _dateDuration_ be ! AdjustDateDurationRecord(_internalDuration_.[[Date]], _targetTime_.[[Days]]).
           1. Let _targetDate_ be ? CalendarDateAdd(_calendar_, _plainRelativeTo_.[[ISODate]], _dateDuration_, ~constrain~).
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_plainRelativeTo_.[[ISODate]], MidnightTimeRecord()).
           1. Let _targetDateTime_ be CombineISODateAndTimeRecord(_targetDate_, _targetTime_).
@@ -490,8 +490,8 @@
         1. Else,
           1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_).
           1. If IsCalendarUnit(_largestUnit_) is *true*, or IsCalendarUnit(_unit_) is *true*, throw a *RangeError* exception.
-          1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
-          1. Let _total_ be TotalTimeDuration(_normalizedDuration_, _unit_).
+          1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
+          1. Let _total_ be TotalTimeDuration(_internalDuration_, _unit_).
         1. Return 𝔽(_total_).
       </emu-alg>
     </emu-clause>
@@ -512,10 +512,10 @@
         1. If _precision_.[[Unit]] is ~nanosecond~ or _precision_.[[Increment]] = 1, then
           1. Return TemporalDurationToString(_duration_, _precision_.[[Precision]]).
         1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_).
-        1. Let _normalizedDuration_ be NormalizeDuration(_duration_).
-        1. Set _normalizedDuration_ to ? RoundTimeDuration(_normalizedDuration_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Let _internalDuration_ be ToInternalDurationRecord(_duration_).
+        1. Set _internalDuration_ to ? RoundTimeDuration(_internalDuration_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
         1. Let _roundedLargestUnit_ be LargerOfTwoTemporalUnits(_largestUnit_, ~second~).
-        1. Let _roundedDuration_ be ! UnnormalizeDuration(_normalizedDuration_, _roundedLargestUnit_).
+        1. Let _roundedDuration_ be ! UnnormalizeDuration(_internalDuration_, _roundedLargestUnit_).
         1. Return TemporalDurationToString(_roundedDuration_, _precision_.[[Precision]]).
       </emu-alg>
     </emu-clause>
@@ -842,14 +842,14 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalized-duration-records">
-      <h1>Normalized Duration Records</h1>
+    <emu-clause id="sec-temporal-internal-duration-records">
+      <h1>Internal Duration Records</h1>
       <p>
-        A <dfn variants="Normalized Duration Records">Normalized Duration Record</dfn> is a Record value used to represent the combination of a Date Duration Record with a Normalized Time Duration Record.
+        A <dfn variants="Internal Duration Records">Internal Duration Record</dfn> is a Record value used to represent the combination of a Date Duration Record with a Normalized Time Duration Record.
         Such Records are used by operations that deal with both date and time portions of durations, such as RoundTimeDuration.
       </p>
-      <p>Normalized Duration Records have the fields listed in <emu-xref href="#table-temporal-normalized-duration-record-fields"></emu-xref>.</p>
-      <emu-table id="table-temporal-normalized-duration-record-fields" caption="Normalized Duration Record Fields">
+      <p>Internal Duration Records have the fields listed in <emu-xref href="#table-temporal-normalized-duration-record-fields"></emu-xref>.</p>
+      <emu-table id="table-temporal-normalized-duration-record-fields" caption="Internal Duration Record Fields">
         <table class="real-table">
           <tr>
             <th>Field Name</th>
@@ -885,15 +885,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalizeduration" type="abstract operation">
+    <emu-clause id="sec-temporal-tointernaldurationrecord" type="abstract operation">
       <h1>
-        NormalizeDuration (
+        ToInternalDurationRecord (
           _duration_: a Temporal.Duration,
-        ): a Normalized Duration Record
+        ): an Internal Duration Record
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _duration_ into its normalized form, for use in duration calculations that may involve time zones. The duration's days are kept separate and not converted into the [[NormalizedTime]] field.</dd>
+        <dd>It converts _duration_ into its internal form, for use in duration calculations that may involve time zones. The duration's days are kept separate and not converted into the [[NormalizedTime]] field.</dd>
       </dl>
       <emu-alg>
         1. Let _dateDuration_ be ! CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]]).
@@ -902,15 +902,15 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalizedurationwith24hourdays" type="abstract operation">
+    <emu-clause id="sec-temporal-tointernaldurationrecordwith24hourdays" type="abstract operation">
       <h1>
-        NormalizeDurationWith24HourDays (
+        ToInternalDurationRecordWith24HourDays (
           _duration_: a Temporal.Duration,
-        ): a Normalized Duration Record
+        ): an Internal Duration Record
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _duration_ into its normalized form, for use in duration calculations that do not involve time zones. The duration's days are assumed to be uniformly 24 hours, and the [[Date]].[[Days]] field of the returned Record is set to 0, while the [[NormalizedTime]] field includes the days.</dd>
+        <dd>It converts _duration_ into its internal form, for use in duration calculations that do not involve time zones. The duration's days are assumed to be uniformly 24 hours, and the [[Date]].[[Days]] field of the returned Record is set to 0, while the [[NormalizedTime]] field includes the days.</dd>
       </dl>
       <emu-alg>
         1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).
@@ -920,34 +920,34 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalizedurationwithouttime" type="abstract operation">
+    <emu-clause id="sec-temporal-todatedurationrecordwithouttime" type="abstract operation">
       <h1>
-        NormalizeDurationWithoutTime (
+        ToDateDurationRecordWithoutTime (
           _duration_: a Temporal.Duration,
         ): either a normal completion containing a Date Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _duration_ into its normalized form, for use in date-only calculations. The duration's days are assumed to be uniformly 24 hours, and the [[Days]] field of the returned Record is set to the [[Days]] internal slot of _duration_, incremented by any whole days that _duration_'s time units added up to.</dd>
+        <dd>It converts _duration_ into only a date part, for use in date-only calculations. The duration's days are assumed to be uniformly 24 hours, and the [[Days]] field of the returned Record is set to the [[Days]] internal slot of _duration_, incremented by any whole days that _duration_'s time units added up to.</dd>
       </dl>
       <emu-alg>
-        1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
-        1. Let _days_ be truncate(NormalizedTimeDurationSeconds(_normalizedDuration_.[[NormalizedTime]]) / 86400).
-        1. Return ? CreateDateDurationRecord(_normalizedDuration_.[[Date]].[[Years]], _normalizedDuration_.[[Date]].[[Months]], _normalizedDuration_.[[Date]].[[Weeks]], _days_).
+        1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
+        1. Let _days_ be truncate(NormalizedTimeDurationSeconds(_internalDuration_.[[NormalizedTime]]) / 86400).
+        1. Return ? CreateDateDurationRecord(_internalDuration_.[[Date]].[[Years]], _internalDuration_.[[Date]].[[Months]], _internalDuration_.[[Date]].[[Weeks]], _days_).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-temporal-unnormalizeduration" type="abstract operation">
       <h1>
         UnnormalizeDuration (
-          _normalizedDuration_: a Normalized Duration Record,
+          _internalDuration_: an Internal Duration Record,
           _largestUnit_: a Temporal unit,
         ): either a normal completion containing a Temporal.Duration, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It converts _normalizedDuration_ back into the form of a `Temporal.Duration` object, with each component stored separately.
+          It converts _internalDuration_ back into the form of a `Temporal.Duration` object, with each component stored separately.
           The time units are balanced up to _largestUnit_.
           The conversion may be lossy if _largestUnit_ is ~millisecond~, ~microsecond~, or ~nanosecond~.
           In that case, the internal slots of the returned Temporal.Duration may contain unsafe (but float64-representable) integers.
@@ -956,8 +956,8 @@
       </dl>
       <emu-alg>
         1. Let _days_, _hours_, _minutes_, _seconds_, _milliseconds_, and _microseconds_ be 0.
-        1. Let _sign_ be NormalizedTimeDurationSign(_normalizedDuration_.[[NormalizedTime]]).
-        1. Let _nanoseconds_ be abs(_normalizedDuration_.[[NormalizedTime]].[[TotalNanoseconds]]).
+        1. Let _sign_ be NormalizedTimeDurationSign(_internalDuration_.[[NormalizedTime]]).
+        1. Let _nanoseconds_ be abs(_internalDuration_.[[NormalizedTime]].[[TotalNanoseconds]]).
         1. If TemporalUnitCategory(_largestUnit_) is ~date~, then
           1. Set _microseconds_ to floor(_nanoseconds_ / 1000).
           1. Set _nanoseconds_ to _nanoseconds_ modulo 1000.
@@ -1009,7 +1009,7 @@
         1. Else,
           1. Assert: _largestUnit_ is ~nanosecond~.
         1. NOTE: When _largestUnit_ is ~millisecond~, ~microsecond~, or ~nanosecond~, _milliseconds_, _microseconds_, or _nanoseconds_ may be an unsafe integer. In this case, care must be taken when implementing the calculation using floating point arithmetic. It can be implemented in C++ using `std::fma()`. String manipulation will also give an exact result, since the multiplication is by a power of 10.
-        1. Return ? CreateTemporalDuration(_normalizedDuration_.[[Date]].[[Years]], _normalizedDuration_.[[Date]].[[Months]], _normalizedDuration_.[[Date]].[[Weeks]], _normalizedDuration_.[[Date]].[[Days]] + _days_ × _sign_, _hours_ × _sign_, _minutes_ × _sign_, _seconds_ × _sign_, _milliseconds_ × _sign_, _microseconds_ × _sign_, _nanoseconds_ × _sign_).
+        1. Return ? CreateTemporalDuration(_internalDuration_.[[Date]].[[Years]], _internalDuration_.[[Date]].[[Months]], _internalDuration_.[[Date]].[[Weeks]], _internalDuration_.[[Date]].[[Days]] + _days_ × _sign_, _hours_ × _sign_, _minutes_ × _sign_, _seconds_ × _sign_, _milliseconds_ × _sign_, _microseconds_ × _sign_, _nanoseconds_ × _sign_).
       </emu-alg>
     </emu-clause>
 
@@ -1062,7 +1062,7 @@
         CombineDateAndNormalizedTimeDuration (
           _dateDuration_: a Date Duration Record,
           _norm_: a Normalized Time Duration Record,
-        ): either a normal completion containing a Normalized Duration Record or a throw completion
+        ): either a normal completion containing an Internal Duration Record or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1072,7 +1072,7 @@
         1. Let _dateSign_ be DateDurationSign(_dateDuration_).
         1. Let _timeSign_ be NormalizedTimeDurationSign(_norm_).
         1. If _dateSign_ ≠ 0 and _timeSign_ ≠ 0 and _dateSign_ ≠ _timeSign_, throw a *RangeError* exception.
-        1. Return Normalized Duration Record {
+        1. Return Internal Duration Record {
           [[Date]]: _dateDuration_,
           [[NormalizedTime]]: _norm_
           }.
@@ -1147,20 +1147,20 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-normalizeddurationsign" type="abstract operation">
+    <emu-clause id="sec-temporal-internaldurationsign" type="abstract operation">
       <h1>
-        NormalizedDurationSign (
-          _normalizedDuration_: a Normalized Duration Record,
+        InternalDurationSign (
+          _internalDuration_: an Internal Duration Record,
         ): -1, 0, or 1
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns 1 if the most significant non-zero field in the _normalizedDuration_ argument is positive, and -1 if the most significant non-zero field is negative. If all of _normalizedDuration_'s fields are zero, it returns 0.</dd>
+        <dd>It returns 1 if the most significant non-zero field in the _internalDuration_ argument is positive, and -1 if the most significant non-zero field is negative. If all of _internalDuration_'s fields are zero, it returns 0.</dd>
       </dl>
       <emu-alg>
-        1. Let _dateSign_ be DateDurationSign(_normalizedDuration_.[[Date]]).
+        1. Let _dateSign_ be DateDurationSign(_internalDuration_.[[Date]]).
         1. If _dateSign_ ≠ 0, return _dateSign_.
-        1. Return NormalizedTimeDurationSign(_normalizedDuration_.[[NormalizedTime]]).
+        1. Return NormalizedTimeDurationSign(_internalDuration_.[[NormalizedTime]]).
       </emu-alg>
     </emu-clause>
 
@@ -1582,16 +1582,16 @@
     <emu-clause id="sec-temporal-roundtimeduration" type="abstract operation">
       <h1>
         RoundTimeDuration (
-          _duration_: a Normalized Duration Record,
+          _duration_: an Internal Duration Record,
           _increment_: a positive integer,
           _unit_: a time unit or ~day~,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Normalized Duration Record, or a throw completion
+        ): either a normal completion containing an Internal Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It rounds a _duration_ according to the rounding parameters _unit_, _increment_, and _roundingMode_, and returns the Normalized Duration Record result.
+          It rounds a _duration_ according to the rounding parameters _unit_, _increment_, and _roundingMode_, and returns the Internal Duration Record result.
         </dd>
       </dl>
       <emu-alg>
@@ -1637,7 +1637,7 @@
           </tr>
           <tr>
             <td>[[Duration]]</td>
-            <td>a Normalized Duration Record</td>
+            <td>an Internal Duration Record</td>
             <td>
               The resulting duration.
             </td>
@@ -1664,7 +1664,7 @@
       <h1>
         NudgeToCalendarUnit (
           _sign_: -1 or 1,
-          _duration_: a Normalized Duration Record,
+          _duration_: an Internal Duration Record,
           _destEpochNs_: a BigInt,
           _isoDateTime_: an ISO Date-Time Record,
           _timeZone_: an available time zone identifier or ~unset~,
@@ -1756,7 +1756,7 @@
       <h1>
         NudgeToZonedTime (
           _sign_: -1 or 1,
-          _duration_: a Normalized Duration Record,
+          _duration_: an Internal Duration Record,
           _isoDateTime_: an ISO Date-Time Record,
           _timeZone_: an available time zone identifier,
           _calendar_: a calendar type,
@@ -1801,7 +1801,7 @@
     <emu-clause id="sec-temporal-nudgetodayortime" type="abstract operation">
       <h1>
         NudgeToDayOrTime (
-          _duration_: a Normalized Duration Record,
+          _duration_: an Internal Duration Record,
           _destEpochNs_: a BigInt,
           _largestUnit_: a Temporal unit,
           _increment_: a positive integer,
@@ -1841,14 +1841,14 @@
       <h1>
         BubbleRelativeDuration (
           _sign_: -1 or 1,
-          _duration_: a Normalized Duration Record,
+          _duration_: an Internal Duration Record,
           _nudgedEpochNs_: a BigInt,
           _isoDateTime_: an ISO Date-Time Record,
           _timeZone_: an available time zone identifier or ~unset~,
           _calendar_: a calendar type,
           _largestUnit_: a date unit,
           _smallestUnit_: a date unit,
-        ): either a normal completion containing a Normalized Duration Record or a throw completion
+        ): either a normal completion containing an Internal Duration Record or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1895,7 +1895,7 @@
     <emu-clause id="sec-temporal-roundrelativeduration" type="abstract operation">
       <h1>
         RoundRelativeDuration (
-          _duration_: a Normalized Duration Record,
+          _duration_: an Internal Duration Record,
           _destEpochNs_: a BigInt,
           _isoDateTime_: an ISO Date-Time Record,
           _timeZone_: an available time zone identifier or ~unset~,
@@ -1904,19 +1904,19 @@
           _increment_: a positive integer,
           _smallestUnit_: a Temporal unit,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Normalized Duration Record or a throw completion
+        ): either a normal completion containing an Internal Duration Record or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It rounds a duration _duration_ relative to _isoDateTime_ according to the rounding parameters _smallestUnit_, _increment_, and _roundingMode_, bubbles overflows up to the next highest unit until _largestUnit_, and returns a normalized duration.
+          It rounds a duration _duration_ relative to _isoDateTime_ according to the rounding parameters _smallestUnit_, _increment_, and _roundingMode_, bubbles overflows up to the next highest unit until _largestUnit_, and returns the rounded duration.
         </dd>
       </dl>
       <emu-alg>
         1. Let _irregularLengthUnit_ be *false*.
         1. If IsCalendarUnit(_smallestUnit_) is *true*, set _irregularLengthUnit_ to *true*.
         1. If _timeZone_ is not ~unset~ and _smallestUnit_ is ~day~, set _irregularLengthUnit_ to *true*.
-        1. If NormalizedDurationSign(_duration_) &lt; 0, let _sign_ be -1; else let _sign_ be 1.
+        1. If InternalDurationSign(_duration_) &lt; 0, let _sign_ be -1; else let _sign_ be 1.
         1. If _irregularLengthUnit_ is *true*, then
           1. Let _record_ be ? NudgeToCalendarUnit(_sign_, _duration_, _destEpochNs_, _isoDateTime_, _timeZone_, _calendar_, _increment_, _smallestUnit_, _roundingMode_).
           1. Let _nudgeResult_ be _record_.[[NudgeResult]].
@@ -1935,7 +1935,7 @@
     <emu-clause id="sec-temporal-totalrelativeduration" type="abstract operation">
       <h1>
         TotalRelativeDuration (
-          _duration_: a Normalized Duration Record,
+          _duration_: an Internal Duration Record,
           _destEpochNs_: a BigInt,
           _isoDateTime_: an ISO Date-Time Record,
           _timeZone_: an available time zone identifier or ~unset~,
@@ -1949,7 +1949,7 @@
       </dl>
       <emu-alg>
         1. If IsCalendarUnit(_unit_) is *true*, or _timeZone_ is not ~unset~ and _unit_ is ~day~, then
-          1. Let _sign_ be NormalizedDurationSign(_duration_).
+          1. Let _sign_ be InternalDurationSign(_duration_).
           1. Let _record_ be ? NudgeToCalendarUnit(_sign_, _duration_, _destEpochNs_, _isoDateTime_, _timeZone_, _calendar_, 1, _unit_, ~trunc~).
           1. Return _record_.[[Total]].
         1. Let _norm_ be ! Add24HourDaysToNormalizedTimeDuration(_duration_.[[NormalizedTime]], _duration_.[[Date]].[[Days]]).
@@ -2021,8 +2021,8 @@
         1. Let _largestUnit2_ be DefaultTemporalLargestUnit(_other_).
         1. Let _largestUnit_ be LargerOfTwoTemporalUnits(_largestUnit1_, _largestUnit2_).
         1. If IsCalendarUnit(_largestUnit_) is *true*, throw a *RangeError* exception.
-        1. Let _d1_ be NormalizeDurationWith24HourDays(_duration_).
-        1. Let _d2_ be NormalizeDurationWith24HourDays(_other_).
+        1. Let _d1_ be ToInternalDurationRecordWith24HourDays(_duration_).
+        1. Let _d2_ be ToInternalDurationRecordWith24HourDays(_other_).
         1. Let _normResult_ be ? AddNormalizedTimeDuration(_d1_.[[NormalizedTime]], _d2_.[[NormalizedTime]]).
         1. Let _result_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), _normResult_).
         1. Return ? UnnormalizeDuration(_result_, _largestUnit_).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -893,7 +893,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _duration_ into its normalized form, for use in duration calculations that may involve time zones. The duration's days are kept separate and not converted into the [[NormalizedDuration]] field.</dd>
+        <dd>It converts _duration_ into its normalized form, for use in duration calculations that may involve time zones. The duration's days are kept separate and not converted into the [[NormalizedTime]] field.</dd>
       </dl>
       <emu-alg>
         1. Let _dateDuration_ be ! CreateDateDurationRecord(_duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]]).
@@ -910,7 +910,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It converts _duration_ into its normalized form, for use in duration calculations that do not involve time zones. The duration's days are assumed to be uniformly 24 hours, and the [[Date]].[[Days]] field of the returned Record is set to 0, while the [[NormalizedDuration]] field includes the days.</dd>
+        <dd>It converts _duration_ into its normalized form, for use in duration calculations that do not involve time zones. The duration's days are assumed to be uniformly 24 hours, and the [[Date]].[[Days]] field of the returned Record is set to 0, while the [[NormalizedTime]] field includes the days.</dd>
       </dl>
       <emu-alg>
         1. Let _norm_ be NormalizeTimeDuration(_duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]]).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -465,7 +465,7 @@
           _roundingIncrement_: a positive integer,
           _smallestUnit_: a time unit or ~day~,
           _roundingMode_: a rounding mode,
-        ): a Normalized Duration Record
+        ): an Internal Duration Record
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -473,8 +473,8 @@
       </dl>
       <emu-alg>
         1. Let _norm_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_ns2_, _ns1_).
-        1. Let _normalizedDuration_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), _norm_).
-        1. Return ! RoundTimeDuration(_normalizedDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Let _internalDuration_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), _norm_).
+        1. Return ! RoundTimeDuration(_internalDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
       </emu-alg>
     </emu-clause>
 
@@ -542,8 +542,8 @@
         1. Set _other_ to ? ToTemporalInstant(_other_).
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, « », ~nanosecond~, ~second~).
-        1. Let _normalizedDuration_ be DifferenceInstant(_instant_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ! UnnormalizeDuration(_normalizedDuration_, _settings_.[[LargestUnit]]).
+        1. Let _internalDuration_ be DifferenceInstant(_instant_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+        1. Let _result_ be ! UnnormalizeDuration(_internalDuration_, _settings_.[[LargestUnit]]).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>
@@ -566,8 +566,8 @@
         1. If _operation_ is ~subtract~, set _duration_ to CreateNegatedTemporalDuration(_duration_).
         1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_).
         1. If TemporalUnitCategory(_largestUnit_) is ~date~, throw a *RangeError* exception.
-        1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
-        1. Let _ns_ be ? AddInstant(_instant_.[[EpochNanoseconds]], _normalizedDuration_.[[NormalizedTime]]).
+        1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
+        1. Let _ns_ be ? AddInstant(_instant_.[[EpochNanoseconds]], _internalDuration_.[[NormalizedTime]]).
         1. Return ! CreateTemporalInstant(_ns_).
       </emu-alg>
     </emu-clause>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -543,7 +543,7 @@
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, « », ~nanosecond~, ~second~).
         1. Let _internalDuration_ be DifferenceInstant(_instant_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ! UnnormalizeDuration(_internalDuration_, _settings_.[[LargestUnit]]).
+        1. Let _result_ be ! TemporalDurationFromInternal(_internalDuration_, _settings_.[[LargestUnit]]).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -443,7 +443,7 @@
       <h1>
         AddInstant (
           _epochNanoseconds_: a BigInt value,
-          _norm_: a Normalized Time Duration Record,
+          _timeDuration_: a time duration,
         ): either a normal completion containing a BigInt or a throw completion
       </h1>
       <dl class="header">
@@ -451,7 +451,7 @@
         <dd>It adds a duration to a number of nanoseconds since the epoch.</dd>
       </dl>
       <emu-alg>
-        1. Let _result_ be AddNormalizedTimeDurationToEpochNanoseconds(_norm_, _epochNanoseconds_).
+        1. Let _result_ be AddTimeDurationToEpochNanoseconds(_timeDuration_, _epochNanoseconds_).
         1. If IsValidEpochNanoseconds(_result_) is *false*, throw a *RangeError* exception.
         1. Return _result_.
       </emu-alg>
@@ -472,8 +472,8 @@
         <dd>It computes the difference between two exact times _ns1_ and _ns2_ expressed in nanoseconds since the epoch, and rounds the result according to the parameters _roundingIncrement_, _smallestUnit_, and _roundingMode_.</dd>
       </dl>
       <emu-alg>
-        1. Let _norm_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_ns2_, _ns1_).
-        1. Let _internalDuration_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), _norm_).
+        1. Let _timeDuration_ be TimeDurationFromEpochNanosecondsDifference(_ns2_, _ns1_).
+        1. Let _internalDuration_ be ! CombineDateAndTimeDuration(ZeroDateDuration(), _timeDuration_).
         1. Return ! RoundTimeDuration(_internalDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
       </emu-alg>
     </emu-clause>
@@ -567,7 +567,7 @@
         1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_).
         1. If TemporalUnitCategory(_largestUnit_) is ~date~, throw a *RangeError* exception.
         1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
-        1. Let _ns_ be ? AddInstant(_instant_.[[EpochNanoseconds]], _internalDuration_.[[NormalizedTime]]).
+        1. Let _ns_ be ? AddInstant(_instant_.[[EpochNanoseconds]], _internalDuration_.[[Time]]).
         1. Return ! CreateTemporalInstant(_ns_).
       </emu-alg>
     </emu-clause>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -898,7 +898,7 @@
         1. If CompareISODate(_temporalDate_.[[ISODate]], _other_.[[ISODate]]) = 0, then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _dateDifference_ be CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_.[[ISODate]], _other_.[[ISODate]], _settings_.[[LargestUnit]]).
-        1. Let _duration_ be ! CombineDateAndNormalizedTimeDuration(_dateDifference_, ZeroTimeDuration()).
+        1. Let _duration_ be ! CombineDateAndTimeDuration(_dateDifference_, ZeroTimeDuration()).
         1. If _settings_.[[SmallestUnit]] is not ~day~ or _settings_.[[RoundingIncrement]] ≠ 1, then
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_temporalDate_.[[ISODate]], MidnightTimeRecord()).
           1. Let _isoDateTimeOther_ be CombineISODateAndTimeRecord(_other_.[[ISODate]], MidnightTimeRecord()).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -904,7 +904,7 @@
           1. Let _isoDateTimeOther_ be CombineISODateAndTimeRecord(_other_.[[ISODate]], MidnightTimeRecord()).
           1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_isoDateTimeOther_).
           1. Set _duration_ to ? RoundRelativeDuration(_duration_, _destEpochNs_, _isoDateTime_, ~unset~, _temporalDate_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ! UnnormalizeDuration(_duration_, ~day~).
+        1. Let _result_ be ! TemporalDurationFromInternal(_duration_, ~day~).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -898,7 +898,7 @@
         1. If CompareISODate(_temporalDate_.[[ISODate]], _other_.[[ISODate]]) = 0, then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _dateDifference_ be CalendarDateUntil(_temporalDate_.[[Calendar]], _temporalDate_.[[ISODate]], _other_.[[ISODate]], _settings_.[[LargestUnit]]).
-        1. Let _duration_ be ! CombineDateAndTimeDuration(_dateDifference_, ZeroTimeDuration()).
+        1. Let _duration_ be ! CombineDateAndTimeDuration(_dateDifference_, 0).
         1. If _settings_.[[SmallestUnit]] is not ~day~ or _settings_.[[RoundingIncrement]] ≠ 1, then
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_temporalDate_.[[ISODate]], MidnightTimeRecord()).
           1. Let _isoDateTimeOther_ be CombineISODateAndTimeRecord(_other_.[[ISODate]], MidnightTimeRecord()).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -927,7 +927,7 @@
         1. Let _calendar_ be _temporalDate_.[[Calendar]].
         1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. If _operation_ is ~subtract~, set _duration_ to CreateNegatedTemporalDuration(_duration_).
-        1. Let _dateDuration_ be ? NormalizeDurationWithoutTime(_duration_).
+        1. Let _dateDuration_ be ? ToDateDurationRecordWithoutTime(_duration_).
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? GetTemporalOverflowOption(_resolvedOptions_).
         1. Let _result_ be ? CalendarDateAdd(_calendar_, _temporalDate_.[[ISODate]], _dateDuration_, _overflow_).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -903,8 +903,7 @@
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_temporalDate_.[[ISODate]], MidnightTimeRecord()).
           1. Let _isoDateTimeOther_ be CombineISODateAndTimeRecord(_other_.[[ISODate]], MidnightTimeRecord()).
           1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_isoDateTimeOther_).
-          1. Let _result_ be ? RoundRelativeDuration(_duration_, _destEpochNs_, _isoDateTime_, ~unset~, _temporalDate_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-          1. Set _duration_ to _result_.[[NormalizedDuration]].
+          1. Set _duration_ to ? RoundRelativeDuration(_duration_, _destEpochNs_, _isoDateTime_, ~unset~, _temporalDate_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
         1. Let _result_ be ! UnnormalizeDuration(_duration_, ~day~).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -967,18 +967,18 @@
         1. Assert: ISODateTimeWithinLimits(_isoDateTime1_) is *true*.
         1. Assert: ISODateTimeWithinLimits(_isoDateTime2_) is *true*.
         1. Let _timeDuration_ be DifferenceTime(_isoDateTime1_.[[Time]], _isoDateTime2_.[[Time]]).
-        1. Let _timeSign_ be NormalizedTimeDurationSign(_timeDuration_).
+        1. Let _timeSign_ be TimeDurationSign(_timeDuration_).
         1. Let _dateSign_ be CompareISODate(_isoDateTime2_.[[ISODate]], _isoDateTime1_.[[ISODate]]).
         1. Let _adjustedDate_ be _isoDateTime2_.[[ISODate]].
         1. If _timeSign_ = -_dateSign_, then
           1. Set _adjustedDate_ to BalanceISODate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]] + _timeSign_).
-          1. Set _timeDuration_ to ? Add24HourDaysToNormalizedTimeDuration(_timeDuration_, -_timeSign_).
+          1. Set _timeDuration_ to ? Add24HourDaysToTimeDuration(_timeDuration_, -_timeSign_).
         1. Let _dateLargestUnit_ be LargerOfTwoTemporalUnits(~day~, _largestUnit_).
         1. Let _dateDifference_ be CalendarDateUntil(_calendar_, _isoDateTime1_.[[ISODate]], _adjustedDate_, _dateLargestUnit_).
         1. If _largestUnit_ is not _dateLargestUnit_, then
-          1. Set _timeDuration_ to ? Add24HourDaysToNormalizedTimeDuration(_timeDuration_, _dateDifference_.[[Days]]).
+          1. Set _timeDuration_ to ? Add24HourDaysToTimeDuration(_timeDuration_, _dateDifference_.[[Days]]).
           1. Set _dateDifference_.[[Days]] to 0.
-        1. Return ? CombineDateAndNormalizedTimeDuration(_dateDifference_, _timeDuration_).
+        1. Return ? CombineDateAndTimeDuration(_dateDifference_, _timeDuration_).
       </emu-alg>
     </emu-clause>
 
@@ -1000,7 +1000,7 @@
       </dl>
       <emu-alg>
         1. If CompareISODateTime(_isoDateTime1_, _isoDateTime2_) = 0, then
-          1. Return ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), ZeroTimeDuration()).
+          1. Return ! CombineDateAndTimeDuration(ZeroDateDuration(), ZeroTimeDuration()).
         1. Let _diff_ be ? DifferenceISODateTime(_isoDateTime1_, _isoDateTime2_, _calendar_, _largestUnit_).
         1. If _smallestUnit_ is ~nanosecond~ and _roundingIncrement_ = 1, return _diff_.
         1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_isoDateTime2_).
@@ -1025,7 +1025,7 @@
         1. If CompareISODateTime(_isoDateTime1_, _isoDateTime2_) = 0, then
           1. Return 0.
         1. Let _diff_ be ? DifferenceISODateTime(_isoDateTime1_, _isoDateTime2_, _calendar_, _unit_).
-        1. If _unit_ is ~nanosecond~, return _diff_.[[NormalizedTime]].[[TotalNanoseconds]].
+        1. If _unit_ is ~nanosecond~, return _diff_.[[Time]].[[TotalNanoseconds]].
         1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_isoDateTime2_).
         1. Return ? TotalRelativeDuration(_diff_, _destEpochNs_, _isoDateTime1_, ~unset~, _calendar_, _unit_).
       </emu-alg>
@@ -1077,7 +1077,7 @@
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? GetTemporalOverflowOption(_resolvedOptions_).
         1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
-        1. Let _timeResult_ be AddTime(_dateTime_.[[ISODateTime]].[[Time]], _internalDuration_.[[NormalizedTime]]).
+        1. Let _timeResult_ be AddTime(_dateTime_.[[ISODateTime]].[[Time]], _internalDuration_.[[Time]]).
         1. Let _dateDuration_ be ? AdjustDateDurationRecord(_internalDuration_.[[Date]], _timeResult_.[[Days]]).
         1. Let _addedDate_ be ? CalendarDateAdd(_dateTime_.[[Calendar]], _dateTime_.[[ISODateTime]].[[ISODate]], _dateDuration_, _overflow_).
         1. Let _result_ be CombineISODateAndTimeRecord(_addedDate_, _timeResult_).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -954,12 +954,12 @@
           _isoDateTime2_: an ISO Date-Time Record,
           _calendar_: a calendar type,
           _largestUnit_: a Temporal unit,
-        ): either a normal completion containing a Normalized Duration Record or a throw completion
+        ): either a normal completion containing an Internal Duration Record or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          The returned Normalized Duration Record contains the elapsed duration from a first date and time, until a second date and time, according to the reckoning of the given calendar.
+          The returned Internal Duration Record contains the elapsed duration from a first date and time, until a second date and time, according to the reckoning of the given calendar.
           The given date and time units are all in the ISO 8601 calendar.
         </dd>
       </dl>
@@ -992,7 +992,7 @@
           _roundingIncrement_: a positive integer,
           _smallestUnit_: a Temporal unit,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Normalized Duration Record or a throw completion
+        ): either a normal completion containing an Internal Duration Record or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1051,8 +1051,8 @@
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~datetime~, « », ~nanosecond~, ~day~).
         1. If CompareISODateTime(_dateTime_.[[ISODateTime]], _other_.[[ISODateTime]]) = 0, then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-        1. Let _normalizedDuration_ be ? DifferencePlainDateTimeWithRounding(_dateTime_.[[ISODateTime]], _other_.[[ISODateTime]], _dateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ? UnnormalizeDuration(_normalizedDuration_, _settings_.[[LargestUnit]]).
+        1. Let _internalDuration_ be ? DifferencePlainDateTimeWithRounding(_dateTime_.[[ISODateTime]], _other_.[[ISODateTime]], _dateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+        1. Let _result_ be ? UnnormalizeDuration(_internalDuration_, _settings_.[[LargestUnit]]).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>
@@ -1076,9 +1076,9 @@
         1. If _operation_ is ~subtract~, set _duration_ to CreateNegatedTemporalDuration(_duration_).
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Let _overflow_ be ? GetTemporalOverflowOption(_resolvedOptions_).
-        1. Let _normalizedDuration_ be NormalizeDurationWith24HourDays(_duration_).
-        1. Let _timeResult_ be AddTime(_dateTime_.[[ISODateTime]].[[Time]], _normalizedDuration_.[[NormalizedTime]]).
-        1. Let _dateDuration_ be ? AdjustDateDurationRecord(_normalizedDuration_.[[Date]], _timeResult_.[[Days]]).
+        1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
+        1. Let _timeResult_ be AddTime(_dateTime_.[[ISODateTime]].[[Time]], _internalDuration_.[[NormalizedTime]]).
+        1. Let _dateDuration_ be ? AdjustDateDurationRecord(_internalDuration_.[[Date]], _timeResult_.[[Days]]).
         1. Let _addedDate_ be ? CalendarDateAdd(_dateTime_.[[Calendar]], _dateTime_.[[ISODateTime]].[[ISODate]], _dateDuration_, _overflow_).
         1. Let _result_ be CombineISODateAndTimeRecord(_addedDate_, _timeResult_).
         1. Return ? CreateTemporalDateTime(_result_, _dateTime_.[[Calendar]]).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1052,7 +1052,7 @@
         1. If CompareISODateTime(_dateTime_.[[ISODateTime]], _other_.[[ISODateTime]]) = 0, then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _internalDuration_ be ? DifferencePlainDateTimeWithRounding(_dateTime_.[[ISODateTime]], _other_.[[ISODateTime]], _dateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ? UnnormalizeDuration(_internalDuration_, _settings_.[[LargestUnit]]).
+        1. Let _result_ be ? TemporalDurationFromInternal(_internalDuration_, _settings_.[[LargestUnit]]).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1000,7 +1000,7 @@
       </dl>
       <emu-alg>
         1. If CompareISODateTime(_isoDateTime1_, _isoDateTime2_) = 0, then
-          1. Return ! CombineDateAndTimeDuration(ZeroDateDuration(), ZeroTimeDuration()).
+          1. Return ! CombineDateAndTimeDuration(ZeroDateDuration(), 0).
         1. Let _diff_ be ? DifferenceISODateTime(_isoDateTime1_, _isoDateTime2_, _calendar_, _largestUnit_).
         1. If _smallestUnit_ is ~nanosecond~ and _roundingIncrement_ = 1, return _diff_.
         1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_isoDateTime2_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -519,7 +519,7 @@
         DifferenceTime (
           _time1_: a Time Record,
           _time2_: a Time Record,
-        ): a Normalized Time Duration Record
+        ): a time duration
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -532,9 +532,9 @@
         1. Let _milliseconds_ be _time2_.[[Millisecond]] - _time1_.[[Millisecond]].
         1. Let _microseconds_ be _time2_.[[Microsecond]] - _time1_.[[Microsecond]].
         1. Let _nanoseconds_ be _time2_.[[Nanosecond]] - _time1_.[[Nanosecond]].
-        1. Let _norm_ be NormalizeTimeDuration(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
-        1. Assert: abs(_norm_.[[TotalNanoseconds]]) &lt; nsPerDay.
-        1. Return _norm_.
+        1. Let _timeDuration_ be TimeDurationFromComponents(_hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_).
+        1. Assert: abs(_timeDuration_) &lt; nsPerDay.
+        1. Return _timeDuration_.
       </emu-alg>
     </emu-clause>
 
@@ -854,7 +854,7 @@
       <h1>
         AddTime (
           _time_: a Time Record,
-          _norm_: a Normalized Time Duration Record,
+          _timeDuration_: a time duration,
         ): a Time Record
       </h1>
       <dl class="header">
@@ -862,8 +862,8 @@
         <dd></dd>
       </dl>
       <emu-alg>
-        1. Let _second_ be _time_.[[Second]] + NormalizedTimeDurationSeconds(_norm_).
-        1. Let _nanosecond_ be _time_.[[Nanosecond]] + NormalizedTimeDurationSubseconds(_norm_).
+        1. Let _second_ be _time_.[[Second]] + TimeDurationSeconds(_timeDuration_).
+        1. Let _nanosecond_ be _time_.[[Nanosecond]] + TimeDurationSubseconds(_timeDuration_).
         1. Return BalanceTime(_time_.[[Hour]], _time_.[[Minute]], _second_, _time_.[[Millisecond]], _time_.[[Microsecond]], _nanosecond_).
       </emu-alg>
     </emu-clause>
@@ -931,8 +931,8 @@
         1. Set _other_ to ? ToTemporalTime(_other_).
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, « », ~nanosecond~, ~hour~).
-        1. Let _norm_ be DifferenceTime(_temporalTime_.[[Time]], _other_.[[Time]]).
-        1. Let _duration_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), _norm_).
+        1. Let _timeDuration_ be DifferenceTime(_temporalTime_.[[Time]], _other_.[[Time]]).
+        1. Let _duration_ be ! CombineDateAndTimeDuration(ZeroDateDuration(), _timeDuration_).
         1. If _settings_.[[SmallestUnit]] is not ~nanosecond~ or _settings_.[[RoundingIncrement]] ≠ 1, then
           1. Set _duration_ to ! RoundTimeDuration(_duration_, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
         1. Let _result_ be ! TemporalDurationFromInternal(_duration_, _settings_.[[LargestUnit]]).
@@ -957,7 +957,7 @@
         1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. If _operation_ is ~subtract~, set _duration_ to CreateNegatedTemporalDuration(_duration_).
         1. Let _internalDuration_ be ToInternalDurationRecord(_duration_).
-        1. Let _result_ be AddTime(_temporalTime_.[[Time]], _internalDuration_.[[NormalizedTime]]).
+        1. Let _result_ be AddTime(_temporalTime_.[[Time]], _internalDuration_.[[Time]]).
         1. Return ! CreateTemporalTime(_result_).
       </emu-alg>
     </emu-clause>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -956,8 +956,8 @@
       <emu-alg>
         1. Let _duration_ be ? ToTemporalDuration(_temporalDurationLike_).
         1. If _operation_ is ~subtract~, set _duration_ to CreateNegatedTemporalDuration(_duration_).
-        1. Let _normalizedDuration_ be NormalizeDuration(_duration_).
-        1. Let _result_ be AddTime(_temporalTime_.[[Time]], _normalizedDuration_.[[NormalizedTime]]).
+        1. Let _internalDuration_ be ToInternalDurationRecord(_duration_).
+        1. Let _result_ be AddTime(_temporalTime_.[[Time]], _internalDuration_.[[NormalizedTime]]).
         1. Return ! CreateTemporalTime(_result_).
       </emu-alg>
     </emu-clause>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -935,7 +935,7 @@
         1. Let _duration_ be ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), _norm_).
         1. If _settings_.[[SmallestUnit]] is not ~nanosecond~ or _settings_.[[RoundingIncrement]] ≠ 1, then
           1. Set _duration_ to ! RoundTimeDuration(_duration_, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ! UnnormalizeDuration(_duration_, _settings_.[[LargestUnit]]).
+        1. Let _result_ be ! TemporalDurationFromInternal(_duration_, _settings_.[[LargestUnit]]).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -862,9 +862,8 @@
         <dd></dd>
       </dl>
       <emu-alg>
-        1. Let _second_ be _time_.[[Second]] + TimeDurationSeconds(_timeDuration_).
-        1. Let _nanosecond_ be _time_.[[Nanosecond]] + TimeDurationSubseconds(_timeDuration_).
-        1. Return BalanceTime(_time_.[[Hour]], _time_.[[Minute]], _second_, _time_.[[Millisecond]], _time_.[[Microsecond]], _nanosecond_).
+        1. Return BalanceTime(_time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]] + _timeDuration_).
+        1. NOTE: If using floating points to implement this operation, add the time components separately before balancing to avoid errors with unsafe integers.
       </emu-alg>
     </emu-clause>
 

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -610,7 +610,7 @@
         1. Let _otherDate_ be ? CalendarDateFromFields(_calendar_, _otherFields_, ~constrain~).
         1. Let _dateDifference_ be CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _settings_.[[LargestUnit]]).
         1. Let _yearsMonthsDifference_ be ! AdjustDateDurationRecord(_dateDifference_, 0, 0).
-        1. Let _duration_ be ! CombineDateAndNormalizedTimeDuration(_yearsMonthsDifference_, ZeroTimeDuration()).
+        1. Let _duration_ be ! CombineDateAndTimeDuration(_yearsMonthsDifference_, ZeroTimeDuration()).
         1. If _settings_.[[SmallestUnit]] is not ~month~ or _settings_.[[RoundingIncrement]] ≠ 1, then
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_thisDate_, MidnightTimeRecord()).
           1. Let _isoDateTimeOther_ be CombineISODateAndTimeRecord(_otherDate_, MidnightTimeRecord()).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -610,7 +610,7 @@
         1. Let _otherDate_ be ? CalendarDateFromFields(_calendar_, _otherFields_, ~constrain~).
         1. Let _dateDifference_ be CalendarDateUntil(_calendar_, _thisDate_, _otherDate_, _settings_.[[LargestUnit]]).
         1. Let _yearsMonthsDifference_ be ! AdjustDateDurationRecord(_dateDifference_, 0, 0).
-        1. Let _duration_ be ! CombineDateAndTimeDuration(_yearsMonthsDifference_, ZeroTimeDuration()).
+        1. Let _duration_ be ! CombineDateAndTimeDuration(_yearsMonthsDifference_, 0).
         1. If _settings_.[[SmallestUnit]] is not ~month~ or _settings_.[[RoundingIncrement]] ≠ 1, then
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_thisDate_, MidnightTimeRecord()).
           1. Let _isoDateTimeOther_ be CombineISODateAndTimeRecord(_otherDate_, MidnightTimeRecord()).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -616,7 +616,7 @@
           1. Let _isoDateTimeOther_ be CombineISODateAndTimeRecord(_otherDate_, MidnightTimeRecord()).
           1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_isoDateTimeOther_).
           1. Set _duration_ to ? RoundRelativeDuration(_duration_, _destEpochNs_, _isoDateTime_, ~unset~, _calendar_, _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).[[Duration]].
-        1. Let _result_ be ? UnnormalizeDuration(_duration_, ~day~).
+        1. Let _result_ be ? TemporalDurationFromInternal(_duration_, ~day~).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -652,7 +652,7 @@
           1. Assert: ISODateWithinLimits(_date_) is *true*.
         1. Else,
           1. Let _date_ be _intermediateDate_.
-        1. Let _durationToAdd_ be ? NormalizeDurationWithoutTime(_duration_).
+        1. Let _durationToAdd_ be ? ToDateDurationRecordWithoutTime(_duration_).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _date_, _durationToAdd_, _overflow_).
         1. Let _addedDateFields_ be ISODateToFields(_calendar_, _addedDate_, ~year-month~).
         1. Let _isoDate_ be ? CalendarYearMonthFromFields(_calendar_, _addedDateFields_, _overflow_).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -314,16 +314,16 @@
         1. Let _nanoseconds_ be _offsetAfter_ - _offsetBefore_.
         1. Assert: abs(_nanoseconds_) ≤ nsPerDay.
         1. If _disambiguation_ is ~earlier~, then
-          1. Let _norm_ be NormalizeTimeDuration(0, 0, 0, 0, 0, -_nanoseconds_).
-          1. Let _earlierTime_ be AddTime(_isoDateTime_.[[Time]], _norm_).
+          1. Let _timeDuration_ be TimeDurationFromComponents(0, 0, 0, 0, 0, -_nanoseconds_).
+          1. Let _earlierTime_ be AddTime(_isoDateTime_.[[Time]], _timeDuration_).
           1. Let _earlierDate_ be BalanceISODate(_isoDateTime_.[[ISODate]].[[Year]], _isoDateTime_.[[ISODate]].[[Month]], _isoDateTime_.[[ISODate]].[[Day]] + _earlierTime_.[[Days]]).
           1. Let _earlierDateTime_ be CombineISODateAndTimeRecord(_earlierDate_, _earlierTime_).
           1. Set _possibleEpochNs_ to ? GetPossibleEpochNanoseconds(_timeZone_, _earlierDateTime_).
           1. Assert: _possibleEpochNs_ is not empty.
           1. Return _possibleEpochNs_[0].
         1. Assert: _disambiguation_ is ~compatible~ or ~later~.
-        1. Let _norm_ be NormalizeTimeDuration(0, 0, 0, 0, 0, _nanoseconds_).
-        1. Let _laterTime_ be AddTime(_isoDateTime_.[[Time]], _norm_).
+        1. Let _timeDuration_ be TimeDurationFromComponents(0, 0, 0, 0, 0, _nanoseconds_).
+        1. Let _laterTime_ be AddTime(_isoDateTime_.[[Time]], _timeDuration_).
         1. Let _laterDate_ be BalanceISODate(_isoDateTime_.[[ISODate]].[[Year]], _isoDateTime_.[[ISODate]].[[Month]], _isoDateTime_.[[ISODate]].[[Day]] + _laterTime_.[[Days]]).
         1. Let _laterDateTime_ be CombineISODateAndTimeRecord(_laterDate_, _laterTime_).
         1. Set _possibleEpochNs_ to ? GetPossibleEpochNanoseconds(_timeZone_, _laterDateTime_).
@@ -378,7 +378,7 @@
         1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).
         1. If _possibleEpochNs_ is not empty, return _possibleEpochNs_[0].
         1. Assert: IsOffsetTimeZoneIdentifier(_timeZone_) is *false*.
-        1. [declared="isoDateTimeAfter"] Let _possibleEpochNsAfter_ be GetNamedTimeZoneEpochNanoseconds(_timeZone_, _isoDateTimeAfter_), where _isoDateTimeAfter_ is the ISO Date-Time Record for which ! DifferenceISODateTime(_isoDateTime_, _isoDateTimeAfter_, *"iso8601"*, ~hour~).[[Norm]] is the smallest possible value > 0 for which _possibleEpochNsAfter_ is not empty (i.e., _isoDateTimeAfter_ represents the first local time after the transition).
+        1. [declared="isoDateTimeAfter"] Let _possibleEpochNsAfter_ be GetNamedTimeZoneEpochNanoseconds(_timeZone_, _isoDateTimeAfter_), where _isoDateTimeAfter_ is the ISO Date-Time Record for which ! DifferenceISODateTime(_isoDateTime_, _isoDateTimeAfter_, *"iso8601"*, ~hour~).[[Time]] is the smallest possible value > 0 for which _possibleEpochNsAfter_ is not empty (i.e., _isoDateTimeAfter_ represents the first local time after the transition).
         1. Assert: _possibleEpochNsAfter_'s length = 1.
         1. Return _possibleEpochNsAfter_[0].
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -401,8 +401,8 @@
         1. Let _tomorrow_ be BalanceISODate(_today_.[[Year]], _today_.[[Month]], _today_.[[Day]] + 1).
         1. Let _todayNs_ be ? GetStartOfDay(_timeZone_, _today_).
         1. Let _tomorrowNs_ be ? GetStartOfDay(_timeZone_, _tomorrow_).
-        1. Let _diff_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_tomorrowNs_, _todayNs_).
-        1. Return 𝔽(DivideNormalizedTimeDuration(_diff_, 3.6 × 10<sup>12</sup>)).
+        1. Let _diff_ be TimeDurationFromEpochNanosecondsDifference(_tomorrowNs_, _todayNs_).
+        1. Return 𝔽(DivideTimeDuration(_diff_, 3.6 × 10<sup>12</sup>)).
       </emu-alg>
     </emu-clause>
 
@@ -657,8 +657,8 @@
           1. Let _endNs_ be ? GetStartOfDay(_timeZone_, _dateEnd_).
           1. Assert: _thisNs_ &lt; _endNs_.
           1. Let _dayLengthNs_ be ℝ(_endNs_ - _startNs_).
-          1. Let _dayProgressNs_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_thisNs_, _startNs_).
-          1. Let _roundedDayNs_ be ! RoundNormalizedTimeDurationToIncrement(_dayProgressNs_, _dayLengthNs_, _roundingMode_).
+          1. Let _dayProgressNs_ be TimeDurationFromEpochNanosecondsDifference(_thisNs_, _startNs_).
+          1. Let _roundedDayNs_ be ! RoundTimeDurationToIncrement(_dayProgressNs_, _dayLengthNs_, _roundingMode_).
           1. Let _epochNanoseconds_ be _startNs_ + _roundedDayNs_.[[TotalNanoseconds]].
         1. Else,
           1. Let _roundResult_ be RoundISODateTime(_isoDateTime_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
@@ -1091,13 +1091,13 @@
       </dl>
       <emu-alg>
         1. If DateDurationSign(_duration_.[[Date]]) = 0, then
-          1. Return ? AddInstant(_epochNanoseconds_, _duration_.[[NormalizedTime]]).
+          1. Return ? AddInstant(_epochNanoseconds_, _duration_.[[Time]]).
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _epochNanoseconds_).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _isoDateTime_.[[ISODate]], _duration_.[[Date]], _overflow_).
         1. Let _intermediateDateTime_ be CombineISODateAndTimeRecord(_addedDate_, _isoDateTime_.[[Time]]).
         1. If ISODateTimeWithinLimits(_intermediateDateTime_) is *false*, throw a *RangeError* exception.
         1. Let _intermediateNs_ be ! GetEpochNanosecondsFor(_timeZone_, _intermediateDateTime_, ~compatible~).
-        1. Return ? AddInstant(_intermediateNs_, _duration_.[[NormalizedTime]]).
+        1. Return ? AddInstant(_intermediateNs_, _duration_.[[Time]]).
       </emu-alg>
     </emu-clause>
 
@@ -1118,28 +1118,28 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _ns1_ = _ns2_, return ! CombineDateAndNormalizedTimeDuration(ZeroDateDuration(), ZeroTimeDuration()).
+        1. If _ns1_ = _ns2_, return ! CombineDateAndTimeDuration(ZeroDateDuration(), ZeroTimeDuration()).
         1. Let _startDateTime_ be GetISODateTimeFor(_timeZone_, _ns1_).
         1. Let _endDateTime_ be GetISODateTimeFor(_timeZone_, _ns2_).
         1. If _ns2_ - _ns1_ &lt; 0, let _sign_ be -1; else let _sign_ be 1.
         1. If _sign_ = 1, let _maxDayCorrection_ be 2; else let _maxDayCorrection_ be 1.
         1. Let _dayCorrection_ be 0.
         1. Let _timeDuration_ be DifferenceTime(_startDateTime_.[[Time]], _endDateTime_.[[Time]]).
-        1. If NormalizedTimeDurationSign(_timeDuration_) = -_sign_, set _dayCorrection_ to _dayCorrection_ + 1.
+        1. If TimeDurationSign(_timeDuration_) = -_sign_, set _dayCorrection_ to _dayCorrection_ + 1.
         1. Let _success_ be *false*.
         1. Repeat, while _dayCorrection_ ≤ _maxDayCorrection_ and _success_ is *false*,
           1. Let _intermediateDate_ be BalanceISODate(_endDateTime_.[[ISODate]].[[Year]], _endDateTime_.[[ISODate]].[[Month]], _endDateTime_.[[ISODate]].[[Day]] - _dayCorrection_ × _sign_).
           1. Let _intermediateDateTime_ be CombineISODateAndTimeRecord(_intermediateDate_, _startDateTime_.[[Time]]).
           1. Let _intermediateNs_ be ? GetEpochNanosecondsFor(_timeZone_, _intermediateDateTime_, ~compatible~).
-          1. Let _norm_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_ns2_, _intermediateNs_).
-          1. Let _timeSign_ be NormalizedTimeDurationSign(_norm_).
+          1. Set _timeDuration_ to TimeDurationFromEpochNanosecondsDifference(_ns2_, _intermediateNs_).
+          1. Let _timeSign_ be TimeDurationSign(_timeDuration_).
           1. If _sign_ ≠ -_timeSign_, then
             1. Set _success_ to *true*.
           1. Set _dayCorrection_ to _dayCorrection_ + 1.
         1. Assert: _success_ is *true*.
         1. Let _dateLargestUnit_ be LargerOfTwoTemporalUnits(_largestUnit_, ~day~).
         1. Let _dateDifference_ be CalendarDateUntil(_calendar_, _startDateTime_.[[ISODate]], _intermediateDateTime_.[[ISODate]], _dateLargestUnit_).
-        1. Return ? CombineDateAndNormalizedTimeDuration(_dateDifference_, _norm_).
+        1. Return ? CombineDateAndTimeDuration(_dateDifference_, _timeDuration_).
       </emu-alg>
     </emu-clause>
 
@@ -1186,7 +1186,7 @@
       </dl>
       <emu-alg>
         1. If TemporalUnitCategory(_unit_) is ~time~, then
-          1. Let _difference_ be NormalizedTimeDurationFromEpochNanosecondsDifference(_ns2_, _ns1_).
+          1. Let _difference_ be TimeDurationFromEpochNanosecondsDifference(_ns2_, _ns1_).
           1. Return TotalTimeDuration(_difference_, _unit_).
         1. Let _difference_ be ? DifferenceZonedDateTime(_ns1_, _ns2_, _timeZone_, _calendar_, _unit_).
         1. Let _dateTime_ be GetISODateTimeFor(_timeZone_, _ns1_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1215,7 +1215,7 @@
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~datetime~, « », ~nanosecond~, ~hour~).
         1. If TemporalUnitCategory(_settings_.[[LargestUnit]]) is not ~date~, then
           1. Let _internalDuration_ be DifferenceInstant(_zonedDateTime_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-          1. Let _result_ be ! UnnormalizeDuration(_internalDuration_, _settings_.[[LargestUnit]]).
+          1. Let _result_ be ! TemporalDurationFromInternal(_internalDuration_, _settings_.[[LargestUnit]]).
           1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
           1. Return _result_.
         1. NOTE: To calculate differences in two different time zones, _settings_.[[LargestUnit]] must be a time unit, because day lengths can vary between time zones due to DST and other UTC offset shifts.
@@ -1224,7 +1224,7 @@
         1. If _zonedDateTime_.[[EpochNanoseconds]] = _other_.[[EpochNanoseconds]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
         1. Let _internalDuration_ be ? DifferenceZonedDateTimeWithRounding(_zonedDateTime_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ? UnnormalizeDuration(_internalDuration_, ~hour~).
+        1. Let _result_ be ? TemporalDurationFromInternal(_internalDuration_, ~hour~).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1214,8 +1214,8 @@
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~datetime~, « », ~nanosecond~, ~hour~).
         1. If TemporalUnitCategory(_settings_.[[LargestUnit]]) is not ~date~, then
-          1. Let _diffRecord_ be DifferenceInstant(_zonedDateTime_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-          1. Let _result_ be ! UnnormalizeDuration(_diffRecord_.[[NormalizedDuration]], _settings_.[[LargestUnit]]).
+          1. Let _internalDuration_ be DifferenceInstant(_zonedDateTime_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+          1. Let _result_ be ! UnnormalizeDuration(_internalDuration_, _settings_.[[LargestUnit]]).
           1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
           1. Return _result_.
         1. NOTE: To calculate differences in two different time zones, _settings_.[[LargestUnit]] must be a time unit, because day lengths can vary between time zones due to DST and other UTC offset shifts.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1078,7 +1078,7 @@
           _epochNanoseconds_: a BigInt,
           _timeZone_: an available time zone identifier,
           _calendar_: a calendar type,
-          _duration_: a Normalized Duration Record,
+          _duration_: an Internal Duration Record,
           _overflow_: ~constrain~ or ~reject~,
         ): either a normal completion containing a BigInt or a throw completion
       </h1>
@@ -1109,7 +1109,7 @@
           _timeZone_: an available time zone identifier,
           _calendar_: a calendar type,
           _largestUnit_: a Temporal unit,
-        ): either a normal completion containing a Normalized Duration Record, or a throw completion
+        ): either a normal completion containing an Internal Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1154,7 +1154,7 @@
           _roundingIncrement_: a positive integer,
           _smallestUnit_: a Temporal unit,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing a Normalized Duration Record, or a throw completion
+        ): either a normal completion containing an Internal Duration Record, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
@@ -1223,8 +1223,8 @@
           1. Throw a *RangeError* exception.
         1. If _zonedDateTime_.[[EpochNanoseconds]] = _other_.[[EpochNanoseconds]], then
           1. Return ! CreateTemporalDuration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0).
-        1. Let _normalizedDuration_ be ? DifferenceZonedDateTimeWithRounding(_zonedDateTime_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
-        1. Let _result_ be ? UnnormalizeDuration(_normalizedDuration_, ~hour~).
+        1. Let _internalDuration_ be ? DifferenceZonedDateTimeWithRounding(_zonedDateTime_.[[EpochNanoseconds]], _other_.[[EpochNanoseconds]], _zonedDateTime_.[[TimeZone]], _zonedDateTime_.[[Calendar]], _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
+        1. Let _result_ be ? UnnormalizeDuration(_internalDuration_, ~hour~).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.
       </emu-alg>
@@ -1250,8 +1250,8 @@
         1. Let _overflow_ be ? GetTemporalOverflowOption(_resolvedOptions_).
         1. Let _calendar_ be _zonedDateTime_.[[Calendar]].
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
-        1. Let _normalizedDuration_ be NormalizeDuration(_duration_).
-        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[EpochNanoseconds]], _timeZone_, _calendar_, _normalizedDuration_, _overflow_).
+        1. Let _internalDuration_ be ToInternalDurationRecord(_duration_).
+        1. Let _epochNanoseconds_ be ? AddZonedDateTime(_zonedDateTime_.[[EpochNanoseconds]], _timeZone_, _calendar_, _internalDuration_, _overflow_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1118,7 +1118,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _ns1_ = _ns2_, return ! CombineDateAndTimeDuration(ZeroDateDuration(), ZeroTimeDuration()).
+        1. If _ns1_ = _ns2_, return ! CombineDateAndTimeDuration(ZeroDateDuration(), 0).
         1. Let _startDateTime_ be GetISODateTimeFor(_timeZone_, _ns1_).
         1. Let _endDateTime_ be GetISODateTimeFor(_timeZone_, _ns2_).
         1. If _ns2_ - _ns1_ &lt; 0, let _sign_ be -1; else let _sign_ be 1.


### PR DESCRIPTION
Rename for reasons described in #2953, and change Normalized Time Duration Record to be an integer within a particular range, which allows simplifying several abstract operations as discussed there.

Closes: #2953