### PR TITLE
Editorial: Add descriptions to abstract operations missing them

### DIFF
--- a/spec/abstractops.html
+++ b/spec/abstractops.html
@@ -1830,7 +1830,7 @@
     </h1>
     <dl class="header">
       <dt>description</dt>
-      <dd></dd>
+      <dd>It converts _isoDate_ to a Calendar Fields Record, populating different fields depending on _type_.</dd>
     </dl>
     <emu-alg>
       1. Let _fields_ be an empty Calendar Fields Record with all fields set to ~unset~.

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1009,7 +1009,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It creates a Date Duration Record from the given date components, or throws a *RangeError* if the resulting duration would be invalid.</dd>
       </dl>
       <emu-alg>
         1. If IsValidDuration(_years_, _months_, _weeks_, _days_, 0, 0, 0, 0, 0, 0) is *false*, throw a *RangeError* exception.
@@ -1051,7 +1051,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It combines _dateDuration_ and _timeDuration_ into an Internal Duration Record.</dd>
       </dl>
       <emu-alg>
         1. Let _dateSign_ be DateDurationSign(_dateDuration_).

--- a/spec/instant.html
+++ b/spec/instant.html
@@ -429,7 +429,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It compares two epoch nanoseconds values, returning 1 if the first is later than the second, 0 if they are the same, or -1 if the first is earlier.</dd>
       </dl>
       <emu-alg>
         1. If _epochNanosecondsOne_ > _epochNanosecondsTwo_, return 1.

--- a/spec/intl.html
+++ b/spec/intl.html
@@ -586,6 +586,8 @@
           ): either a DateTime Format Record or *null*
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It selects the best matching DateTime Format Record from _formats_ based on _matcher_, _options_, _required_, _defaults_, and _inherit_.</dd>
         </dl>
         <emu-alg>
           1. If _required_ is ~date~, then
@@ -1025,6 +1027,8 @@
           ): a Boolean
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It returns *true* if _value_ is an instance of a Temporal type that can be formatted.</dd>
         </dl>
         <emu-alg>
           1. If _value_ is not an Object, return *false*.
@@ -1095,6 +1099,8 @@
           ): either a normal completion containing a Value Format Record or a throw completion
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It prepares _temporalDate_ for formatting by _dateTimeFormat_, returning a Value Format Record, or throws if the calendars are incompatible or _dateTimeFormat_ has no suitable format.</dd>
         </dl>
         <emu-alg>
           1. If _temporalDate_.[[Calendar]] is not either _dateTimeFormat_.[[Calendar]] or *"iso8601"*, throw a *RangeError* exception.
@@ -1118,6 +1124,8 @@
           ): either a normal completion containing a Value Format Record or a throw completion
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It prepares _temporalYearMonth_ for formatting by _dateTimeFormat_, returning a Value Format Record, or throws if the calendars are incompatible or _dateTimeFormat_ has no suitable format.</dd>
         </dl>
         <emu-alg>
           1. If _temporalYearMonth_.[[Calendar]] is not equal to _dateTimeFormat_.[[Calendar]], throw a *RangeError* exception.
@@ -1141,6 +1149,8 @@
           ): either a normal completion containing a Value Format Record or a throw completion
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It prepares _temporalMonthDay_ for formatting by _dateTimeFormat_, returning a Value Format Record, or throws if the calendars are incompatible or _dateTimeFormat_ has no suitable format.</dd>
         </dl>
         <emu-alg>
           1. If _temporalMonthDay_.[[Calendar]] is not equal to _dateTimeFormat_.[[Calendar]], throw a *RangeError* exception.
@@ -1164,6 +1174,8 @@
           ): either a normal completion containing a Value Format Record or a throw completion
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It prepares _temporalTime_ for formatting by _dateTimeFormat_, returning a Value Format Record, or throws if _dateTimeFormat_ has no suitable format.</dd>
         </dl>
         <emu-alg>
           1. Let _isoDate_ be CreateISODateRecord(1970, 1, 1).
@@ -1187,6 +1199,8 @@
           ): either a normal completion containing a Value Format Record or a throw completion
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It prepares _dateTime_ for formatting by _dateTimeFormat_, returning a Value Format Record, or throws if the calendars are incompatible.</dd>
         </dl>
         <emu-alg>
           1. If _dateTime_.[[Calendar]] is not *"iso8601"* and not equal to _dateTimeFormat_.[[Calendar]], throw a *RangeError* exception.
@@ -1208,6 +1222,8 @@
           ): a Value Format Record
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It prepares _instant_ for formatting by _dateTimeFormat_, returning a Value Format Record.</dd>
         </dl>
         <emu-alg>
           1. Let _format_ be _dateTimeFormat_.[[TemporalInstantFormat]].
@@ -1227,6 +1243,8 @@
           ): either a normal completion containing a Value Format Record or a throw completion
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It prepares the Number value _x_ for formatting by _dateTimeFormat_, returning a Value Format Record, or throws if _x_ is not a finite time value.</dd>
         </dl>
         <emu-alg>
           1. Set _x_ to TimeClip(_x_).
@@ -1249,6 +1267,8 @@
           ): either a normal completion containing a Value Format Record or a throw completion
         </h1>
         <dl class="header">
+          <dt>description</dt>
+          <dd>It dispatches _x_ to the appropriate handler based on its type for formatting by _dateTimeFormat_.</dd>
         </dl>
         <emu-alg>
           1. If _x_ is a Number, return ? HandleDateTimeOthers(_dateTimeFormat_, _x_).

--- a/spec/plaindate.html
+++ b/spec/plaindate.html
@@ -616,7 +616,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It creates an ISO Date Record from the given _year_, _month_, and _day_ values.</dd>
       </dl>
       <emu-alg>
         1. Assert: IsValidISODate(_year_, _month_, _day_) is *true*.

--- a/spec/plaindatetime.html
+++ b/spec/plaindatetime.html
@@ -850,7 +850,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It balances the given date and time components so that each falls within its conventional range, carrying over excess into the next larger unit, and returns the result as an ISO Date-Time Record.</dd>
       </dl>
       <emu-alg>
         1. Let _balancedTime_ be BalanceTime(_hour_, _minute_, _second_, _millisecond_, _microsecond_, _nanosecond_).
@@ -993,7 +993,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It computes the difference between _isoDateTime1_ and _isoDateTime2_, rounding the result according to _roundingIncrement_, _smallestUnit_, and _roundingMode_. It throws a *RangeError* if either datetime is outside the representable limits.</dd>
       </dl>
       <emu-alg>
         1. If CompareISODateTime(_isoDateTime1_, _isoDateTime2_) = 0, return CombineDateAndTimeDuration(ZeroDateDuration(), 0).
@@ -1017,7 +1017,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It computes the total difference between _isoDateTime1_ and _isoDateTime2_ as a mathematical value in units of _unit_. It throws a *RangeError* if either datetime is outside the representable limits.</dd>
       </dl>
       <emu-alg>
         1. If CompareISODateTime(_isoDateTime1_, _isoDateTime2_) = 0, return 0.

--- a/spec/plaintime.html
+++ b/spec/plaintime.html
@@ -675,7 +675,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It balances the given time components so that each falls within its conventional range, carrying over excess into the next larger unit, and returns the result as a Time Record.</dd>
       </dl>
       <emu-alg>
         1. Set _microsecond_ to _microsecond_ + floor(_nanosecond_ / 1000).
@@ -721,6 +721,8 @@
         ): either a normal completion containing a TemporalTimeLike Record or a throw completion
       </h1>
       <dl class="header">
+        <dt>description</dt>
+        <dd>It converts _temporalTimeLike_ to a TemporalTimeLike Record by reading time component properties, with missing components set to 0 if _completeness_ is ~complete~ or to ~unset~ if ~partial~. It throws a *TypeError* if _temporalTimeLike_ has no recognized time component properties.</dd>
       </dl>
       <emu-alg>
         1. If _completeness_ is not present, set _completeness_ to ~complete~.
@@ -853,7 +855,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It adds _timeDuration_ to _time_ and returns the balanced result.</dd>
       </dl>
       <emu-alg>
         1. Return BalanceTime(_time_.[[Hour]], _time_.[[Minute]], _time_.[[Second]], _time_.[[Millisecond]], _time_.[[Microsecond]], _time_.[[Nanosecond]] + _timeDuration_).

--- a/spec/plainyearmonth.html
+++ b/spec/plainyearmonth.html
@@ -519,7 +519,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It balances _year_ and _month_ so that _month_ falls within the range 1 to 12, carrying over excess into _year_.</dd>
       </dl>
       <emu-alg>
         1. Set _year_ to _year_ + floor((_month_ - 1) / 12).

--- a/spec/temporal.html
+++ b/spec/temporal.html
@@ -199,7 +199,7 @@
       <h1>SystemUTCEpochMilliseconds ( ): a Number</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It returns the current UTC date and time as a Number of milliseconds since the epoch.</dd>
       </dl>
       <emu-alg>
         1. Let _global_ be GetGlobalObject().
@@ -212,7 +212,7 @@
       <h1>SystemUTCEpochNanoseconds ( ): a BigInt</h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It returns the current UTC date and time as a BigInt of nanoseconds since the epoch.</dd>
       </dl>
       <emu-alg>
         1. Let _global_ be GetGlobalObject().
@@ -229,7 +229,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It returns the current date and time in the time zone specified by _temporalTimeZoneLike_, or the system time zone if _temporalTimeZoneLike_ is *undefined*.</dd>
       </dl>
       <emu-alg>
         1. If _temporalTimeZoneLike_ is *undefined*, then

--- a/spec/timezone.html
+++ b/spec/timezone.html
@@ -250,8 +250,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>
-        </dd>
+        <dd>It converts _epochNs_ to a wall-clock date and time in the time zone _timeZone_.</dd>
       </dl>
       <emu-alg>
         1. Let _offsetNanoseconds_ be GetOffsetNanosecondsFor(_timeZone_, _epochNs_).
@@ -270,8 +269,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>
-        </dd>
+        <dd>It converts _isoDateTime_ to an epoch nanoseconds value in the time zone _timeZone_, using _disambiguation_ to resolve ambiguity.</dd>
       </dl>
       <emu-alg>
         1. Let _possibleEpochNs_ be ? GetPossibleEpochNanoseconds(_timeZone_, _isoDateTime_).

--- a/spec/zoneddatetime.html
+++ b/spec/zoneddatetime.html
@@ -1164,7 +1164,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It computes the difference between the zoned date-times represented by _ns1_ and _ns2_, rounding the result according to _roundingIncrement_, _smallestUnit_, and _roundingMode_.</dd>
       </dl>
       <emu-alg>
         1. If TemporalUnitCategory(_largestUnit_) is ~time~, return DifferenceInstant(_ns1_, _ns2_, _roundingIncrement_, _smallestUnit_, _roundingMode_).
@@ -1187,7 +1187,7 @@
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd></dd>
+        <dd>It computes the total difference between the zoned date-times represented by _ns1_ and _ns2_ as a mathematical value in units of _unit_.</dd>
       </dl>
       <emu-alg>
         1. If TemporalUnitCategory(_unit_) is ~time~, then


### PR DESCRIPTION
Closes #2929.

Adds short description text to new Temporal abstract operations that were missing. Only new Temporal AOs were touched; some 262 and 402 AOs also show up here with empty descriptions, but I didn't touch them (they already have empty descriptions in 262/402). In many cases it's not clear to me that we have anything more to add that the description that ecmarkup would provide on its own.