### PR TITLE
Use `Temporal.Now.timeZoneId()` instead of `timeZone()`

### DIFF
--- a/docs/cookbook/fromLegacyDate.mjs
+++ b/docs/cookbook/fromLegacyDate.mjs
@@ -17,7 +17,7 @@ assert.equal(instant.toString(), '1970-01-01T00:00:01Z');
 
 // To use the system's local time zone, which corresponds to using
 // legacy Date's getFullYear(), getMonth(), etc. methods, pass
-// Temporal.Now.timeZone() as the time zone. In a browser, this
+// Temporal.Now.timeZoneId() as the time zone. In a browser, this
 // will be the user's time zone, but on a server the value may not
 // be what you expect, so avoid doing this in a server context.
 

--- a/docs/instant.md
+++ b/docs/instant.md
@@ -55,7 +55,7 @@ Conversions to narrower types like `Temporal.PlainDate` or `Temporal.PlainTime` 
 ```javascript
 date = new Date(2019, 11, 31, 18, 30);  // => Tue Dec 31 2019 18:30:00 GMT-0800 (Pacific Standard Time)
 instant = date.toTemporalInstant();     // => 2020-01-01T02:30:00Z
-zonedDateTime = instant.toZonedDateTimeISO(Temporal.Now.timeZone());
+zonedDateTime = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
                                         // => 2019-12-31T18:30:00-08:00[America/Los_Angeles]
 zonedDateTime.day;                      // => 31
 dateOnly = zonedDateTime.toPlainDate(); // => 2019-12-31
@@ -63,7 +63,7 @@ dateOnly = zonedDateTime.toPlainDate(); // => 2019-12-31
 <!-- prettier-ignore-end -->
 
 Bugs in `Date`=>`Temporal` conversions can be caused by picking the wrong time zone when converting from `Temporal.Instant` to `Temporal.ZonedDateTime`.
-For example, the example above constructs the `Date` using local-timezone parameters, so it uses the system time zone: `Temporal.Now.timeZone()`.
+For example, the example above constructs the `Date` using local-timezone parameters, so it uses the system time zone: `Temporal.Now.timeZoneId()`.
 But if the `Date` had been initialized with a string like `'2019-12-31'`, then getting the same date back in a `Temporal.PlainDate` would require using the `'UTC'` time zone instead.
 
 For discussion and code examples about picking the correct time zone, and also about `Date`<=>`Temporal` interoperability in general, see [Converting between `Temporal` types and legacy `Date`](cookbook.md#converting-between-temporal-types-and-legacy-date) in the documentation cookbook.

--- a/docs/now.md
+++ b/docs/now.md
@@ -13,7 +13,7 @@ The `Temporal.Now` object has several methods which give information about the c
 
 ## Methods
 
-### Temporal.Now.**zonedDateTimeISO**(_timeZone_: object | string = Temporal.Now.timeZone()) : Temporal.ZonedDateTime
+### Temporal.Now.**zonedDateTimeISO**(_timeZone_: object | string = Temporal.Now.timeZoneId()) : Temporal.ZonedDateTime
 
 **Parameters:**
 
@@ -93,7 +93,7 @@ console.log(`At ${nextTransition} the offset will change from UTC ${before} to $
 // At 2025-03-09T03:00:00-07:00[America/Los_Angeles] the offset will change from UTC -08:00 to -07:00
 ```
 
-### Temporal.Now.**plainDateTimeISO**(_timeZone_: object | string = Temporal.Now.timeZone()) : Temporal.PlainDateTime
+### Temporal.Now.**plainDateTimeISO**(_timeZone_: object | string = Temporal.Now.timeZoneId()) : Temporal.PlainDateTime
 
 **Parameters:**
 
@@ -129,7 +129,7 @@ Object.entries(financialCentres).forEach(([name, timeZone]) => {
 ```
 <!-- prettier-ignore-end -->
 
-### Temporal.Now.**plainDateISO**(_timeZone_: object | string = Temporal.Now.timeZone()) : Temporal.PlainDate
+### Temporal.Now.**plainDateISO**(_timeZone_: object | string = Temporal.Now.timeZoneId()) : Temporal.PlainDate
 
 **Parameters:**
 
@@ -156,7 +156,7 @@ date = Temporal.Now.plainDateISO().withCalendar('persian');
 if (date.month === 1 && date.day === 1) console.log('New year!');
 ```
 
-### Temporal.Now.**plainTimeISO**(_timeZone_: object | string = Temporal.Now.timeZone()) : Temporal.PlainTime
+### Temporal.Now.**plainTimeISO**(_timeZone_: object | string = Temporal.Now.timeZoneId()) : Temporal.PlainTime
 
 **Parameters:**
 


### PR DESCRIPTION
Found this minor documentation bug, `Temporal.Now.timeZone()` does not exist so it should be `timeZoneId()`.