### PR TITLE
Polyfill: Change check to assertion in getTimeZoneTransition

### DIFF
--- a/polyfill/lib/zoneddatetime.mjs
+++ b/polyfill/lib/zoneddatetime.mjs
@@ -444,7 +444,7 @@ export class ZonedDateTime {
       directionParam = ES.GetOptionsObject(directionParam);
     }
     const direction = ES.GetDirectionOption(directionParam);
-    if (direction === undefined) throw new TypeErrorCtor('direction option is required');
+    assert(direction !== undefined);
 
     // Offset time zones or UTC have no transitions
     if (ES.IsOffsetTimeZoneIdentifier(timeZone) || timeZone === 'UTC') {


### PR DESCRIPTION
direction can never be undefined, because GetDirectionOption calls GetOption with the REQUIRED argument.