### PR TITLE
Editorial: Remove no-op ValidateTemporalUnitValue call

### DIFF
--- a/polyfill/lib/duration.mjs
+++ b/polyfill/lib/duration.mjs
@@ -194,7 +194,6 @@ export class Duration {
     }
 
     let largestUnit = ES.GetTemporalUnitValuedOption(roundTo, 'largestUnit');
-    ES.ValidateTemporalUnitValue(largestUnit, 'datetime', ['auto']);
     let { plainRelativeTo, zonedRelativeTo } = ES.GetTemporalRelativeToOption(roundTo);
     const roundingIncrement = ES.GetRoundingIncrementOption(roundTo);
     const roundingMode = ES.GetRoundingModeOption(roundTo, 'halfExpand');

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -403,7 +403,6 @@
         1. Let _largestUnitPresent_ be *true*.
         1. NOTE: The following steps read options and perform independent validation in alphabetical order (GetTemporalRelativeToOption reads *"relativeTo"*, GetRoundingIncrementOption reads *"roundingIncrement"* and GetRoundingModeOption reads *"roundingMode"*).
         1. Let _largestUnit_ be ? GetTemporalUnitValuedOption(_roundTo_, *"largestUnit"*, ~unset~).
-        1. Perform ? ValidateTemporalUnitValue(_largestUnit_, ~datetime~, « ~auto~ »).
         1. Let _relativeToRecord_ be ? GetTemporalRelativeToOption(_roundTo_).
         1. Let _zonedRelativeTo_ be _relativeToRecord_.[[ZonedRelativeTo]].
         1. Let _plainRelativeTo_ be _relativeToRecord_.[[PlainRelativeTo]].


### PR DESCRIPTION
largestUnit can be any unit, ~auto~, or ~unset~ here. ValidateTemporalUnitValue just checks if it is any unit, ~auto~, or ~unset~, so it's a no-op.