### PR TITLE
polyfill: Remove `ZonedDateTime` from `Formattable` type

### DIFF
--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1176,7 +1176,6 @@ declare namespace Intl {
   type Formattable =
     | Date
     | Temporal.Instant
-    | Temporal.ZonedDateTime
     | Temporal.PlainDate
     | Temporal.PlainTime
     | Temporal.PlainDateTime


### PR DESCRIPTION
`Temporal.ZonedDateTime` can't be formatted in `Intl.DateTimeFormat` methods, thus the type definition is wrong.

cf. https://github.com/fullcalendar/temporal-polyfill/issues/78 https://github.com/fullcalendar/temporal-polyfill/pull/81