### PR TITLE
Editorial: Split ISO and non-ISO calendar operations

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -475,7 +475,25 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-calendardateadd" type="implementation-defined abstract operation">
+    <emu-clause id="sec-temporal-nonisodateadd" type="implementation-defined abstract operation">
+      <h1>
+        NonISODateAdd (
+          _calendar_: a calendar type that is not *"iso8601"*,
+          _isoDate_: an ISO Date Record,
+          _duration_: a Date Duration Record,
+          _overflow_: ~constrain~ or ~reject~,
+        ): either a normal completion containing an ISO Date Record or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          The operation performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by _calendar_ and returns the corresponding day, month and year of the result in the ISO 8601 calendar values as an ISO Date Record.
+          It may throw a *RangeError* exception if _overflow_ is ~reject~ and the resulting month or day would need to be clamped in order to form a valid date in _calendar_.
+        </dd>
+      </dl>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendardateadd" type="abstract operation">
       <h1>
         CalendarDateAdd (
           _calendar_: a calendar type,
@@ -498,17 +516,31 @@
           1. Let _d_ be _intermediate_.[[Day]] + _duration_.[[Days]] + 7 × _duration_.[[Weeks]].
           1. Let _result_ be BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _d_).
         1. Else,
-          1. Let _result_ be an implementation-defined ISO Date Record, or throw a *RangeError* exception, as described below.
+          1. Let _result_ be ? NonISODateAdd(_calendar_, _isoDate_, _duration_, _overflow_).
         1. If ISODateWithinLimits(_result_) is *false*, throw a *RangeError* exception.
         1. Return _result_.
       </emu-alg>
-      <p>
-        When _calendar_ is not *"iso8601"*, the operation performs implementation-defined processing to add _duration_ to _date_ in the context of the calendar represented by _calendar_ and returns the corresponding day, month and year of the result in the ISO 8601 calendar values as an ISO Date Record.
-        It may throw a *RangeError* exception if _overflow_ is ~reject~ and the resulting month or day would need to be clamped in order to form a valid date in _calendar_.
-      </p>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-calendardateuntil" type="implementation-defined abstract operation">
+    <emu-clause id="sec-temporal-nonisodateuntil" type="implementation-defined abstract operation">
+      <h1>
+        NonISODateUntil (
+          _calendar_: a calendar type that is not *"iso8601"*,
+          _one_: an ISO Date Record,
+          _two_: an ISO Date Record,
+          _largestUnit_: a date unit,
+        ): a Date Duration Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It performs implementation-defined processing to determine the difference between the dates _one_ and _two_ using the years, months, and weeks reckoning of _calendar_.
+          No fields larger than _largestUnit_ will be non-zero in the resulting Date Duration Record.
+        </dd>
+      </dl>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendardateuntil" type="abstract operation">
       <h1>
         CalendarDateUntil (
           _calendar_: a calendar type,
@@ -560,7 +592,7 @@
             1. Set _candidateDays_ to _candidateDays_ + _sign_.
             1. Set _intermediate_ to BalanceISODate(_intermediate_.[[Year]], _intermediate_.[[Month]], _intermediate_.[[Day]] + _sign_).
           1. Return ! CreateDateDurationRecord(_years_, _months_, _weeks_, _days_).
-        1. Return an implementation-defined Date Duration Record as described above.
+        1. Return NonISODateUntil(_calendar_, _one_, _two_, _largestUnit_).
       </emu-alg>
     </emu-clause>
 
@@ -805,10 +837,10 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-calendardatetoiso" type="implementation-defined abstract operation">
+    <emu-clause id="sec-temporal-nonisocalendardatetoiso" type="implementation-defined abstract operation">
       <h1>
-        CalendarDateToISO (
-          _calendar_: a calendar type,
+        NonISOCalendarDateToISO (
+          _calendar_: a calendar type that is not *"iso8601"*,
           _fields_: a Calendar Fields Record,
           _overflow_: ~constrain~ or ~reject~,
         ): either a normal completion containing an ISO Date Record or a throw completion
@@ -821,12 +853,6 @@
           For ~constrain~, values that do not form a valid date are clamped to their respective valid range.
         </dd>
       </dl>
-      <emu-alg>
-        1. If _calendar_ is *"iso8601"*, then
-          1. Assert: _fields_.[[Year]], _fields_.[[Month]], and _fields_.[[Day]] are not ~unset~.
-          1. Return ? RegulateISODate(_fields_.[[Year]], _fields_.[[Month]], _fields_.[[Day]], _overflow_).
-        1. Return an implementation-defined ISO Date Record, or throw a *RangeError* exception, as described below.
-      </emu-alg>
       <p>Like RegulateISODate, the operation throws a *RangeError* exception when _overflow_ is ~reject~ and the date described by _fields_ does not exist.</p>
       <p>Clamping an invalid date to the correct range when _overflow_ is ~constrain~ is a behaviour specific to each calendar other than *"iso8601"*, but all calendars follow this guideline:</p>
       <ul>
@@ -837,9 +863,33 @@
       </ul>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-calendarmonthdaytoisoreferencedate" type="implementation-defined abstract operation">
+    <emu-clause id="sec-temporal-calendardatetoiso" type="abstract operation">
       <h1>
-        CalendarMonthDayToISOReferenceDate (
+        CalendarDateToISO (
+          _calendar_: a calendar type,
+          _fields_: a Calendar Fields Record,
+          _overflow_: ~constrain~ or ~reject~,
+        ): either a normal completion containing an ISO Date Record or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It converts _fields_, which represents either a date or a year and month in the built-in calendar identified by _calendar_, to a corresponding representative date in the ISO 8601 calendar, subject to overflow correction specified by _overflow_.
+          For ~reject~, values that do not form a valid date cause an exception to be thrown, as described below.
+          For ~constrain~, values that do not form a valid date are clamped to their respective valid range.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. If _calendar_ is *"iso8601"*, then
+          1. Assert: _fields_.[[Year]], _fields_.[[Month]], and _fields_.[[Day]] are not ~unset~.
+          1. Return ? RegulateISODate(_fields_.[[Year]], _fields_.[[Month]], _fields_.[[Day]], _overflow_).
+        1. Return ? NonISOCalendarDateToISO(_calendar_, _fields_, _overflow_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-nonisomonthdaytoisoreferencedate" type="implementation-defined abstract operation">
+      <h1>
+        NonISOMonthDayToISOReferenceDate (
           _calendar_: a calendar type that is not *"iso8601"*,
           _fields_: a Calendar Fields Record,
           _overflow_: ~constrain~ or ~reject~,
@@ -853,15 +903,6 @@
           For ~constrain~, values that do not form a valid date are clamped to their respective valid range as in CalendarDateToISO.
         </dd>
       </dl>
-      <emu-alg>
-        1. If _calendar_ is *"iso8601"*, then
-          1. Assert: _fields_.[[Month]] and _fields_.[[Day]] are not ~unset~.
-          1. Let _referenceISOYear_ be 1972 (the first ISO 8601 leap year after the epoch).
-          1. If _fields_.[[Year]] is ~unset~, let _year_ be _referenceISOYear_; else let _year_ be _fields_.[[Year]].
-          1. Let _result_ be ? RegulateISODate(_year_, _fields_.[[Month]], _fields_.[[Day]], _overflow_).
-          1. Return CreateISODateRecord(_referenceISOYear_, _result_.[[Month]], _result_.[[Day]]).
-        1. Return an implementation-defined ISO Date Record, or throw a *RangeError* exception, as described below.
-      </emu-alg>
       <p>
         The fields of the returned ISO Date Record represent a reference date in the ISO 8601 calendar that, when converted to _calendar_, corresponds to the month code and day of _fields_ in an arbitrary but deterministically chosen reference year.
         The reference date is the latest ISO 8601 date corresponding to the calendar date, that is also earlier than or equal to the ISO 8601 date December 31, 1972.
@@ -884,7 +925,56 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-calendarisotodate" type="implementation-defined abstract operation">
+    <emu-clause id="sec-temporal-calendarmonthdaytoisoreferencedate" type="abstract operation">
+      <h1>
+        CalendarMonthDayToISOReferenceDate (
+          _calendar_: a calendar type,
+          _fields_: a Calendar Fields Record,
+          _overflow_: ~constrain~ or ~reject~,
+        ): either a normal completion containing an ISO Date Record or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It converts _fields_, which represents a calendar date without a year (i.e., month code and day pair, or equivalent) in the built-in calendar identified by _calendar_, to a corresponding reference date in the ISO 8601 calendar as described below, subject to overflow correction specified by _overflow_.
+          For ~reject~, values that do not form a valid date cause an exception to be thrown.
+          For ~constrain~, values that do not form a valid date are clamped to their respective valid range as in CalendarDateToISO.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. If _calendar_ is *"iso8601"*, then
+          1. Assert: _fields_.[[Month]] and _fields_.[[Day]] are not ~unset~.
+          1. Let _referenceISOYear_ be 1972 (the first ISO 8601 leap year after the epoch).
+          1. If _fields_.[[Year]] is ~unset~, let _year_ be _referenceISOYear_; else let _year_ be _fields_.[[Year]].
+          1. Let _result_ be ? RegulateISODate(_year_, _fields_.[[Month]], _fields_.[[Day]], _overflow_).
+          1. Return CreateISODateRecord(_referenceISOYear_, _result_.[[Month]], _result_.[[Day]]).
+        1. Return ? NonISOMonthDayToISOReferenceDate(_calendar_, _fields_, _overflow_).
+      </emu-alg>
+      <p>
+        The fields of the returned ISO Date Record represent a reference date in the ISO 8601 calendar that, when converted to _calendar_, corresponds to the month code and day of _fields_ in an arbitrary but deterministically chosen reference year.
+        For the ISO 8601 calendar, the reference year is always 1972. For other calendars, see the note in NonISOMonthDayToISOReferenceDate.
+      </p>
+      <p>Like RegulateISODate, the operation throws a *RangeError* exception if _overflow_ is ~reject~ and the month and day described by _fields_ does not exist (or does not exist within the year described by _fields_ when there is such a year).</p>
+      <p>Also like RegulateISODate, if _overflow_ is ~constrain~ and the date or month and day described by _fields_ does not exist (or does not exist within the year described by _fields_ when there is such a year), the values of those fields are clamped to their respective valid range. As in CalendarDateToISO, such clamping is calendar-specific.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-nonisocalendarisotodate" type="implementation-defined abstract operation">
+      <h1>
+        NonISOCalendarISOToDate (
+          _calendar_: a calendar type that is not *"iso8601"*,
+          _isoDate_: an ISO Date Record,
+        ): a Calendar Date Record
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It performs implementation-defined processing to find the the date corresponding to _isoDate_ in the context of the calendar represented by _calendar_ and returns a Calendar Date Record representing that calendar date, with its fields filled in according to their descriptions in <emu-xref href="#table-temporal-calendar-date-record-fields"></emu-xref>.</dd>
+      </dl>
+      <emu-note>
+        <p>Implementations are encouraged to elide fields that are not read by the caller.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarisotodate" type="abstract operation">
       <h1>
         CalendarISOToDate (
           _calendar_: a calendar type,
@@ -893,7 +983,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It performs implementation-defined processing to find the the date corresponding to _isoDate_ in the context of the calendar represented by _calendar_ and returns a Calendar Date Record representing that calendar date, with its fields filled in according to their descriptions.</dd>
+        <dd>It finds the the date corresponding to _isoDate_ in the context of the calendar represented by _calendar_ and returns a Calendar Date Record representing that calendar date, with its fields filled in according to their descriptions.</dd>
       </dl>
       <emu-alg>
         1. If _calendar_ is *"iso8601"*, then
@@ -916,7 +1006,7 @@
               [[MonthsInYear]]: 12,
               [[InLeapYear]]: _inLeapYear_
             }.
-        1. Return an implementation-defined Calendar Date Record with fields as described in <emu-xref href="#table-temporal-calendar-date-record-fields"></emu-xref>.
+        1. Return NonISOCalendarISOToDate(_calendar_, _isoDate_).
       </emu-alg>
       <emu-note>
         <p>Implementations are encouraged to elide fields that are not read by the caller.</p>
@@ -940,36 +1030,25 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-calendarfieldkeystoignore" type="implementation-defined abstract operation">
+    <emu-clause id="sec-temporal-nonisofieldkeystoignore" type="implementation-defined abstract operation">
       <h1>
-        CalendarFieldKeysToIgnore (
-          _calendar_: a calendar type,
+        NonISOFieldKeysToIgnore (
+          _calendar_: a calendar type that is not *"iso8601"*,
           _keys_: a List of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"></emu-xref>,
         ): a List of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"></emu-xref>
       </h1>
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It determines which calendar date fields changing any of the fields named in _keys_ can potentially conflict with or invalidate, for the given _calendar_.
+          It performs implementation-defined processing to determine which calendar date fields changing any of the fields named in _keys_ can potentially conflict with or invalidate, for the given _calendar_.
           A field always invalidates at least itself.
         </dd>
       </dl>
-      <emu-alg>
-        1. If _calendar_ is *"iso8601"*, then
-          1. Let _ignoredKeys_ be an empty List.
-          1. For each element _key_ of _keys_, do
-            1. Append _key_ to _ignoredKeys_.
-            1. If _key_ is ~month~, append ~month-code~ to _ignoredKeys_.
-            1. Else if _key_ is ~month-code~, append ~month~ to _ignoredKeys_.
-          1. NOTE: While _ignoredKeys_ can have duplicate elements, this is not intended to be meaningful. This specification only checks whether particular keys are or are not members of the list.
-          1. Return _ignoredKeys_.
-        1. Return an implementation-defined List as described below.
-      </emu-alg>
       <p>This operation is relevant for calendars which accept fields other than the standard set of ISO 8601 calendar fields, in order to implement the Temporal objects' `with()` methods in such a way that the result is free of ambiguity or conflicts.</p>
       <p>
         For example, given a _calendar_ that uses eras, such as *"gregory"*, a key in _keys_ being any one of ~year~, ~era~, or ~era-year~ would exclude all three.
         Passing any one of the three to a `with()` method might conflict with either of the other two properties on the receiver object, so those properties of the receiver object should be ignored.
-        Given this, in addition to the ISO 8601 mutual exclusion of ~month~ and ~month-code~ as above, a possible implementation might produce the following results when _calendar_ is *"gregory"*:
+        Given this, in addition to the ISO 8601 mutual exclusion of ~month~ and ~month-code~, a possible implementation might produce the following results when _calendar_ is *"gregory"*:
       </p>
       <emu-table id="table-calendarfieldkeystoignore-example">
         <emu-caption>Example results of CalendarFieldKeysToIgnore</emu-caption>
@@ -1015,10 +1094,37 @@
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-temporal-calendarresolvefields" type="implementation-defined abstract operation">
+    <emu-clause id="sec-temporal-calendarfieldkeystoignore" type="abstract operation">
       <h1>
-        CalendarResolveFields (
+        CalendarFieldKeysToIgnore (
           _calendar_: a calendar type,
+          _keys_: a List of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"></emu-xref>,
+        ): a List of values from the Enumeration Key column of <emu-xref href="#table-temporal-calendar-fields-record-fields"></emu-xref>
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It determines which calendar date fields changing any of the fields named in _keys_ can potentially conflict with or invalidate, for the given _calendar_.
+          A field always invalidates at least itself.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. If _calendar_ is *"iso8601"*, then
+          1. Let _ignoredKeys_ be an empty List.
+          1. For each element _key_ of _keys_, do
+            1. Append _key_ to _ignoredKeys_.
+            1. If _key_ is ~month~, append ~month-code~ to _ignoredKeys_.
+            1. Else if _key_ is ~month-code~, append ~month~ to _ignoredKeys_.
+          1. NOTE: While _ignoredKeys_ can have duplicate elements, this is not intended to be meaningful. This specification only checks whether particular keys are or are not members of the list.
+          1. Return _ignoredKeys_.
+        1. Return NonISOFieldKeysToIgnore(_calendar_, _keys_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-nonisoresolvefields" type="implementation-defined abstract operation">
+      <h1>
+        NonISOResolveFields (
+          _calendar_: a calendar type that is not *"iso8601"*,
           _fields_: a Calendar Fields Record,
           _type_: ~date~, ~year-month~, or ~month-day~,
         ): either a normal completion containing ~unused~ or a throw completion
@@ -1029,28 +1135,6 @@
           It performs implementation-defined processing to validate that _fields_ (which describes a date or partial date in the built-in calendar identified by _calendar_) is sufficiently complete to satisfy _type_ and not internally inconsistent, and mutates _fields_ into acceptable input for <emu-xref href="#sec-temporal-calendardatetoiso" title></emu-xref> or <emu-xref href="#sec-temporal-calendarmonthdaytoisoreferencedate" title></emu-xref> by merging data that can be represented in multiple forms into standard fields and removing redundant fields (for example, merging [[Month]] and [[MonthCode]] into [[Month]] and merging [[Era]] and [[EraYear]] into [[Year]]).
         </dd>
       </dl>
-      <emu-alg>
-        1. If _calendar_ is *"iso8601"*, then
-          1. If _type_ is ~date~ or ~year-month~ and _fields_.[[Year]] is ~unset~, throw a *TypeError* exception.
-          1. If _type_ is ~date~ or ~month-day~ and _fields_.[[Day]] is ~unset~, throw a *TypeError* exception.
-          1. Let _month_ be _fields_.[[Month]].
-          1. Let _monthCode_ be _fields_.[[MonthCode]].
-          1. If _monthCode_ is ~unset~, then
-            1. If _month_ is ~unset~, throw a *TypeError* exception.
-            1. Return ~unused~.
-          1. Assert: _monthCode_ is a String.
-          1. NOTE: The ISO 8601 calendar does not include leap months.
-          1. If the length of _monthCode_ is not 3, throw a *RangeError* exception.
-          1. If the first code unit of _monthCode_ is not 0x004D (LATIN CAPITAL LETTER M), throw a *RangeError* exception.
-          1. Let _monthCodeDigits_ be the substring of _monthCode_ from 1.
-          1. If ParseText(StringToCodePoints(_monthCodeDigits_), |DateMonth|) is a List of errors, throw a *RangeError* exception.
-          1. Let _monthCodeInteger_ be ℝ(StringToNumber(_monthCodeDigits_)).
-          1. If _month_ is not ~unset~ and _month_ ≠ _monthCodeInteger_, throw a *RangeError* exception.
-          1. Set _fields_.[[Month]] to _monthCodeInteger_.
-        1. Else,
-          1. Perform implementation-defined processing to mutate _fields_, or throw a *TypeError* or *RangeError* exception, as described below.
-        1. Return ~unused~.
-      </emu-alg>
       <p>The operation throws a *TypeError* exception if the non-~unset~ fields of _fields_ are insufficient to identify a unique instance of _type_ in the calendar (e.g., when at least one field in each combination capable of determining some part of its data is ~unset~) or a *RangeError* exception if the fields are sufficient but their values are internally inconsistent within the calendar (e.g., when fields such as [[Month]] and [[MonthCode]] have conflicting non-~unset~ values). For example:</p>
       <ul>
         <li>If _type_ is ~date~ or ~month-day~ and "day" in the calendar has an interpretation similar to ISO 8601 and _fields_.[[Day]] is ~unset~.</li>
@@ -1078,6 +1162,44 @@
       <emu-note>
         When _type_ is ~month-day~ and _fields_.[[Month]] is not ~unset~, it is recommended that all built-in calendars other than the ISO 8601 calendar require a disambiguating year (e.g., either _fields_.[[Year]] or _fields_.[[Era]] and _fields_.[[EraYear]]) to avoid a *TypeError*, regardless of whether or not _fields_.[[MonthCode]] is also ~unset~. The ISO 8601 calendar allows _fields_.[[Year]] to be ~unset~ in this case because it is a special default calendar that is permanently stable for automated processing.
       </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-temporal-calendarresolvefields" type="abstract operation">
+      <h1>
+        CalendarResolveFields (
+          _calendar_: a calendar type,
+          _fields_: a Calendar Fields Record,
+          _type_: ~date~, ~year-month~, or ~month-day~,
+        ): either a normal completion containing ~unused~ or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          It validates that _fields_ (which describes a date or partial date in the built-in calendar identified by _calendar_) is sufficiently complete to satisfy _type_ and not internally inconsistent, and mutates _fields_ into acceptable input for <emu-xref href="#sec-temporal-calendardatetoiso" title></emu-xref> or <emu-xref href="#sec-temporal-calendarmonthdaytoisoreferencedate" title></emu-xref> by merging data that can be represented in multiple forms into standard fields and removing redundant fields (for example, merging [[Month]] and [[MonthCode]] into [[Month]] and merging [[Era]] and [[EraYear]] into [[Year]]).
+        </dd>
+      </dl>
+      <emu-alg>
+        1. If _calendar_ is *"iso8601"*, then
+          1. If _type_ is ~date~ or ~year-month~ and _fields_.[[Year]] is ~unset~, throw a *TypeError* exception.
+          1. If _type_ is ~date~ or ~month-day~ and _fields_.[[Day]] is ~unset~, throw a *TypeError* exception.
+          1. Let _month_ be _fields_.[[Month]].
+          1. Let _monthCode_ be _fields_.[[MonthCode]].
+          1. If _monthCode_ is ~unset~, then
+            1. If _month_ is ~unset~, throw a *TypeError* exception.
+            1. Return ~unused~.
+          1. Assert: _monthCode_ is a String.
+          1. NOTE: The ISO 8601 calendar does not include leap months.
+          1. If the length of _monthCode_ is not 3, throw a *RangeError* exception.
+          1. If the first code unit of _monthCode_ is not 0x004D (LATIN CAPITAL LETTER M), throw a *RangeError* exception.
+          1. Let _monthCodeDigits_ be the substring of _monthCode_ from 1.
+          1. If ParseText(StringToCodePoints(_monthCodeDigits_), |DateMonth|) is a List of errors, throw a *RangeError* exception.
+          1. Let _monthCodeInteger_ be ℝ(StringToNumber(_monthCodeDigits_)).
+          1. If _month_ is not ~unset~ and _month_ ≠ _monthCodeInteger_, throw a *RangeError* exception.
+          1. Set _fields_.[[Month]] to _monthCodeInteger_.
+        1. Else,
+          1. Perform ? NonISOResolveFields(_calendar_, _fields_, _type_).
+        1. Return ~unused~.
+      </emu-alg>
     </emu-clause>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
The purpose of this is to provide implementation-defined stubs for only the non-ISO calendar operations, for the Intl Era Monthcode proposal to override.

See: tc39/proposal-intl-era-monthcode#54