### PR TITLE
Editorial: In GetDifferenceSettings, move NegateRoundingMode call

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1874,8 +1874,6 @@
       1. If _largestUnit_ is ~unset~, then
         1. Set _largestUnit_ to ~auto~.
       1. If _disallowedUnits_ contains _largestUnit_, throw a *RangeError* exception.
-      1. If _operation_ is ~since~, then
-        1. Set _roundingMode_ to NegateRoundingMode(_roundingMode_).
       1. Perform ? ValidateTemporalUnitValue(_smallestUnit_, _unitGroup_).
       1. If _smallestUnit_ is ~unset~, then
         1. Set _smallestUnit_ to _fallbackSmallestUnit_.
@@ -1885,6 +1883,8 @@
       1. If LargerOfTwoTemporalUnits(_largestUnit_, _smallestUnit_) is not _largestUnit_, throw a *RangeError* exception.
       1. Let _maximum_ be MaximumTemporalDurationRoundingIncrement(_smallestUnit_).
       1. If _maximum_ is not ~unset~, perform ? ValidateTemporalRoundingIncrement(_roundingIncrement_, _maximum_, *false*).
+      1. If _operation_ is ~since~, then
+        1. Set _roundingMode_ to NegateRoundingMode(_roundingMode_).
       1. Return the Record {
         [[SmallestUnit]]: _smallestUnit_,
         [[LargestUnit]]: _largestUnit_,


### PR DESCRIPTION
Move this step to immediately precede the return. This is unobservable since nothing relies on _roundingMode_ before the return.

Closes #3178