### PR TITLE
Replace BalanceISODate(Time) and rearrange time zone offset checks 

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -111,16 +111,15 @@
   <emu-clause id="sec-checkisodaysrange" type="abstract operation">
     <h1>
       CheckISODaysRange (
-        _isoDate_: an ISO Date Record,
+        _isoDateTime_: an ISO Date-Time Record,
       ): either a normal completion containing ~unused~ or a throw completion
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>It checks that the given date is within the range of 10<sup>8</sup> days from the epoch.</dd>
+      <dd>It checks that the given date-time is within the range of 10<sup>8</sup> days from the epoch.</dd>
     </dl>
     <emu-alg>
-      1. Let _dateTime_ be CombineISODateAndTimeRecord(_isoDate_, MidnightTimeRecord()).
-      1. If ISODateTimeWithinLimits(_dateTime_) is *false*, then
+      1. If ISODateTimeWithinLimits(_isoDateTime_) is *false*, then
         1. Throw a *RangeError* exception.
       1. Return ~unused~.
     </emu-alg>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -108,27 +108,6 @@
     <emu-note type="editor"> Note that the operation EpochTimeToMonthInYear(_t_) uses 0-based months unlike rest of Temporal since it's intended to be unified with MonthFromTime(_t_) when the above mentioned issue is fixed.</emu-note>
   </emu-clause>
 
-  <emu-clause id="sec-checkisodaysrange" type="abstract operation">
-    <h1>
-      CheckISODaysRange (
-        _isoDateTime_: an ISO Date-Time Record,
-      ): either a normal completion containing ~unused~ or a throw completion
-    </h1>
-    <dl class="header">
-      <dt>description</dt>
-      <dd>It checks that the given date-time is within the range of 10<sup>8</sup> days from the epoch.</dd>
-    </dl>
-    <emu-alg>
-      1. If ISODateTimeWithinLimits(_isoDateTime_) is *false*, then
-        1. Throw a *RangeError* exception.
-      1. Return ~unused~.
-    </emu-alg>
-    <emu-note type="editor">
-      This operation is solely present to ensure that GetUTCEpochNanoseconds is not called with numbers that are too large.
-      This operation can be removed with no observable effect when https://github.com/tc39/ecma262/issues/1087 is fixed.
-    </emu-note>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-units">
     <h1>Units</h1>
     <p>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -119,13 +119,13 @@
       <dd>It checks that the given date is within the range of 10<sup>8</sup> days from the epoch.</dd>
     </dl>
     <emu-alg>
-      1. If abs(ISODateToEpochDays(_isoDate_.[[Year]], _isoDate_.[[Month]] - 1, _isoDate_.[[Day]])) > 10<sup>8</sup>, then
+      1. Let _dateTime_ be CombineISODateAndTimeRecord(_isoDate_, MidnightTimeRecord()).
+      1. If ISODateTimeWithinLimits(_dateTime_) is *false*, then
         1. Throw a *RangeError* exception.
       1. Return ~unused~.
     </emu-alg>
     <emu-note type="editor">
       This operation is solely present to ensure that GetUTCEpochNanoseconds is not called with numbers that are too large.
-      It is distinct from ISODateWithinLimits, which uses GetUTCEpochNanoseconds.
       This operation can be removed with no observable effect when https://github.com/tc39/ecma262/issues/1087 is fixed.
     </emu-note>
   </emu-clause>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -624,13 +624,11 @@
           1. Return the Record { [[PlainRelativeTo]]: _plainDate_, [[ZonedRelativeTo]]: *undefined* }.
         1. Let _calendar_ be ? GetTemporalCalendarIdentifierWithISODefault(_value_).
         1. Let _fields_ be ? PrepareCalendarFields(_calendar_, _value_, « ~year~, ~month~, ~month-code~, ~day~ », « ~hour~, ~minute~, ~second~, ~millisecond~, ~microsecond~, ~nanosecond~, ~offset~, ~time-zone~ », «»).
-        1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, ~constrain~).
+        1. Let _isoDateTime_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, ~constrain~).
         1. Let _timeZone_ be _fields_.[[TimeZone]].
         1. Let _offsetString_ be _fields_.[[Offset]].
         1. If _offsetString_ is ~unset~, then
           1. Set _offsetBehaviour_ to ~wall~.
-        1. Let _isoDate_ be _result_.[[ISODate]].
-        1. Let _time_ be _result_.[[Time]].
       1. Else,
         1. If _value_ is not a String, throw a *TypeError* exception.
         1. Let _result_ be ? ParseISODateTime(_value_, « |TemporalDateTimeString[+Zoned]|, |TemporalDateTimeString[~Zoned]| »).
@@ -650,14 +648,20 @@
         1. Set _calendar_ to ? CanonicalizeCalendar(_calendar_).
         1. Let _isoDate_ be CreateISODateRecord(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
         1. Let _time_ be _result_.[[Time]].
+        1. If _time_ is ~start-of-day~, then
+          1. If _timeZone_ is not ~unset~, then
+            1. Assert: _offsetBehaviour_ is ~wall~.
+            1. Return ? GetStartOfDay(_timeZone_, _isoDate_).
+          1. Set _time_ to MidnightTimeRecord().
+        1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, _time_).
       1. If _timeZone_ is ~unset~, then
-        1. Let _plainDate_ be ? CreateTemporalDate(_isoDate_, _calendar_).
+        1. Let _plainDate_ be ? CreateTemporalDate(_isoDateTime_.[[ISODate]], _calendar_).
         1. Return the Record { [[PlainRelativeTo]]: _plainDate_, [[ZonedRelativeTo]]: *undefined* }.
       1. If _offsetBehaviour_ is ~option~, then
         1. Let _offsetNs_ be ! ParseDateTimeUTCOffset(_offsetString_).
       1. Else,
         1. Let _offsetNs_ be 0.
-      1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_isoDate_, _time_, _offsetBehaviour_, _offsetNs_, _timeZone_, ~compatible~, ~reject~, _matchBehaviour_).
+      1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_isoDateTime_, _offsetBehaviour_, _offsetNs_, _timeZone_, ~compatible~, ~reject~, _matchBehaviour_).
       1. Let _zonedRelativeTo_ be ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       1. Return the Record { [[PlainRelativeTo]]: *undefined*, [[ZonedRelativeTo]]: _zonedRelativeTo_ }.
     </emu-alg>

--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -495,8 +495,8 @@
         1. If _calendar_ is *"iso8601"*, then
           1. Let _intermediate_ be BalanceISOYearMonth(_isoDate_.[[Year]] + _duration_.[[Years]], _isoDate_.[[Month]] + _duration_.[[Months]]).
           1. Set _intermediate_ to ? RegulateISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _isoDate_.[[Day]], _overflow_).
-          1. Let _d_ be _intermediate_.[[Day]] + _duration_.[[Days]] + 7 × _duration_.[[Weeks]].
-          1. Let _result_ be BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _d_).
+          1. Let _days_ be _duration_.[[Days]] + 7 × _duration_.[[Weeks]].
+          1. Let _result_ be AddDaysToISODate(_intermediate_, _days_).
         1. Else,
           1. Let _result_ be an implementation-defined ISO Date Record, or throw a *RangeError* exception, as described below.
         1. If ISODateWithinLimits(_result_) is *false*, throw a *RangeError* exception.
@@ -547,18 +547,18 @@
           1. Let _weeks_ be 0.
           1. If _largestUnit_ is ~week~, then
             1. Let _candidateWeeks_ be _sign_.
-            1. Set _intermediate_ to BalanceISODate(_constrained_.[[Year]], _constrained_.[[Month]], _constrained_.[[Day]] + 7 × _candidateWeeks_).
+            1. Set _intermediate_ to AddDaysToISODate(_constrained_, 7 × _candidateWeeks_).
             1. Repeat, while ISODateSurpasses(_sign_, _intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]], _two_) is *false*,
               1. Set _weeks_ to _candidateWeeks_.
               1. Set _candidateWeeks_ to _candidateWeeks_ + sign.
-              1. Set _intermediate_ to BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]] + 7 × _sign_).
+              1. Set _intermediate_ to AddDaysToISODate(_intermediate_, 7 × _sign_).
           1. Let _days_ be 0.
           1. Let _candidateDays_ be _sign_.
-          1. Set _intermediate_ to BalanceISODate(_constrained_.[[Year]], _constrained_.[[Month]], _constrained_.[[Day]] + 7 × _weeks_ + _candidateDays_).
+          1. Set _intermediate_ to AddDaysToISODate(_constrained_, 7 × _weeks_ + _candidateDays_).
           1. Repeat, while ISODateSurpasses(_sign_, _intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]], _two_) is *false*,
             1. Set _days_ to _candidateDays_.
             1. Set _candidateDays_ to _candidateDays_ + _sign_.
-            1. Set _intermediate_ to BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]] + _sign_).
+            1. Set _intermediate_ to AddDaysToISODate(_intermediate_, _sign_).
           1. Return ! CreateDateDurationRecord(_years_, _months_, _weeks_, _days_).
         1. Return an implementation-defined Date Duration Record as described above.
       </emu-alg>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1614,7 +1614,7 @@
         1. Else if _unit_ is ~week~, then
           1. Let _yearsMonths_ be ! AdjustDateDurationRecord(_duration_.[[Date]], 0, 0).
           1. Let _weeksStart_ be ? CalendarDateAdd(_calendar_, _isoDateTime_.[[ISODate]], _yearsMonths_, ~constrain~).
-          1. Let _weeksEnd_ be BalanceISODate(_weeksStart_.[[Year]], _weeksStart_.[[Month]], _weeksStart_.[[Day]] + _duration_.[[Date]].[[Days]]).
+          1. Let _weeksEnd_ be AddDaysToISODate(_weeksStart_, _duration_.[[Date]].[[Days]]).
           1. Let _untilResult_ be CalendarDateUntil(_calendar_, _weeksStart_, _weeksEnd_, ~week~).
           1. Let _weeks_ be RoundNumberToIncrement(_duration_.[[Date]].[[Weeks]] + _untilResult_.[[Weeks]], _increment_, ~trunc~).
           1. Let _r1_ be _weeks_.
@@ -1692,7 +1692,7 @@
       <emu-alg>
         1. Let _start_ be ? CalendarDateAdd(_calendar_, _isoDateTime_.[[ISODate]], _duration_.[[Date]], ~constrain~).
         1. Let _startDateTime_ be CombineISODateAndTimeRecord(_start_, _isoDateTime_.[[Time]]).
-        1. Let _endDate_ be BalanceISODate(_start_.[[Year]], _start_.[[Month]], _start_.[[Day]] + _sign_).
+        1. Let _endDate_ be AddDaysToISODate(_start_, _sign_).
         1. Let _endDateTime_ be CombineISODateAndTimeRecord(_endDate_, _isoDateTime_.[[Time]]).
         1. Let _startEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _startDateTime_, ~compatible~).
         1. Let _endEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _endDateTime_, ~compatible~).

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1638,6 +1638,8 @@
           1. Let _startEpochNs_ be GetUTCEpochNanoseconds(_startDateTime_).
           1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_endDateTime_).
         1. Else,
+          1. Perform ? CheckISODaysRange(_startDateTime_).
+          1. Perform ? CheckISODaysRange(_endDateTime_).
           1. Let _startEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _startDateTime_, ~compatible~).
           1. Let _endEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _endDateTime_, ~compatible~).
         1. If _sign_ is 1, then
@@ -1692,8 +1694,10 @@
       <emu-alg>
         1. Let _start_ be ? CalendarDateAdd(_calendar_, _isoDateTime_.[[ISODate]], _duration_.[[Date]], ~constrain~).
         1. Let _startDateTime_ be CombineISODateAndTimeRecord(_start_, _isoDateTime_.[[Time]]).
+        1. Perform ? CheckISODaysRange(_startDateTime_).
         1. Let _endDate_ be AddDaysToISODate(_start_, _sign_).
         1. Let _endDateTime_ be CombineISODateAndTimeRecord(_endDate_, _isoDateTime_.[[Time]]).
+        1. Perform ? CheckISODaysRange(_endDateTime_).
         1. Let _startEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _startDateTime_, ~compatible~).
         1. Let _endEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _endDateTime_, ~compatible~).
         1. Let _daySpan_ be TimeDurationFromEpochNanosecondsDifference(_endEpochNs_, _startEpochNs_).
@@ -1798,6 +1802,7 @@
             1. If _timeZone_ is ~unset~, then
               1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_endDateTime_).
             1. Else,
+              1. Perform ? CheckISODaysRange(_endDateTime_).
               1. Let _endEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _endDateTime_, ~compatible~).
             1. Let _beyondEnd_ be _nudgedEpochNs_ - _endEpochNs_.
             1. If _beyondEnd_ &lt; 0, let _beyondEndSign_ be -1; else if _beyondEnd_ > 0, let _beyondEndSign_ be 1; else let _beyondEndSign_ be 0.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1638,8 +1638,8 @@
           1. Let _startEpochNs_ be GetUTCEpochNanoseconds(_startDateTime_).
           1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_endDateTime_).
         1. Else,
-          1. Perform ? CheckISODaysRange(_startDateTime_).
-          1. Perform ? CheckISODaysRange(_endDateTime_).
+          1. If ISODateTimeWithinLimits(_startDateTime_) is *false*, throw a *RangeError* exception.
+          1. If ISODateTimeWithinLimits(_endDateTime_) is *false*, throw a *RangeError* exception.
           1. Let _startEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _startDateTime_, ~compatible~).
           1. Let _endEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _endDateTime_, ~compatible~).
         1. If _sign_ is 1, then
@@ -1694,10 +1694,10 @@
       <emu-alg>
         1. Let _start_ be ? CalendarDateAdd(_calendar_, _isoDateTime_.[[ISODate]], _duration_.[[Date]], ~constrain~).
         1. Let _startDateTime_ be CombineISODateAndTimeRecord(_start_, _isoDateTime_.[[Time]]).
-        1. Perform ? CheckISODaysRange(_startDateTime_).
+        1. If ISODateTimeWithinLimits(_startDateTime_) is *false*, throw a *RangeError* exception.
         1. Let _endDate_ be AddDaysToISODate(_start_, _sign_).
         1. Let _endDateTime_ be CombineISODateAndTimeRecord(_endDate_, _isoDateTime_.[[Time]]).
-        1. Perform ? CheckISODaysRange(_endDateTime_).
+        1. If ISODateTimeWithinLimits(_endDateTime_) is *false*, throw a *RangeError* exception.
         1. Let _startEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _startDateTime_, ~compatible~).
         1. Let _endEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _endDateTime_, ~compatible~).
         1. Let _daySpan_ be TimeDurationFromEpochNanosecondsDifference(_endEpochNs_, _startEpochNs_).
@@ -1802,7 +1802,7 @@
             1. If _timeZone_ is ~unset~, then
               1. Let _endEpochNs_ be GetUTCEpochNanoseconds(_endDateTime_).
             1. Else,
-              1. Perform ? CheckISODaysRange(_endDateTime_).
+              1. If ISODateTimeWithinLimits(_endDateTime_) is *false*, throw a *RangeError* exception.
               1. Let _endEpochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _endDateTime_, ~compatible~).
             1. Let _beyondEnd_ be _nudgedEpochNs_ - _endEpochNs_.
             1. If _beyondEnd_ &lt; 0, let _beyondEndSign_ be -1; else if _beyondEnd_ > 0, let _beyondEndSign_ be 1; else let _beyondEndSign_ be 0.

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -413,9 +413,10 @@
         1. Assert: Either _parsed_.[[TimeZone]].[[OffsetString]] is not ~empty~ or _parsed_.[[TimeZone]].[[Z]] is *true*, but not both.
         1. If _parsed_.[[TimeZone]].[[Z]] is *true*, let _offsetNanoseconds_ be 0; otherwise, let _offsetNanoseconds_ be ! ParseDateTimeUTCOffset(_parsed_.[[TimeZone]].[[OffsetString]]).
         1. If _parsed_.[[Time]] is ~start-of-day~, let _time_ be MidnightTimeRecord(); else let _time_ be _parsed_.[[Time]].
-        1. Let _balanced_ be BalanceISODateTime(_parsed_.[[Year]], _parsed_.[[Month]], _parsed_.[[Day]], _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]] - _offsetNanoseconds_).
-        1. Perform ? CheckISODaysRange(_balanced_.[[ISODate]]).
-        1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_balanced_).
+        1. Let _isoDate_ be CreateISODateRecord(_parsed_.[[Year]], _parsed_.[[Month]], _parsed_.[[Day]]).
+        1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, _time_).
+        1. Perform ? CheckISODaysRange(_isoDate_).
+        1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_) - _offsetNanoseconds_.
         1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).
       </emu-alg>

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -415,7 +415,7 @@
         1. If _parsed_.[[Time]] is ~start-of-day~, let _time_ be MidnightTimeRecord(); else let _time_ be _parsed_.[[Time]].
         1. Let _isoDate_ be CreateISODateRecord(_parsed_.[[Year]], _parsed_.[[Month]], _parsed_.[[Day]]).
         1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, _time_).
-        1. Perform ? CheckISODaysRange(_isoDateTime_).
+        1. If ISODateTimeWithinLimits(_isoDateTime_) is *false*, throw a *RangeError* exception.
         1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_) - _offsetNanoseconds_.
         1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -415,7 +415,7 @@
         1. If _parsed_.[[Time]] is ~start-of-day~, let _time_ be MidnightTimeRecord(); else let _time_ be _parsed_.[[Time]].
         1. Let _isoDate_ be CreateISODateRecord(_parsed_.[[Year]], _parsed_.[[Month]], _parsed_.[[Day]]).
         1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, _time_).
-        1. Perform ? CheckISODaysRange(_isoDate_).
+        1. Perform ? CheckISODaysRange(_isoDateTime_).
         1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_) - _offsetNanoseconds_.
         1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ! CreateTemporalInstant(_epochNanoseconds_).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -460,7 +460,7 @@
         1. Else,
           1. Set _temporalTime_ to ? ToTemporalTime(_temporalTime_).
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_temporalDate_.[[ISODate]], _temporalTime_.[[Time]]).
-          1. If ISODateTimeWithinLimits(_isoDateTime_) is *false*, throw a *RangeError* exception.
+          1. Perform ? CheckISODaysRange(_isoDateTime_).
           1. Let _epochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, ~compatible~).
         1. Return ! CreateTemporalZonedDateTime(_epochNs_, _timeZone_, _temporalDate_.[[Calendar]]).
       </emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -460,7 +460,7 @@
         1. Else,
           1. Set _temporalTime_ to ? ToTemporalTime(_temporalTime_).
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_temporalDate_.[[ISODate]], _temporalTime_.[[Time]]).
-          1. Perform ? CheckISODaysRange(_isoDateTime_).
+          1. If ISODateTimeWithinLimits(_isoDateTime_) is *false*, throw a *RangeError* exception.
           1. Let _epochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, ~compatible~).
         1. Return ! CreateTemporalZonedDateTime(_epochNs_, _timeZone_, _temporalDate_.[[Calendar]]).
       </emu-alg>

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -773,23 +773,22 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-balanceisodate" type="abstract operation">
+    <emu-clause id="sec-temporal-adddaystoisodate" type="abstract operation">
       <h1>
-        BalanceISODate (
-          _year_: an integer,
-          _month_: an integer,
-          _day_: an integer,
+        AddDaysToISODate (
+          _isoDate_: an ISO Date Record,
+          _days_: an integer,
         ): an ISO Date Record
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It converts the given _year_, _month_, and _day_ into a valid calendar date in the ISO 8601 calendar as given by IsValidISODate, by overflowing out-of-range _month_ or _day_ values into the next-highest unit.
+          It adds _days_ to _isoDate_ into a valid calendar date in the ISO 8601 calendar as given by IsValidISODate, by overflowing out-of-range month or day values into the next-highest unit.
           This date may be outside the range given by ISODateTimeWithinLimits.
         </dd>
       </dl>
       <emu-alg>
-        1. Let _epochDays_ be ISODateToEpochDays(_year_, _month_ - 1, _day_).
+        1. Let _epochDays_ be ISODateToEpochDays(_isoDate_.[[Year]], _isoDate_.[[Month]] - 1, _isoDate_.[[Day]]) + _days_.
         1. Let _ms_ be EpochDaysToEpochMs(_epochDays_, 0).
         1. Return CreateISODateRecord(EpochTimeToEpochYear(_ms_), EpochTimeToMonthInYear(_ms_) + 1, EpochTimeToDate(_ms_)).
       </emu-alg>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -836,24 +836,6 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-addoffsetnanosecondstoisodatetime" type="abstract operation">
-      <h1>
-        AddOffsetNanosecondsToISODateTime (
-          _isoDateTime_: an ISO Date-Time Record,
-          _nanoseconds_: an integer in the interval from -86400 × 10<sup>9</sup> (exclusive) to 86400 × 10<sup>9</sup> (exclusive),
-        ): an ISO Date-Time Record
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd></dd>
-      </dl>
-      <emu-alg>
-        1. Let _balancedTime_ be BalanceTime(_isoDateTime_.[[Time]].[[Hour]], _isoDateTime_.[[Time]].[[Minute]], _isoDateTime_.[[Time]].[[Second]], _isoDateTime_.[[Time]].[[Millisecond]], _isoDateTime_.[[Time]].[[Microsecond]], _isoDateTime_.[[Time]].[[Nanosecond]] + _nanoseconds_).
-        1. Let _balancedDate_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _balancedTime_.[[Days]]).
-        1. Return CombineISODateAndTimeRecord(_balancedDate_, _balancedTime_).
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-temporal-createtemporaldatetime" type="abstract operation">
       <h1>
         CreateTemporalDateTime (

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -836,18 +836,11 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-balanceisodatetime" type="abstract operation">
+    <emu-clause id="sec-temporal-addoffsetnanosecondstoisodatetime" type="abstract operation">
       <h1>
-        BalanceISODateTime (
-          _year_: an integer,
-          _month_: an integer,
-          _day_: an integer,
-          _hour_: an integer,
-          _minute_: an integer,
-          _second_: an integer,
-          _millisecond_: an integer,
-          _microsecond_: an integer,
-          _nanosecond_: an integer,
+        AddOffsetNanosecondsToISODateTime (
+          _isoDateTime_: an ISO Date-Time Record,
+          _nanoseconds_: an integer in the interval from -86400 × 10<sup>9</sup> (exclusive) to 86400 × 10<sup>9</sup> (exclusive),
         ): an ISO Date-Time Record
       </h1>
       <dl class="header">
@@ -855,8 +848,8 @@
         <dd></dd>
       </dl>
       <emu-alg>
-        1. Let _balancedTime_ be BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
-        1. Let _balancedDate_ be BalanceISODate(_year_, _month_, _day_ + _balancedTime_.[[Days]]).
+        1. Let _balancedTime_ be BalanceTime(_isoDateTime_.[[Time]].[[Hour]], _isoDateTime_.[[Time]].[[Minute]], _isoDateTime_.[[Time]].[[Second]], _isoDateTime_.[[Time]].[[Millisecond]], _isoDateTime_.[[Time]].[[Microsecond]], _isoDateTime_.[[Time]].[[Nanosecond]] + _nanoseconds_).
+        1. Let _balancedDate_ be BalanceISODate(_isoDateTime_.[[ISODate]].[[Year]], _isoDateTime_.[[ISODate]].[[Month]], _isoDateTime_.[[ISODate]].[[Day]] + _balancedTime_.[[Days]]).
         1. Return CombineISODateAndTimeRecord(_balancedDate_, _balancedTime_).
       </emu-alg>
     </emu-clause>

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -849,7 +849,7 @@
       </dl>
       <emu-alg>
         1. Let _balancedTime_ be BalanceTime(_isoDateTime_.[[Time]].[[Hour]], _isoDateTime_.[[Time]].[[Minute]], _isoDateTime_.[[Time]].[[Second]], _isoDateTime_.[[Time]].[[Millisecond]], _isoDateTime_.[[Time]].[[Microsecond]], _isoDateTime_.[[Time]].[[Nanosecond]] + _nanoseconds_).
-        1. Let _balancedDate_ be BalanceISODate(_isoDateTime_.[[ISODate]].[[Year]], _isoDateTime_.[[ISODate]].[[Month]], _isoDateTime_.[[ISODate]].[[Day]] + _balancedTime_.[[Days]]).
+        1. Let _balancedDate_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _balancedTime_.[[Days]]).
         1. Return CombineISODateAndTimeRecord(_balancedDate_, _balancedTime_).
       </emu-alg>
     </emu-clause>
@@ -935,7 +935,7 @@
       <emu-alg>
         1. Assert: ISODateTimeWithinLimits(_isoDateTime_) is *true*.
         1. Let _roundedTime_ be RoundTime(_isoDateTime_.[[Time]], _increment_, _unit_, _roundingMode_).
-        1. Let _balanceResult_ be BalanceISODate(_isoDateTime_.[[ISODate]].[[Year]], _isoDateTime_.[[ISODate]].[[Month]], _isoDateTime_.[[ISODate]].[[Day]] + _roundedTime_.[[Days]]).
+        1. Let _balanceResult_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _roundedTime_.[[Days]]).
         1. Return CombineISODateAndTimeRecord(_balanceResult_, _roundedTime_).
       </emu-alg>
     </emu-clause>
@@ -964,7 +964,7 @@
         1. Let _dateSign_ be CompareISODate(_isoDateTime2_.[[ISODate]], _isoDateTime1_.[[ISODate]]).
         1. Let _adjustedDate_ be _isoDateTime2_.[[ISODate]].
         1. If _timeSign_ = -_dateSign_, then
-          1. Set _adjustedDate_ to BalanceISODate(_adjustedDate_.[[Year]], _adjustedDate_.[[Month]], _adjustedDate_.[[Day]] + _timeSign_).
+          1. Set _adjustedDate_ to AddDaysToISODate(_adjustedDate_, _timeSign_).
           1. Set _timeDuration_ to ? Add24HourDaysToTimeDuration(_timeDuration_, -_timeSign_).
         1. Let _dateLargestUnit_ be LargerOfTwoTemporalUnits(~day~, _largestUnit_).
         1. Let _dateDifference_ be CalendarDateUntil(_calendar_, _isoDateTime1_.[[ISODate]], _adjustedDate_, _dateLargestUnit_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -648,7 +648,7 @@
         1. If _sign_ &lt; 0, then
           1. Let _oneMonthDuration_ be ! CreateDateDurationRecord(0, 1, 0, 0).
           1. Let _nextMonth_ be ? CalendarDateAdd(_calendar_, _intermediateDate_, _oneMonthDuration_, ~constrain~).
-          1. Let _date_ be BalanceISODate(_nextMonth_.[[Year]], _nextMonth_.[[Month]], _nextMonth_.[[Day]] - 1).
+          1. Let _date_ be AddDaysToISODate(_nextMonth_, -1).
           1. Assert: ISODateWithinLimits(_date_) is *true*.
         1. Else,
           1. Let _date_ be _intermediateDate_.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -294,6 +294,7 @@
         <dd>It chooses from a List of possible exact times the one indicated by the _disambiguation_ parameter.</dd>
       </dl>
       <emu-alg>
+        1. Assert: ISODateTimeWithinLimits(_isoDateTime_) is *true*.
         1. Let _n_ be _possibleEpochNs_'s length.
         1. If _n_ = 1, then
           1. Return _possibleEpochNs_[0].

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -257,8 +257,10 @@
       <emu-alg>
         1. Assert: IsValidEpochNanoseconds(_epochNs_) is *true*.
         1. Let _offsetNanoseconds_ be GetOffsetNanosecondsFor(_timeZone_, _epochNs_).
-        1. Let _result_ be GetISOPartsFromEpoch(ℝ(_epochNs_)).
-        1. Return AddOffsetNanosecondsToISODateTime(_result_, _offsetNanoseconds_).
+        1. Let _isoDateTime_ be GetISOPartsFromEpoch(ℝ(_epochNs_)).
+        1. Let _balancedTime_ be BalanceTime(_isoDateTime_.[[Time]].[[Hour]], _isoDateTime_.[[Time]].[[Minute]], _isoDateTime_.[[Time]].[[Second]], _isoDateTime_.[[Time]].[[Millisecond]], _isoDateTime_.[[Time]].[[Microsecond]], _isoDateTime_.[[Time]].[[Nanosecond]] + _offsetNanoseconds_).
+        1. Let _balancedDate_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _balancedTime_.[[Days]]).
+        1. Return CombineISODateAndTimeRecord(_balancedDate_, _balancedTime_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -276,7 +276,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Perform ? CheckISODaysRange(_isoDateTime_).
+        1. Assert: ISODateTimeWithinLimits(_isoDateTime_) is *true*.
         1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).
         1. Return ? DisambiguatePossibleEpochNanoseconds(_possibleEpochNs_, _timeZone_, _isoDateTime_, _disambiguation_).
       </emu-alg>

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -257,7 +257,7 @@
       <emu-alg>
         1. Let _offsetNanoseconds_ be GetOffsetNanosecondsFor(_timeZone_, _epochNs_).
         1. Let _result_ be GetISOPartsFromEpoch(ℝ(_epochNs_)).
-        1. Return BalanceISODateTime(_result_.[[ISODate]].[[Year]], _result_.[[ISODate]].[[Month]], _result_.[[ISODate]].[[Day]], _result_.[[Time]].[[Hour]], _result_.[[Time]].[[Minute]], _result_.[[Time]].[[Second]], _result_.[[Time]].[[Millisecond]], _result_.[[Time]].[[Microsecond]], _result_.[[Time]].[[Nanosecond]] + _offsetNanoseconds_).
+        1. Return AddOffsetNanosecondsToISODateTime(_result_, _offsetNanoseconds_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -255,6 +255,7 @@
         </dd>
       </dl>
       <emu-alg>
+        1. Assert: IsValidEpochNanoseconds(_epochNs_) is *true*.
         1. Let _offsetNanoseconds_ be GetOffsetNanosecondsFor(_timeZone_, _epochNs_).
         1. Let _result_ be GetISOPartsFromEpoch(ℝ(_epochNs_)).
         1. Return AddOffsetNanosecondsToISODateTime(_result_, _offsetNanoseconds_).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -323,7 +323,7 @@
           1. Let _earlierTime_ be AddTime(_isoDateTime_.[[Time]], _timeDuration_).
           1. Let _earlierDate_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _earlierTime_.[[Days]]).
           1. Let _earlierDateTime_ be CombineISODateAndTimeRecord(_earlierDate_, _earlierTime_).
-          1. Perform ? CheckISODaysRange(_earlierDateTime_).
+          1. If ISODateTimeWithinLimits(_earlierDateTime_) is *false*, throw a *RangeError* exception.
           1. Set _possibleEpochNs_ to ? GetPossibleEpochNanoseconds(_timeZone_, _earlierDateTime_).
           1. Assert: _possibleEpochNs_ is not empty.
           1. Return _possibleEpochNs_[0].
@@ -332,7 +332,7 @@
         1. Let _laterTime_ be AddTime(_isoDateTime_.[[Time]], _timeDuration_).
         1. Let _laterDate_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _laterTime_.[[Days]]).
         1. Let _laterDateTime_ be CombineISODateAndTimeRecord(_laterDate_, _laterTime_).
-        1. Perform ? CheckISODaysRange(_laterDateTime_).
+        1. If ISODateTimeWithinLimits(_laterDateTime_) is *false*, throw a *RangeError* exception.
         1. Set _possibleEpochNs_ to ? GetPossibleEpochNanoseconds(_timeZone_, _laterDateTime_).
         1. Set _n_ to _possibleEpochNs_'s length.
         1. Assert: _n_ ≠ 0.
@@ -381,7 +381,7 @@
       </dl>
       <emu-alg>
         1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, MidnightTimeRecord()).
-        1. Perform ? CheckISODaysRange(_isoDateTime_).
+        1. If ISODateTimeWithinLimits(_isoDateTime_) is *false*, throw a *RangeError* exception.
         1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).
         1. If _possibleEpochNs_ is not empty, return _possibleEpochNs_[0].
         1. Assert: IsOffsetTimeZoneIdentifier(_timeZone_) is *false*.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -347,14 +347,13 @@
         </dd>
       </dl>
       <emu-alg>
+        1. Perform ? CheckISODaysRange(_isoDateTime_.[[ISODate]]).
         1. Let _parseResult_ be ! ParseTimeZoneIdentifier(_timeZone_).
         1. If _parseResult_.[[OffsetMinutes]] is not ~empty~, then
           1. Let _offsetNanoseconds_ be _parseResult_.[[OffsetMinutes]] × 6 × 10<sup>10</sup>.
-          1. Perform ? CheckISODaysRange(_isoDateTime_.[[ISODate]]).
           1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_) - _offsetNanoseconds_.
           1. Let _possibleEpochNanoseconds_ be « _epochNanoseconds_ ».
         1. Else,
-          1. Perform ? CheckISODaysRange(_isoDateTime_.[[ISODate]]).
           1. Let _possibleEpochNanoseconds_ be GetNamedTimeZoneEpochNanoseconds(_parseResult_.[[Name]], _isoDateTime_).
         1. For each value _epochNanoseconds_ in _possibleEpochNanoseconds_, do
           1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -316,7 +316,7 @@
         1. If _disambiguation_ is ~earlier~, then
           1. Let _timeDuration_ be TimeDurationFromComponents(0, 0, 0, 0, 0, -_nanoseconds_).
           1. Let _earlierTime_ be AddTime(_isoDateTime_.[[Time]], _timeDuration_).
-          1. Let _earlierDate_ be BalanceISODate(_isoDateTime_.[[ISODate]].[[Year]], _isoDateTime_.[[ISODate]].[[Month]], _isoDateTime_.[[ISODate]].[[Day]] + _earlierTime_.[[Days]]).
+          1. Let _earlierDate_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _earlierTime_.[[Days]]).
           1. Let _earlierDateTime_ be CombineISODateAndTimeRecord(_earlierDate_, _earlierTime_).
           1. Set _possibleEpochNs_ to ? GetPossibleEpochNanoseconds(_timeZone_, _earlierDateTime_).
           1. Assert: _possibleEpochNs_ is not empty.
@@ -324,7 +324,7 @@
         1. Assert: _disambiguation_ is ~compatible~ or ~later~.
         1. Let _timeDuration_ be TimeDurationFromComponents(0, 0, 0, 0, 0, _nanoseconds_).
         1. Let _laterTime_ be AddTime(_isoDateTime_.[[Time]], _timeDuration_).
-        1. Let _laterDate_ be BalanceISODate(_isoDateTime_.[[ISODate]].[[Year]], _isoDateTime_.[[ISODate]].[[Month]], _isoDateTime_.[[ISODate]].[[Day]] + _laterTime_.[[Days]]).
+        1. Let _laterDate_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _laterTime_.[[Days]]).
         1. Let _laterDateTime_ be CombineISODateAndTimeRecord(_laterDate_, _laterTime_).
         1. Set _possibleEpochNs_ to ? GetPossibleEpochNanoseconds(_timeZone_, _laterDateTime_).
         1. Set _n_ to _possibleEpochNs_'s length.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -349,9 +349,9 @@
       <emu-alg>
         1. Let _parseResult_ be ! ParseTimeZoneIdentifier(_timeZone_).
         1. If _parseResult_.[[OffsetMinutes]] is not ~empty~, then
-          1. Let _balanced_ be BalanceISODateTime(_isoDateTime_.[[ISODate]].[[Year]], _isoDateTime_.[[ISODate]].[[Month]], _isoDateTime_.[[ISODate]].[[Day]], _isoDateTime_.[[Time]].[[Hour]], _isoDateTime_.[[Time]].[[Minute]] - _parseResult_.[[OffsetMinutes]], _isoDateTime_.[[Time]].[[Second]], _isoDateTime_.[[Time]].[[Millisecond]], _isoDateTime_.[[Time]].[[Microsecond]], _isoDateTime_.[[Time]].[[Nanosecond]]).
-          1. Perform ? CheckISODaysRange(_balanced_.[[ISODate]]).
-          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_balanced_).
+          1. Let _offsetNanoseconds_ be _parseResult_.[[OffsetMinutes]] × 6 × 10<sup>10</sup>.
+          1. Perform ? CheckISODaysRange(_isoDateTime_.[[ISODate]]).
+          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_) - _offsetNanoseconds_.
           1. Let _possibleEpochNanoseconds_ be « _epochNanoseconds_ ».
         1. Else,
           1. Perform ? CheckISODaysRange(_isoDateTime_.[[ISODate]]).

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -347,7 +347,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Perform ? CheckISODaysRange(_isoDateTime_.[[ISODate]]).
+        1. Perform ? CheckISODaysRange(_isoDateTime_).
         1. Let _parseResult_ be ! ParseTimeZoneIdentifier(_timeZone_).
         1. If _parseResult_.[[OffsetMinutes]] is not ~empty~, then
           1. Let _offsetNanoseconds_ be _parseResult_.[[OffsetMinutes]] × 6 × 10<sup>10</sup>.

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -276,6 +276,7 @@
         </dd>
       </dl>
       <emu-alg>
+        1. Perform ? CheckISODaysRange(_isoDateTime_).
         1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).
         1. Return ? DisambiguatePossibleEpochNanoseconds(_possibleEpochNs_, _timeZone_, _isoDateTime_, _disambiguation_).
       </emu-alg>
@@ -320,6 +321,7 @@
           1. Let _earlierTime_ be AddTime(_isoDateTime_.[[Time]], _timeDuration_).
           1. Let _earlierDate_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _earlierTime_.[[Days]]).
           1. Let _earlierDateTime_ be CombineISODateAndTimeRecord(_earlierDate_, _earlierTime_).
+          1. Perform ? CheckISODaysRange(_earlierDateTime_).
           1. Set _possibleEpochNs_ to ? GetPossibleEpochNanoseconds(_timeZone_, _earlierDateTime_).
           1. Assert: _possibleEpochNs_ is not empty.
           1. Return _possibleEpochNs_[0].
@@ -328,6 +330,7 @@
         1. Let _laterTime_ be AddTime(_isoDateTime_.[[Time]], _timeDuration_).
         1. Let _laterDate_ be AddDaysToISODate(_isoDateTime_.[[ISODate]], _laterTime_.[[Days]]).
         1. Let _laterDateTime_ be CombineISODateAndTimeRecord(_laterDate_, _laterTime_).
+        1. Perform ? CheckISODaysRange(_laterDateTime_).
         1. Set _possibleEpochNs_ to ? GetPossibleEpochNanoseconds(_timeZone_, _laterDateTime_).
         1. Set _n_ to _possibleEpochNs_'s length.
         1. Assert: _n_ ≠ 0.
@@ -349,7 +352,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Perform ? CheckISODaysRange(_isoDateTime_).
+        1. Assert: ISODateTimeWithinLimits(_isoDateTime_) is *true*.
         1. Let _parseResult_ be ! ParseTimeZoneIdentifier(_timeZone_).
         1. If _parseResult_.[[OffsetMinutes]] is not ~empty~, then
           1. Let _offsetNanoseconds_ be _parseResult_.[[OffsetMinutes]] × 6 × 10<sup>10</sup>.
@@ -376,6 +379,7 @@
       </dl>
       <emu-alg>
         1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, MidnightTimeRecord()).
+        1. Perform ? CheckISODaysRange(_isoDateTime_).
         1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).
         1. If _possibleEpochNs_ is not empty, return _possibleEpochNs_[0].
         1. Assert: IsOffsetTimeZoneIdentifier(_timeZone_) is *false*.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -398,7 +398,7 @@
         1. Let _timeZone_ be _zonedDateTime_.[[TimeZone]].
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _zonedDateTime_.[[EpochNanoseconds]]).
         1. Let _today_ be _isoDateTime_.[[ISODate]].
-        1. Let _tomorrow_ be BalanceISODate(_today_.[[Year]], _today_.[[Month]], _today_.[[Day]] + 1).
+        1. Let _tomorrow_ be AddDaysToISODate(_today_, 1).
         1. Let _todayNs_ be ? GetStartOfDay(_timeZone_, _today_).
         1. Let _tomorrowNs_ be ? GetStartOfDay(_timeZone_, _tomorrow_).
         1. Let _diff_ be TimeDurationFromEpochNanosecondsDifference(_tomorrowNs_, _todayNs_).
@@ -651,7 +651,7 @@
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _thisNs_).
         1. If _smallestUnit_ is ~day~, then
           1. Let _dateStart_ be _isoDateTime_.[[ISODate]].
-          1. Let _dateEnd_ be BalanceISODate(_dateStart_.[[Year]], _dateStart_.[[Month]], _dateStart_.[[Day]] + 1).
+          1. Let _dateEnd_ be AddDaysToISODate(_dateStart_, 1).
           1. Let _startNs_ be ? GetStartOfDay(_timeZone_, _dateStart_).
           1. Assert: _thisNs_ ≥ _startNs_.
           1. Let _endNs_ be ? GetStartOfDay(_timeZone_, _dateEnd_).
@@ -1127,7 +1127,7 @@
         1. If TimeDurationSign(_timeDuration_) = -_sign_, set _dayCorrection_ to _dayCorrection_ + 1.
         1. Let _success_ be *false*.
         1. Repeat, while _dayCorrection_ ≤ _maxDayCorrection_ and _success_ is *false*,
-          1. Let _intermediateDate_ be BalanceISODate(_endDateTime_.[[ISODate]].[[Year]], _endDateTime_.[[ISODate]].[[Month]], _endDateTime_.[[ISODate]].[[Day]] - _dayCorrection_ × _sign_).
+          1. Let _intermediateDate_ be AddDaysToISODate(_endDateTime_.[[ISODate]], _dayCorrection_ × -_sign_).
           1. Let _intermediateDateTime_ be CombineISODateAndTimeRecord(_intermediateDate_, _startDateTime_.[[Time]]).
           1. Let _intermediateNs_ be ? GetEpochNanosecondsFor(_timeZone_, _intermediateDateTime_, ~compatible~).
           1. Set _timeDuration_ to TimeDurationFromEpochNanosecondsDifference(_ns2_, _intermediateNs_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -906,7 +906,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Perform ? CheckISODaysRange(_isoDateTime_.[[ISODate]]).
+        1. Perform ? CheckISODaysRange(_isoDateTime_).
         1. If _offsetBehaviour_ is ~wall~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~ignore~, then
           1. Return ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, _disambiguation_).
         1. If _offsetBehaviour_ is ~exact~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~use~, then

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -915,9 +915,8 @@
         1. If _offsetBehaviour_ is ~wall~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~ignore~, then
           1. Return ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, _disambiguation_).
         1. If _offsetBehaviour_ is ~exact~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~use~, then
-          1. Let _balanced_ be BalanceISODateTime(_isoDate_.[[Year]], _isoDate_.[[Month]], _isoDate_.[[Day]], _time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]] - _offsetNanoseconds_).
-          1. Perform ? CheckISODaysRange(_balanced_.[[ISODate]]).
-          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_balanced_).
+          1. Perform ? CheckISODaysRange(_isoDate_).
+          1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_) - _offsetNanoseconds_.
           1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
           1. Return _epochNanoseconds_.
         1. Assert: _offsetBehaviour_ is ~option~.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -907,6 +907,7 @@
         </dd>
       </dl>
       <emu-alg>
+        1. Perform ? CheckISODaysRange(_isoDate_).
         1. If _time_ is ~start-of-day~, then
           1. Assert: _offsetBehaviour_ is ~wall~.
           1. Assert: _offsetNanoseconds_ is 0.
@@ -915,13 +916,11 @@
         1. If _offsetBehaviour_ is ~wall~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~ignore~, then
           1. Return ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, _disambiguation_).
         1. If _offsetBehaviour_ is ~exact~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~use~, then
-          1. Perform ? CheckISODaysRange(_isoDate_).
           1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_) - _offsetNanoseconds_.
           1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
           1. Return _epochNanoseconds_.
         1. Assert: _offsetBehaviour_ is ~option~.
         1. Assert: _offsetOption_ is ~prefer~ or ~reject~.
-        1. Perform ? CheckISODaysRange(_isoDate_).
         1. Let _utcEpochNanoseconds_ be GetUTCEpochNanoseconds(_isoDateTime_).
         1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).
         1. For each element _candidate_ of _possibleEpochNs_, do

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1120,19 +1120,19 @@
         1. If _ns1_ = _ns2_, return ! CombineDateAndTimeDuration(ZeroDateDuration(), 0).
         1. Let _startDateTime_ be GetISODateTimeFor(_timeZone_, _ns1_).
         1. Let _endDateTime_ be GetISODateTimeFor(_timeZone_, _ns2_).
-        1. If _ns2_ - _ns1_ &lt; 0, let _sign_ be -1; else let _sign_ be 1.
-        1. If _sign_ = 1, let _maxDayCorrection_ be 2; else let _maxDayCorrection_ be 1.
+        1. If _ns2_ - _ns1_ &lt; 0, let _sign_ be 1; else let _sign_ be -1.
+        1. If _sign_ = -1, let _maxDayCorrection_ be 2; else let _maxDayCorrection_ be 1.
         1. Let _dayCorrection_ be 0.
         1. Let _timeDuration_ be DifferenceTime(_startDateTime_.[[Time]], _endDateTime_.[[Time]]).
-        1. If TimeDurationSign(_timeDuration_) = -_sign_, set _dayCorrection_ to _dayCorrection_ + 1.
+        1. If TimeDurationSign(_timeDuration_) = _sign_, set _dayCorrection_ to _dayCorrection_ + 1.
         1. Let _success_ be *false*.
         1. Repeat, while _dayCorrection_ ≤ _maxDayCorrection_ and _success_ is *false*,
-          1. Let _intermediateDate_ be AddDaysToISODate(_endDateTime_.[[ISODate]], _dayCorrection_ × -_sign_).
+          1. Let _intermediateDate_ be AddDaysToISODate(_endDateTime_.[[ISODate]], _dayCorrection_ × _sign_).
           1. Let _intermediateDateTime_ be CombineISODateAndTimeRecord(_intermediateDate_, _startDateTime_.[[Time]]).
           1. Let _intermediateNs_ be ? GetEpochNanosecondsFor(_timeZone_, _intermediateDateTime_, ~compatible~).
           1. Set _timeDuration_ to TimeDurationFromEpochNanosecondsDifference(_ns2_, _intermediateNs_).
           1. Let _timeSign_ be TimeDurationSign(_timeDuration_).
-          1. If _sign_ ≠ -_timeSign_, then
+          1. If _sign_ ≠ _timeSign_, then
             1. Set _success_ to *true*.
           1. Set _dayCorrection_ to _dayCorrection_ + 1.
         1. Assert: _success_ is *true*.

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -550,6 +550,7 @@
         1. Else,
           1. Let _plainTime_ be ? ToTemporalTime(_plainTimeLike_).
           1. Let _resultISODateTime_ be CombineISODateAndTimeRecord(_isoDateTime_.[[ISODate]], _plainTime_.[[Time]]).
+          1. Perform ? CheckISODaysRange(_resultISODateTime_).
           1. Let _epochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _resultISODateTime_, ~compatible~).
         1. Return ! CreateTemporalZonedDateTime(_epochNs_, _timeZone_, _calendar_).
       </emu-alg>
@@ -1127,6 +1128,7 @@
         1. Repeat, while _dayCorrection_ ≤ _maxDayCorrection_ and _success_ is *false*,
           1. Let _intermediateDate_ be AddDaysToISODate(_endDateTime_.[[ISODate]], _dayCorrection_ × _sign_).
           1. Let _intermediateDateTime_ be CombineISODateAndTimeRecord(_intermediateDate_, _startDateTime_.[[Time]]).
+          1. Perform ? CheckISODaysRange(_intermediateDateTime_).
           1. Let _intermediateNs_ be ? GetEpochNanosecondsFor(_timeZone_, _intermediateDateTime_, ~compatible~).
           1. Set _timeDuration_ to TimeDurationFromEpochNanosecondsDifference(_ns2_, _intermediateNs_).
           1. Let _timeSign_ be TimeDurationSign(_timeDuration_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -531,7 +531,7 @@
         1. Let _overflow_ be ? GetTemporalOverflowOption(_resolvedOptions_).
         1. Let _dateTimeResult_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _overflow_).
         1. Let _newOffsetNanoseconds_ be ! ParseDateTimeUTCOffset(_fields_.[[OffsetString]]).
-        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_.[[ISODate]], _dateTimeResult_.[[Time]], ~option~, _newOffsetNanoseconds_, _timeZone_, _disambiguation_, _offset_, ~match-exactly~).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_dateTimeResult_, ~option~, _newOffsetNanoseconds_, _timeZone_, _disambiguation_, _offset_, ~match-exactly~).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -663,7 +663,7 @@
         1. Else,
           1. Let _roundResult_ be RoundISODateTime(_isoDateTime_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
           1. Let _offsetNanoseconds_ be GetOffsetNanosecondsFor(_timeZone_, _thisNs_).
-          1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_.[[ISODate]], _roundResult_.[[Time]], ~option~, _offsetNanoseconds_, _timeZone_, ~compatible~, ~prefer~, ~match-exactly~).
+          1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_roundResult_, ~option~, _offsetNanoseconds_, _timeZone_, ~compatible~, ~prefer~, ~match-exactly~).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>
@@ -883,8 +883,7 @@
     <emu-clause id="sec-temporal-interpretisodatetimeoffset" type="abstract operation">
       <h1>
         InterpretISODateTimeOffset (
-          _isoDate_: an ISO Date Record,
-          _time_: a Time Record or ~start-of-day~,
+          _isoDateTime_: an ISO Date-Time Record,
           _offsetBehaviour_: ~option~, ~exact~, or ~wall~,
           _offsetNanoseconds_: an integer,
           _timeZone_: an available time zone identifier,
@@ -907,12 +906,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Perform ? CheckISODaysRange(_isoDate_).
-        1. If _time_ is ~start-of-day~, then
-          1. Assert: _offsetBehaviour_ is ~wall~.
-          1. Assert: _offsetNanoseconds_ is 0.
-          1. Return ? GetStartOfDay(_timeZone_, _isoDate_).
-        1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, _time_).
+        1. Perform ? CheckISODaysRange(_isoDateTime_.[[ISODate]]).
         1. If _offsetBehaviour_ is ~wall~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~ignore~, then
           1. Return ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, _disambiguation_).
         1. If _offsetBehaviour_ is ~exact~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~use~, then
@@ -971,9 +965,7 @@
           1. Let _disambiguation_ be ? GetTemporalDisambiguationOption(_resolvedOptions_).
           1. Let _offsetOption_ be ? GetTemporalOffsetOption(_resolvedOptions_, ~reject~).
           1. Let _overflow_ be ? GetTemporalOverflowOption(_resolvedOptions_).
-          1. Let _result_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _overflow_).
-          1. Let _isoDate_ be _result_.[[ISODate]].
-          1. Let _time_ be _result_.[[Time]].
+          1. Let _isoDateTime_ be ? InterpretTemporalDateTimeFields(_calendar_, _fields_, _overflow_).
         1. Else,
           1. If _item_ is not a String, throw a *TypeError* exception.
           1. Let _result_ be ? ParseISODateTime(_item_, « |TemporalDateTimeString[+Zoned]| »).
@@ -995,10 +987,14 @@
           1. Perform ? GetTemporalOverflowOption(_resolvedOptions_).
           1. Let _isoDate_ be CreateISODateRecord(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
           1. Let _time_ be _result_.[[Time]].
+          1. If _time_ is ~start-of-day~, then
+            1. Assert: _offsetBehaviour_ is ~wall~.
+            1. Return ? GetStartOfDay(_timeZone_, _isoDate_).
+          1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, _time_).
         1. Let _offsetNanoseconds_ be 0.
         1. If _offsetBehaviour_ is ~option~, then
           1. Set _offsetNanoseconds_ to ! ParseDateTimeUTCOffset(_offsetString_).
-        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_isoDate_, _time_, _offsetBehaviour_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offsetOption_, _matchBehaviour_).
+        1. Let _epochNanoseconds_ be ? InterpretISODateTimeOffset(_isoDateTime_, _offsetBehaviour_, _offsetNanoseconds_, _timeZone_, _disambiguation_, _offsetOption_, _matchBehaviour_).
         1. Return ! CreateTemporalZonedDateTime(_epochNanoseconds_, _timeZone_, _calendar_).
       </emu-alg>
     </emu-clause>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1091,7 +1091,7 @@
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _epochNanoseconds_).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _isoDateTime_.[[ISODate]], _duration_.[[Date]], _overflow_).
         1. Let _intermediateDateTime_ be CombineISODateAndTimeRecord(_addedDate_, _isoDateTime_.[[Time]]).
-        1. If ISODateTimeWithinLimits(_intermediateDateTime_) is *false*, throw a *RangeError* exception.
+        1. Perform ? CheckISODaysRange(_intermediateDateTime_).
         1. Let _intermediateNs_ be ! GetEpochNanosecondsFor(_timeZone_, _intermediateDateTime_, ~compatible~).
         1. Return ? AddInstant(_intermediateNs_, _duration_.[[Time]]).
       </emu-alg>

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -550,7 +550,7 @@
         1. Else,
           1. Let _plainTime_ be ? ToTemporalTime(_plainTimeLike_).
           1. Let _resultISODateTime_ be CombineISODateAndTimeRecord(_isoDateTime_.[[ISODate]], _plainTime_.[[Time]]).
-          1. Perform ? CheckISODaysRange(_resultISODateTime_).
+          1. If ISODateTimeWithinLimits(_resultISODateTime_) is *false*, throw a *RangeError* exception.
           1. Let _epochNs_ be ? GetEpochNanosecondsFor(_timeZone_, _resultISODateTime_, ~compatible~).
         1. Return ! CreateTemporalZonedDateTime(_epochNs_, _timeZone_, _calendar_).
       </emu-alg>
@@ -907,7 +907,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. Perform ? CheckISODaysRange(_isoDateTime_).
+        1. If ISODateTimeWithinLimits(_isoDateTime_) is *false*, throw a *RangeError* exception.
         1. If _offsetBehaviour_ is ~wall~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~ignore~, then
           1. Return ? GetEpochNanosecondsFor(_timeZone_, _isoDateTime_, _disambiguation_).
         1. If _offsetBehaviour_ is ~exact~, or _offsetBehaviour_ is ~option~ and _offsetOption_ is ~use~, then
@@ -1091,7 +1091,7 @@
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _epochNanoseconds_).
         1. Let _addedDate_ be ? CalendarDateAdd(_calendar_, _isoDateTime_.[[ISODate]], _duration_.[[Date]], _overflow_).
         1. Let _intermediateDateTime_ be CombineISODateAndTimeRecord(_addedDate_, _isoDateTime_.[[Time]]).
-        1. Perform ? CheckISODaysRange(_intermediateDateTime_).
+        1. If ISODateTimeWithinLimits(_intermediateDateTime_) is *false*, throw a *RangeError* exception.
         1. Let _intermediateNs_ be ! GetEpochNanosecondsFor(_timeZone_, _intermediateDateTime_, ~compatible~).
         1. Return ? AddInstant(_intermediateNs_, _duration_.[[Time]]).
       </emu-alg>
@@ -1128,7 +1128,7 @@
         1. Repeat, while _dayCorrection_ ≤ _maxDayCorrection_ and _success_ is *false*,
           1. Let _intermediateDate_ be AddDaysToISODate(_endDateTime_.[[ISODate]], _dayCorrection_ × _sign_).
           1. Let _intermediateDateTime_ be CombineISODateAndTimeRecord(_intermediateDate_, _startDateTime_.[[Time]]).
-          1. Perform ? CheckISODaysRange(_intermediateDateTime_).
+          1. If ISODateTimeWithinLimits(_intermediateDateTime_) is *false*, throw a *RangeError* exception.
           1. Let _intermediateNs_ be ? GetEpochNanosecondsFor(_timeZone_, _intermediateDateTime_, ~compatible~).
           1. Set _timeDuration_ to TimeDurationFromEpochNanosecondsDifference(_ns2_, _intermediateNs_).
           1. Let _timeSign_ be TimeDurationSign(_timeDuration_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1084,6 +1084,7 @@
         </dd>
       </dl>
       <emu-alg>
+        1. Assert: IsValidEpochNanoseconds(_epochNanoseconds_) is *true*.
         1. If DateDurationSign(_duration_.[[Date]]) = 0, then
           1. Return ? AddInstant(_epochNanoseconds_, _duration_.[[Time]]).
         1. Let _isoDateTime_ be GetISODateTimeFor(_timeZone_, _epochNanoseconds_).
@@ -1112,6 +1113,8 @@
         </dd>
       </dl>
       <emu-alg>
+        1. Assert: IsValidEpochNanoseconds(_ns1_) is *true*.
+        1. Assert: IsValidEpochNanoseconds(_ns2_) is *true*.
         1. If _ns1_ = _ns2_, return ! CombineDateAndTimeDuration(ZeroDateDuration(), 0).
         1. Let _startDateTime_ be GetISODateTimeFor(_timeZone_, _ns1_).
         1. Let _endDateTime_ be GetISODateTimeFor(_timeZone_, _ns2_).
@@ -1155,6 +1158,8 @@
         <dd></dd>
       </dl>
       <emu-alg>
+        1. Assert: IsValidEpochNanoseconds(_ns1_) is *true*.
+        1. Assert: IsValidEpochNanoseconds(_ns2_) is *true*.
         1. If TemporalUnitCategory(_largestUnit_) is ~time~, then
           1. Return DifferenceInstant(_ns1_, _ns2_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
         1. Let _difference_ be ? DifferenceZonedDateTime(_ns1_, _ns2_, _timeZone_, _calendar_, _largestUnit_).
@@ -1179,6 +1184,8 @@
         <dd></dd>
       </dl>
       <emu-alg>
+        1. Assert: IsValidEpochNanoseconds(_ns1_) is *true*.
+        1. Assert: IsValidEpochNanoseconds(_ns2_) is *true*.
         1. If TemporalUnitCategory(_unit_) is ~time~, then
           1. Let _difference_ be TimeDurationFromEpochNanosecondsDifference(_ns2_, _ns1_).
           1. Return TotalTimeDuration(_difference_, _unit_).


### PR DESCRIPTION
Disclaimer: I haven't yet implemented these changes, so it's possible that there are still some bugs in the proposed changes.

1. The first three commits replace `BalanceISODateTime` and `BalanceISODate` with less general operations.
    - `BalanceISODateTime` is only used to add a time zone offset to a date-time. It seems like all but one occurrence can be replaced by plain subtraction. For that one caller where subtraction isn't possible, either rename `BalanceISODateTime` to `AddOffsetNanosecondsToISODateTime` or alternatively just inline it into `GetISODateTimeFor`. Commits for both alternatives are prepared.
    - And `BalanceISODate` is only used to add a days amount to an ISO Date record. Replace it with `AddDaysToISODate`, so it's easier to see what this operation does. 
1. The remaining commits reorder `CheckISODaysRange` calls to happen earlier, so it's easier to see (and implement) when ISO Date-Time records contain out-of-range values. 
    - `CheckISODaysRange` currently allows inputs from `nsMinInstant` (inclusive) to `nsMaxInstant + nsPerDay` (exclusive). That looks like a bug, I think the lower limit should be `nsMinInstant - nsPerDay` (exclusive). This range can be checked through `ISODateTimeWithinLimits`. 
    - In two places `ISODateTimeWithinLimits` is used to check `GetUTCEpochNanoseconds` inputs instead of `CheckISODaysRange`. Either use `CheckISODaysRange` consistently or inline `CheckISODaysRange` everywhere. Commits for both alternative are also prepared here.
    - All changes are editorial, because they only reorder when `RangeError` exceptions are thrown, but this isn't visible from user-code, because no other side-effects can happen.