### PR TITLE
Editorial: Revert inadvertent observable change

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1946,7 +1946,6 @@ export function GetPossibleEpochNanoseconds(timeZone, isoDateTime) {
     return [epochNs];
   }
 
-  CheckISODaysRange(isoDateTime.isoDate);
   return GetNamedTimeZoneEpochNanoseconds(timeZone, isoDateTime);
 }
 

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -360,7 +360,6 @@
           1. Let _epochNanoseconds_ be GetUTCEpochNanoseconds(_balanced_).
           1. Let _possibleEpochNanoseconds_ be « _epochNanoseconds_ ».
         1. Else,
-          1. Perform ? CheckISODaysRange(_isoDateTime_.[[ISODate]]).
           1. Let _possibleEpochNanoseconds_ be GetNamedTimeZoneEpochNanoseconds(_parseResult_.[[Name]], _isoDateTime_).
         1. For each value _epochNanoseconds_ in _possibleEpochNanoseconds_, do
           1. If IsValidEpochNanoseconds(_epochNanoseconds_) is *false*, throw a *RangeError* exception.


### PR DESCRIPTION
In #2989 I added checks to prevent calling GetUTCEpochNanoseconds with out-of-range arguments, which, per ECMA-262, is legal but ill-defined. (See https://github.com/tc39/ecma262/issues/1087). These checks should not have changed any observable semantics, just caused some inputs to throw that would have thrown anyway.

These checks later became CheckISODateRange.

However, in one of the checks I made a mistake: the GetUTCEpochNanoseconds call in GetNamedTimeZoneEpochNanoseconds can never trigger the ill-defined behaviour because the time zone is always UTC in the time-zone-unaware algorithm given there. So the extra check was not necessary, and in fact was incorrect for time-zone-aware implementations, causing an observable change in semantics as they would throw where they previously did not.

Since this was an unintended and unwanted change to observable semantics, which was not approved in committee, we must revert it.

Web compatibility status: Firefox ships the correct behaviour. Chrome currently ships the broken behaviour, but that has not yet been exposed to the web unflagged. Safari has not implemented this part of the proposal yet.