### PR TITLE
Editorial: Change TimeDuration to use time durations instead of internal durations

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -448,7 +448,14 @@
         1. If IsCalendarUnit(_existingLargestUnit_) is *true*, or IsCalendarUnit(_largestUnit_) is *true*, throw a *RangeError* exception.
         1. Assert: IsCalendarUnit(_smallestUnit_) is *false*.
         1. Let _internalDuration_ be ToInternalDurationRecordWith24HourDays(_duration_).
-        1. Set _internalDuration_ to ? RoundTimeDuration(_internalDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. If _smallestUnit_ is ~day~, then
+          1. Let _fractionalDays_ be DivideTimeDuration(_internalDuration_.[[Time]], nsPerDay).
+          1. Let _days_ be RoundNumberToIncrement(_fractionalDays_, _roundingIncrement_, _roundingMode_).
+          1. Let _dateDuration_ be ? CreateDateDurationRecord(0, 0, 0, _days_).
+          1. Set _internalDuration_ to ! CombineDateAndTimeDuration(_dateDuration_, 0).
+        1. Else,
+          1. Let _timeDuration_ be ? RoundTimeDuration(_internalDuration_.[[Time]], _roundingIncrement_, _smallestUnit_, _roundingMode_).
+          1. Set _internalDuration_ to ! CombineDateAndTimeDuration(ZeroDateDuration(), _timeDuration_).
         1. Return ? TemporalDurationFromInternal(_internalDuration_, _largestUnit_).
       </emu-alg>
     </emu-clause>
@@ -513,9 +520,10 @@
           1. Return TemporalDurationToString(_duration_, _precision_.[[Precision]]).
         1. Let _largestUnit_ be DefaultTemporalLargestUnit(_duration_).
         1. Let _internalDuration_ be ToInternalDurationRecord(_duration_).
-        1. Set _internalDuration_ to ? RoundTimeDuration(_internalDuration_, _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Let _timeDuration_ be ? RoundTimeDuration(_internalDuration_.[[Time]], _precision_.[[Increment]], _precision_.[[Unit]], _roundingMode_).
+        1. Set _internalDuration_ to ! CombineDateAndTimeDuration(_internalDuration_.[[Date]], _timeDuration_).
         1. Let _roundedLargestUnit_ be LargerOfTwoTemporalUnits(_largestUnit_, ~second~).
-        1. Let _roundedDuration_ be ! TemporalDurationFromInternal(_internalDuration_, _roundedLargestUnit_).
+        1. Let _roundedDuration_ be ? TemporalDurationFromInternal(_internalDuration_, _roundedLargestUnit_).
         1. Return TemporalDurationToString(_roundedDuration_, _precision_.[[Precision]]).
       </emu-alg>
     </emu-clause>
@@ -1500,28 +1508,21 @@
     <emu-clause id="sec-temporal-roundtimeduration" type="abstract operation">
       <h1>
         RoundTimeDuration (
-          _duration_: an Internal Duration Record,
+          _timeDuration_: a time duration,
           _increment_: a positive integer,
-          _unit_: a time unit or ~day~,
+          _unit_: a time unit,
           _roundingMode_: a rounding mode,
-        ): either a normal completion containing an Internal Duration Record, or a throw completion
+        ): either a normal completion containing a time duration, or a throw completion
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It rounds a _duration_ according to the rounding parameters _unit_, _increment_, and _roundingMode_, and returns the Internal Duration Record result.
+          It rounds a _timeDuration_ according to the rounding parameters _unit_, _increment_, and _roundingMode_, and returns the time duration result.
         </dd>
       </dl>
       <emu-alg>
-        1. If _unit_ is ~day~, then
-          1. Let _fractionalDays_ be _duration_.[[Date]].[[Days]] + DivideTimeDuration(_duration_.[[Time]], nsPerDay).
-          1. Let _days_ be RoundNumberToIncrement(_fractionalDays_, _increment_, _roundingMode_).
-          1. Let _dateDuration_ be ? AdjustDateDurationRecord(_duration_.[[Date]], _days_).
-          1. Return ! CombineDateAndTimeDuration(_dateDuration_, 0).
-        1. Assert: TemporalUnitCategory(_unit_) is ~time~.
         1. Let _divisor_ be the value in the "Length in Nanoseconds" column of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _unit_.
-        1. Let _rounded_ be ? RoundTimeDurationToIncrement(_duration_.[[Time]], _divisor_ × _increment_, _roundingMode_).
-        1. Return ? CombineDateAndTimeDuration(_duration_.[[Date]], _rounded_).
+        1. Return ? RoundTimeDurationToIncrement(_timeDuration_, _divisor_ × _increment_, _roundingMode_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -463,7 +463,7 @@
           _ns1_: a BigInt,
           _ns2_: a BigInt,
           _roundingIncrement_: a positive integer,
-          _smallestUnit_: a time unit or ~day~,
+          _smallestUnit_: a time unit,
           _roundingMode_: a rounding mode,
         ): an Internal Duration Record
       </h1>
@@ -473,8 +473,8 @@
       </dl>
       <emu-alg>
         1. Let _timeDuration_ be TimeDurationFromEpochNanosecondsDifference(_ns2_, _ns1_).
-        1. Let _internalDuration_ be ! CombineDateAndTimeDuration(ZeroDateDuration(), _timeDuration_).
-        1. Return ! RoundTimeDuration(_internalDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Set _timeDuration_ to ! RoundTimeDuration(_timeDuration_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
+        1. Return ! CombineDateAndTimeDuration(ZeroDateDuration(), _timeDuration_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -931,9 +931,8 @@
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Let _settings_ be ? GetDifferenceSettings(_operation_, _resolvedOptions_, ~time~, « », ~nanosecond~, ~hour~).
         1. Let _timeDuration_ be DifferenceTime(_temporalTime_.[[Time]], _other_.[[Time]]).
+        1. Set _timeDuration_ to ! RoundTimeDuration(_timeDuration_, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
         1. Let _duration_ be ! CombineDateAndTimeDuration(ZeroDateDuration(), _timeDuration_).
-        1. If _settings_.[[SmallestUnit]] is not ~nanosecond~ or _settings_.[[RoundingIncrement]] ≠ 1, then
-          1. Set _duration_ to ! RoundTimeDuration(_duration_, _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
         1. Let _result_ be ! TemporalDurationFromInternal(_duration_, _settings_.[[LargestUnit]]).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.


### PR DESCRIPTION
Changes:
- Move handling for `day` units from `RoundTimeDuration` to `Temporal.Duration.prototype.round`.
- Correct argument type for `DifferenceInstant` to only allow time units.
- `RoundTimeDuration` is now only called with time units and its input and output is a time duration.
- Remove the no rounding fast path from `DifferenceTemporalPlainTime` to match `DifferenceInstant`.

Fixes:
`TemporalDurationFromInternal` is fallible in `Temporal.Duration.prototype.toString`:
```js
Temporal.Duration.from({
  days: 1,
  seconds: 2**53 - 1 - (24*60*60),
  nanoseconds: 999_999_999
}).toString({
  roundingMode: "ceil",
  fractionalSecondDigits: 7
});
```