### PR TITLE
Polyfill: Change check to assertion in dateUntil

### DIFF
--- a/polyfill/lib/calendar.mjs
+++ b/polyfill/lib/calendar.mjs
@@ -193,7 +193,8 @@ impl['iso8601'] = {
   },
   dateUntil(one, two, largestUnit) {
     const sign = -ES.CompareISODate(one, two);
-    if (sign === 0) return { years: 0, months: 0, weeks: 0, days: 0 };
+    // This case was checked in CalendarDateUntil
+    assert(sign !== 0);
 
     let years = 0;
     let months = 0;


### PR DESCRIPTION
As of https://github.com/tc39/proposal-temporal/pull/3218 , this check is always done before calling dateUntil.