### PR TITLE
Delete unreachable code

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -802,9 +802,6 @@ const nonIsoHelperBase = {
       } else {
         year = eraYear + matchingEra.anchorEpoch.year - (matchingEra.hasYearZero ? 0 : 1);
       }
-      if (calendarDate.year !== undefined && calendarDate.year !== year) {
-        throw new RangeErrorCtor(`Input year ${calendarDate.year} doesn't match calculated value ${year}`);
-      }
       // We'll accept dates where the month/day is earlier than the start of
       // the era or after its end as long as it's in the same year. If that
       // happens, we'll adjust the era/eraYear pair to be the correct era for


### PR DESCRIPTION
This code is unreachable because it's inside an `else` clause attached to `if (year !== undefined)`, and `year` equals `calendarDate.year`.