### PR TITLE
Polyfill: Simplify initialization code in constructors

### DIFF
--- a/polyfill/lib/plaindatetime.mjs
+++ b/polyfill/lib/plaindatetime.mjs
@@ -29,13 +29,13 @@ export class PlainDateTime {
     const year = ES.ToIntegerWithTruncation(isoYear);
     const month = ES.ToIntegerWithTruncation(isoMonth);
     const day = ES.ToIntegerWithTruncation(isoDay);
-    hour = hour === undefined ? 0 : ES.ToIntegerWithTruncation(hour);
-    minute = minute === undefined ? 0 : ES.ToIntegerWithTruncation(minute);
-    second = second === undefined ? 0 : ES.ToIntegerWithTruncation(second);
-    millisecond = millisecond === undefined ? 0 : ES.ToIntegerWithTruncation(millisecond);
-    microsecond = microsecond === undefined ? 0 : ES.ToIntegerWithTruncation(microsecond);
-    nanosecond = nanosecond === undefined ? 0 : ES.ToIntegerWithTruncation(nanosecond);
-    calendar = calendar === undefined ? 'iso8601' : ES.RequireString(calendar);
+    hour = ES.ToIntegerWithTruncation(hour);
+    minute = ES.ToIntegerWithTruncation(minute);
+    second = ES.ToIntegerWithTruncation(second);
+    millisecond = ES.ToIntegerWithTruncation(millisecond);
+    microsecond = ES.ToIntegerWithTruncation(microsecond);
+    nanosecond = ES.ToIntegerWithTruncation(nanosecond);
+    calendar = ES.RequireString(calendar);
     calendar = ES.CanonicalizeCalendar(calendar);
 
     ES.RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);

--- a/polyfill/lib/plainmonthday.mjs
+++ b/polyfill/lib/plainmonthday.mjs
@@ -9,7 +9,7 @@ export class PlainMonthDay {
   constructor(isoMonth, isoDay, calendar = 'iso8601', referenceISOYear = 1972) {
     const month = ES.ToIntegerWithTruncation(isoMonth);
     const day = ES.ToIntegerWithTruncation(isoDay);
-    calendar = calendar === undefined ? 'iso8601' : ES.RequireString(calendar);
+    calendar = ES.RequireString(calendar);
     calendar = ES.CanonicalizeCalendar(calendar);
     const year = ES.ToIntegerWithTruncation(referenceISOYear);
 

--- a/polyfill/lib/plaintime.mjs
+++ b/polyfill/lib/plaintime.mjs
@@ -16,12 +16,12 @@ import { GetSlot, TIME } from './slots.mjs';
 
 export class PlainTime {
   constructor(isoHour = 0, isoMinute = 0, isoSecond = 0, isoMillisecond = 0, isoMicrosecond = 0, isoNanosecond = 0) {
-    const hour = isoHour === undefined ? 0 : ES.ToIntegerWithTruncation(isoHour);
-    const minute = isoMinute === undefined ? 0 : ES.ToIntegerWithTruncation(isoMinute);
-    const second = isoSecond === undefined ? 0 : ES.ToIntegerWithTruncation(isoSecond);
-    const millisecond = isoMillisecond === undefined ? 0 : ES.ToIntegerWithTruncation(isoMillisecond);
-    const microsecond = isoMicrosecond === undefined ? 0 : ES.ToIntegerWithTruncation(isoMicrosecond);
-    const nanosecond = isoNanosecond === undefined ? 0 : ES.ToIntegerWithTruncation(isoNanosecond);
+    const hour = ES.ToIntegerWithTruncation(isoHour);
+    const minute = ES.ToIntegerWithTruncation(isoMinute);
+    const second = ES.ToIntegerWithTruncation(isoSecond);
+    const millisecond = ES.ToIntegerWithTruncation(isoMillisecond);
+    const microsecond = ES.ToIntegerWithTruncation(isoMicrosecond);
+    const nanosecond = ES.ToIntegerWithTruncation(isoNanosecond);
 
     ES.RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
     const time = { hour, minute, second, millisecond, microsecond, nanosecond };

--- a/polyfill/lib/plainyearmonth.mjs
+++ b/polyfill/lib/plainyearmonth.mjs
@@ -9,7 +9,7 @@ export class PlainYearMonth {
   constructor(isoYear, isoMonth, calendar = 'iso8601', referenceISODay = 1) {
     const year = ES.ToIntegerWithTruncation(isoYear);
     const month = ES.ToIntegerWithTruncation(isoMonth);
-    calendar = calendar === undefined ? 'iso8601' : ES.RequireString(calendar);
+    calendar = ES.RequireString(calendar);
     calendar = ES.CanonicalizeCalendar(calendar);
     const day = ES.ToIntegerWithTruncation(referenceISODay);
 

--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -35,7 +35,7 @@ export class ZonedDateTime {
     } else {
       timeZone = ES.FormatOffsetTimeZoneIdentifier(offsetMinutes);
     }
-    calendar = calendar === undefined ? 'iso8601' : ES.RequireString(calendar);
+    calendar = ES.RequireString(calendar);
     calendar = ES.CanonicalizeCalendar(calendar);
 
     ES.CreateTemporalZonedDateTimeSlots(this, epochNanoseconds, timeZone, calendar);


### PR DESCRIPTION
Several constructors had redundant code that checked a value for undefined and set it to 0 if so. This was redundant because the constructor already initializes these values.