### PR TITLE
A couple minor fixes to DifferenceTemporalPlainYearMonth

### DIFF
--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -615,7 +615,7 @@
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_thisDate_, MidnightTimeRecord()).
           1. Let _isoDateTimeOther_ be CombineISODateAndTimeRecord(_otherDate_, MidnightTimeRecord()).
           1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_isoDateTimeOther_).
-          1. Set _duration_ to ? RoundRelativeDuration(_duration_, _destEpochNs_, _isoDateTime_, ~unset~, _calendar_, _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).[[Duration]].
+          1. Set _duration_ to ? RoundRelativeDuration(_duration_, _destEpochNs_, _isoDateTime_, ~unset~, _calendar_, _settings_.[[LargestUnit]], _settings_.[[RoundingIncrement]], _settings_.[[SmallestUnit]], _settings_.[[RoundingMode]]).
         1. Let _result_ be ? TemporalDurationFromInternal(_duration_, ~day~).
         1. If _operation_ is ~since~, set _result_ to CreateNegatedTemporalDuration(_result_).
         1. Return _result_.


### PR DESCRIPTION
If we use `yearMonth` here, we end up comparing the same dates.