### PR TITLE
Polyfill: Change some checks to assertions

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -762,7 +762,7 @@ const nonIsoHelperBase = {
             // The year must be negative, because the reverse-sign era is always last,
             // and if the year was positive, the (comparison >= 0) would have been true
             // and this closure would already have returned true
-            assert(year <= 0, "year must not be positive in eraFromYear");
+            assert(year <= 0, 'year must not be positive in eraFromYear');
             eraYear = e.anchorEpoch.year - year;
             return true;
           }


### PR DESCRIPTION
Some checks in eraFromYear must always be true; change exception-throwing code to assertions and document why the assertions are always true.