### PR TITLE
Thorough tests for roundtripping Temporal objects

### DIFF
--- a/polyfill/test/thorough/all.sh
+++ b/polyfill/test/thorough/all.sh
@@ -17,26 +17,34 @@ there_were_errors=0
 for test in \
   dateaddition \
   datedifference \
+  dateroundtrip \
   datetimeaddition \
   datetimedifference \
   datetimerounding \
+  datetimeroundtrip \
   durationaddition \
+  durationroundtrip \
   durationtotal \
   gregorian \
   instantaddition \
   instantdifference \
   instantrounding \
+  instantroundtrip \
   monthdayrefyear \
+  monthdayroundtrip \
   startofday \
   timeaddition \
   timedifference \
   timerounding \
+  timeroundtrip \
   yearcycle \
   yearmonthaddition \
   yearmonthdifference \
+  yearmonthroundtrip \
   zonedaddition \
   zoneddifference \
-  zonedrounding
+  zonedrounding \
+  zonedroundtrip
 do
   echo "== Running $test.mjs =="
   $interpreter "$test.mjs" || there_were_errors=1

--- a/polyfill/test/thorough/dateroundtrip.mjs
+++ b/polyfill/test/thorough/dateroundtrip.mjs
@@ -1,0 +1,40 @@
+import { assertTemporalEqual, getProgressBar, makeDateCases, temporalImpl as T, time } from './support.mjs';
+
+const opts = { overflow: 'reject' };
+const interestingDates = makeDateCases();
+const total = interestingDates.length;
+
+await time(async (start) => {
+  const progress = getProgressBar(start, total);
+
+  for (const [date, dateStr] of interestingDates) {
+    progress.tick(1, { test: dateStr });
+
+    const { year, month, monthCode, day } = date;
+
+    const propertyBagMonth = { year, month, day };
+    assertTemporalEqual(T.PlainDate.from(propertyBagMonth, opts), date, 'from property bag with month');
+
+    const propertyBagMonthCode = { year, monthCode, day };
+    assertTemporalEqual(T.PlainDate.from(propertyBagMonthCode, opts), date, 'from property bag with monthCode');
+
+    const propertyBagAll = { year, month, monthCode, day };
+    assertTemporalEqual(T.PlainDate.from(propertyBagAll, opts), date, 'from property bag with month and monthCode');
+
+    assertTemporalEqual(T.PlainDate.from(dateStr), date, 'from ISO string');
+
+    const stringCalendar = date.toString({ calendarName: 'always' });
+    assertTemporalEqual(T.PlainDate.from(stringCalendar), date, 'from ISO string with calendar');
+
+    const stringTime = date.toPlainDateTime({ hour: 12 }).toString();
+    assertTemporalEqual(T.PlainDate.from(stringTime), date, 'from ISO string with time');
+
+    const yPart = `${year < 0 ? '-' : '+'}${String(Math.abs(year)).padStart(6, '0')}`;
+    const monPart = String(month).padStart(2, '0');
+    const dPart = String(day).padStart(2, '0');
+    const weirdString = `${yPart}${monPart}${dPart} 123456,7+1234`;
+    assertTemporalEqual(T.PlainDate.from(weirdString), date, 'from ISO string with weird but allowed formatting');
+  }
+
+  return total;
+});

--- a/polyfill/test/thorough/datetimeroundtrip.mjs
+++ b/polyfill/test/thorough/datetimeroundtrip.mjs
@@ -1,0 +1,51 @@
+import { assertTemporalEqual, getProgressBar, makeDateTimeCases, temporalImpl as T, time } from './support.mjs';
+
+const opts = { overflow: 'reject' };
+const interestingDateTimes = makeDateTimeCases();
+const total = interestingDateTimes.length;
+
+await time(async (start) => {
+  const progress = getProgressBar(start, total);
+
+  for (const [dateTime, dateTimeStr] of interestingDateTimes) {
+    progress.tick(1, { test: dateTimeStr });
+
+    const { year, month, monthCode, day, hour, minute, second, millisecond, microsecond, nanosecond } = dateTime;
+
+    const propertyBagMonth = { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
+    assertTemporalEqual(T.PlainDateTime.from(propertyBagMonth, opts), dateTime, 'from property bag with month');
+
+    const propertyBagMonthCode = { year, monthCode, day, hour, minute, second, millisecond, microsecond, nanosecond };
+    assertTemporalEqual(T.PlainDateTime.from(propertyBagMonthCode, opts), dateTime, 'from property bag with monthCode');
+
+    const propertyBagAll = { year, month, monthCode, day, hour, minute, second, millisecond, microsecond, nanosecond };
+    assertTemporalEqual(
+      T.PlainDateTime.from(propertyBagAll, opts),
+      dateTime,
+      'from property bag with month and monthCode'
+    );
+
+    assertTemporalEqual(T.PlainDateTime.from(dateTimeStr), dateTime, 'from ISO string');
+
+    const stringCalendar = dateTime.toString({ calendarName: 'always' });
+    assertTemporalEqual(T.PlainDateTime.from(stringCalendar), dateTime, 'from ISO string with calendar');
+
+    const yPart = `${year < 0 ? '-' : '+'}${String(Math.abs(year)).padStart(6, '0')}`;
+    const monPart = String(month).padStart(2, '0');
+    const dPart = String(day).padStart(2, '0');
+    const hPart = String(hour).padStart(2, '0');
+    const minPart = String(minute).padStart(2, '0');
+    const sPart = String(second).padStart(2, '0');
+    const msPart = String(millisecond).padStart(3, '0');
+    const µsPart = String(microsecond).padStart(3, '0');
+    const nsPart = String(nanosecond).padStart(3, '0');
+    const weirdString = `${yPart}${monPart}${dPart} ${hPart}${minPart}${sPart},${msPart}${µsPart}${nsPart}+1234`;
+    assertTemporalEqual(
+      T.PlainDateTime.from(weirdString),
+      dateTime,
+      'from ISO string with weird but allowed formatting'
+    );
+  }
+
+  return total;
+});

--- a/polyfill/test/thorough/durationroundtrip.mjs
+++ b/polyfill/test/thorough/durationroundtrip.mjs
@@ -1,0 +1,44 @@
+import { assertDurationsEqual, getProgressBar, makeDurationCases, temporalImpl as T, time } from './support.mjs';
+
+const interestingCases = makeDurationCases().concat(makeDurationCases().map(([d, str]) => [d.negated(), `-${str}`]));
+const total = interestingCases.length;
+
+await time(async (start) => {
+  const progress = getProgressBar(start, total);
+
+  for (const [duration, durationStr] of interestingCases) {
+    progress.tick(1, { test: durationStr });
+
+    const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
+
+    const propertyBag = {
+      years,
+      months,
+      weeks,
+      days,
+      hours,
+      minutes,
+      seconds,
+      milliseconds,
+      microseconds,
+      nanoseconds
+    };
+    assertDurationsEqual(T.Duration.from(propertyBag), duration, 'from property bag');
+
+    // Durations where the subsecond units overflow don't roundtrip from a string
+    if (Math.abs(milliseconds) > 999 || Math.abs(microseconds) > 999 || Math.abs(nanoseconds) > 999) continue;
+
+    const isoString = duration.toString();
+    assertDurationsEqual(T.Duration.from(isoString), duration, 'from ISO string');
+
+    const sign = duration.sign < 0 ? '-' : '+';
+    const f = Math.abs;
+    const fracPart = String(f(milliseconds) * 1000000 + f(microseconds) * 1000 + f(nanoseconds)).padStart(9, '0');
+    const weirdString = `${sign}p${f(years)}y${f(months)}m${f(weeks)}w${f(days)}dt${f(hours)}h${f(minutes)}m${f(
+      seconds
+    )},${fracPart}s`;
+    assertDurationsEqual(T.Duration.from(weirdString), duration, 'from ISO string with weird but allowed formatting');
+  }
+
+  return total;
+});

--- a/polyfill/test/thorough/instantroundtrip.mjs
+++ b/polyfill/test/thorough/instantroundtrip.mjs
@@ -1,0 +1,23 @@
+import { assertTemporalEqual, getProgressBar, makeInstantCases, temporalImpl as T, time } from './support.mjs';
+
+const interestingInstants = makeInstantCases();
+const total = interestingInstants.length;
+
+await time(async (start) => {
+  const progress = getProgressBar(start, total);
+
+  for (const [instant, instantStr] of interestingInstants) {
+    progress.tick(1, { test: instantStr });
+
+    assertTemporalEqual(T.Instant.from(instantStr), instant, 'from ISO string');
+
+    const stringTimeZone = instant.toString({ fractionalSecondDigits: 9, timeZone: 'UTC' });
+    assertTemporalEqual(T.Instant.from(stringTimeZone), instant, 'from ISO string with full digits and time zone');
+
+    const weirdString =
+      stringTimeZone[0] + stringTimeZone.slice(1).replace('T', ' ').replace('.', ',').replaceAll(/-:/g, '');
+    assertTemporalEqual(T.Instant.from(weirdString), instant, 'from ISO string with weird but allowed formatting');
+  }
+
+  return total;
+});

--- a/polyfill/test/thorough/monthdayroundtrip.mjs
+++ b/polyfill/test/thorough/monthdayroundtrip.mjs
@@ -1,0 +1,58 @@
+import { assertTemporalEqual, getProgressBar, temporalImpl as T, time } from './support.mjs';
+
+const opts = { overflow: 'reject' };
+const daysInMonth = [undefined, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+const interestingMonthDays = [];
+for (let month = 1; month < 13; month++) {
+  for (let day = 1; day < daysInMonth[month] + 1; day++) {
+    const md = T.PlainMonthDay.from({ year: 1972, month, day });
+    interestingMonthDays.push([md, md.toString()]);
+  }
+}
+const total = interestingMonthDays.length;
+
+await time(async (start) => {
+  const progress = getProgressBar(start, total);
+
+  for (const [md, mdStr] of interestingMonthDays) {
+    progress.tick(1, { test: mdStr });
+
+    const { monthCode, day } = md;
+    const year = 1972;
+    const month = +monthCode.slice(1);
+
+    const propertyBagYearMonth = { year, month, day };
+    assertTemporalEqual(T.PlainMonthDay.from(propertyBagYearMonth, opts), md, 'from property bag with year and month');
+
+    const propertyBagMonthCode = { monthCode, day };
+    assertTemporalEqual(T.PlainMonthDay.from(propertyBagMonthCode, opts), md, 'from property bag with monthCode');
+
+    const propertyBagYearMonthCode = { year, monthCode, day };
+    assertTemporalEqual(
+      T.PlainMonthDay.from(propertyBagYearMonthCode, opts),
+      md,
+      'from property bag with year and monthCode'
+    );
+
+    const propertyBagAll = { year, month, monthCode, day };
+    assertTemporalEqual(T.PlainMonthDay.from(propertyBagAll, opts), md, 'from property bag with month and monthCode');
+
+    assertTemporalEqual(T.PlainMonthDay.from(mdStr), md, 'from ISO string');
+
+    const stringCalendar = md.toString({ calendarName: 'always' });
+    assertTemporalEqual(T.PlainMonthDay.from(stringCalendar), md, 'from ISO string with calendar');
+
+    const stringTime = md.toPlainDate({ year: 1972 }).toPlainDateTime({ hour: 12 }).toString();
+    assertTemporalEqual(T.PlainMonthDay.from(stringTime), md, 'from ISO string with time');
+
+    const monPart = monthCode.slice(1);
+    const dPart = String(day).padStart(2, '0');
+    const weirdString = `+222220${monPart}${dPart} 123456,7+1234`;
+    assertTemporalEqual(T.PlainMonthDay.from(weirdString), md, 'from ISO string with weird but allowed formatting');
+
+    const dashString = `--${monPart}-${dPart}`;
+    assertTemporalEqual(T.PlainMonthDay.from(dashString), md, 'from ISO string with leading double dash');
+  }
+
+  return total;
+});

--- a/polyfill/test/thorough/timeroundtrip.mjs
+++ b/polyfill/test/thorough/timeroundtrip.mjs
@@ -1,0 +1,34 @@
+import { assertTemporalEqual, getProgressBar, makeTimeCases, temporalImpl as T, time } from './support.mjs';
+
+const opts = { overflow: 'reject' };
+const interestingTimes = makeTimeCases();
+const total = interestingTimes.length;
+
+await time(async (start) => {
+  const progress = getProgressBar(start, total);
+
+  for (const [time, timeStr] of interestingTimes) {
+    progress.tick(1, { test: timeStr });
+
+    const { hour, minute, second, millisecond, microsecond, nanosecond } = time;
+
+    const propertyBag = { hour, minute, second, millisecond, microsecond, nanosecond };
+    assertTemporalEqual(T.PlainTime.from(propertyBag, opts), time, 'from property bag');
+
+    assertTemporalEqual(T.PlainTime.from(timeStr), time, 'from ISO string');
+
+    const stringCalendar = time.toString({ calendarName: 'always' });
+    assertTemporalEqual(T.PlainTime.from(stringCalendar), time, 'from ISO string with calendar');
+
+    const hPart = String(hour).padStart(2, '0');
+    const minPart = String(minute).padStart(2, '0');
+    const sPart = String(second).padStart(2, '0');
+    const msPart = String(millisecond).padStart(3, '0');
+    const µsPart = String(microsecond).padStart(3, '0');
+    const nsPart = String(nanosecond).padStart(3, '0');
+    const weirdString = `t${hPart}${minPart}${sPart},${msPart}${µsPart}${nsPart}+1234`;
+    assertTemporalEqual(T.PlainTime.from(weirdString), time, 'from ISO string with weird but allowed formatting');
+  }
+
+  return total;
+});

--- a/polyfill/test/thorough/yearmonthroundtrip.mjs
+++ b/polyfill/test/thorough/yearmonthroundtrip.mjs
@@ -1,0 +1,39 @@
+import { assertTemporalEqual, getProgressBar, makeYearMonthCases, temporalImpl as T, time } from './support.mjs';
+
+const opts = { overflow: 'reject' };
+const interestingYearMonths = makeYearMonthCases();
+const total = interestingYearMonths.length;
+
+await time(async (start) => {
+  const progress = getProgressBar(start, total);
+
+  for (const [ym, ymStr] of interestingYearMonths) {
+    progress.tick(1, { test: ymStr });
+
+    const { year, month, monthCode } = ym;
+
+    const propertyBagMonth = { year, month };
+    assertTemporalEqual(T.PlainYearMonth.from(propertyBagMonth, opts), ym, 'from property bag with month');
+
+    const propertyBagMonthCode = { year, monthCode };
+    assertTemporalEqual(T.PlainYearMonth.from(propertyBagMonthCode, opts), ym, 'from property bag with monthCode');
+
+    const propertyBagAll = { year, month, monthCode };
+    assertTemporalEqual(T.PlainYearMonth.from(propertyBagAll, opts), ym, 'from property bag with month and monthCode');
+
+    assertTemporalEqual(T.PlainYearMonth.from(ymStr), ym, 'from ISO string');
+
+    const stringCalendar = ym.toString({ calendarName: 'always' });
+    assertTemporalEqual(T.PlainYearMonth.from(stringCalendar), ym, 'from ISO string with calendar');
+
+    const stringTime = ym.toPlainDate({ day: 2 }).toPlainDateTime({ hour: 12 }).toString();
+    assertTemporalEqual(T.PlainYearMonth.from(stringTime), ym, 'from ISO string with day and time');
+
+    const yPart = `${year < 0 ? '-' : '+'}${String(Math.abs(year)).padStart(6, '0')}`;
+    const monPart = String(month).padStart(2, '0');
+    const weirdString = `${yPart}${monPart}14 123456,7+1234`;
+    assertTemporalEqual(T.PlainYearMonth.from(weirdString), ym, 'from ISO string with weird but allowed formatting');
+  }
+
+  return total;
+});

--- a/polyfill/test/thorough/zonedroundtrip.mjs
+++ b/polyfill/test/thorough/zonedroundtrip.mjs
@@ -1,0 +1,106 @@
+import { assertTemporalEqual, getProgressBar, makeZonedCases, temporalImpl as T, time } from './support.mjs';
+
+const opts = { overflow: 'reject', offset: 'reject', disambiguation: 'reject' };
+const interestingDateTimes = makeZonedCases();
+const total = interestingDateTimes.length;
+
+await time(async (start) => {
+  const progress = getProgressBar(start, total);
+
+  for (const [dateTime, dateTimeStr] of interestingDateTimes) {
+    progress.tick(1, { test: dateTimeStr });
+
+    const {
+      year,
+      month,
+      monthCode,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      offset,
+      timeZoneId: timeZone
+    } = dateTime;
+    const propertyBagCommon = { year, day, hour, minute, second, millisecond, microsecond, nanosecond, timeZone };
+
+    const propertyBagMonth = { ...propertyBagCommon, month };
+    const earlier = T.ZonedDateTime.from(propertyBagMonth, { disambiguation: 'earlier' });
+    const later = T.ZonedDateTime.from(propertyBagMonth, { disambiguation: 'later' });
+    const isAmbiguous = !earlier.equals(later);
+
+    if (!isAmbiguous) {
+      assertTemporalEqual(T.ZonedDateTime.from(propertyBagMonth, opts), dateTime, 'from property bag with month');
+
+      const propertyBagMonthCode = { ...propertyBagCommon, monthCode };
+      assertTemporalEqual(
+        T.ZonedDateTime.from(propertyBagMonthCode, opts),
+        dateTime,
+        'from property bag with monthCode'
+      );
+
+      const propertyBagMonthMonthCode = { ...propertyBagCommon, month, monthCode };
+      assertTemporalEqual(
+        T.ZonedDateTime.from(propertyBagMonthMonthCode, opts),
+        dateTime,
+        'from property bag with month and monthCode'
+      );
+    }
+
+    // Can't be constructed from string or property bag with offset:
+    if (year === -271821 && month === 4 && day === 19) continue;
+
+    const propertyBagMonthOffset = { ...propertyBagCommon, month, offset };
+    assertTemporalEqual(
+      T.ZonedDateTime.from(propertyBagMonthOffset, opts),
+      dateTime,
+      'from property bag with monthCode and offset'
+    );
+
+    const propertyBagMonthCodeOffset = { ...propertyBagCommon, monthCode, offset };
+    assertTemporalEqual(
+      T.ZonedDateTime.from(propertyBagMonthCodeOffset, opts),
+      dateTime,
+      'from property bag with monthCode and offset'
+    );
+
+    const propertyBagAll = { ...propertyBagCommon, month, monthCode, offset };
+    assertTemporalEqual(
+      T.ZonedDateTime.from(propertyBagAll, opts),
+      dateTime,
+      'from property bag with month, monthCode, and offset'
+    );
+
+    assertTemporalEqual(T.ZonedDateTime.from(dateTimeStr, opts), dateTime, 'from ISO string');
+
+    const stringCalendar = dateTime.toString({ calendarName: 'always', timeZoneName: 'critical' });
+    assertTemporalEqual(
+      T.ZonedDateTime.from(stringCalendar, opts),
+      dateTime,
+      'from ISO string with calendar and critical time zone'
+    );
+
+    const yPart = `${year < 0 ? '-' : '+'}${String(Math.abs(year)).padStart(6, '0')}`;
+    const monPart = String(month).padStart(2, '0');
+    const dPart = String(day).padStart(2, '0');
+    const hPart = String(hour).padStart(2, '0');
+    const minPart = String(minute).padStart(2, '0');
+    const sPart = String(second).padStart(2, '0');
+    const msPart = String(millisecond).padStart(3, '0');
+    const µsPart = String(microsecond).padStart(3, '0');
+    const nsPart = String(nanosecond).padStart(3, '0');
+    const offPart = offset.replace('.', ',').replaceAll(':', '');
+    const tzPart = `[${timeZone.toLowerCase()}]`;
+    const weirdString =
+      `${yPart}${monPart}${dPart} ${hPart}${minPart}${sPart},` + `${msPart}${µsPart}${nsPart}${offPart}${tzPart}`;
+    assertTemporalEqual(
+      T.ZonedDateTime.from(weirdString, opts),
+      dateTime,
+      'from ISO string with weird but allowed formatting'
+    );
+  }
+
+  return total;
+});


### PR DESCRIPTION
Adds a thorough test file for each type, testing that it can be constructed using its from() static method, from variations on ISO strings and property bags.

~~Also includes the commit from #3200 distributing the "interesting" durations a bit more throughout the testing space, to avoid rebase conflicts.~~