### PR TITLE
Normative: Reject too large dates in ToTemporalMonthDay

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1332,13 +1332,14 @@ export function ToTemporalMonthDay(item, options = undefined) {
   calendar = CanonicalizeCalendar(calendar);
 
   GetTemporalOverflowOption(GetOptionsObject(options));
-  if (referenceISOYear === undefined) {
-    assert(calendar === 'iso8601', `missing year with non-"iso8601" calendar identifier ${calendar}`);
+  if (calendar === 'iso8601') {
     const isoCalendarReferenceYear = 1972; // First leap year after Unix epoch
     return CreateTemporalMonthDay({ year: isoCalendarReferenceYear, month, day }, calendar);
   }
-  const result = ISODateToFields(calendar, { year: referenceISOYear, month, day }, 'month-day');
-  const isoDate = CalendarMonthDayFromFields(calendar, result, 'constrain');
+  let isoDate = { year: referenceISOYear, month, day };
+  RejectDateRange(isoDate);
+  const result = ISODateToFields(calendar, isoDate, 'month-day');
+  isoDate = CalendarMonthDayFromFields(calendar, result, 'constrain');
   return CreateTemporalMonthDay(isoDate, calendar);
 }
 

--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -37,3 +37,6 @@ staging/sm/Temporal/PlainDate/from-islamic-umalqura.js
 # Faulty leap month calculations in Chinese calendar in ICU4C
 # https://unicode-org.atlassian.net/browse/ICU-22230
 staging/sm/Temporal/PlainMonthDay/from-chinese-leap-month-uncommon.js
+
+# Fails until Intl.DurationFormat available in Node.js release
+intl402/Temporal/Duration/prototype/toLocaleString/returns-same-results-as-DurationFormat.js

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -307,12 +307,12 @@
         1. Set _calendar_ to ? CanonicalizeCalendar(_calendar_).
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Perform ? GetTemporalOverflowOption(_resolvedOptions_).
-        1. If _result_.[[Year]] is ~empty~, then
-          1. Assert: _calendar_ is *"iso8601"*.
+        1. If _calendar_ is *"iso8601"*, then
           1. Let _referenceISOYear_ be 1972 (the first ISO 8601 leap year after the epoch).
           1. Let _isoDate_ be CreateISODateRecord(_referenceISOYear_, _result_.[[Month]], _result_.[[Day]]).
           1. Return ! CreateTemporalMonthDay(_isoDate_, _calendar_).
         1. Let _isoDate_ be CreateISODateRecord(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
+        1. If ISODateWithinLimits(_isoDate_) is *false*, throw a *RangeError* exception.
         1. Set _result_ to ISODateToFields(_calendar_, _isoDate_, ~month-day~).
         1. NOTE: The following operation is called with ~constrain~ regardless of the value of _overflow_, in order for the calendar to store a canonical value in the [[Year]] field of the [[ISODate]] internal slot of the result.
         1. Set _isoDate_ to ? CalendarMonthDayFromFields(_calendar_, _result_, ~constrain~).


### PR DESCRIPTION
Follow-up to #3008 / #3002 to reject too large dates. 