### PR TITLE
Editorial: Next batch of editorial issues

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3479,6 +3479,8 @@ export function DifferencePlainDateTimeWithRounding(
     return { date: ZeroDateDuration(), time: TimeDuration.ZERO };
   }
 
+  RejectDateTimeRange(isoDateTime1);
+  RejectDateTimeRange(isoDateTime2);
   const duration = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, largestUnit);
 
   if (smallestUnit === 'nanosecond' && roundingIncrement === 1) return duration;
@@ -3500,6 +3502,8 @@ export function DifferencePlainDateTimeWithRounding(
 export function DifferencePlainDateTimeWithTotal(isoDateTime1, isoDateTime2, calendar, unit) {
   if (CompareISODateTime(isoDateTime1, isoDateTime2) == 0) return 0;
 
+  RejectDateTimeRange(isoDateTime1);
+  RejectDateTimeRange(isoDateTime2);
   const duration = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, unit);
 
   if (unit === 'nanosecond') return duration.time.totalNs.toJSNumber();

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -30,6 +30,7 @@ import {
   EPOCHNANOSECONDS,
   ISO_DATE,
   ISO_DATE_TIME,
+  ORIGINAL,
   SetSlot,
   TIME,
   CALENDAR
@@ -41,7 +42,6 @@ const MD = SymbolCtor('md');
 const TIME_FMT = SymbolCtor('time');
 const DATETIME = SymbolCtor('datetime');
 const INST = SymbolCtor('instant');
-const ORIGINAL = SymbolCtor('original');
 const TZ_CANONICAL = SymbolCtor('timezone-canonical');
 const TZ_ORIGINAL = SymbolCtor('timezone-original');
 const CAL_ID = SymbolCtor('calendar-id');

--- a/polyfill/lib/intrinsicclass.mjs
+++ b/polyfill/lib/intrinsicclass.mjs
@@ -9,6 +9,7 @@ import {
   SymbolFor,
   SymbolToStringTag
 } from './primordials.mjs';
+import { GetSlot, ORIGINAL } from './slots.mjs';
 
 import Call from 'es-abstract/2024/Call.js';
 
@@ -17,6 +18,9 @@ import ESGetIntrinsic from 'es-abstract/GetIntrinsic.js';
 const INTRINSICS = {};
 
 const customUtilInspectFormatters = {
+  ['Intl.DateTimeFormat'](depth, options, inspect) {
+    return inspect(GetSlot(this, ORIGINAL), { depth, ...options });
+  },
   ['Temporal.Duration'](depth, options) {
     const descr = options.stylize(this._repr_, 'special');
     if (depth < 1) return descr;

--- a/polyfill/lib/slots.mjs
+++ b/polyfill/lib/slots.mjs
@@ -38,6 +38,9 @@ export const MILLISECONDS = 'slot-milliseconds';
 export const MICROSECONDS = 'slot-microseconds';
 export const NANOSECONDS = 'slot-nanoseconds';
 
+// Intl.DateTimeFormat
+export const ORIGINAL = 'slot-original';
+
 const slots = new WeakMapCtor();
 export function CreateSlots(container) {
   Call(WeakMapPrototypeSet, slots, [container, ObjectCreate(null)]);

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -865,7 +865,7 @@
               1. Set _formatOptions_.[[&lt;_prop_>]] to _value_.
               1. Set _needDefaults_ to *false*.
           1. If _needDefaults_ is *true*, then
-            1. If _anyPresent_ is *true*, return *null*.
+            1. If _anyPresent_ is *true* and _inherit_ is ~relevant~, return *null*.
             1. For each property name _prop_ of _defaultOptions_, do
               1. Set _formatOptions_.[[&lt;_prop_>]] to *"numeric"*.
             1. If _defaults_ is ~zoned-date-time~, then

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1651,7 +1651,7 @@
       <li><ins>[[TemporalPlainMonthDayFormat]] is a DateTime Format Record or *null*.</ins></li>
       <li><ins>[[TemporalPlainTimeFormat]] is a DateTime Format Record or *null*.</ins></li>
       <li><ins>[[TemporalPlainDateTimeFormat]] is a DateTime Format Record.</ins></li>
-      <li><ins>[[TemporalInstantFormat]] is a DateTime Format Records</ins></li>
+      <li><ins>[[TemporalInstantFormat]] is a DateTime Format Record.</ins></li>
     </ul>
 
     <p>Finally, Intl.DateTimeFormat instances have a [[BoundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref>).</p>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -820,7 +820,7 @@
             _required_: ~date~, ~time~, ~year-month~, ~month-day~, or ~any~,
             _defaults_: ~date~, ~time~, ~year-month~, ~month-day~, ~zoned-date-time~, or ~all~,
             _inherit_: ~all~ or ~relevant~,
-          ): a DateTime Format Record
+          ): a DateTime Format Record or *null*
         </h1>
         <dl class="header">
         </dl>

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -864,8 +864,8 @@
             1. If _value_ is not *undefined*, then
               1. Set _formatOptions_.[[&lt;_prop_>]] to _value_.
               1. Set _needDefaults_ to *false*.
-          1. If _anyPresent_ is *true* and _needDefaults_ is *true*, return *null*.
           1. If _needDefaults_ is *true*, then
+            1. If _anyPresent_ is *true*, return *null*.
             1. For each property name _prop_ of _defaultOptions_, do
               1. Set _formatOptions_.[[&lt;_prop_>]] to *"numeric"*.
             1. If _defaults_ is ~zoned-date-time~, then

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -1001,6 +1001,7 @@
       <emu-alg>
         1. If CompareISODateTime(_isoDateTime1_, _isoDateTime2_) = 0, then
           1. Return CombineDateAndTimeDuration(ZeroDateDuration(), 0).
+        1. If ISODateTimeWithinLimits(_isoDateTime1_) is *false* or ISODateTimeWithinLimits(_isoDateTime2_) is *false*, throw a *RangeError* exception.
         1. Let _diff_ be DifferenceISODateTime(_isoDateTime1_, _isoDateTime2_, _calendar_, _largestUnit_).
         1. If _smallestUnit_ is ~nanosecond~ and _roundingIncrement_ = 1, return _diff_.
         1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_isoDateTime2_).
@@ -1024,6 +1025,7 @@
       <emu-alg>
         1. If CompareISODateTime(_isoDateTime1_, _isoDateTime2_) = 0, then
           1. Return 0.
+        1. If ISODateTimeWithinLimits(_isoDateTime1_) is *false* or ISODateTimeWithinLimits(_isoDateTime2_) is *false*, throw a *RangeError* exception.
         1. Let _diff_ be DifferenceISODateTime(_isoDateTime1_, _isoDateTime2_, _calendar_, _unit_).
         1. If _unit_ is ~nanosecond~, return _diff_.[[Time]].
         1. Let _destEpochNs_ be GetUTCEpochNanoseconds(_isoDateTime2_).


### PR DESCRIPTION
- Updates test262 to bring in test coverage for #3015 and ensures assertion is not hit
- Drive-by fix for custom devtools representation of polyfilled Intl.DateTimeFormat
- Reverts unintended observable change affecting `new Date().toLocale{Date,Time,}String()` (see #3049)
- Proofreading/clarity fixes