### PR TITLE
Editorial: Remove an unreachable path in `TimeZoneEquals` AO

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -1814,22 +1814,15 @@ export function ToTemporalTimeZoneIdentifier(temporalTimeZoneLike) {
 
 export function TimeZoneEquals(one, two) {
   if (one === two) return true;
-  const offsetMinutes1 = ParseTimeZoneIdentifier(one).offsetMinutes;
-  const offsetMinutes2 = ParseTimeZoneIdentifier(two).offsetMinutes;
-  if (offsetMinutes1 === undefined && offsetMinutes2 === undefined) {
-    // Calling GetAvailableNamedTimeZoneIdentifier is costly, so (unlike the
-    // spec) the polyfill will early-return if one of them isn't recognized. Try
-    // the second ID first because it's more likely to be unknown, because it
-    // can come from the argument of TimeZone.p.equals as opposed to the first
-    // ID which comes from the receiver.
-    const idRecord2 = GetAvailableNamedTimeZoneIdentifier(two);
-    assert(idRecord2, `${JSONStringify(two)} has an invalid time zone`);
+  if (!IsOffsetTimeZoneIdentifier(one) && !IsOffsetTimeZoneIdentifier(two)) {
     const idRecord1 = GetAvailableNamedTimeZoneIdentifier(one);
+    const idRecord2 = GetAvailableNamedTimeZoneIdentifier(two);
     assert(idRecord1, `${JSONStringify(one)} has an invalid time zone`);
+    assert(idRecord2, `${JSONStringify(two)} has an invalid time zone`);
     return idRecord1.primaryIdentifier === idRecord2.primaryIdentifier;
-  } else {
-    return offsetMinutes1 === offsetMinutes2;
   }
+  assert(ParseTimeZoneIdentifier(one).offsetMinutes !== ParseTimeZoneIdentifier(two).offsetMinutes);
+  return false;
 }
 
 export function GetOffsetNanosecondsFor(timeZone, epochNs) {

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -401,14 +401,13 @@
       </dl>
       <emu-alg>
         1. If _one_ is _two_, return *true*.
-        1. Let _offsetMinutesOne_ be ! ParseTimeZoneIdentifier(_one_).[[OffsetMinutes]].
-        1. Let _offsetMinutesTwo_ be ! ParseTimeZoneIdentifier(_two_).[[OffsetMinutes]].
-        1. If _offsetMinutesOne_ is ~empty~ and _offsetMinutesTwo_ is ~empty~, then
+        1. If IsOffsetTimeZoneIdentifier(_one_) is *false* and IsOffsetTimeZoneIdentifier(_two_) is *false*, then
           1. Let _recordOne_ be GetAvailableNamedTimeZoneIdentifier(_one_).
           1. Let _recordTwo_ be GetAvailableNamedTimeZoneIdentifier(_two_).
-          1. If _recordOne_ is not ~empty~ and _recordTwo_ is not ~empty~ and _recordOne_.[[PrimaryIdentifier]] is _recordTwo_.[[PrimaryIdentifier]], return *true*.
-        1. Else,
-          1. If _offsetMinutesOne_ is not ~empty~ and _offsetMinutesTwo_ is not ~empty~ and _offsetMinutesOne_ = _offsetMinutesTwo_, return *true*.
+          1. Assert: _recordOne_ is not ~empty~.
+          1. Assert: _recordTwo_ is not ~empty~.
+          1. If _recordOne_.[[PrimaryIdentifier]] is _recordTwo_.[[PrimaryIdentifier]], return *true*.
+        1. Assert: If _one_ and _two_ are both offset time zone identifiers, they do not represent the same number of offset minutes.
         1. Return *false*.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Both `one` and `two` are always valid time zone identifiers in the current spec, and different fixed-offset time zone identifiers never have the same offset because `ToTemporalTimeZoneIdentifier` normalizes them (e.g. `-00` to `+00:00`). Therefore I think an `else` clause in `TimeZoneEquals` is unreachable and can be removed.