### PR TITLE
Polyfill: Date.prototype.toTemporalInstant should not be a constructor

### DIFF
--- a/polyfill/lib/legacydate.mjs
+++ b/polyfill/lib/legacydate.mjs
@@ -5,7 +5,18 @@ import { Instant } from './instant.mjs';
 
 import bigInt from 'big-integer';
 
-export function toTemporalInstant() {
-  const epochNanoseconds = bigInt(ES.Call(DatePrototypeValueOf, this, [])).multiply(1e6);
-  return new Instant(ES.BigIntIfAvailable(epochNanoseconds));
+// By default, a plain function can be called as a constructor. A method such as
+// Date.prototype.toTemporalInstant should not be able to. We could check
+// new.target in the body of toTemporalInstant, but that is not sufficient for
+// preventing construction when passing it as the newTarget parameter of
+// Reflect.construct. So we create it as a method of an otherwise unused class,
+// and monkeypatch it onto Date.prototype.
+
+class LegacyDateImpl {
+  toTemporalInstant() {
+    const epochNanoseconds = bigInt(ES.Call(DatePrototypeValueOf, this, [])).multiply(1e6);
+    return new Instant(ES.BigIntIfAvailable(epochNanoseconds));
+  }
 }
+
+export const toTemporalInstant = LegacyDateImpl.prototype.toTemporalInstant;

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -19,3 +19,6 @@ intl402/DateTimeFormat/proto-from-ctor-realm.js
 
 # https://github.com/tc39/ecma402/issues/402
 intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
+
+# Fails until CLDR 46 (released 2024-10-24) makes its way into a Node.js release
+staging/Intl402/Temporal/old/non-iso-calendars.js


### PR DESCRIPTION
This PR updates test262 and adds a fix for a newly-added test that the reference code fails.