### PR TITLE
Editorial: Remove early return in BubbleRelativeDuration

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1767,12 +1767,11 @@
         </dd>
       </dl>
       <emu-alg>
-        1. If _smallestUnit_ is _largestUnit_, return _duration_.
         1. Let _largestUnitIndex_ be the ordinal index of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _largestUnit_.
-        1. Let _smallestUnitIndex_ be the ordinal index of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _smallestUnit_.
-        1. Let _unitIndex_ be _smallestUnitIndex_ - 1.
+        1. Let _unitIndex_ be the ordinal index of the row of <emu-xref href="#table-temporal-units"></emu-xref> whose "Value" column contains _smallestUnit_.
         1. Let _done_ be *false*.
-        1. Repeat, while _unitIndex_ ≥ _largestUnitIndex_ and _done_ is *false*,
+        1. Repeat, while _unitIndex_ > _largestUnitIndex_ and _done_ is *false*,
+          1. Set _unitIndex_ to _unitIndex_ - 1.
           1. Let _unit_ be the value in the "Value" column of <emu-xref href="#table-temporal-units"></emu-xref> in the row whose ordinal index is _unitIndex_.
           1. If _unit_ is not ~week~, or _largestUnit_ is ~week~, then
             1. If _unit_ is ~year~, then
@@ -1797,7 +1796,6 @@
               1. Set _duration_ to CombineDateAndTimeDuration(_endDuration_, 0).
             1. Else,
               1. Set _done_ to *true*.
-          1. Set _unitIndex_ to _unitIndex_ - 1.
         1. Return _duration_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
`BubbleRelativeDuration` can be called `largestUnit` being a smaller unit than `smallestUnit`, but the algorithm only returns early when both units are equal to each other. Removing the early return and changing the loop condition and loop counter simplifies this operation a bit.