### PR TITLE
Polyfill: Fix type definition of Duration.toLocaleString

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -508,6 +508,36 @@ export namespace Temporal {
   };
 
   /**
+   * Options for Intl.DurationFormat
+   */
+  export type DurationFormatOptions = {
+    localeMatcher?: 'lookup' | 'best fit' | undefined;
+    numberingSystem?: string | undefined;
+    style?: 'long' | 'short' | 'narrow' | 'digital' | undefined;
+    years?: 'long' | 'short' | 'narrow' | undefined;
+    yearsDisplay?: 'always' | 'auto' | undefined;
+    months?: 'long' | 'short' | 'narrow' | undefined;
+    monthsDisplay?: 'always' | 'auto' | undefined;
+    weeks?: 'long' | 'short' | 'narrow' | undefined;
+    weeksDisplay?: 'always' | 'auto' | undefined;
+    days?: 'long' | 'short' | 'narrow' | undefined;
+    daysDisplay?: 'always' | 'auto' | undefined;
+    hours?: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit' | undefined;
+    hoursDisplay?: 'always' | 'auto' | undefined;
+    minutes?: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit' | undefined;
+    minutesDisplay?: 'always' | 'auto' | undefined;
+    seconds?: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit' | undefined;
+    secondsDisplay?: 'always' | 'auto' | undefined;
+    milliseconds?: 'long' | 'short' | 'narrow' | 'numeric' | undefined;
+    millisecondsDisplay?: 'always' | 'auto' | undefined;
+    microseconds?: 'long' | 'short' | 'narrow' | 'numeric' | undefined;
+    microsecondsDisplay?: 'always' | 'auto' | undefined;
+    nanoseconds?: 'long' | 'short' | 'narrow' | 'numeric' | undefined;
+    nanosecondsDisplay?: 'always' | 'auto' | undefined;
+    fractionalDigits?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined;
+  };
+
+  /**
    *
    * A `Temporal.Duration` represents an immutable duration of time which can be
    * used in date/time arithmetic.
@@ -552,7 +582,7 @@ export namespace Temporal {
     subtract(other: Temporal.Duration | DurationLike | string): Temporal.Duration;
     round(roundTo: DurationRoundTo): Temporal.Duration;
     total(totalOf: DurationTotalOf): number;
-    toLocaleString(locales?: globalThis.Intl.LocalesArgument, options?: globalThis.Intl.DateTimeFormatOptions): string;
+    toLocaleString(locales?: globalThis.Intl.LocalesArgument, options?: DurationFormatOptions): string;
     toJSON(): string;
     toString(options?: ToStringPrecisionOptions): string;
     valueOf(): never;


### PR DESCRIPTION
The options argument of `Duration.toLocaleString` is incorrectly typed as `Intl.DateTimeFormatOptions` which is incorrect. For example this code fails typechecking:

```ts
duration.toLocaleString('en', { style: 'digital' })`
```

TypeScript's lib.d.ts does not yet include type definitions for Intl.DurationFormat, so I've added the relevant options manually. This can be removed once TypeScript has shipped support.