### PR TITLE
Editorial: fix repeated 'the' in a couple of AO headers

### DIFF
--- a/spec/calendar.html
+++ b/spec/calendar.html
@@ -1036,7 +1036,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It performs implementation-defined processing to find the the date corresponding to _isoDate_ in the context of the calendar represented by _calendar_ and returns a Calendar Date Record representing that calendar date, with its fields filled in according to their descriptions in <emu-xref href="#table-temporal-calendar-date-record-fields"></emu-xref>.</dd>
+        <dd>It performs implementation-defined processing to find the date corresponding to _isoDate_ in the context of the calendar represented by _calendar_ and returns a Calendar Date Record representing that calendar date, with its fields filled in according to their descriptions in <emu-xref href="#table-temporal-calendar-date-record-fields"></emu-xref>.</dd>
       </dl>
       <emu-note>
         <p>Implementations are encouraged to elide fields that are not read by the caller.</p>
@@ -1052,7 +1052,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It finds the the date corresponding to _isoDate_ in the context of the calendar represented by _calendar_ and returns a Calendar Date Record representing that calendar date, with its fields filled in according to their descriptions.</dd>
+        <dd>It finds the date corresponding to _isoDate_ in the context of the calendar represented by _calendar_ and returns a Calendar Date Record representing that calendar date, with its fields filled in according to their descriptions.</dd>
       </dl>
       <emu-alg>
         1. If _calendar_ is *"iso8601"*, then


### PR DESCRIPTION
Tiny typo fix -- changed a couple of 'the the's to just 'the'.