### PR TITLE
Polyfill: Replace unreachable retry with assertion in NudgeToCalendarUnit

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3308,25 +3308,11 @@ function NudgeToCalendarUnit(
       didExpandCalendarUnit = true;
     }
   } else if (sign == -1) {
-    if (!(nudgeWindow.endEpochNs.leq(destEpochNs) && destEpochNs.leq(nudgeWindow.startEpochNs))) {
-      // Retry nudge window if it's out of bounds
-      nudgeWindow = ComputeNudgeWindow(
-        sign,
-        duration,
-        originEpochNs,
-        isoDateTime,
-        timeZone,
-        calendar,
-        increment,
-        unit,
-        true
-      );
-      assert(
-        nudgeWindow.endEpochNs.leq(destEpochNs) && destEpochNs.leq(nudgeWindow.startEpochNs),
-        `${unit} was 0 days long`
-      );
-      didExpandCalendarUnit = true;
-    }
+    /* c8 ignore next */
+    assert(
+      nudgeWindow.endEpochNs.leq(destEpochNs) && destEpochNs.leq(nudgeWindow.startEpochNs),
+      `sign===-1 nudge window should always contain destEpochNs for ${unit}`
+    );
   }
   ({ r1, r2, startEpochNs, endEpochNs, startDuration, endDuration } = nudgeWindow);
 

--- a/spec/duration.html
+++ b/spec/duration.html
@@ -1672,10 +1672,8 @@
             1. Assert: _nudgeWindow_.[[StartEpochNs]] ≤ _destEpochNs_ ≤ _nudgeWindow_.[[EndEpochNs]].
             1. Set _didExpandCalendarUnit_ to *true*.
         1. Else,
-          1. If _endEpochNs_ ≤ _destEpochNs_ ≤ _startEpochNs_ is *false*, then
-            1. Set _nudgeWindow_ to ? ComputeNudgeWindow(_sign_, _duration_, _originEpochNs_, _isoDateTime_, _timeZone_, _calendar_, _increment_, _unit_, *true*).
-            1. Assert: _nudgeWindow_.[[EndEpochNs]] ≤ _destEpochNs_ ≤ _nudgeWindow_.[[StartEpochNs]].
-            1. Set _didExpandCalendarUnit_ to *true*.
+          1. Assert: _endEpochNs_ ≤ _destEpochNs_ ≤ _startEpochNs_.
+          1. NOTE: For negative durations, end-of-month constraining can only reduce the day number, which moves the endpoint further from the origin, so the nudge window always contains _destEpochNs_ without an additional shift.
         1. Let _r1_ be _nudgeWindow_.[[R1]].
         1. Let _r2_ be _nudgeWindow_.[[R2]].
         1. Set _startEpochNs_ to _nudgeWindow_.[[StartEpochNs]].


### PR DESCRIPTION
The retry path for negative durations appears unreachable: end-of-month constraining reduces the day, which for negative durations pushes the endpoint further from the origin, so the nudge window always contains the destination.

This isn't a rigorous proof of unreachability, but we haven't been able to construct a test case that exercises this path. Replace the retry block with an assertion guarding the invariant, so that if we're wrong, we'll get a clear error rather than silent misbehavior.

Closes #3235