### PR TITLE
Polyfill fix to format plain Temporal objects in UTC

### DIFF
--- a/polyfill/lib/intl.mjs
+++ b/polyfill/lib/intl.mjs
@@ -66,10 +66,16 @@ const OPTIONS = SymbolCtor('options');
 // Construction of built-in Intl.DateTimeFormat objects is sloooooow,
 // so we'll only create those instances when we need them.
 // See https://bugs.chromium.org/p/v8/issues/detail?id=6528
-function getSlotLazy(obj, slot) {
+function getSlotLazy(obj, slot, isPlain) {
   let val = GetSlot(obj, slot);
   if (typeof val === 'function') {
-    val = new IntlDateTimeFormat(GetSlot(obj, LOCALE), val(GetSlot(obj, OPTIONS)));
+    const baseOptions = val(GetSlot(obj, OPTIONS));
+    const options = ObjectAssign({}, baseOptions);
+    const amendedOptions = val(options);
+    if (isPlain) {
+      amendedOptions.timeZone = 'UTC';
+    }
+    val = new IntlDateTimeFormat(GetSlot(obj, LOCALE), amendedOptions);
     SetSlot(obj, slot, val);
   }
   return val;
@@ -596,8 +602,8 @@ function extractOverrides(temporalObj, main) {
       time: GetSlot(temporalObj, TIME)
     };
     return {
-      epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
-      formatter: getSlotLazy(main, TIME_FMT)
+      epochNs: ES.GetUTCEpochNanoseconds(isoDateTime),
+      formatter: getSlotLazy(main, TIME_FMT, /* isPlain = */ true)
     };
   }
 
@@ -611,8 +617,8 @@ function extractOverrides(temporalObj, main) {
     }
     const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(temporalObj, ISO_DATE), ES.NoonTimeRecord());
     return {
-      epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
-      formatter: getSlotLazy(main, YM)
+      epochNs: ES.GetUTCEpochNanoseconds(isoDateTime),
+      formatter: getSlotLazy(main, YM, /* isPlain = */ true)
     };
   }
 
@@ -626,8 +632,8 @@ function extractOverrides(temporalObj, main) {
     }
     const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(temporalObj, ISO_DATE), ES.NoonTimeRecord());
     return {
-      epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
-      formatter: getSlotLazy(main, MD)
+      epochNs: ES.GetUTCEpochNanoseconds(isoDateTime),
+      formatter: getSlotLazy(main, MD, /* isPlain = */ true)
     };
   }
 
@@ -641,8 +647,8 @@ function extractOverrides(temporalObj, main) {
     }
     const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(temporalObj, ISO_DATE), ES.NoonTimeRecord());
     return {
-      epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
-      formatter: getSlotLazy(main, DATE)
+      epochNs: ES.GetUTCEpochNanoseconds(isoDateTime),
+      formatter: getSlotLazy(main, DATE, /* isPlain = */ true)
     };
   }
 
@@ -656,8 +662,8 @@ function extractOverrides(temporalObj, main) {
     }
     const isoDateTime = GetSlot(temporalObj, ISO_DATE_TIME);
     return {
-      epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
-      formatter: getSlotLazy(main, DATETIME)
+      epochNs: ES.GetUTCEpochNanoseconds(isoDateTime),
+      formatter: getSlotLazy(main, DATETIME, /* isPlain = */ true)
     };
   }
 
@@ -670,7 +676,7 @@ function extractOverrides(temporalObj, main) {
   if (ES.IsTemporalInstant(temporalObj)) {
     return {
       epochNs: GetSlot(temporalObj, EPOCHNANOSECONDS),
-      formatter: getSlotLazy(main, INST)
+      formatter: getSlotLazy(main, INST, /* isPlain = */ false)
     };
   }
 


### PR DESCRIPTION
without regard to DST.

This implements normative change of PR https://github.com/tc39/proposal-temporal/pull/3246 in the polyfill.

Related to issue #3212 

This adds a new (boolean) argument `isPlain` to `getSlotLazy`, which, when `isPlain` is set to `true` copies the options object of the cached `Intl.DateTimeFormat` object and amends the copied options to have `timeZone = 'UTC'`.

Then from `extractOverrides` we use `GetUTCEpochNanoseconds` to calculate the nanoseconds of the plain temporal objects, and get a formatter for these using `getSlotLazy` with the `isPlain` argument set to `true`. Thus the formatter for the plain objects can be aware that the nanoseconds calculated for these objects are UTC based, independent of the actual timezone it was created in.

This makes the plain* objects be UTC based, implementing the changes in https://github.com/tc39/proposal-temporal/pull/3246 as closely as possible.