### PR TITLE
Editorial: Use consistent wording for throwing on undefined NewTarget

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -34,8 +34,7 @@
       <h1>Temporal.Duration ( [ _years_ [ , _months_ [ , _weeks_ [ , _days_ [ , _hours_ [ , _minutes_ [ , _seconds_ [ , _milliseconds_ [ , _microseconds_ [ , _nanoseconds_ ] ] ] ] ] ] ] ] ] ] )</h1>
       <p>The `Temporal.Duration` function performs the following steps when called:</p>
       <emu-alg>
-        1. If NewTarget is *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. If _years_ is *undefined*, let _y_ be 0; else let _y_ be ? ToIntegerIfIntegral(_years_).
         1. If _months_ is *undefined*, let _mo_ be 0; else let _mo_ be ? ToIntegerIfIntegral(_months_).
         1. If _weeks_ is *undefined*, let _w_ be 0; else let _w_ be ? ToIntegerIfIntegral(_weeks_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -27,8 +27,7 @@
       <h1>Temporal.Instant ( _epochNanoseconds_ )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If NewTarget is *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _epochNanoseconds_ be ? ToBigInt(_epochNanoseconds_).
         1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. Return ? CreateTemporalInstant(_epochNanoseconds_, NewTarget).

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -27,8 +27,7 @@
       <h1>Temporal.PlainDateTime ( _isoYear_, _isoMonth_, _isoDay_ [ , _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ [ , _microsecond_ [ , _nanosecond_ [ , _calendar_ ] ] ] ] ] ] ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If NewTarget is *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Set _isoYear_ to ? ToIntegerWithTruncation(_isoYear_).
         1. Set _isoMonth_ to ? ToIntegerWithTruncation(_isoMonth_).
         1. Set _isoDay_ to ? ToIntegerWithTruncation(_isoDay_).

--- a/spec/plainmonthday.html
+++ b/spec/plainmonthday.html
@@ -27,8 +27,7 @@
       <h1>Temporal.PlainMonthDay ( _isoMonth_, _isoDay_ [ , _calendar_ [ , _referenceISOYear_ ] ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If NewTarget is *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. If _referenceISOYear_ is *undefined*, then
           1. Set _referenceISOYear_ to *1972*<sub>𝔽</sub> (the first ISO 8601 leap year after the epoch).
         1. Let _m_ be ? ToIntegerWithTruncation(_isoMonth_).

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -30,8 +30,7 @@
       <h1>Temporal.PlainTime ( [ _hour_ [ , _minute_ [ , _second_ [ , _millisecond_ [ , _microsecond_ [ , _nanosecond_ ] ] ] ] ] ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If NewTarget is *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. If _hour_ is *undefined*, set _hour_ to 0; else set _hour_ to ? ToIntegerWithTruncation(_hour_).
         1. If _minute_ is *undefined*, set _minute_ to 0; else set _minute_ to ? ToIntegerWithTruncation(_minute_).
         1. If _second_ is *undefined*, set _second_ to 0; else set _second_ to ? ToIntegerWithTruncation(_second_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -27,8 +27,7 @@
       <h1>Temporal.PlainYearMonth ( _isoYear_, _isoMonth_ [ , _calendar_ [ , _referenceISODay_ ] ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If NewTarget is *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. If _referenceISODay_ is *undefined*, then
           1. Set _referenceISODay_ to *1*<sub>𝔽</sub>.
         1. Let _y_ be ? ToIntegerWithTruncation(_isoYear_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -27,8 +27,7 @@
       <h1>Temporal.ZonedDateTime ( _epochNanoseconds_, _timeZone_ [ , _calendar_ ] )</h1>
       <p>This function performs the following steps when called:</p>
       <emu-alg>
-        1. If NewTarget is *undefined*, then
-          1. Throw a *TypeError* exception.
+        1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Set _epochNanoseconds_ to ? ToBigInt(_epochNanoseconds_).
         1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.
         1. If _timeZone_ is not a String, throw a *TypeError* exception.


### PR DESCRIPTION
The PlainDate constructor was the only one that already had it written this way, which seems to be the preferred style in upstream ECMA-262.