### PR TITLE
Editorial: correct description of LargerOfTwoTemporalUnits

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -672,7 +672,7 @@
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd>Given two strings representing Temporal units, it returns the string representing the larger of the two units.</dd>
+      <dd>Given two Temporal units, it returns the larger of the two units.</dd>
     </dl>
     <emu-alg>
       1. For each row of <emu-xref href="#table-temporal-units"></emu-xref>, except the header row, in table order, do


### PR DESCRIPTION
This AO doesn't work with strings.