### PR TITLE
Change checks in TimeZoneEquals to assertions

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -42,6 +42,7 @@ import {
   IntlDateTimeFormatPrototypeGetFormat,
   IntlDateTimeFormatPrototypeResolvedOptions,
   IntlSupportedValuesOf,
+  JSONStringify,
   MapPrototypeGet,
   MapPrototypeHas,
   MapPrototypeSet,
@@ -1812,9 +1813,9 @@ export function TimeZoneEquals(one, two) {
     // can come from the argument of TimeZone.p.equals as opposed to the first
     // ID which comes from the receiver.
     const idRecord2 = GetAvailableNamedTimeZoneIdentifier(two);
-    if (!idRecord2) return false;
+    assert(idRecord2, `${JSONStringify(two)} has an invalid time zone`);
     const idRecord1 = GetAvailableNamedTimeZoneIdentifier(one);
-    if (!idRecord1) return false;
+    assert(idRecord1, `${JSONStringify(one)} has an invalid time zone`);
     return idRecord1.primaryIdentifier === idRecord2.primaryIdentifier;
   } else {
     return offsetMinutes1 === offsetMinutes2;


### PR DESCRIPTION
If the time zones were invalid, that error would have been signaled when converting `two` or `one` to a ZonedDateTime; so just assert that the time zones are valid.