### PR TITLE
Editorial: Add explanatory note to CalendarMonthDayFromFields

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -762,7 +762,7 @@
       <emu-alg>
         1. Perform ? CalendarResolveFields(_calendar_, _fields_, ~month-day~).
         1. Let _result_ be ? CalendarMonthDayToISOReferenceDate(_calendar_, _fields_, _overflow_).
-        1. Assert: ISODateWithinLimits(_result_).
+        1. Assert: ISODateWithinLimits(_result_) is *true*.
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Explain why the ISODateWithinLimits check is necessary.