### PR TITLE
Meta: Add a GitHub repository link in the rendered spec

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf8">
 <pre class="metadata">
-title: Temporal proposal
+title: Temporal
+status: proposal
 stage: 3
+shortname: &lt;a href="https://github.com/tc39/proposal-temporal"&gt;proposal-temporal&lt;/a&gt;
 contributors: Maggie Pint, Matt Johnson, Brian Terlson, Daniel Ehrenberg, Philipp Dunkel, Sasha Pierson, Ujjwal Sharma, Philip Chimento, Justin Grant
 markEffects: true
 </pre>


### PR DESCRIPTION
It's admittedly late in the game, but I've wanted this for a while and finally got around to opening a PR.