### PR TITLE
Polyfill: Change check to assertion in minMaxMonthLength for Hebrew calendar

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1280,7 +1280,7 @@ const helperHebrew = makeNonISOHelper([{ code: 'am', isoEpoch: { year: -3760, mo
     const { month, year } = calendarDate;
     const monthCode = calendarDate.monthCode ?? this.getMonthCode(year, month);
     const daysInMonth = this.monthLengths[monthCode];
-    if (daysInMonth === undefined) throw new RangeErrorCtor(`unmatched Hebrew month: ${month}`);
+    assert(daysInMonth, `missing daysInMonth for Hebrew month ${monthCode}`);
     return typeof daysInMonth === 'number' ? daysInMonth : daysInMonth[minOrMax];
   },
   maxLengthOfMonthCodeInAnyYear(monthCode) {


### PR DESCRIPTION
This is called on dates that have already been validated, so it should be an internal error if there is no length for a valid month code.