### PR TITLE
WIP solution to #3310, extra nudge

### DIFF
--- a/polyfill/lib/ecmascript.mjs
+++ b/polyfill/lib/ecmascript.mjs
@@ -3209,16 +3209,16 @@ function ComputeNudgeWindow(
       const weeksEnd = AddDaysToISODate(weeksStart, duration.date.days);
       const untilResult = CalendarDateUntil(calendar, weeksStart, weeksEnd, 'week');
       const weeks = RoundNumberToIncrement(duration.date.weeks + untilResult.weeks, increment, 'trunc');
-      r1 = weeks;
-      r2 = weeks + increment * sign;
+      r1 = !additionalShift ? weeks : weeks + increment * sign;
+      r2 = r1 + increment * sign;
       startDuration = AdjustDateDurationRecord(duration.date, 0, r1);
       endDuration = AdjustDateDurationRecord(duration.date, 0, r2);
       break;
     }
     case 'day': {
       const days = RoundNumberToIncrement(duration.date.days, increment, 'trunc');
-      r1 = days;
-      r2 = days + increment * sign;
+      r1 = !additionalShift ? days : days + increment * sign;
+      r2 = r1 + increment * sign;
       startDuration = AdjustDateDurationRecord(duration.date, r1);
       endDuration = AdjustDateDurationRecord(duration.date, r2);
       break;
@@ -3290,7 +3290,13 @@ function NudgeToCalendarUnit(
 
   // Round the smallestUnit within the epoch-nanosecond span
   if (sign === 1) {
-    if (!(nudgeWindow.startEpochNs.leq(destEpochNs) && destEpochNs.leq(nudgeWindow.endEpochNs))) {
+    if (
+      !(nudgeWindow.startEpochNs.leq(destEpochNs) && destEpochNs.leq(nudgeWindow.endEpochNs)) ||
+      // If zero-size nudge window, try again
+      // TODO: maybe converge with condition above?
+      // TODO: might not need this when sign === 1
+      endEpochNs.equals(startEpochNs)
+    ) {
       // Retry nudge window if it's out of bounds
       nudgeWindow = ComputeNudgeWindow(
         sign,
@@ -3310,7 +3316,12 @@ function NudgeToCalendarUnit(
       didExpandCalendarUnit = true;
     }
   } else if (sign == -1) {
-    if (!(nudgeWindow.endEpochNs.leq(destEpochNs) && destEpochNs.leq(nudgeWindow.startEpochNs))) {
+    if (
+      !(nudgeWindow.endEpochNs.leq(destEpochNs) && destEpochNs.leq(nudgeWindow.startEpochNs)) ||
+      // If zero-size nudge window, try again
+      // TODO: maybe converge with condition above?
+      endEpochNs.equals(startEpochNs)
+    ) {
       // Retry nudge window if it's out of bounds
       nudgeWindow = ComputeNudgeWindow(
         sign,


### PR DESCRIPTION
I was thinking same thing as @justingrant https://github.com/tc39/proposal-temporal/issues/3310#issuecomment-4402754768:

> Could the solultion be to extend the nudge window by one day until it's nonzero length?

For relative-duration math, we have the notion of a "nudge window" that contains the epoch-nanoseconds of the "destination" (relativeTo+duration). I visualize infinite windows emanating from relativeTo, as `relativeTo + duration * n` and the goal is to find the one that bounds the destination.

With the the test case from #3310 in mind, I prefer to first think of a case where the duration has some extra time units that push it within the nudge window rather that residing exactly on the start:

```js
const relativeTo = Temporal.ZonedDateTime.from('2012-01-01T12:00:00[Pacific/Apia]');
const d = Temporal.Duration.from({ days: -1, seconds: -5 });
d.total({ unit: 'days', relativeTo });
// this PR's result: -2.0000578703703704
```

```js
// Broken down into individual operations...

// first nudge window
const relativeTo = Temporal.ZonedDateTime.from('2012-01-01T12:00:00[Pacific/Apia]');
const destination = relativeTo.add({ days: -1, seconds: -5 })
const windowStart = relativeTo.add({ days: -1 })
const windowEnd = relativeTo.add({ days: -2 })
const numerator = relativeTo.epochNanoseconds - windowStart.epochNanoseconds // 86400000000000n
const denominator = windowEnd.epochNanoseconds - windowStart.epochNanoseconds // 0n
// ^invalid denominator so trying another nudge..

// second nudge window
const relativeTo = Temporal.ZonedDateTime.from('2012-01-01T12:00:00[Pacific/Apia]');
const destination = relativeTo.add({ days: -1, seconds: -5 })
const windowStart = relativeTo.add({ days: -2 })
const windowEnd = relativeTo.add({ days: -3 })
const numerator = destination.epochNanoseconds - windowStart.epochNanoseconds // -5000000000n
const denominator = windowEnd.epochNanoseconds - windowStart.epochNanoseconds // -86400000000000n
// fraction: 0.0000578703703704
// result: -2.0000578703703704
```

Now for the clean `day: -1` case:

```js
const relativeTo = Temporal.ZonedDateTime.from('2012-01-01T12:00:00[Pacific/Apia]');
const d = Temporal.Duration.from({ days: -1 });
d.total({ unit: 'days', relativeTo });
// this PR's result: -2
```

```js
// Broken down into individual operations...

// first nudge window
const relativeTo = Temporal.ZonedDateTime.from('2012-01-01T12:00:00[Pacific/Apia]');
const destination = relativeTo.add({ days: -1 })
const windowStart = relativeTo.add({ days: -1 })
const windowEnd = relativeTo.add({ days: -2 })
const numerator = relativeTo.epochNanoseconds - windowStart.epochNanoseconds // 86400000000000n
const denominator = windowEnd.epochNanoseconds - windowStart.epochNanoseconds // 0n
// ^invalid denominator? (and definitely a weird sign for numerator)
// we could maybe say the `destination` landed in the zero-width nudge-window,
// and thus the fraction could be 0 and the result could be -1 + 0 ?
// This PR does NOT do this however. Let's be consistent with above,
// so let's trying another nudge..

// second nudge window
const relativeTo = Temporal.ZonedDateTime.from('2012-01-01T12:00:00[Pacific/Apia]');
const destination = relativeTo.add({ days: -1 })
const windowStart = relativeTo.add({ days: -2 })
const windowEnd = relativeTo.add({ days: -3 })
const numerator = destination.epochNanoseconds - windowStart.epochNanoseconds // 0n
const denominator = windowEnd.epochNanoseconds - windowStart.epochNanoseconds // -86400000000000n
// fraction: 0
// result: -2
```

## Conclusion

This -2 funny business seems "correct" according to the original algorithm, but feels rather unintuitive on its face.

Maybe the -2 feels weird but is more consistent with other operations, so overall better. Need to play around with this more.
