### PR TITLE
Revert "Editorial: Move AnnotatedTime early error to a separate parse step"

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1230,7 +1230,9 @@
       AnnotatedTime :::
         TimeDesignator Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
         Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
-
+    </emu-grammar>
+    <p>Note the disambiguation between the second alternative without |TimeDesignator|, and |DateSpecMonthDay|/|DateSpecYearMonth| in <emu-xref href="#sec-temporal-iso8601grammar-static-semantics-early-errors"></emu-xref>.</p>
+    <emu-grammar type="definition">
       AnnotatedDateTime[Zoned, TimeRequired] :::
         [~Zoned] DateTime[~Z, ?TimeRequired] TimeZoneAnnotation? Annotations?
         [+Zoned] DateTime[+Z, ?TimeRequired] TimeZoneAnnotation Annotations?
@@ -1300,10 +1302,6 @@
         AnnotatedTime
         AnnotatedDateTime[~Zoned, +TimeRequired]
 
-      AmbiguousTemporalTimeString :::
-        DateSpecMonthDay TimeZoneAnnotation? Annotations?
-        DateSpecYearMonth TimeZoneAnnotation? Annotations?
-
       TemporalYearMonthString :::
         AnnotatedYearMonth
         AnnotatedDateTime[~Zoned, ~TimeRequired]
@@ -1344,6 +1342,18 @@
 
     <emu-clause id="sec-temporal-iso8601grammar-static-semantics-early-errors">
       <h1>Static Semantics: Early Errors</h1>
+      <emu-grammar>
+        AnnotatedTime :::
+          Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
+      </emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if ParseText(|Time| |DateTimeUTCOffset[~Z]|, |DateSpecMonthDay|) is a Parse Node.
+        </li>
+        <li>
+          It is a Syntax Error if ParseText(|Time| |DateTimeUTCOffset[~Z]|, |DateSpecYearMonth|) is a Parse Node.
+        </li>
+      </ul>
       <emu-grammar>
         DateSpec[Extended] :::
           DateYear DateSeparator[?Extended] DateMonth DateSeparator[?Extended] DateDay

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -573,9 +573,9 @@
         1. Else,
           1. If _item_ is not a String, throw a *TypeError* exception.
           1. Let _parseResult_ be ? ParseISODateTime(_item_, « |TemporalTimeString| »).
-          1. If ParseText(StringToCodePoints(_item_), |AmbiguousTemporalTimeString|) is a Parse Node, throw a *RangeError* exception.
           1. Assert: _parseResult_.[[Time]] is not ~start-of-day~.
           1. Set _result_ to _parseResult_.[[Time]].
+          1. NOTE: A successful parse using |TemporalTimeString| guarantees absence of ambiguity with respect to any ISO 8601 date-only, year-month, or month-day representation.
           1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
           1. Perform ? GetTemporalOverflowOption(_resolvedOptions_).
         1. Return ! CreateTemporalTime(_result_).


### PR DESCRIPTION
This reverts commit fa3d0b913bb59551966b901858ce6ddebadf2baf. It introduced a regression; see discussion in https://github.com/tc39/proposal-temporal/issues/3237.

Closes: #3237