### PR TITLE
Editorial: Fix type assertion in BubbleRelativeDuration

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1748,7 +1748,7 @@
           _isoDateTime_: an ISO Date-Time Record,
           _timeZone_: an available time zone identifier or ~unset~,
           _calendar_: a calendar type,
-          _largestUnit_: a date unit,
+          _largestUnit_: a Temporal unit,
           _smallestUnit_: a date unit,
         ): either a normal completion containing an Internal Duration Record or a throw completion
       </h1>


### PR DESCRIPTION
This operation can be called with a time unit as largestUnit. It should continue to work as advertised, the type assertion in the header was just wrong.

Closes: #3121