### PR TITLE
Polyfill: Reject time strings with unbalanced separators

### DIFF
--- a/polyfill/lib/regex.mjs
+++ b/polyfill/lib/regex.mjs
@@ -28,7 +28,9 @@ const timesecond = new RegExpCtor('(?<second>\\d{2})');
 const fraction = new RegExpCtor('(?:[.,](?<fraction>\\d{1,9}))');
 const secondspart = new RegExpCtor(`(?:${timesecond.source})(?:${fraction.source})?`);
 const hourminutesecondNoSep = new RegExpCtor(`(?<hour>\\d{2})(?:(?<minute>\\d{2}))?(?:${secondspart.source})?`);
-const hourminutesecondSep = new RegExpCtor(`(?<hour>\\d{2})(?:${sep.source}(?<minute>\\d{2}))?(?:${sep.source}${secondspart.source})?`);
+const hourminutesecondSep = new RegExpCtor(
+  `(?<hour>\\d{2})(?:${sep.source}(?<minute>\\d{2}))?(?:${sep.source}${secondspart.source})?`
+);
 const timesplit = new RegExpCtor(`(?:(?:${hourminutesecondSep.source})|(?:${hourminutesecondNoSep.source}))`);
 const sign = /[+-]/;
 const hour = /[01][0-9]|2[0-3]/;


### PR DESCRIPTION
Previously, strings like "00:000" or "0000:00" were being accepted by PlainTime.from.