### PR TITLE
Canonicalize calendar before checking YYYY-MM or MM-DD format

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -550,8 +550,11 @@ export function ParseTemporalYearMonthString(isoString) {
     year = +yearString;
     month = +match[2];
     referenceISODay = 1;
-    if (calendar !== undefined && calendar !== 'iso8601') {
-      throw new RangeErrorCtor('YYYY-MM format is only valid with iso8601 calendar');
+    if (calendar !== undefined) {
+      calendar = ASCIILowercase(calendar);
+      if (calendar !== 'iso8601') {
+        throw new RangeErrorCtor('YYYY-MM format is only valid with iso8601 calendar');
+      }
     }
   } else {
     let z;
@@ -568,8 +571,11 @@ export function ParseTemporalMonthDayString(isoString) {
     calendar = processAnnotations(match[3]);
     month = +match[1];
     day = +match[2];
-    if (calendar !== undefined && calendar !== 'iso8601') {
-      throw new RangeErrorCtor('MM-DD format is only valid with iso8601 calendar');
+    if (calendar !== undefined) {
+      calendar = ASCIILowercase(calendar);
+      if (calendar !== 'iso8601') {
+        throw new RangeErrorCtor('MM-DD format is only valid with iso8601 calendar');
+      }
     }
   } else {
     let z;


### PR DESCRIPTION
This fixes one of the two bugs reported in
https://github.com/tc39/proposal-temporal/issues/3269

In particular, without this fix the following two statements throw incorrectly:

```
Temporal.PlainMonthDay.from('11-18[+01:00][u-ca=ISO8601]')
Temporal.PlainYearMonth.from('1976-11[u-ca=ISO8601]')
```