### PR TITLE
Polyfill: Remove dead code

### DIFF
--- a/polyfill/lib/math.mjs
+++ b/polyfill/lib/math.mjs
@@ -42,7 +42,7 @@ export function TruncatingDivModByPowerOf10(x, p) {
 export function FMAPowerOf10(x, p, z) {
   if (x === 0) return z;
 
-  const sign = MathSign(x) || MathSign(z);
+  const sign = MathSign(x);
   x = MathAbs(x);
   z = MathAbs(z);
 


### PR DESCRIPTION
The previous line of code returns if x is 0, so
MathSign(x) || MathSign(z) can just be MathSign(x).