### PR TITLE
Polyfill: Change check to assertion in getMonthInfo for Indian calendar

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1509,7 +1509,7 @@ const helperIndian = makeNonISOHelper([{ code: 'shaka', isoEpoch: { year: 79, mo
   getMonthInfo(calendarDate) {
     const { month } = calendarDate;
     let monthInfo = this.months[month];
-    if (monthInfo === undefined) throw new RangeErrorCtor(`Invalid month: ${month}`);
+    assert(monthInfo, `getMonthInfo called on date with invalid month ${month}`);
     if (this.inLeapYear(calendarDate) && monthInfo.leap) monthInfo = monthInfo.leap;
     return monthInfo;
   },
@@ -1898,9 +1898,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
   daysInMonth(calendarDate, cache) {
     const { month, year } = calendarDate;
     const matchingMonthEntry = this.getMonthList(year, cache)[month];
-    if (matchingMonthEntry === undefined) {
-      throw new RangeErrorCtor(`Invalid month ${month} in ${this.id} year ${year}`);
-    }
+    assert(matchingMonthEntry, `Invalid month ${month} in ${this.id} year ${year}`);
     return matchingMonthEntry.daysInMonth;
   },
   daysInPreviousMonth(calendarDate, cache) {


### PR DESCRIPTION
This method is only called on valid dates, so monthInfo should never be undefined.

Also includes a similar change for the Chinese calendar.