### PR TITLE
Allow reference years after 1972 in calendars that need them

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -971,9 +971,9 @@
       </dl>
       <p>
         The fields of the returned ISO Date Record represent a reference date in the ISO 8601 calendar that, when converted to _calendar_, corresponds to the month code and day of _fields_ in an arbitrary but deterministically chosen reference year.
-        The reference date is the latest ISO 8601 date corresponding to the calendar date, that is also earlier than or equal to the ISO 8601 date December 31, 1972.
-        If that calendar date never occurs on or before the ISO 8601 date December 31, 1972, then the reference date is the earliest ISO 8601 date corresponding to that calendar date.
+        The reference date is the latest ISO 8601 date corresponding to the calendar date that is between January 1, 1900 and December 31, 1972 inclusive. If there is no such date, it is the earliest ISO 8601 date corresponding to the calendar date between January 1, 1973 and December 31, 2035. If there is still no such date, it is the latest ISO 8601 date corresponding to the calendar date on or before December 31, 1899.
         The reference year is almost always 1972 (the first ISO 8601 leap year after the epoch), with exceptions for calendars where some dates (e.g. leap days or days in leap months) didn't occur during that ISO 8601 year. For example, Hebrew calendar leap month Adar I occurred in calendar years 5730 and 5733 (respectively overlapping ISO 8601 February/March 1970 and February/March 1973), but did not occur between them, so the reference year for days of that month is 1970.
+        In lunisolar calendars with leap months that occur irregularly, such as the Chinese calendar, there might be dates that don't occur between 1900 and 1972. For example, there is no month M11L in that range. In that case, implementations should favor picking a modern date (between 1972 and 2035) over a historical date (before 1900), since historical dates might change as more is discovered about how the calendar was used. However, dates after 2035 should never be chosen since they may be subject to change by calendar authorities.
       </p>
       <p>
         Like RegulateISODate, the operation throws a *RangeError* exception if _overflow_ is ~reject~ and the month and day described by _fields_ does not exist (or does not exist within the year described by _fields_ when there is such a year).


### PR DESCRIPTION
See https://github.com/tc39/proposal-intl-era-monthcode/issues/60

When implementing reference years in the Chinese calendar, I found that there are a number of dates that require going back centuries or even millennia. Dates that far back are not trustworthy, because they are subject to change as we discover more about the ground truth. The farthest back I would generally like to go is 1900, which is the first year of data published by the Purple Mountain Observatory (see https://github.com/tc39/proposal-intl-era-monthcode/issues/63#issuecomment-3128261698).

I also acknowledge that it's dangerous to go into the future, since calendar algorithms could change. However, dates between 1972 and 2025 are definitely safe, and dates that are already published in a table should also be safe.

The HKO publishes Chinese calendar data through 2100 (although PMO only publishes through 2025), and KASI publishes Dangi calendar dates through 2050. To be extra conservative, in this PR, I say that we should look forward to 2035, which covers the main motivating use case (Chinese year 2033 has a M11L, https://github.com/unicode-org/icu4x/issues/6454#issuecomment-3304742594).

CC @benallen @Manishearth 