### PR TITLE
Editorial: Rewrite CalendarDateUntil to be simpler and more general

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -525,42 +525,33 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _calendar_ is *"iso8601"*, then
-          1. Let _sign_ be -CompareISODate(_one_, _two_).
-          1. If _sign_ = 0, return ZeroDateDuration().
-          1. Let _years_ be 0.
-          1. If _largestUnit_ is ~year~, then
-            1. Let _candidateYears_ be _sign_.
-            1. Repeat, while ISODateSurpasses(_sign_, _one_.[[Year]] + _candidateYears_, _one_.[[Month]], _one_.[[Day]], _two_) is *false*,
-              1. Set _years_ to _candidateYears_.
-              1. Set _candidateYears_ to _candidateYears_ + _sign_.
-          1. Let _months_ be 0.
-          1. If _largestUnit_ is ~year~ or _largestUnit_ is ~month~, then
-            1. Let _candidateMonths_ be _sign_.
-            1. Let _intermediate_ be BalanceISOYearMonth(_one_.[[Year]] + _years_, _one_.[[Month]] + _candidateMonths_).
-            1. Repeat, while ISODateSurpasses(_sign_, _intermediate_.[[Year]], _intermediate_.[[Month]], _one_.[[Day]], _two_) is *false*,
-              1. Set _months_ to _candidateMonths_.
-              1. Set _candidateMonths_ to _candidateMonths_ + _sign_.
-              1. Set _intermediate_ to BalanceISOYearMonth(_intermediate_.[[Year]], _intermediate_.[[Month]] + _sign_).
-          1. Set _intermediate_ to BalanceISOYearMonth(_one_.[[Year]] + _years_, _one_.[[Month]] + _months_).
-          1. Let _constrained_ be ! RegulateISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _one_.[[Day]], ~constrain~).
-          1. Let _weeks_ be 0.
-          1. If _largestUnit_ is ~week~, then
-            1. Let _candidateWeeks_ be _sign_.
-            1. Set _intermediate_ to BalanceISODate(_constrained_.[[Year]], _constrained_.[[Month]], _constrained_.[[Day]] + 7 × _candidateWeeks_).
-            1. Repeat, while ISODateSurpasses(_sign_, _intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]], _two_) is *false*,
-              1. Set _weeks_ to _candidateWeeks_.
-              1. Set _candidateWeeks_ to _candidateWeeks_ + sign.
-              1. Set _intermediate_ to BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]] + 7 × _sign_).
-          1. Let _days_ be 0.
-          1. Let _candidateDays_ be _sign_.
-          1. Set _intermediate_ to BalanceISODate(_constrained_.[[Year]], _constrained_.[[Month]], _constrained_.[[Day]] + 7 × _weeks_ + _candidateDays_).
-          1. Repeat, while ISODateSurpasses(_sign_, _intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]], _two_) is *false*,
-            1. Set _days_ to _candidateDays_.
-            1. Set _candidateDays_ to _candidateDays_ + _sign_.
-            1. Set _intermediate_ to BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]] + _sign_).
-          1. Return ! CreateDateDurationRecord(_years_, _months_, _weeks_, _days_).
-        1. Return an implementation-defined Date Duration Record as described above.
+        1. Let _sign_ be -CompareISODate(_one_, _two_).
+        1. If _sign_ = 0, return ZeroDateDuration().
+        1. Let _duration_ be CreateDateDurationRecord(0, 0, 0, 0).
+        1. If _largestUnit_ is ~year~, then
+          1. Let _intermediate_ be _one_.
+          1. Repeat, while CompareISODate(_intermediate_, _two_) != _sign_,
+            1. Set _duration_.[[Years]] to _duration_.[[Years]] + _sign_.
+            1. Set _intermediate_ to CalendarDateAdd(_calendar_, _one_, _duration_, ~constrain~).
+          1. Set _duration_.[[Years]] to _duration_.[[Years]] - _sign_.
+        1. If _largestUnit_ is ~year~ or _largestUnit_ is ~month~, then
+          1. Let _intermediate_ be _one_.
+          1. Repeat, while CompareISODate(_intermediate_, _two_) != _sign_,
+            1. Set _duration_.[[Months]] to _duration_.[[Months]] + _sign_.
+            1. Set _intermediate_ to CalendarDateAdd(_calendar_, _one_, _duration_, ~constrain~).
+          1. Set _duration_.[[Months]] to _duration_.[[Months]] - _sign_.
+        1. If _largestUnit_ is ~week~, then
+          1. Let _intermediate_ be _one_.
+          1. Repeat, while CompareISODate(_intermediate_, _two_) != _sign_,
+            1. Set _duration_.[[Weeks]] to _duration_.[[Weeks]] + _sign_.
+            1. Set _intermediate_ to CalendarDateAdd(_calendar_, _one_, _duration_, ~constrain~).
+          1. Set _duration_.[[Weeks]] to _duration_.[[Weeks]] - _sign_.
+        1. Let _intermediate_ be _one_.
+        1. Repeat, while CompareISODate(_intermediate_, _two_) != _sign_,
+          1. Set _duration_.[[Days]] to _duration_.[[Days]] + _sign_.
+          1. Set _intermediate_ to CalendarDateAdd(_calendar_, _one_, _duration_, ~constrain~).
+        1. Set _duration_.[[Days]] to _duration_.[[Days]] - _sign_.
+        1. Return ! _duration_.
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
This changes CalendarDateUntil so that it is based purely on CalendarDateAdd instead of using ISO-specific AOs like ISODateSurpasses and RegulateISODate. It means that the same CalendarDateUntil can be used for both ISO and non-ISO calendars.

Please double- and triple-check my work. I haven't come up with a counter-example where behavior differs, but that doesn't mean there isn't one that I didn't think of. I have not implemented this in code.