### PR TITLE
Editorial: Fix IsPartialTemporalObject parameter name

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -733,7 +733,7 @@
   <emu-clause id="sec-temporal-ispartialtemporalobject" type="abstract operation">
     <h1>
       IsPartialTemporalObject (
-        _object_: an ECMAScript language value,
+        _value_: an ECMAScript language value,
       ): either a normal completion containing a Boolean or a throw completion
     </h1>
     <dl class="header">


### PR DESCRIPTION
It is referred to as `value` in the subsequent description and steps.