### PR TITLE
Polyfill: In Chinese calendar getMonthList, change check to assertion

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -1963,7 +1963,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
     }
   },
   getMonthList(calendarYear, cache) {
-    assert(calendarYear, 'getMonthList called on undefined year');
+    assert(calendarYear !== undefined, 'getMonthList called on undefined year');
     const key = OneObjectCache.generateMonthListKey(calendarYear);
     const cached = cache.get(key);
     if (cached) return cached;


### PR DESCRIPTION
This is only called on valid dates, so year should always be defined.