### PR TITLE
docs: Update typo of string formatting output

### DIFF
--- a/docs/strings.md
+++ b/docs/strings.md
@@ -67,7 +67,7 @@ zdt.withTimeZone('Europe/Paris')
   .toPlainDate()
   .subtract({ years: 3000 })
   .toLocaleString('fr-FR', { calendar: 'gregory', dateStyle: 'long' });
-  // => "28 février 2022"
+  // => "28 février 979"
 
 zdt.withTimeZone('America/New_York')
   .toPlainDate()


### PR DESCRIPTION
The actual output is: `28 février 22`

This example demonstrates date wrap around the era notation, but doesn't note the era. An alternative example might demonstrate subtraction without passing past 0 CE, but for now let's just fix the typo.