### PR TITLE
Update status of implementations as of early January

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Additional tests and documentation content are also being added during Stage 3.
 Implementation status:
 
 - [SpiderMonkey/Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1912511): [shipped](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/139#javascript) in Firefox 139 (on 2025-05-27)
-- [V8/Chrome](https://crbug.com/42201538): [planned to ship](https://developer.chrome.com/blog/chrome-144-beta#the_temporal_api) in Chrome 144 (on 2026-01-13)
+- [V8/Chrome](https://crbug.com/42201538): [shipped](https://developer.chrome.com/release-notes/144#temporal_in_ecma262) in Chrome 144 (on 2026-01-13)
 - [Node.js](https://github.com/nodejs/node/issues/57127)
 - [JavaScriptCore/Safari](https://bugs.webkit.org/show_bug.cgi?id=223166)
 - [Boa](https://github.com/boa-dev/boa/issues/1804)
-- [GraalJS](https://github.com/oracle/graaljs/issues/851)
+- [GraalJS](https://github.com/oracle/graaljs/issues/851): [planned to ship](https://github.com/oracle/graaljs/milestone/5?closed=1) in GraalVM 25.1.0
 - [Kiesel](https://codeberg.org/kiesel-js/kiesel/issues/124)
 
 ## Champions


### PR DESCRIPTION
Chrome has officially shipped now, I've tested that it's present in stable Chrome myself this morning, now that 144 seems to be updating for everyone. And Graal have reportedly finished their implementation and will ship it with their next minor release as well.

> Significant in-the-field experience with shipping implementations, such as that provided by two independent VMs

IIRC this means that Temporal can move to Stage 4 now, right? I don't know about the Test262 results of course, but the we do have 2 big VMs shipping it now in stable without any flags.

> March TC39 Meeting: Stage 4 proposals are incorporated, final semantics are approved, and the new spec version is branched from main. Only editorial changes are accepted from this point forward.

Which would mean that it could be incorporated officially in ECMA Script 2026 in time if I'm not mistaken.