### PR TITLE
Fix ZDT diff issue with ymd travel with opposite sign of ns travel

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3104,16 +3104,19 @@ export function DifferenceZonedDateTime(ns1, ns2, timeZone, calendar, largestUni
   // Convert start/end instants to datetimes
   const isoDtStart = GetISODateTimeFor(timeZone, ns1);
   const isoDtEnd = GetISODateTimeFor(timeZone, ns2);
+  const isoDtLexSign = CompareISODate(isoDtStart.isoDate, isoDtEnd.isoDate);
 
-  // If year-month-day values are same-day,
-  // there's no point involving the calendar/timezone for zdt->pdt conversions.
-  // It also avoids a situation where dayCorrection backs up too far on same-day diffs
-  // with reverse-direction wallclock delta due to DST:
-  // https://github.com/tc39/proposal-temporal/issues/3141
   if (
-    isoDtStart.isoDate.year === isoDtEnd.isoDate.year &&
-    isoDtStart.isoDate.month === isoDtEnd.isoDate.month &&
-    isoDtStart.isoDate.day === isoDtEnd.isoDate.day
+    // If year-month-day values are same-day,
+    // there's no point involving the calendar/timezone for zdt->pdt conversions.
+    // It also avoids a situation where dayCorrection backs up too far on same-day diffs
+    // with reverse-direction wallclock delta due to DST:
+    // https://github.com/tc39/proposal-temporal/issues/3141
+    isoDtLexSign === 0 ||
+    // If year-month-day diff is opposite sign from overall nanosecond diff, then the time zone
+    // likely repeated a whole day (ex: America/Adak). In this case, do all math in time realm.
+    // https://github.com/tc39/proposal-temporal/issues/3311
+    isoDtLexSign !== sign
   ) {
     const timeDuration = new TimeDuration(nsDiff);
     return { date: ZeroDateDuration(), time: timeDuration };
@@ -3152,6 +3155,15 @@ export function DifferenceZonedDateTime(ns1, ns2, timeZone, calendar, largestUni
 
     // Convert intermediate datetime to epoch-nanoseconds (may disambiguate)
     const intermediateNs = GetEpochNanosecondsFor(timeZone, intermediateDateTime, 'compatible');
+
+    // For when intermediate datetime backs up too far beyond the starting point, likely due to a
+    // time zone's repeated day (ex: America/Adak). In this case, do all math in time realm.
+    const intermediateNsDiff = intermediateNs.subtract(ns1);
+    const intermediateSign = intermediateNsDiff.lt(0) ? 1 : -1;
+    if (intermediateSign !== sign) {
+      const timeDuration = new TimeDuration(nsDiff);
+      return { date: ZeroDateDuration(), time: timeDuration };
+    }
 
     // Compute the nanosecond diff between the intermediate instant and the final destination
     timeDuration = TimeDuration.fromEpochNsDiff(ns2, intermediateNs);


### PR DESCRIPTION
Fix for #3311

Just some strategically placed short-circuits guarding against weird scenarios, falling back to time-only math.

Output:

```js
const zdt1 = Temporal.ZonedDateTime.from('1867-10-18T12:44:35.000000001-11:47[America/Adak]');
const zdt2 = Temporal.ZonedDateTime.from('1867-10-19T00:00:00+12:13[America/Adak]');
const realDuration = zdt1.since(zdt2); // PT12H44M35.000000001S

zdt1.since(zdt2, { largestUnit: 'days' }); // PT12H44M35.000000001S
zdt2.until(zdt1, { largestUnit: 'days' }); // PT12H44M35.000000001S
realDuration.round({ largestUnit: 'days', relativeTo: zdt2 }); // PT12H44M35.000000001S
realDuration.total({ unit: 'days', relativeTo: zdt2 }); // 0.26548032407407984

// from ptomato's follow-up investigation
realDuration.round({ largestUnit: 'days', relativeTo: zdt1 }); // PT12H44M35.000000001S
realDuration.total({ unit: 'days', relativeTo: zdt1 }); // 0.5309606481481597
```

All results look reasonable, except for maybe the first .total one. Gotta think through if that's correct. Might be related to another PR I'm about to make...