### PR TITLE
polyfill: Update type definition to support `exactOptionalPropertyTypes`

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -26,7 +26,7 @@ export namespace Temporal {
      *
      * The default is `'constrain'`.
      */
-    overflow?: 'constrain' | 'reject';
+    overflow?: 'constrain' | 'reject' | undefined;
   };
 
   /**
@@ -45,7 +45,7 @@ export namespace Temporal {
      *
      * The default is `'constrain'`.
      */
-    overflow?: 'constrain' | 'balance';
+    overflow?: 'constrain' | 'balance' | undefined;
   };
 
   /**
@@ -75,7 +75,7 @@ export namespace Temporal {
      * The default is `'compatible'`.
      *
      * */
-    disambiguation?: 'compatible' | 'earlier' | 'later' | 'reject';
+    disambiguation?: 'compatible' | 'earlier' | 'later' | 'reject' | undefined;
   };
 
   type OffsetDisambiguationOptions = {
@@ -111,7 +111,7 @@ export namespace Temporal {
      * be used to choose the correct instant. However, if the offset is used
      * then the `disambiguation` option will be ignored.
      */
-    offset?: 'use' | 'prefer' | 'ignore' | 'reject';
+    offset?: 'use' | 'prefer' | 'ignore' | 'reject' | undefined;
   };
 
   export type ZonedDateTimeAssignmentOptions = Partial<
@@ -130,7 +130,7 @@ export namespace Temporal {
      *
      * The default is `'constrain'`.
      */
-    overflow?: 'constrain' | 'reject';
+    overflow?: 'constrain' | 'reject' | undefined;
   };
 
   export type DateUnit = 'year' | 'month' | 'week' | 'day';
@@ -163,8 +163,8 @@ export namespace Temporal {
    * Options for outputting precision in toString() on types with seconds
    */
   export type ToStringPrecisionOptions = {
-    fractionalSecondDigits?: 'auto' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
-    smallestUnit?: SmallestUnit<'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>;
+    fractionalSecondDigits?: 'auto' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined;
+    smallestUnit?: SmallestUnit<'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'> | undefined;
 
     /**
      * Controls how rounding is performed:
@@ -180,19 +180,19 @@ export namespace Temporal {
      *   negative infinity which is usually unexpected. For this reason, `trunc`
      *   is recommended for most use cases.
      */
-    roundingMode?: RoundingMode;
+    roundingMode?: RoundingMode | undefined;
   };
 
   export type ShowCalendarOption = {
-    calendarName?: 'auto' | 'always' | 'never' | 'critical';
+    calendarName?: 'auto' | 'always' | 'never' | 'critical' | undefined;
   };
 
   export type CalendarTypeToStringOptions = Partial<ToStringPrecisionOptions & ShowCalendarOption>;
 
   export type ZonedDateTimeToStringOptions = Partial<
     CalendarTypeToStringOptions & {
-      timeZoneName?: 'auto' | 'never' | 'critical';
-      offset?: 'auto' | 'never';
+      timeZoneName?: 'auto' | 'never' | 'critical' | undefined;
+      offset?: 'auto' | 'never' | undefined;
     }
   >;
 
@@ -213,7 +213,7 @@ export namespace Temporal {
      * `since()`, because those methods default behavior is not to round.
      * However, the same property is required for `round()`.
      */
-    smallestUnit?: SmallestUnit<T>;
+    smallestUnit?: SmallestUnit<T> | undefined;
 
     /**
      * The largest unit to allow in the resulting `Temporal.Duration` object.
@@ -231,14 +231,14 @@ export namespace Temporal {
      * The default is always `'auto'`, though the meaning of this depends on the
      * type being used.
      */
-    largestUnit?: LargestUnit<T>;
+    largestUnit?: LargestUnit<T> | undefined;
 
     /**
      * Allows rounding to an integer number of units. For example, to round to
      * increments of a half hour, use `{ smallestUnit: 'minute',
      * roundingIncrement: 30 }`.
      */
-    roundingIncrement?: number;
+    roundingIncrement?: number | undefined;
 
     /**
      * Controls how rounding is performed:
@@ -256,7 +256,7 @@ export namespace Temporal {
      *   negative infinity which is usually unexpected. For this reason, `trunc`
      *   is recommended for most use cases.
      */
-    roundingMode?: RoundingMode;
+    roundingMode?: RoundingMode | undefined;
   }
 
   /**
@@ -282,7 +282,7 @@ export namespace Temporal {
          * increments of a half hour, use `{ smallestUnit: 'minute',
          * roundingIncrement: 30 }`.
          */
-        roundingIncrement?: number;
+        roundingIncrement?: number | undefined;
 
         /**
          * Controls how rounding is performed:
@@ -298,7 +298,7 @@ export namespace Temporal {
          *   negative infinity which is usually unexpected. For this reason, `trunc`
          *   is recommended for most use cases.
          */
-        roundingMode?: RoundingMode;
+        roundingMode?: RoundingMode | undefined;
       };
 
   /**
@@ -340,7 +340,7 @@ export namespace Temporal {
              * If `smallestUnit` is larger, then `smallestUnit` will be used as
              * `largestUnit`, superseding a caller-supplied or default value.
              */
-            largestUnit?: LargestUnit<DateTimeUnit>;
+            largestUnit?: LargestUnit<DateTimeUnit> | undefined;
           }
         | {
             /**
@@ -349,7 +349,7 @@ export namespace Temporal {
              * required, but is optional if `largestUnit` is provided and not
              * undefined.
              */
-            smallestUnit?: SmallestUnit<DateTimeUnit>;
+            smallestUnit?: SmallestUnit<DateTimeUnit> | undefined;
 
             /**
              * The largest unit to allow in the resulting `Temporal.Duration`
@@ -378,7 +378,7 @@ export namespace Temporal {
          * to increments of a half hour, use `{ smallestUnit: 'minute',
          * roundingIncrement: 30 }`.
          */
-        roundingIncrement?: number;
+        roundingIncrement?: number | undefined;
 
         /**
          * Controls how rounding is performed:
@@ -397,7 +397,7 @@ export namespace Temporal {
          *   unexpected. For this reason, `trunc` is recommended for most "round
          *   down" use cases.
          */
-        roundingMode?: RoundingMode;
+        roundingMode?: RoundingMode | undefined;
 
         /**
          * The starting point to use for rounding and conversions when
@@ -423,7 +423,13 @@ export namespace Temporal {
          * time zone transitions and all days will be assumed to be 24 hours
          * long.
          */
-        relativeTo?: Temporal.PlainDateTime | Temporal.ZonedDateTime | PlainDateTimeLike | ZonedDateTimeLike | string;
+        relativeTo?:
+          | Temporal.PlainDateTime
+          | Temporal.ZonedDateTime
+          | PlainDateTimeLike
+          | ZonedDateTimeLike
+          | string
+          | undefined;
       });
 
   /**
@@ -459,7 +465,13 @@ export namespace Temporal {
          * this option is omitted), then the operation will ignore time zone
          * transitions and all days will be assumed to be 24 hours long.
          */
-        relativeTo?: Temporal.ZonedDateTime | Temporal.PlainDateTime | ZonedDateTimeLike | PlainDateTimeLike | string;
+        relativeTo?:
+          | Temporal.ZonedDateTime
+          | Temporal.PlainDateTime
+          | ZonedDateTimeLike
+          | PlainDateTimeLike
+          | string
+          | undefined;
       };
 
   /**
@@ -486,7 +498,13 @@ export namespace Temporal {
      * this option is omitted), then the operation will ignore time zone
      * transitions and all days will be assumed to be 24 hours long.
      */
-    relativeTo?: Temporal.ZonedDateTime | Temporal.PlainDateTime | ZonedDateTimeLike | PlainDateTimeLike | string;
+    relativeTo?:
+      | Temporal.ZonedDateTime
+      | Temporal.PlainDateTime
+      | ZonedDateTimeLike
+      | PlainDateTimeLike
+      | string
+      | undefined;
   }
 
   /**
@@ -495,16 +513,16 @@ export namespace Temporal {
   export type TransitionDirection = 'next' | 'previous' | { direction: 'next' | 'previous' };
 
   export type DurationLike = {
-    years?: number;
-    months?: number;
-    weeks?: number;
-    days?: number;
-    hours?: number;
-    minutes?: number;
-    seconds?: number;
-    milliseconds?: number;
-    microseconds?: number;
-    nanoseconds?: number;
+    years?: number | undefined;
+    months?: number | undefined;
+    weeks?: number | undefined;
+    days?: number | undefined;
+    hours?: number | undefined;
+    minutes?: number | undefined;
+    seconds?: number | undefined;
+    milliseconds?: number | undefined;
+    microseconds?: number | undefined;
+    nanoseconds?: number | undefined;
   };
 
   /**
@@ -615,11 +633,11 @@ export namespace Temporal {
   export type PlainDateLike = {
     era?: string | undefined;
     eraYear?: number | undefined;
-    year?: number;
-    month?: number;
-    monthCode?: string;
-    day?: number;
-    calendar?: CalendarLike;
+    year?: number | undefined;
+    month?: number | undefined;
+    monthCode?: string | undefined;
+    day?: number | undefined;
+    calendar?: CalendarLike | undefined;
   };
 
   /**
@@ -673,7 +691,7 @@ export namespace Temporal {
         | string
         | {
             timeZone: TimeZoneLike;
-            plainTime?: Temporal.PlainTime | PlainTimeLike | string;
+            plainTime?: Temporal.PlainTime | PlainTimeLike | string | undefined;
           }
     ): Temporal.ZonedDateTime;
     toPlainYearMonth(): Temporal.PlainYearMonth;
@@ -688,17 +706,17 @@ export namespace Temporal {
   export type PlainDateTimeLike = {
     era?: string | undefined;
     eraYear?: number | undefined;
-    year?: number;
-    month?: number;
-    monthCode?: string;
-    day?: number;
-    hour?: number;
-    minute?: number;
-    second?: number;
-    millisecond?: number;
-    microsecond?: number;
-    nanosecond?: number;
-    calendar?: CalendarLike;
+    year?: number | undefined;
+    month?: number | undefined;
+    monthCode?: string | undefined;
+    day?: number | undefined;
+    hour?: number | undefined;
+    minute?: number | undefined;
+    second?: number | undefined;
+    millisecond?: number | undefined;
+    microsecond?: number | undefined;
+    nanosecond?: number | undefined;
+    calendar?: CalendarLike | undefined;
   };
 
   /**
@@ -791,11 +809,11 @@ export namespace Temporal {
   export type PlainMonthDayLike = {
     era?: string | undefined;
     eraYear?: number | undefined;
-    year?: number;
-    month?: number;
-    monthCode?: string;
-    day?: number;
-    calendar?: CalendarLike;
+    year?: number | undefined;
+    month?: number | undefined;
+    monthCode?: string | undefined;
+    day?: number | undefined;
+    calendar?: CalendarLike | undefined;
   };
 
   /**
@@ -825,12 +843,12 @@ export namespace Temporal {
   }
 
   export type PlainTimeLike = {
-    hour?: number;
-    minute?: number;
-    second?: number;
-    millisecond?: number;
-    microsecond?: number;
-    nanosecond?: number;
+    hour?: number | undefined;
+    minute?: number | undefined;
+    second?: number | undefined;
+    millisecond?: number | undefined;
+    microsecond?: number | undefined;
+    nanosecond?: number | undefined;
   };
 
   /**
@@ -898,10 +916,10 @@ export namespace Temporal {
   export type PlainYearMonthLike = {
     era?: string | undefined;
     eraYear?: number | undefined;
-    year?: number;
-    month?: number;
-    monthCode?: string;
-    calendar?: CalendarLike;
+    year?: number | undefined;
+    month?: number | undefined;
+    monthCode?: string | undefined;
+    calendar?: CalendarLike | undefined;
   };
 
   /**
@@ -957,19 +975,19 @@ export namespace Temporal {
   export type ZonedDateTimeLike = {
     era?: string | undefined;
     eraYear?: number | undefined;
-    year?: number;
-    month?: number;
-    monthCode?: string;
-    day?: number;
-    hour?: number;
-    minute?: number;
-    second?: number;
-    millisecond?: number;
-    microsecond?: number;
-    nanosecond?: number;
-    offset?: string;
-    timeZone?: TimeZoneLike;
-    calendar?: CalendarLike;
+    year?: number | undefined;
+    month?: number | undefined;
+    monthCode?: string | undefined;
+    day?: number | undefined;
+    hour?: number | undefined;
+    minute?: number | undefined;
+    second?: number | undefined;
+    millisecond?: number | undefined;
+    microsecond?: number | undefined;
+    nanosecond?: number | undefined;
+    offset?: string | undefined;
+    timeZone?: TimeZoneLike | undefined;
+    calendar?: CalendarLike | undefined;
   };
 
   export class ZonedDateTime {

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -114,9 +114,7 @@ export namespace Temporal {
     offset?: 'use' | 'prefer' | 'ignore' | 'reject' | undefined;
   };
 
-  export type ZonedDateTimeAssignmentOptions = Partial<
-    AssignmentOptions & ToInstantOptions & OffsetDisambiguationOptions
-  >;
+  export type ZonedDateTimeAssignmentOptions = AssignmentOptions & ToInstantOptions & OffsetDisambiguationOptions;
 
   /**
    * Options for arithmetic operations like `add()` and `subtract()`
@@ -187,20 +185,16 @@ export namespace Temporal {
     calendarName?: 'auto' | 'always' | 'never' | 'critical' | undefined;
   };
 
-  export type CalendarTypeToStringOptions = Partial<ToStringPrecisionOptions & ShowCalendarOption>;
+  export type CalendarTypeToStringOptions = ToStringPrecisionOptions & ShowCalendarOption;
 
-  export type ZonedDateTimeToStringOptions = Partial<
-    CalendarTypeToStringOptions & {
-      timeZoneName?: 'auto' | 'never' | 'critical' | undefined;
-      offset?: 'auto' | 'never' | undefined;
-    }
-  >;
+  export type ZonedDateTimeToStringOptions = CalendarTypeToStringOptions & {
+    timeZoneName?: 'auto' | 'never' | 'critical' | undefined;
+    offset?: 'auto' | 'never' | undefined;
+  };
 
-  export type InstantToStringOptions = Partial<
-    ToStringPrecisionOptions & {
-      timeZone: TimeZoneLike;
-    }
-  >;
+  export type InstantToStringOptions = ToStringPrecisionOptions & {
+    timeZone?: TimeZoneLike | undefined;
+  };
 
   /**
    * Options to control the result of `until()` and `since()` methods in


### PR DESCRIPTION
The `exactOptionalPropertyTypes` option in TypeScript bans passing `undefined` to optional properties unless `undefined` is allowed explicitly, because optional properties and `undefined` properties behave differently in JavaScript, to be precise.

https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes

```typescript
function foo(
  dateTime: Temporal.ZonedDateTime,
  disambiguation?: "compatible" | "earlier" | "later" | "reject",
) {
  dateTime.with({ day: 1 }, { disambiguation });
}
```

For example, above code result in the error below with `exactOptionalPropertyTypes`.

```
Argument of type '{ disambiguation: "reject" | "compatible" | "earlier" | "later" | undefined; }' is not assignable to parameter of type 'Partial<AssignmentOptions & ToInstantOptions & OffsetDisambiguationOptions>' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'disambiguation' are incompatible.
    Type '"reject" | "compatible" | "earlier" | "later" | undefined' is not assignable to type '"reject" | "compatible" | "earlier" | "later"'.
      Type 'undefined' is not assignable to type '"reject" | "compatible" | "earlier" | "later"'.
```

As I understand it, Temporal's API doesn't distinguish optional properties and properties with `undefined` in passed objects (`XXLike` objects and options) and passing `undefined` as a value is safe.

This pull request allows passing `undefined` to Temporal's built-in methods under the `exactOptionalPropertyTypes` option in TypeScript.

note: usage of `Partial` in the type definition is no longer necessary because original type contains only optional properties, so I removed it for clean-up. I'll revert it if there is a reason to leave `Partial` as is.
