### PR TITLE
Polyfill: Remove weeks and days arguments from ISODateSurpasses

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -132,19 +132,11 @@ function calendarDateWeekOfYear(id, isoDate) {
   return { week: woy, year: yow };
 }
 
-function ISODateSurpasses(sign, baseDate, isoDate2, years, months, weeks, days) {
+function ISODateSurpasses(sign, baseDate, isoDate2, years, months) {
   const yearMonth = ES.BalanceISOYearMonth(baseDate.year + years, baseDate.month + months);
   let y1 = yearMonth.year;
   let m1 = yearMonth.month;
   let d1 = baseDate.day;
-  if (weeks !== 0 || days !== 0) {
-    const regulatedDate = ES.RegulateISODate(y1, m1, d1, 'constrain');
-    ({
-      year: y1,
-      month: m1,
-      day: d1
-    } = ES.BalanceISODate(regulatedDate.year, regulatedDate.month, regulatedDate.day + 7 * weeks + days));
-  }
   if (y1 !== isoDate2.year) {
     if (sign * (y1 - isoDate2.year) > 0) return true;
   } else if (m1 !== isoDate2.month) {


### PR DESCRIPTION
The polyfill always calls ISODateSurpasses with weeks and days equal to 0, and the arguments are only used when they're not equal to 0, so remove them altogether. (In the spec, ISODateSurpasses is called with non-zero weeks and days, but the polyfill does an optimization that means it's not called with non-zero weeks or days.)