### PR TITLE
Editorial: Check total nanoseconds in IsValidDuration

### DIFF
--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1184,7 +1184,7 @@
         1. If abs(_months_) ≥ 2<sup>32</sup>, return *false*.
         1. If abs(_weeks_) ≥ 2<sup>32</sup>, return *false*.
         1. Let _normalizedNanoseconds_ be _days_ × 86,400 × 10<sup>9</sup> + _hours_ × 3600 × 10<sup>9</sup> + _minutes_ × 60 × 10<sup>9</sup> + _seconds_ × 10<sup>9</sup> + ℝ(𝔽(_milliseconds_)) × 10<sup>6</sup> + ℝ(𝔽(_microseconds_)) × 10<sup>3</sup> + ℝ(𝔽(_nanoseconds_)).
-        1. NOTE: The above step cannot be implemented directly using 64-bit floating-point arithmetic. Multiplying by 10<sup>-3</sup>, 10<sup>-6</sup>, and 10<sup>-9</sup> respectively may be imprecise when _milliseconds_, _microseconds_, or _nanoseconds_ is an unsafe integer. The step can be implemented using 128-bit integers. It could also be implemented in C++ with an implementation of `std::remquo()` with sufficient bits in the quotient. String manipulation will also give an exact result, since the multiplication is by a power of 10.
+        1. NOTE: The above step cannot be implemented directly using 64-bit floating-point arithmetic. Multiplying by 10<sup>-3</sup>, 10<sup>-6</sup>, and 10<sup>-9</sup> respectively may be imprecise when _milliseconds_, _microseconds_, or _nanoseconds_ is an unsafe integer. The step can be implemented by using 128-bit integers and performing all arithmetic on nanosecond values. It could also be implemented in C++ with an implementation of `std::remquo()` with sufficient bits in the quotient. String manipulation will also give an exact result, since the multiplication is by a power of 10.
         1. If abs(_normalizedNanoseconds_) ≥ 10<sup>9</sup> × 2<sup>53</sup>, return *false*.
         1. Return *true*.
       </emu-alg>


### PR DESCRIPTION
Make it clear that it's acceptable for an implementation to use 128-bit integers and do the validity check in terms of nanoseconds.

Closes #3177 