### PR TITLE
Editorial: Compute offsetBehaviour after parsing is complete

### DIFF
--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -952,7 +952,7 @@
       </dl>
       <emu-alg>
         1. If _options_ is not present, set _options_ to *undefined*.
-        1. Let _offsetBehaviour_ be ~option~.
+        1. Let _hasUTCDesignator_ be *false*.
         1. Let _matchBehaviour_ be ~match-exactly~.
         1. If _item_ is an Object, then
           1. If _item_ has an [[InitializedTemporalZonedDateTime]] internal slot, then
@@ -966,8 +966,6 @@
           1. Let _fields_ be ? PrepareCalendarFields(_calendar_, _item_, « ~year~, ~month~, ~month-code~, ~day~ », « ~hour~, ~minute~, ~second~, ~millisecond~, ~microsecond~, ~nanosecond~, ~offset~, ~time-zone~ », « ~time-zone~ »).
           1. Let _timeZone_ be _fields_.[[TimeZone]].
           1. Let _offsetString_ be _fields_.[[OffsetString]].
-          1. If _offsetString_ is ~unset~, then
-            1. Set _offsetBehaviour_ to ~wall~.
           1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
           1. Let _disambiguation_ be ? GetTemporalDisambiguationOption(_resolvedOptions_).
           1. Let _offsetOption_ be ? GetTemporalOffsetOption(_resolvedOptions_, ~reject~).
@@ -983,9 +981,7 @@
           1. Let _timeZone_ be ? ToTemporalTimeZoneIdentifier(_annotation_).
           1. Let _offsetString_ be _result_.[[TimeZone]].[[OffsetString]].
           1. If _result_.[[TimeZone]].[[Z]] is *true*, then
-            1. Set _offsetBehaviour_ to ~exact~.
-          1. Else if _offsetString_ is ~empty~, then
-            1. Set _offsetBehaviour_ to ~wall~.
+            1. Set _hasUTCDesignator_ to *true*.
           1. Let _calendar_ be _result_.[[Calendar]].
           1. If _calendar_ is ~empty~, set _calendar_ to *"iso8601"*.
           1. Set _calendar_ to ? CanonicalizeCalendar(_calendar_).
@@ -1000,6 +996,12 @@
           1. Perform ? GetTemporalOverflowOption(_resolvedOptions_).
           1. Let _isoDate_ be CreateISODateRecord(_result_.[[Year]], _result_.[[Month]], _result_.[[Day]]).
           1. Let _time_ be _result_.[[Time]].
+        1. If _hasUTCDesignator_ is *true*, then
+          1. Let _offsetBehaviour_ be ~exact~.
+        1. Else if _offsetString_ is ~empty~ or _offsetString_ is ~unset~, then
+          1. Let _offsetBehaviour_ be ~wall~.
+        1. Else,
+          1. Let _offsetBehaviour_ be ~option~.
         1. Let _offsetNanoseconds_ be 0.
         1. If _offsetBehaviour_ is ~option~, then
           1. Set _offsetNanoseconds_ to ! ParseDateTimeUTCOffset(_offsetString_).


### PR DESCRIPTION
This clarifies that the property of the parse result that influence later steps is a boolean of whether the string contained a UTCDesignator (Z).

See https://github.com/boa-dev/temporal/issues/408

CC @Manishearth @nekevss