### PR TITLE
Add a link to a new polyfill implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A cookbook to help you get started and learn the ins and outs of Temporal is ava
 | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------- |
 | **[@js-temporal/polyfill](https://www.npmjs.com/package/@js-temporal/polyfill)** | [js-temporal/temporal-polyfill](https://github.com/js-temporal/temporal-polyfill)   | Alpha release available |
 | **[temporal-polyfill](https://www.npmjs.com/package/temporal-polyfill)**         | [fullcalendar/temporal-polyfill](https://github.com/fullcalendar/temporal-polyfill) | Beta release available  |
+| **[temporal-polyfill-lite](https://www.npmjs.com/package/temporal-polyfill-lite)** | [fabon-f/temporal-polyfill-lite](https://github.com/fabon-f/temporal-polyfill-lite) | Release Candidate available |
 
 If you're working on a polyfill, please file an issue or PR so we can add yours here.
 


### PR DESCRIPTION
I made a new production-ready polyfill from scratch. It supports all time zones and basic calendars (only `iso8601` and `gregory`). I believe it covers 95% of Temporal use cases in practice and thus it is a good trade-off between bundle size and completeness, but perhaps I would add opt-out support of other calendars in the future. Also it is slightly smaller (about 1 kb) than `temporal-polyfill` after minification and compression.

It follows the latest (January 2026) spec of Temporal and Intl era and monthCode Proposal (only for `gregory` calendar) with few deviations. It is basically a "word-by-word" implementation of the spec and tested by test262 and thorough snapshot tests in this repository.

I need to thank champions of Temporal, because I couldn't have finished the implementation without `temporal-test262-runner`, test262 with near 100% coverage, and thorough snapshot tests.