### PR TITLE
Integrate Intl.DurationFormat into Temporal

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -18,6 +18,7 @@ import {
 } from './primordials.mjs';
 import { assert } from './assert.mjs';
 import * as ES from './ecmascript.mjs';
+import { ModifiedIntlDurationFormatPrototypeFormat } from './intl.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
 import {
   YEARS,
@@ -377,7 +378,8 @@ export class Duration {
   toLocaleString(locales = undefined, options = undefined) {
     if (!ES.IsTemporalDuration(this)) throw new TypeErrorCtor('invalid receiver');
     if (typeof IntlDurationFormat === 'function') {
-      return new IntlDurationFormat(locales, options).format(this);
+      const formatter = new IntlDurationFormat(locales, options);
+      return ES.Call(ModifiedIntlDurationFormatPrototypeFormat, formatter, [this]);
     }
     warn('Temporal.Duration.prototype.toLocaleString() requires Intl.DurationFormat.');
     return ES.TemporalDurationToString(this, 'auto');

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -14,6 +14,9 @@ import {
   IntlDateTimeFormatPrototypeFormatRangeToParts,
   IntlDateTimeFormatPrototypeFormatToParts,
   IntlDateTimeFormatPrototypeResolvedOptions,
+  IntlDurationFormatPrototype,
+  IntlDurationFormatPrototypeFormat,
+  IntlDurationFormatPrototypeResolvedOptions,
   ObjectAssign,
   ObjectCreate,
   ObjectDefineProperties,
@@ -25,14 +28,24 @@ import * as ES from './ecmascript.mjs';
 import { MakeIntrinsicClass } from './intrinsicclass.mjs';
 import {
   CreateSlots,
+  DAYS,
   GetSlot,
   HasSlot,
   EPOCHNANOSECONDS,
+  HOURS,
   ISO_DATE,
   ISO_DATE_TIME,
+  MICROSECONDS,
+  MILLISECONDS,
+  MINUTES,
+  MONTHS,
+  NANOSECONDS,
   ORIGINAL,
+  SECONDS,
   SetSlot,
   TIME,
+  WEEKS,
+  YEARS,
   CALENDAR
 } from './slots.mjs';
 
@@ -631,4 +644,26 @@ function extractOverrides(temporalObj, main) {
   }
 
   return {};
+}
+
+function temporalDurationToCompatibilityRecord(duration) {
+  const record = ObjectCreate(null);
+  record.years = GetSlot(duration, YEARS);
+  record.months = GetSlot(duration, MONTHS);
+  record.weeks = GetSlot(duration, WEEKS);
+  record.days = GetSlot(duration, DAYS);
+  record.hours = GetSlot(duration, HOURS);
+  record.minutes = GetSlot(duration, MINUTES);
+  record.seconds = GetSlot(duration, SECONDS);
+  record.milliseconds = GetSlot(duration, MILLISECONDS);
+  record.microseconds = GetSlot(duration, MICROSECONDS);
+  record.nanoseconds = GetSlot(duration, NANOSECONDS);
+  return record;
+}
+
+export function ModifiedIntlDurationFormatPrototypeFormat(durationLike) {
+  ES.Call(IntlDurationFormatPrototypeResolvedOptions, this); // brand check
+  const duration = ES.ToTemporalDuration(durationLike);
+  const record = temporalDurationToCompatibilityRecord(duration);
+  return ES.Call(IntlDurationFormatPrototypeFormat, this, [record]);
 }

--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -16,6 +16,7 @@ import {
   IntlDateTimeFormatPrototypeResolvedOptions,
   IntlDurationFormatPrototype,
   IntlDurationFormatPrototypeFormat,
+  IntlDurationFormatPrototypeFormatToParts,
   IntlDurationFormatPrototypeResolvedOptions,
   ObjectAssign,
   ObjectCreate,
@@ -666,4 +667,14 @@ export function ModifiedIntlDurationFormatPrototypeFormat(durationLike) {
   const duration = ES.ToTemporalDuration(durationLike);
   const record = temporalDurationToCompatibilityRecord(duration);
   return ES.Call(IntlDurationFormatPrototypeFormat, this, [record]);
+}
+
+if (IntlDurationFormatPrototype) {
+  IntlDurationFormatPrototype.format = ModifiedIntlDurationFormatPrototypeFormat;
+  IntlDurationFormatPrototype.formatToParts = function formatToParts(durationLike) {
+    ES.Call(IntlDurationFormatPrototypeResolvedOptions, this); // brand check
+    const duration = ES.ToTemporalDuration(durationLike);
+    const record = temporalDurationToCompatibilityRecord(duration);
+    return ES.Call(IntlDurationFormatPrototypeFormatToParts, this, [record]);
+  };
 }

--- a/polyfill/lib/primordials.mjs
+++ b/polyfill/lib/primordials.mjs
@@ -96,6 +96,7 @@ export const {
 export const IntlDurationFormatPrototype = IntlDurationFormat?.prototype ?? ObjectCreate(null);
 export const {
   format: IntlDurationFormatPrototypeFormat,
+  formatToParts: IntlDurationFormatPrototypeFormatToParts,
   resolvedOptions: IntlDurationFormatPrototypeResolvedOptions
 } = IntlDurationFormatPrototype;
 export const { stringify: JSONStringify } = JSON;

--- a/polyfill/lib/primordials.mjs
+++ b/polyfill/lib/primordials.mjs
@@ -93,6 +93,11 @@ export const {
   formatToParts: IntlDateTimeFormatPrototypeFormatToParts,
   resolvedOptions: IntlDateTimeFormatPrototypeResolvedOptions
 } = IntlDateTimeFormat?.prototype || ObjectCreate(null);
+export const IntlDurationFormatPrototype = IntlDurationFormat?.prototype ?? ObjectCreate(null);
+export const {
+  format: IntlDurationFormatPrototypeFormat,
+  resolvedOptions: IntlDurationFormatPrototypeResolvedOptions
+} = IntlDurationFormatPrototype;
 export const { stringify: JSONStringify } = JSON;
 export const {
   prototype: { entries: MapPrototypeEntries, get: MapPrototypeGet, has: MapPrototypeHas, set: MapPrototypeSet }

--- a/spec.html
+++ b/spec.html
@@ -6,6 +6,7 @@ stage: 3
 contributors: Maggie Pint, Matt Johnson, Brian Terlson, Daniel Ehrenberg, Philipp Dunkel, Sasha Pierson, Ujjwal Sharma, Philip Chimento, Justin Grant
 markEffects: true
 </pre>
+<emu-biblio href="spec/biblio.json"></emu-biblio>
 
 <emu-intro id="sec-temporal-intro">
   <h1>Introduction</h1>

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1769,23 +1769,6 @@
     </emu-alg>
   </emu-clause>
 
-  <emu-clause id="sec-tointegerifintegral" type="abstract operation">
-    <h1>
-      ToIntegerIfIntegral (
-        _argument_: an ECMAScript language value,
-      ): either a normal completion containing an integer or a throw completion
-    </h1>
-    <dl class="header">
-      <dt>description</dt>
-      <dd>It converts _argument_ to an integer representing its Number value, or throws a *RangeError* when that value is not <emu-xref href="#integral-number">integral</emu-xref>.</dd>
-    </dl>
-    <emu-alg>
-      1. Let _number_ be ? ToNumber(_argument_).
-      1. If _number_ is not an integral Number, throw a *RangeError* exception.
-      1. Return ℝ(_number_).
-    </emu-alg>
-  </emu-clause>
-
   <emu-clause id="sec-temporal-tomonthcode" type="abstract operation">
     <h1>
       ToMonthCode (

--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -1,0 +1,37 @@
+[
+  {
+    "location": "https://tc39.es/ecma402/",
+    "entries": [
+      {
+        "type": "op",
+        "aoid": "FormatNumericHours",
+        "id": "sec-formatnumerichours"
+      },
+      {
+        "type": "op",
+        "aoid": "FormatNumericMinutes",
+        "id": "sec-formatnumericminutes"
+      },
+      {
+        "type": "op",
+        "aoid": "FormatNumericSeconds",
+        "id": "sec-formatnumericseconds"
+      },
+      {
+        "type": "op",
+        "aoid": "NextUnitFractional",
+        "id": "sec-nextunitfractional"
+      },
+      {
+        "type": "op",
+        "aoid": "ListFormatParts",
+        "id": "sec-listformatparts"
+      },
+      {
+        "type": "clause",
+        "number": "Table 21",
+        "id": "table-partition-duration-format-pattern"
+      }
+    ]
+  }
+]

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1149,7 +1149,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-isvalidduration" type="abstract operation">
+    <emu-clause id="sec-isvalidduration" type="abstract operation">
       <h1>
         IsValidDuration (
           _years_: an integer,
@@ -1166,7 +1166,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It returns *true* if its arguments form valid input from which to construct a `Temporal.Duration`, and *false* otherwise.</dd>
+        <dd>It returns *true* if its arguments form valid input from which to construct a <del>Duration Record</del><ins>Temporal.Duration</ins>, and *false* otherwise.</dd>
       </dl>
       <emu-alg>
         1. Let _sign_ be 0.
@@ -1181,9 +1181,9 @@
         1. If abs(_years_) ≥ 2<sup>32</sup>, return *false*.
         1. If abs(_months_) ≥ 2<sup>32</sup>, return *false*.
         1. If abs(_weeks_) ≥ 2<sup>32</sup>, return *false*.
-        1. Let _totalFractionalSeconds_ be _days_ × 86,400 + _hours_ × 3600 + _minutes_ × 60 + _seconds_ + ℝ(𝔽(_milliseconds_)) × 10<sup>-3</sup> + ℝ(𝔽(_microseconds_)) × 10<sup>-6</sup> + ℝ(𝔽(_nanoseconds_)) × 10<sup>-9</sup>.
+        1. Let _normalizedSeconds_ be _days_ × 86,400 + _hours_ × 3600 + _minutes_ × 60 + _seconds_ + ℝ(𝔽(_milliseconds_)) × 10<sup>-3</sup> + ℝ(𝔽(_microseconds_)) × 10<sup>-6</sup> + ℝ(𝔽(_nanoseconds_)) × 10<sup>-9</sup>.
         1. NOTE: The above step cannot be implemented directly using floating-point arithmetic. Multiplying by 10<sup>-3</sup>, 10<sup>-6</sup>, and 10<sup>-9</sup> respectively may be imprecise when _milliseconds_, _microseconds_, or _nanoseconds_ is an unsafe integer. This multiplication can be implemented in C++ with an implementation of `std::remquo()` with sufficient bits in the quotient. String manipulation will also give an exact result, since the multiplication is by a power of 10.
-        1. If abs(_totalFractionalSeconds_) ≥ 2<sup>53</sup>, return *false*.
+        1. If abs(_normalizedSeconds_) ≥ 2<sup>53</sup>, return *false*.
         1. Return *true*.
       </emu-alg>
     </emu-clause>

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1096,10 +1096,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-durationsign" type="abstract operation">
+    <emu-clause id="sec-durationsign" type="abstract operation">
       <h1>
         DurationSign (
-          _duration_: a Temporal.Duration,
+          _duration_: a <del>Duration Record</del><ins>Temporal.Duration</ins>,
         ): -1, 0, or 1
       </h1>
       <dl class="header">

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1727,12 +1727,18 @@
 
         <emu-clause id="sup-temporal.duration.prototype.tolocalestring">
           <h1>Temporal.Duration.prototype.toLocaleString ( [ _locales_ [ , _options_ ] ] )</h1>
-          <emu-note type="editor">
-            <p>
-              This function is currently not specified.
-              See <a href="https://tc39.es/proposal-intl-duration-format/">the Intl.DurationFormat proposal</a>.
-            </p>
-          </emu-note>
+          <p>This definition supersedes the definition provided in <emu-xref href="#sec-temporal.duration.prototype.tolocalestring"></emu-xref>.</p>
+          <p>This method performs the following steps when called:</p>
+          <emu-alg>
+            1. Let _duration_ be the *this* value.
+            1. Perform ? RequireInternalSlot(_duration_, [[InitializedTemporalDuration]]).
+            1. Let _formatter_ be ? Construct(%Intl.DurationFormat%, « _locales_, _options_ »).
+            1. Let _parts_ be PartitionDurationFormatPattern(_formatter_, _duration_).
+            1. Let _result_ be the empty String.
+            1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+              1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
+            1. Return _result_.
+          </emu-alg>
         </emu-clause>
       </emu-clause>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1302,6 +1302,35 @@
     <p>Finally, Intl.DateTimeFormat instances have a [[BoundFormat]] internal slot that caches the function returned by the format accessor (<emu-xref href="#sec-intl.datetimeformat.prototype.format"></emu-xref>).</p>
   </emu-clause>
 
+  <emu-clause id="sec-ecma402-intl-durationformat-abstracts">
+    <h1><a href="https://tc39.es/ecma402/#sec-intl-durationformat-abstracts">Abstract Operations for DurationFormat Objects</a></h1>
+
+    <emu-note type="editor">
+      <p>These definitions are moved into ECMA-262.</p>
+    </emu-note>
+
+    <del class="block">
+      <emu-clause id="sec-tointegerifintegral-deleted" type="abstract operation">
+        <h1>
+          ToIntegerIfIntegral (
+            _argument_: an ECMAScript language value,
+          ): either a normal completion containing an integer or a throw completion
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It converts _argument_ to an integer representing its Number value, or throws a *RangeError* when that value is not <emu-xref href="#integral-number">integral</emu-xref>.</dd>
+          <dt>redefinition</dt>
+          <dd>true</dd>
+        </dl>
+        <emu-alg>
+          1. Let _number_ be ? ToNumber(_argument_).
+          1. If _number_ is not an integral Number, throw a *RangeError* exception.
+          1. Return ℝ(_number_).
+        </emu-alg>
+      </emu-clause>
+    </del>
+  </emu-clause>
+
   <emu-clause id="locale-sensitive-functions">
     <h1><a href="https://tc39.es/ecma402/#locale-sensitive-functions">Locale Sensitive Functions of the ECMAScript Language Specification</a></h1>
 

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1306,10 +1306,88 @@
     <h1><a href="https://tc39.es/ecma402/#sec-intl-durationformat-abstracts">Abstract Operations for DurationFormat Objects</a></h1>
 
     <emu-note type="editor">
-      <p>These definitions are moved into ECMA-262.</p>
+      <p>The deleted definitions of ToIntegerIfIntegral, DurationSign, and IsValidDuration are moved into ECMA-262.</p>
     </emu-note>
 
     <del class="block">
+
+      <emu-clause id="sec-duration-records-deleted">
+        <h1>Duration Records</h1>
+        <p>A <dfn variants="Duration Records">Duration Record</dfn> is a Record value used to represent a Duration.</p>
+        <p>Duration Records have the fields listed in <emu-xref href="#table-duration-record-fields"></emu-xref></p>
+        <emu-table id="table-duration-record-fields" caption="Duration Record Fields">
+          <table class="real-table">
+            <tr>
+              <th>Field</th>
+              <th>Meaning</th>
+            </tr>
+            <tr>
+              <td>[[Years]]</td>
+              <td>
+                The number of years in the duration.
+              </td>
+            </tr>
+            <tr>
+              <td>[[Months]]</td>
+              <td>
+                The number of months in the duration.
+              </td>
+            </tr>
+            <tr>
+              <td>[[Weeks]]</td>
+              <td>
+                The number of weeks in the duration.
+              </td>
+            </tr>
+            <tr>
+              <td>[[Days]]</td>
+              <td>
+                The number of days in the duration.
+              </td>
+            </tr>
+            <tr>
+              <td>[[Hours]]</td>
+              <td>
+                The number of hours in the duration.
+              </td>
+            </tr>
+            <tr>
+              <td>[[Minutes]]</td>
+              <td>
+                The number of minutes in the duration.
+              </td>
+            </tr>
+            <tr>
+              <td>[[Seconds]]</td>
+              <td>
+                The number of seconds in the duration.
+              </td>
+            </tr>
+            <tr>
+              <td>[[Milliseconds]]</td>
+              <td>
+                The number of milliseconds in the duration.
+              </td>
+            </tr>
+            <tr>
+              <td>[[Microseconds]]</td>
+              <td>
+                The number of microseconds in the duration.
+              </td>
+            </tr>
+            <tr>
+              <td>[[Nanoseconds]]</td>
+              <td>
+                The number of nanoseconds in the duration.
+              </td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+    </del>
+
+    <del class="block">
+
       <emu-clause id="sec-tointegerifintegral-deleted" type="abstract operation">
         <h1>
           ToIntegerIfIntegral (
@@ -1331,6 +1409,76 @@
     </del>
 
     <del class="block">
+
+      <emu-clause id="sec-todurationrecord-deleted" type="abstract operation">
+        <h1>
+          ToDurationRecord (
+            _input_: an ECMAScript language value,
+          ): either a normal completion containing a Duration Record, or an abrupt completion
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It converts a given object that represents a Duration into a Duration Record.</dd>
+        </dl>
+
+        <emu-alg>
+          1. If _input_ is not an Object, then
+            1. If _input_ is a String, throw a *RangeError* exception.
+            1. Throw a *TypeError* exception.
+          1. Let _result_ be a new Duration Record with each field set to 0.
+          1. Let _days_ be ? Get(_input_, *"days"*).
+          1. If _days_ is not *undefined*, set _result_.[[Days]] to ? ToIntegerIfIntegral(_days_).
+          1. Let _hours_ be ? Get(_input_, *"hours"*).
+          1. If _hours_ is not *undefined*, set _result_.[[Hours]] to ? ToIntegerIfIntegral(_hours_).
+          1. Let _microseconds_ be ? Get(_input_, *"microseconds"*).
+          1. If _microseconds_ is not *undefined*, set _result_.[[Microseconds]] to ? ToIntegerIfIntegral(_microseconds_).
+          1. Let _milliseconds_ be ? Get(_input_, *"milliseconds"*).
+          1. If _milliseconds_ is not *undefined*, set _result_.[[Milliseconds]] to ? ToIntegerIfIntegral(_milliseconds_).
+          1. Let _minutes_ be ? Get(_input_, *"minutes"*).
+          1. If _minutes_ is not *undefined*, set _result_.[[Minutes]] to ? ToIntegerIfIntegral(_minutes_).
+          1. Let _months_ be ? Get(_input_, *"months"*).
+          1. If _months_ is not *undefined*, set _result_.[[Months]] to ? ToIntegerIfIntegral(_months_).
+          1. Let _nanoseconds_ be ? Get(_input_, *"nanoseconds"*).
+          1. If _nanoseconds_ is not *undefined*, set _result_.[[Nanoseconds]] to ? ToIntegerIfIntegral(_nanoseconds_).
+          1. Let _seconds_ be ? Get(_input_, *"seconds"*).
+          1. If _seconds_ is not *undefined*, set _result_.[[Seconds]] to ? ToIntegerIfIntegral(_seconds_).
+          1. Let _weeks_ be ? Get(_input_, *"weeks"*).
+          1. If _weeks_ is not *undefined*, set _result_.[[Weeks]] to ? ToIntegerIfIntegral(_weeks_).
+          1. Let _years_ be ? Get(_input_, *"years"*).
+          1. If _years_ is not *undefined*, set _result_.[[Years]] to ? ToIntegerIfIntegral(_years_).
+          1. If _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, and _nanoseconds_ are all *undefined*, throw a *TypeError* exception.
+          1. If IsValidDuration( _result_.[[Years]], _result_.[[Months]], _result_.[[Weeks]], _result_.[[Days]], _result_.[[Hours]], _result_.[[Minutes]], _result_.[[Seconds]], _result_.[[Milliseconds]], _result_.[[Microseconds]], _result_.[[Nanoseconds]]) is *false*, then
+            1. Throw a *RangeError* exception.
+          1. Return _result_.
+        </emu-alg>
+      </emu-clause>
+    </del>
+
+    <del class="block">
+
+      <emu-clause id="sec-durationsign-deleted" type="abstract operation">
+        <h1>
+          DurationSign (
+            _duration_: a Duration Record,
+          ): -1, 0, or 1
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns 1 if the most significant non-zero element in its arguments is positive, and -1 if the most significant non-zero element is negative. If all of its arguments are zero, it returns 0.</dd>
+          <dt>redefinition</dt>
+          <dd>true</dd>
+        </dl>
+        <emu-alg>
+          1. For each value _v_ of « _duration_.[[Years]], _duration_.[[Months]], _duration_.[[Weeks]], _duration_.[[Days]], _duration_.[[Hours]], _duration_.[[Minutes]], _duration_.[[Seconds]], _duration_.[[Milliseconds]], _duration_.[[Microseconds]], _duration_.[[Nanoseconds]] », do
+            1. If _v_ &lt; 0, return -1.
+            1. If _v_ > 0, return 1.
+          1. Return 0.
+        </emu-alg>
+      </emu-clause>
+    </del>
+
+    <del class="block">
+
       <emu-clause id="sec-isvalidduration-deleted" type="abstract operation">
         <h1>
           IsValidDuration (
@@ -1372,6 +1520,201 @@
         </emu-alg>
       </emu-clause>
     </del>
+
+    <emu-clause id="sec-computefractionaldigits" oldids="sec-addfractionaldigits" type="abstract operation">
+      <h1>
+        ComputeFractionalDigits (
+          _durationFormat_: a DurationFormat Object,
+          _duration_: a <del>Duration Record</del><ins>Temporal.Duration</ins>,
+        ): a mathematical value
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It computes the sum of all values in _durationFormat_ units with *"fractional"* style, expressed as a fraction of the smallest unit of _durationFormat_ that does not use *"fractional"* style.</dd>
+      </dl>
+
+      <emu-alg>
+        1. Let _result_ be 0.
+        1. Let _exponent_ be 3.
+        1. For each row of <emu-xref href="#table-partition-duration-format-pattern"></emu-xref>, except the header row, in table order, do
+          1. Let _style_ be the value of _durationFormat_'s internal slot whose name is the Style Slot value of the current row.
+          1. If _style_ is *"fractional"*, then
+            1. Assert: The Unit value of the current row is *"milliseconds"*, *"microseconds"*, or *"nanoseconds"*.
+            1. Let _value_ be the value of _duration_'s field whose name is the Value Field value of the current row.
+            1. Set _value_ to _value_ / 10<sup>_exponent_</sup>.
+            1. Set _result_ to _result_ + _value_.
+            1. Set _exponent_ to _exponent_ + 3.
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-formatnumericunits" type="abstract operation">
+      <h1>
+        FormatNumericUnits (
+          _durationFormat_: a DurationFormat Object,
+          _duration_: a <del>Duration Record</del><ins>Temporal.Duration</ins>,
+          _firstNumericUnit_: a String,
+          _signDisplayed_: a Boolean,
+        ): a List of Records
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates the parts representing the elements of _duration_ that use *"numeric"* or *"2-digit"* style according to the effective locale and the formatting options of _durationFormat_.</dd>
+      </dl>
+
+      <emu-alg>
+        1. Assert: _firstNumericUnit_ is *"hours"*, *"minutes"*, or *"seconds"*.
+        1. Let _numericPartsList_ be a new empty List.
+        1. Let _hoursValue_ be _duration_.[[Hours]].
+        1. Let _hoursDisplay_ be _durationFormat_.[[HoursDisplay]].
+        1. Let _minutesValue_ be _duration_.[[Minutes]].
+        1. Let _minutesDisplay_ be _durationFormat_.[[MinutesDisplay]].
+        1. Let _secondsValue_ be _duration_.[[Seconds]].
+        1. If _duration_.[[Milliseconds]] is not 0 or _duration_.[[Microseconds]] is not 0 or _duration_.[[Nanoseconds]] is not 0, then
+          1. Set _secondsValue_ to _secondsValue_ + ComputeFractionalDigits(_durationFormat_, _duration_).
+        1. Let _secondsDisplay_ be _durationFormat_.[[SecondsDisplay]].
+        1. Let _hoursFormatted_ be *false*.
+        1. If _firstNumericUnit_ is *"hours"*, then
+          1. If _hoursValue_ is not 0 or _hoursDisplay_ is *"always"*, then
+            1. Set _hoursFormatted_ to *true*.
+        1. If _secondsValue_ is not 0 or _secondsDisplay_ is *"always"*, then
+          1. Let _secondsFormatted_ be *true*.
+        1. Else,
+          1. Let _secondsFormatted_ be *false*.
+        1. Let _minutesFormatted_ be *false*.
+        1. If _firstNumericUnit_ is *"hours"* or _firstNumericUnit_ is *"minutes"*, then
+          1. If _hoursFormatted_ is *true* and _secondsFormatted_ is *true*, then
+            1. Set _minutesFormatted_ to *true*.
+          1. Else if _minutesValue_ is not 0 or _minutesDisplay_ is *"always"*, then
+            1. Set _minutesFormatted_ to *true*.
+        1. If _hoursFormatted_ is *true*, then
+          1. If _signDisplayed_ is *true*, then
+            1. If _hoursValue_ is 0 and DurationSign(_duration_) is -1, then
+              1. Set _hoursValue_ to ~negative-zero~.
+          1. Let _hoursParts_ be FormatNumericHours(_durationFormat_, _hoursValue_, _signDisplayed_).
+          1. Set _numericPartsList_ to the list-concatenation of _numericPartsList_ and _hoursParts_.
+          1. Set _signDisplayed_ to *false*.
+        1. If _minutesFormatted_ is *true*, then
+          1. If _signDisplayed_ is *true*, then
+            1. If _minutesValue_ is 0 and DurationSign(_duration_) is -1, then
+              1. Set _minutesValue_ to ~negative-zero~.
+          1. Let _minutesParts_ be FormatNumericMinutes(_durationFormat_, _minutesValue_, _hoursFormatted_, _signDisplayed_).
+          1. Set _numericPartsList_ to the list-concatenation of _numericPartsList_ and _minutesParts_.
+          1. Set _signDisplayed_ to *false*.
+        1. If _secondsFormatted_ is *true*, then
+          1. Let _secondsParts_ be FormatNumericSeconds(_durationFormat_, _secondsValue_, _minutesFormatted_, _signDisplayed_).
+          1. Set _numericPartsList_ to the list-concatenation of _numericPartsList_ and _secondsParts_.
+        1. Return _numericPartsList_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-partitiondurationformatpattern" type="abstract operation">
+      <h1>
+        PartitionDurationFormatPattern (
+          _durationFormat_: a DurationFormat,
+          _duration_: a <del>Duration Record</del><ins>Temporal.Duration</ins>,
+        ): a List
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It creates the corresponding parts for _duration_ according to the effective locale and the formatting options of _durationFormat_.</dd>
+      </dl>
+
+      <emu-alg>
+        1. Let _result_ be a new empty List.
+        1. Let _signDisplayed_ be *true*.
+        1. Let _numericUnitFound_ be *false*.
+        1. While _numericUnitFound_ is *false*, repeat for each row in <emu-xref href="#table-partition-duration-format-pattern"></emu-xref> in table order, except the header row:
+          1. Let _value_ be the value of _duration_'s field whose name is the Value Field value of the current row.
+          1. Let _style_ be the value of _durationFormat_'s internal slot whose name is the Style Slot value of the current row.
+          1. Let _display_ be the value of _durationFormat_'s internal slot whose name is the Display Slot value of the current row.
+          1. Let _unit_ be the Unit value of the current row.
+          1. If _style_ is *"numeric"* or *"2-digit"*, then
+            1. Append FormatNumericUnits(_durationFormat_, _duration_, _unit_, _signDisplayed_) to _result_.
+            1. Let _numericPartsList_ be FormatNumericUnits(_durationFormat_, _duration_, _unit_, _signDisplayed_).
+            1. If _numericPartsList_ is not empty, append _numericPartsList_ to _result_.
+            1. Set _numericUnitFound_ to *true*.
+          1. Else,
+            1. Let _nfOpts_ be OrdinaryObjectCreate(*null*).
+            1. If _unit_ is *"seconds"*, *"milliseconds"*, or *"microseconds"*, then
+              1. If NextUnitFractional(_durationFormat_, _unit_) is *true*, then
+                1. Set _value_ to _value_ + ComputeFractionalDigits(_durationFormat_, _duration_).
+                1. If _durationFormat_.[[FractionalDigits]] is *undefined*, then
+                  1. Let _maximumFractionDigits_ be *9*<sub>𝔽</sub>.
+                  1. Let _minimumFractionDigits_ be *+0*<sub>𝔽</sub>.
+                1. Else,
+                  1. Let _maximumFractionDigits_ be _durationFormat_.[[FractionalDigits]].
+                  1. Let _minimumFractionDigits_ be _durationFormat_.[[FractionalDigits]].
+                1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"maximumFractionDigits"*, _maximumFractionDigits_).
+                1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"minimumFractionDigits"*, _minimumFractionDigits_).
+                1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"roundingMode"*, *"trunc"*).
+                1. Set _numericUnitFound_ to *true*.
+            1. If _value_ is not 0 or _display_ is *"always"*, then
+              1. Let _numberingSystem_ be _durationFormat_.[[NumberingSystem]].
+              1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"numberingSystem"*, _numberingSystem_).
+              1. If _signDisplayed_ is *true*, then
+                1. Set _signDisplayed_ to *false*.
+                1. If _value_ is 0 and DurationSign(_duration_) is -1, then
+                  1. Set _value_ to ~negative-zero~.
+              1. Else,
+                1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"signDisplay"*, *"never"*).
+              1. Let _numberFormatUnit_ be the NumberFormat Unit value of the current row.
+              1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"style"*, *"unit"*).
+              1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"unit"*, _numberFormatUnit_).
+              1. Perform ! CreateDataPropertyOrThrow(_nfOpts_, *"unitDisplay"*, _style_).
+              1. Let _nf_ be ! Construct(%Intl.NumberFormat%, « _durationFormat_.[[Locale]], _nfOpts_ »).
+              1. Let _parts_ be PartitionNumberPattern(_nf_, _value_).
+              1. Let _list_ be a new empty List.
+              1. For each Record { [[Type]], [[Value]] } _part_ of _parts_, do
+                1. Append the Record { [[Type]]: _part_.[[Type]], [[Value]]: _part_.[[Value]], [[Unit]]: _numberFormatUnit_ } to _list_.
+              1. Append _list_ to _result_.
+        1. Return ListFormatParts(_durationFormat_, _result_).
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-ecma402-properties-of-intl-durationformat-prototype-object">
+    <h1><a href="https://tc39.es/ecma402/#sec-properties-of-intl-durationformat-prototype-object">Properties of the Intl.DurationFormat Prototype Object</a></h1>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.format">
+      <h1>Intl.DurationFormat.prototype.format ( <del>_duration_</del><ins>_durationLike_</ins> )</h1>
+
+      <p>When the `format` method is called with an argument <del>_duration_</del><ins>_durationLike_</ins>, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let <del>_record_</del><ins>_duration_</ins> be ? <del>ToDurationRecord(_duration_)</del><ins>ToTemporalDuration(_durationLike_)</ins>.
+        1. Let _parts_ be PartitionDurationFormatPattern(_df_, <del>_record_</del><ins>_duration_</ins>).
+        1. Let _result_ be the empty String.
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+          1. Set _result_ to the string-concatenation of _result_ and _part_.[[Value]].
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.DurationFormat.prototype.formatToParts">
+      <h1>Intl.DurationFormat.prototype.formatToParts ( <del>_duration_</del><ins>_durationLike_</ins> )</h1>
+
+      <p>When the `formatToParts` method is called with an argument <del>_duration_</del><ins>_durationLike_</ins>, the following steps are taken:</p>
+
+      <emu-alg>
+        1. Let _df_ be the *this* value.
+        1. Perform ? RequireInternalSlot(_df_, [[InitializedDurationFormat]]).
+        1. Let <del>_record_</del><ins>_duration_</ins> be ? <del>ToDurationRecord(_duration_)</del><ins>ToTemporalDuration(_durationLike_)</ins>.
+        1. Let _parts_ be PartitionDurationFormatPattern(_df_, <del>_record_</del><ins>_duration_</ins>).
+        1. Let _result_ be ! ArrayCreate(0).
+        1. Let _n_ be 0.
+        1. For each Record { [[Type]], [[Value]], [[Unit]] } _part_ in _parts_, do
+          1. Let _obj_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"type"*, _part_.[[Type]]).
+          1. Perform ! CreateDataPropertyOrThrow(_obj_, *"value"*, _part_.[[Value]]).
+          1. If _part_.[[Unit]] is not ~empty~, perform ! CreateDataPropertyOrThrow(_obj_, *"unit"*, _part_.[[Unit]]).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, ! ToString(_n_), _obj_).
+          1. Set _n_ to _n_ + 1.
+        1. Return _result_.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="locale-sensitive-functions">

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1329,6 +1329,49 @@
         </emu-alg>
       </emu-clause>
     </del>
+
+    <del class="block">
+      <emu-clause id="sec-isvalidduration-deleted" type="abstract operation">
+        <h1>
+          IsValidDuration (
+            _years_: an integer,
+            _months_: an integer,
+            _weeks_: an integer,
+            _days_: an integer,
+            _hours_: an integer,
+            _minutes_: an integer,
+            _seconds_: an integer,
+            _milliseconds_: an integer,
+            _microseconds_: an integer,
+            _nanoseconds_: an integer,
+          ): a Boolean
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns *true* if its arguments form valid input from which to construct a Duration Record, and *false* otherwise.</dd>
+          <dt>redefinition</dt>
+          <dd>true</dd>
+        </dl>
+        <emu-alg>
+          1. Let _sign_ be 0.
+          1. For each value _v_ of « _years_, _months_, _weeks_, _days_, _hours_, _minutes_, _seconds_, _milliseconds_, _microseconds_, _nanoseconds_ », do
+            1. If 𝔽(_v_) is not finite, return *false*.
+            1. If _v_ &lt; 0, then
+              1. If _sign_ > 0, return *false*.
+              1. Set _sign_ to -1.
+            1. Else if _v_ > 0, then
+              1. If _sign_ &lt; 0, return *false*.
+              1. Set _sign_ to 1.
+          1. If abs(_years_) ≥ 2<sup>32</sup>, return *false*.
+          1. If abs(_months_) ≥ 2<sup>32</sup>, return *false*.
+          1. If abs(_weeks_) ≥ 2<sup>32</sup>, return *false*.
+          1. Let _normalizedSeconds_ be _days_ × 86,400 + _hours_ × 3600 + _minutes_ × 60 + _seconds_ + ℝ(𝔽(_milliseconds_)) × 10<sup>-3</sup> + ℝ(𝔽(_microseconds_)) × 10<sup>-6</sup> + ℝ(𝔽(_nanoseconds_)) × 10<sup>-9</sup>.
+          1. NOTE: The above step cannot be implemented directly using floating-point arithmetic. Multiplying by 10<sup>-3</sup>, 10<sup>-6</sup>, and 10<sup>-9</sup> respectively may be imprecise when _milliseconds_, _microseconds_, or _nanoseconds_ is an unsafe integer. This multiplication can be implemented in C++ with an implementation of `std::remquo()` with sufficient bits in the quotient. String manipulation will also give an exact result, since the multiplication is by a power of 10.
+          1. If abs(_normalizedSeconds_) ≥ 2<sup>53</sup>, return *false*.
+          1. Return *true*.
+        </emu-alg>
+      </emu-clause>
+    </del>
   </emu-clause>
 
   <emu-clause id="locale-sensitive-functions">

--- a/spec/mainadditions.html
+++ b/spec/mainadditions.html
@@ -75,6 +75,34 @@
   <emu-clause id="sec-ecma262-abstract-operations">
     <h1><a href="https://tc39.es/ecma262/#sec-abstract-operations">Abstract Operations</a></h1>
 
+    <emu-clause id="sec-ecma262-type-conversion">
+      <h1><a href="https://tc39.es/ecma262/#sec-type-conversion">Type Conversion</a></h1>
+
+      <p>[...]</p>
+
+      <!-- Copied from ECMA-402 ToIntegerIfIntegral -->
+
+      <ins class="block">
+
+        <emu-clause id="sec-tointegerifintegral" type="abstract operation">
+          <h1>
+            ToIntegerIfIntegral (
+              _argument_: an ECMAScript language value,
+            ): either a normal completion containing an integer or a throw completion
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It converts _argument_ to an integer representing its Number value, or throws a *RangeError* when that value is not <emu-xref href="#integral-number">integral</emu-xref>.</dd>
+          </dl>
+          <emu-alg>
+            1. Let _number_ be ? ToNumber(_argument_).
+            1. If _number_ is not an integral Number, throw a *RangeError* exception.
+            1. Return ℝ(_number_).
+          </emu-alg>
+        </emu-clause>
+      </ins>
+    </emu-clause>
+
     <p>[...]</p>
 
     <ins class="block">


### PR DESCRIPTION
Intl.DurationFormat is stage 4, so we can now incorporate the necessary changes to use it in Temporal.Duration.prototype.toLocaleString and to accept Temporal.Duration as an argument to Intl.DurationFormat.prototype.format and formatToParts. Some operations need to move from ECMA-402 into ECMA-262.

Closes: #452