### PR TITLE
Polyfill: Add note to expected-failures.txt

### DIFF
--- a/polyfill/test/expected-failures.txt
+++ b/polyfill/test/expected-failures.txt
@@ -38,6 +38,7 @@ intl402/DateTimeFormat/prototype/resolvedOptions/resolved-numbering-system-unico
 # ICU4C internal error in extreme dates in chinese/dangi calendars
 intl402/Temporal/PlainDate/from/extreme-dates.js
 intl402/Temporal/PlainDateTime/from/extreme-dates.js
+# Also fails because of https://github.com/tc39/proposal-temporal/issues/3251
 intl402/Temporal/PlainYearMonth/from/extreme-dates.js
 intl402/Temporal/ZonedDateTime/from/extreme-dates.js
 


### PR DESCRIPTION
intl402/Temporal/PlainYearMonth/from/extreme-dates.js was already in the expected-failures file, but add a note that it will also fail as long as https://github.com/tc39/proposal-temporal/issues/3251 is an issue.