### PR TITLE
Editorial: Make explicit that ToTemporalYearMonth rejects too-large ISO year strings

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1390,9 +1390,11 @@ export function ToTemporalYearMonth(item, options = undefined) {
   if (calendar === undefined) calendar = 'iso8601';
   calendar = CanonicalizeCalendar(calendar);
 
-  const result = ISODateToFields(calendar, { year, month, day: referenceISODay }, 'year-month');
   GetTemporalOverflowOption(GetOptionsObject(options));
-  const isoDate = CalendarYearMonthFromFields(calendar, result, 'constrain');
+  let isoDate = { year, month, day: referenceISODay };
+  RejectYearMonthRange(isoDate);
+  const result = ISODateToFields(calendar, isoDate, 'year-month');
+  isoDate = CalendarYearMonthFromFields(calendar, result, 'constrain');
   return CreateTemporalYearMonth(isoDate, calendar);
 }
 

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -477,10 +477,10 @@
         1. Let _calendar_ be _result_.[[Calendar]].
         1. If _calendar_ is ~empty~, set _calendar_ to *"iso8601"*.
         1. Set _calendar_ to ? CanonicalizeCalendar(_calendar_).
-        1. Let _isoDate_ be CreateISODateRecord(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
-        1. Set _result_ to ISODateToFields(_calendar_, _isoDate_, ~year-month~).
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Perform ? GetTemporalOverflowOption(_resolvedOptions_).
+        1. Let _isoDate_ be CreateISODateRecord(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
+        1. Set _result_ to ISODateToFields(_calendar_, _isoDate_, ~year-month~).
         1. NOTE: The following operation is called with ~constrain~ regardless of the value of _overflow_, in order for the calendar to store a canonical value in the [[Day]] field of the [[ISODate]] internal slot of the result.
         1. Set _isoDate_ to ? CalendarYearMonthFromFields(_calendar_, _result_, ~constrain~).
         1. Return ! CreateTemporalYearMonth(_isoDate_, _calendar_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -480,6 +480,7 @@
         1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
         1. Perform ? GetTemporalOverflowOption(_resolvedOptions_).
         1. Let _isoDate_ be CreateISODateRecord(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
+        1. If ISOYearMonthWithinLimits(_isoDate_) is *false*, throw a *RangeError* exception.
         1. Set _result_ to ISODateToFields(_calendar_, _isoDate_, ~year-month~).
         1. NOTE: The following operation is called with ~constrain~ regardless of the value of _overflow_, in order for the calendar to store a canonical value in the [[Day]] field of the [[ISODate]] internal slot of the result.
         1. Set _isoDate_ to ? CalendarYearMonthFromFields(_calendar_, _result_, ~constrain~).


### PR DESCRIPTION
The call to CalendarYearMonthFromFields will already reject too large dates, but adding an explicit step makes it more obvious that ISODateToFields doesn't require support for mapping large ISO dates to calendar dates. And it also aligns ToTemporalYearMonth with ToTemporalMonthDay after #3054.

Taken from @anba's PR #3054, this is the editorial/unobservable part.