### PR TITLE
Polyfill: Adjust time zone transition search window

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -2391,6 +2391,31 @@ export function GetNamedTimeZoneDateTimeParts(id, epochNanoseconds) {
   return BalanceISODateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
 }
 
+// Most time zones never transition twice within a short span of days. We still
+// accommodate twitchy zones, albeit at a performance penalty. 19 days is the
+// default window, past which we'd need to start adding many more special cases.
+function searchWindowForTransitions(id) {
+  if (id === 'Africa/El_Aaiun') return DAY_MS * 17;
+  if (id === 'America/Argentina/Tucuman') return DAY_MS * 12;
+  if (id === 'Europe/Tirane') return DAY_MS * 11;
+  if (id === 'Europe/Riga') return DAY_MS * 10;
+  if (id === 'Europe/Simferopol' || id === 'Europe/Vienna') return DAY_MS * 9;
+  if (id === 'Africa/Tunis') return DAY_MS * 8;
+  if (
+    id === 'America/Boa_Vista' ||
+    id === 'America/Fortaleza' ||
+    id === 'America/Maceio' ||
+    id === 'America/Noronha' ||
+    id === 'America/Recife' ||
+    id === 'Asia/Gaza' || // dubious, only in future calculations
+    id === 'Asia/Hebron' || // ditto
+    id === 'Brazil/DeNoronha'
+  ) {
+    return DAY_MS * 6;
+  }
+  return DAY_MS * 19;
+}
+
 export function GetNamedTimeZoneNextTransition(id, epochNanoseconds) {
   if (id === 'UTC') return null; // UTC fast path
 
@@ -2413,8 +2438,9 @@ export function GetNamedTimeZoneNextTransition(id, epochNanoseconds) {
   let leftOffsetNs = GetNamedTimeZoneOffsetNanosecondsImpl(id, leftMs);
   let rightMs = leftMs;
   let rightOffsetNs = leftOffsetNs;
+  const searchWindow = searchWindowForTransitions(id);
   while (leftOffsetNs === rightOffsetNs && leftMs < uppercap) {
-    rightMs = leftMs + DAY_MS * 2 * 7;
+    rightMs = leftMs + searchWindow;
     if (rightMs > MS_MAX) return null;
     rightOffsetNs = GetNamedTimeZoneOffsetNanosecondsImpl(id, rightMs);
     if (leftOffsetNs === rightOffsetNs) {
@@ -2471,8 +2497,9 @@ export function GetNamedTimeZonePreviousTransition(id, epochNanoseconds) {
   let rightOffsetNs = GetNamedTimeZoneOffsetNanosecondsImpl(id, rightMs);
   let leftMs = rightMs;
   let leftOffsetNs = rightOffsetNs;
+  const searchWindow = searchWindowForTransitions(id);
   while (rightOffsetNs === leftOffsetNs && rightMs > BEFORE_FIRST_DST) {
-    leftMs = rightMs - DAY_MS * 2 * 7;
+    leftMs = rightMs - searchWindow;
     if (leftMs < BEFORE_FIRST_DST) return null;
     leftOffsetNs = GetNamedTimeZoneOffsetNanosecondsImpl(id, leftMs);
     if (rightOffsetNs === leftOffsetNs) {


### PR DESCRIPTION
For a few time zones, the two-week search window for an interval to bisect is too large, because transitions occur less than two weeks apart. Special-case these time zones.

This allows increasing the default window to 19 days (a bunch of Argentinian time zones have transitions less than 20 days apart, so this seems like a good boundary where we don't have to add too many special cases.) This gives a small performance improvement in the common case.

Closes: #3110