### PR TITLE
Clarify grammar early errors

### DIFF
--- a/polyfill/test/validStrings.mjs
+++ b/polyfill/test/validStrings.mjs
@@ -315,18 +315,7 @@ const dateTime = (z, timeRequired) =>
   );
 const annotatedTime = choice(
   seq(timeDesignator, time, [dateTimeUTCOffset(false)], [timeZoneAnnotation], [annotations]),
-  seq(
-    withSyntaxConstraints(seq(time, [dateTimeUTCOffset(false)]), (result) => {
-      if (/^(?:(?!02-?30)(?:0[1-9]|1[012])-?(?:0[1-9]|[12][0-9]|30)|(?:0[13578]|10|12)-?31)$/.test(result)) {
-        throw new SyntaxError('valid PlainMonthDay');
-      }
-      if (/^(?!-000000)(?:[0-9]{4}|[+-][0-9]{6})-?(?:0[1-9]|1[012])$/.test(result)) {
-        throw new SyntaxError('valid PlainYearMonth');
-      }
-    }),
-    [timeZoneAnnotation],
-    [annotations]
-  )
+  seq(time, [dateTimeUTCOffset(false)], [timeZoneAnnotation], [annotations])
 );
 const annotatedDateTime = (zoned, timeRequired) =>
   seq(dateTime(zoned, timeRequired), zoned ? timeZoneAnnotation : [timeZoneAnnotation], [annotations]);
@@ -462,7 +451,20 @@ const goals = {
   DateTime: annotatedDateTime(false, false),
   Duration: duration,
   MonthDay: choice(annotatedMonthDay, annotatedDateTime(false, false)),
-  Time: choice(annotatedTime, annotatedDateTime(false, true)),
+  Time: withSyntaxConstraints(choice(annotatedTime, annotatedDateTime(false, true)), (result) => {
+    try {
+      ES.ParseTemporalMonthDayString(result);
+      throw new SyntaxError('valid PlainMonthDay');
+    } catch (e) {
+      if (e instanceof SyntaxError) throw e;
+    }
+    try {
+      ES.ParseTemporalYearMonthString(result);
+      throw new SyntaxError('valid PlainYearMonth');
+    } catch (e) {
+      if (e instanceof SyntaxError) throw e;
+    }
+  }),
   TimeZone: choice(timeZoneIdentifier, zonedDateTime, instant),
   YearMonth: choice(annotatedYearMonth, annotatedDateTime(false, false)),
   ZonedDateTime: zonedDateTime

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1108,7 +1108,9 @@
       DateYear :::
         DecimalDigit DecimalDigit DecimalDigit DecimalDigit
         ASCIISign DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit DecimalDigit
-
+    </emu-grammar>
+    <p>Note the prohibition on negative zero in <emu-xref href="#sec-temporal-iso8601grammar-static-semantics-early-errors"></emu-xref>.</p>
+    <emu-grammar type="definition">
       DateMonth :::
         `0` NonZeroDigit
         `10`
@@ -1129,10 +1131,14 @@
       DateSpecMonthDay :::
         `--`? DateMonth DateSeparator[+Extended] DateDay
         `--`? DateMonth DateSeparator[~Extended] DateDay
-
+    </emu-grammar>
+    <p>Note the prohibition on invalid combinations of month and day in <emu-xref href="#sec-temporal-iso8601grammar-static-semantics-early-errors"></emu-xref>.</p>
+    <emu-grammar type="definition">
       DateSpec[Extended] :::
         DateYear DateSeparator[?Extended] DateMonth DateSeparator[?Extended] DateDay
-
+    </emu-grammar>
+    <p>Note the prohibition on invalid combinations of month and day in <emu-xref href="#sec-temporal-iso8601grammar-static-semantics-early-errors"></emu-xref>.</p>
+    <emu-grammar type="definition">
       Date :::
         DateSpec[+Extended]
         DateSpec[~Extended]
@@ -1224,7 +1230,9 @@
       AnnotatedTime :::
         TimeDesignator Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
         Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
-
+    </emu-grammar>
+    <p>Note the disambiguation between the second alternative without |TimeDesignator|, and |DateSpecMonthDay|/|DateSpecYearMonth| in <emu-xref href="#sec-temporal-iso8601grammar-static-semantics-early-errors"></emu-xref>.</p>
+    <emu-grammar type="definition">
       AnnotatedDateTime[Zoned, TimeRequired] :::
         [~Zoned] DateTime[~Z, ?TimeRequired] TimeZoneAnnotation? Annotations?
         [+Zoned] DateTime[+Z, ?TimeRequired] TimeZoneAnnotation Annotations?

--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1230,9 +1230,7 @@
       AnnotatedTime :::
         TimeDesignator Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
         Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
-    </emu-grammar>
-    <p>Note the disambiguation between the second alternative without |TimeDesignator|, and |DateSpecMonthDay|/|DateSpecYearMonth| in <emu-xref href="#sec-temporal-iso8601grammar-static-semantics-early-errors"></emu-xref>.</p>
-    <emu-grammar type="definition">
+
       AnnotatedDateTime[Zoned, TimeRequired] :::
         [~Zoned] DateTime[~Z, ?TimeRequired] TimeZoneAnnotation? Annotations?
         [+Zoned] DateTime[+Z, ?TimeRequired] TimeZoneAnnotation Annotations?
@@ -1302,6 +1300,10 @@
         AnnotatedTime
         AnnotatedDateTime[~Zoned, +TimeRequired]
 
+      AmbiguousTemporalTimeString :::
+        DateSpecMonthDay TimeZoneAnnotation? Annotations?
+        DateSpecYearMonth TimeZoneAnnotation? Annotations?
+
       TemporalYearMonthString :::
         AnnotatedYearMonth
         AnnotatedDateTime[~Zoned, ~TimeRequired]
@@ -1342,18 +1344,6 @@
 
     <emu-clause id="sec-temporal-iso8601grammar-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
-      <emu-grammar>
-        AnnotatedTime :::
-          Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
-      </emu-grammar>
-      <ul>
-        <li>
-          It is a Syntax Error if ParseText(|Time| |DateTimeUTCOffset[~Z]|, |DateSpecMonthDay|) is a Parse Node.
-        </li>
-        <li>
-          It is a Syntax Error if ParseText(|Time| |DateTimeUTCOffset[~Z]|, |DateSpecYearMonth|) is a Parse Node.
-        </li>
-      </ul>
       <emu-grammar>
         DateSpec[Extended] :::
           DateYear DateSeparator[?Extended] DateMonth DateSeparator[?Extended] DateDay

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -571,9 +571,9 @@
         1. Else,
           1. If _item_ is not a String, throw a *TypeError* exception.
           1. Let _parseResult_ be ? ParseISODateTime(_item_, « |TemporalTimeString| »).
+          1. If ParseText(StringToCodePoints(_item_), |AmbiguousTemporalTimeString|) is a Parse Node, throw a *RangeError* exception.
           1. Assert: _parseResult_.[[Time]] is not ~start-of-day~.
           1. Set _result_ to _parseResult_.[[Time]].
-          1. NOTE: A successful parse using |TemporalTimeString| guarantees absence of ambiguity with respect to any ISO 8601 date-only, year-month, or month-day representation.
           1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
           1. Perform ? GetTemporalOverflowOption(_resolvedOptions_).
         1. Return ! CreateTemporalTime(_result_).


### PR DESCRIPTION
The first commit adds links to the early error section from the grammar so that it's not so easy for implementors to miss.

Note the second commit is optional. I haven't decided whether it's an improvement or not. I don't know how much more clarity it offers, against the downside of not having as much of the string validation as possible in the grammar.

Closes: #3128