### PR TITLE
Polyfill: Validate result in UTC fast path in GetPossibleEpochNanoseconds

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1921,7 +1921,9 @@ export function GetPossibleEpochNanoseconds(timeZone, isoDateTime) {
   // UTC fast path
   if (timeZone === 'UTC') {
     CheckISODaysRange(isoDateTime.isoDate);
-    return [GetUTCEpochNanoseconds(isoDateTime)];
+    const epochNs = GetUTCEpochNanoseconds(isoDateTime);
+    ValidateEpochNanoseconds(epochNs);
+    return [epochNs];
   }
 
   const offsetMinutes = ParseTimeZoneIdentifier(timeZone).offsetMinutes;


### PR DESCRIPTION
The `IsValidEpochNanoseconds` check was previously omitted when the time zone was UTC.

Closes https://github.com/tc39/proposal-temporal/issues/3203