### PR TITLE
Normative: Block formatting plain Temporal objects in non-UTC formatter

### DIFF
--- a/spec/intl.html
+++ b/spec/intl.html
@@ -1014,8 +1014,9 @@
         </dl>
         <emu-alg>
           1. If _temporalDate_.[[Calendar]] is not _dateTimeFormat_.[[Calendar]] or *"iso8601"*, throw a *RangeError* exception.
+          1. If _dateTimeFormat_.[[TimeZone]] is not *"UTC"*, throw a *TypeError* exception.
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_temporalDate_.[[ISODate]], NoonTimeRecord()).
-          1. Let _epochNs_ be ? GetEpochNanosecondsFor(_dateTimeFormat_.[[TimeZone]], _isoDateTime_, ~compatible~).
+          1. Let _epochNs_ be GetUTCEpochNanoseconds(_isoDateTime_).
           1. Let _format_ be _dateTimeFormat_.[[TemporalPlainDateFormat]].
           1. If _format_ is *null*, throw a *TypeError* exception.
           1. Return Value Format Record {
@@ -1037,8 +1038,9 @@
         <emu-alg>
           1. If _temporalYearMonth_.[[Calendar]] is not equal to _dateTimeFormat_.[[Calendar]], then
             1. Throw a *RangeError* exception.
+          1. If _dateTimeFormat_.[[TimeZone]] is not *"UTC"*, throw a *TypeError* exception.
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_temporalYearMonth_.[[ISODate]], NoonTimeRecord()).
-          1. Let _epochNs_ be ? GetEpochNanosecondsFor(_dateTimeFormat_.[[TimeZone]], _isoDateTime_, ~compatible~).
+          1. Let _epochNs_ be GetUTCEpochNanoseconds(_isoDateTime_).
           1. Let _format_ be _dateTimeFormat_.[[TemporalPlainYearMonthFormat]].
           1. If _format_ is *null*, throw a *TypeError* exception.
           1. Return Value Format Record {
@@ -1060,8 +1062,9 @@
         <emu-alg>
           1. If _temporalMonthDay_.[[Calendar]] is not equal to _dateTimeFormat_.[[Calendar]], then
             1. Throw a *RangeError* exception.
+          1. If _dateTimeFormat_.[[TimeZone]] is not *"UTC"*, throw a *TypeError* exception.
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_temporalMonthDay_.[[ISODate]], NoonTimeRecord()).
-          1. Let _epochNs_ be ? GetEpochNanosecondsFor(_dateTimeFormat_.[[TimeZone]], _isoDateTime_, ~compatible~).
+          1. Let _epochNs_ be GetUTCEpochNanoseconds(_isoDateTime_).
           1. Let _format_ be _dateTimeFormat_.[[TemporalPlainMonthDayFormat]].
           1. If _format_ is *null*, throw a *TypeError* exception.
           1. Return Value Format Record {
@@ -1081,9 +1084,10 @@
         <dl class="header">
         </dl>
         <emu-alg>
+          1. If _dateTimeFormat_.[[TimeZone]] is not *"UTC"*, throw a *TypeError* exception.
           1. Let _isoDate_ be CreateISODateRecord(1970, 1, 1).
           1. Let _isoDateTime_ be CombineISODateAndTimeRecord(_isoDate_, _temporalTime_.[[Time]]).
-          1. Let _epochNs_ be ? GetEpochNanosecondsFor(_dateTimeFormat_.[[TimeZone]], _isoDateTime_, ~compatible~).
+          1. Let _epochNs_ be GetUTCEpochNanoseconds(_isoDateTime_).
           1. Let _format_ be _dateTimeFormat_.[[TemporalPlainTimeFormat]].
           1. If _format_ is *null*, throw a *TypeError* exception.
           1. Return Value Format Record {
@@ -1105,7 +1109,8 @@
         <emu-alg>
           1. If _dateTime_.[[Calendar]] is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], then
             1. Throw a *RangeError* exception.
-          1. Let _epochNs_ be ? GetEpochNanosecondsFor(_dateTimeFormat_.[[TimeZone]], _dateTime_.[[ISODateTime]], ~compatible~).
+          1. If _dateTimeFormat_.[[TimeZone]] is not *"UTC"*, throw a *TypeError* exception.
+          1. Let _epochNs_ be GetUTCEpochNanoseconds(_dateTime_.[[ISODateTime]]).
           1. Let _format_ be _dateTimeFormat_.[[TemporalPlainDateTimeFormat]].
           1. Return Value Format Record {
             [[Format]]: _format_,
@@ -1767,7 +1772,7 @@
           <emu-alg>
             1. Let _plainDate_ be the *this* value.
             1. Perform ? RequireInternalSlot(_plainDate_, [[InitializedTemporalDate]]).
-            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~date~, ~date~).
+            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~date~, ~date~, *"UTC"*).
             1. Return ? FormatDateTime(_dateFormat_, _plainDate_).
           </emu-alg>
         </emu-clause>
@@ -1783,7 +1788,7 @@
           <emu-alg>
             1. Let _plainDateTime_ be the *this* value.
             1. Perform ? RequireInternalSlot(_plainDateTime_, [[InitializedTemporalDateTime]]).
-            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~any~, ~all~).
+            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~any~, ~all~, *"UTC"*).
             1. Return ? FormatDateTime(_dateFormat_, _plainDateTime_).
           </emu-alg>
         </emu-clause>
@@ -1799,7 +1804,7 @@
           <emu-alg>
             1. Let _plainMonthDay_ be the *this* value.
             1. Perform ? RequireInternalSlot(_plainMonthDay_, [[InitializedTemporalMonthDay]]).
-            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~date~, ~date~).
+            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~date~, ~date~, *"UTC"*).
             1. Return ? FormatDateTime(_dateFormat_, _plainMonthDay_).
           </emu-alg>
         </emu-clause>
@@ -1815,7 +1820,7 @@
           <emu-alg>
             1. Let _plainTime_ be the *this* value.
             1. Perform ? RequireInternalSlot(_plainTime_, [[InitializedTemporalTime]]).
-            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~time~, ~time~).
+            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~time~, ~time~, *"UTC"*).
             1. Return ? FormatDateTime(_dateFormat_, _plainTime_).
           </emu-alg>
         </emu-clause>
@@ -1831,7 +1836,7 @@
           <emu-alg>
             1. Let _plainYearMonth_ be the *this* value.
             1. Perform ? RequireInternalSlot(_plainYearMonth_, [[InitializedTemporalYearMonth]]).
-            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~date~, ~date~).
+            1. Let _dateFormat_ be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, _locales_, _options_, ~date~, ~date~, *"UTC"*).
             1. Return ? FormatDateTime(_dateFormat_, _plainYearMonth_).
           </emu-alg>
         </emu-clause>


### PR DESCRIPTION
This makes DateTimeFormat's various formatting methods throw when given a Temporal.Plain___ object, unless the formatter's time zone is UTC.

The one-off formatter objects constructed in the Plain types' toLocaleString methods get their time zone overridden to be UTC.

Closes: #3212