### PR TITLE
Polyfill: Fix precision loss rounding large durations to days

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -4254,9 +4254,9 @@ export function RoundTime(
 }
 
 export function RoundTimeDuration(timeDuration, increment, unit, roundingMode) {
-  // unit must be a time unit
   const divisor = Call(MapPrototypeGet, NS_PER_TIME_UNIT, [unit]);
-  return timeDuration.round(divisor * increment, roundingMode);
+  // Use bigInt multiplication to avoid exceeding MAX_SAFE_INTEGER
+  return timeDuration.round(bigInt(divisor).multiply(increment), roundingMode);
 }
 
 export function TotalTimeDuration(timeDuration, unit) {


### PR DESCRIPTION
Fixes #3259.

Adds defensiveness for handling non-integer numbers of days by using bigInt-backed rounding for the `smallestUnit === 'day'` path, matching how other time units are already handled. Other time units don't appear to be affected.