### PR TITLE
Polyfill: Require `newDays` argument in AdjustDateDurationRecord

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -751,7 +751,7 @@ export function ToTemporalPartialDurationRecord(temporalDurationLike) {
   return result;
 }
 
-export function AdjustDateDurationRecord({ years, months, weeks, days }, newDays, newWeeks, newMonths) {
+export function AdjustDateDurationRecord({ years, months, weeks }, newDays, newWeeks, newMonths) {
   assert(newDays !== undefined, 'days must be provided to AdjustDateDurationRecord');
   return {
     years,


### PR DESCRIPTION
AdjustDateDurationRecord is always called with a non-undefined `newDays`, so add an assertion to that effect and remove the ?? operator for `days`.